### PR TITLE
Socket listener: handle dropped listeners.

### DIFF
--- a/babushka-core/Cargo.toml
+++ b/babushka-core/Cargo.toml
@@ -16,12 +16,12 @@ num-traits = "^0.2"
 redis = { path = "../submodules/redis-rs/redis", features = ["aio", "tokio-comp", "tls", "tokio-native-tls-comp"] }
 signal-hook = "^0.3"
 signal-hook-tokio = {version = "^0.3", features = ["futures-v0_3"] }
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "time"] }
 logger_core = {path = "../logger_core"}
 dispose = "0.4.0"
 tokio-util = {version = "^0.7", features = ["rt"]}
 num_cpus = "^1.15"
-
+rand = "0.8.5"
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
When trying to connect to a socket, we can either create a new socket,
connect to an existing socket listener, or if the socket file exists but
there's no listener connected, delete the socket file and try again.

In addition to adding this loop, this change also changes the
assumptions used by `SocketListener` - `cleanup_socket` is initially
false, since we assume that the majority of clients will be created
when a listener already exists, and so the common case is that a dropped
socket listener doesn't need to close the socket connection.