### PR TITLE
Node: Added MacOS and AmazonLinux build tests to the CI

### DIFF
--- a/.github/workflows/build-node-wrapper/action.yml
+++ b/.github/workflows/build-node-wrapper/action.yml
@@ -1,0 +1,42 @@
+name: Build Node wrapper
+
+inputs:
+    os:
+        description: "The current operating system"
+        required: true
+        type: string
+        options:
+          - macOS
+          - ubuntu
+          - amazon-linux
+    release_mode:
+        description: "Enable building the wrapper in release mode"
+        required: false
+        type: boolean
+        default: 'false'
+
+env:
+    CARGO_TERM_COLOR: always
+
+runs:
+    using: "composite"
+    steps:
+        - name: Install software dependencies
+          uses: ./.github/workflows/install-shared-dependencies
+          with:
+              os: ${{ inputs.os }}
+
+        - name: npm install
+          shell: bash
+          working-directory: ./node/rust-client
+          run: |
+              rm -rf node_modules && npm install --frozen-lockfile
+              npm install
+
+        - name: Build
+          shell: bash
+          run: |
+              source "$HOME/.cargo/env"
+              rm -rf node_modules && npm install --frozen-lockfile
+              npm run build
+          working-directory: ./node

--- a/.github/workflows/build-python-wrapper/action.yml
+++ b/.github/workflows/build-python-wrapper/action.yml
@@ -21,24 +21,10 @@ env:
 runs:
     using: "composite"
     steps:        
-        - name: Install software dependencies for macOS
-          shell: bash
-          if: "${{ inputs.os == 'macOS' }}"
-          run: |
-              brew install git gcc pkgconfig protobuf openssl redis
-        
-        - name: Install software dependencies for Ubuntu
-          shell: bash
-          if: "${{ inputs.os == 'ubuntu' }}"
-          run: |
-              sudo apt update
-              sudo apt install protobuf-compiler
-
-        - name: Install software dependencies for Amazon-Linux
-          shell: bash
-          if: "${{ inputs.os == 'amazon-linux' }}"
-          run: |
-              yum install -y python3 gcc pkgconfig protobuf-compiler openssl openssl-devel which curl redis6 --allowerasing
+        - name: Install software dependencies
+          uses: ./.github/workflows/install-shared-dependencies
+          with:
+              os: ${{ inputs.os }}
 
         - name: Install Python software dependencies
           shell: bash
@@ -46,11 +32,6 @@ runs:
               python3 -m ensurepip --upgrade
               python3 -m pip install --upgrade pip
               python3 -m pip install virtualenv mypy-protobuf
