### PR TITLE
Allow developers to run CI on demand

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -24,6 +24,7 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+    workflow_dispatch:
 
 permissions:
     contents: read

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,10 +24,11 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+    workflow_dispatch:
+
 concurrency:
     group: go-${{ github.head_ref || github.ref }}
     cancel-in-progress: true
-
 
 jobs:
     load-engine-matrix:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -24,6 +24,7 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+    workflow_dispatch:
 
 concurrency:
     group: java-${{ github.head_ref || github.ref }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -28,6 +28,7 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+    workflow_dispatch:
 
 concurrency:
     group: node-${{ github.head_ref || github.ref }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,6 +29,7 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+    workflow_dispatch:
 
 concurrency:
     group: python-${{ github.head_ref || github.ref }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,7 @@ on:
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+    workflow_dispatch:
 
 concurrency:
     group: rust-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
With the given change a developer can start CI job on any branch without creating a PR nor patching CI workflow.
This adds a button on **Actions** tab on those CI jobs to run it manually on a selected branch.
![image](https://github.com/user-attachments/assets/e8e1990c-9a31-466d-8ff0-4f50fe8a59ba)
