### PR TITLE
Fixed Java CI 

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -1,11 +1,18 @@
 name: Java CI
 
 on:
-  pull_request:
   push:
     paths:
+      - babushka-core/**
+      - submodules/**
       - "java/**"
       - ".github/workflows/java.yml"
+  pull_request:
+    paths:
+      - babushka-core/**
+      - submodules/**
+      - "java/**"
+      - ".github/workflows/java.yml"  
 
 # Run only most latest job on a branch and cancel previous ones
 concurrency:


### PR DESCRIPTION
- Fixed Java CI not to run Java checks on PRs with non relevant paths (see https://github.com/aws/babushka/pull/502 for example)
- Added submodules and babushka-core to Java CI paths


