### PR TITLE
Simplify memory reserve operations.

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,6 @@
     "main": "build-ts/index.js",
     "types": "build-ts/index.d.ts",
     "dependencies": {
-        "@types/bit-twiddle": "^1.0.1",
         "acorn": "^8.7.1",
         "acorn-jsx": "^5.3.2",
         "aggregate-error": "^3.1.0",
@@ -28,7 +27,6 @@
         "balanced-match": "^1.0.2",
         "benchmark": "^2.1.4",
         "benny": "^3.7.1",
-        "bit-twiddle": "^1.0.2",
         "brace-expansion": "^1.1.11",
         "braces": "^3.0.2",
         "browserslist": "^4.21.3",

--- a/node/src/SocketConnection.ts
+++ b/node/src/SocketConnection.ts
@@ -1,6 +1,5 @@
 import { BabushkaInternal } from "../";
 import * as net from "net";
-import { nextPow2 } from "bit-twiddle";
 const {
     StartSocketConnection,
     HEADER_LENGTH_IN_BYTES,
@@ -105,7 +104,7 @@ export class SocketConnection {
         const requiredLength = priorBuffer.length + data.byteLength;
 
         if (this.backingReadBuffer.byteLength < requiredLength) {
-            this.backingReadBuffer = new ArrayBuffer(nextPow2(requiredLength));
+            this.backingReadBuffer = new ArrayBuffer(requiredLength);
         }
         const array = new Uint8Array(this.backingReadBuffer, 0, requiredLength);
         array.set(priorBuffer);
@@ -179,7 +178,7 @@ export class SocketConnection {
                         this.backingWriteBuffer.byteLength < requiredLength
                     ) {
                         this.backingWriteBuffer = new ArrayBuffer(
-                            nextPow2(requiredLength)
+                            requiredLength
                         );
                     }
 

--- a/redis-rs/src/socket_listener/rotating_buffer.rs
+++ b/redis-rs/src/socket_listener/rotating_buffer.rs
@@ -125,11 +125,7 @@ impl RotatingBuffer {
 
     /// Adjusts the current buffer size so that it will fit [required_length]
     fn match_capacity(&mut self, required_length: usize) {
-        if required_length <= self.current_read_buffer.len() {
-            return;
-        }
-
-        let extra_capacity = required_length.next_power_of_two() - self.current_read_buffer.len();
+        let extra_capacity = required_length - self.current_read_buffer.len();
         self.current_read_buffer.reserve(extra_capacity);
     }
 

--- a/redis-rs/src/socket_listener/socket_listener_impl.rs
+++ b/redis-rs/src/socket_listener/socket_listener_impl.rs
@@ -22,6 +22,7 @@ use tokio::sync::Notify;
 use tokio::task;
 use ClosingReason::*;
 use PipeListeningResult::*;
+
 /// The socket file name
 pub const SOCKET_FILE_NAME: &str = "babushka-socket";
 
@@ -176,10 +177,7 @@ async fn send_set_request(
 fn get_vec(pool: &Pool<Vec<u8>>, required_capacity: usize) -> RcRecycled<Vec<u8>> {
     let mut vec = pool.new_rc();
     vec.clear();
-    let current_capacity = vec.capacity();
-    if required_capacity > current_capacity {
-        vec.reserve(required_capacity.next_power_of_two() - current_capacity);
-    }
+    vec.reserve(required_capacity);
     vec
 }
 


### PR DESCRIPTION
After testing, there isn't any clear perf benefit to allocating more memory than required, so this change removes some unnecessary code.