### PR TITLE
Run cargo update before installing

### DIFF
--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -38,6 +38,7 @@ runs:
               args: --manifest-path ${{ inputs.cargo-toml-folder }}/Cargo.toml --all-features --all-targets -- -D warnings
         
         - run: |
+              cargo update
               cargo install cargo-deny
               cd ${{ inputs.cargo-toml-folder }}
               cargo deny check licenses --config ${GITHUB_WORKSPACE}/deny.toml


### PR DESCRIPTION
Fixes issue:
```
error[E0308]: mismatched types
   --> /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-deny-0.13.9/src/lib.rs:301:23
    |
301 |             features: pkg.features,
    |                       ^^^^^^^^^^^^ expected struct `HashMap`, found struct `BTreeMap`
    |
    = note: expected struct `HashMap<std::string::String, Vec<std::string::String>>`
               found struct `BTreeMap<std::string::String, Vec<std::string::String>>`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `cargo-deny` due to previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `cargo-deny v0.13.9`, intermediate artifacts can be found at `/tmp/cargo-installAuOaYe`