### PR TITLE
TMP_COMMIT: remove macos platforms from the code deployment actions

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -17,22 +17,6 @@
         "CONTAINER": "2_28"
     },
     {
-        "OS": "macos",
-        "NAMED_OS": "darwin",
-        "RUNNER": "macos-12",
-        "ARCH": "x64",
-        "TARGET": "x86_64-apple-darwin",
-        "PACKAGE_MANAGERS": ["pypi", "npm"]
-    },
-    {
-        "OS": "macos",
-        "NAMED_OS": "darwin",
-        "RUNNER": "macos-latest",
-        "ARCH": "arm64",
-        "TARGET": "aarch64-apple-darwin",
-        "PACKAGE_MANAGERS": ["pypi", "npm"]
-    },
-    {
         "OS": "ubuntu",
         "NAMED_OS": "linux",
         "ARCH": "arm64",

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -65,18 +65,18 @@ jobs:
                     CLASSIFIER: linux-aarch_64,
                     CONTAINER: "2_28"
                   }
-                  - {
-                    OS: macos,
-                    RUNNER: macos-12,
-                    TARGET: x86_64-apple-darwin,
-                    CLASSIFIER: osx-x86_64
-                  }
-                  - {
-                    OS: macos,
-                    RUNNER: macos-latest,
-                    TARGET: aarch64-apple-darwin,
-                    CLASSIFIER: osx-aarch_64
-                  }
+                  # - {
+                  #   OS: macos,
+                  #   RUNNER: macos-12,
+                  #   TARGET: x86_64-apple-darwin,
+                  #   CLASSIFIER: osx-x86_64
+                  # }
+                  # - {
+                  #   OS: macos,
+                  #   RUNNER: macos-latest,
+                  #   TARGET: aarch64-apple-darwin,
+                  #   CLASSIFIER: osx-aarch_64
+                  # }
 
         runs-on: ${{ matrix.host.RUNNER }}
 


### PR DESCRIPTION
macos runners aren't picking up jobs, probably due to reaching the org's macos minutes limitation. Temporarily disables deployment to macos until payment issue fixed.