### PR TITLE
Reduce rust tests concurrency.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
 
             - name: Run tests
               working-directory: ./babushka-core
-              run: cargo test -- --nocapture
+              run: cargo test -- --nocapture --test-threads=1 # TODO remove the concurrency limit after we fix test flakyness.
 
             - name: Check features
               working-directory: ./babushka-core


### PR DESCRIPTION
This is done in order to reduce flakyness, which we assume is partially caused by multiple clusters running at the same time.