### PR TITLE
Improve Java rust's tooling.

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -72,3 +72,16 @@ jobs:
             # - uses: ./.github/workflows/test-benchmark
             #   with:
             #       language-flag: -java
+            
+    lint-rust:
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                submodules: recursive
+
+            - uses: ./.github/workflows/lint-rust
+              with:
+                cargo-toml-folder: ./java
+              name: lint java rust                      

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
         "logger_core/Cargo.toml",
         "csharp/lib/Cargo.toml",
         "submodules/redis-rs/Cargo.toml",
-        "benchmarks/rust/Cargo.toml"
+        "benchmarks/rust/Cargo.toml",
+        "java/Cargo.toml"
     ],
     "rust-analyzer.runnableEnv": {
         "REDISRS_SERVER_TYPE": "tcp"

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1,12 +1,11 @@
 use babushka::start_socket_listener;
 
 use jni::objects::{JClass, JObject, JThrowable};
-use jni::JNIEnv;
 use jni::sys::jlong;
-use std::sync::mpsc;
+use jni::JNIEnv;
 use log::error;
-use logger_core::Level;
 use redis::Value;
+use std::sync::mpsc;
 
 fn redis_value_to_java(mut env: JNIEnv, val: Value) -> JObject {
     match val {
@@ -14,13 +13,15 @@ fn redis_value_to_java(mut env: JNIEnv, val: Value) -> JObject {
         Value::Status(str) => JObject::from(env.new_string(str).unwrap()),
         Value::Okay => JObject::from(env.new_string("OK").unwrap()),
         // TODO use primitive integer
-        Value::Int(num) => env.new_object("java/lang/Integer", "(I)V", &[num.into()]).unwrap(),
+        Value::Int(num) => env
+            .new_object("java/lang/Integer", "(I)V", &[num.into()])
+            .unwrap(),
         Value::Data(data) => match std::str::from_utf8(data.as_ref()) {
             Ok(val) => JObject::from(env.new_string(val).unwrap()),
             Err(_err) => {
                 let _ = env.throw("Error decoding Unicode data");
                 JObject::null()
-            },
+            }
         },
         Value::Bulk(_bulk) => {
             let _ = env.throw("Not implemented");
@@ -31,22 +32,24 @@ fn redis_value_to_java(mut env: JNIEnv, val: Value) -> JObject {
 
 #[no_mangle]
 pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_valueFromPointer<'local>(
-    mut env: JNIEnv<'local>,
+    env: JNIEnv<'local>,
     _class: JClass<'local>,
-    pointer: jlong
+    pointer: jlong,
 ) -> JObject<'local> {
     let value = unsafe { Box::from_raw(pointer as *mut Value) };
     redis_value_to_java(env, *value)
 }
 
 #[no_mangle]
-pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_startSocketListenerExternal<'local>(
-    mut env: JNIEnv<'local>,
-    _class: JClass<'local>
+pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_startSocketListenerExternal<
+    'local,
+>(
+    env: JNIEnv<'local>,
+    _class: JClass<'local>,
 ) -> JObject<'local> {
     let (tx, rx) = mpsc::channel::<Result<String, String>>();
 
-    start_socket_listener(move |socket_path : Result<String, String>| {
+    start_socket_listener(move |socket_path: Result<String, String>| {
         // Signals that thread has started
         let _ = tx.send(socket_path);
     });
@@ -55,13 +58,11 @@ pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_startSocketLi
     let socket_path = rx.recv();
 
     match socket_path {
-        Ok(Ok(path)) => {
-            env.new_string(path).unwrap().into()
-        },
+        Ok(Ok(path)) => env.new_string(path).unwrap().into(),
         Ok(Err(error_message)) => {
             throw_java_exception(env, error_message);
             JObject::null()
-        },
+        }
         Err(error) => {
             throw_java_exception(env, error.to_string());
             JObject::null()
@@ -73,16 +74,19 @@ fn throw_java_exception(mut env: JNIEnv, message: String) {
     let res = env.new_object(
         "java/lang/Exception",
         "(Ljava/lang/String;)V",
-        &[
-            (&env.new_string(message.clone()).unwrap()).into(),
-        ]);
+        &[(&env.new_string(message.clone()).unwrap()).into()],
+    );
 
     match res {
         Ok(res) => {
             let _ = env.throw(JThrowable::from(res));
-        },
+        }
         Err(err) => {
-            error!("Failed to create exception with string {}: {}", message, err.to_string());
+            error!(
+                "Failed to create exception with string {}: {}",
+                message,
+                err.to_string()
+            );
         }
     };
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lint Java's rust library on CI, and allow rust-analyzer to analyze it in VSCode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
