### PR TITLE
Java: Removing singing due Polyglot using publishToMavenLocal

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -128,6 +128,12 @@ jobs:
                   sed -i $SED_FOR_MACOS 's/placeholder/${{ matrix.host.CLASSIFIER }}/g' build.gradle
                   sed -i $SED_FOR_MACOS "s/255.255.255/${{ env.RELEASE_VERSION }}/g" build.gradle
 
+            - name: Add signing to java.client build.grade
+              shell: bash
+              working-directory: ./java/client
+              run: |
+                  echo "signing { sign publishing.publications }" >> build.gradle
+
             - name: Build java client
               working-directory: java
               run: |

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -215,9 +215,13 @@ publishing {
     }
 }
 
-signing {
-    sign publishing.publications
-}
+// signing removal due Polyglot requires to use publishToMavenLocal
+// code to sign will be re-introduced only during java-cd.yml workflow
+// TODO remove the comments and the additional java-cd.yml step "Add signing to java.client build.grade"
+// as soon Polyglot remove their dependency with the publishToMavenLocal
+//signing {
+//    sign publishing.publications
+//}
 
 tasks.withType(Test) {
     testLogging {

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -215,7 +215,7 @@ publishing {
     }
 }
 
-// signing removal due Polyglot requires to use publishToMavenLocal
+// signing removal due Polyglot use publishToMavenLocal
 // code to sign will be re-introduced only during java-cd.yml workflow
 // TODO remove the comments and the additional java-cd.yml step "Add signing to java.client build.grade"
 // as soon Polyglot remove their dependency with the publishToMavenLocal


### PR DESCRIPTION
Removed singing block from client build.gradle
The signing will only be added back during java-cd.yml runtime