### PR TITLE
Raise closing error when trying to use the client after it was closed

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -178,6 +178,7 @@ export class BaseClient {
     private writeInProgress = false;
     private remainingReadData: Uint8Array | undefined;
     private readonly requestTimeout: number; // Timeout in milliseconds
+    private isClosed = false;
 
     private handleReadData(data: Buffer) {
         const buf = this.remainingReadData
@@ -283,6 +284,9 @@ export class BaseClient {
         command: redis_request.Command | redis_request.Command[],
         route?: redis_request.Routes
     ): Promise<T> {
+        if (this.isClosed) {
+            throw new ClosingError("Unable to execute requests; the client is closed. Please create a new client.");
+        }
         return new Promise((resolve, reject) => {
             const callbackIndex = this.getCallbackIndex();
             this.promiseCallbackFunctions[callbackIndex] = [resolve, reject];
@@ -933,6 +937,7 @@ export class BaseClient {
      * @param errorMessage - If defined, this error message will be passed along with the exceptions when closing all open promises.
      */
     public close(errorMessage?: string): void {
+        this.isClosed = true;
         this.promiseCallbackFunctions.forEach(([, reject]) => {
             reject(new ClosingError(errorMessage));
         });

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2,6 +2,7 @@ import { expect, it } from "@jest/globals";
 import { exec } from "child_process";
 import { v4 as uuidv4 } from "uuid";
 import {
+    ClosingError,
     ExpireOptions,
     InfoOptions,
     ProtocolVersion,
@@ -68,6 +69,23 @@ export function runBaseTests<Context>(config: {
 
                 expect(result).toContain("lib-name=GlideJS");
                 expect(result).toContain("lib-ver=0.1.0");
+            });
+        },
+        config.timeout
+    );
+
+    it(
+        "closed client raises error",
+        async () => {
+            await runTest(async (client: BaseClient) => {
+                client.close();
+                try {
+                    expect(await client.set("foo", "bar")).toThrow();
+                } catch (e) {
+                    expect((e as ClosingError).message).toMatch(
+                        "Unable to execute requests; the client is closed. Please create a new client."
+                    );
+                }
             });
         },
         config.timeout

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -247,6 +247,13 @@ class TestRedisClients:
         client_info = await redis_client.custom_command(["CLIENT", "INFO"])
         assert "name=TEST_CLIENT_NAME" in client_info
 
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    async def test_closed_client_raises_error(self, redis_client: TRedisClient):
+        await redis_client.close()
+        with pytest.raises(ClosingError) as e:
+            await redis_client.set("foo", "bar")
+        assert "the client is closed" in str(e)
+
 
 @pytest.mark.asyncio
 class TestCommands:


### PR DESCRIPTION
Fixing python not to hang when accessing a closed client.
Raising an informative error. 