### PR TITLE
Remove unsafe logic from logger.

### DIFF
--- a/babushka-core/tests/test_socket_listener.rs
+++ b/babushka-core/tests/test_socket_listener.rs
@@ -310,7 +310,7 @@ mod socket_listener {
         write_get(&mut buffer, CALLBACK2_INDEX, key);
         test_basics.socket.write_all(&buffer).unwrap();
         // we set the length to a longer value, just in case we'll get more data - which is a failure for the test.
-        unsafe { buffer.set_len(approx_message_length) };
+        buffer.resize(approx_message_length, 0);
         let _size = test_basics.socket.read(&mut buffer).unwrap();
         assert_response(
             &buffer,
@@ -391,7 +391,7 @@ mod socket_listener {
         let response_header_length = u32::required_space(size_of::<usize>() as u32);
         let expected_length = size_of::<usize>() + response_header_length + 2; // 2 bytes for callbackIdx and value type
                                                                                // we set the length to a longer value, just in case we'll get more data - which is a failure for the test.
-        unsafe { buffer.set_len(approx_message_length) };
+        buffer.resize(approx_message_length, 0);
         let mut size = 0;
         while size < expected_length {
             let next_read = test_basics.socket.read(&mut buffer[size..]).unwrap();


### PR DESCRIPTION
Instead of using a mutable global static guard, use a `RwLock` to safely mutate the guarad.
This was the cause of the various memory errors that caused our Rust tests to fail occasionally:
`malloc_consolidate(): unaligned fastbin chunk detected` `malloc(): unaligned tcache chunk detected`
`tcache_thread_shutdown(): unaligned tcache chunk detected`

Found using address sanitizer.