### PR TITLE
Add missing step names.

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -74,3 +74,4 @@ jobs:
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./node/rust-client
+              name: lint node rust

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -99,4 +99,5 @@ jobs:
 
             - uses: ./.github/workflows/lint-rust
               with:
-                  cargo-toml-folder: ./python
+                  cargo-toml-folder: ./python                  
+              name: lint python-rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,11 +70,14 @@ jobs:
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./babushka-core
+              name: lint babushka-core
 
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./logger_core
+              name: lint logger
 
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./benchmarks/rust
+              name: lint benchmark


### PR DESCRIPTION
I wasted a lot of time by trying to debug issues in the wrong step. Now all steps will be properly named, and easy to understand where failures happen.