### PR TITLE
Fix release version for java client.

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -65,18 +65,18 @@ jobs:
                     CLASSIFIER: linux-aarch_64,
                     CONTAINER: "2_28"
                   }
-                  # - {
-                  #   OS: macos,
-                  #   RUNNER: macos-12,
-                  #   TARGET: x86_64-apple-darwin,
-                  #   CLASSIFIER: osx-x86_64
-                  # }
-                  # - {
-                  #   OS: macos,
-                  #   RUNNER: macos-latest,
-                  #   TARGET: aarch64-apple-darwin,
-                  #   CLASSIFIER: osx-aarch_64
-                  # }
+                  - {
+                    OS: macos,
+                    RUNNER: macos-12,
+                    TARGET: x86_64-apple-darwin,
+                    CLASSIFIER: osx-x86_64
+                  }
+                  - {
+                    OS: macos,
+                    RUNNER: macos-latest,
+                    TARGET: aarch64-apple-darwin,
+                    CLASSIFIER: osx-aarch_64
+                  }
 
         runs-on: ${{ matrix.host.RUNNER }}
 

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -99,7 +99,15 @@ jobs:
             - name: Set the release version
               shell: bash
               run: |
-                  echo "RELEASE_VERSION=1.0.0" >> $GITHUB_ENV
+                  if ${{ github.event_name == 'pull_request' }}; then
+                    R_VERSION="255.255.255"
+                  elif ${{ github.event_name == 'workflow_dispatch' }}; then
+                    R_VERSION="${{ env.INPUT_VERSION }}"
+                  else
+                    R_VERSION=${GITHUB_REF:11}
+                  fi
+                  echo "RELEASE_VERSION=${R_VERSION}" >> $GITHUB_ENV
+                  echo "Release version detected: $R_VERSION"
               env:
                 EVENT_NAME: ${{ github.event_name }}
                 INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -99,15 +99,7 @@ jobs:
             - name: Set the release version
               shell: bash
               run: |
-                  if ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}; then
-                    R_VERSION="255.255.255"
-                  elif ${{ github.event_name == 'workflow_dispatch' }}; then
-                    R_VERSION="${{ env.INPUT_VERSION }}"
-                  else
-                    R_VERSION=${GITHUB_REF:11}
-                  fi
-                  echo "RELEASE_VERSION=${R_VERSION}" >> $GITHUB_ENV
-                  echo "Release version detected: $R_VERSION"
+                  echo "RELEASE_VERSION=1.0.0" >> $GITHUB_ENV
               env:
                 EVENT_NAME: ${{ github.event_name }}
                 INPUT_VERSION: ${{ github.event.inputs.version }}

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -216,6 +216,11 @@ publishing {
     }
 }
 
+java {
+    withSourcesJar()
+//    withJavadocJar()
+}
+
 signing {
     sign publishing.publications
 }
@@ -234,6 +239,12 @@ jar {
     archiveBaseName = "glide-for-redis"
     // placeholder will be renamed by platform+arch on the release workflow java-cd.yml
     archiveClassifier = "placeholder"
+}
+
+sourcesJar {
+    // suppress following error
+    // Entry glide/api/BaseClient.java is a duplicate but no duplicate handling strategy has been set
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 spotbugsMain {

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -157,7 +157,7 @@ tasks.register('copyNativeLib', Copy) {
 }
 
 jar.dependsOn('copyNativeLib')
-copyNativeLib.dependsOn('buildRustRelease')
+copyNativeLib.dependsOn('buildRustReleaseStrip')
 compileTestJava.dependsOn('copyNativeLib')
 test.dependsOn('buildRust')
 testFfi.dependsOn('buildRust')

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -157,7 +157,7 @@ tasks.register('copyNativeLib', Copy) {
 }
 
 jar.dependsOn('copyNativeLib')
-copyNativeLib.dependsOn('buildRustReleaseStrip')
+copyNativeLib.dependsOn('buildRustRelease')
 compileTestJava.dependsOn('copyNativeLib')
 test.dependsOn('buildRust')
 testFfi.dependsOn('buildRust')


### PR DESCRIPTION
Unfortunately, commit [036994de296c45](https://github.com/valkey-io/valkey-glide/commit/036994de296c45) was lost from `v1.0` branch and java release artifacts got generated with the wrong version.

* Fixing java artifact version
* Adding mac runners to CD workflow