### PR TITLE
[Closing...] Java: API layer with RedisClient and basic commands

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1,0 +1,13 @@
+package glide.api;
+
+import glide.managers.CommandManager;
+import glide.managers.ConnectionManager;
+import lombok.AllArgsConstructor;
+
+/** Base Client class for connecting to Redis */
+@AllArgsConstructor
+public abstract class BaseClient implements AutoCloseable {
+
+  protected ConnectionManager connectionManager;
+  protected CommandManager commandManager;
+}

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -1,0 +1,214 @@
+package glide.api;
+
+import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
+
+import glide.api.commands.BaseCommands;
+import glide.api.commands.Command;
+import glide.api.commands.RedisExceptionCheckedFunction;
+import glide.api.commands.StringCommands;
+import glide.api.commands.Transaction;
+import glide.api.commands.VoidCommands;
+import glide.api.models.commands.SetOptions;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import glide.api.models.exceptions.RedisException;
+import glide.connectors.handlers.CallbackDispatcher;
+import glide.connectors.handlers.ChannelHandler;
+import glide.managers.CommandManager;
+import glide.managers.ConnectionManager;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import response.ResponseOuterClass.Response;
+
+/** Factory class for creating Glide/Redis-client connections */
+public class RedisClient extends BaseClient implements BaseCommands, StringCommands, VoidCommands {
+
+  public static CompletableFuture<RedisClient> CreateClient() {
+    RedisClientConfiguration config =
+        RedisClientConfiguration.builder()
+            .address(NodeAddress.builder().build())
+            .useTLS(false)
+            .build();
+
+    return CreateClient(config);
+  }
+
+  public static CompletableFuture<RedisClient> CreateClient(String host, Integer port) {
+    RedisClientConfiguration config =
+        RedisClientConfiguration.builder()
+            .address(NodeAddress.builder().host(host).port(port).build())
+            .useTLS(false)
+            .build();
+
+    return CreateClient(config);
+  }
+
+  /**
+   * Async (non-blocking) connection to Redis.
+   *
+   * @param config - Redis Client Configuration
+   * @return a promise to connect and return a RedisClient
+   */
+  public static CompletableFuture<RedisClient> CreateClient(RedisClientConfiguration config) {
+
+    // TODO: send request to connection manager
+    AtomicBoolean connectionStatus = new AtomicBoolean(false);
+
+    CallbackDispatcher callbackDispatcher = new CallbackDispatcher();
+    ChannelHandler channelHandler = new ChannelHandler(callbackDispatcher, getSocket());
+    var connectionManager = new ConnectionManager();
+    var commandManager = new CommandManager(new CompletableFuture<>());
+    // TODO: send request with configuration to connection Manager as part of a follow-up PR
+    return connectionManager
+        .connectToRedis(
+            config.getAddresses().get(0).getHost(),
+            config.getAddresses().get(0).getPort(),
+            config.isUseTLS(),
+            false)
+        .thenApplyAsync(
+            b -> {
+              if (b) {
+                return new RedisClient(connectionManager, commandManager);
+              }
+              throw new RedisException("Unable to connect to Redis");
+            });
+  }
+
+  protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
+    super(connectionManager, commandManager);
+  }
+
+  /**
+   * Closes this resource, relinquishing any underlying resources. This method is invoked
+   * automatically on objects managed by the try-with-resources statement. see: <a
+   * href="https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html#close--">AutoCloseable::close()</a>
+   */
+  @Override
+  public void close() throws ExecutionException {
+    try {
+      connectionManager
+          .closeConnection()
+          .thenComposeAsync(ignore -> commandManager.closeConnection())
+          .thenApplyAsync(ignore -> this)
+          .get();
+    } catch (InterruptedException interruptedException) {
+      // AutoCloseable functions are strongly advised to avoid throwing InterruptedExceptions
+      // TODO: marking resources as closed:
+      // https://github.com/orgs/Bit-Quill/projects/4/views/6?pane=issue&itemId=48063887
+      throw new RuntimeException(interruptedException);
+    }
+  }
+
+  /**
+   * Execute a single command against Redis. <br>
+   *
+   * @param command to be executed
+   * @param responseHandler handler responsible for assigning type to the response
+   * @return A CompletableFuture completed with the result from Redis
+   * @param <T> Response value type
+   */
+  protected <T> CompletableFuture exec(
+      Command command, RedisExceptionCheckedFunction<Response, T> responseHandler) {
+    return commandManager.submitNewCommand(command, responseHandler);
+  }
+
+  /**
+   * Execute a transaction by processing the queued commands. <br>
+   * See https://redis.io/topics/Transactions/ for details on Redis Transactions. <br>
+   *
+   * @param transaction with commands to be executed
+   * @return A CompletableFuture completed with the results from Redis
+   */
+  @Override
+  public CompletableFuture<List<Object>> exec(Transaction transaction) {
+    // TODO: call commandManager.submitNewTransaction()
+    return exec(transaction, BaseCommands::handleTransactionResponse);
+  }
+
+  /**
+   * Execute a transaction by processing the queued commands. <br>
+   * See https://redis.io/topics/Transactions/ for details on Redis Transactions. <br>
+   *
+   * @param transaction with commands to be executed
+   * @param responseHandler handler responsible for assigning type to the list of response objects
+   * @return A CompletableFuture completed with the results from Redis
+   */
+  protected CompletableFuture<List<Object>> exec(
+      Transaction transaction, Function<Response, List<Object>> responseHandler) {
+    // TODO: call commandManager.submitNewTransaction()
+    return new CompletableFuture<>();
+  }
+
+  /**
+   * Executes a single custom command, without checking inputs. Every part of the command, including
+   * subcommands, should be added as a separate value in args.
+   *
+   * @param args command and arguments for the custom command call
+   * @return CompletableFuture with the response
+   */
+  public CompletableFuture<Object> customCommand(String[] args) {
+    Command command =
+        Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
+    return exec(command, BaseCommands::handleObjectResponse);
+  }
+
+  /**
+   * Get the value associated with the given key, or null if no such value exists. See
+   * https://redis.io/commands/set/ for details.
+   *
+   * @param key - The key to retrieve from the database.
+   * @return If `key` exists, returns the value of `key` as a string. Otherwise, return null
+   */
+  public CompletableFuture<String> get(String key) {
+    Command command =
+        Command.builder()
+            .requestType(Command.RequestType.GET_STRING)
+            .arguments(new String[] {key})
+            .build();
+    return exec(command, StringCommands::handleStringResponse);
+  }
+
+  /**
+   * Set the given key with the given value. Return value is dependent on the passed options. See
+   * https://redis.io/commands/set/ for details.
+   *
+   * @param key - The key to store.
+   * @param value - The value to store with the given key.
+   * @return null
+   */
+  public CompletableFuture<Void> set(String key, String value) {
+    Command command =
+        Command.builder()
+            .requestType(Command.RequestType.SET_STRING)
+            .arguments(new String[] {key, value})
+            .build();
+    return exec(command, VoidCommands::handleVoidResponse);
+  }
+
+  /**
+   * Set the given key with the given value. Return value is dependent on the passed options. See
+   * https://redis.io/commands/set/ for details.
+   *
+   * @param key - The key to store.
+   * @param value - The value to store with the given key.
+   * @param options - The Set options
+   * @return string or null If value isn't set because of `onlyIfExists` or `onlyIfDoesNotExist`
+   *     conditions, return null. If `returnOldValue` is set, return the old value as a string.
+   */
+  public CompletableFuture<String> set(String key, String value, SetOptions options) {
+    LinkedList<String> args = new LinkedList<>();
+    args.add(key);
+    args.add(value);
+    args.addAll(SetOptions.createSetOptions(options));
+    Command command =
+        Command.builder()
+            .requestType(Command.RequestType.SET_STRING)
+            .arguments(args.toArray(new String[0]))
+            .build();
+    return exec(command, StringCommands::handleStringResponse);
+  }
+}

