### PR TITLE
Use napi version 2.14.

### DIFF
--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -15,8 +15,8 @@ redis = { path = "../../submodules/redis-rs/redis", features = ["aio", "tokio-co
 babushka = { path = "../../babushka-core" }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
-napi = {version = "2.10", features = ["napi4", "napi6"] }
-napi-derive = "2"
+napi = {version = "2.14", features = ["napi4", "napi6"] }
+napi-derive = "2.14"
 logger_core = {path = "../../logger_core"}
 tracing-subscriber = "0.3.16"
 byteorder = "1.4.3"


### PR DESCRIPTION
The changes introduced in https://github.com/aws/babushka/pull/582 implicitly rely on macro changes in napi 2.14, and will break builds on machines with older versions of the library, so we should make this dependency explicit.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
