### PR TITLE
Improve Java rust's tooling.

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -72,3 +72,16 @@ jobs:
             # - uses: ./.github/workflows/test-benchmark
             #   with:
             #       language-flag: -java
+            
+    lint-rust:
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                submodules: recursive
+
+            - uses: ./.github/workflows/lint-rust
+              with:
+                cargo-toml-folder: ./java
+              name: lint java rust                      

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
         "logger_core/Cargo.toml",
         "csharp/lib/Cargo.toml",
         "submodules/redis-rs/Cargo.toml",
-        "benchmarks/rust/Cargo.toml"
+        "benchmarks/rust/Cargo.toml",
+        "java/Cargo.toml"
     ],
     "rust-analyzer.runnableEnv": {
         "REDISRS_SERVER_TYPE": "tcp"

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -27,12 +27,12 @@ fn redis_value_to_java(mut env: JNIEnv, val: Value) -> JObject {
             let _ = env.throw("Not implemented");
             JObject::null()
         }
-        Value::Map(map) => todo!(),
-        Value::Double(float) => todo!(),
-        Value::Boolean(bool) => todo!(),
-        Value::VerbatimString { format: _, text } => todo!(),
-        Value::BigNumber(num) => todo!(),
-        Value::Set(array) => todo!(),
+        Value::Map(_map) => todo!(),
+        Value::Double(_float) => todo!(),
+        Value::Boolean(_bool) => todo!(),
+        Value::VerbatimString { format: _, text: _ } => todo!(),
+        Value::BigNumber(_num) => todo!(),
+        Value::Set(_array) => todo!(),
         Value::Attribute {
             data: _,
             attributes: _,
@@ -43,7 +43,7 @@ fn redis_value_to_java(mut env: JNIEnv, val: Value) -> JObject {
 
 #[no_mangle]
 pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_valueFromPointer<'local>(
-    mut env: JNIEnv<'local>,
+    env: JNIEnv<'local>,
     _class: JClass<'local>,
     pointer: jlong,
 ) -> JObject<'local> {
@@ -55,7 +55,7 @@ pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_valueFromPoin
 pub extern "system" fn Java_babushka_BabushkaCoreNativeDefinitions_startSocketListenerExternal<
     'local,
 >(
-    mut env: JNIEnv<'local>,
+    env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> JObject<'local> {
     let (tx, rx) = mpsc::channel::<Result<String, String>>();


### PR DESCRIPTION
Lint Java's rust library on CI, and allow rust-analyzer to analyze it in VSCode.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
