### PR TITLE
Fix fill_db.ts to fill all indices

### DIFF
--- a/benchmarks/utilities/fill_db.ts
+++ b/benchmarks/utilities/fill_db.ts
@@ -20,7 +20,7 @@ async function fill_database(
     const sets = Array.from(Array(CONCURRENT_SETS).keys()).map(
         async (index) => {
             for (let i = 0; i < SIZE_SET_KEYSPACE / CONCURRENT_SETS; ++i) {
-                const key = (index * CONCURRENT_SETS + index).toString();
+                const key = (i * CONCURRENT_SETS + index).toString();
                 await client.set(key, data);
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

When running `fill_database` function, we were pushing data more than once into the database at `key`.  

Observed keys to set by adding a `console.log(key)` at [line 24 of fill_db.ts](https://github.com/aws/babushka/blob/main/benchmarks/utilities/fill_db.ts#L24). 
```
~/git/bq/babushka/benchmarks> ./install_and_test.sh -no-tls
/opt/homebrew/bin/python3

up to date, audited 18 packages in 233ms

found 0 vulnerabilities

> utilities@1.0.0 flush
> node flush_db.js --host localhost

Flushing localhost

> utilities@1.0.0 fill
> node fill_db.js --dataSize 100 --host localhost

Filling localhost with data size 100
0
0
0
... repeat x1000
1001
1001
1001
... repeat x1000
etc
```

Expected: 
```
0
1000
2000
3000
4000
5000
6000
7000
8000
9000
10000
11000
12000
13000
14000
15000
16000
17000
18000
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
