### PR TITLE
Fixed building the DB scripts

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -81,6 +81,7 @@ function runRustBenchmark(){
 function flushDB() {
   cd $utilitiesDir
   npm install
+  npx tsc
   npm run flush -- --host $host $tlsFlag $clusterFlag $portFlag
 }
 

--- a/benchmarks/utilities/package.json
+++ b/benchmarks/utilities/package.json
@@ -15,6 +15,7 @@
         "redis": "^4.6.8"
     },
     "devDependencies": {
-        "@types/command-line-args": "^5.2.1"
+        "@types/command-line-args": "^5.2.1",
+        "@types/node": "^20.8.0"
     }
 }


### PR DESCRIPTION
Fixed issues with building the DB scripts in the benchmark run:

1.
```
Error: Cannot find module '/home/ubuntu/babushka/benchmarks/utilities/flush_db.js'
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1026:15)
    at Function.Module._load (node:internal/modules/cjs/loader:871:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
``` 
fixed by adding npx tsc

2. 
```
flush_db.ts:47:9 - error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

47         process.exit(0);
           ~~~~~~~
```
fixed by adding "@types/node": "^20.8.0" to devDependencies 