### PR TITLE
Node: Fix issue with ESLint installation documentation

### DIFF
--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -157,9 +157,11 @@ Development on the Node wrapper may involve changes in either the TypeScript or 
 
 1. TypeScript
     ```bash
-    # Run from the `node` folder
+    # Run from the root folder of the GLIDE repository
     npm install eslint-plugin-import@latest  @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tsdoc eslint typescript eslint-plugin-import@latest eslint-config-prettier prettier
     npm i
+    
+    # Run from the `node` folder
     npx eslint . --max-warnings=0
     npx prettier --check .
     ```

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -129,6 +129,11 @@ To run tests, use the following command:
 npm test
 ```
 
+To run the integration tests with existing servers, run the following command:
+```bash
+npm run test -- --cluster-endpoints=localhost:7000 --standalone-endpoints=localhost:6379
+```
+
 ### Submodules
 
 After pulling new changes, ensure that you update the submodules by running the following command:
@@ -164,6 +169,21 @@ Development on the Node wrapper may involve changes in either the TypeScript or 
     cd node
     npx eslint . --max-warnings=0
     npx prettier --check .
+    ```
+
+    To automatically apply prettier recommendations, run the following command:
+    ```bash
+    npx prettier -w .
+    ```
+
+    To avoid getting ESLint warnings from protobuf generated files, run the following command:
+    ```bash
+    npx eslint --ignore-pattern ProtobufMessage.* .
+    ```
+
+    To automatically apply ESLint recommendations, run the following command:
+    ```bash
+    npx eslint --ignore-pattern ProtobufMessage.* --ignore-pattern 'build-ts/**' --fix .
     ```
 
 2. Rust

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -130,6 +130,7 @@ npm test
 ```
 
 To run the integration tests with existing servers, run the following command:
+
 ```bash
 npm run test -- --cluster-endpoints=localhost:7000 --standalone-endpoints=localhost:6379
 ```
@@ -172,16 +173,19 @@ Development on the Node wrapper may involve changes in either the TypeScript or 
     ```
 
     To automatically apply prettier recommendations, run the following command:
+
     ```bash
     npx prettier -w .
     ```
 
     To avoid getting ESLint warnings from protobuf generated files, run the following command:
+
     ```bash
     npx eslint --ignore-pattern ProtobufMessage.* .
     ```
 
     To automatically apply ESLint recommendations, run the following command:
+
     ```bash
     npx eslint --ignore-pattern ProtobufMessage.* --ignore-pattern 'build-ts/**' --fix .
     ```

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -156,15 +156,16 @@ Development on the Node wrapper may involve changes in either the TypeScript or 
 #### Running the linters
 
 1. TypeScript
+
     ```bash
     # Run from the root folder of the GLIDE repository
     npm install eslint-plugin-import@latest  @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tsdoc eslint typescript eslint-plugin-import@latest eslint-config-prettier prettier
     npm i
-    
-    # Run from the `node` folder
+    cd node
     npx eslint . --max-warnings=0
     npx prettier --check .
     ```
+
 2. Rust
     ```bash
     # Run from the `node/rust-client` folder


### PR DESCRIPTION
Following the current documentation for installing ESLint gives users this error:
```
Oops! Something went wrong! :(

ESLint: 8.57.0

ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".
```

This change adjusts the documentation so that users can avoid this error and install ESLint correctly.