### PR TITLE
CSV exporter: Remove JSON files when done.

### DIFF
--- a/benchmarks/utilities/csv_exporter.py
+++ b/benchmarks/utilities/csv_exporter.py
@@ -44,3 +44,6 @@ with open(output_file_name, "w+") as output_file:
                 relevant_fields = python_fields if language == "python" else base_fields
                 values = [json_object[field] for field in relevant_fields]
                 writer.writerow(values)
+
+for json_file_full_path in sys.argv[1:-1]:
+    os.remove(json_file_full_path)


### PR DESCRIPTION
All of the info is in the CSV, so the JSONs are no longer needed. This leaves the folder cleaner.