### PR TITLE
Use trait instead of MultiplexedConnection type.

### DIFF
--- a/babushka-core/src/client.rs
+++ b/babushka-core/src/client.rs
@@ -1,0 +1,5 @@
+use redis::aio::{ConnectionLike, MultiplexedConnection};
+
+pub(super) trait BabushkaClient: ConnectionLike + Send + Clone {}
+
+impl BabushkaClient for MultiplexedConnection {}

--- a/babushka-core/src/lib.rs
+++ b/babushka-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 /// Contains information that determines how the request and response headers are shaped.
 pub mod headers;
 pub mod headers_legacy;


### PR DESCRIPTION
This will reduce the coupling with MultiplexedConnection, and will allow us to easily replace the client we use.