### PR TITLE
Use try_read_buf to read to rotating_buffer.

### DIFF
--- a/redis-rs/src/socket_listener/headers.rs
+++ b/redis-rs/src/socket_listener/headers.rs
@@ -26,9 +26,11 @@ pub const CALLBACK_INDEX_END: usize = MESSAGE_LENGTH_END + CALLBACK_INDEX_FIELD_
 pub const TYPE_END: usize = CALLBACK_INDEX_END + TYPE_FIELD_LENGTH;
 /// The length of the header.
 pub const HEADER_END: usize = TYPE_END;
+/// The length of the header, when it contains a second argument.
+pub const HEADER_WITH_KEY_LENGTH_END: usize = HEADER_END + MESSAGE_LENGTH_FIELD_LENGTH;
 
 /// An enum representing the values of the request type field.
-#[derive(FromPrimitive)]
+#[derive(ToPrimitive, FromPrimitive)]
 pub enum RequestType {
     /// Type of a get string request.
     GetString = 1,

--- a/redis-rs/src/socket_listener/socket_listener_impl.rs
+++ b/redis-rs/src/socket_listener/socket_listener_impl.rs
@@ -56,13 +56,13 @@ impl SocketListener {
 
             let read_result = self
                 .read_socket
-                .try_read(self.rotating_buffer.current_buffer());
+                .try_read_buf(self.rotating_buffer.current_buffer());
             match read_result {
                 Ok(0) => {
                     return ReadSocketClosed.into();
                 }
-                Ok(size) => {
-                    return match self.rotating_buffer.get_requests(size) {
+                Ok(_) => {
+                    return match self.rotating_buffer.get_requests() {
                         Ok(requests) => ReceivedValues(requests),
                         Err(err) => UnhandledError(err.into()).into(),
                     };


### PR DESCRIPTION
This allows us to remove unsafe code, where we set the length of the buffer
artifically. The large part of the change is in rotating_buffer, where the
buffers are now cleared instead of set with length,
which changes the behavior of the tests - they now write into the
buffers, instead of into slices of the buffers.
Some helper test functions were added, to make the tests more readable and
easier to refactor in the future.