### PR TITLE
Fixed Java ORT not to include irrelevant dependencies

### DIFF
--- a/java/.ort.yml
+++ b/java/.ort.yml
@@ -11,10 +11,13 @@ excludes:
   scopes:
     - pattern: "test.*"
       reason: "TEST_DEPENDENCY_OF"
-      comment: Packages for testing only. Not part of released artifacts."
+      comment: Packages for testing only. Not part of released artifacts.
     - pattern: "(spotbugs.*|spotbugsSlf4j.*)"
       reason: "TEST_DEPENDENCY_OF"
-      comment: Packages for static analysis only. Not part of released artifacts."
+      comment: Packages for static analysis only. Not part of released artifacts.
     - pattern: "jacoco.*"
       reason: "TEST_DEPENDENCY_OF"
-      comment: Packages for code coverage verification only. Not part of released artifacts."
+      comment: Packages for code coverage verification only. Not part of released artifacts.
+    - pattern: "compileClasspath.*"
+      reason: "TEST_DEPENDENCY_OF"
+      comment: Packages for Gradle compiler only. Not part of released artifacts.

--- a/java/.ort.yml
+++ b/java/.ort.yml
@@ -20,4 +20,4 @@ excludes:
       comment: Packages for code coverage verification only. Not part of released artifacts.
     - pattern: "compileClasspath.*"
       reason: "TEST_DEPENDENCY_OF"
-      comment: Packages for Gradle compiler only. Not part of released artifacts.
+      comment: Packages for Gradle only. Not part of released artifacts.


### PR DESCRIPTION
Fixes #1971 by removing unnecessary spotbugs from the attribution files