### PR TITLE
RotatingBuffer: Use zero-copy deserialization.

### DIFF
--- a/babushka-core/Cargo.toml
+++ b/babushka-core/Cargo.toml
@@ -22,7 +22,7 @@ dispose = "0.4.0"
 tokio-util = {version = "^0.7", features = ["rt"]}
 num_cpus = "^1.15"
 tokio-retry = "0.3.0"
-protobuf = "3"
+protobuf = {version= "3", features = ["bytes", "with-bytes"]}
 integer-encoding = "3.0.4"
 thiserror = "1"
 rand = "0.8.5"
@@ -39,7 +39,10 @@ ctor = "0.2.2"
 
 [build-dependencies]
 protobuf-codegen = "3"
-protoc-rust = "^2.0"
+
+[[bench]]
+name = "rotating_buffer_benchmark"
+harness = false
 
 [[bench]]
 name = "connections_benchmark"

--- a/babushka-core/benches/connections_benchmark.rs
+++ b/babushka-core/benches/connections_benchmark.rs
@@ -98,7 +98,7 @@ fn create_connection_request(address: ConnectionAddr) -> ConnectionRequest {
         ConnectionAddr::Tcp(host, port) => {
             request.tls_mode = TlsMode::NoTls.into();
             let mut address_info = AddressInfo::new();
-            address_info.host = host;
+            address_info.host = host.into();
             address_info.port = port as u32;
             request.addresses.push(address_info);
         }
@@ -113,7 +113,7 @@ fn create_connection_request(address: ConnectionAddr) -> ConnectionRequest {
                 TlsMode::SecureTls.into()
             };
             let mut address_info = AddressInfo::new();
-            address_info.host = host;
+            address_info.host = host.into();
             address_info.port = port as u32;
             request.addresses.push(address_info);
         }