--- a/java/client/src/main/java/glide/api/RequestBuilder.java
+++ b/java/client/src/main/java/glide/api/RequestBuilder.java
@@ -1,0 +1,63 @@
+package glide.api;
+
+import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
+import connection_request.ConnectionRequestOuterClass.NodeAddress;
+import connection_request.ConnectionRequestOuterClass.ReadFrom;
+import connection_request.ConnectionRequestOuterClass.TlsMode;
+import glide.api.models.configuration.BaseClientConfiguration;
+import glide.managers.CallbackManager;
+import java.util.List;
+import redis_request.RedisRequestOuterClass.Command;
+import redis_request.RedisRequestOuterClass.Command.ArgsArray;
+import redis_request.RedisRequestOuterClass.RedisRequest;
+import redis_request.RedisRequestOuterClass.RequestType;
+import redis_request.RedisRequestOuterClass.Routes;
+import redis_request.RedisRequestOuterClass.SimpleRoutes;
+
+public class RequestBuilder {
+
+  /** Build a protobuf connection request.<br> */
+  public static ConnectionRequest createConnectionRequest(
+      String host, int port, boolean useSsl, boolean clusterMode) {
+    // TODO: temporary placeholder until
+    // https://github.com/orgs/Bit-Quill/projects/4?pane=issue&itemId=48028158
+    return ConnectionRequest.newBuilder()
+        .addAddresses(NodeAddress.newBuilder().setHost(host).setPort(port).build())
+        .setTlsMode(useSsl ? TlsMode.SecureTls : TlsMode.NoTls)
+        .setClusterModeEnabled(clusterMode)
+        .setReadFrom(ReadFrom.Primary)
+        .setDatabaseId(0)
+        .build();
+  }
+
+  /** Build a protobuf connection request.<br> */
+  public static ConnectionRequest createConnectionRequest(BaseClientConfiguration configuration) {
+    // TODO: temporary placeholder until
+    // https://github.com/orgs/Bit-Quill/projects/4?pane=issue&itemId=48028158
+    return ConnectionRequest.newBuilder().build();
+  }
+
+  /**
+   * Build a protobuf command/transaction request draft.
+   *
+   * @return An uncompleted request. {@link CallbackManager} is responsible to complete it by adding
+   *     a callback id.
+   */
+  public static RedisRequest.Builder prepareRequest(RequestType command, List<String> args) {
+    var commandArgs = ArgsArray.newBuilder();
+    for (var arg : args) {
+      commandArgs.addArgs(arg);
+    }
+
+    return RedisRequest.newBuilder()
+        .setSingleCommand( // set command
+            Command.newBuilder()
+                .setRequestType(command) // set command name
+                .setArgsArray(commandArgs.build()) // set arguments
+                .build())
+        .setRoute( // set route
+            Routes.newBuilder()
+                .setSimpleRoutes(SimpleRoutes.AllNodes) // set route type
+                .build());
+  }
+}

--- a/java/client/src/main/java/glide/api/commands/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommandResponseResolver.java
@@ -1,0 +1,57 @@
+package glide.api.commands;
+
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RedisException;
+import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
+import lombok.AllArgsConstructor;
+import response.ResponseOuterClass;
+
+/**
+ * Response resolver responsible for evaluating the Redis response object with a success or failure.
+ */
+@AllArgsConstructor
+public class BaseCommandResponseResolver
+    implements RedisExceptionCheckedFunction<ResponseOuterClass.Response, Object> {
+
+  private RedisExceptionCheckedFunction<Long, Object> respPointerResolver;
+
+  /**
+   * Extracts value from the RESP pointer. <br>
+   * Throws errors when the response is unsuccessful.
+   *
+   * @return A generic Object with the Response | null if the response is empty
+   */
+  public Object apply(ResponseOuterClass.Response response) throws RedisException {
+    // TODO: handle object if the object is small
+    // TODO: handle RESP2 object if configuration is set
+    if (response.hasRequestError()) {
+      ResponseOuterClass.RequestError error = response.getRequestError();
+      String msg = error.getMessage();
+      switch (error.getType()) {
+        case Unspecified:
+          throw new RedisException(msg);
+        case ExecAbort:
+          throw new ExecAbortException(msg);
+        case Timeout:
+          throw new TimeoutException(msg);
+        case Disconnect:
+          throw new ConnectionException(msg);
+      }
+      throw new RequestException(response.getRequestError().getMessage());
+    }
+    if (response.hasClosingError()) {
+      throw new ClosingException(response.getClosingError());
+    }
+    if (response.hasRespPointer()) {
+      return respPointerResolver.apply(response.getRespPointer());
+    }
+    if (response.hasConstantResponse()) {
+      // TODO: confirm
+      return "Ok";
+    }
+    return null;
+  }
+}

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -1,0 +1,58 @@
+package glide.api.commands;
+
+import glide.ffi.resolvers.RedisValueResolver;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import response.ResponseOuterClass.Response;
+
+/** Base Commands interface to handle generic command and transaction requests. */
+public interface BaseCommands {
+
+  /**
+   * default Object handler from response
+   *
+   * @return BaseCommandResponseResolver to deliver the response
+   */
+  static BaseCommandResponseResolver applyBaseCommandResponseResolver() {
+    return new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer);
+  }
+
+  /**
+   * Extracts the response from the Protobuf response and either throws an exception or returns the
+   * appropriate response has an Object
+   *
+   * @param response Redis protobuf message
+   * @return Response Object
+   */
+  static Object handleObjectResponse(Response response) {
+    // return function to convert protobuf.Response into the response object by
+    // calling valueFromPointer
+    return BaseCommands.applyBaseCommandResponseResolver().apply(response);
+  }
+
+  public static List<Object> handleTransactionResponse(Response response) {
+    // return function to convert protobuf.Response into the response object by
+    // calling valueFromPointer
+
+    List<Object> transactionResponse =
+        (List<Object>) BaseCommands.applyBaseCommandResponseResolver().apply(response);
+    return transactionResponse;
+  }
+
+  /**
+   * Execute a @see{Command} by sending command via socket manager
+   *
+   * @param args arguments for the custom command
+   * @return a CompletableFuture with response result from Redis
+   */
+  CompletableFuture<Object> customCommand(String[] args);
+
+  /**
+   * Execute a transaction by processing the queued commands. <br>
+   * See https://redis.io/topics/Transactions/ for details on Redis Transactions. <br>
+   *
+   * @param transaction with commands to be executed
+   * @return A CompletableFuture completed with the results from Redis
+   */
+  CompletableFuture<List<Object>> exec(Transaction transaction);
+}

