### PR TITLE
Use LocalPoolHandle in socket listener.

### DIFF
--- a/babushka-core/Cargo.toml
+++ b/babushka-core/Cargo.toml
@@ -19,6 +19,9 @@ signal-hook-tokio = {version = "^0.3", features = ["futures-v0_3"] }
 tokio = { version = "1", features = ["macros"] }
 logger_core = {path = "../logger_core"}
 dispose = "0.4.0"
+tokio-util = {version = "^0.7", features = ["rt"]}
+num_cpus = "^1.15"
+
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/babushka-core/src/socket_listener.rs
+++ b/babushka-core/src/socket_listener.rs
@@ -22,6 +22,7 @@ use tokio::runtime::Builder;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::Mutex;
 use tokio::task;
+use tokio_util::task::LocalPoolHandle;
 use ClosingReason::*;
 use PipeListeningResult::*;
 
@@ -473,26 +474,24 @@ impl SocketListener {
                 return;
             }
         };
-        let local = task::LocalSet::new();
         init_callback(Ok(self.socket_path.clone()));
-        local
-            .run_until(async move {
-                loop {
-                    tokio::select! {
-                        listen_v = listener.accept() => {
-                            if let Ok((stream, _addr)) = listen_v {
-                                // New client
-                                task::spawn_local(listen_on_client_stream(stream));
-                            } else if listen_v.is_err() {
-                                return
-                            }
-                        },
-                        // Interrupt was received, close the socket
-                        _ = handle_signals() => return
+        let local_set_pool = LocalPoolHandle::new(num_cpus::get());
+        loop {
+            tokio::select! {
+                listen_v = listener.accept() => {
+                    if let Ok((stream, _addr)) = listen_v {
+                        // New client
+                        local_set_pool.spawn_pinned(move || {
+                            listen_on_client_stream(stream)
+                        });
+                    } else if listen_v.is_err() {
+                        return
                     }
-                }
-            })
-            .await;
+                },
+                // Interrupt was received, close the socket
+                _ = handle_signals() => return
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This change will spread the clients work among a number of threads equal to the number of available CPUs. Benchmarks have shown that this increases performance in almost scenarios where there's more than a single client.