### PR TITLE
Ensure cluster_mode_enabled is set.

### DIFF
--- a/babushka-core/tests/utilities/cluster.rs
+++ b/babushka-core/tests/utilities/cluster.rs
@@ -1,6 +1,6 @@
 use super::{
     build_keys_and_certs_for_tls, create_connection_request, get_available_port,
-    wait_for_server_to_become_ready, Module, RedisServer,
+    wait_for_server_to_become_ready, ClusterMode, Module, RedisServer,
 };
 use babushka::client::Client;
 use futures::future::{join_all, BoxFuture};
@@ -295,10 +295,13 @@ pub async fn setup_test_basics_internal(
     if let Some(redis_connection_info) = &connection_info {
         setup_acl_for_cluster(&cluster.get_server_addresses(), redis_connection_info).await;
     }
-    let mut connection_request =
-        create_connection_request(&cluster.get_server_addresses(), use_tls, connection_info);
+    let connection_request = create_connection_request(
+        &cluster.get_server_addresses(),
+        use_tls,
+        connection_info,
+        ClusterMode::Enabled,
+    );
 
-    connection_request.cluster_mode_enabled = true;
     let client = Client::new(connection_request).await.unwrap();
     ClusterTestBasics { cluster, client }
 }

--- a/babushka-core/tests/utilities/mod.rs
+++ b/babushka-core/tests/utilities/mod.rs
@@ -521,10 +521,17 @@ pub async fn setup_acl(addr: &ConnectionAddr, connection_info: &RedisConnectionI
     connection.req_packed_command(&cmd).await.unwrap();
 }
 
+#[derive(PartialEq)]
+pub enum ClusterMode {
+    Disabled,
+    Enabled,
+}
+
 pub fn create_connection_request(
     addresses: &[ConnectionAddr],
     use_tls: bool,
     connection_info: Option<RedisConnectionInfo>,
+    cluster_mode: ClusterMode,
 ) -> connection_request::ConnectionRequest {
     let addresses_info = addresses.iter().map(get_address_info).collect();
     let mut connection_request = connection_request::ConnectionRequest::new();
@@ -535,6 +542,7 @@ pub fn create_connection_request(
         connection_request::TlsMode::NoTls
     }
     .into();
+    connection_request.cluster_mode_enabled = ClusterMode::Enabled == cluster_mode;
     set_connection_info_to_connection_request(
         connection_info.unwrap_or_default(),
         &mut connection_request,
@@ -551,11 +559,14 @@ async fn setup_test_basics_internal(
     if let Some(redis_connection_info) = &connection_info {
         setup_acl(&server.get_client_addr(), redis_connection_info).await;
     }
-    let mut connection_request =
-        create_connection_request(&[server.get_client_addr()], use_tls, connection_info);
+    let mut connection_request = create_connection_request(
+        &[server.get_client_addr()],
+        use_tls,
+        connection_info,
+        ClusterMode::Disabled,
+    );
     connection_request.connection_retry_strategy =
         protobuf::MessageField::from_option(connection_retry_strategy);
-    connection_request.cluster_mode_enabled = false;
     let client = ClientCMD::create_client(connection_request).await.unwrap();
     TestBasics { server, client }
 }


### PR DESCRIPTION
Some socket listener CME tests didn't set this, and accidentally passed.

This was found as part of the attempt to reuse DBs during tests, after spending many an hour trying to understand why the cluster client kept returning "MOVED" errors.