### PR TITLE
added info command in nodejs

### DIFF
--- a/node/index.ts
+++ b/node/index.ts
@@ -1,4 +1,4 @@
-export { SetOptions } from "./src/Commands";
+export { InfoOptions, SetOptions } from "./src/Commands";
 export { setLoggerConfig } from "./src/Logger";
 export { ConnectionOptions, RedisClient, ReturnType } from "./src/RedisClient";
 export { RedisClusterClient } from "./src/RedisClusterClient";

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -104,6 +104,53 @@ export function createSet(
     return createCommand(RequestType.SetString, args);
 }
 
+export enum InfoOptions {
+    /// INFO option: a specific section of information:
+
+    /// -SERVER: General information about the Redis server
+    Server = "server",
+    /// -CLIENTS: Client connections section
+    Clients = "clients",
+    /// -MEMORY: Memory consumption related information
+    Memory = "memory",
+    /// -PERSISTENCE: RDB and AOF related information
+    Persistence = "persistence",
+    /// -STATS: General statistics
+    Stats = "stats",
+    /// -REPLICATION: Master/replica replication information
+    Replication = "replication",
+    /// -CPU: CPU consumption statistics
+    Cpu = "cpu",
+    /// -COMMANDSTATS: Redis command statistics
+    Commandstats = "commandstats",
+    /// -LATENCYSTATS: Redis command latency percentile distribution statistics
+    Latencystats = "latencystats",
+    /// -SENTINEL: Redis Sentinel section (only applicable to Sentinel instances)
+    Sentinel = "sentinel",
+    /// -CLUSTER: Redis Cluster section
+    Cluster = "cluster",
+    /// -MODULES: Modules section
+    Modules = "modules",
+    /// -KEYSPACE: Database related statistics
+    Keyspace = "keyspace",
+    /// -ERRORSTATS: Redis error statistics
+    Errorstats = "errorstats",
+    /// -ALL: Return all sections (excluding module generated ones)
+    All = "all",
+    /// -DEFAULT: Return only the default set of sections
+    Default = "default",
+    /// EVERYTHING: Includes all and modules
+    Everything = "everything"
+    /// When no parameter is provided, the default option is assumed.
+}
+
+export function createInfo(
+    options?: InfoOptions[]
+): redis_request.Command {
+    const args: string[] = (options == undefined) ? [] : options;
+    return createCommand(RequestType.Info, args);
+}
+
 export function createCustomCommand(commandName: string, args: string[]) {
     return createCommand(RequestType.CustomCommand, [commandName, ...args]);
 }

