### PR TITLE
Java: Updates `glide-for-redis` references

### DIFF
--- a/java/DEVELOPER.md
+++ b/java/DEVELOPER.md
@@ -77,7 +77,7 @@ Before starting this step, make sure you've installed all software dependencies.
     ```bash
     VERSION=0.1.0 # You can modify this to other released version or set it to "main" to get the unstable branch
     git clone --branch ${VERSION} https://github.com/valkey-io/valkey-glide.git
-    cd glide-for-redis/java
+    cd valkey-glide/java
     ```
 2. Initialize git submodule:
     ```bash

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -231,7 +231,7 @@ tasks.withType(Test) {
 }
 
 jar {
-    archiveBaseName = "glide-for-redis"
+    archiveBaseName = "valkey-glide"
     // placeholder will be renamed by platform+arch on the release workflow java-cd.yml
     archiveClassifier = "placeholder"
 }


### PR DESCRIPTION
Replaces obsolete references to `glide-for-redis` with `valkey-glide`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.