### PR TITLE
Reuse servers & clusters in Rust tests.

### DIFF
--- a/babushka-core/Cargo.toml
+++ b/babushka-core/Cargo.toml
@@ -37,6 +37,7 @@ ctor = "0.2.2"
 redis = { path = "../submodules/redis-rs/redis", features = ["tls-rustls-insecure"] }
 iai-callgrind = "0.3.1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+once_cell = "1.18.0"
 
 [build-dependencies]
 protobuf-codegen = "3"

--- a/babushka-core/tests/test_client_cmd.rs
+++ b/babushka-core/tests/test_client_cmd.rs
@@ -21,7 +21,7 @@ mod client_cmd_tests {
         let server_available_event_clone = server_available_event.clone();
         block_on_all(async move {
             let test_basics = setup_test_basics(use_tls).await;
-            let server = test_basics.server;
+            let server = test_basics.server.unwrap();
             let mut client = test_basics.client;
             let address = server.get_client_addr();
             drop(server);

--- a/babushka-core/tests/test_client_cme.rs
+++ b/babushka-core/tests/test_client_cme.rs
@@ -30,6 +30,7 @@ mod client_cme_tests {
         block_on_all(async {
             let mut test_basics = setup_test_basics_internal(TestConfiguration {
                 cluster_mode: ClusterMode::Enabled,
+                shared_server: true,
                 ..Default::default()
             })
             .await;
@@ -54,6 +55,7 @@ mod client_cme_tests {
         block_on_all(async {
             let mut test_basics = setup_test_basics_internal(TestConfiguration {
                 cluster_mode: ClusterMode::Enabled,
+                shared_server: true,
                 ..Default::default()
             })
             .await;
@@ -81,6 +83,7 @@ mod client_cme_tests {
         block_on_all(async {
             let mut test_basics = setup_test_basics_internal(TestConfiguration {
                 cluster_mode: ClusterMode::Enabled,
+                shared_server: true,
                 ..Default::default()
             })
             .await;
@@ -108,6 +111,7 @@ mod client_cme_tests {
         block_on_all(async {
             let mut test_basics = setup_test_basics_internal(TestConfiguration {
                 cluster_mode: ClusterMode::Enabled,
+                shared_server: true,
                 ..Default::default()
             })
             .await;
@@ -137,6 +141,7 @@ mod client_cme_tests {
         block_on_all(async {
             let mut test_basics = setup_test_basics_internal(TestConfiguration {
                 cluster_mode: ClusterMode::Enabled,
+                shared_server: true,
                 ..Default::default()
             })
             .await;


### PR DESCRIPTION
Save static `RedisServer`/`RedisCluster` instead of recreating them for
each test. By default each test uses a new server, and tests opt into
using a shared server. Shared servers can't have ACL rules.

This reduces the single-threaded run time of the tests in half - from
~370 seconds to ~160 seconds on my machine.