### PR TITLE
Ignores VSCode-created `bin` directories (#402)

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -9,3 +9,6 @@ protobuf
 
 # Must be ignored as part of Maven Central publishing process
 gradle.properties
+
+# Ignore VSCode JUnit extension directories
+bin/


### PR DESCRIPTION
The VSCode Extension Pack for Java is widely used and includes a Test Runner for Java extension that automatically creates `bin` folders and `junit-platform.properties` files. These files should not be committed. This change adds a `bin/` pattern to the `./java/.gitignore` file to ignore any files automatically created by the extension.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.