### PR TITLE
Fix python's transaction API.

### DIFF
--- a/python/python/pybushka/async_socket_client.py
+++ b/python/python/pybushka/async_socket_client.py
@@ -156,7 +156,7 @@ class RedisAsyncSocketClient(CoreCommands):
         await response_future
         return response_future.result()
 
-    async def execute_command_Transaction(
+    async def execute_transaction(
         self, commands: List[Union[TRequestType, List[str]]]
     ) -> TResult:
         request = RedisRequest()


### PR DESCRIPTION
Decided to remove the connection's `multi` call, because it implies a change in connection state, which is incorrect.
As the fix shows, the existing code was confusing enough that we awaited the `multi` function, even though it's unnecessary.