### PR TITLE
Fix language column in benchmark CSV.

### DIFF
--- a/benchmarks/utilities/csv_exporter.py
+++ b/benchmarks/utilities/csv_exporter.py
@@ -38,7 +38,15 @@ with open(output_file_name, "w+") as output_file:
             json_objects = json.load(file)
 
             json_file_name = os.path.basename(json_file_full_path)
-            language = json_file_name.split("-")[0]
+
+            languages = ["csharp", "node", "python"]
+            language = next(
+                (language for language in languages if language in json_file_name),
+                None
+            )
+
+            if not language:
+                raise "Unknown language for " + json_file_name
             for json_object in json_objects:
                 json_object["language"] = language
                 relevant_fields = python_fields if language == "python" else base_fields


### PR DESCRIPTION
The language column was incorrect when adding prefix to file name, because it used the first word before a dash, and the prefix added a dash. This change ensures that only a known language will be used.