--- a/java/client/src/main/java/glide/api/commands/Command.java
+++ b/java/client/src/main/java/glide/api/commands/Command.java
@@ -1,0 +1,33 @@
+package glide.api.commands;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+
+/** Base Command class to send a single request to Redis. */
+@Builder
+@EqualsAndHashCode
+public class Command {
+
+  /** Redis command request type */
+  final RequestType requestType;
+
+  /** List of Arguments for the Redis command request */
+  final String[] arguments;
+
+  public enum RequestType {
+    /** */
+    CUSTOM_COMMAND,
+    /**
+     * Get the value of key.
+     *
+     * @see: <href=https://redis.io/commands/get/>command reference</a>
+     */
+    GET_STRING,
+    /**
+     * Set key to hold the string value.
+     *
+     * @see: <href=https://redis.io/commands/set/>command reference</a>
+     */
+    SET_STRING,
+  }
+}

--- a/java/client/src/main/java/glide/api/commands/RedisExceptionCheckedFunction.java
+++ b/java/client/src/main/java/glide/api/commands/RedisExceptionCheckedFunction.java
@@ -1,0 +1,16 @@
+package glide.api.commands;
+
+import glide.api.models.exceptions.RedisException;
+
+@FunctionalInterface
+public interface RedisExceptionCheckedFunction<R, T> {
+
+  /**
+   * Functional response handler that throws RedisException on a fail
+   *
+   * @param response - Redis Response
+   * @return T - response payload type
+   * @throws RedisException
+   */
+  T apply(R response) throws RedisException;
+}

--- a/java/client/src/main/java/glide/api/commands/StringCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringCommands.java
@@ -1,0 +1,29 @@
+package glide.api.commands;
+
+import glide.api.models.exceptions.RedisException;
+import java.util.concurrent.CompletableFuture;
+import response.ResponseOuterClass.Response;
+
+/** String Commands interface to handle single commands that return Strings. */
+public interface StringCommands {
+
+  /**
+   * Extracts the response from the Protobuf response and either throws an exception or returns the
+   * appropriate response has a String
+   *
+   * @param response Redis protobuf message
+   * @return Response as a String
+   */
+  static String handleStringResponse(Response response) {
+    // return function to convert protobuf.Response into the response object by
+    // calling valueFromPointer
+    Object value = BaseCommands.applyBaseCommandResponseResolver().apply(response);
+    if (value instanceof String) {
+      return (String) value;
+    }
+    throw new RedisException(
+        "Unexpected return type from Redis: got " + value.getClass() + " expected String");
+  }
+
+  CompletableFuture<?> get(String key);
+}

--- a/java/client/src/main/java/glide/api/commands/Transaction.java
+++ b/java/client/src/main/java/glide/api/commands/Transaction.java
@@ -1,0 +1,4 @@
+package glide.api.commands;
+
+/** Class for encapsulating multi-request Transactions to Redis. */
+public class Transaction {}

--- a/java/client/src/main/java/glide/api/commands/VoidCommands.java
+++ b/java/client/src/main/java/glide/api/commands/VoidCommands.java
@@ -1,0 +1,55 @@
+package glide.api.commands;
+
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RedisException;
+import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
+import java.util.concurrent.CompletableFuture;
+import response.ResponseOuterClass.RequestError;
+import response.ResponseOuterClass.Response;
+
+/** String Commands interface to handle single commands that have no payload. */
+public interface VoidCommands {
+
+  /**
+   * Check for errors in the Response and return null Throws an error if an unexpected value is
+   * returned
+   *
+   * @return null if the response is empty
+   */
+  static Void handleVoidResponse(Object respObject) {
+    Response response = (Response) respObject;
+    if (response.hasRequestError()) {
+      RequestError error = response.getRequestError();
+      String msg = error.getMessage();
+      switch (error.getType()) {
+        case Unspecified:
+          throw new RedisException("Unexpected result: " + msg);
+        case ExecAbort:
+          throw new ExecAbortException("ExecAbortException: " + msg);
+        case Timeout:
+          throw new TimeoutException("TimeoutException: " + msg);
+        case Disconnect:
+          throw new ConnectionException("Disconnection: " + msg);
+      }
+      throw new RequestException(response.getRequestError().getMessage());
+    }
+    if (response.hasClosingError()) {
+      throw new ClosingException(response.getClosingError());
+    }
+    if (response.hasRespPointer()) {
+      throw new RuntimeException(
+          "Unexpected object returned in response - expected constantResponse or null");
+    }
+    if (response.hasConstantResponse()) {
+      return null; // Void
+    }
+    // TODO commented out due to #710: empty response means a successful connection
+    // https://github.com/aws/babushka/issues/710
+    return null;
+  }
+
+  CompletableFuture<?> set(String key, String value);
+}

