### PR TITLE
Fix benchmark script never filling the DB.

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -239,10 +239,10 @@ done
 
 for currentDataSize in $dataSize
 do
-    if [ -z "$minimal" ];
+    if [ -n "$minimalFlag" ];
     then
-        flushDB
         echo "Minimal run, not filling database"
+        flushDB
     else 
         fillDB $currentDataSize
     fi


### PR DESCRIPTION
The wrong variable name was checked for the minimal flag.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
