### PR TITLE
Add rust lint config for unknown cfgs.

### DIFF
--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 glide-core = { path = ".", features = ["socket-layer"] } # always enable this feature in tests.
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(standalone_heartbeat)']
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(standalone_heartbeat)'] }
 
 [build-dependencies]
 protobuf-codegen = "3"

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -45,6 +45,8 @@ iai-callgrind = "0.9"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 glide-core = { path = ".", features = ["socket-layer"] } # always enable this feature in tests.
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(standalone_heartbeat)']
 
 [build-dependencies]
 protobuf-codegen = "3"

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -193,7 +193,7 @@ impl RedisServer {
                 // prepare redis with TLS
                 redis_cmd
                     .arg("--tls-port")
-                    .arg(&port.to_string())
+                    .arg(port.to_string())
                     .arg("--port")
                     .arg("0")
                     .arg("--tls-cert-file")

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -22,3 +22,6 @@ bytes = { version = "1.6.0" }
 [profile.release]
 lto = true
 debug = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ffi_test)'] }


### PR DESCRIPTION
Yesterday new version of rust was released (1.80) which switches `unexpected_cfgs` lint to `warn` mode by default.

Even without rust code changes, CI started to fail:
https://github.com/valkey-io/valkey-glide/actions/runs/10098572063/job/27925904384?pr=2007
<details>
<summary>Error message</summary>

```
error: unexpected `cfg` condition name: `ffi_test`
  --> src/lib.rs:28:7
   |
28 | #[cfg(ffi_test)]
   |       ^^^^^^^^
   |
   = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ffi_test)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(ffi_test)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

</details>

[Rust blog post](https://blog.rust-lang.org/2024/05/06/check-cfg.html), [docs](https://doc.rust-lang.org/nightly/rustc/check-cfg.html), [more docs](https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table)