### PR TITLE
fix type hints in python

### DIFF
--- a/python/python/pybushka/async_commands/cluster_commands.py
+++ b/python/python/pybushka/async_commands/cluster_commands.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Dict, List, Mapping, Optional, TypeVar, Union, cast
 
 from pybushka.async_commands.core import CoreCommands, InfoSection

--- a/python/python/pybushka/async_commands/standalone_commands.py
+++ b/python/python/pybushka/async_commands/standalone_commands.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import List, Mapping, Optional, cast
 
 from pybushka.async_commands.core import CoreCommands, InfoSection


### PR DESCRIPTION
Fixes error in python < 3.10:
```
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

Inherit support for type | type hints in python 3.9 and older
