### PR TITLE
Changed MacOS 13 runner to a normal-sized runner

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -27,7 +27,7 @@
     {
         "OS": "macos",
         "NAMED_OS": "darwin",
-        "RUNNER": "macos-13-xlarge",
+        "RUNNER": "macos-13",
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",
         "PACKAGE_MANAGERS": ["pypi", "npm"]

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -27,7 +27,7 @@
     {
         "OS": "macos",
         "NAMED_OS": "darwin",
-        "RUNNER": "macos-13",
+        "RUNNER": "macos-13-arm64",
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",
         "PACKAGE_MANAGERS": ["pypi", "npm"]

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -27,7 +27,7 @@
     {
         "OS": "macos",
         "NAMED_OS": "darwin",
-        "RUNNER": "macos-13-arm64",
+        "RUNNER": "macos-latest",
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",
         "PACKAGE_MANAGERS": ["pypi", "npm"]

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -12,6 +12,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
     pull_request:
         paths:
             - csharp/**
@@ -22,6 +23,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 
 permissions:
     contents: read

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
     pull_request:
         paths:
             - glide-core/src/**
@@ -22,6 +23,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 concurrency:
     group: go-${{ github.head_ref || github.ref }}
     cancel-in-progress: true

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -72,7 +72,7 @@ jobs:
                   }
                   - {
                     OS: macos,
-                    RUNNER: macos-13-xlarge,
+                    RUNNER: macos-latest,
                     TARGET: aarch64-apple-darwin,
                     CLASSIFIER: osx-aarch_64
                   }

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -6,6 +6,7 @@ on:
             - .github/workflows/java-cd.yml
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/start-self-hosted-runner/action.yml
+            - .github/json_matrices/build-matrix.json
     push:
         tags:
             - "v*.*"

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -12,6 +12,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
     pull_request:
         paths:
             - glide-core/src/**
@@ -22,6 +23,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 
 concurrency:
     group: java-${{ github.head_ref || github.ref }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -14,6 +14,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
     pull_request:
         paths:
             - glide-core/src/**
@@ -26,6 +27,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 
 concurrency:
     group: node-${{ github.head_ref || github.ref }}

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -11,6 +11,7 @@ on:
         - .github/workflows/install-rust-and-protoc/action.yml
         - .github/workflows/install-shared-dependencies/action.yml
         - .github/workflows/install-valkey/action.yml
+        - .github/json_matrices/build-matrix.json
     push:
         tags:
             - "v*.*"

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -10,6 +10,7 @@ on:
         - .github/workflows/start-self-hosted-runner/action.yml
         - .github/workflows/install-shared-dependencies/action.yml
         - .github/workflows/install-valkey/action.yml
+        - .github/json_matrices/build-matrix.json
     push:
         tags:
             - "v*.*"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 
     pull_request:
         paths:
@@ -27,6 +28,7 @@ on:
             - .github/workflows/test-benchmark/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 
 concurrency:
     group: python-${{ github.head_ref || github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
             - .github/workflows/rust.yml
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
     pull_request:
         paths:
             - logger_core/**
@@ -20,6 +21,7 @@ on:
             - .github/workflows/rust.yml
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/json_matrices/build-matrix.json
 
 concurrency:
     group: rust-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
We used macos-13-xlarge as at that time it was the only github runner for macos on arm64. Now, the macos-latest runner already runs on arm64, so we don't need to use the xl anymore.

Resolves this error:
 > The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings.
 

