### PR TITLE
Closing errors should close the client early.

### DIFF
--- a/csharp/lib/AsyncSocketClient.cs
+++ b/csharp/lib/AsyncSocketClient.cs
@@ -269,8 +269,18 @@ namespace babushka
                 {
                     return new ArraySegment<byte>(buffer, counter, messageLength - counter);
                 }
-                var message = messageContainer.GetMessage((int)header.callbackIndex);
-                ResolveMessage(message, header, buffer, counter);
+
+                if (header.responseType == ResponseType.ClosingError)
+                {
+                    var stringLength = header.length - HEADER_LENGTH_IN_BYTES;
+                    var result = Encoding.UTF8.GetString(new Span<byte>(buffer, counter + HEADER_LENGTH_IN_BYTES, (int)stringLength));
+                    DisposeWithError(new Exception(result));
+                }
+                else
+                {
+                    var message = messageContainer.GetMessage((int)header.callbackIndex);
+                    ResolveMessage(message, header, buffer, counter);
+                }
 
                 counter += (int)header.length;
             }


### PR DESCRIPTION
We don't want to get the Task/Future for the matching callback index, because it might be out of bounds - closing errors can be sent without a matching callback index. Therefore, if the wrapper receives a closing error, it should bail without trying to find the Task/Future that matches the index, otherwise we might get out-of-bounds errors