### PR TITLE
Java: `XRange`/`XRevRange` should return `null` instead of `GlideException` when given a negative count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 #### Fixes
 * Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
-* Java: Fix XRange/XRevRange with a negative count ([#1920](https://github.com/valkey-io/valkey-glide/pull/1920))
+* Java: `XRange`/`XRevRange` should return `null` instead of `GlideException` when given a negative count  ([#1920](https://github.com/valkey-io/valkey-glide/pull/1920))
 
 ## 1.0.0 (2024-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 #### Fixes
 * Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
+* Java: Fix XRange/XRevRange with a negative count ([#TOODOO](TOODOO))
 
 ## 1.0.0 (2024-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 #### Fixes
 * Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
-* Java: Fix XRange/XRevRange with a negative count ([#TOODOO](TOODOO))
+* Java: Fix XRange/XRevRange with a negative count ([#1920](https://github.com/valkey-io/valkey-glide/pull/1920))
 
 ## 1.0.0 (2024-07-09)
 

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -2706,7 +2706,9 @@ public abstract class BaseClient
             @NonNull String key, @NonNull StreamRange start, @NonNull StreamRange end, long count) {
         String[] arguments = ArrayUtils.addFirst(StreamRange.toArgs(start, end, count), key);
         return commandManager.submitNewCommand(
-                XRange, arguments, response -> castMapOf2DArray(handleMapResponse(response), String.class));
+                XRange,
+                arguments,
+                response -> castMapOf2DArray(handleMapOrNullResponse(response), String.class));
     }
 
     @Override
@@ -2719,7 +2721,8 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(
                 XRange,
                 arguments,
-                response -> castMapOf2DArray(handleBinaryStringMapResponse(response), GlideString.class));
+                response ->
+                        castMapOf2DArray(handleBinaryStringMapOrNullResponse(response), GlideString.class));
     }
 
     @Override
@@ -2752,7 +2755,7 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(
                 XRevRange,
                 arguments,
-                response -> castMapOf2DArray(handleMapResponse(response), String.class));
+                response -> castMapOf2DArray(handleMapOrNullResponse(response), String.class));
     }
 
     @Override
@@ -2765,7 +2768,8 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(
                 XRevRange,
                 arguments,
-                response -> castMapOf2DArray(handleBinaryStringMapResponse(response), GlideString.class));
+                response ->
+                        castMapOf2DArray(handleBinaryStringMapOrNullResponse(response), GlideString.class));
     }
 
     @Override

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -6292,6 +6292,12 @@ public class SharedCommandTests {
         assertEquals(1, newRevResult.size());
         assertNotNull(newRevResult.get(streamId3));
 
+        // xrange, xrevrange should return null with a zero/negative count
+        assertNull(client.xrange(key, InfRangeBound.MIN, InfRangeBound.MAX, 0L).get());
+        assertNull(client.xrevrange(key, InfRangeBound.MAX, InfRangeBound.MIN, 0L).get());
+        assertNull(client.xrange(key, InfRangeBound.MIN, InfRangeBound.MAX, -5L).get());
+        assertNull(client.xrevrange(key, InfRangeBound.MAX, InfRangeBound.MIN, -1L).get());
+
         // xrange against an emptied stream
         assertEquals(3, client.xdel(key, new String[] {streamId1, streamId2, streamId3}).get());
         Map<String, String[][]> emptiedResult =


### PR DESCRIPTION
[XRange](https://valkey.io/commands/xrange/) and [XRevRange](https://valkey.io/commands/xrevrange/) will thrown an error when count is less than or equal to zero:
```
GlideException: Unexpected return type from Glide: got null expected Map
```