### PR TITLE
Socket init callback: Return string on error.

### DIFF
--- a/babushka-core/src/socket_listener_legacy.rs
+++ b/babushka-core/src/socket_listener_legacy.rs
@@ -416,7 +416,7 @@ async fn listen_on_client_stream(
 
 async fn listen_on_socket<InitCallback>(init_callback: InitCallback)
 where
-    InitCallback: FnOnce(Result<String, RedisError>) + Send + 'static,
+    InitCallback: FnOnce(Result<String, String>) + Send + 'static,
 {
     // Bind to socket
     let listener = match UnixListener::bind(get_socket_path()) {
@@ -426,7 +426,7 @@ where
             return;
         }
         Err(err) => {
-            init_callback(Err(err.into()));
+            init_callback(Err(err.to_string()));
             return;
         }
     };
@@ -511,7 +511,7 @@ async fn handle_signals() {
 /// * `init_callback` - called when the socket listener fails to initialize, with the reason for the failure.
 pub fn start_socket_listener<InitCallback>(init_callback: InitCallback)
 where
-    InitCallback: FnOnce(Result<String, RedisError>) + Send + 'static,
+    InitCallback: FnOnce(Result<String, String>) + Send + 'static,
 {
     thread::Builder::new()
         .name("socket_listener_thread".to_string())
@@ -526,7 +526,7 @@ where
                 }
                 Err(err) => {
                     close_socket();
-                    init_callback(Err(err.into()))
+                    init_callback(Err(err.to_string()))
                 }
             };
         })

--- a/csharp/lib/src/lib.rs
+++ b/csharp/lib/src/lib.rs
@@ -133,8 +133,8 @@ pub extern "C" fn start_socket_listener_wrapper(
                     init_callback(c_str.as_ptr(), std::ptr::null());
                 }
             }
-            Err(error) => {
-                let c_str = CString::new(error.to_string()).unwrap();
+            Err(error_message) => {
+                let c_str = CString::new(error_message).unwrap();
                 unsafe {
                     init_callback(std::ptr::null(), c_str.as_ptr());
                 }

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -120,7 +120,7 @@ pub fn start_socket_listener_external(env: Env) -> Result<JsObject> {
     start_socket_listener(move |result| {
         match result {
             Ok(path) => deferred.resolve(|_| Ok(path)),
-            Err(e) => deferred.reject(to_js_error(e)),
+            Err(error_message) => deferred.reject(napi::Error::new(Status::Unknown, error_message)),
         };
     });
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -166,8 +166,8 @@ fn pybushka(_py: Python, m: &PyModule) -> PyResult<()> {
                     Ok(path) => {
                         let _ = init_callback.call(py, (path, py.None()), None);
                     }
-                    Err(err) => {
-                        let _ = init_callback.call(py, (py.None(), err.to_string()), None);
+                    Err(error_message) => {
+                        let _ = init_callback.call(py, (py.None(), error_message), None);
                     }
                 };
             });


### PR DESCRIPTION
This is part of a refactor that is meant to reduce the number of `unwrap` and `expect` calls in the codebase.
This will allow the socket listener to report any kind of error on initialization. It's assumed that the calling code doesn't care about the type of error, and only passes the error message to the wrapper.