### PR TITLE
Changed Python Logger to use class methods

### DIFF
--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -13,10 +13,10 @@ import redis.asyncio as redispy
 from pybushka import (
     AddressInfo,
     ClientConfiguration,
+    Logger,
     LogLevel,
     RedisClient,
     RedisClusterClient,
-    set_logger_config,
 )
 
 
@@ -242,7 +242,7 @@ async def main(
 ):
     # Demo - Setting the internal logger to log every log that has a level of info and above,
     # and save the logs to the first log file.
-    set_logger_config(LogLevel.INFO, "first.log")
+    Logger.set_logger_config(LogLevel.INFO, "first.log")
 
     if clients_to_run == "all":
         client_class = redispy.RedisCluster if is_cluster else redispy.Redis

--- a/examples/python/client_example.py
+++ b/examples/python/client_example.py
@@ -5,27 +5,25 @@ from pybushka import (
     AddressInfo,
     AllNodes,
     ClientConfiguration,
+    Logger,
     LogLevel,
     RedisClient,
     RedisClusterClient,
-    set_logger_config,
 )
 
 
-def set_console_logger(level: Type["LogLevel"] = LogLevel.WARN):
-    set_logger_config(level)
+def set_console_logger(level: LogLevel = LogLevel.WARN):
+    Logger.set_logger_config(level)
 
 
-def set_file_logger(
-    level: Type["LogLevel"] = LogLevel.WARN, file: Optional[str] = None
-):
+def set_file_logger(level: LogLevel = LogLevel.WARN, file: Optional[str] = None):
     if file is None:
         from datetime import datetime, timezone
 
         curr_time = datetime.now(timezone.utc)
