### PR TITLE
Remove alignment to 4 in Rust responses.

### DIFF
--- a/python/python/pybushka/async_socket_client.py
+++ b/python/python/pybushka/async_socket_client.py
@@ -182,12 +182,8 @@ class RedisAsyncSocketClient(CoreCommands):
         else:
             msg_length = length - HEADER_LENGTH_IN_BYTES
             if msg_length > 0:
-                aligned_msg_length = msg_length
-                offset = msg_length % 4
-                if offset != 0:
-                    aligned_msg_length += 4 - offset
                 # Wait for the rest of the message
-                message = await self._reader.readexactly(aligned_msg_length)
+                message = await self._reader.readexactly(msg_length)
                 response = message[:msg_length].decode("UTF-8")
             else:
                 response = ""

--- a/redis-rs/src/socket_listener/socket_listener_impl.rs
+++ b/redis-rs/src/socket_listener/socket_listener_impl.rs
@@ -202,10 +202,6 @@ async fn send_get_request(
                 length,
             )?;
             output_buffer.extend_from_slice(&result_bytes);
-            let offset = output_buffer.len() % 4;
-            if offset != 0 {
-                output_buffer.resize(length + 4 - offset, 0);
-            }
             write_to_output(&output_buffer, &write_socket, &write_lock).await;
         }
         None => {

--- a/redis-rs/tests/test_socket_listener.rs
+++ b/redis-rs/tests/test_socket_listener.rs
@@ -162,11 +162,10 @@ fn test_socket_set_and_get() {
     test_basics.socket.write_all(&buffer).unwrap();
 
     let expected_length = VALUE_LENGTH + HEADER_END;
-    let expected_aligned_length = expected_length + (4 - expected_length % 4);
     // we set the length to a longer value, just in case we'll get more data - which is a failure for the test.
     unsafe { buffer.set_len(message_length) };
     let size = test_basics.socket.read(&mut buffer).unwrap();
-    assert_eq!(size, expected_aligned_length);
+    assert_eq!(size, expected_length);
     assert_eq!(
         (&buffer[..MESSAGE_LENGTH_END])
             .read_u32::<LittleEndian>()


### PR DESCRIPTION
The alignment doesn't have a measurable perf benefit, and was necessary only to use Uint32Array in JavaScript. Since we can use DataView, and the alignment is a recurring point of confusion for devs, I want to remove it.