### PR TITLE
Fix the way we check repo owner on cd workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -108,7 +108,6 @@ jobs:
               run: make test
 
     build-amazonlinux-latest:
-        if: github.repository_owner == 'valkey-io'
         strategy:
             # Run all jobs
             fail-fast: false

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -15,8 +15,6 @@ on:
         version:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
-env:
-    HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:
     group: java-cd-${{ github.head_ref || github.ref }}
@@ -27,7 +25,7 @@ permissions:
 
 jobs:
     start-self-hosted-runner:
-        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
+        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -45,7 +43,7 @@ jobs:
 
     create-binaries-to-publish:
         needs: start-self-hosted-runner
-        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
+        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
         timeout-minutes: 35
         env:
             JAVA_VERSION: '11'

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -15,6 +15,8 @@ on:
         version:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
+env:
+    HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:
     group: java-cd-${{ github.head_ref || github.ref }}
@@ -25,7 +27,7 @@ permissions:
 
 jobs:
     start-self-hosted-runner:
-        if: github.repository_owner == 'valkey-io'
+        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -43,7 +45,7 @@ jobs:
 
     create-binaries-to-publish:
         needs: start-self-hosted-runner
-        if: github.repository_owner == 'valkey-io'
+        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
         timeout-minutes: 35
         env:
             JAVA_VERSION: '11'

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
     start-self-hosted-runner:
-        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
+        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -43,7 +43,7 @@ jobs:
 
     create-binaries-to-publish:
         needs: start-self-hosted-runner
-        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
+        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
         timeout-minutes: 35
         env:
             JAVA_VERSION: '11'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -119,7 +119,6 @@ jobs:
                       java/client/build/reports/spotbugs/**
 
     build-amazonlinux-latest:
-        if: github.repository_owner == 'valkey-io'
         strategy:
             # Run all jobs
             fail-fast: false

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
     start-self-hosted-runner:
-        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
+        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -64,7 +64,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
+        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
         container:

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -20,6 +20,8 @@ on:
         version:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
+env:
+    HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:
     group: npm-${{ github.head_ref || github.ref }}
@@ -30,13 +32,10 @@ permissions:
 
 jobs:
     start-self-hosted-runner:
-        if: github.repository_owner == 'valkey-io'
+        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
-          - run: echo $OWNER
-            env:
-              OWNER: ${{ github.repository_owner }}
           - name: Checkout
             uses: actions/checkout@v4
             with:
@@ -67,7 +66,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: github.repository_owner == 'valkey-io'
+        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
         container:

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -20,8 +20,6 @@ on:
         version:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
-env:
-    HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:
     group: npm-${{ github.head_ref || github.ref }}
@@ -32,7 +30,7 @@ permissions:
 
 jobs:
     start-self-hosted-runner:
-        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
+        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -66,7 +64,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
+        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
         container:

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -49,7 +49,7 @@ jobs:
                 
 
     start-self-hosted-runner:
-        if: ${{ HEAD_OWNER }} == 'valkey-io'
+        if: $HEAD_OWNER == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -64,7 +64,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: ${{ HEAD_OWNER }} == 'valkey-io'
+        if: $HEAD_OWNER == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
         timeout-minutes: 25

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -19,6 +19,8 @@ on:
         version:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
+env:
+    HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:
     group: pypi-${{ github.head_ref || github.ref }}
@@ -46,7 +48,7 @@ jobs:
                 
 
     start-self-hosted-runner:
-        if: github.repository_owner == 'valkey-io'
+        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -61,7 +63,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: github.repository_owner == 'valkey-io'
+        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
         timeout-minutes: 25

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -20,9 +20,6 @@ on:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
 
-env:
-    HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
-
 concurrency:
     group: pypi-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
@@ -49,7 +46,7 @@ jobs:
                 
 
     start-self-hosted-runner:
-        if: $HEAD_OWNER == 'valkey-io'
+        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -64,7 +61,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: $HEAD_OWNER == 'valkey-io'
+        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
         timeout-minutes: 25

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -20,7 +20,7 @@ on:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
 
-env:
+variables:
     HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -61,7 +61,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
+        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
         timeout-minutes: 25

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -19,7 +19,8 @@ on:
         version:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
-env:
+
+variables:
     HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:
@@ -48,7 +49,7 @@ jobs:
                 
 
     start-self-hosted-runner:
-        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
+        if: ${{ HEAD_OWNER }} == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:
@@ -63,7 +64,7 @@ jobs:
 
     publish-binaries:
         needs: [start-self-hosted-runner, load-platform-matrix]
-        if: ${{ env.HEAD_OWNER }} == 'valkey-io'
+        if: ${{ HEAD_OWNER }} == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
         timeout-minutes: 25

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -46,7 +46,7 @@ jobs:
                 
 
     start-self-hosted-runner:
-        if: ${{ github.event.pull_request.head.repo.owner.login }} == 'valkey-io'
+        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         steps:

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -20,7 +20,7 @@ on:
           description: 'The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*'
           required: true
 
-variables:
+env:
     HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
 
 concurrency:


### PR DESCRIPTION
1. Until now, we always checked the repo owner using  `github.repository_owner` which is always equal to valkey-io (upstream owner name) 
But we want to check the pr's branch repo owner, and this is done using `${{ github.event.pull_request.head.repo.owner.login }}`

2. Removed the check of repo owner from amazonlinux CI on java and go workflows