-        curr_time = curr_time.strftime("%Y-%m-%dT%H:%M:%SZ")
-        file = f"{curr_time}-babushka.log"
-    set_logger_config(level, file)
+        curr_time_str = curr_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        file = f"{curr_time_str}-babushka.log"
+    Logger.set_logger_config(level, file)
 
 
 async def send_set_and_get(

--- a/python/python/pybushka/Logger.py
+++ b/python/python/pybushka/Logger.py
@@ -13,13 +13,15 @@ class Level(Enum):
     TRACE = internalLevel.Trace
 
 
-# A class that allows logging which is consistent with logs from the internal rust core.
-# Only one instance of this class can exist at any given time. The logger can be set up in 2 ways -
-#     1. By calling init, which creates and modifies a new logger only if one doesn't exist.
-#     2. By calling setConfig, which replaces the existing logger, and means that new logs will not be saved with the logs that were sent before the call.
-# If no call to any of these function is received, the first log attempt will initialize a new logger with default level decided by rust core (normally - console, error).
-# External users shouldn't use Logger, and instead setLoggerConfig Before starting to use the client.
-class Logger(object):
+class Logger:
+    """
+    A class that allows logging which is consistent with logs from the internal rust core.
+    Logger.set_logger_config should be called before starting to use the client.
+    The loggeing setting can be changed by calling set_logger_config, which replaces the existing logger, and means that new logs will
+    not be saved with the logs that were sent before the call.
+    If set_logger_config wasn't called, the first log attempt will initialize a new logger with default level (console, WARN).
+    """
+
     _instance = None
     logger_level = None
 
@@ -28,48 +30,31 @@ class Logger(object):
             level = level.value
         Logger.logger_level = py_init(level, file_name)
 
-    # Initialize a logger instance if none were initialized before - this method is meant to be used when there is no intention to replace an existing logger.
-    # The logger will filter all logs with a level lower than the given level,
-    # If given a file_name argument, will write the logs to files postfixed with file_name. If file_name isn't provided, the logs will be written to the console.
-    @staticmethod
-    def init(level: Optional[Level] = None, file_name: str = None) -> super:
-        if Logger._instance:
-            return Logger._instance
-        Logger._instance = Logger(level, file_name)
-        return Logger._instance
+    @classmethod
+    def log(cls, log_level: Level, log_identifier: str, message: str):
+        """Logs the provided message if the provided log level is lower then the logger level.
 
-    # returning the logger instance - if doesn't exist initiate new with default config decided by rust core
-    @staticmethod
-    def instance() -> super:
-        if Logger._instance:
-            return Logger._instance
-        Logger._instance = Logger()
-
-    # config the logger instance - in fact - create new logger instance with the new args
-    # exist in addition to init for two main reason's:
-    # 1. if Babushka dev want intentionally to change the logger instance configuration
-    # 2. external user want to set the logger and we don't want to return to him the logger itself, just config it
-    # the level argument is the level of the logs you want the system to provide (error logs, warn logs, etc.)
-    # the file_name argument is optional - if provided the target of the logs will be the file mentioned, else will be the console
-    @staticmethod
-    def set_config(level: Optional[Level] = None, file_name: str = None) -> super:
-        Logger._instance = Logger(level, file_name)
-        return
-
-    # take the arguments from the user and provide to the core-logger (see ../logger-core)
-    # if the level is higher then the logger level (error is 0, warn 1, etc.) simply return without operation
-    # if a logger instance doesn't exist, create new one with default mode (decided by rust core, normally - level: error, target: console)
-    # logIdentifier arg is a string contain data that suppose to give the log a context and make it easier to find certain type of logs.
-    # when the log is connect to certain task the identifier should be the task id, when the log is not part of specific task the identifier should give a context to the log - for example, "socket connection".
-    def log(log_level: Level, log_identifier: str, message: str):
-        if not Logger._instance:
-            Logger(None)
+        Args:
+            log_level (Level): The log level of the provided message
+            log_identifier (str): The log identifier should give the log a context.
+            message (str): The message to log.
+        """
+        if not cls._instance:
+            cls._instance = cls(None)
         if not log_level.value.is_lower(Logger.logger_level):
             return
         py_log(log_level.value, log_identifier, message)
 
+    @classmethod
+    def set_logger_config(
+        cls, level: Optional[Level] = None, file_name: Optional[str] = None
+    ):
+        """Creates a new logger instance and configure it with the provided log level and file name.
 
-# This function is the interface for logging that will be provided to external user
-# for more details see setConfig function above
-def set_logger_config(level: Optional[Level] = None, file_name: str = None):
-    Logger.set_config(level, file_name)
+        Args:
+            level (Optional[Level]): Set the logger level to one of [ERROR, WARN, INFO, DEBUG, TRACE].
+                If log level isn't provided, the default level will be set to WARN.
+            file_name (Optional[str]):  If providedv the target of the logs will be the file mentioned.
+                Otherwise, logs will be printed to the console.
+        """
+        Logger._instance = Logger(level, file_name)

--- a/python/python/pybushka/__init__.py
+++ b/python/python/pybushka/__init__.py
@@ -4,7 +4,7 @@ from pybushka.async_commands.core import ConditionalSet, ExpirySet, ExpiryType
 from pybushka.config import AddressInfo, ClientConfiguration, ReadFromReplica
 from pybushka.constants import OK
 from pybushka.Logger import Level as LogLevel
-from pybushka.Logger import Logger, set_logger_config
+from pybushka.Logger import Logger
 from pybushka.redis_client import RedisClient, RedisClusterClient
 from pybushka.routes import (
     AllNodes,
@@ -27,7 +27,6 @@ __all__ = [
     "ReadFromReplica",
     "RedisClient",
     "RedisClusterClient",
-    "set_logger_config",
     "Transaction",
     "ClusterTransaction",
     # Routes

--- a/python/python/pybushka/redis_client.py
+++ b/python/python/pybushka/redis_client.py
@@ -17,7 +17,7 @@ from pybushka.constants import (
     TResult,
 )
 from pybushka.Logger import Level as LogLevel
-from pybushka.Logger import Logger
+from pybushka.Logger import Logger as ClientLogger
 from pybushka.protobuf.redis_request_pb2 import Command, RedisRequest
 from pybushka.protobuf.response_pb2 import Response
 from pybushka.protobuf_codec import PartialMessageException, ProtobufCodec
@@ -58,7 +58,7 @@ class BaseRedisClient(CoreCommands):
 
         # will log if the logger was created (wrapper or costumer) on info
         # level or higher
-        Logger.log(LogLevel.INFO, "connection info", "new connection established")
+        ClientLogger.log(LogLevel.INFO, "connection info", "new connection established")
         # Wait for the socket listener to complete its initialization
         await init_future
         # Create UDS connection

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -3,14 +3,14 @@ import random
 import pytest
 from pybushka.config import AddressInfo, ClientConfiguration
 from pybushka.Logger import Level as logLevel
-from pybushka.Logger import set_logger_config
+from pybushka.Logger import Logger
 from pybushka.redis_client import BaseRedisClient, RedisClient, RedisClusterClient
 from tests.utils.cluster import RedisCluster
 
 default_host = "localhost"
 default_port = 6379
 
-set_logger_config(logLevel.INFO)
+Logger.set_logger_config(logLevel.INFO)
 
 
 def pytest_addoption(parser):

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -14,7 +14,7 @@ from pybushka.async_commands.core import (
 )
 from pybushka.constants import OK
 from pybushka.Logger import Level as logLevel
-from pybushka.Logger import set_logger_config
+from pybushka.Logger import Logger
 from pybushka.redis_client import BaseRedisClient, RedisClient, RedisClusterClient
 from pybushka.routes import (
     AllNodes,
@@ -25,7 +25,7 @@ from pybushka.routes import (
     SlotType,
 )
 
-set_logger_config(logLevel.INFO)
+Logger.set_logger_config(logLevel.INFO)
 
 
 def get_first_result(res: str | List[str] | List[List[str]]) -> str:


### PR DESCRIPTION
Changed Python Logger set_logger_config and log functions to be a class methods instead of exporting the direct function