### PR TITLE
Filter number of clients according to tasks.

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -361,7 +361,7 @@ public static class MainClass
             .ParseArguments<CommandLineOptions>(args).WithParsed<CommandLineOptions>(parsed => { options = parsed; });
 
         var product = options.concurrentTasks.SelectMany(concurrentTasks =>
-            options.clientCount.Select(clientCount => (concurrentTasks, options.dataSize, clientCount)));
+            options.clientCount.Select(clientCount => (concurrentTasks: concurrentTasks, dataSize: options.dataSize, clientCount: clientCount))).Where(tuple => tuple.concurrentTasks >= tuple.clientCount);
         foreach (var (concurrentTasks, dataSize, clientCount) in product)
         {
             await run_with_parameters(number_of_iterations(concurrentTasks), dataSize, concurrentTasks, options.clientsToRun, options.host, clientCount, options.tls);

--- a/benchmarks/node/node_benchmark.ts
+++ b/benchmarks/node/node_benchmark.ts
@@ -310,12 +310,16 @@ Promise.resolve() // just added to clean the indentation of the rest of the call
             numOfClients: string,
             concurrentTasks: string
         ) => [parseInt(concurrentTasks), data_size, parseInt(numOfClients)];
-        const product: [number, number, number][] = concurrent_tasks.flatMap(
-            (concurrentTasks: string) =>
+        const product: [number, number, number][] = concurrent_tasks
+            .flatMap((concurrentTasks: string) =>
                 clientCount.map((clientCount) =>
                     lambda(clientCount, concurrentTasks)
                 )
-        );
+            )
+            .filter(
+                ([concurrent_tasks, _, clientCount]) =>
+                    clientCount <= concurrent_tasks
+            );
 
         for (const [concurrent_tasks, data_size, clientCount] of product) {
             await main(

--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -306,6 +306,7 @@ if __name__ == "__main__":
         (data_size, int(num_of_concurrent_tasks), int(number_of_clients))
         for num_of_concurrent_tasks in concurrent_tasks
         for number_of_clients in client_count
+        if int(number_of_clients) <= int(num_of_concurrent_tasks)
     ]
 
     for data_size, num_of_concurrent_tasks, number_of_clients in product_of_arguments:


### PR DESCRIPTION
There's no need to create more clients than the number of concurrent
tasks, since the extra clients won't be used.