### PR TITLE
Reduce number of python tasks.

### DIFF
--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -296,7 +296,7 @@ async def main(
 
 
 def number_of_iterations(num_of_concurrent_tasks):
-    return min(max(100000, num_of_concurrent_tasks * 10000), 10000000)
+    return min(max(100000, num_of_concurrent_tasks * 10000), 5000000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python is slow to scale in higher concurrency, so we reduce the time to run the benchmark in the higher throughput mode.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