-
-        - name: Install Rust
-          shell: bash
-          run: |
-              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
         - name: Generate protobuf files
           shell: bash

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -1,0 +1,38 @@
+name: Install shared software dependencies
+
+inputs:
+    os:
+        description: "The current operating system"
+        required: true
+        type: string
+        options:
+          - macOS
+          - ubuntu
+          - amazon-linux
+
+runs:
+    using: "composite"
+    steps:        
+        - name: Install software dependencies for macOS
+          shell: bash
+          if: "${{ inputs.os == 'macOS' }}"
+          run: |
+              brew install git gcc pkgconfig protobuf openssl redis
+        
+        - name: Install software dependencies for Ubuntu
+          shell: bash
+          if: "${{ inputs.os == 'ubuntu' }}"
+          run: |
+              sudo apt update
+              sudo apt install protobuf-compiler
+
+        - name: Install software dependencies for Amazon-Linux
+          shell: bash
+          if: "${{ inputs.os == 'amazon-linux' }}"
+          run: |
+              yum install -y gcc pkgconfig protobuf-compiler openssl openssl-devel which curl redis6 --allowerasing
+
+        - name: Install Rust
+          shell: bash
+          run: |
+              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,18 +8,24 @@ on:
             - submodules/**
             - node/**
             - utils/cluster_manager.py
+            - .github/workflows/node.yml
+            - .github/workflows/build-node-wrapper/action.yml
+            - .github/workflows/install-shared-dependencies/action.yml
     pull_request:
         paths:
             - babushka-core/src/**
             - submodules/**
             - node/**
             - utils/cluster_manager.py
+            - .github/workflows/node.yml
+            - .github/workflows/build-node-wrapper/action.yml
+            - .github/workflows/install-shared-dependencies/action.yml
 
 env:
     CARGO_TERM_COLOR: always
 
 jobs:
-    build:
+    test-ubuntu-latest:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         strategy:
@@ -49,17 +55,10 @@ jobs:
               with:
                   node-version: 16.x
 
-            - name: npm install and test
-              run: |
-                  rm -rf node_modules && npm install --frozen-lockfile
-                  npm install
-              working-directory: ./node/rust-client
-
-            - name: build
-              run: |
-                  rm -rf node_modules && npm install --frozen-lockfile
-                  npm run build
-              working-directory: ./node
+            - name: Build Node wrapper
+              uses: ./.github/workflows/build-node-wrapper
+              with:
+                  os: 'ubuntu'
 
             - name: test
               run: npm test
@@ -77,3 +76,69 @@ jobs:
               with:
                   cargo-toml-folder: ./node/rust-client
               name: lint node rust
+
+    build-macos-latest:
+        runs-on: macos-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+            - name: Set up Homebrew
+              uses: Homebrew/actions/setup-homebrew@master
+
+            - name: Install NodeJS
+              run: |
+                  brew install node
+
+            - name: Downgrade npm major version to 8
+              run: |
+                  npm i -g npm@8
+
+            - name: Build Node wrapper
+              uses: ./.github/workflows/build-node-wrapper
+              with:
+                  os: 'macOS'
+
+            - name: Test compatibility 
+              run: npm test -- -t "set and get flow works"
+              working-directory: ./node
+
+    build-amazonlinux-latest:
+        runs-on: ubuntu-latest
+        container: amazonlinux:latest
+        timeout-minutes: 15
+        steps:
+            - name: Install git
+              run: |
+                yum -y remove git
+                yum -y remove git-*
+                yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+                yum install -y git 
+                git --version
+
+            - uses: actions/checkout@v3
+
+            - name: Checkout submodules
+              run: |
+                git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                git submodule update --init --recursive
+
+            - name: Install NodeJS
+              run: |
+                yum install -y nodejs
+
+            - name: Build Node wrapper
+              uses: ./.github/workflows/build-node-wrapper
+              with:
+                  os: 'amazon-linux'
+
+            - name: Create a symbolic Link for redis6 binaries
+              working-directory: ./node
+              run: |
+                  ln -s /usr/bin/redis6-server /usr/bin/redis-server
+                  ln -s /usr/bin/redis6-cli /usr/bin/redis-cli
+          
+            - name: Test compatibility 
+              run: npm test -- -t "set and get flow works"
+              working-directory: ./node

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,8 @@ on:
             - submodules/**
             - utils/cluster_manager.py
             - .github/workflows/python.yml
+            - .github/workflows/build-python-wrapper/action.yml
+            - .github/workflows/install-shared-dependencies/action.yml
     pull_request:
         paths:
             - python/**
@@ -16,6 +18,8 @@ on:
             - submodules/**
             - utils/cluster_manager.py
             - .github/workflows/python.yml
+            - .github/workflows/build-python-wrapper/action.yml
+            - .github/workflows/install-shared-dependencies/action.yml
 
 permissions:
     contents: read
@@ -145,6 +149,10 @@ jobs:
             run: |
               git config --global --add safe.directory "$GITHUB_WORKSPACE"
               git submodule update --init --recursive
+
+          - name: Install python
+            run: |
+              yum install -y python3
 
           - name: Build Python wrapper
             uses: ./.github/workflows/build-python-wrapper


### PR DESCRIPTION
This PR adds CI build tests on MacOS and AmazonLinux to Node's CI.
The shared prerequisites dependencies across languages were moved to a separate action ("install-shared-dependencies").