### PR TITLE
Remove uvloop and aioredis from python benchmark.

### DIFF
--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -6,11 +6,8 @@ import random
 import time
 from enum import Enum
 from statistics import mean
-
-import aioredis
 import numpy as np
 import redis.asyncio as redispy
-import uvloop
 from pybushka import ClientConfiguration, RedisAsyncFFIClient, RedisAsyncSocketClient
 
 
@@ -218,17 +215,6 @@ async def main(
             data_size,
         )
 
-        # AIORedis
-        aioredis_client = await aioredis.from_url(f"redis://{host}:{PORT}")
-        await run_client(
-            aioredis_client,
-            "aioredis",
-            event_loop_name,
-            total_commands,
-            num_of_concurrent_tasks,
-            data_size,
-        )
-
     if (
         clients_to_run == "all"
         or clients_to_run == "ffi"
@@ -283,20 +269,6 @@ if __name__ == "__main__":
         asyncio.run(
             main(
                 "asyncio",
-                number_of_iterations(num_of_concurrent_tasks),
-                num_of_concurrent_tasks,
-                data_size,
-                clients_to_run,
-                host,
-            )
-        )
-
-    uvloop.install()
-
-    for (data_size, num_of_concurrent_tasks) in product_of_arguments:
-        asyncio.run(
-            main(
-                "uvloop",
                 number_of_iterations(num_of_concurrent_tasks),
                 num_of_concurrent_tasks,
                 data_size,

--- a/benchmarks/python/requirements.txt
+++ b/benchmarks/python/requirements.txt
@@ -1,11 +1,5 @@
 hiredis
-uvloop
 numpy
-
-
-# aioredis
-aioredis>=1.1.0
-#-e git+https://github.com/aio-libs/aioredis#egg=aioredis
 
 # asyncio_redis
 asyncio_redis>=0.14.3


### PR DESCRIPTION
The benchmark is quite slow ATM, and these haven't provided us with any additional data.