--- a/java/client/src/main/java/glide/api/models/commands/SetOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/SetOptions.java
@@ -1,0 +1,130 @@
+package glide.api.models.commands;
+
+import glide.api.models.exceptions.RequestException;
+import java.util.LinkedList;
+import java.util.List;
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+@NonNull
+public class SetOptions {
+
+  /**
+   * if `conditional` is not set the value will be set regardless of prior value existence. <br>
+   * If value isn't set because of the condition, return null.
+   */
+  private ConditionalSet conditionalSet;
+
+  /**
+   * Return the old string stored at key, or null if key did not exist. An error is returned and SET
+   * aborted if the value stored at key is not a string. Equivalent to `GET` in the Redis API.
+   */
+  private boolean returnOldValue;
+
+  /** If not set, no expiry time will be set for the value. */
+  private TimeToLive expiry;
+
+  public enum ConditionalSet {
+    /**
+     * Only set the key if it does not already exist. <br>
+     * Equivalent to `NX` in the Redis API.
+     */
+    ONLY_IF_EXISTS,
+    /**
+     * Only set the key if it already exists. <br>
+     * Equivalent to `EX` in the Redis API.
+     */
+    ONLY_IF_DOES_NOT_EXIST
+  }
+
+  @Builder
+  public static class TimeToLive {
+    /** Expiry type for the time to live */
+    @NonNull private TimeToLiveType type;
+
+    /**
+     * The amount of time to live before the key expires. Ignored when KEEP_EXISTING type is set.
+     */
+    private Integer count;
+  }
+
+  public enum TimeToLiveType {
+    /**
+     * Retain the time to live associated with the key. <br>
+     * Equivalent to `KEEPTTL` in the Redis API.
+     */
+    KEEP_EXISTING,
+    /**
+     * Set the specified expire time, in seconds. <br>
+     * Equivalent to `EX` in the Redis API.
+     */
+    SECONDS,
+    /**
+     * Set the specified expire time, in milliseconds. <br>
+     * Equivalent to `PX` in the Redis API.
+     */
+    MILLISECONDS,
+    /**
+     * Set the specified Unix time at which the key will expire, in seconds. <br>
+     * Equivalent to `EXAT` in the Redis API.
+     */
+    UNIX_SECONDS,
+    /**
+     * Set the specified Unix time at which the key will expire, in milliseconds. <br>
+     * Equivalent to `PXAT` in the Redis API.
+     */
+    UNIX_MILLISECONDS
+  }
+
+  public static String CONDITIONAL_SET_ONLY_IF_EXISTS = "XX";
+  public static String CONDITIONAL_SET_ONLY_IF_DOES_NOT_EXIST = "NX";
+  public static String RETURN_OLD_VALUE = "GET";
+  public static String TIME_TO_LIVE_KEEP_EXISTING = "KEEPTTL";
+  public static String TIME_TO_LIVE_SECONDS = "EX";
+  public static String TIME_TO_LIVE_MILLISECONDS = "PX";
+  public static String TIME_TO_LIVE_UNIX_SECONDS = "EXAT";
+  public static String TIME_TO_LIVE_UNIX_MILLISECONDS = "PXAT";
+
+  public static List createSetOptions(SetOptions options) {
+    List optionArgs = new LinkedList();
+    if (options.conditionalSet != null) {
+      if (options.conditionalSet == ConditionalSet.ONLY_IF_EXISTS) {
+        optionArgs.add(CONDITIONAL_SET_ONLY_IF_EXISTS);
+      } else if (options.conditionalSet == ConditionalSet.ONLY_IF_DOES_NOT_EXIST) {
+        optionArgs.add(CONDITIONAL_SET_ONLY_IF_DOES_NOT_EXIST);
+      }
+    }
+
+    if (options.returnOldValue) {
+      optionArgs.add(RETURN_OLD_VALUE);
+    }
+
+    if (options.expiry != null) {
+      if (options.expiry.type == TimeToLiveType.KEEP_EXISTING) {
+        optionArgs.add(TIME_TO_LIVE_KEEP_EXISTING);
+      } else {
+        if (options.expiry.count == null) {
+          throw new RequestException(
+              "Set command received expiry type " + options.expiry.type + "but count was not set.");
+        }
+        switch (options.expiry.type) {
+          case SECONDS:
+            optionArgs.add(TIME_TO_LIVE_SECONDS + " " + options.expiry.count);
+            break;
+          case MILLISECONDS:
+            optionArgs.add(TIME_TO_LIVE_MILLISECONDS + " " + options.expiry.count);
+            break;
+          case UNIX_SECONDS:
+            optionArgs.add(TIME_TO_LIVE_UNIX_SECONDS + " " + options.expiry.count);
+            break;
+          case UNIX_MILLISECONDS:
+            optionArgs.add(TIME_TO_LIVE_UNIX_MILLISECONDS + " " + options.expiry.count);
+            break;
+        }
+      }
+    }
+
+    return optionArgs;
+  }
+}

--- a/java/client/src/main/java/glide/api/models/configuration/BackoffStrategy.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BackoffStrategy.java
@@ -1,0 +1,29 @@
+package glide.api.models.configuration;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Represents the strategy used to determine how and when to reconnect, in case of connection
+ * failures. The time between attempts grows exponentially, to the formula rand(0 ... factor *
+ * (exponentBase ^ N)), where N is the number of failed attempts. Once the maximum value is reached,
+ * that will remain the time between retry attempts until a reconnect attempt is successful. The
+ * client will attempt to reconnect indefinitely.
+ */
+@Getter
+@Builder
+public class BackoffStrategy {
+  /**
+   * Number of retry attempts that the client should perform when disconnected from the server,
+   * where the time between retries increases. Once the retries have reached the maximum value, the
+   * time between
+   */
+  @NonNull private final Integer numOfRetries;
+
+  /** The multiplier that will be applied to the waiting time between each retry. */
+  @NonNull private final Integer factor;
+
+  /** The exponent base configured for the strategy. */
+  @NonNull private final Integer exponentBase;
+}

