### PR TITLE
Fix action.yml. 

### DIFF
--- a/.github/workflows/install-redis/action.yml
+++ b/.github/workflows/install-redis/action.yml
@@ -18,13 +18,13 @@ runs:
 
     - uses: actions/checkout@v3
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache-redis
       with:
         path: |
           ~/redis-binaries/redis-cli
           ~/redis-binaries/redis-server
-        key: ${{ runner.os }}-redis
+        key: ${{ runner.os }}-install-redis
 
     - name: Install redis
       shell: bash
@@ -37,4 +37,4 @@ runs:
 
     - name: Copy executable to place
       shell: bash
-      run: sudo mv ~/redis-binaries/redis-server ~/redis-binaries/redis-cli /usr/bin/
+      run: sudo cp ~/redis-binaries/redis-server ~/redis-binaries/redis-cli /usr/bin/


### PR DESCRIPTION
The last cache that was created was empty. This fix prevents empty cache
creation, and changes the cache key.

1. Instead of moving the files, copy them. If the files are moved,
there's nothing to cache.

2. Update cache version to V3 - this should prevent similar errors in
the future, since V3 checks for empty cache.