--- a/node/src/RedisClient.ts
+++ b/node/src/RedisClient.ts
@@ -6,10 +6,12 @@ import {
 import * as net from "net";
 import { Buffer, BufferWriter, Reader, Writer } from "protobufjs";
 import {
+    InfoOptions,
     SetOptions,
     createCustomCommand,
     createGet,
-    createSet,
+    createInfo,
+    createSet
 } from "./Commands";
 import { Logger } from "./Logger";
 import { connection_request, redis_request, response } from "./ProtobufMessage";
@@ -233,6 +235,13 @@ export class RedisClient {
         options?: SetOptions
     ): Promise<"OK" | string | null> {
         return this.createWritePromise(createSet(key, value, options));
+    }
+
+    /// Returns information and statistics about the server according to the given arguments.
+    /// When no parameter is provided, the default option is assumed.
+    /// See https://redis.io/commands/info/ for details.
+    public info(options?: InfoOptions[]): Promise<string> {
+        return this.createWritePromise(createInfo(options));
     }
 
     /** Executes a single command, without checking inputs. Every part of the command, including subcommands,

--- a/node/src/RedisClusterClient.ts
+++ b/node/src/RedisClusterClient.ts
@@ -1,5 +1,5 @@
 import * as net from "net";
-import { createCustomCommand } from "./Commands";
+import { InfoOptions, createCustomCommand, createInfo } from "./Commands";
 import { connection_request, redis_request } from "./ProtobufMessage";
 import { ConnectionOptions, RedisClient, ReturnType } from "./RedisClient";
 
@@ -122,5 +122,11 @@ export class RedisClusterClient extends RedisClient {
     ): Promise<ReturnType> {
         const command = createCustomCommand(commandName, args);
         return super.createWritePromise(command, toProtobufRoute(route));
+    }
+
+    /// Returns information and statistics about the server according to the given arguments.
+    /// See https://redis.io/commands/info/ for details.
+    public info(options?: InfoOptions[], route?: Routes): Promise<string> {
+        return this.createWritePromise(createInfo(options), toProtobufRoute(route));
     }
 }

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1,8 +1,10 @@
 import {
+    InfoOptions,
     SetOptions,
     createCustomCommand,
     createGet,
-    createSet,
+    createInfo,
+    createSet
 } from "./Commands";
 import { redis_request } from "./ProtobufMessage";
 
@@ -19,6 +21,12 @@ export class Transaction {
     /// See https://redis.io/commands/set/ for details.
     public set(key: string, value: string, options?: SetOptions) {
         this.commands.push(createSet(key, value, options));
+    }
+
+    /// Returns information and statistics about the server according to the given arguments.
+    /// See https://redis.io/commands/info/ for details.
+    public info(options?: InfoOptions[]) {
+        this.commands.push(createInfo(options));
     }
 
     /** Executes a single command, without checking inputs. Every part of the command, including subcommands,

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -102,6 +102,16 @@ describe("RedisClient", () => {
             "bar4",
         ]);
     });
+    
+    it("info without parameters", async () => {
+        const client = await RedisClient.createClient(getOptions(port));
+        const result = await client.info();
+        expect(result).toEqual(expect.stringContaining('# Server'));
+        expect(result).toEqual(expect.stringContaining('# Replication'));
+        expect(result).toEqual(expect.not.stringContaining('# Latencystats'));
+        client.dispose();
+    }
+    );
 
     runBaseTests<Context>({
         init: async () => {

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, afterEach, beforeAll, describe } from "@jest/globals";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "@jest/globals";
 import { exec } from "child_process";
-import { ConnectionOptions, RedisClusterClient } from "../build-ts";
+import { ConnectionOptions, InfoOptions, RedisClusterClient } from "../build-ts";
 import { runBaseTests } from "./SharedTests";
 import { flushallOnPort } from "./TestUtilities";
 
@@ -132,4 +132,30 @@ describe("RedisClusterClient", () => {
         },
         timeout: TIMEOUT,
     });
+
+    it("info with server and replication", async () => {
+        const client = await RedisClusterClient.createClient(getOptions(cluster.ports()));
+        const result = await client.info([InfoOptions.Server, InfoOptions.Replication]);
+        const clusterNodes = await client.customCommand("CLUSTER", ["NODES"]);
+        expect((clusterNodes as string)?.split("master").length - 1).toEqual(result.length);
+        for (let i = 0; i < result.length; i++) {
+            expect(result?.[i][1]).toEqual(expect.stringContaining('# Server'));
+            expect(result?.[i][1]).toEqual(expect.stringContaining('# Replication'));
+            expect(result?.[i][1]).toEqual(expect.not.stringContaining('# Errorstats'));
+        }
+        client.dispose();
+    },
+        TIMEOUT,
+    );
+
+    it("info with server and randomNode route", async () => {
+        const client = await RedisClusterClient.createClient(getOptions(cluster.ports()));
+        const result = await client.info([InfoOptions.Server], "randomNode");
+        expect(typeof result).toEqual("string");
+        expect(result).toEqual(expect.stringContaining('# Server'));
+        expect(result).toEqual(expect.not.stringContaining('# Errorstats'));
+        client.dispose();
+    },
+        TIMEOUT,
+    );
 });


### PR DESCRIPTION
added the info command in NodeJS with three tests: two in CME, one with default routing and one with "randomNode" routing, and one test in CMD that tests the default parameter. 
INFO command : request_policy - all_shards, response_policy - special.