### PR TITLE
Fix C# benchmarks.

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -350,7 +350,7 @@ public static class MainClass
 
     private static int number_of_iterations(int num_of_concurrent_tasks)
     {
-        return Math.min(Math.Max(100000, num_of_concurrent_tasks * 10000), 10000000);
+        return Math.Min(Math.Max(100000, num_of_concurrent_tasks * 10000), 10000000);
     }
 
     public static async Task Main(string[] args)

--- a/csharp/lib/src/lib.rs
+++ b/csharp/lib/src/lib.rs
@@ -1,4 +1,4 @@
-use babushka::start_legacy_socket_listener;
+use babushka::start_socket_listener;
 use redis::aio::MultiplexedConnection;
 use redis::{AsyncCommands, RedisResult};
 use std::{
@@ -125,7 +125,7 @@ pub extern "C" fn get(connection_ptr: *const c_void, callback_index: usize, key:
 pub extern "C" fn start_socket_listener_wrapper(
     init_callback: unsafe extern "C" fn(*const c_char, *const c_char) -> (),
 ) {
-    start_legacy_socket_listener(move |result| {
+    start_socket_listener(move |result| {
         match result {
             Ok(socket_name) => {
                 let c_str = CString::new(socket_name).unwrap();


### PR DESCRIPTION
*Description of changes:*
1. Change EOLs in C# benchmark app `\r\n` to `\n`
2. Typo fix in C# benchmark (line 353)
3. Typo fix in rust part of C# client

Changes 2 & 3 make C# client and its benchmark compilable and executable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
