### PR TITLE
- Java: extended the Rust API to allow returning non utf-8 encoded st…

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -180,6 +180,8 @@ import glide.ffi.resolvers.RedisValueResolver;
 import glide.managers.BaseCommandResponseResolver;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -238,7 +240,8 @@ public abstract class BaseClient
                     .connectToRedis(config)
                     .thenApply(ignore -> constructor.apply(connectionManager, commandManager));
         } catch (InterruptedException e) {
-            // Something bad happened while we were establishing netty connection to UDS
+            // Something bad happened while we were establishing netty connection to
+            // UDS
             var future = new CompletableFuture<T>();
             future.completeExceptionally(e);
             return future;
@@ -257,7 +260,8 @@ public abstract class BaseClient
         try {
             connectionManager.closeConnection().get();
         } catch (InterruptedException e) {
-            // suppressing the interrupted exception - it is already suppressed in the future
+            // suppressing the interrupted exception - it is already suppressed in the
+            // future
             throw new RuntimeException(e);
         }
     }
@@ -289,10 +293,15 @@ public abstract class BaseClient
      * @throws RedisException On a type mismatch.
      */
     @SuppressWarnings("unchecked")
-    protected <T> T handleRedisResponse(Class<T> classType, boolean isNullable, Response response)
-            throws RedisException {
+    protected <T> T handleRedisResponse(
+            Class<T> classType, EnumSet<ResponseFlags> flags, Response response) throws RedisException {
+        boolean encodingUtf8 = flags.contains(ResponseFlags.ENCODING_UTF8);
+        boolean isNullable = flags.contains(ResponseFlags.IS_NULLABLE);
         Object value =
-                new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response);
+                encodingUtf8
+                        ? new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response)
+                        : new BaseCommandResponseResolver(RedisValueResolver::valueFromPointerBinary)
+                                .apply(response);
         if (isNullable && (value == null)) {
             return null;
         }
@@ -308,43 +317,52 @@ public abstract class BaseClient
     }
 
     protected Object handleObjectOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(Object.class, true, response);
