### PR TITLE
Fix warning in benchmark script.

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -24,6 +24,7 @@ runAllBenchmarks=1
 runPython=0
 runNode=0
 runCsharp=0
+runRust=0
 concurrentTasks="1 10 100 1000"
 dataSize="100 4000"
 clientCount="1"


### PR DESCRIPTION
`$runRust == 1` raises a warning if `runRust` isn't defined as a number.