### PR TITLE
Python: removed 'deadcode' linter due to prohibited license

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,7 +51,7 @@ jobs:
               working-directory: ./python
               run: |
                   python -m pip install --upgrade pip
-                  pip install flake8 isort black mypy-protobuf deadcode
+                  pip install flake8 isort black mypy-protobuf
 
             - name: Lint with isort
               working-directory: ./python
@@ -70,11 +70,6 @@ jobs:
               working-directory: ./python
               run: |
                   black --target-version py36 --check --diff .
-
-            - name: Lint with deadcode
-              working-directory: .
-              run: |
-                  deadcode . --ignore-definitions=InfoSection,Level,ExpireOptions,*protobuf*,*pytest*
 
             - name: Start redis server
               working-directory: ./python

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -3,4 +3,3 @@ flake8 == 5.0
 isort == 5.10
 mypy == 1.2
 mypy-protobuf == 3.5
-deadcode == 2.1


### PR DESCRIPTION
We use deadcode:2.1.0 library to detect unused variables and functions in the Python code. However, deadcode has (AGPL) license which is prohibited.
Therefore, we'll remove this library and find a different linter for detecting unused code.

#566 