+        return handleRedisResponse(
+                Object.class, EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8), response);
     }
 
     protected String handleStringResponse(Response response) throws RedisException {
-        return handleRedisResponse(String.class, false, response);
+        return handleRedisResponse(String.class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
     }
 
     protected String handleStringOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(String.class, true, response);
+        return handleRedisResponse(
+                String.class, EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8), response);
+    }
+
+    protected byte[] handleBytesOrNullResponse(Response response) throws RedisException {
+        return handleRedisResponse(byte[].class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     protected Boolean handleBooleanResponse(Response response) throws RedisException {
-        return handleRedisResponse(Boolean.class, false, response);
+        return handleRedisResponse(Boolean.class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     protected Long handleLongResponse(Response response) throws RedisException {
-        return handleRedisResponse(Long.class, false, response);
+        return handleRedisResponse(Long.class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     protected Long handleLongOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(Long.class, true, response);
+        return handleRedisResponse(Long.class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     protected Double handleDoubleResponse(Response response) throws RedisException {
-        return handleRedisResponse(Double.class, false, response);
+        return handleRedisResponse(Double.class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     protected Double handleDoubleOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(Double.class, true, response);
+        return handleRedisResponse(Double.class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     protected Object[] handleArrayResponse(Response response) throws RedisException {
-        return handleRedisResponse(Object[].class, false, response);
+        return handleRedisResponse(Object[].class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
     }
 
     protected Object[] handleArrayOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(Object[].class, true, response);
+        return handleRedisResponse(
+                Object[].class,
+                EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8),
+                response);
     }
 
     /**
@@ -354,7 +372,7 @@ public abstract class BaseClient
      */
     @SuppressWarnings("unchecked") // raw Map cast to Map<String, V>
     protected <V> Map<String, V> handleMapResponse(Response response) throws RedisException {
-        return handleRedisResponse(Map.class, false, response);
+        return handleRedisResponse(Map.class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
     }
 
     /**
@@ -364,12 +382,13 @@ public abstract class BaseClient
      */
     @SuppressWarnings("unchecked") // raw Map cast to Map<String, V>
     protected <V> Map<String, V> handleMapOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(Map.class, true, response);
+        return handleRedisResponse(
+                Map.class, EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8), response);
     }
 
     @SuppressWarnings("unchecked") // raw Set cast to Set<String>
     protected Set<String> handleSetResponse(Response response) throws RedisException {
-        return handleRedisResponse(Set.class, false, response);
+        return handleRedisResponse(Set.class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
     }
 
     @Override
@@ -384,9 +403,21 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<byte[]> get(@NonNull byte[] key) {
+        return commandManager.submitNewCommand(
+                Get, Arrays.asList(key), this::handleBytesOrNullResponse);
+    }
+
+    @Override
     public CompletableFuture<String> getdel(@NonNull String key) {
         return commandManager.submitNewCommand(
                 GetDel, new String[] {key}, this::handleStringOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> set(@NonNull byte[] key, @NonNull byte[] value) {
+        return commandManager.submitNewCommand(
+                Set, Arrays.asList(key, value), this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/ResponseFlags.java
+++ b/java/client/src/main/java/glide/api/ResponseFlags.java
@@ -1,0 +1,9 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api;
+
+public enum ResponseFlags {
+    /** Strings in the response are UTF-8 encoded */
+    ENCODING_UTF8,
+    /** Null is a valid response */
+    IS_NULLABLE,
+}

--- a/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
@@ -35,6 +35,25 @@ public interface StringBaseCommands {
     CompletableFuture<String> get(String key);
 
     /**
+     * Gets the value associated with the given <code>key</code>, or <code>null</code> if no such
+     * value exists.
+     *
+     * @see <a href="https://redis.io/commands/get/">redis.io</a> for details.
+     * @param key The <code>key</code> to retrieve from the database.
+     * @return Response from Redis. If <code>key</code> exists, returns the <code>value</code> of
+     *     <code>key</code> as a <code>String</code>. Otherwise, return <code>null</code>.
+     * @example
+     *     <pre>{@code
+     * byte[] value = client.get("key").get();
+     * assert Arrays.equals(value, "value".getBytes());
+     *
+     * String value = client.get("non_existing_key").get();
+     * assert value.equals(null);
+     * }</pre>
+     */
+    CompletableFuture<byte[]> get(byte[] key);
+
+    /**
      * Gets a string value associated with the given <code>key</code> and deletes the key.
      *
      * @see <a href="https://redis.io/docs/latest/commands/getdel/">redis.io</a> for details.
@@ -66,6 +85,21 @@ public interface StringBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> set(String key, String value);
+
+    /**
+     * Sets the given <code>key</code> with the given value.
+     *
+     * @see <a href="https://redis.io/commands/set/">redis.io</a> for details.
+     * @param key The <code>key</code> to store.
+     * @param value The value to store with the given <code>key</code>.
+     * @return Response from Redis containing <code>"OK"</code>.
+     * @example
+     *     <pre>{@code
+     * String value = client.set("key".getBytes(), "value".getBytes()).get();
+     * assert value.equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<String> set(byte[] key, byte[] value);
 
     /**
      * Sets the given key with the given value. Return value is dependent on the passed options.

--- a/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
@@ -17,4 +17,13 @@ public class RedisValueResolver {
      * @return A RESP3 value
      */
     public static native Object valueFromPointer(long pointer);
+
+    /**
+     * Resolve a value received from Redis using given C-style pointer. This method does not assume
+     * that strings are valid UTF-8 encoded strings
+     *
+     * @param pointer A memory pointer from {@link Response}
+     * @return A RESP3 value
+     */
+    public static native Object valueFromPointerBinary(long pointer);
 }

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -39,6 +39,7 @@ import glide.api.models.configuration.RequestRoutingConfiguration.SingleNodeRout
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import glide.managers.RedisExceptionCheckedFunction;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -138,7 +139,8 @@ public class RedisClusterClientTest {
         }
 
         @Override
-        protected <T> T handleRedisResponse(Class<T> classType, boolean isNullable, Response response) {
+        protected <T> T handleRedisResponse(
+                Class<T> classType, EnumSet<ResponseFlags> flags, Response response) {
             @SuppressWarnings("unchecked")
             T returnValue = (T) object;
             return returnValue;

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -249,7 +249,7 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void get_requires_a_key(BaseClient client) {
-        assertThrows(NullPointerException.class, () -> client.get(null));
+        assertThrows(NullPointerException.class, () -> client.get((String) null));
     }
 
     @SneakyThrows
@@ -306,6 +306,17 @@ public class SharedCommandTests {
         client.set(key, ANOTHER_VALUE, options).get();
         String data = client.get(key).get();
         assertEquals(ANOTHER_VALUE, data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void set_get_binary_data(BaseClient client) {
+        byte[] key = "set_get_binary_data_key".getBytes();
+        byte[] value = {(byte) 0x01, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x02};
+        assert client.set(key, value).get().equals("OK");
+        byte[] data = client.get(key).get();
+        assert Arrays.equals(data, value);
     }
 
     @SneakyThrows


### PR DESCRIPTION
- Java: extended the Rust API to allow returning non utf-8 encoded strings
- Java: implemented overloading for `client.set(..)` and `client.get(..)` that are able to work binary data