--- a/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
@@ -1,0 +1,42 @@
+package glide.api.models.configuration;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.experimental.SuperBuilder;
+
+/** Represents the configuration settings for a Redis client. */
+@Getter
+@SuperBuilder
+public abstract class BaseClientConfiguration {
+  /**
+   * DNS Addresses and ports of known nodes in the cluster. If the server is in cluster mode the
+   * list can be partial, as the client will attempt to map out the cluster and find all nodes. If
+   * the server is in standalone mode, only nodes whose addresses were provided will be used by the
+   * client. For example: [ {address:sample-address-0001.use1.cache.amazonaws.com, port:6379},
+   * {address: sample-address-0002.use2.cache.amazonaws.com, port:6379} ]. If none are set, a
+   * default address localhost:6379 will be used.
+   */
+  @Singular private final List<NodeAddress> addresses;
+
+  /** True if communication with the cluster should use Transport Level Security. */
+  @Builder.Default private final boolean useTLS = false;
+
+  /** If not set, `PRIMARY` will be used. */
+  @Builder.Default private final ReadFrom readFrom = ReadFrom.PRIMARY;
+
+  /**
+   * Credentials for authentication process. If none are set, the client will not authenticate
+   * itself with the server.
+   */
+  private final RedisCredentials credentials;
+
+  /**
+   * The duration in milliseconds that the client should wait for a request to complete. This
+   * duration encompasses sending the request, awaiting for a response from the server, and any
+   * required reconnections or retries. If the specified timeout is exceeded for a pending request,
+   * it will result in a timeout error. If not set, a default value will be used.
+   */
+  private final Integer requestTimeout;
+}

--- a/java/client/src/main/java/glide/api/models/configuration/NodeAddress.java
+++ b/java/client/src/main/java/glide/api/models/configuration/NodeAddress.java
@@ -1,0 +1,16 @@
+package glide.api.models.configuration;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/** Represents the address and port of a node in the cluster. */
+@Getter
+@Builder
+public class NodeAddress {
+  public static String DEFAULT_HOST = "localhost";
+  public static Integer PORT = 6379;
+
+  @NonNull @Builder.Default private final String host = DEFAULT_HOST;
+  @NonNull @Builder.Default private final Integer port = 6379;
+}

--- a/java/client/src/main/java/glide/api/models/configuration/ReadFrom.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ReadFrom.java
@@ -1,0 +1,12 @@
+package glide.api.models.configuration;
+
+/** Represents the client's read from strategy. */
+public enum ReadFrom {
+  /** Always get from primary, in order to get the freshest data. */
+  PRIMARY,
+  /**
+   * Spread the requests between all replicas in a round-robin manner. If no replica is available,
+   * route the requests to the primary.
+   */
+  PREFER_REPLICA
+}

--- a/java/client/src/main/java/glide/api/models/configuration/RedisClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/RedisClientConfiguration.java
@@ -1,0 +1,15 @@
+package glide.api.models.configuration;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+/** Represents the configuration settings for a Standalone Redis client. */
+@Getter
+@SuperBuilder
+public class RedisClientConfiguration extends BaseClientConfiguration {
+  /** Strategy used to determine how and when to reconnect, in case of connection failures. */
+  private final BackoffStrategy reconnectStrategy;
+
+  /** Index of the logical database to connect to. */
+  private final Integer databaseId;
+}

--- a/java/client/src/main/java/glide/api/models/configuration/RedisClusterClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/RedisClusterClientConfiguration.java
@@ -1,0 +1,11 @@
+package glide.api.models.configuration;
+
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Represents the configuration settings for a Cluster Redis client. Notes: Currently, the
+ * reconnection strategy in cluster mode is not configurable, and exponential backoff with fixed
+ * values is used.
+ */
+@SuperBuilder
+public class RedisClusterClientConfiguration extends BaseClientConfiguration {}

--- a/java/client/src/main/java/glide/api/models/configuration/RedisCredentials.java
+++ b/java/client/src/main/java/glide/api/models/configuration/RedisCredentials.java
@@ -1,0 +1,19 @@
+package glide.api.models.configuration;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/** Represents the credentials for connecting to a Redis server. */
+@Getter
+@Builder
+public class RedisCredentials {
+  /** The password that will be used for authenticating connections to the Redis servers. */
+  @NonNull private final String password;
+
+  /**
+   * The username that will be used for authenticating connections to the Redis servers. If not
+   * supplied, "default" will be used.
+   */
+  private final String username;
+}

