### PR TITLE
Add missing dev dependency to benchmark utilities.

### DIFF
--- a/benchmarks/utilities/package.json
+++ b/benchmarks/utilities/package.json
@@ -15,6 +15,7 @@
         "redis": "^4.6.8"
     },
     "devDependencies": {
-        "@types/command-line-args": "^5.2.1"
+        "@types/command-line-args": "^5.2.1",
+        "@types/node": "^20.6.3"
     }
 }


### PR DESCRIPTION
This is required for TypeScript to know the types of Node functions.