### PR TITLE
Refactored Python's socket async client

### DIFF
--- a/python/python/pybushka/__init__.py
+++ b/python/python/pybushka/__init__.py
@@ -3,8 +3,7 @@ from pybushka.config import AddressInfo, ClientConfiguration
 from pybushka.constants import OK
 from pybushka.Logger import Level as LogLevel
 from pybushka.Logger import Logger, set_logger_config
-from pybushka.redis_client import RedisClient
-from pybushka.redis_cluster_client import RedisClusterClient
+from pybushka.redis_client import RedisClient, RedisClusterClient
 
 __all__ = [
     "AddressInfo",

--- a/python/python/pybushka/redis_client.py
+++ b/python/python/pybushka/redis_client.py
@@ -32,7 +32,7 @@ def _protobuf_encode_delimited(b_arr, request: TRequest) -> None:
     b_arr.extend(bytes_request)
 
 
-class RedisClient(CoreCommands):
+class BaseRedisClient(CoreCommands):
     @classmethod
     async def create(cls, config: ClientConfiguration = None) -> Self:
         config = config or ClientConfiguration()
@@ -226,3 +226,12 @@ class RedisClient(CoreCommands):
                         res_future.set_result(OK)
                     else:
                         res_future.set_result(None)
+
+
+class RedisClusterClient(BaseRedisClient):
+    def _get_protobuf_conn_request(self) -> TConnectionRequest:
+        return self.config.convert_to_protobuf_request(cluster_mode=True)
+
+
+class RedisClient(BaseRedisClient):
+    pass

--- a/python/python/pybushka/redis_cluster_client.py
+++ b/python/python/pybushka/redis_cluster_client.py
@@ -1,7 +1,0 @@
-from pybushka.constants import TConnectionRequest
-from pybushka.redis_client import RedisClient
-
-
-class RedisClusterClient(RedisClient):
-    def _get_protobuf_conn_request(self) -> TConnectionRequest:
-        return self.config.convert_to_protobuf_request(cluster_mode=True)

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -17,14 +17,13 @@ from pybushka.config import AddressInfo, ClientConfiguration
 from pybushka.constants import OK
 from pybushka.Logger import Level as logLevel
 from pybushka.Logger import set_logger_config
-from pybushka.redis_client import RedisClient
-from pybushka.redis_cluster_client import RedisClusterClient
+from pybushka.redis_client import BaseRedisClient, RedisClient, RedisClusterClient
 
 set_logger_config(logLevel.INFO)
 
 
 @pytest.fixture()
-async def async_socket_client(request, cluster_mode) -> RedisClient:
+async def async_socket_client(request, cluster_mode) -> BaseRedisClient:
     "Get async socket client for tests"
     host = request.config.getoption("--host")
     port = request.config.getoption("--port")
@@ -70,7 +69,7 @@ def get_random_string(length):
     return result_str
 
 
-async def check_if_server_version_lt(client: RedisClient, min_version: str) -> bool:
+async def check_if_server_version_lt(client: BaseRedisClient, min_version: str) -> bool:
     # TODO: change it to pytest fixture after we'll implement a sync client
     info_str = await client.custom_command(["INFO", "server"])
     redis_version = parse_info_response(info_str).get("redis_version")
@@ -80,14 +79,14 @@ async def check_if_server_version_lt(client: RedisClient, min_version: str) -> b
 @pytest.mark.asyncio
 class TestSocketClient:
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_socket_set_get(self, async_socket_client: RedisClient):
+    async def test_socket_set_get(self, async_socket_client: BaseRedisClient):
         key = get_random_string(10)
         value = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
         assert await async_socket_client.set(key, value) == OK
         assert await async_socket_client.get(key) == value
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_large_values(self, async_socket_client: RedisClient):
+    async def test_large_values(self, async_socket_client: BaseRedisClient):
         length = 2**16
         key = get_random_string(length)
         value = get_random_string(length)
@@ -97,7 +96,7 @@ class TestSocketClient:
         assert await async_socket_client.get(key) == value
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_non_ascii_unicode(self, async_socket_client: RedisClient):
+    async def test_non_ascii_unicode(self, async_socket_client: BaseRedisClient):
         key = "foo"
         value = "שלום hello 汉字"
         assert value == "שלום hello 汉字"
@@ -106,7 +105,9 @@ class TestSocketClient:
 
     @pytest.mark.parametrize("value_size", [100, 2**16])
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_concurrent_tasks(self, async_socket_client: RedisClient, value_size):
+    async def test_concurrent_tasks(
+        self, async_socket_client: BaseRedisClient, value_size
+    ):
         num_of_concurrent_tasks = 100
         running_tasks = set()
 
@@ -124,7 +125,7 @@ class TestSocketClient:
         await asyncio.gather(*(list(running_tasks)))
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_conditional_set(self, async_socket_client: RedisClient):
+    async def test_conditional_set(self, async_socket_client: BaseRedisClient):
         key = get_random_string(10)
         value = get_random_string(10)
         res = await async_socket_client.set(
@@ -143,7 +144,7 @@ class TestSocketClient:
         assert await async_socket_client.get(key) == value
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_set_return_old_value(self, async_socket_client: RedisClient):
+    async def test_set_return_old_value(self, async_socket_client: BaseRedisClient):
         min_version = "6.2.0"
         if await check_if_server_version_lt(async_socket_client, min_version):
             # TODO: change it to pytest fixture after we'll implement a sync client
@@ -159,7 +160,9 @@ class TestSocketClient:
         assert await async_socket_client.get(key) == new_value
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_custom_command_single_arg(self, async_socket_client: RedisClient):
+    async def test_custom_command_single_arg(
+        self, async_socket_client: BaseRedisClient
+    ):
         # Test single arg command
         res: str = await async_socket_client.custom_command(["INFO"])
         info_dict = parse_info_response(res)
@@ -170,7 +173,7 @@ class TestSocketClient:
         )
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_custom_command_multi_arg(self, async_socket_client: RedisClient):
+    async def test_custom_command_multi_arg(self, async_socket_client: BaseRedisClient):
         # Test multi args command
         res: str = to_str(
             await async_socket_client.custom_command(
@@ -183,7 +186,7 @@ class TestSocketClient:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     async def test_custom_command_lower_and_upper_case(
-        self, async_socket_client: RedisClient
+        self, async_socket_client: BaseRedisClient
     ):
         # Test multi args command
         res: str = to_str(
@@ -197,7 +200,7 @@ class TestSocketClient:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     async def test_request_error_raises_exception(
-        self, async_socket_client: RedisClient
+        self, async_socket_client: BaseRedisClient
     ):
         key = get_random_string(10)
         value = get_random_string(10)
@@ -210,7 +213,7 @@ class TestSocketClient:
 @pytest.mark.asyncio
 class TestTransaction:
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_transaction_set_get(self, async_socket_client: RedisClient):
+    async def test_transaction_set_get(self, async_socket_client: BaseRedisClient):
         key = get_random_string(10)
         value = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
         transaction = Transaction()
@@ -221,7 +224,7 @@ class TestTransaction:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     async def test_transaction_multiple_commands(
-        self, async_socket_client: RedisClient
+        self, async_socket_client: BaseRedisClient
     ):
         key = get_random_string(10)
         key2 = "{{{}}}:{}".format(key, get_random_string(3))  # to get the same slot
@@ -236,7 +239,7 @@ class TestTransaction:
 
     @pytest.mark.parametrize("cluster_mode", [True])
     async def test_transaction_with_different_slots(
-        self, async_socket_client: RedisClient
+        self, async_socket_client: BaseRedisClient
     ):
         transaction = Transaction()
         transaction.set("key1", "value1")
@@ -246,7 +249,9 @@ class TestTransaction:
         assert "Moved" in str(e)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_transaction_custom_command(self, async_socket_client: RedisClient):
+    async def test_transaction_custom_command(
+        self, async_socket_client: BaseRedisClient
+    ):
         key = get_random_string(10)
         transaction = Transaction()
         transaction.custom_command(["HSET", key, "foo", "bar"])
@@ -256,7 +261,7 @@ class TestTransaction:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     async def test_transaction_custom_unsupported_command(
-        self, async_socket_client: RedisClient
+        self, async_socket_client: BaseRedisClient
     ):
         key = get_random_string(10)
         transaction = Transaction()
@@ -268,7 +273,9 @@ class TestTransaction:
         )  # TODO : add an assert on EXEC ABORT
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_transaction_discard_command(self, async_socket_client: RedisClient):
+    async def test_transaction_discard_command(
+        self, async_socket_client: BaseRedisClient
+    ):
         key = get_random_string(10)
         await async_socket_client.set(key, "1")
         transaction = Transaction()
@@ -281,7 +288,7 @@ class TestTransaction:
         assert value == "1"
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    async def test_transaction_exec_abort(self, async_socket_client: RedisClient):
+    async def test_transaction_exec_abort(self, async_socket_client: BaseRedisClient):
         key = get_random_string(10)
         transaction = Transaction()
         transaction.custom_command(["INCR", key, key, key])


### PR DESCRIPTION
Refactored Python's socket async client to separate CME and CMD clients, with a base client they extend.
This PR is a base for Python's routing support PR