### PR TITLE
Adding timeouts to CI jobs.

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
     run-tests:
+        timeout-minutes: 10
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -53,6 +54,7 @@ jobs:
               run: dotnet test
 
     lint-rust:
+        timeout-minutes: 10
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,6 +19,7 @@ env:
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         strategy:
             fail-fast: false
             matrix:
@@ -28,17 +29,17 @@ jobs:
         steps:
             - uses: actions/checkout@v3
               with:
-                submodules: recursive
+                  submodules: recursive
 
             - name: Install redis
               uses: ./.github/workflows/install-redis
               with:
                   redis-version: ${{ matrix.redis }}
-            
+
             - name: Install protoc
               run: |
-                sudo apt update
-                sudo apt install protobuf-compiler
+                  sudo apt update
+                  sudo apt install protobuf-compiler
 
             - name: Use Node.js 16.x
               uses: actions/setup-node@v3
@@ -62,11 +63,12 @@ jobs:
               working-directory: ./node
 
     lint-rust:
+        timeout-minutes: 10
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
               with:
-                submodules: recursive
+                  submodules: recursive
 
             - uses: ./.github/workflows/lint-rust
               with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         strategy:
             fail-fast: false
             matrix:
@@ -84,6 +85,7 @@ jobs:
 
     lint-rust:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v3
               with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ env:
 jobs:
     build:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         strategy:
             fail-fast: false
             matrix:
@@ -35,11 +36,11 @@ jobs:
               uses: ./.github/workflows/install-redis
               with:
                   redis-version: ${{ matrix.redis }}
-            
+
             - name: Install protoc
               run: |
-                sudo apt update
-                sudo apt install protobuf-compiler
+                  sudo apt update
+                  sudo apt install protobuf-compiler
 
             - name: Install toolchain
               uses: actions-rs/toolchain@v1
@@ -62,6 +63,7 @@ jobs:
 
     lint:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
After seeing a job hang for over 5 hours, we need to timeout early to prevent such waste.
https://github.com/barshaul/babushka/actions/runs/4352750414/jobs/7605916442