### PR TITLE
Allow running redis-rs tests VScode test lens.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
     "python.testing.pytestEnabled": true,
     "[yaml]": {
         "editor.tabSize": 4
+    },
+    "rust-analyzer.runnableEnv": {
+        "REDISRS_SERVER_TYPE": "tcp"
     }
 }


### PR DESCRIPTION
This adds the env variable required to run tests from redis-rs.