### PR TITLE
client tests: initialize client once.

### DIFF
--- a/babushka-core/tests/test_client.rs
+++ b/babushka-core/tests/test_client.rs
@@ -27,15 +27,17 @@ mod shared_client_tests {
                 client: cluster_basics.client,
             }
         } else {
-            let cmd_basics = utilities::setup_test_basics_internal(&configuration).await;
+            let server = RedisServer::new(ServerType::Tcp {
+                tls: configuration.use_tls,
+            });
             let client = Client::new(create_connection_request(
-                &[cmd_basics.server.get_client_addr()],
+                &[server.get_client_addr()],
                 &configuration,
             ))
             .await
             .unwrap();
             TestBasics {
-                server: BackingServer::Cmd(cmd_basics.server),
+                server: BackingServer::Cmd(server),
                 client,
             }
         }


### PR DESCRIPTION
Don't use `setup_test_basics_internal`, since it creates a CMD connection that is immediately dropped.