### PR TITLE
Add connection benchmarks.

### DIFF
--- a/babushka-core/Cargo.toml
+++ b/babushka-core/Cargo.toml
@@ -13,7 +13,7 @@ futures = "^0.3"
 lifeguard = "^0.6"
 num-derive = "^0.3"
 num-traits = "^0.2"
-redis = { path = "../submodules/redis-rs/redis", features = ["aio", "tokio-comp", "tls", "tokio-native-tls-comp"] }
+redis = { path = "../submodules/redis-rs/redis", features = ["aio", "tokio-comp", "tls", "tokio-native-tls-comp", "connection-manager"] }
 signal-hook = "^0.3"
 signal-hook-tokio = {version = "^0.3", features = ["futures-v0_3"] }
 tokio = { version = "1", features = ["macros", "time"] }
@@ -32,7 +32,12 @@ rsevents = "0.3.1"
 socket2 = "0.4.7"
 tempfile = "3.3.0"
 rstest = "0.16.0"
+criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
 
 [build-dependencies]
 protobuf-codegen = "3"
 protoc-rust = "^2.0"
+
+[[bench]]
+name = "connections_benchmark"
+harness = false

--- a/babushka-core/benches/connections_benchmark.rs
+++ b/babushka-core/benches/connections_benchmark.rs
@@ -1,0 +1,132 @@
+use babushka::client::BabushkaClient;
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures::future::join_all;
+use redis::{
+    AsyncCommands, Client, ConnectionAddr, ConnectionInfo, RedisConnectionInfo, RedisResult, Value,
+};
+use std::env;
+use tokio::runtime::{Builder, Runtime};
+
+async fn run_get(mut connection: impl BabushkaClient) -> RedisResult<Value> {
+    connection.get("foo").await
+}
+
+fn benchmark_single_get(
+    c: &mut Criterion,
+    connection_id: &str,
+    test_group: &str,
+    connection: impl BabushkaClient,
+    runtime: &Runtime,
+) {
+    let mut group = c.benchmark_group(test_group);
+    group.significance_level(0.1).sample_size(500);
+    group.bench_function(format!("{connection_id}-single get"), move |b| {
+        b.to_async(runtime).iter(|| run_get(connection.clone()));
+    });
+}
+
+fn benchmark_concurrent_gets(
+    c: &mut Criterion,
+    connection_id: &str,
+    test_group: &str,
+    connection: impl BabushkaClient,
+    runtime: &Runtime,
+) {
+    const ITERATIONS: usize = 100;
+    let mut group = c.benchmark_group(test_group);
+    group.significance_level(0.1).sample_size(150);
+    group.bench_function(format!("{connection_id}-concurrent gets"), move |b| {
+        b.to_async(runtime).iter(|| {
+            let mut actions = Vec::with_capacity(ITERATIONS);
+            for _ in 0..ITERATIONS {
+                actions.push(run_get(connection.clone()));
+            }
+            join_all(actions)
+        });
+    });
+}
+
+fn benchmark<Fun, Con>(
+    c: &mut Criterion,
+    address: ConnectionAddr,
+    connection_id: &str,
+    group: &str,
+    connection_creation: Fun,
+) where
+    Con: BabushkaClient,
+    Fun: FnOnce(ConnectionAddr, &Runtime) -> Con,
+{
+    let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+    let connection = connection_creation(address, &runtime);
+    benchmark_single_get(c, connection_id, group, connection.clone(), &runtime);
+    benchmark_concurrent_gets(c, connection_id, group, connection, &runtime);
+}
+
+fn get_connection_info(address: ConnectionAddr) -> redis::ConnectionInfo {
+    ConnectionInfo {
+        addr: address,
+        redis: RedisConnectionInfo::default(),
+    }
+}
+
+fn multiplexer_benchmark(c: &mut Criterion, address: ConnectionAddr, group: &str) {
+    benchmark(c, address, "multiplexer", group, |address, runtime| {
+        let client = Client::open(get_connection_info(address)).unwrap();
+        runtime.block_on(async { client.get_multiplexed_tokio_connection().await.unwrap() })
+    });
+}
+
+fn connection_manager_benchmark(c: &mut Criterion, address: ConnectionAddr, group: &str) {
+    benchmark(
+        c,
+        address,
+        "connection-manager",
+        group,
+        |address, runtime| {
+            let client = Client::open(get_connection_info(address)).unwrap();
+            runtime.block_on(async { client.get_tokio_connection_manager().await.unwrap() })
+        },
+    );
+}
+
+fn local_benchmark<F: FnOnce(&mut Criterion, ConnectionAddr, &str)>(c: &mut Criterion, f: F) {
+    f(
+        c,
+        ConnectionAddr::Tcp("localhost".to_string(), 6379),
+        "local",
+    );
+}
+
+fn get_tls_address() -> Result<ConnectionAddr, impl std::error::Error> {
+    env::var("HOST").map(|host| ConnectionAddr::TcpTls {
+        host,
+        port: 6379,
+        insecure: false,
+    })
+}
+
+fn remote_benchmark<F: FnOnce(&mut Criterion, ConnectionAddr, &str)>(c: &mut Criterion, f: F) {
+    let Ok(address) = get_tls_address() else {
+        eprintln!("*** HOST must be set as an env parameter for remote server benchmark ***");
+        return;
+    };
+    f(c, address, "remote");
+}
+
+fn multiplexer_benchmarks(c: &mut Criterion) {
+    remote_benchmark(c, multiplexer_benchmark);
+    local_benchmark(c, multiplexer_benchmark)
+}
+
+fn connection_manager_benchmarks(c: &mut Criterion) {
+    remote_benchmark(c, connection_manager_benchmark);
+    local_benchmark(c, connection_manager_benchmark)
+}
+
+criterion_group!(
+    benches,
+    connection_manager_benchmarks,
+    multiplexer_benchmarks,
+);
+
+criterion_main!(benches);

--- a/babushka-core/src/client.rs
+++ b/babushka-core/src/client.rs
@@ -1,5 +1,6 @@
-use redis::aio::{ConnectionLike, MultiplexedConnection};
+use redis::aio::{ConnectionLike, ConnectionManager, MultiplexedConnection};
 
-pub(super) trait BabushkaClient: ConnectionLike + Send + Clone {}
+pub trait BabushkaClient: ConnectionLike + Send + Clone {}
 
 impl BabushkaClient for MultiplexedConnection {}
+impl BabushkaClient for ConnectionManager {}


### PR DESCRIPTION
This adds benchmarks for anything that implements `BabushkaClient`, in order to achieve a lower-resolution benchmark.