### PR TITLE
Increase C# CI timeout limit

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
     run-tests:
-        timeout-minutes: 10
+        timeout-minutes: 15
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false


### PR DESCRIPTION
due to failure:
https://github.com/aws/babushka/actions/runs/7378050628/job/20072716624?pr=688