--- a/babushka-core/benches/rotating_buffer_benchmark.rs
+++ b/babushka-core/benches/rotating_buffer_benchmark.rs
@@ -1,0 +1,234 @@
+use std::io::Write;
+
+use babushka::{
+    redis_request::{command, redis_request},
+    redis_request::{Command, RedisRequest, RequestType},
+    rotating_buffer::RotatingBuffer,
+};
+use bytes::BufMut;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use integer_encoding::VarInt;
+use protobuf::Message;
+use rand::{distributions::Alphanumeric, Rng};
+
+fn benchmark(
+    c: &mut Criterion,
+    test_group: &str,
+    mut benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+    test_name: &str,
+    test_data: Vec<Vec<u8>>,
+) {
+    let mut group = c.benchmark_group(test_group);
+    group.sample_size(5000);
+
+    group.bench_function(test_name, move |b| {
+        b.iter(|| benchmark_fn(black_box(&test_data)));
+    });
+}
+
+fn benchmark_short_test_data(
+    c: &mut Criterion,
+    test_group: &str,
+    benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+) {
+    benchmark(
+        c,
+        test_group,
+        benchmark_fn,
+        "short_Test_data",
+        short_test_data(),
+    );
+}
+fn benchmark_medium_test_data(
+    c: &mut Criterion,
+    test_group: &str,
+    benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+) {
+    benchmark(
+        c,
+        test_group,
+        benchmark_fn,
+        "medium_test_data",
+        medium_test_data(),
+    );
+}
+fn benchmark_long_pointer_test_data(
+    c: &mut Criterion,
+    test_group: &str,
+    benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+) {
+    benchmark(
+        c,
+        test_group,
+        benchmark_fn,
+        "long_pointer_test_data",
+        long_pointer_test_data(),
+    );
+}
+fn benchmark_long_test_data(
+    c: &mut Criterion,
+    test_group: &str,
+    benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+) {
+    benchmark(
+        c,
+        test_group,
+        benchmark_fn,
+        "long_test_data",
+        long_test_data(),
+    );
+}
+fn benchmark_multiple_requests_test_data(
+    c: &mut Criterion,
+    test_group: &str,
+    benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+) {
+    benchmark(
+        c,
+        test_group,
+        benchmark_fn,
+        "multiple_requests_test_data",
+        multiple_requests_test_data(),
+    );
+}
+fn benchmark_split_data(
+    c: &mut Criterion,
+    test_group: &str,
+    benchmark_fn: impl FnMut(&Vec<Vec<u8>>),
+) {
+    benchmark(c, test_group, benchmark_fn, "split_data", split_data());
+}
+
+fn generate_random_string(length: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(length)
+        .map(char::from)
+        .collect()
+}
+
+fn write_length(buffer: &mut Vec<u8>, length: u32) {
+    let required_space = u32::required_space(length);
+    let new_len = buffer.len() + required_space;
+    buffer.resize(new_len, 0_u8);
+    u32::encode_var(length, &mut buffer[new_len - required_space..]);
+}
+
+fn message_buffer(request: RedisRequest) -> Vec<u8> {
+    let message_length = request.compute_size() as usize;
+    let mut buffer = Vec::with_capacity(message_length);
+    write_length(&mut buffer, message_length as u32);
+    let _ = buffer.write_all(&request.write_to_bytes().unwrap());
+    buffer
+}
+
+fn short_test_data() -> Vec<Vec<u8>> {
+    vec![message_buffer(short_request())]
+}
+
+fn medium_test_data() -> Vec<Vec<u8>> {
+    vec![message_buffer(medium_request())]
+}
+
+fn long_test_data() -> Vec<Vec<u8>> {
+    vec![message_buffer(long_request(false))]
+}
+
+fn long_pointer_test_data() -> Vec<Vec<u8>> {
+    vec![message_buffer(long_request(true))]
+}
+
+fn multiple_requests_test_data() -> Vec<Vec<u8>> {
+    let mut vec = Vec::new();
+    vec.append(&mut message_buffer(long_request(false)));
+    vec.append(&mut message_buffer(medium_request()));
+    vec.append(&mut message_buffer(long_request(true)));
+    vec![vec]
+}
+
+fn split_data() -> Vec<Vec<u8>> {
+    let mut vec = Vec::new();
+    vec.append(&mut message_buffer(long_request(false)));
+    vec.append(&mut message_buffer(medium_request()));
+    vec.append(&mut message_buffer(long_request(true)));
+    vec.append(&mut message_buffer(long_request(true)));
+    vec.append(&mut message_buffer(medium_request()));
+    vec.append(&mut message_buffer(short_request()));
+    vec.append(&mut message_buffer(long_request(false)));
+    let mut vec1 = vec.split_off(200);
+    let vec2 = vec1.split_off(2000);
+    vec![vec, vec1, vec2]
+}
+
+fn create_request(args: Vec<String>, args_pointer: bool) -> RedisRequest {
+    let mut request = RedisRequest::new();
+    request.callback_idx = 1;
+    let mut command = Command::new();
+    command.request_type = RequestType::CustomCommand.into();
+    if args_pointer {
+        command.args = Some(command::Args::ArgsVecPointer(Box::leak(Box::new(args))
+            as *mut Vec<String>
+            as u64));
+    } else {
+        let mut args_array = command::ArgsArray::new();
+        args_array.args = args.into_iter().map(|str| str.into()).collect();
+        command.args = Some(command::Args::ArgsArray(args_array));
+    }
+    request.command = Some(redis_request::Command::SingleCommand(command));
+    request
+}
+
+fn short_request() -> RedisRequest {
+    create_request(vec!["GET".into(), "goo".into(), "bar".into()], false)
+}
+
+fn medium_request() -> RedisRequest {
+    create_request(
+        vec![
+            "GET".into(),
+            generate_random_string(126),
+            generate_random_string(512),
+        ],
+        false,
+    )
+}
+
+fn long_request(args_pointer: bool) -> RedisRequest {
+    create_request(
+        vec![
+            "GET".into(),
+            generate_random_string(1021),
+            generate_random_string(2042),
+            generate_random_string(1023),
+            generate_random_string(4097),
+        ],
+        args_pointer,
+    )
+}
+
+macro_rules! run_bench {
+    ($test_name: ident, $c:ident, $rotating_buffer:ident) => {
+        $test_name($c, "rotating_buffer", |test_data: &Vec<Vec<u8>>| {
+            for data in test_data {
+                $rotating_buffer.current_buffer().put(&data[..]);
+                $rotating_buffer.get_requests::<RedisRequest>().unwrap();
+            }
+            $rotating_buffer.current_buffer().clear()
+        });
+    };
+}
+
+fn rotating_buffer_bench(c: &mut Criterion) {
+    let mut rotating_buffer = RotatingBuffer::new(1024);
+
+    run_bench!(benchmark_short_test_data, c, rotating_buffer);
+    run_bench!(benchmark_medium_test_data, c, rotating_buffer);
+    run_bench!(benchmark_long_test_data, c, rotating_buffer);
+    run_bench!(benchmark_long_pointer_test_data, c, rotating_buffer);
+    run_bench!(benchmark_multiple_requests_test_data, c, rotating_buffer);
+    run_bench!(benchmark_split_data, c, rotating_buffer);
+}
+
+criterion_group!(rotating_buffer, rotating_buffer_bench,);
+
+criterion_main!(rotating_buffer);

--- a/babushka-core/build.rs
+++ b/babushka-core/build.rs
@@ -1,9 +1,14 @@
 fn main() {
+    let customization_options = protobuf_codegen::Customize::default()
+        .lite_runtime(false)
+        .tokio_bytes(true)
+        .tokio_bytes_for_string(true);
     protobuf_codegen::Codegen::new()
         .cargo_out_dir("protobuf")
         .include("src")
         .input("src/protobuf/redis_request.proto")
         .input("src/protobuf/response.proto")
         .input("src/protobuf/connection_request.proto")
+        .customize(customization_options)
         .run_from_script();
 }

