### PR TITLE
Ensure UTC TZ is always used with datetime in python code.

### DIFF
--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -4,7 +4,7 @@ import functools
 import json
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from statistics import mean
@@ -196,7 +196,7 @@ async def run_clients(
     data_size,
     is_cluster,
 ):
-    now = datetime.now().strftime("%H:%M:%S")
+    now = datetime.now(timezone.utc).strftime("%H:%M:%S")
     print(
         f"Starting {client_name} data size: {data_size} concurrency:"
         f"{num_of_concurrent_tasks} client count: {len(clients)} {now}"

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -254,7 +254,7 @@ class TestCommands:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     async def test_socket_set_get(self, redis_client: TRedisClient):
         key = get_random_string(10)
-        value = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
+        value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
         assert await redis_client.set(key, value) == OK
         assert await redis_client.get(key) == value
 
@@ -945,7 +945,8 @@ class TestCommandsUnitTests:
         assert exp_unix_sec.get_cmd_args() == ["EXAT", "1682575739"]
 
         exp_unix_sec_datetime = ExpirySet(
-            ExpiryType.UNIX_SEC, datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc)
+            ExpiryType.UNIX_SEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
         )
         assert exp_unix_sec_datetime.get_cmd_args() == ["EXAT", "1682639759"]
 
@@ -953,7 +954,8 @@ class TestCommandsUnitTests:
         assert exp_unix_millisec.get_cmd_args() == ["PXAT", "1682586559964"]
 
         exp_unix_millisec_datetime = ExpirySet(
-            ExpiryType.UNIX_MILLSEC, datetime(2023, 4, 27, 23, 55, 59, 342380)
+            ExpiryType.UNIX_MILLSEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
         )
         assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]
 

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Union
 
 import pytest
@@ -25,7 +25,7 @@ def transaction_test(
     key6 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key7 = "{{{}}}:{}".format(keyslot, get_random_string(3))
 
-    value = datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
+    value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
     value2 = get_random_string(5)
 
     transaction.set(key, value)

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -960,7 +960,7 @@ def main():
         tic = time.perf_counter()
         cluster_prefix = f"tls-{args.prefix}" if args.tls else args.prefix
         cluster_folder = create_cluster_folder(args.folder_path, cluster_prefix)
-        logging.info(f"{datetime.now()} Starting script for cluster {cluster_folder}")
+        logging.info(f"{datetime.now(timezone.utc)} Starting script for cluster {cluster_folder}")
         logfile = (
             f"{cluster_folder}/cluster_manager.log"
             if not args.logfile
@@ -1010,7 +1010,7 @@ def main():
             )
         tic = time.perf_counter()
         logging.info(
-            f"{datetime.now()} Stopping script for cluster/s {args.cluster_folder or f'{args.prefix}*'} in {args.folder_path}"
+            f"{datetime.now(timezone.utc)} Stopping script for cluster/s {args.cluster_folder or f'{args.prefix}*'} in {args.folder_path}"
         )
 
         stop_clusters(


### PR DESCRIPTION
*Issue #, if available:*
Flakiness in some test_expiry_cmd_args test. Other issues might arise due to TZ ambiguity   

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
