### PR TITLE
Added GITHUB_TOKEN to the setup-protoc workflow to avoid rate limiting

### DIFF
--- a/.github/workflows/build-node-wrapper/action.yml
+++ b/.github/workflows/build-node-wrapper/action.yml
@@ -39,6 +39,10 @@ inputs:
         required: false
         type: string
         default: ""
+    github-token:
+        description: "GITHUB_TOKEN, GitHub App installation access token"
+        required: true
+        type: string
 
 env:
     CARGO_TERM_COLOR: always
@@ -51,6 +55,7 @@ runs:
           with:
               os: ${{ inputs.os }}
               target: ${{ inputs.target }}
+              github-token: ${{ inputs.github-token }}
 
         - name: Create package.json file
           shell: bash

--- a/.github/workflows/build-python-wrapper/action.yml
+++ b/.github/workflows/build-python-wrapper/action.yml
@@ -18,7 +18,10 @@ inputs:
         required: false
         type: boolean
         default: "false"
-
+    github-token:
+        description: "GITHUB_TOKEN, GitHub App installation access token"
+        required: true
+        type: string
 env:
     CARGO_TERM_COLOR: always
 
@@ -30,6 +33,7 @@ runs:
           with:
               os: ${{ inputs.os }}
               target: ${{ inputs.target }}
+              github-token: ${{ inputs.github-token }}
 
         - name: Install Python software dependencies
           shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,6 +71,7 @@ jobs:
                   target: ${{ matrix.build.TARGET }}
                   npm_scope: ${{ vars.NPM_SCOPE }}
                   publish: "true"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Publish to NPM
               shell: bash
@@ -138,6 +139,7 @@ jobs:
               with:
                   os: ubuntu-latest
                   target: "x86_64-unknown-linux-gnu"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Create a directory for the packed packages
               shell: bash

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -19,6 +19,10 @@ inputs:
             - aarch64-unknown-linux-gnu
             - x86_64-apple-darwin
             - aarch64-apple-darwin
+    github-token:
+        description: "GITHUB_TOKEN, GitHub App installation access token"
+        required: true
+        type: string
 
 runs:
     using: "composite"
@@ -50,4 +54,5 @@ runs:
         - name: Install protoc (protobuf)
           uses: arduino/setup-protoc@v2.1.0
           with:
-            version: "25.1"
+              version: "25.1"
+              repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -55,6 +55,7 @@ jobs:
               with:
                   os: "ubuntu-latest"
                   target: "x86_64-unknown-linux-gnu"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: test
               run: npm test
@@ -101,6 +102,7 @@ jobs:
                   os: "macos-latest"
                   named_os: "darwin"
                   target: "x86_64-apple-darwin"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Test compatibility
               run: npm test -- -t "set and get flow works"
@@ -135,6 +137,7 @@ jobs:
               with:
                   os: "amazon-linux"
                   target: "x86_64-unknown-linux-gnu"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Create a symbolic Link for redis6 binaries
               working-directory: ./node

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
                   redis-version: ${{ matrix.redis }}
 
             - name: Set up Python 3.10
-              uses: actions/setup-python@v3
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
 
@@ -79,6 +79,7 @@ jobs:
               with:
                   os: "ubuntu-latest"
                   target: "x86_64-unknown-linux-gnu"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Type check with mypy
               working-directory: ./python
@@ -129,6 +130,7 @@ jobs:
               with:
                   os: "macos-latest"
                   target: "x86_64-apple-darwin"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Test compatibility with pytest
               working-directory: ./python
@@ -165,6 +167,7 @@ jobs:
               with:
                   os: "amazon-linux"
                   target: "x86_64-unknown-linux-gnu"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Create a symbolic Link for redis6 binaries
               working-directory: ./python


### PR DESCRIPTION
See https://github.com/arduino/setup-protoc: Usage:
> "...The action queries the GitHub API to fetch releases data, to avoid rate limiting, pass the default token with the repo-token variable"

The github token can't be directly used in the install-shared-dependencies / build-node / build-python with ${{ secrets.GITHUB_TOKEN }}, it must be passed as a variable from the calling workflows.

