### PR TITLE
Log benchmark logs to unique files.

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -335,11 +335,11 @@ public static class MainClass
 
     public static async Task Main(string[] args)
     {
-        Logger.SetLoggerConfig(Level.Info, null);
         CommandLineOptions options = new CommandLineOptions();
         Parser.Default
             .ParseArguments<CommandLineOptions>(args).WithParsed<CommandLineOptions>(parsed => { options = parsed; });
 
+        Logger.SetLoggerConfig(Level.Info, Path.GetFileNameWithoutExtension(options.resultsFile));
         var product = options.concurrentTasks.SelectMany(concurrentTasks =>
             options.clientCount.Select(clientCount => (concurrentTasks: concurrentTasks, dataSize: options.dataSize, clientCount: clientCount))).Where(tuple => tuple.concurrentTasks >= tuple.clientCount);
         foreach (var (concurrentTasks, dataSize, clientCount) in product)

--- a/benchmarks/node/node_benchmark.ts
+++ b/benchmarks/node/node_benchmark.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "fs";
 import { Logger, RedisClient, RedisClusterClient } from "glide-for-redis";
+import { parse } from "path";
 import percentile from "percentile";
 import { RedisClientType, createClient, createCluster } from "redis";
 import { stdev } from "stats-lite";
@@ -19,8 +20,9 @@ enum ChosenAction {
     GET_EXISTING,
     SET,
 }
-// Demo - Setting the internal logger to log every log that has a level of info and above, and save the logs to the first.log file.
-Logger.setLoggerConfig("info", "first.log");
+// Setting the internal logger to log every log that has a level of info and above,
+// and save the logs to a file with the name of the results file.
+Logger.setLoggerConfig("info", parse(receivedOptions.resultsFile).name);
 
 let started_tasks_counter = 0;
 const running_tasks: Promise<void>[] = [];
@@ -127,7 +129,8 @@ async function run_clients(
 ) {
     const now = new Date();
     console.log(
-        `Starting ${client_name} data size: ${data_size} concurrency: ${num_of_concurrent_tasks} client count: ${clients.length
+        `Starting ${client_name} data size: ${data_size} concurrency: ${num_of_concurrent_tasks} client count: ${
+            clients.length
         } is_cluster: ${is_cluster} ${now.toLocaleTimeString()}`
     );
     const action_latencies = {
@@ -231,14 +234,14 @@ async function main(
             };
             const node_redis_client = clusterModeEnabled
                 ? createCluster({
-                    rootNodes: [{ socket: { host, port, tls: useTLS } }],
-                    defaults: {
-                        socket: {
-                            tls: useTLS,
-                        },
-                    },
-                    useReplicas: true,
-                })
+                      rootNodes: [{ socket: { host, port, tls: useTLS } }],
+                      defaults: {
+                          socket: {
+                              tls: useTLS,
+                          },
+                      },
+                      useReplicas: true,
+                  })
                 : createClient(node);
             await node_redis_client.connect();
             return node_redis_client;

--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -6,6 +6,7 @@ import random
 import time
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from statistics import mean
 from typing import List
 
@@ -251,10 +252,6 @@ async def main(
     use_tls,
     is_cluster,
 ):
-    # Demo - Setting the internal logger to log every log that has a level of info and above,
-    # and save the logs to the first log file.
-    Logger.set_logger_config(LogLevel.INFO, "first.log")
-
     if clients_to_run == "all":
         client_class = redispy.RedisCluster if is_cluster else redispy.Redis
         clients = await create_clients(
@@ -311,6 +308,10 @@ if __name__ == "__main__":
     use_tls = args.tls
     port = args.port
     is_cluster = args.clusterModeEnabled
+
+    # Setting the internal logger to log every log that has a level of info and above,
+    # and save the logs to a file with the name of the results file.
+    Logger.set_logger_config(LogLevel.INFO, Path(args.resultsFile).stem)
 
     product_of_arguments = [
         (data_size, int(num_of_concurrent_tasks), int(number_of_clients))

--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use std::{
     cmp::max,
     collections::HashMap,
+    path::Path,
     sync::{atomic::AtomicUsize, Arc},
     time::Duration,
 };
@@ -62,9 +63,13 @@ enum ChosenAction {
 }
 
 fn main() {
-    logger_core::init(Some(logger_core::Level::Warn), None);
-
     let args = Args::parse();
+    logger_core::init(
+        Some(logger_core::Level::Warn),
+        Path::new(&args.results_file)
+            .file_stem()
+            .and_then(|os_str| os_str.to_str()),
+    );
 
     // We can test using single or multi threading, by changing the runtime.
     let runtime = tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
Each benchmark will be logged to a file matching the name of the intended result file, which should be a unique name.

An alternative solution to the problem of finding the right logs for a benchmark is to avoid logging to files, and instead log only to console.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
