### PR TITLE
Node: increase ubuntu wokflow run time

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -53,7 +53,7 @@ jobs:
     test-ubuntu-latest:
         runs-on: ubuntu-latest
         needs: load-engine-matrix
-        timeout-minutes: 15
+        timeout-minutes: 25
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
due to failure https://github.com/valkey-io/valkey-glide/actions/runs/10076781196/job/27857892422