### PR TITLE
Add flags for running only some benchmarks.

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -x
+#remove comment to print the lines running.
+#set -x
 
 if command -v python
 then


### PR DESCRIPTION
This allows the user to pass to install_and_test the options -node, -python, or -csharp to select only these benchmarks, or -no-csv to skip the final analysis stage.