### PR TITLE
Update logging level in benchmark.

### DIFF
--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -59,7 +59,7 @@ enum ChosenAction {
 }
 
 fn main() {
-    logger_core::init(Some(logger_core::Level::Debug), None);
+    logger_core::init(Some(logger_core::Level::Warn), None);
 
     let args = Args::parse();
 


### PR DESCRIPTION
We shouldn't add the cost of logs to the benchmark with verbose logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
