### PR TITLE
Increase python CI timeout limit.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
     test-ubuntu-latest:
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 25
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
due to failures -
https://github.com/aws/babushka/actions/runs/7323212831/job/19945582889?pr=726 https://github.com/aws/babushka/actions/runs/7323212831/job/19945582972?pr=726

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
