### PR TITLE
Fix Rust benchmark.

### DIFF
--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -38,7 +38,7 @@ struct Args {
     #[arg(name = "clusterModeEnabled", long, default_value_t = false)]
     cluster_mode_enabled: bool,
 
-    #[arg(name = "port", short, long, default_value_t = PORT)]
+    #[arg(name = "port", long, default_value_t = PORT)]
     port: u32,
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed short options of Rust benchmarking app to avoid conflicts. The app crashed on start.

<details>
<summary>Errors produced</summary>

```
     Running `target/debug/rust-benchmark --resultsFile=../results/___.json --dataSize 20 --concurrentTasks 10 --host localhost --clientCount 1`
thread 'main' panicked at 'Command rust-benchmark: Short option names must be unique for each argument, but '-c' is in use by both 'concurrentTasks' and 'clientCount'', /home/yuryf/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.1/src/builder/debug_asserts.rs:112:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
     Running `target/debug/rust-benchmark --resultsFile=../results/___.json --dataSize 20 --concurrentTasks 10 --host localhost --clientCount 1`
thread 'main' panicked at 'Command rust-benchmark: Short option names must be unique for each argument, but '-h' is in use by both 'host' and 'help' (call `cmd.disable_help_flag(true)` to remove the auto-generated `--help`)', /home/yuryf/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.1/src/builder/debug_asserts.rs:112:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
