### PR TITLE
Increase cluster connection timeout in tests.

### DIFF
--- a/babushka-core/tests/utilities/cluster.rs
+++ b/babushka-core/tests/utilities/cluster.rs
@@ -181,7 +181,8 @@ pub async fn setup_test_basics_internal(mut configuration: TestConfiguration) ->
         setup_acl_for_cluster(&cluster.get_server_addresses(), redis_connection_info).await;
     }
     configuration.cluster_mode = ClusterMode::Enabled;
-    configuration.response_timeout = Some(10000);
+    configuration.response_timeout = configuration.response_timeout.or(Some(10000));
+    configuration.connection_timeout = configuration.connection_timeout.or(Some(10000));
     let connection_request =
         create_connection_request(&cluster.get_server_addresses(), &configuration);
 


### PR DESCRIPTION
When running multiple concurrent tests, the clusters might be slow to respond. This change reduces the chance that this will cause a timeout.