### PR TITLE
Rename StandaloneClientConfiguration.

### DIFF
--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -8,7 +8,7 @@ async function sendPingToNode() {
             port: 6379,
         },
     ];
-    // Check `StandaloneClientConfiguration/ClusterClientConfiguration` for additional options.
+    // Check `RedisClientConfiguration/ClusterClientConfiguration` for additional options.
     const client = await RedisClient.createClient({
         addresses: addresses,
         // useTLS: true,
@@ -35,7 +35,7 @@ async function sendPingToRandomNodeInCluster() {
             port: 6380,
         },
     ];
-    // Check `StandaloneClientConfiguration/ClusterClientConfiguration` for additional options.
+    // Check `RedisClientConfiguration/ClusterClientConfiguration` for additional options.
     const client = await RedisClusterClient.createClient({
         addresses: addresses,
         useTLS: true,

--- a/examples/python/client_example.py
+++ b/examples/python/client_example.py
@@ -37,7 +37,7 @@ async def test_standalone_client(host: str = "localhost", port: int = 6379):
     # When in Redis is in standalone mode, add address of the primary node,
     # and any replicas you'd like to be able to read from.
     addresses = [AddressInfo(host, port)]
-    # Check `StandaloneClientConfiguration/ClusterClientConfiguration` for additional options.
+    # Check `RedisClientConfiguration/ClusterClientConfiguration` for additional options.
     config = BaseClientConfiguration(
         addresses=addresses,
         # use_tls=True
@@ -54,7 +54,7 @@ async def test_standalone_client(host: str = "localhost", port: int = 6379):
 async def test_cluster_client(host: str = "localhost", port: int = 6379):
     # When in Redis is cluster mode, add address of any nodes, and the client will find all nodes in the cluster.
     addresses = [AddressInfo(host, port)]
-    # Check `StandaloneClientConfiguration/ClusterClientConfiguration` for additional options.
+    # Check `RedisClientConfiguration/ClusterClientConfiguration` for additional options.
     config = BaseClientConfiguration(
         addresses=addresses,
         # use_tls=True

--- a/node/src/RedisClient.ts
+++ b/node/src/RedisClient.ts
@@ -16,7 +16,7 @@ import {
 import { connection_request } from "./ProtobufMessage";
 import { Transaction } from "./Transaction";
 
-export type StandaloneClientConfiguration = BaseClientConfiguration & {
+export type RedisClientConfiguration = BaseClientConfiguration & {
     /**
      * index of the logical database to connect to.
      */
@@ -50,7 +50,7 @@ export type StandaloneClientConfiguration = BaseClientConfiguration & {
 
 export class RedisClient extends BaseClient {
     protected createClientRequest(
-        options: StandaloneClientConfiguration
+        options: RedisClientConfiguration
     ): connection_request.IConnectionRequest {
         const configuration = super.createClientRequest(options);
         configuration.databaseId = options.databaseId;
@@ -59,7 +59,7 @@ export class RedisClient extends BaseClient {
     }
 
     public static createClient(
-        options: StandaloneClientConfiguration
+        options: RedisClientConfiguration
     ): Promise<RedisClient> {
         return super.createClientInternal<RedisClient>(
             options,

--- a/node/tests/RedisClientInternals.test.ts
+++ b/node/tests/RedisClientInternals.test.ts
@@ -14,7 +14,7 @@ import {
     RequestError,
     TimeoutError,
 } from "../build-ts";
-import { StandaloneClientConfiguration } from "../build-ts/src/RedisClient";
+import { RedisClientConfiguration } from "../build-ts/src/RedisClient";
 import {
     connection_request,
     redis_request,
@@ -75,7 +75,7 @@ function sendResponse(
 
 function getConnectionAndSocket(
     checkRequest?: (request: connection_request.ConnectionRequest) => boolean,
-    connectionOptions?: ClusterClientConfiguration | StandaloneClientConfiguration,
+    connectionOptions?: ClusterClientConfiguration | RedisClientConfiguration,
     isCluster?: boolean
 ): Promise<{
     socket: net.Socket;

--- a/python/python/pybushka/__init__.py
+++ b/python/python/pybushka/__init__.py
@@ -10,7 +10,7 @@ from pybushka.config import (
     BaseClientConfiguration,
     ClusterClientConfiguration,
     ReadFrom,
-    StandaloneClientConfiguration,
+    RedisClientConfiguration,
 )
 from pybushka.constants import OK
 from pybushka.logger import Level as LogLevel
@@ -29,7 +29,7 @@ __all__ = [
     "AddressInfo",
     "BaseClientConfiguration",
     "ClusterClientConfiguration",
-    "StandaloneClientConfiguration",
+    "RedisClientConfiguration",
     "ConditionalSet",
     "ExpireOptions",
     "ExpirySet",

--- a/python/python/pybushka/config.py
+++ b/python/python/pybushka/config.py
@@ -150,7 +150,7 @@ class BaseClientConfiguration:
         return request
 
 
-class StandaloneClientConfiguration(BaseClientConfiguration):
+class RedisClientConfiguration(BaseClientConfiguration):
     """
     Represents the configuration settings for a Standalone Redis client.
 

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -5,8 +5,8 @@ import pytest
 from pybushka.config import (
     AddressInfo,
     ClusterClientConfiguration,
+    RedisClientConfiguration,
     RedisCredentials,
-    StandaloneClientConfiguration,
 )
 from pybushka.logger import Level as logLevel
 from pybushka.logger import Logger
@@ -102,7 +102,7 @@ async def create_client(
         )
         return await RedisClusterClient.create(cluster_config)
     else:
-        config = StandaloneClientConfiguration(
+        config = RedisClientConfiguration(
             addresses=[AddressInfo(host=host, port=port)],
             use_tls=use_tls,
             credentials=credentials,


### PR DESCRIPTION
This is done in order to match the client names - `RedisClient` name doesn't contain `standalone`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