--- a/babushka-core/src/client/mod.rs
+++ b/babushka-core/src/client/mod.rs
@@ -30,11 +30,11 @@ pub(super) fn get_port(address: &AddressInfo) -> u16 {
     }
 }
 
-pub(super) fn string_to_option(str: String) -> Option<String> {
-    if str.is_empty() {
+pub(super) fn chars_to_option(chars: &::protobuf::Chars) -> Option<String> {
+    if chars.is_empty() {
         None
     } else {
-        Some(str)
+        Some(chars.to_string())
     }
 }
 
@@ -44,8 +44,8 @@ pub(super) fn get_redis_connection_info(
     match authentication_info {
         Some(info) => redis::RedisConnectionInfo {
             db: 0,
-            username: string_to_option(info.username),
-            password: string_to_option(info.password),
+            username: chars_to_option(&info.username),
+            password: chars_to_option(&info.password),
         },
         None => redis::RedisConnectionInfo::default(),
     }
@@ -58,12 +58,12 @@ pub(super) fn get_connection_info(
 ) -> redis::ConnectionInfo {
     let addr = if tls_mode != TlsMode::NoTls {
         redis::ConnectionAddr::TcpTls {
-            host: address.host.clone(),
+            host: address.host.to_string(),
             port: get_port(address),
             insecure: tls_mode == TlsMode::InsecureTls,
         }
     } else {
-        redis::ConnectionAddr::Tcp(address.host.clone(), get_port(address))
+        redis::ConnectionAddr::Tcp(address.host.to_string(), get_port(address))
     };
     redis::ConnectionInfo {
         addr,

--- a/babushka-core/src/lib.rs
+++ b/babushka-core/src/lib.rs
@@ -1,6 +1,6 @@
 include!(concat!(env!("OUT_DIR"), "/protobuf/mod.rs"));
 pub mod client;
 mod retry_strategies;
-mod rotating_buffer;
+pub mod rotating_buffer;
 mod socket_listener;
 pub use socket_listener::*;

--- a/babushka-core/tests/test_socket_listener.rs
+++ b/babushka-core/tests/test_socket_listener.rs
@@ -173,7 +173,7 @@ mod socket_listener {
                 as u64));
         } else {
             let mut args_array = ArgsArray::new();
-            args_array.args = components.args;
+            args_array.args = components.args.into_iter().map(|str| str.into()).collect();
             command.args = Some(Args::ArgsArray(args_array));
         }
         command

--- a/babushka-core/tests/utilities/cluster.rs
+++ b/babushka-core/tests/utilities/cluster.rs
@@ -101,7 +101,7 @@ impl RedisCluster {
         for node in nodes {
             let node_parts = node.split(':').collect::<Vec<&str>>();
             let mut address_info = AddressInfo::new();
-            address_info.host = node_parts.first().unwrap().to_string();
+            address_info.host = node_parts.first().unwrap().to_string().into();
             address_info.port = node_parts.get(1).unwrap().parse::<u32>().unwrap();
             address_vec.push(address_info);
         }

--- a/babushka-core/tests/utilities/mod.rs
+++ b/babushka-core/tests/utilities/mod.rs
@@ -381,7 +381,7 @@ pub fn get_address_info(address: &ConnectionAddr) -> AddressInfo {
     let mut address_info = AddressInfo::new();
     match address {
         ConnectionAddr::Tcp(host, port) => {
-            address_info.host = host.clone();
+            address_info.host = host.to_string().into();
             address_info.port = *port as u32;
         }
         ConnectionAddr::TcpTls {
@@ -389,7 +389,7 @@ pub fn get_address_info(address: &ConnectionAddr) -> AddressInfo {
             port,
             insecure: _,
         } => {
-            address_info.host = host.clone();
+            address_info.host = host.to_string().into();
             address_info.port = *port as u32;
         }
         ConnectionAddr::Unix(_) => unreachable!("Unix connection not tested"),
@@ -438,8 +438,8 @@ fn set_connection_info_to_connection_request(
     if connection_info.password.is_some() {
         connection_request.authentication_info =
             protobuf::MessageField(Some(Box::new(AuthenticationInfo {
-                password: connection_info.password.unwrap(),
-                username: connection_info.username.unwrap_or_default(),
+                password: connection_info.password.unwrap().into(),
+                username: connection_info.username.unwrap_or_default().into(),
                 ..Default::default()
             })));
     }


### PR DESCRIPTION
Additionally, remove the memory pool, which no longer served any functional purpose, and harmed performance.
This reduces the amount of allocations performed, and improves the buffer's performance by ~10%.