### PR TITLE
Make the C# benchmark release mode.

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -61,8 +61,8 @@ function runNodeBenchmark(){
 function runCSharpBenchmark(){
   cd ${BENCH_FOLDER}/csharp
   dotnet clean
-  dotnet build
-  dotnet run --property:Configuration=Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag
+  dotnet build --configuration Release
+  dotnet run --configuration Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag
 }
 
 function flushDB() {


### PR DESCRIPTION
This saves building in debug mode, and makes it clearer to the reader that the code is run in release mode.