### PR TITLE
Simplify benchmark names.

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -282,7 +282,7 @@ public static class MainClass
         int clientCount,
         bool useTLS)
     {
-        if (clientsToRun == "all" || clientsToRun == "ffi" || clientsToRun == "babushka")
+        if (clientsToRun == "all" || clientsToRun == "babushka")
         {
             var clients = await createClients(clientCount, () =>
             {
@@ -295,7 +295,7 @@ public static class MainClass
 
             await run_clients(
                 clients,
-                "babushka FFI",
+                "babushka",
                 total_commands,
                 data_size,
                 num_of_concurrent_tasks

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -214,12 +214,6 @@ do
             runAllBenchmarks=0
             runRust=1
             ;;
-        -only-socket)
-            chosenClients="socket"
-            ;;
-        -only-ffi)
-            chosenClients="ffi"
-            ;;
         -only-babushka)
             chosenClients="babushka"
             ;;

--- a/benchmarks/node/node_benchmark.ts
+++ b/benchmarks/node/node_benchmark.ts
@@ -192,7 +192,7 @@ async function main(
     total_commands: number,
     num_of_concurrent_tasks: number,
     data_size: number,
-    clients_to_run: "all" | "ffi" | "socket" | "babushka",
+    clients_to_run: "all" | "babushka",
     host: string,
     clientCount: number,
     useTLS: boolean,
@@ -200,11 +200,7 @@ async function main(
     port: number
 ) {
     const data = generate_value(data_size);
-    if (
-        clients_to_run == "socket" ||
-        clients_to_run == "all" ||
-        clients_to_run == "babushka"
-    ) {
+    if (clients_to_run == "all" || clients_to_run == "babushka") {
         const clientClass = clusterModeEnabled
             ? RedisClusterClient
             : RedisClient;
@@ -216,7 +212,7 @@ async function main(
         );
         await run_clients(
             clients,
-            "babushka socket",
+            "babushka",
             total_commands,
             num_of_concurrent_tasks,
             data_size,

--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -276,7 +276,6 @@ async def main(
 
     if (
         clients_to_run == "all"
-        or clients_to_run == "socket"
         or clients_to_run == "babushka"
     ):
         # Babushka Socket
@@ -290,7 +289,7 @@ async def main(
         )
         await run_clients(
             clients,
-            "babushka-socket",
+            "babushka",
             event_loop_name,
             total_commands,
             num_of_concurrent_tasks,


### PR DESCRIPTION
We no longer need the distinction between FFI and Socket clients.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
