### PR TITLE
fixed errors with node tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ benchmarks/node/*.js
 node/build-ts/src/*.js
 /redis-rs/target/*
 node/rust-client/index.js
+logger_core/target/*

--- a/node/jest.config.js
+++ b/node/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-};

--- a/node/package.json
+++ b/node/package.json
@@ -350,6 +350,10 @@
         "build-external": "rm -rf build-ts && npx tsc",
         "test": "jest"
     },
+    "devDependencies": {
+        "@babel/preset-env": "^7.20.2",
+        "babel-jest": "^28.1.3"
+    },
     "author": "",
     "license": "MIT"
 }


### PR DESCRIPTION
As far as i understand - Error started because linter ask to use import and not require as the new standard but because jest doesn't have package.json with configuration as a module and the conf that coming from jest.config.js are old and they block other configuration coming from other places, "babel" wasn't able to translate jest as needed by the new standard (es6).
The fix is not using jest.config.js and move the config to the module package.json with the right conf and leave the work to babel as should.
@shachlanAmazon 
