### PR TITLE
Merge from redis-rs and fixes for rust 1.80.0 

### DIFF
--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -30,6 +30,7 @@ nanoid = "0.4.0"
 
 [features]
 socket-layer = ["directories", "integer-encoding", "num_cpus", "protobuf", "tokio-util"]
+standalone_heartbeat = []
 
 [dev-dependencies]
 rsevents = "0.3.1"

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -6,7 +6,7 @@ use super::reconnecting_connection::ReconnectingConnection;
 use super::{ConnectionRequest, NodeAddress, TlsMode};
 use crate::retry_strategies::RetryStrategy;
 use futures::{future, stream, StreamExt};
-#[cfg(standalone_heartbeat)]
+#[cfg(feature = "standalone_heartbeat")]
 use logger_core::log_debug;
 use logger_core::log_warn;
 use rand::Rng;
@@ -15,7 +15,7 @@ use redis::{PushInfo, RedisError, RedisResult, Value};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-#[cfg(standalone_heartbeat)]
+#[cfg(feature = "standalone_heartbeat")]
 use tokio::task;
 
 #[derive(Debug)]
@@ -185,7 +185,7 @@ impl StandaloneClient {
         }
         let read_from = get_read_from(connection_request.read_from);
 
-        #[cfg(standalone_heartbeat)]
+        #[cfg(feature = "standalone_heartbeat")]
         for node in nodes.iter() {
             Self::start_heartbeat(node.clone());
         }
@@ -363,7 +363,7 @@ impl StandaloneClient {
         }
     }
 
-    #[cfg(standalone_heartbeat)]
+    #[cfg(feature = "standalone_heartbeat")]
     fn start_heartbeat(reconnecting_connection: ReconnectingConnection) {
         task::spawn(async move {
             loop {

--- a/glide-core/tests/test_standalone_client.rs
+++ b/glide-core/tests/test_standalone_client.rs
@@ -5,9 +5,8 @@ mod utilities;
 
 #[cfg(test)]
 mod standalone_client_tests {
-    use std::collections::HashMap;
-
     use crate::utilities::mocks::{Mock, ServerMock};
+    use std::collections::HashMap;
 
     use super::*;
     use glide_core::{
@@ -59,12 +58,12 @@ mod standalone_client_tests {
     #[rstest]
     #[serial_test::serial]
     #[timeout(LONG_STANDALONE_TEST_TIMEOUT)]
-    #[cfg(standalone_heartbeat)]
+    #[cfg(feature = "standalone_heartbeat")]
     fn test_detect_disconnect_and_reconnect_using_heartbeat(#[values(false, true)] use_tls: bool) {
         let (sender, receiver) = tokio::sync::oneshot::channel();
         block_on_all(async move {
             let mut test_basics = setup_test_basics(use_tls).await;
-            let server = test_basics.server;
+            let server = test_basics.server.expect("Server shouldn't be None");
             let address = server.get_client_addr();
             drop(server);
 
@@ -79,7 +78,7 @@ mod standalone_client_tests {
 
             let _new_server = receiver.await;
             tokio::time::sleep(
-                glide_core::client::HEARTBEAT_SLEEP_DURATION + Duration::from_secs(1),
+                glide_core::client::HEARTBEAT_SLEEP_DURATION + std::time::Duration::from_secs(1),
             )
             .await;
 

--- a/logger_core/Cargo.toml
+++ b/logger_core/Cargo.toml
@@ -13,7 +13,7 @@ test-env-helpers = "0.2.2"
 
 [dependencies]
 tracing = "0.1"
-tracing-appender = "0.2.2"
+tracing-appender = { version = "0.2.3", default-features = false }
 once_cell = "1.16.0"
 file-rotate = "0.7.1"
 tracing-subscriber = "0.3.17"


### PR DESCRIPTION
[Fixes for rust 1.80.0](https://github.com/valkey-io/valkey-glide/commit/102775283dc6601cb98b0aa871558877b944d807):
Including: 
- Removed default features from tracing-appender that has `time` dependency hardcoded with old version, causing to this build error: https://github.com/rust-lang/rust/issues/127343#issuecomment-2218261296
- Lint: Fixed unexpected config for the standalone_heartbeat feature https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/builtin/static.UNEXPECTED_CFGS.html

[Merge from upstream redis-rs](https://github.com/valkey-io/valkey-glide/commit/d58129dd04be8a3e2019b14ba4330d74d340e569):
Including: 
- Removed IP constrains
- Changed non-key based commands not to be routed to a random node
- Rust 1.80.0 linter fixes
