### PR TITLE
Fix editor config's indentation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,8 @@ root = true
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
+indent_size = 4
+tab_width = 4
 
 # Xml files
 [*.xml]
@@ -16,8 +18,6 @@ indent_size = 2
 #### Core EditorConfig Options ####
 
 # Indentation and spacing
-indent_size = 4
-tab_width = 4
 
 # New line preferences
 end_of_line = lf


### PR DESCRIPTION
The `Prettier` formatter takes its config from this file, and since there's no default indentation, it resets its indentation to 2 spaces. This change fixes the issue by adding default indentation to all languages.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
