### PR TITLE
Remove usage of yarn from critical path.

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -42,15 +42,15 @@ function runPythonBenchmark(){
 }
 
 function runNodeBenchmark(){
-  yarn install
+  npm install
   cd ${BENCH_FOLDER}/../node
-  yarn install
+  npm install
   rm -rf build-ts
-  yarn run build
+  npm run build
   cd ${BENCH_FOLDER}/node
-  yarn install
+  npm install
   npx tsc
-  yarn run bench --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host
+  npm run bench -- --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host
 }
 
 function runCSharpBenchmark(){

--- a/node/package.json
+++ b/node/package.json
@@ -348,9 +348,9 @@
     },
     "scripts": {
         "initial-build": "npm install --location=global yarn && cd rust-client && yarn install",
-        "build": "yarn build-internal && yarn build-external",
+        "build": "npm run build-internal && npm run build-external",
         "build-internal": "cd rust-client && yarn build",
-        "build-external": "rm -rf build-ts && yarn tsc",
+        "build-external": "rm -rf build-ts && npx tsc",
         "test": "jest"
     },
     "author": "",


### PR DESCRIPTION
Due to [this](https://github.com/yarnpkg/yarn/issues/2165) and similar issues, yarn doesn't refresh the local cache, and prevents local package updates.