### PR TITLE
Node: Rework transaction IT.

### DIFF
--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -33,6 +33,7 @@ import {
     parseCommandLineArgs,
     parseEndpoints,
     transactionTest,
+    validateTransactionResponse,
 } from "./TestUtilities";
 
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -167,8 +168,23 @@ describe("GlideClient", () => {
             const expectedRes = await transactionTest(transaction);
             transaction.select(0);
             const result = await client.exec(transaction);
-            expectedRes.push("OK");
-            expect(intoString(result)).toEqual(intoString(expectedRes));
+            expectedRes.push(["select(0)", "OK"]);
+
+            validateTransactionResponse(result, expectedRes);
+            /*
+            const failedChecks: string[] = [];
+            for (let i = 0; i < expectedRes.length; i++) {
+                const [testName, expectedResponse] = expectedRes[i];
+
+                try {
+                    expect(intoString(result?.[i])).toEqual(intoString(expectedResponse));
+                } catch(e) {
+                    failedChecks.push(`${testName} failed, expected <${expectedResponse}>, actual <${result?.[i]}>`);
+                }
+            }
+            if (failedChecks.length > 0) {
+                throw new Error("Checks failed in transaction response:\n" + failedChecks.join("\n"));
+            }*/
         },
     );
 

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -171,20 +171,6 @@ describe("GlideClient", () => {
             expectedRes.push(["select(0)", "OK"]);
 
             validateTransactionResponse(result, expectedRes);
-            /*
-            const failedChecks: string[] = [];
-            for (let i = 0; i < expectedRes.length; i++) {
-                const [testName, expectedResponse] = expectedRes[i];
-
-                try {
-                    expect(intoString(result?.[i])).toEqual(intoString(expectedResponse));
-                } catch(e) {
-                    failedChecks.push(`${testName} failed, expected <${expectedResponse}>, actual <${result?.[i]}>`);
-                }
-            }
-            if (failedChecks.length > 0) {
-                throw new Error("Checks failed in transaction response:\n" + failedChecks.join("\n"));
-            }*/
         },
     );
 

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -36,6 +36,7 @@ import {
     parseCommandLineArgs,
     parseEndpoints,
     transactionTest,
+    validateTransactionResponse,
 } from "./TestUtilities";
 type Context = {
     client: GlideClusterClient;
@@ -243,7 +244,7 @@ describe("GlideClusterClient", () => {
             const transaction = new ClusterTransaction();
             const expectedRes = await transactionTest(transaction);
             const result = await client.exec(transaction);
-            expect(intoString(result)).toEqual(intoString(expectedRes));
+            validateTransactionResponse(result, expectedRes);
         },
         TIMEOUT,
     );

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -39,6 +39,8 @@ function intoArrayInternal(obj: any, builder: Array<string>) {
         builder.push("null");
     } else if (typeof obj === "string") {
         builder.push(obj);
+    } else if (typeof obj === "number") {
+        builder.push(obj.toPrecision(3));
     } else if (obj instanceof Uint8Array) {
         builder.push(obj.toString());
     } else if (obj instanceof Array) {
@@ -339,9 +341,43 @@ export function compareMaps(
     return JSON.stringify(map) == JSON.stringify(map2);
 }
 
+/**
+ * Check transaction response.
+ * @param response - Transaction result received from `exec` call.
+ * @param expectedResponseData - Expected result data from {@link transactionTest}.
+ */
+export function validateTransactionResponse(
+    response: ReturnType[] | null,
+    expectedResponseData: [string, ReturnType][],
+) {
+    const failedChecks: string[] = [];
+
+    for (let i = 0; i < expectedResponseData.length; i++) {
+        const [testName, expectedResponse] = expectedResponseData[i];
+
+        if (intoString(response?.[i]) != intoString(expectedResponse)) {
+            failedChecks.push(
+                `${testName} failed, expected <${JSON.stringify(expectedResponse)}>, actual <${JSON.stringify(response?.[i])}>`,
+            );
+        }
+    }
+
+    if (failedChecks.length > 0) {
+        throw new Error(
+            "Checks failed in transaction response:\n" +
+                failedChecks.join("\n"),
+        );
+    }
+}
+
+/**
+ * Populates a transaction with commands to test.
+ * @param baseTransaction - A transaction.
+ * @returns Array of tuples, where first element is a test name/description, second - expected return value.
+ */
 export async function transactionTest(
     baseTransaction: Transaction | ClusterTransaction,
-): Promise<ReturnType[]> {
+): Promise<[string, ReturnType][]> {
     const key1 = "{key}" + uuidv4();
     const key2 = "{key}" + uuidv4();
     const key3 = "{key}" + uuidv4();
@@ -362,103 +398,105 @@ export async function transactionTest(
     const key18 = "{key}" + uuidv4(); // Geospatial Data/ZSET
     const field = uuidv4();
     const value = uuidv4();
-    const args: ReturnType[] = [];
+    // array of tuples - first element is test name/description, second - expected return value
+    const responseData: [string, ReturnType][] = [];
     baseTransaction.flushall();
-    args.push("OK");
+    responseData.push(["flushall()", "OK"]);
     baseTransaction.flushall(FlushMode.SYNC);
-    args.push("OK");
+    responseData.push(["flushall(FlushMode.SYNC)", "OK"]);
     baseTransaction.flushdb();
-    args.push("OK");
+    responseData.push(["flushdb()", "OK"]);
     baseTransaction.flushdb(FlushMode.SYNC);
-    args.push("OK");
+    responseData.push(["flushdb(FlushMode.SYNC)", "OK"]);
     baseTransaction.dbsize();
-    args.push(0);
+    responseData.push(["dbsize()", 0]);
     baseTransaction.set(key1, "bar");
-    args.push("OK");
+    responseData.push(['set(key1, "bar")', "OK"]);
     baseTransaction.getdel(key1);
-    args.push("bar");
+    responseData.push(["getdel(key1)", "bar"]);
     baseTransaction.set(key1, "bar");
-    args.push("OK");
+    responseData.push(['set(key1, "bar")', "OK"]);
     baseTransaction.objectEncoding(key1);
-    args.push("embstr");
+    responseData.push(["objectEncoding(key1)", "embstr"]);
     baseTransaction.type(key1);
-    args.push("string");
+    responseData.push(["type(key1)", "string"]);
     baseTransaction.echo(value);
-    args.push(value);
+    responseData.push(["echo(value)", value]);
     baseTransaction.persist(key1);
-    args.push(false);
-    baseTransaction.set(key2, "baz", {
-        returnOldValue: true,
-    });
-    args.push(null);
+    responseData.push(["persist(key1)", false]);
+    baseTransaction.set(key2, "baz", { returnOldValue: true });
+    responseData.push(['set(key2, "baz", { returnOldValue: true })', null]);
     baseTransaction.customCommand(["MGET", key1, key2]);
-    args.push(["bar", "baz"]);
+    responseData.push(['customCommand(["MGET", key1, key2])', ["bar", "baz"]]);
     baseTransaction.mset({ [key3]: value });
-    args.push("OK");
+    responseData.push(["mset({ [key3]: value })", "OK"]);
     baseTransaction.mget([key1, key2]);
-    args.push(["bar", "baz"]);
+    responseData.push(["mget([key1, key2])", ["bar", "baz"]]);
     baseTransaction.strlen(key1);
-    args.push(3);
+    responseData.push(["strlen(key1)", 3]);
     baseTransaction.del([key1]);
-    args.push(1);
+    responseData.push(["del([key1])", 1]);
     baseTransaction.hset(key4, { [field]: value });
-    args.push(1);
+    responseData.push(["hset(key4, { [field]: value })", 1]);
     baseTransaction.hlen(key4);
-    args.push(1);
+    responseData.push(["hlen(key4)", 1]);
     baseTransaction.hsetnx(key4, field, value);
-    args.push(false);
+    responseData.push(["hsetnx(key4, field, value)", false]);
     baseTransaction.hvals(key4);
-    args.push([value]);
+    responseData.push(["hvals(key4)", [value]]);
     baseTransaction.hget(key4, field);
-    args.push(value);
+    responseData.push(["hget(key4, field)", value]);
     baseTransaction.hgetall(key4);
-    args.push({ [field]: value });
+    responseData.push(["hgetall(key4)", { [field]: value }]);
     baseTransaction.hdel(key4, [field]);
-    args.push(1);
+    responseData.push(["hdel(key4, [field])", 1]);
     baseTransaction.hmget(key4, [field]);
-    args.push([null]);
+    responseData.push(["hmget(key4, [field])", [null]]);
     baseTransaction.hexists(key4, field);
-    args.push(false);
+    responseData.push(["hexists(key4, field)", false]);
     baseTransaction.lpush(key5, [
         field + "1",
         field + "2",
         field + "3",
         field + "4",
     ]);
-    args.push(4);
+    responseData.push(["lpush(key5, [1, 2, 3, 4])", 4]);
     baseTransaction.lpop(key5);
-    args.push(field + "4");
+    responseData.push(["lpop(key5)", field + "4"]);
     baseTransaction.llen(key5);
-    args.push(3);
+    responseData.push(["llen(key5)", 3]);
     baseTransaction.lrem(key5, 1, field + "1");
-    args.push(1);
+    responseData.push(['lrem(key5, 1, field + "1")', 1]);
     baseTransaction.ltrim(key5, 0, 1);
-    args.push("OK");
+    responseData.push(["ltrim(key5, 0, 1)", "OK"]);
     baseTransaction.lset(key5, 0, field + "3");
-    args.push("OK");
+    responseData.push(['lset(key5, 0, field + "3")', "OK"]);
     baseTransaction.lrange(key5, 0, -1);
-    args.push([field + "3", field + "2"]);
+    responseData.push(["lrange(key5, 0, -1)", [field + "3", field + "2"]]);
     baseTransaction.lpopCount(key5, 2);
-    args.push([field + "3", field + "2"]);
+    responseData.push(["lpopCount(key5, 2)", [field + "3", field + "2"]]);
     baseTransaction.linsert(
         key5,
         InsertPosition.Before,
         "nonExistingPivot",
         "element",
     );
-    args.push(0);
+    responseData.push(["linsert", 0]);
     baseTransaction.rpush(key6, [field + "1", field + "2", field + "3"]);
-    args.push(3);
+    responseData.push([
+        'rpush(key6, [field + "1", field + "2", field + "3"])',
+        3,
+    ]);
     baseTransaction.lindex(key6, 0);
-    args.push(field + "1");
+    responseData.push(["lindex(key6, 0)", field + "1"]);
     baseTransaction.rpop(key6);
-    args.push(field + "3");
+    responseData.push(["rpop(key6)", field + "3"]);
     baseTransaction.rpopCount(key6, 2);
-    args.push([field + "2", field + "1"]);
+    responseData.push(["rpopCount(key6, 2)", [field + "2", field + "1"]]);
     baseTransaction.rpushx(key15, ["_"]); // key15 is empty
-    args.push(0);
+    responseData.push(['rpushx(key15, ["_"])', 0]);
     baseTransaction.lpushx(key15, ["_"]);
-    args.push(0);
+    responseData.push(['lpushx(key15, ["_"])', 0]);
     baseTransaction.rpush(key16, [
         field + "1",
         field + "1",
@@ -466,59 +504,68 @@ export async function transactionTest(
         field + "3",
         field + "3",
     ]);
-    args.push(5);
+    responseData.push(["rpush(key16, [1, 1, 2, 3, 3,])", 5]);
     baseTransaction.lpos(key16, field + "1", new LPosOptions({ rank: 2 }));
-    args.push(1);
+    responseData.push([
+        'lpos(key16, field + "1", new LPosOptions({ rank: 2 }))',
+        1,
+    ]);
     baseTransaction.lpos(
         key16,
         field + "1",
         new LPosOptions({ rank: 2, count: 0 }),
     );
-    args.push([1]);
+    responseData.push([
+        'lpos(key16, field + "1", new LPosOptions({ rank: 2, count: 0 }))',
+        [1],
+    ]);
     baseTransaction.sadd(key7, ["bar", "foo"]);
-    args.push(2);
+    responseData.push(['sadd(key7, ["bar", "foo"])', 2]);
     baseTransaction.sunionstore(key7, [key7, key7]);
-    args.push(2);
+    responseData.push(["sunionstore(key7, [key7, key7])", 2]);
     baseTransaction.sunion([key7, key7]);
-    args.push(new Set(["bar", "foo"]));
+    responseData.push(["sunion([key7, key7])", new Set(["bar", "foo"])]);
     baseTransaction.sinter([key7, key7]);
-    args.push(new Set(["bar", "foo"]));
+    responseData.push(["sinter([key7, key7])", new Set(["bar", "foo"])]);
 
     if (!(await checkIfServerVersionLessThan("7.0.0"))) {
         baseTransaction.sintercard([key7, key7]);
-        args.push(2);
+        responseData.push(["sintercard([key7, key7])", 2]);
         baseTransaction.sintercard([key7, key7], 1);
-        args.push(1);
+        responseData.push(["sintercard([key7, key7], 1)", 1]);
     }
 
     baseTransaction.sinterstore(key7, [key7, key7]);
-    args.push(2);
+    responseData.push(["sinterstore(key7, [key7, key7])", 2]);
     baseTransaction.sdiff([key7, key7]);
-    args.push(new Set());
+    responseData.push(["sdiff([key7, key7])", new Set()]);
     baseTransaction.sdiffstore(key7, [key7]);
-    args.push(2);
+    responseData.push(["sdiffstore(key7, [key7])", 2]);
     baseTransaction.srem(key7, ["foo"]);
-    args.push(1);
+    responseData.push(['srem(key7, ["foo"])', 1]);
     baseTransaction.scard(key7);
-    args.push(1);
+    responseData.push(["scard(key7)", 1]);
     baseTransaction.sismember(key7, "bar");
-    args.push(true);
+    responseData.push(['sismember(key7, "bar")', true]);
 
     if (!(await checkIfServerVersionLessThan("6.2.0"))) {
         baseTransaction.smismember(key7, ["bar", "foo", "baz"]);
-        args.push([true, true, false]);
+        responseData.push([
+            'smismember(key7, ["bar", "foo", "baz"])',
+            [true, true, false],
+        ]);
     }
 
     baseTransaction.smembers(key7);
-    args.push(new Set(["bar"]));
+    responseData.push(["smembers(key7)", new Set(["bar"])]);
     baseTransaction.spop(key7);
-    args.push("bar");
+    responseData.push(["spop(key7)", "bar"]);
     baseTransaction.spopCount(key7, 2);
-    args.push(new Set());
+    responseData.push(["spopCount(key7, 2)", new Set()]);
     baseTransaction.smove(key7, key7, "non_existing_member");
-    args.push(false);
+    responseData.push(['smove(key7, key7, "non_existing_member")', false]);
     baseTransaction.scard(key7);
-    args.push(0);
+    responseData.push(["scard(key7)", 0]);
     baseTransaction.zadd(key8, {
         member1: 1,
         member2: 2,
@@ -526,140 +573,171 @@ export async function transactionTest(
         member4: 4,
         member5: 5,
     });
-    args.push(5);
+    responseData.push(["zadd(key8, { ... } ", 5]);
     baseTransaction.zrank(key8, "member1");
-    args.push(0);
+    responseData.push(['zrank(key8, "member1")', 0]);
 
     if (!(await checkIfServerVersionLessThan("7.2.0"))) {
         baseTransaction.zrankWithScore(key8, "member1");
-        args.push([0, 1]);
+        responseData.push(['zrankWithScore(key8, "member1")', [0, 1]]);
     }
 
     baseTransaction.zrevrank(key8, "member5");
-    args.push(0);
+    responseData.push(['zrevrank(key8, "member5")', 0]);
 
     if (!(await checkIfServerVersionLessThan("7.2.0"))) {
         baseTransaction.zrevrankWithScore(key8, "member5");
-        args.push([0, 5]);
+        responseData.push(['zrevrankWithScore(key8, "member5")', [0, 5]]);
     }
 
     baseTransaction.zaddIncr(key8, "member2", 1);
-    args.push(3);
+    responseData.push(['zaddIncr(key8, "member2", 1)', 3]);
     baseTransaction.zrem(key8, ["member1"]);
-    args.push(1);
+    responseData.push(['zrem(key8, ["member1"])', 1]);
     baseTransaction.zcard(key8);
-    args.push(4);
+    responseData.push(["zcard(key8)", 4]);
+
     baseTransaction.zscore(key8, "member2");
-    args.push(3.0);
+    responseData.push(['zscore(key8, "member2")', 3.0]);
     baseTransaction.zrange(key8, { start: 0, stop: -1 });
-    args.push(["member2", "member3", "member4", "member5"]);
+    responseData.push([
+        "zrange(key8, { start: 0, stop: -1 })",
+        ["member2", "member3", "member4", "member5"],
+    ]);
     baseTransaction.zrangeWithScores(key8, { start: 0, stop: -1 });
-    args.push({ member2: 3, member3: 3.5, member4: 4, member5: 5 });
+    responseData.push([
+        "zrangeWithScores(key8, { start: 0, stop: -1 })",
+        { member2: 3, member3: 3.5, member4: 4, member5: 5 },
+    ]);
     baseTransaction.zadd(key12, { one: 1, two: 2 });
-    args.push(2);
+    responseData.push(["zadd(key12, { one: 1, two: 2 })", 2]);
     baseTransaction.zadd(key13, { one: 1, two: 2, three: 3.5 });
-    args.push(3);
+    responseData.push(["zadd(key13, { one: 1, two: 2, three: 3.5 })", 3]);
 
     if (!(await checkIfServerVersionLessThan("6.2.0"))) {
         baseTransaction.zdiff([key13, key12]);
-        args.push(["three"]);
+        responseData.push(["zdiff([key13, key12])", ["three"]]);
         baseTransaction.zdiffWithScores([key13, key12]);
-        args.push({ three: 3.5 });
+        responseData.push(["zdiffWithScores([key13, key12])", { three: 3.5 }]);
         baseTransaction.zdiffstore(key13, [key13, key13]);
-        args.push(0);
+        responseData.push(["zdiffstore(key13, [key13, key13])", 0]);
         baseTransaction.zmscore(key12, ["two", "one"]);
-        args.push([2.0, 1.0]);
+        responseData.push(['zmscore(key12, ["two", "one"]', [2.0, 1.0]]);
+        baseTransaction.zinterstore(key12, [key12, key13]);
+        responseData.push(["zinterstore(key12, [key12, key13])", 0]);
+    } else {
+        baseTransaction.zinterstore(key12, [key12, key13]);
+        responseData.push(["zinterstore(key12, [key12, key13])", 2]);
     }
 
-    baseTransaction.zinterstore(key12, [key12, key13]);
-    args.push(2);
     baseTransaction.zcount(key8, { value: 2 }, "positiveInfinity");
-    args.push(4);
+    responseData.push(['zcount(key8, { value: 2 }, "positiveInfinity")', 4]);
     baseTransaction.zpopmin(key8);
-    args.push({ member2: 3.0 });
+    responseData.push(["zpopmin(key8)", { member2: 3.0 }]);
     baseTransaction.zpopmax(key8);
-    args.push({ member5: 5 });
+    responseData.push(["zpopmax(key8)", { member5: 5 }]);
     baseTransaction.zremRangeByRank(key8, 1, 1);
-    args.push(1);
+    responseData.push(["zremRangeByRank(key8, 1, 1)", 1]);
     baseTransaction.zremRangeByScore(
         key8,
         "negativeInfinity",
         "positiveInfinity",
     );
-    args.push(1); // key8 is now empty
+    responseData.push(["zremRangeByScore(key8, -Inf, +Inf)", 1]); // key8 is now empty
 
     if (!(await checkIfServerVersionLessThan("7.0.0"))) {
         baseTransaction.zadd(key14, { one: 1.0, two: 2.0 });
-        args.push(2);
+        responseData.push(["zadd(key14, { one: 1.0, two: 2.0 })", 2]);
         baseTransaction.zintercard([key8, key14]);
-        args.push(0);
+        responseData.push(["zintercard([key8, key14])", 0]);
         baseTransaction.zintercard([key8, key14], 1);
-        args.push(0);
+        responseData.push(["zintercard([key8, key14], 1)", 0]);
         baseTransaction.zmpop([key14], ScoreFilter.MAX);
-        args.push([key14, { two: 2.0 }]);
+        responseData.push(["zmpop([key14], MAX)", [key14, { two: 2.0 }]]);
         baseTransaction.zmpop([key14], ScoreFilter.MAX, 1);
-        args.push([key14, { one: 1.0 }]);
+        responseData.push(["zmpop([key14], MAX, 1)", [key14, { one: 1.0 }]]);
     }
 
     baseTransaction.xadd(key9, [["field", "value1"]], { id: "0-1" });
-    args.push("0-1");
+    responseData.push([
+        'xadd(key9, [["field", "value1"]], { id: "0-1" })',
+        "0-1",
+    ]);
     baseTransaction.xadd(key9, [["field", "value2"]], { id: "0-2" });
-    args.push("0-2");
+    responseData.push([
+        'xadd(key9, [["field", "value2"]], { id: "0-2" })',
+        "0-2",
+    ]);
     baseTransaction.xadd(key9, [["field", "value3"]], { id: "0-3" });
-    args.push("0-3");
+    responseData.push([
+        'xadd(key9, [["field", "value3"]], { id: "0-3" })',
+        "0-3",
+    ]);
     baseTransaction.xlen(key9);
-    args.push(3);
+    responseData.push(["xlen(key9)", 3]);
     baseTransaction.xread({ [key9]: "0-1" });
-    args.push({
-        [key9]: {
-            "0-2": [["field", "value2"]],
-            "0-3": [["field", "value3"]],
+    responseData.push([
+        'xread({ [key9]: "0-1" })',
+        {
+            [key9]: {
+                "0-2": [["field", "value2"]],
+                "0-3": [["field", "value3"]],
+            },
         },
-    });
+    ]);
     baseTransaction.xtrim(key9, {
         method: "minid",
         threshold: "0-2",
         exact: true,
     });
-    args.push(1);
+    responseData.push([
+        'xtrim(key9, { method: "minid", threshold: "0-2", exact: true }',
+        1,
+    ]);
     baseTransaction.rename(key9, key10);
-    args.push("OK");
+    responseData.push(["rename(key9, key10)", "OK"]);
     baseTransaction.exists([key10]);
-    args.push(1);
+    responseData.push(["exists([key10])", 1]);
     baseTransaction.renamenx(key10, key9);
-    args.push(true);
+    responseData.push(["renamenx(key10, key9)", true]);
     baseTransaction.exists([key9, key10]);
-    args.push(1);
+    responseData.push(["exists([key9, key10])", 1]);
     baseTransaction.rpush(key6, [field + "1", field + "2", field + "3"]);
-    args.push(3);
+    responseData.push([
+        'rpush(key6, [field + "1", field + "2", field + "3"])',
+        3,
+    ]);
     baseTransaction.brpop([key6], 0.1);
-    args.push([key6, field + "3"]);
+    responseData.push(["brpop([key6], 0.1)", [key6, field + "3"]]);
     baseTransaction.blpop([key6], 0.1);
-    args.push([key6, field + "1"]);
+    responseData.push(["blpop([key6], 0.1)", [key6, field + "1"]]);
 
     baseTransaction.setbit(key17, 1, 1);
-    args.push(0);
+    responseData.push(["setbit(key17, 1, 1)", 0]);
     baseTransaction.getbit(key17, 1);
-    args.push(1);
+    responseData.push(["getbit(key17, 1)", 1]);
     baseTransaction.set(key17, "foobar");
-    args.push("OK");
+    responseData.push(['set(key17, "foobar")', "OK"]);
     baseTransaction.bitcount(key17);
-    args.push(26);
+    responseData.push(["bitcount(key17)", 26]);
     baseTransaction.bitcount(key17, new BitOffsetOptions(1, 1));
-    args.push(6);
+    responseData.push(["bitcount(key17, new BitOffsetOptions(1, 1))", 6]);
 
     if (!(await checkIfServerVersionLessThan("7.0.0"))) {
         baseTransaction.bitcount(
             key17,
             new BitOffsetOptions(5, 30, BitmapIndexType.BIT),
         );
-        args.push(17);
+        responseData.push([
+            "bitcount(key17, new BitOffsetOptions(5, 30, BitmapIndexType.BIT))",
+            17,
+        ]);
     }
 
     baseTransaction.pfadd(key11, ["a", "b", "c"]);
-    args.push(1);
+    responseData.push(['pfadd(key11, ["a", "b", "c"])', 1]);
     baseTransaction.pfcount([key11]);
-    args.push(3);
+    responseData.push(["pfcount([key11])", 3]);
     baseTransaction.geoadd(
         key18,
         new Map([
@@ -667,18 +745,27 @@ export async function transactionTest(
             ["Catania", new GeospatialData(15.087269, 37.502669)],
         ]),
     );
-    args.push(2);
+    responseData.push(["geoadd(key18, { Palermo: ..., Catania: ... })", 2]);
     baseTransaction.geopos(key18, ["Palermo", "Catania"]);
-    args.push([
-        [13.36138933897018433, 38.11555639549629859],
-        [15.08726745843887329, 37.50266842333162032],
+    responseData.push([
+        'geopos(key18, ["Palermo", "Catania"])',
+        [
+            [13.36138933897018433, 38.11555639549629859],
+            [15.08726745843887329, 37.50266842333162032],
+        ],
     ]);
     baseTransaction.geodist(key18, "Palermo", "Catania");
-    args.push(166274.1516);
+    responseData.push(['geodist(key18, "Palermo", "Catania")', 166274.1516]);
     baseTransaction.geodist(key18, "Palermo", "Catania", GeoUnit.KILOMETERS);
-    args.push(166.2742);
+    responseData.push([
+        'geodist(key18, "Palermo", "Catania", GeoUnit.KILOMETERS)',
+        166.2742,
+    ]);
     baseTransaction.geohash(key18, ["Palermo", "Catania", "NonExisting"]);
-    args.push(["sqc8b49rny0", "sqdtr74hyu0", null]);
+    responseData.push([
+        'geohash(key18, ["Palermo", "Catania", "NonExisting"])',
+        ["sqc8b49rny0", "sqdtr74hyu0", null],
+    ]);
 
     const libName = "mylib1C" + uuidv4().replaceAll("-", "");
     const funcName = "myfunc1c" + uuidv4().replaceAll("-", "");
@@ -690,18 +777,18 @@ export async function transactionTest(
 
     if (!(await checkIfServerVersionLessThan("7.0.0"))) {
         baseTransaction.functionLoad(code);
-        args.push(libName);
+        responseData.push(["functionLoad(code)", libName]);
         baseTransaction.functionLoad(code, true);
-        args.push(libName);
+        responseData.push(["functionLoad(code, true)", libName]);
         baseTransaction.functionDelete(libName);
-        args.push("OK");
+        responseData.push(["functionDelete(libName)", "OK"]);
         baseTransaction.functionFlush();
-        args.push("OK");
+        responseData.push(["functionFlush()", "OK"]);
         baseTransaction.functionFlush(FlushMode.ASYNC);
-        args.push("OK");
+        responseData.push(["functionFlush(FlushMode.ASYNC)", "OK"]);
         baseTransaction.functionFlush(FlushMode.SYNC);
-        args.push("OK");
+        responseData.push(["functionFlush(FlushMode.SYNC)", "OK"]);
     }
 
-    return args;
+    return responseData;
 }


### PR DESCRIPTION
Make failure of transaction IT readable. Also fix checking numbers in the transaction response (they were just ignored).

Failure before: https://github.com/valkey-io/valkey-glide/actions/runs/10069186874/job/27835788398?pr=2007#step:5:25100
```
  ● GlideClient › can send transactions_1

    expect(received).toEqual(expected) // deep equality

    Expected: "OKOKOKOK0.00OKbarOKembstrstring03184ec2-47a1-4617-9415-a9122ed3610cnullbarbazOKbarbaz3.001.001.001.0003184ec2-47a1-4617-9415-a9122ed3610c03184ec2-47a1-4617-9415-a9122ed3610c1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b03184ec2-47a1-4617-9415-a9122ed3610c1.00null4.001367dc0b-fa35-4902-8e8a-ac9cb4b05b8b43.001.00OKOK1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b31367dc0b-fa35-4902-8e8a-ac9cb4b05b8b21367dc0b-fa35-4902-8e8a-ac9cb4b05b8b31367dc0b-fa35-4902-8e8a-ac9cb4b05b8b20.003.001367dc0b-fa35-4902-8e8a-ac9cb4b05b8b11367dc0b-fa35-4902-8e8a-ac9cb4b05b8b31367dc0b-fa35-4902-8e8a-ac9cb4b05b8b21367dc0b-fa35-4902-8e8a-ac9cb4b05b8b10.000.005.001.001.002.002.00barfoobarfoo2.001.002.002.001.001.00barbar0.005.000.000.001.000.000.005.003.001.004.003.00member2member3member4member5member23.00member33.50member44.00member55.002.003.00threethree3.500.002.001.002.004.00member23.00member55.001.001.002.000.000.00{key}362226fb-2335-40d3-b311-4a3ee3e2c435two2.00{key}362226fb-2335-40d3-b311-4a3ee3e2c435one1.000-10-20-33.00{key}17589b48-bb5f-4ae0-82b5-929169f6698a0-2fieldvalue20-3fieldvalue31.00OK1.001.003.00{key}9de9af26-5907-44c3-bf3b-5ba94f78b8ac1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b3{key}9de9af26-5907-44c3-bf3b-5ba94f78b8ac1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b10.001.00OK26.06.0017.01.003.002.0013.438.115.137.51.66e+5166sqc8b49rny0sqdtr74hyu0nullPalermoCataniaPalermoCataniaPalermo0.003.48e+1513.438.1Catania1663.48e+1515.137.5Catania56.43.48e+1515.137.5Palermo1903.48e+1513.438.1mylib1C461cfa718d9a4089b56e47e593c4b3b0mylib1C461cfa718d9a4089b56e47e593c4b3b0OKOKOKOKOK"
    Received: "OKOKOKOK0.00OKbarOKembstrstring03184ec2-47a1-4617-9415-a9122ed3610cnullbarbazOKbarbaz3.001.001.001.0003184ec2-47a1-4617-9415-a9122ed3610c03184ec2-47a1-4617-9415-a9122ed3610c1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b03184ec2-47a1-4617-9415-a9122ed3610c1.00null4.001367dc0b-fa35-4902-8e8a-ac9cb4b05b8b43.001.00OKOK1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b31367dc0b-fa35-4902-8e8a-ac9cb4b05b8b21367dc0b-fa35-4902-8e8a-ac9cb4b05b8b31367dc0b-fa35-4902-8e8a-ac9cb4b05b8b20.003.001367dc0b-fa35-4902-8e8a-ac9cb4b05b8b11367dc0b-fa35-4902-8e8a-ac9cb4b05b8b31367dc0b-fa35-4902-8e8a-ac9cb4b05b8b21367dc0b-fa35-4902-8e8a-ac9cb4b05b8b10.000.005.001.001.002.002.00barfoobarfoo2.001.002.002.001.001.00barbar0.005.000.000.001.000.000.005.003.001.004.003.00member2member3member4member5member23.00member33.50member44.00member55.002.003.00threethree3.500.002.001.000.004.00member23.00member55.001.001.002.000.000.00{key}362226fb-2335-40d3-b311-4a3ee3e2c435two2.00{key}362226fb-2335-40d3-b311-4a3ee3e2c435one1.000-10-20-33.00{key}17589b48-bb5f-4ae0-82b5-929169f6698a0-2fieldvalue20-3fieldvalue31.00OK1.001.003.00{key}9de9af26-5907-44c3-bf3b-5ba94f78b8ac1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b3{key}9de9af26-5907-44c3-bf3b-5ba94f78b8ac1367dc0b-fa35-4902-8e8a-ac9cb4b05b8b10.001.00OK26.06.0017.01.003.002.0013.438.115.137.51.66e+5166sqc8b49rny0sqdtr74hyu0nullPalermoCataniaPalermoCataniaPalermo0.003.48e+1513.438.1Catania1663.48e+1515.137.5Catania56.43.48e+1515.137.5Palermo1903.48e+1513.438.1mylib1C461cfa718d9a4089b56e47e593c4b3b0mylib1C461cfa718d9a4089b56e47e593c4b3b0OKOKOKOKOK"

      169 |             const result = await client.exec(transaction);
      170 |             expectedRes.push("OK");
    > 171 |             expect(intoString(result)).toEqual(intoString(expectedRes));
          |                                        ^
      172 |         },
      173 |     );
      174 |

      at tests/RedisClient.test.ts:171:40
      at fulfilled (tests/RedisClient.test.ts:8:58)
          at runMicrotasks (<anonymous>)

```

Failure now:
```
  ● GlideClusterClient › can send transactions_0

    Checks failed in transaction response:
    zdiff([key13, key12]) failed, expected <["three"]>, actual <[]>
    zdiffWithScores([key13, key12]) failed, expected <{"three":3.5}>, actual <{}>

      357 |     }
      358 |     if (failedChecks.length > 0) {
    > 359 |         throw new Error("Checks failed in transaction response:\n" + failedChecks.join("\n"));
          |               ^
      360 |     }
      361 | }
      362 |

      at validateTransactionResponse (tests/TestUtilities.ts:359:15)
      at tests/RedisClusterClient.test.ts:247:40
      at fulfilled (tests/RedisClusterClient.test.ts:8:58)
```
![image](https://github.com/user-attachments/assets/0d50917c-b19d-4a88-9e76-f125b3a817f9)