--- a/java/client/src/main/java/glide/api/models/exceptions/ClosingException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/ClosingException.java
@@ -1,0 +1,19 @@
+package glide.api.models.exceptions;
+
+public class ClosingException extends RedisException {
+  public ClosingException() {
+    super();
+  }
+
+  public ClosingException(String message) {
+    super(message);
+  }
+
+  public ClosingException(Throwable cause) {
+    super(cause);
+  }
+
+  public ClosingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/client/src/main/java/glide/api/models/exceptions/ConnectionException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/ConnectionException.java
@@ -1,0 +1,19 @@
+package glide.api.models.exceptions;
+
+public class ConnectionException extends RedisException {
+  public ConnectionException() {
+    super();
+  }
+
+  public ConnectionException(String message) {
+    super(message);
+  }
+
+  public ConnectionException(Throwable cause) {
+    super(cause);
+  }
+
+  public ConnectionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/client/src/main/java/glide/api/models/exceptions/ExecAbortException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/ExecAbortException.java
@@ -1,0 +1,19 @@
+package glide.api.models.exceptions;
+
+public class ExecAbortException extends RedisException {
+  public ExecAbortException() {
+    super();
+  }
+
+  public ExecAbortException(String message) {
+    super(message);
+  }
+
+  public ExecAbortException(Throwable cause) {
+    super(cause);
+  }
+
+  public ExecAbortException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/client/src/main/java/glide/api/models/exceptions/RedisException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/RedisException.java
@@ -1,0 +1,20 @@
+package glide.api.models.exceptions;
+
+public class RedisException extends RuntimeException {
+
+  public RedisException() {
+    super();
+  }
+
+  public RedisException(String message) {
+    super(message);
+  }
+
+  public RedisException(Throwable cause) {
+    super(cause);
+  }
+
+  public RedisException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/client/src/main/java/glide/api/models/exceptions/RequestException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/RequestException.java
@@ -1,0 +1,19 @@
+package glide.api.models.exceptions;
+
+public class RequestException extends RedisException {
+  public RequestException() {
+    super();
+  }
+
+  public RequestException(String message) {
+    super(message);
+  }
+
+  public RequestException(Throwable cause) {
+    super(cause);
+  }
+
+  public RequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/client/src/main/java/glide/api/models/exceptions/TimeoutException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/TimeoutException.java
@@ -1,0 +1,19 @@
+package glide.api.models.exceptions;
+
+public class TimeoutException extends RedisException {
+  public TimeoutException() {
+    super();
+  }
+
+  public TimeoutException(String message) {
+    super(message);
+  }
+
+  public TimeoutException(Throwable cause) {
+    super(cause);
+  }
+
+  public TimeoutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
@@ -1,0 +1,13 @@
+package glide.ffi.resolvers;
+
+import response.ResponseOuterClass.Response;
+
+public class RedisValueResolver {
+  /**
+   * Resolve a value received from Redis using given C-style pointer.
+   *
+   * @param pointer A memory pointer from {@link Response}
+   * @return A RESP3 value
+   */
+  public static native Object valueFromPointer(long pointer);
+}

--- a/java/client/src/main/java/glide/ffi/resolvers/SocketListenerResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/SocketListenerResolver.java
@@ -1,12 +1,12 @@
 package glide.ffi.resolvers;
 
-public class GlideCoreNativeDefinitions {
-  public static native String startSocketListenerExternal() throws Exception;
+public class SocketListenerResolver {
 
-  public static native Object valueFromPointer(long pointer);
+  /** Make an FFI call to Glide to open a UDS socket to connect to. */
+  private static native String startSocketListener() throws Exception;
 
   static {
-    System.loadLibrary("glide-rs");
+    System.loadLibrary("glide_rs");
   }
 
   /**
@@ -16,7 +16,7 @@ public class GlideCoreNativeDefinitions {
    */
   public static String getSocket() {
     try {
-      return startSocketListenerExternal();
+      return startSocketListener();
     } catch (Exception | UnsatisfiedLinkError e) {
       System.err.printf("Failed to create a UDS connection: %s%n%n", e);
       throw new RuntimeException(e);

--- a/java/client/src/main/java/glide/managers/CallbackManager.java
+++ b/java/client/src/main/java/glide/managers/CallbackManager.java
@@ -1,0 +1,63 @@
+package glide.managers;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import org.apache.commons.lang3.tuple.Pair;
+import response.ResponseOuterClass.Response;
+
+/** Holder for resources required to dispatch responses and used by ReadHandler. */
+public class CallbackManager {
+  /** Unique request ID (callback ID). Thread-safe. */
+  private final AtomicInteger requestId = new AtomicInteger(0);
+
+  /**
+   * Storage of Futures to handle responses. Map key is callback id, which starts from 1.<br>
+   * Each future is a promise for every submitted by user request.
+   */
+  private final Map<Integer, CompletableFuture<Response>> responses = new ConcurrentHashMap<>();
+
+  /**
+   * Storage for connection request similar to {@link #responses}. Unfortunately, connection
+   * requests can't be stored in the same storage, because callback ID = 0 is hardcoded for
+   * connection requests.
+   */
+  @Getter private final CompletableFuture<Response> connectionPromise = new CompletableFuture<>();
+
+  /**
+   * Register a new request to be sent. Once response received, the given future completes with it.
+   *
+   * @return A pair of unique callback ID which should set into request and a client promise for
+   *     response.
+   */
+  public Pair<Integer, CompletableFuture<Response>> registerRequest() {
+    int callbackId = requestId.incrementAndGet();
+    var future = new CompletableFuture<Response>();
+    responses.put(callbackId, future);
+    return Pair.of(callbackId, future);
+  }
+
+  /**
+   * Complete the corresponding client promise and free resources.
+   *
+   * @param response A response received
+   */
+  public void completeRequest(Response response) {
+    int callbackId = response.getCallbackIdx();
+    if (callbackId == 0) {
+      connectionPromise.completeAsync(() -> response);
+    } else {
+      responses.get(callbackId).completeAsync(() -> response);
+      responses.remove(callbackId);
+    }
+  }
+
+  public void shutdownGracefully() {
+    connectionPromise.completeExceptionally(new InterruptedException());
+    responses.forEach(
+        (callbackId, future) -> future.completeExceptionally(new InterruptedException()));
+    responses.clear();
+  }
+}

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -1,0 +1,30 @@
+package glide.managers;
+
+import glide.api.commands.Command;
+import glide.api.commands.RedisExceptionCheckedFunction;
+import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import response.ResponseOuterClass.Response;
+
+@AllArgsConstructor
+public class CommandManager {
+
+  CompletableFuture<Response> channel;
+
+  /**
+   * @param command
+   * @param responseHandler
+   * @return
+   */
+  public <T> CompletableFuture<T> submitNewCommand(
+      Command command, RedisExceptionCheckedFunction<Response, T> responseHandler) {
+    // register callback
+    // create protobuf message from command
+    // submit async call
+    return channel.thenApplyAsync(response -> responseHandler.apply(response));
+  }
+
+  public CompletableFuture<Void> closeConnection() {
+    return new CompletableFuture<>();
+  }
+}

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -1,0 +1,15 @@
+package glide.managers;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ConnectionManager {
+
+  public CompletableFuture<Boolean> connectToRedis(
+      String host, int port, boolean useSsl, boolean clusterMode) {
+    return new CompletableFuture<>();
+  }
+
+  public CompletableFuture<Void> closeConnection() {
+    return new CompletableFuture<>();
+  }
+}

--- a/java/client/src/test/java/glide/api/Awaiter.java
+++ b/java/client/src/test/java/glide/api/Awaiter.java
@@ -1,0 +1,28 @@
+package glide.api;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class Awaiter {
+  private static final long DEFAULT_TIMEOUT_MILLISECONDS = 1000;
+
+  /** Get the future result with default timeout. */
+  public static <T> T await(CompletableFuture<T> future) {
+    return await(future, DEFAULT_TIMEOUT_MILLISECONDS);
+  }
+
+  /** Get the future result with given timeout in ms. */
+  public static <T> T await(CompletableFuture<T> future, long timeout) {
+    try {
+      return future.get(timeout, TimeUnit.MILLISECONDS);
+    } catch (ExecutionException | InterruptedException | TimeoutException e) {
+      // TODO: handle exceptions:
+      // InterruptedException: should shutdown the client service
+      // TimeoutException: should be propagated with an error message thrown
+      // ExecutionException: throw runtime exception
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -1,0 +1,216 @@
+package glide.api;
+
+import static glide.api.models.commands.SetOptions.CONDITIONAL_SET_ONLY_IF_DOES_NOT_EXIST;
+import static glide.api.models.commands.SetOptions.CONDITIONAL_SET_ONLY_IF_EXISTS;
+import static glide.api.models.commands.SetOptions.RETURN_OLD_VALUE;
+import static glide.api.models.commands.SetOptions.TIME_TO_LIVE_KEEP_EXISTING;
+import static glide.api.models.commands.SetOptions.TIME_TO_LIVE_UNIX_SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import glide.api.commands.Command;
+import glide.api.models.commands.SetOptions;
+import glide.managers.CommandManager;
+import glide.managers.ConnectionManager;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RedisClientTest {
+
+  RedisClient service;
+
+  ConnectionManager connectionManager;
+
+  CommandManager commandManager;
+
+  @BeforeEach
+  public void setUp() {
+    connectionManager = mock(ConnectionManager.class);
+    commandManager = mock(CommandManager.class);
+    service = new RedisClient(connectionManager, commandManager);
+  }
+
+  @Test
+  public void customCommand_success() throws ExecutionException, InterruptedException {
+    // setup
+    String key = "testKey";
+    Object value = "testValue";
+    String cmd = "GETSTRING";
+    CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenReturn(value);
+    when(commandManager.submitNewCommand(any(), any())).thenReturn(testResponse);
+
+    // exercise
+    CompletableFuture<Object> response = service.customCommand(new String[] {cmd, key});
+    String payload = (String) response.get();
+
+    // verify
+    assertEquals(testResponse, response);
+    assertEquals(value, payload);
+
+    // teardown
+  }
+
+  @Test
+  public void customCommand_interruptedException() throws ExecutionException, InterruptedException {
+    // setup
+    String key = "testKey";
+    Object value = "testValue";
+    String cmd = "GETSTRING";
+    CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenThrow(new InterruptedException());
+    when(commandManager.submitNewCommand(any(), any())).thenReturn(testResponse);
+
+    // exercise
+    InterruptedException exception =
+        assertThrows(
+            InterruptedException.class,
+            () -> {
+              CompletableFuture<String> response = service.get(key);
+              response.get();
+            });
+
+    // verify
+
+    // teardown
+  }
+
+  @Test
+  public void get_success() throws ExecutionException, InterruptedException {
+    // setup
+    // TODO: randomize keys
+    String key = "testKey";
+    String value = "testValue";
+    Command cmd =
+        Command.builder()
+            .requestType(Command.RequestType.GET_STRING)
+            .arguments(new String[] {key})
+            .build();
+    CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenReturn(value);
+    when(commandManager.<String>submitNewCommand(any(), any())).thenReturn(testResponse);
+
+    // exercise
+    CompletableFuture<String> response = service.get(key);
+    String payload = response.get();
+
+    // verify
+    assertEquals(testResponse, response);
+    assertEquals(value, payload);
+
+    // teardown
+  }
+
+  @Test
+  public void set_success() throws ExecutionException, InterruptedException {
+    // setup
+    // TODO: randomize keys
+    String key = "testKey";
+    String value = "testValue";
+    Command cmd =
+        Command.builder()
+            .requestType(Command.RequestType.SET_STRING)
+            .arguments(new String[] {key, value})
+            .build();
+    CompletableFuture<Void> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenReturn(null);
+    when(commandManager.<Void>submitNewCommand(any(), any())).thenReturn(testResponse);
+
+    // exercise
+    CompletableFuture<Void> response = service.set(key, value);
+    Object nullResponse = response.get();
+
+    // verify
+    assertEquals(testResponse, response);
+    assertNull(nullResponse);
+
+    // teardown
+  }
+
+  @Test
+  public void set_withOptionsOnlyIfExists_success()
+      throws ExecutionException, InterruptedException {
+    // setup
+    String key = "testKey";
+    String value = "testValue";
+    SetOptions setOptions =
+        SetOptions.builder()
+            .conditionalSet(SetOptions.ConditionalSet.ONLY_IF_EXISTS)
+            .returnOldValue(false)
+            .expiry(
+                SetOptions.TimeToLive.builder()
+                    .type(SetOptions.TimeToLiveType.KEEP_EXISTING)
+                    .build())
+            .build();
+    Command cmd =
+        Command.builder()
+            .requestType(Command.RequestType.SET_STRING)
+            .arguments(
+                new String[] {
+                  key, value, CONDITIONAL_SET_ONLY_IF_EXISTS, TIME_TO_LIVE_KEEP_EXISTING
+                })
+            .build();
+    CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenReturn(null);
+    when(commandManager.<String>submitNewCommand(eq(cmd), any())).thenReturn(testResponse);
+
+    // exercise
+    CompletableFuture<String> response = service.set(key, value, setOptions);
+
+    // verify
+    assertNotNull(response);
+    assertNull(response.get());
+
+    // teardown
+  }
+
+  @Test
+  public void set_withOptionsOnlyIfDoesNotExist_success()
+      throws ExecutionException, InterruptedException {
+    // setup
+    String key = "testKey";
+    String value = "testValue";
+    SetOptions setOptions =
+        SetOptions.builder()
+            .conditionalSet(SetOptions.ConditionalSet.ONLY_IF_DOES_NOT_EXIST)
+            .returnOldValue(true)
+            .expiry(
+                SetOptions.TimeToLive.builder()
+                    .type(SetOptions.TimeToLiveType.UNIX_SECONDS)
+                    .count(60)
+                    .build())
+            .build();
+    Command cmd =
+        Command.builder()
+            .requestType(Command.RequestType.SET_STRING)
+            .arguments(
+                new String[] {
+                  key,
+                  value,
+                  CONDITIONAL_SET_ONLY_IF_DOES_NOT_EXIST,
+                  RETURN_OLD_VALUE,
+                  TIME_TO_LIVE_UNIX_SECONDS + " 60"
+                })
+            .build();
+    CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenReturn(value);
+    when(commandManager.<String>submitNewCommand(eq(cmd), any())).thenReturn(testResponse);
+
+    // exercise
+    CompletableFuture<String> response = service.set(key, value, setOptions);
+
+    // verify
+    assertNotNull(response);
+    assertEquals(value, response.get());
+
+    // teardown
+  }
+}

--- a/java/client/src/test/java/glide/managers/CommandManagerTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerTest.java
@@ -1,0 +1,244 @@
+package glide.managers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import glide.api.commands.BaseCommandResponseResolver;
+import glide.api.commands.Command;
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RedisException;
+import glide.api.models.exceptions.TimeoutException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import response.ResponseOuterClass.RequestError;
+import response.ResponseOuterClass.Response;
+
+public class CommandManagerTest {
+
+  CommandManager service;
+
+  // ignored for now
+  Command command;
+
+  @Test
+  public void submitNewCommand_returnObjectResult()
+      throws ExecutionException, InterruptedException {
+
+    CompletableFuture<Response> channel = new CompletableFuture<>();
+    CommandManager service = new CommandManager(channel);
+
+    long pointer = -1;
+    Response respPointerResponse = Response.newBuilder().setRespPointer(pointer).build();
+    Object respObject = mock(Object.class);
+
+    CompletableFuture result =
+        service.submitNewCommand(
+            command, new BaseCommandResponseResolver((ptr) -> ptr == pointer ? respObject : null));
+    channel.complete(respPointerResponse);
+    Object respPointer = result.get();
+
+    assertEquals(respObject, respPointer);
+  }
+
+  @Test
+  public void submitNewCommand_returnNullResult() throws ExecutionException, InterruptedException {
+
+    CompletableFuture<Response> channel = new CompletableFuture<>();
+    CommandManager service = new CommandManager(channel);
+
+    Response respPointerResponse = Response.newBuilder().build();
+
+    CompletableFuture result =
+        service.submitNewCommand(
+            command, new BaseCommandResponseResolver((p) -> new RuntimeException("")));
+    channel.complete(respPointerResponse);
+    Object respPointer = result.get();
+
+    assertNull(respPointer);
+  }
+
+  @Test
+  public void submitNewCommand_returnStringResult()
+      throws ExecutionException, InterruptedException {
+
+    long pointer = 123;
+    String testString = "TEST STRING";
+
+    CompletableFuture<Response> channel = new CompletableFuture<>();
+    CommandManager service = new CommandManager(channel);
+
+    Response respPointerResponse = Response.newBuilder().setRespPointer(pointer).build();
+
+    CompletableFuture result =
+        service.submitNewCommand(
+            command, new BaseCommandResponseResolver((p) -> p == pointer ? testString : null));
+    channel.complete(respPointerResponse);
+    Object respPointer = result.get();
+
+    assertTrue(respPointer instanceof String);
+    assertEquals(testString, respPointer);
+  }
+
+  @Test
+  public void submitNewCommand_throwClosingException() {
+
+    String errorMsg = "Closing";
+
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture<Response> channel = new CompletableFuture<>();
+              CommandManager service = new CommandManager(channel);
+
+              Response closingErrorResponse =
+                  Response.newBuilder().setClosingError(errorMsg).build();
+
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              channel.complete(closingErrorResponse);
+              result.get();
+            });
+
+    assertTrue(e.getCause() instanceof ClosingException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_throwConnectionException() {
+
+    int disconnectedType = 3;
+    String errorMsg = "Disconnected";
+
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture<Response> channel = new CompletableFuture<>();
+              CommandManager service = new CommandManager(channel);
+
+              Response respPointerResponse =
+                  Response.newBuilder()
+                      .setRequestError(
+                          RequestError.newBuilder()
+                              .setTypeValue(disconnectedType)
+                              .setMessage(errorMsg)
+                              .build())
+                      .build();
+
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              channel.complete(respPointerResponse);
+              result.get();
+            });
+
+    assertTrue(e.getCause() instanceof ConnectionException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_throwTimeoutException() {
+
+    int timeoutType = 2;
+    String errorMsg = "Timeout";
+
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture<Response> channel = new CompletableFuture<>();
+              CommandManager service = new CommandManager(channel);
+
+              Response timeoutErrorResponse =
+                  Response.newBuilder()
+                      .setRequestError(
+                          RequestError.newBuilder()
+                              .setTypeValue(timeoutType)
+                              .setMessage(errorMsg)
+                              .build())
+                      .build();
+
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              channel.complete(timeoutErrorResponse);
+              result.get();
+            });
+
+    assertTrue(e.getCause() instanceof TimeoutException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_throwExecAbortException() {
+
+    int execAbortType = 1;
+    String errorMsg = "ExecAbort";
+
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture<Response> channel = new CompletableFuture<>();
+              CommandManager service = new CommandManager(channel);
+
+              Response execAbortErrorResponse =
+                  Response.newBuilder()
+                      .setRequestError(
+                          RequestError.newBuilder()
+                              .setTypeValue(execAbortType)
+                              .setMessage(errorMsg)
+                              .build())
+                      .build();
+
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              channel.complete(execAbortErrorResponse);
+              result.get();
+            });
+
+    assertTrue(e.getCause() instanceof ExecAbortException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_handledUnspecifiedError() {
+    int unspecifiedType = 0;
+    String errorMsg = "Unspecified";
+
+    ExecutionException executionException =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture<Response> channel = new CompletableFuture<>();
+              CommandManager service = new CommandManager(channel);
+
+              Response unspecifiedErrorResponse =
+                  Response.newBuilder()
+                      .setRequestError(
+                          RequestError.newBuilder()
+                              .setTypeValue(unspecifiedType)
+                              .setMessage(errorMsg)
+                              .build())
+                      .build();
+
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              channel.complete(unspecifiedErrorResponse);
+              result.get();
+            });
+
+    assertTrue(executionException.getCause() instanceof RedisException);
+    assertEquals(errorMsg, executionException.getCause().getMessage());
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/aws/babushka/pull/717. 

*Issue #, if available:*

API layer for: https://github.com/aws/babushka/issues/589

*Description of changes:*

In this PR, we're adding an API layer that creates a RedisClient using a RedisConfiguration.  
Introduces the get & set & customCommand calls that allow a user to use the RedisClient.  
This PR ensures that the type returned from the get/set/customCommand is correct for the type.  A request using Exec returns a generic instead. 

### Out of Scope
* Connection and Command Managers that send the data to the backend Data Access layer (https://github.com/aws/babushka/pull/717)
* CreateClient configuration will be added in a follow-up PR. 
* Transaction commands will be added in a follow-up PR. 

### Use cases
```java
// connect to Redis
CompletableFuture<babushka.client.api.RedisClient> redisClientConnection =
    babushka.client.api.RedisClient.CreateClient(configuration);

// resolve the Future and get a RedisClient
babushka.client.api.RedisClient redisClient = redisClientConnection.get();

SetOptions setOptions = SetOptions.builder()
    .returnOldValue(true) // returns a String
    .build();
CompletableFuture<String> setRequest = redisClient.set("apples", "oranges", setOptions);
String oldValue = setRequest.get(); // returns a string unless .returnOldValue() is not true

CompletableFuture<String> getRequest = redisClient.get("apples");
String getValueStr = getRequest.get();
getValueStr == "oranges";  
```

![design-java-api-detailed-level](https://github.com/Bit-Quill/babushka/assets/104530826/6f1d75ab-edf8-49e1-8398-bd1ce83ee281)

![design-java-api-sequence-datatypes](https://github.com/Bit-Quill/babushka/assets/104530826/09dcabb8-bf68-4154-93a1-c4683cfc3cdb)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
