### PR TITLE
Python - adds config reset stat command

### DIFF
--- a/python/python/pybushka/async_commands/cmd_commands.py
+++ b/python/python/pybushka/async_commands/cmd_commands.py
@@ -31,7 +31,7 @@ class CMDCommands(CoreCommands):
 
                 connection.customCommand(["CLIENT", "LIST","TYPE", "PUBSUB"])
         Args:
-            command_args (List[str]): List of strings of the command's arguements.
+            command_args (List[str]): List of strings of the command's arguments.
             Every part of the command, including the command name and subcommands, should be added as a separate value in args.
 
         Returns:
@@ -86,3 +86,11 @@ class CMDCommands(CoreCommands):
             A simple OK response.
         """
         return await self._execute_command(RequestType.Select, [str(index)])
+
+    async def config_reset_stat(self) -> OK:
+        """Reset the statistics reported by Redis.
+        See https://redis.io/commands/config-resetstat/ for details.
+        Returns:
+            OK: Returns "OK" to confirm that the statistics were successfully reset.
+        """
+        return await self._execute_command(RequestType.ConfigResetStat, [])

--- a/python/python/pybushka/async_commands/cme_commands.py
+++ b/python/python/pybushka/async_commands/cme_commands.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 
 from pybushka.async_commands.core import BaseTransaction, CoreCommands, InfoSection
-from pybushka.constants import TResult
+from pybushka.constants import OK, TResult
 from pybushka.protobuf.redis_request_pb2 import RequestType
 from pybushka.routes import TRoute
 
@@ -24,9 +24,9 @@ class CMECommands(CoreCommands):
 
                 connection.customCommand(["CLIENT", "LIST","TYPE", "PUBSUB"], AllNodes())
         Args:
-            command_args (List[str]): List of strings of the command's arguements.
+            command_args (List[str]): List of strings of the command's arguments.
             Every part of the command, including the command name and subcommands, should be added as a separate value in args.
-            route (Optional[TRoute], optional): The command will be routed automatically, unless `route` is provided, in which
+            route (Optional[TRoute]): The command will be routed automatically, unless `route` is provided, in which
             case the client will initially try to route the command to the nodes defined by `route`. Defaults to None.
 
         Returns:
@@ -47,7 +47,7 @@ class CMECommands(CoreCommands):
         Args:
             sections (Optional[List[InfoSection]]): A list of InfoSection values specifying which sections of
             information to retrieve. When no parameter is provided, the default option is assumed.
-            route (Optional[TRoute], optional): The command will be routed automatically, unless `route` is provided, in which
+            route (Optional[TRoute]): The command will be routed automatically, unless `route` is provided, in which
             case the client will initially try to route the command to the nodes defined by `route`. Defaults to None.
 
         Returns:
@@ -68,7 +68,7 @@ class CMECommands(CoreCommands):
 
         Args:
             transaction (ClusterTransaction): A ClusterTransaction object containing a list of commands to be executed.
-            route (Optional[TRoute], optional): The command will be routed automatically, unless `route` is provided, in which
+            route (Optional[TRoute]): The command will be routed automatically, unless `route` is provided, in which
             case the client will initially try to route the command to the nodes defined by `route`. Defaults to None.
 
         Returns:
@@ -78,3 +78,17 @@ class CMECommands(CoreCommands):
         """
         commands = transaction.commands[:]
         return await self.execute_transaction(commands, route)
+
+    async def config_reset_stat(
+        self,
+        route: Optional[TRoute] = None,
+    ) -> OK:
+        """Reset the statistics reported by Redis.
+        See https://redis.io/commands/config-resetstat/ for details.
+        Args:
+            route (Optional[TRoute]): The command will be routed automatically, unless `route` is provided, in which
+            case the client will initially try to route the command to the nodes defined by `route`. Defaults to None.
+        Returns:
+            OK: Returns "OK" to confirm that the statistics were successfully reset.
+        """
+        return await self._execute_command(RequestType.ConfigResetStat, [], route)

--- a/python/python/pybushka/async_commands/core.py
+++ b/python/python/pybushka/async_commands/core.py
@@ -193,7 +193,7 @@ class BaseTransaction:
 
                 connection.customCommand(["CLIENT", "LIST","TYPE", "PUBSUB"])
         Args:
-            command_args (List[str]): List of strings of the command's arguements.
+            command_args (List[str]): List of strings of the command's arguments.
             Every part of the command, including the command name and subcommands, should be added as a separate value in args.
 
         Command response:
@@ -227,6 +227,14 @@ class BaseTransaction:
             int: The number of keys that were deleted.
         """
         self.append_command(RequestType.Del, keys)
+
+    def config_reset_stat(self):
+        """Reset the statistics reported by Redis.
+        See https://redis.io/commands/config-resetstat/ for details.
+        Command response:
+            OK: Returns "OK" to confirm that the statistics were successfully reset.
+        """
+        self.append_command(RequestType.ConfigResetStat, [])
 
 
 class CoreCommands:


### PR DESCRIPTION
**CONFIG RESETSTAT COMMAND:**
request_policy: all_nodes
response_policy: all_succeeded