### PR TITLE
Add instructions and profiles for stripped builds.

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -54,7 +54,7 @@ function runNodeBenchmark(){
   cd ${BENCH_FOLDER}/../node
   npm install
   rm -rf build-ts
-  npm run build:release
+  npm run build:benchmark
   cd ${BENCH_FOLDER}/node
   npm install
   npx tsc
@@ -81,12 +81,14 @@ function runRustBenchmark(){
 function flushDB() {
   cd $utilitiesDir
   npm install
+  npx tsc
   npm run flush -- --host $host $tlsFlag $clusterFlag $portFlag
 }
 
 function fillDB(){
   flushDB
   cd $utilitiesDir
+  npx tsc
   npm run fill -- --dataSize $1 --host $host $tlsFlag $clusterFlag $portFlag
 }
 

--- a/node/README.md
+++ b/node/README.md
@@ -22,7 +22,8 @@ Enter this folder in your terminal.
 On the first install, run `npm i`, to install all dependencies. Also enter the `rust-client` folder, and run `npm i` there, too.
 
 make sure that all dependencies, including rustup, have been installed.
-Run `npm run build:release` runs a full build in release mode. This might take a while.
+Run `npm run build:release` runs a full build in release mode, stripped from all symbols. This might take a while.
+Run `npm run build:benchmark` runs a fully optimized build with release symbols. This creates a larger binary than release build, but the binary can be profiled.
 
 For testing purposes, you can run `npm run build` runs a full, unoptimized build.
 If you've only made changes to the Rust code, run `npm run build-internal` to build the internal package and generates TypeSCript code.

--- a/node/package.json
+++ b/node/package.json
@@ -10,12 +10,12 @@
         "protobufjs": "^7.2.2"
     },
     "scripts": {
-        "build": "npm run build:debug",
+        "build": "npm run build-internal && npm run build-protobuf && npm run build-external",
         "build:release": "npm run build-internal:release &&  npm run build-protobuf && npm run build-external",
-        "build:debug": "npm run build-internal:debug && npm run build-protobuf && npm run build-external",
-        "build-internal": "npm run build-internal:debug",
-        "build-internal:debug": "cd rust-client && npm run build:debug",
-        "build-internal:release": "cd rust-client && npm run build",
+        "build:benchmark": "npm run build-internal:benchmark &&  npm run build-protobuf && npm run build-external",
+        "build-internal": "cd rust-client && npm run build",
+        "build-internal:release": "cd rust-client && npm run build:release",
+        "build-internal:benchmark": "cd rust-client && npm run build:benchmark",
         "build-external": "rm -rf build-ts && npx tsc",
         "build-protobuf": "npm run compile-protobuf-files && npm run fix-protobuf-file",
         "compile-protobuf-files": "cd src && pbjs -t static-module -o ProtobufMessage.js ../../babushka-core/src/protobuf/*.proto && pbts -o ProtobufMessage.d.ts ProtobufMessage.js",

--- a/node/rust-client/package.json
+++ b/node/rust-client/package.json
@@ -35,8 +35,9 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "npm install && napi build --platform --release --pipe \"prettier -w\"",
-    "build:debug": "npm install && napi build --platform --pipe \"prettier -w\"",
+    "build": "npm install && napi build --platform --pipe \"prettier -w\"",
+    "build:release": "npm install && napi build --platform --release --strip --pipe \"prettier -w\"",
+    "build:benchmark": "npm install && napi build --platform --release --pipe \"prettier -w\"",
     "format": "run-p format:prettier format:rs",
     "format:prettier": "prettier . -w",
     "format:rs": "cargo fmt",

--- a/python/README.md
+++ b/python/README.md
@@ -24,6 +24,7 @@ Install python-venv: run `sudo apt install python3.10-venv` (with the relevant p
 ### [Optional] Build for release
 
 `maturin develop --release` to build rust code optimized for release and create python wrapper.
+`maturin develop --release --strip` to build optimized code without symbols, ready for release.
 
 ### [Optional] Autogenerate protobuf files
 
@@ -60,6 +61,6 @@ flake8 . --count --exit-zero --max-complexity=12 --max-line-length=127 --statist
 # generate protobuf type files
 MYPY_PROTOC_PATH=`which protoc-gen-mypy`
 protoc --plugin=protoc-gen-mypy=${MYPY_PROTOC_PATH} -Iprotobuf=../babushka-core/src/protobuf/ --python_out=$./python/pybushka --mypy_out=./python/pybushka ../babushka-core/src/protobuf/*.proto
-# run type check 
+# run type check
 mypy .
 ```


### PR DESCRIPTION
Stripping symbols from release builds reduces the binary's size from ~70MB to ~3MB.