### PR TITLE
Node: fix ZADD bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
 * Node: Added LPOS command ([#1927](https://github.com/valkey-io/valkey-glide/pull/1927))
 * Node: Added FUNCTION LOAD command ([#1969](https://github.com/valkey-io/valkey-glide/pull/1969))
 * Node: Added FUNCTION FLUSH command ([#1984](https://github.com/valkey-io/valkey-glide/pull/1984))
-* Node: Fix ZADD bug ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
+
+#### Fixes
+* Node: Fix ZADD bug where command could not be called with only the "changed" optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
 
 ## 1.0.0 (2024-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Node: Added FUNCTION FLUSH command ([#1984](https://github.com/valkey-io/valkey-glide/pull/1984))
 
 #### Fixes
-* Node: Fix ZADD bug where command could not be called with only the "changed" optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
+* Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
 
 ## 1.0.0 (2024-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Node: Added LPOS command ([#1927](https://github.com/valkey-io/valkey-glide/pull/1927))
 * Node: Added FUNCTION LOAD command ([#1969](https://github.com/valkey-io/valkey-glide/pull/1969))
 * Node: Added FUNCTION FLUSH command ([#1984](https://github.com/valkey-io/valkey-glide/pull/1984))
+* Node: Fix ZADD bug ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
 
 ## 1.0.0 (2024-07-09)
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2186,21 +2186,20 @@ export class BaseClient {
      * @param key - The key of the sorted set.
      * @param membersScoresMap - A mapping of members to their corresponding scores.
      * @param options - The ZAdd options.
-     * @param changed - Modify the return value from the number of new elements added, to the total number of elements changed.
      * @returns The number of elements added to the sorted set.
      * If `changed` is set, returns the number of elements updated in the sorted set.
      *
      * @example
      * ```typescript
      * // Example usage of the zadd method to add elements to a sorted set
-     * const result = await client.zadd("my_sorted_set", \{ "member1": 10.5, "member2": 8.2 \});
+     * const result = await client.zadd("my_sorted_set", { "member1": 10.5, "member2": 8.2 });
      * console.log(result); // Output: 2 - Indicates that two elements have been added to the sorted set "my_sorted_set."
      * ```
      *
      * @example
      * ```typescript
      * // Example usage of the zadd method to update scores in an existing sorted set
-     * const result = await client.zadd("existing_sorted_set", { member1: 15.0, member2: 5.5 }, options={ conditionalChange: "onlyIfExists" } , changed=true);
+     * const result = await client.zadd("existing_sorted_set", { member1: 15.0, member2: 5.5 }, { conditionalChange: "onlyIfExists", changed: true });
      * console.log(result); // Output: 2 - Updates the scores of two existing members in the sorted set "existing_sorted_set."
      * ```
      */
@@ -2210,11 +2209,7 @@ export class BaseClient {
         options?: ZAddOptions,
     ): Promise<number> {
         return this.createWritePromise(
-            createZAdd(
-                key,
-                membersScoresMap,
-                options,
-            ),
+            createZAdd(key, membersScoresMap, options),
         );
     }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2208,14 +2208,12 @@ export class BaseClient {
         key: string,
         membersScoresMap: Record<string, number>,
         options?: ZAddOptions,
-        changed?: boolean,
     ): Promise<number> {
         return this.createWritePromise(
             createZAdd(
                 key,
                 membersScoresMap,
                 options,
-                changed ? "CH" : undefined,
             ),
         );
     }
@@ -2253,7 +2251,7 @@ export class BaseClient {
         options?: ZAddOptions,
     ): Promise<number | null> {
         return this.createWritePromise(
-            createZAdd(key, { [member]: increment }, options, "INCR"),
+            createZAdd(key, { [member]: increment }, options, true),
         );
     }
 

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -928,6 +928,7 @@ export type ZAddOptions = {
      * is greater than the current score. Equivalent to `GT` in the Redis API.
      */
     updateOptions?: "scoreLessThanCurrent" | "scoreGreaterThanCurrent";
+    changed?: boolean;
 };
 
 /**
@@ -937,7 +938,7 @@ export function createZAdd(
     key: string,
     membersScoresMap: Record<string, number>,
     options?: ZAddOptions,
-    changedOrIncr?: "CH" | "INCR",
+    incr: boolean = false,
 ): command_request.Command {
     let args = [key];
 
@@ -959,10 +960,14 @@ export function createZAdd(
         } else if (options.updateOptions === "scoreGreaterThanCurrent") {
             args.push("GT");
         }
+
+        if (options.changed) {
+            args.push("CH");
+        }
     }
 
-    if (changedOrIncr) {
-        args.push(changedOrIncr);
+    if (incr) {
+        args.push("INCR");
     }
 
     args = args.concat(

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -928,6 +928,9 @@ export type ZAddOptions = {
      * is greater than the current score. Equivalent to `GT` in the Redis API.
      */
     updateOptions?: "scoreLessThanCurrent" | "scoreGreaterThanCurrent";
+    /**
+     * Modify the return value from the number of new elements added, to the total number of elements changed.
+     */
     changed?: boolean;
 };
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1109,7 +1109,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key of the sorted set.
      * @param membersScoresMap - A mapping of members to their corresponding scores.
      * @param options - The ZAdd options.
-     * @param changed - Modify the return value from the number of new elements added, to the total number of elements changed.
      *
      * Command Response - The number of elements added to the sorted set.
      * If `changed` is set, returns the number of elements updated in the sorted set.
@@ -1119,13 +1118,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         membersScoresMap: Record<string, number>,
         options?: ZAddOptions,
     ): T {
-        return this.addAndReturn(
-            createZAdd(
-                key,
-                membersScoresMap,
-                options,
-            ),
-        );
+        return this.addAndReturn(createZAdd(key, membersScoresMap, options));
     }
 
     /** Increments the score of member in the sorted set stored at `key` by `increment`.
@@ -1147,7 +1140,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         increment: number,
         options?: ZAddOptions,
     ): T {
-
         return this.addAndReturn(
             createZAdd(key, { [member]: increment }, options, true),
         );

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1118,14 +1118,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         key: string,
         membersScoresMap: Record<string, number>,
         options?: ZAddOptions,
-        changed?: boolean,
     ): T {
         return this.addAndReturn(
             createZAdd(
                 key,
                 membersScoresMap,
                 options,
-                changed ? "CH" : undefined,
             ),
         );
     }
@@ -1149,8 +1147,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         increment: number,
         options?: ZAddOptions,
     ): T {
+
         return this.addAndReturn(
-            createZAdd(key, { [member]: increment }, options, "INCR"),
+            createZAdd(key, { [member]: increment }, options, true),
         );
     }
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2061,9 +2061,13 @@ export function runBaseTests<Context>(config: {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
                 const membersScores = { one: 1, two: 2, three: 3 };
+                const newMembersScores = { one: 2, two: 3};
 
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zaddIncr(key, "one", 2)).toEqual(3.0);
+                expect(
+                    await client.zadd(key, newMembersScores, { changed: true }),
+                ).toEqual(2);
             }, protocol);
         },
         config.timeout,
@@ -2119,8 +2123,8 @@ export function runBaseTests<Context>(config: {
                         membersScores,
                         {
                             updateOptions: "scoreGreaterThanCurrent",
+                            changed: true,
                         },
-                        true,
                     ),
                 ).toEqual(1);
 
@@ -2130,8 +2134,8 @@ export function runBaseTests<Context>(config: {
                         membersScores,
                         {
                             updateOptions: "scoreLessThanCurrent",
+                            changed: true,
                         },
-                        true,
                     ),
                 ).toEqual(0);
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2061,7 +2061,7 @@ export function runBaseTests<Context>(config: {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
                 const membersScores = { one: 1, two: 2, three: 3 };
-                const newMembersScores = { one: 2, two: 3};
+                const newMembersScores = { one: 2, two: 3 };
 
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zaddIncr(key, "one", 2)).toEqual(3.0);
@@ -2118,25 +2118,17 @@ export function runBaseTests<Context>(config: {
                 membersScores["one"] = 10;
 
                 expect(
-                    await client.zadd(
-                        key,
-                        membersScores,
-                        {
-                            updateOptions: "scoreGreaterThanCurrent",
-                            changed: true,
-                        },
-                    ),
+                    await client.zadd(key, membersScores, {
+                        updateOptions: "scoreGreaterThanCurrent",
+                        changed: true,
+                    }),
                 ).toEqual(1);
 
                 expect(
-                    await client.zadd(
-                        key,
-                        membersScores,
-                        {
-                            updateOptions: "scoreLessThanCurrent",
-                            changed: true,
-                        },
-                    ),
+                    await client.zadd(key, membersScores, {
+                        updateOptions: "scoreLessThanCurrent",
+                        changed: true,
+                    }),
                 ).toEqual(0);
 
                 expect(


### PR DESCRIPTION
### Description
The bug in the ZADD implementation does not allow for users to call `zadd` with only the `changed` parameter. This PR will allow for `zadd("key", { one: 1, two: 2 }, { changed: true });` to be supported.