### PR TITLE
Node: add minimal binary support

### DIFF
--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -160,19 +160,33 @@ pub fn init(level: Option<Level>, file_name: Option<&str>) -> Level {
     logger_level.into()
 }
 
-fn redis_value_to_js(val: Value, js_env: Env) -> Result<JsUnknown> {
+fn redis_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<JsUnknown> {
     match val {
         Value::Nil => js_env.get_null().map(|val| val.into_unknown()),
-        Value::SimpleString(str) => Ok(js_env
-            .create_buffer_with_data(str.as_bytes().to_vec())?
-            .into_unknown()),
+        Value::SimpleString(str) => {
+            if string_decoder {
+                Ok(js_env.create_string_from_std(str)
+                .map(|val| val.into_unknown())?)
+            } else {
+                Ok(js_env
+                .create_buffer_with_data(str.as_bytes().to_vec())?
+                .into_unknown())
+            }
+        },
         Value::Okay => js_env.create_string("OK").map(|val| val.into_unknown()),
         Value::Int(num) => js_env.create_int64(num).map(|val| val.into_unknown()),
-        Value::BulkString(data) => Ok(js_env.create_buffer_with_data(data)?.into_unknown()),
+         Value::BulkString(data) => {
+            if string_decoder {
+                let str = to_js_result(std::str::from_utf8(data.as_ref()))?;
+                Ok(js_env.create_string(str).map(|val| val.into_unknown())?)
+            } else {
+                Ok(js_env.create_buffer_with_data(data)?.into_unknown())
+            }
+        }
         Value::Array(array) => {
             let mut js_array_view = js_env.create_array_with_length(array.len())?;
             for (index, item) in array.into_iter().enumerate() {
-                js_array_view.set_element(index as u32, redis_value_to_js(item, js_env)?)?;
+                js_array_view.set_element(index as u32, redis_value_to_js(item, js_env, string_decoder)?)?;
             }
             Ok(js_array_view.into_unknown())
         }
@@ -180,7 +194,7 @@ fn redis_value_to_js(val: Value, js_env: Env) -> Result<JsUnknown> {
             let mut obj = js_env.create_object()?;
             for (key, value) in map {
                 let field_name = String::from_owned_redis_value(key).map_err(to_js_error)?;
-                let value = redis_value_to_js(value, js_env)?;
+                let value = redis_value_to_js(value, js_env, string_decoder)?;
                 obj.set_named_property(&field_name, value)?;
             }
             Ok(obj.into_unknown())
@@ -192,10 +206,16 @@ fn redis_value_to_js(val: Value, js_env: Env) -> Result<JsUnknown> {
         // "type and the String type, and return a string in both cases.""
         // https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md
         Value::VerbatimString { format: _, text } => {
-            // VerbatimString is binary safe -> convert it into such
-            Ok(js_env
-                .create_buffer_with_data(text.as_bytes().to_vec())?
-                .into_unknown())
+            if string_decoder {
+                Ok(js_env
+                    .create_string_from_std(text)
+                    .map(|val| val.into_unknown())?)
+            } else {
+                // VerbatimString is binary safe -> convert it into such
+                Ok(js_env
+                    .create_buffer_with_data(text.as_bytes().to_vec())?
+                    .into_unknown())
+            }
         }
         Value::BigNumber(num) => {
             let sign = num.is_negative();
@@ -208,16 +228,16 @@ fn redis_value_to_js(val: Value, js_env: Env) -> Result<JsUnknown> {
             // TODO - return a set object instead of an array object
             let mut js_array_view = js_env.create_array_with_length(array.len())?;
             for (index, item) in array.into_iter().enumerate() {
-                js_array_view.set_element(index as u32, redis_value_to_js(item, js_env)?)?;
+                js_array_view.set_element(index as u32, redis_value_to_js(item, js_env, string_decoder)?)?;
             }
             Ok(js_array_view.into_unknown())
         }
         Value::Attribute { data, attributes } => {
             let mut obj = js_env.create_object()?;
-            let value = redis_value_to_js(*data, js_env)?;
+            let value = redis_value_to_js(*data, js_env, string_decoder)?;
             obj.set_named_property("value", value)?;
 
-            let value = redis_value_to_js(Value::Map(attributes), js_env)?;
+            let value = redis_value_to_js(Value::Map(attributes), js_env, string_decoder)?;
             obj.set_named_property("attributes", value)?;
 
             Ok(obj.into_unknown())
@@ -227,7 +247,7 @@ fn redis_value_to_js(val: Value, js_env: Env) -> Result<JsUnknown> {
             obj.set_named_property("kind", format!("{kind:?}"))?;
             let js_array_view = data
                 .into_iter()
-                .map(|item| redis_value_to_js(item, js_env))
+                .map(|item| redis_value_to_js(item, js_env, string_decoder))
                 .collect::<Result<Vec<_>, _>>()?;
             obj.set_named_property("values", js_array_view)?;
             Ok(obj.into_unknown())
@@ -238,7 +258,7 @@ fn redis_value_to_js(val: Value, js_env: Env) -> Result<JsUnknown> {
 #[napi(
     ts_return_type = "null | string | Uint8Array | number | {} | Boolean | BigInt | Set<any> | any[]"
 )]
-pub fn value_from_split_pointer(js_env: Env, high_bits: u32, low_bits: u32) -> Result<JsUnknown> {
+pub fn value_from_split_pointer(js_env: Env, high_bits: u32, low_bits: u32, string_decoder: bool) -> Result<JsUnknown> {
     let mut bytes = [0_u8; 8];
     (&mut bytes[..4])
         .write_u32::<LittleEndian>(low_bits)
@@ -248,7 +268,7 @@ pub fn value_from_split_pointer(js_env: Env, high_bits: u32, low_bits: u32) -> R
         .unwrap();
     let pointer = u64::from_le_bytes(bytes);
     let value = unsafe { Box::from_raw(pointer as *mut Value) };
-    redis_value_to_js(*value, js_env)
+    redis_value_to_js(*value, js_env, string_decoder)
 }
 
 // Pointers are split because JS cannot represent a full usize using its `number` object.

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -165,17 +165,18 @@ fn redis_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<Js
         Value::Nil => js_env.get_null().map(|val| val.into_unknown()),
         Value::SimpleString(str) => {
             if string_decoder {
-                Ok(js_env.create_string_from_std(str)
-                .map(|val| val.into_unknown())?)
+                Ok(js_env
+                    .create_string_from_std(str)
+                    .map(|val| val.into_unknown())?)
             } else {
                 Ok(js_env
-                .create_buffer_with_data(str.as_bytes().to_vec())?
-                .into_unknown())
+                    .create_buffer_with_data(str.as_bytes().to_vec())?
+                    .into_unknown())
             }
-        },
+        }
         Value::Okay => js_env.create_string("OK").map(|val| val.into_unknown()),
         Value::Int(num) => js_env.create_int64(num).map(|val| val.into_unknown()),
-         Value::BulkString(data) => {
+        Value::BulkString(data) => {
             if string_decoder {
                 let str = to_js_result(std::str::from_utf8(data.as_ref()))?;
                 Ok(js_env.create_string(str).map(|val| val.into_unknown())?)
@@ -186,7 +187,10 @@ fn redis_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<Js
         Value::Array(array) => {
             let mut js_array_view = js_env.create_array_with_length(array.len())?;
             for (index, item) in array.into_iter().enumerate() {
-                js_array_view.set_element(index as u32, redis_value_to_js(item, js_env, string_decoder)?)?;
+                js_array_view.set_element(
+                    index as u32,
+                    redis_value_to_js(item, js_env, string_decoder)?,
+                )?;
             }
             Ok(js_array_view.into_unknown())
         }
@@ -228,7 +232,10 @@ fn redis_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<Js
             // TODO - return a set object instead of an array object
             let mut js_array_view = js_env.create_array_with_length(array.len())?;
             for (index, item) in array.into_iter().enumerate() {
-                js_array_view.set_element(index as u32, redis_value_to_js(item, js_env, string_decoder)?)?;
+                js_array_view.set_element(
+                    index as u32,
+                    redis_value_to_js(item, js_env, string_decoder)?,
+                )?;
             }
             Ok(js_array_view.into_unknown())
         }
@@ -258,7 +265,12 @@ fn redis_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<Js
 #[napi(
     ts_return_type = "null | string | Uint8Array | number | {} | Boolean | BigInt | Set<any> | any[]"
 )]
-pub fn value_from_split_pointer(js_env: Env, high_bits: u32, low_bits: u32, string_decoder: bool) -> Result<JsUnknown> {
+pub fn value_from_split_pointer(
+    js_env: Env,
+    high_bits: u32,
+    low_bits: u32,
+    string_decoder: bool,
+) -> Result<JsUnknown> {
     let mut bytes = [0_u8; 8];
     (&mut bytes[..4])
         .write_u32::<LittleEndian>(low_bits)

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -441,8 +441,10 @@ export class BaseClient {
             const pointer = message.respPointer;
 
             if (typeof pointer === "number") {
+                // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/1953
                 resolve(valueFromSplitPointer(0, pointer, true));
             } else {
+                // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/1953
                 resolve(valueFromSplitPointer(pointer.high, pointer.low, true));
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -709,12 +709,14 @@ export class BaseClient {
                 nextPushNotificationValue = valueFromSplitPointer(
                     responsePointer.high,
                     responsePointer.low,
+                    // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/2052
                     true,
                 ) as Record<string, unknown>;
             } else {
                 nextPushNotificationValue = valueFromSplitPointer(
                     0,
                     responsePointer,
+                    // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/2052
                     true,
                 ) as Record<string, unknown>;
             }

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -441,9 +441,9 @@ export class BaseClient {
             const pointer = message.respPointer;
 
             if (typeof pointer === "number") {
-                resolve(valueFromSplitPointer(0, pointer));
+                resolve(valueFromSplitPointer(0, pointer, true));
             } else {
-                resolve(valueFromSplitPointer(pointer.high, pointer.low));
+                resolve(valueFromSplitPointer(pointer.high, pointer.low, true));
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {
             resolve("OK");
@@ -707,11 +707,13 @@ export class BaseClient {
                 nextPushNotificationValue = valueFromSplitPointer(
                     responsePointer.high,
                     responsePointer.low,
+                    true,
                 ) as Record<string, unknown>;
             } else {
                 nextPushNotificationValue = valueFromSplitPointer(
                     0,
                     responsePointer,
+                    true,
                 ) as Record<string, unknown>;
             }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -441,10 +441,10 @@ export class BaseClient {
             const pointer = message.respPointer;
 
             if (typeof pointer === "number") {
-                // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/1953
+                // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/2052
                 resolve(valueFromSplitPointer(0, pointer, true));
             } else {
-                // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/1953
+                // TODO: change according to https://github.com/valkey-io/valkey-glide/pull/2052
                 resolve(valueFromSplitPointer(pointer.high, pointer.low, true));
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -19,7 +19,6 @@ import { command_request } from "../src/ProtobufMessage";
 import { runBaseTests } from "./SharedTests";
 import {
     checkFunctionListResponse,
-    checkSimple,
     convertStringArrayToBuffer,
     flushAndCloseClient,
     generateLuaLibCode,
@@ -132,23 +131,23 @@ describe("GlideClient", () => {
             client = await GlideClient.createClient(
                 getClientConfigurationOption(cluster.getAddresses(), protocol),
             );
-            checkSimple(await client.select(0)).toEqual("OK");
+            expect(await client.select(0)).toEqual("OK");
 
             const key = uuidv4();
             const value = uuidv4();
             const result = await client.set(key, value);
-            checkSimple(result).toEqual("OK");
+            expect(result).toEqual("OK");
 
-            checkSimple(await client.select(1)).toEqual("OK");
+            expect(await client.select(1)).toEqual("OK");
             expect(await client.get(key)).toEqual(null);
-            checkSimple(await client.flushdb()).toEqual("OK");
+            expect(await client.flushdb()).toEqual("OK");
             expect(await client.dbsize()).toEqual(0);
 
-            checkSimple(await client.select(0)).toEqual("OK");
-            checkSimple(await client.get(key)).toEqual(value);
+            expect(await client.select(0)).toEqual("OK");
+            expect(await client.get(key)).toEqual(value);
 
             expect(await client.dbsize()).toBeGreaterThan(0);
-            checkSimple(await client.flushdb(FlushMode.SYNC)).toEqual("OK");
+            expect(await client.flushdb(FlushMode.SYNC)).toEqual("OK");
             expect(await client.dbsize()).toEqual(0);
         },
     );
@@ -400,7 +399,7 @@ describe("GlideClient", () => {
                 }),
             ).toEqual(true);
             expect(await client.select(index1)).toEqual("OK");
-            checkSimple(await client.get(destination)).toEqual(value1);
+            expect(await client.get(destination)).toEqual(value1);
 
             // new value for source key
             expect(await client.select(index0)).toEqual("OK");
@@ -422,9 +421,9 @@ describe("GlideClient", () => {
 
             // new value only gets copied to DB 2
             expect(await client.select(index1)).toEqual("OK");
-            checkSimple(await client.get(destination)).toEqual(value1);
+            expect(await client.get(destination)).toEqual(value1);
             expect(await client.select(index2)).toEqual("OK");
-            checkSimple(await client.get(destination)).toEqual(value2);
+            expect(await client.get(destination)).toEqual(value2);
 
             // both exists, with REPLACE, when value isn't the same, source always get copied to
             // destination
@@ -436,7 +435,7 @@ describe("GlideClient", () => {
                 }),
             ).toEqual(true);
             expect(await client.select(index1)).toEqual("OK");
-            checkSimple(await client.get(destination)).toEqual(value2);
+            expect(await client.get(destination)).toEqual(value2);
 
             //transaction tests
             const transaction = new Transaction();
@@ -449,7 +448,7 @@ describe("GlideClient", () => {
             transaction.get(destination);
             const results = await client.exec(transaction);
 
-            checkSimple(results).toEqual(["OK", "OK", true, value1]);
+            expect(results).toEqual(["OK", "OK", true, value1]);
 
             client.close();
         },
@@ -475,12 +474,12 @@ describe("GlideClient", () => {
                 );
                 expect(await client.functionList()).toEqual([]);
 
-                checkSimple(await client.functionLoad(code)).toEqual(libName);
+                expect(await client.functionLoad(code)).toEqual(libName);
 
-                checkSimple(
+                expect(
                     await client.fcall(funcName, [], ["one", "two"]),
                 ).toEqual("one");
-                checkSimple(
+                expect(
                     await client.fcallReadonly(funcName, [], ["one", "two"]),
                 ).toEqual("one");
 
@@ -508,9 +507,7 @@ describe("GlideClient", () => {
                 );
 
                 // re-load library with replace
-                checkSimple(await client.functionLoad(code, true)).toEqual(
-                    libName,
-                );
+                expect(await client.functionLoad(code, true)).toEqual(libName);
 
                 // overwrite lib with new code
                 const func2Name = "myfunc2c" + uuidv4().replaceAll("-", "");
@@ -522,7 +519,7 @@ describe("GlideClient", () => {
                     ]),
                     true,
                 );
-                checkSimple(await client.functionLoad(newCode, true)).toEqual(
+                expect(await client.functionLoad(newCode, true)).toEqual(
                     libName,
                 );
 
@@ -544,10 +541,10 @@ describe("GlideClient", () => {
                     newCode,
                 );
 
-                checkSimple(
+                expect(
                     await client.fcall(func2Name, [], ["one", "two"]),
                 ).toEqual(2);
-                checkSimple(
+                expect(
                     await client.fcallReadonly(func2Name, [], ["one", "two"]),
                 ).toEqual(2);
             } finally {
@@ -578,7 +575,7 @@ describe("GlideClient", () => {
                 // verify function does not yet exist
                 expect(await client.functionList()).toEqual([]);
 
-                checkSimple(await client.functionLoad(code)).toEqual(libName);
+                expect(await client.functionLoad(code)).toEqual(libName);
 
                 // Flush functions
                 expect(await client.functionFlush(FlushMode.SYNC)).toEqual(
@@ -592,7 +589,7 @@ describe("GlideClient", () => {
                 expect(await client.functionList()).toEqual([]);
 
                 // Attempt to re-load library without overwriting to ensure FLUSH was effective
-                checkSimple(await client.functionLoad(code)).toEqual(libName);
+                expect(await client.functionLoad(code)).toEqual(libName);
             } finally {
                 expect(await client.functionFlush()).toEqual("OK");
                 client.close();
@@ -620,7 +617,7 @@ describe("GlideClient", () => {
                 // verify function does not yet exist
                 expect(await client.functionList()).toEqual([]);
 
-                checkSimple(await client.functionLoad(code)).toEqual(libName);
+                expect(await client.functionLoad(code)).toEqual(libName);
 
                 // Delete the function
                 expect(await client.functionDelete(libName)).toEqual("OK");

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -2,14 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import {
-    afterAll,
-    afterEach,
-    beforeAll,
-    describe,
-    expect,
-    it,
-} from "@jest/globals";
+import { afterAll, afterEach, beforeAll, describe, it } from "@jest/globals";
 import { gte } from "semver";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -28,7 +21,6 @@ import { runBaseTests } from "./SharedTests";
 import {
     checkClusterResponse,
     checkFunctionListResponse,
-    checkSimple,
     flushAndCloseClient,
     generateLuaLibCode,
     getClientConfigurationOption,
@@ -561,7 +553,7 @@ describe("GlideClusterClient", () => {
             // source exists, destination does not
             expect(await client.set(source, value1)).toEqual("OK");
             expect(await client.copy(source, destination, false)).toEqual(true);
-            checkSimple(await client.get(destination)).toEqual(value1);
+            expect(await client.get(destination)).toEqual(value1);
 
             // new value for source key
             expect(await client.set(source, value2)).toEqual("OK");
@@ -571,11 +563,11 @@ describe("GlideClusterClient", () => {
             expect(await client.copy(source, destination, false)).toEqual(
                 false,
             );
-            checkSimple(await client.get(destination)).toEqual(value1);
+            expect(await client.get(destination)).toEqual(value1);
 
             // both exists, with REPLACE
             expect(await client.copy(source, destination, true)).toEqual(true);
-            checkSimple(await client.get(destination)).toEqual(value2);
+            expect(await client.get(destination)).toEqual(value2);
 
             //transaction tests
             const transaction = new ClusterTransaction();
@@ -584,7 +576,7 @@ describe("GlideClusterClient", () => {
             transaction.get(destination);
             const results = await client.exec(transaction);
 
-            checkSimple(results).toEqual(["OK", true, value1]);
+            expect(results).toEqual(["OK", true, value1]);
 
             client.close();
         },
@@ -598,20 +590,20 @@ describe("GlideClusterClient", () => {
             );
 
             expect(await client.dbsize()).toBeGreaterThanOrEqual(0);
-            checkSimple(await client.set(uuidv4(), uuidv4())).toEqual("OK");
+            expect(await client.set(uuidv4(), uuidv4())).toEqual("OK");
             expect(await client.dbsize()).toBeGreaterThan(0);
 
-            checkSimple(await client.flushall()).toEqual("OK");
+            expect(await client.flushall()).toEqual("OK");
             expect(await client.dbsize()).toEqual(0);
 
-            checkSimple(await client.set(uuidv4(), uuidv4())).toEqual("OK");
+            expect(await client.set(uuidv4(), uuidv4())).toEqual("OK");
             expect(await client.dbsize()).toEqual(1);
-            checkSimple(await client.flushdb(FlushMode.ASYNC)).toEqual("OK");
+            expect(await client.flushdb(FlushMode.ASYNC)).toEqual("OK");
             expect(await client.dbsize()).toEqual(0);
 
-            checkSimple(await client.set(uuidv4(), uuidv4())).toEqual("OK");
+            expect(await client.set(uuidv4(), uuidv4())).toEqual("OK");
             expect(await client.dbsize()).toEqual(1);
-            checkSimple(await client.flushdb(FlushMode.SYNC)).toEqual("OK");
+            expect(await client.flushdb(FlushMode.SYNC)).toEqual("OK");
             expect(await client.dbsize()).toEqual(0);
 
             client.close();
@@ -662,9 +654,9 @@ describe("GlideClusterClient", () => {
                                     (value) => expect(value).toEqual([]),
                                 );
                                 // load the library
-                                checkSimple(
-                                    await client.functionLoad(code),
-                                ).toEqual(libName);
+                                expect(await client.functionLoad(code)).toEqual(
+                                    libName,
+                                );
 
                                 functionList = await client.functionList(
                                     { libNamePattern: libName },
@@ -699,8 +691,7 @@ describe("GlideClusterClient", () => {
                                 checkClusterResponse(
                                     fcall as object,
                                     singleNodeRoute,
-                                    (value) =>
-                                        checkSimple(value).toEqual("one"),
+                                    (value) => expect(value).toEqual("one"),
                                 );
                                 fcall = await client.fcallReadonlyWithRoute(
                                     funcName,
@@ -710,8 +701,7 @@ describe("GlideClusterClient", () => {
                                 checkClusterResponse(
                                     fcall as object,
                                     singleNodeRoute,
-                                    (value) =>
-                                        checkSimple(value).toEqual("one"),
+                                    (value) => expect(value).toEqual("one"),
                                 );
 
                                 // re-load library without replace
@@ -722,7 +712,7 @@ describe("GlideClusterClient", () => {
                                 );
 
                                 // re-load library with replace
-                                checkSimple(
+                                expect(
                                     await client.functionLoad(code, true),
                                 ).toEqual(libName);
 
@@ -737,7 +727,7 @@ describe("GlideClusterClient", () => {
                                     ]),
                                     true,
                                 );
-                                checkSimple(
+                                expect(
                                     await client.functionLoad(newCode, true),
                                 ).toEqual(libName);
 
@@ -850,7 +840,7 @@ describe("GlideClusterClient", () => {
                                 );
 
                                 // load the library
-                                checkSimple(
+                                expect(
                                     await client.functionLoad(
                                         code,
                                         undefined,
@@ -881,7 +871,7 @@ describe("GlideClusterClient", () => {
                                 );
 
                                 // Attempt to re-load library without overwriting to ensure FLUSH was effective
-                                checkSimple(
+                                expect(
                                     await client.functionLoad(
                                         code,
                                         undefined,
@@ -945,7 +935,7 @@ describe("GlideClusterClient", () => {
                                     (value) => expect(value).toEqual([]),
                                 );
                                 // load the library
-                                checkSimple(
+                                expect(
                                     await client.functionLoad(
                                         code,
                                         undefined,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -5702,7 +5702,7 @@ export function runBaseTests<Context>(config: {
                 const randmember = await client.zrandmember(key1);
 
                 if (randmember !== null) {
-                    checkSimple(randmember in elements).toEqual(true);
+                    expect(elements.includes(randmember)).toEqual(true);
                 }
 
                 // non existing key should return null

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -477,6 +477,7 @@ export function runBaseTests<Context>(config: {
             await runTest(async (client: BaseClient) => {
                 const key1 = `{key}-${uuidv4()}`;
                 const key2 = `{key}-${uuidv4()}`;
+                const key3 = `{key}-${uuidv4()}`;
                 const keys = [key1, key2];
                 const destination = `{key}-${uuidv4()}`;
                 const nonExistingKey1 = `{key}-${uuidv4()}`;
@@ -529,14 +530,17 @@ export function runBaseTests<Context>(config: {
                     ]),
                 ).toEqual(1);
                 expect(await client.get(destination)).toEqual("a");
+
+                // Sets to a string (not a space character) with value 11000010 10011110.
+                expect(await client.set(key3, "")).toEqual("OK");
+                expect(await client.getbit(key3, 0)).toEqual(1);
                 expect(
                     await client.bitop(BitwiseOperation.NOT, destination, [
-                        key1,
+                        key3,
                     ]),
-                ).toEqual(1);
-                // First bit is flipped to 1 and throws 'utf-8' codec can't decode byte 0x9e in position 0:
-                // invalid start byte. TODO: discuss this case
-                // expect(intoString(await client.get(destination))).toEqual("�");
+                ).toEqual(2);
+                // Value becomes 00111101 01100001.
+                expect(await client.get(destination)).toEqual("=a");
 
                 expect(await client.setbit(key1, 0, 1)).toEqual(0);
                 expect(

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -45,10 +45,8 @@ import { SingleNodeRoute } from "../build-ts/src/GlideClusterClient";
 import {
     Client,
     GetAndSetRandomValue,
-    checkSimple,
     compareMaps,
     getFirstResult,
-    intoArray,
     intoString,
 } from "./TestUtilities";
 
@@ -100,8 +98,8 @@ export function runBaseTests<Context>(config: {
                 }
 
                 const result = await client.customCommand(["CLIENT", "INFO"]);
-                expect(intoString(result)).toContain("lib-name=GlideJS");
-                expect(intoString(result)).toContain("lib-ver=unknown");
+                expect(result).toContain("lib-name=GlideJS");
+                expect(result).toContain("lib-ver=unknown");
             }, protocol);
         },
         config.timeout,
@@ -156,9 +154,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(
                 async (client: BaseClient) => {
-                    expect(intoString(await client.clientGetName())).toBe(
-                        "TEST_CLIENT",
-                    );
+                    expect(await client.clientGetName()).toBe("TEST_CLIENT");
                 },
                 protocol,
                 "TEST_CLIENT",
@@ -179,9 +175,9 @@ export function runBaseTests<Context>(config: {
                     key,
                     value,
                 ]);
-                checkSimple(setResult).toEqual("OK");
+                expect(setResult).toEqual("OK");
                 const result = await client.customCommand(["GET", key]);
-                checkSimple(result).toEqual(value);
+                expect(result).toEqual(value);
             }, protocol);
         },
         config.timeout,
@@ -202,20 +198,20 @@ export function runBaseTests<Context>(config: {
                     key1,
                     value1,
                 ]);
-                checkSimple(setResult1).toEqual("OK");
+                expect(setResult1).toEqual("OK");
                 const setResult2 = await client.customCommand([
                     "SET",
                     key2,
                     value2,
                 ]);
-                checkSimple(setResult2).toEqual("OK");
+                expect(setResult2).toEqual("OK");
                 const mget_result = await client.customCommand([
                     "MGET",
                     key1,
                     key2,
                     key3,
                 ]);
-                checkSimple(mget_result).toEqual([value1, value2, null]);
+                expect(mget_result).toEqual([value1, value2, null]);
             }, protocol);
         },
         config.timeout,
@@ -258,15 +254,13 @@ export function runBaseTests<Context>(config: {
         `test config rewrite_%p`,
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
-                const serverInfo = intoString(
-                    await client.info([InfoOptions.Server]),
-                );
+                const serverInfo = await client.info([InfoOptions.Server]);
                 const conf_file = parseInfoResponse(
                     getFirstResult(serverInfo).toString(),
                 )["config_file"];
 
                 if (conf_file.length > 0) {
-                    checkSimple(await client.configRewrite()).toEqual("OK");
+                    expect(await client.configRewrite()).toEqual("OK");
                 } else {
                     try {
                         /// We expect Redis to return an error since the test cluster doesn't use redis.conf file
@@ -292,11 +286,9 @@ export function runBaseTests<Context>(config: {
                 const oldResult = await client.info([InfoOptions.Commandstats]);
                 const oldResultAsString = intoString(oldResult);
                 expect(oldResultAsString).toContain("cmdstat_set");
-                checkSimple(await client.configResetStat()).toEqual("OK");
+                expect(await client.configResetStat()).toEqual("OK");
 
-                const result = intoArray(
-                    await client.info([InfoOptions.Commandstats]),
-                );
+                const result = await client.info([InfoOptions.Commandstats]);
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },
@@ -316,8 +308,8 @@ export function runBaseTests<Context>(config: {
                     [key2]: value,
                     [key3]: value,
                 };
-                checkSimple(await client.mset(keyValueList)).toEqual("OK");
-                checkSimple(
+                expect(await client.mset(keyValueList)).toEqual("OK");
+                expect(
                     await client.mget([key1, key2, "nonExistingKey", key3]),
                 ).toEqual([value, value, null, value]);
             }, protocol);
@@ -330,13 +322,13 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "10")).toEqual("OK");
+                expect(await client.set(key, "10")).toEqual("OK");
                 expect(await client.incr(key)).toEqual(11);
-                checkSimple(await client.get(key)).toEqual("11");
-                checkSimple(await client.incrBy(key, 4)).toEqual(15);
-                checkSimple(await client.get(key)).toEqual("15");
-                checkSimple(await client.incrByFloat(key, 1.5)).toEqual(16.5);
-                checkSimple(await client.get(key)).toEqual("16.5");
+                expect(await client.get(key)).toEqual("11");
+                expect(await client.incrBy(key, 4)).toEqual(15);
+                expect(await client.get(key)).toEqual("15");
+                expect(await client.incrByFloat(key, 1.5)).toEqual(16.5);
+                expect(await client.get(key)).toEqual("16.5");
             }, protocol);
         },
         config.timeout,
@@ -351,11 +343,11 @@ export function runBaseTests<Context>(config: {
                 const key3 = uuidv4();
                 /// key1 and key2 does not exist, so it set to 0 before performing the operation.
                 expect(await client.incr(key1)).toEqual(1);
-                checkSimple(await client.get(key1)).toEqual("1");
+                expect(await client.get(key1)).toEqual("1");
                 expect(await client.incrBy(key2, 2)).toEqual(2);
-                checkSimple(await client.get(key2)).toEqual("2");
+                expect(await client.get(key2)).toEqual("2");
                 expect(await client.incrByFloat(key3, -0.5)).toEqual(-0.5);
-                checkSimple(await client.get(key3)).toEqual("-0.5");
+                expect(await client.get(key3)).toEqual("-0.5");
             }, protocol);
         },
         config.timeout,
@@ -366,7 +358,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
 
                 try {
                     expect(await client.incr(key)).toThrow();
@@ -400,8 +392,8 @@ export function runBaseTests<Context>(config: {
         `ping test_%p`,
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
-                checkSimple(await client.ping()).toEqual("PONG");
-                checkSimple(await client.ping("Hello")).toEqual("Hello");
+                expect(await client.ping()).toEqual("PONG");
+                expect(await client.ping("Hello")).toEqual("Hello");
             }, protocol);
         },
         config.timeout,
@@ -424,11 +416,11 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "10")).toEqual("OK");
+                expect(await client.set(key, "10")).toEqual("OK");
                 expect(await client.decr(key)).toEqual(9);
-                checkSimple(await client.get(key)).toEqual("9");
+                expect(await client.get(key)).toEqual("9");
                 expect(await client.decrBy(key, 4)).toEqual(5);
-                checkSimple(await client.get(key)).toEqual("5");
+                expect(await client.get(key)).toEqual("5");
             }, protocol);
         },
         config.timeout,
@@ -443,10 +435,10 @@ export function runBaseTests<Context>(config: {
                 /// key1 and key2 does not exist, so it set to 0 before performing the operation.
                 expect(await client.get(key1)).toBeNull();
                 expect(await client.decr(key1)).toEqual(-1);
-                checkSimple(await client.get(key1)).toEqual("-1");
+                expect(await client.get(key1)).toEqual("-1");
                 expect(await client.get(key2)).toBeNull();
                 expect(await client.decrBy(key2, 3)).toEqual(-3);
-                checkSimple(await client.get(key2)).toEqual("-3");
+                expect(await client.get(key2)).toEqual("-3");
             }, protocol);
         },
         config.timeout,
@@ -499,24 +491,24 @@ export function runBaseTests<Context>(config: {
                 const value1 = "foobar";
                 const value2 = "abcdef";
 
-                checkSimple(await client.set(key1, value1)).toEqual("OK");
-                checkSimple(await client.set(key2, value2)).toEqual("OK");
+                expect(await client.set(key1, value1)).toEqual("OK");
+                expect(await client.set(key2, value2)).toEqual("OK");
                 expect(
                     await client.bitop(BitwiseOperation.AND, destination, keys),
                 ).toEqual(6);
-                checkSimple(await client.get(destination)).toEqual("`bc`ab");
+                expect(await client.get(destination)).toEqual("`bc`ab");
                 expect(
                     await client.bitop(BitwiseOperation.OR, destination, keys),
                 ).toEqual(6);
-                checkSimple(await client.get(destination)).toEqual("goofev");
+                expect(await client.get(destination)).toEqual("goofev");
 
                 // reset values for simplicity of results in XOR
-                checkSimple(await client.set(key1, "a")).toEqual("OK");
-                checkSimple(await client.set(key2, "b")).toEqual("OK");
+                expect(await client.set(key1, "a")).toEqual("OK");
+                expect(await client.set(key2, "b")).toEqual("OK");
                 expect(
                     await client.bitop(BitwiseOperation.XOR, destination, keys),
                 ).toEqual(1);
-                checkSimple(await client.get(destination)).toEqual("\u0003");
+                expect(await client.get(destination)).toEqual("\u0003");
 
                 // test single source key
                 expect(
@@ -524,25 +516,27 @@ export function runBaseTests<Context>(config: {
                         key1,
                     ]),
                 ).toEqual(1);
-                checkSimple(await client.get(destination)).toEqual("a");
+                expect(await client.get(destination)).toEqual("a");
                 expect(
                     await client.bitop(BitwiseOperation.OR, destination, [
                         key1,
                     ]),
                 ).toEqual(1);
-                checkSimple(await client.get(destination)).toEqual("a");
+                expect(await client.get(destination)).toEqual("a");
                 expect(
                     await client.bitop(BitwiseOperation.XOR, destination, [
                         key1,
                     ]),
                 ).toEqual(1);
-                checkSimple(await client.get(destination)).toEqual("a");
+                expect(await client.get(destination)).toEqual("a");
                 expect(
                     await client.bitop(BitwiseOperation.NOT, destination, [
                         key1,
                     ]),
                 ).toEqual(1);
-                checkSimple(await client.get(destination)).toEqual("�");
+                // First bit is flipped to 1 and throws 'utf-8' codec can't decode byte 0x9e in position 0:
+                // invalid start byte. TODO: discuss this case
+                // expect(intoString(await client.get(destination))).toEqual("�");
 
                 expect(await client.setbit(key1, 0, 1)).toEqual(0);
                 expect(
@@ -550,7 +544,7 @@ export function runBaseTests<Context>(config: {
                         key1,
                     ]),
                 ).toEqual(1);
-                checkSimple(await client.get(destination)).toEqual("\u001e");
+                expect(await client.get(destination)).toEqual("\u001e");
 
                 // stores null when all keys hold empty strings
                 expect(
@@ -674,7 +668,7 @@ export function runBaseTests<Context>(config: {
                 const setKey = `{key}-${uuidv4()}`;
                 const value = "?f0obar"; // 00111111 01100110 00110000 01101111 01100010 01100001 01110010
 
-                checkSimple(await client.set(key, value)).toEqual("OK");
+                expect(await client.set(key, value)).toEqual("OK");
                 expect(await client.bitpos(key, 0)).toEqual(0);
                 expect(await client.bitpos(key, 1)).toEqual(2);
                 expect(await client.bitpos(key, 1, 1)).toEqual(9);
@@ -1075,15 +1069,15 @@ export function runBaseTests<Context>(config: {
                 const prevTimeout = (await client.configGet([
                     "timeout",
                 ])) as Record<string, string>;
-                checkSimple(
-                    await client.configSet({ timeout: "1000" }),
-                ).toEqual("OK");
+                expect(await client.configSet({ timeout: "1000" })).toEqual(
+                    "OK",
+                );
                 const currTimeout = (await client.configGet([
                     "timeout",
                 ])) as Record<string, string>;
-                checkSimple(currTimeout).toEqual({ timeout: "1000" });
+                expect(currTimeout).toEqual({ timeout: "1000" });
                 /// Revert to the pervious configuration
-                checkSimple(
+                expect(
                     await client.configSet({
                         timeout: prevTimeout["timeout"],
                     }),
@@ -1102,7 +1096,7 @@ export function runBaseTests<Context>(config: {
                 const key2 = uuidv4();
 
                 expect(await client.set(key1, value1)).toEqual("OK");
-                checkSimple(await client.getdel(key1)).toEqual(value1);
+                expect(await client.getdel(key1)).toEqual(value1);
                 expect(await client.getdel(key1)).toEqual(null);
 
                 // key isn't a string
@@ -1126,8 +1120,8 @@ export function runBaseTests<Context>(config: {
                     [field2]: value,
                 };
                 expect(await client.hset(key, fieldValueMap)).toEqual(2);
-                checkSimple(await client.hget(key, field1)).toEqual(value);
-                checkSimple(await client.hget(key, field2)).toEqual(value);
+                expect(await client.hget(key, field1)).toEqual(value);
+                expect(await client.hget(key, field2)).toEqual(value);
                 expect(await client.hget(key, "nonExistingField")).toEqual(
                     null,
                 );
@@ -1175,7 +1169,7 @@ export function runBaseTests<Context>(config: {
                     [field2]: value,
                 };
                 expect(await client.hset(key, fieldValueMap)).toEqual(2);
-                checkSimple(
+                expect(
                     await client.hmget(key, [
                         field1,
                         "nonExistingField",
@@ -1228,12 +1222,10 @@ export function runBaseTests<Context>(config: {
                 };
                 expect(await client.hset(key, fieldValueMap)).toEqual(2);
 
-                expect(intoString(await client.hgetall(key))).toEqual(
-                    intoString({
-                        [field1]: value,
-                        [field2]: value,
-                    }),
-                );
+                expect(await client.hgetall(key)).toEqual({
+                    [field1]: value,
+                    [field2]: value,
+                });
 
                 expect(await client.hgetall("nonExistingKey")).toEqual({});
             }, protocol);
@@ -1355,12 +1347,9 @@ export function runBaseTests<Context>(config: {
                 };
 
                 expect(await client.hset(key1, fieldValueMap)).toEqual(2);
-                checkSimple(await client.hvals(key1)).toEqual([
-                    "value1",
-                    "value2",
-                ]);
+                expect(await client.hvals(key1)).toEqual(["value1", "value2"]);
                 expect(await client.hdel(key1, [field1])).toEqual(1);
-                checkSimple(await client.hvals(key1)).toEqual(["value2"]);
+                expect(await client.hvals(key1)).toEqual(["value2"]);
                 expect(await client.hvals("nonExistingHash")).toEqual([]);
             }, protocol);
         },
@@ -1379,9 +1368,9 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hsetnx(key1, field, "newValue")).toEqual(
                     false,
                 );
-                checkSimple(await client.hget(key1, field)).toEqual("value");
+                expect(await client.hget(key1, field)).toEqual("value");
 
-                checkSimple(await client.set(key2, "value")).toEqual("OK");
+                expect(await client.set(key2, "value")).toEqual("OK");
                 await expect(
                     client.hsetnx(key2, field, "value"),
                 ).rejects.toThrow();
@@ -1408,7 +1397,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hstrlen(key2, "field")).toBe(0);
 
                 // key exists but holds non hash type value
-                checkSimple(await client.set(key2, "value")).toEqual("OK");
+                expect(await client.set(key2, "value")).toEqual("OK");
                 await expect(client.hstrlen(key2, field)).rejects.toThrow(
                     RequestError,
                 );
@@ -1424,13 +1413,13 @@ export function runBaseTests<Context>(config: {
                 const key = uuidv4();
                 const valueList = ["value4", "value3", "value2", "value1"];
                 expect(await client.lpush(key, valueList)).toEqual(4);
-                checkSimple(await client.lpop(key)).toEqual("value1");
-                checkSimple(await client.lrange(key, 0, -1)).toEqual([
+                expect(await client.lpop(key)).toEqual("value1");
+                expect(await client.lrange(key, 0, -1)).toEqual([
                     "value2",
                     "value3",
                     "value4",
                 ]);
-                checkSimple(await client.lpopCount(key, 2)).toEqual([
+                expect(await client.lpopCount(key, 2)).toEqual([
                     "value2",
                     "value3",
                 ]);
@@ -1448,7 +1437,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
 
                 try {
                     expect(await client.lpush(key, ["bar"])).toThrow();
@@ -1488,7 +1477,7 @@ export function runBaseTests<Context>(config: {
 
                 expect(await client.lpush(key1, ["0"])).toEqual(1);
                 expect(await client.lpushx(key1, ["1", "2", "3"])).toEqual(4);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([
+                expect(await client.lrange(key1, 0, -1)).toEqual([
                     "3",
                     "2",
                     "1",
@@ -1496,10 +1485,10 @@ export function runBaseTests<Context>(config: {
                 ]);
 
                 expect(await client.lpushx(key2, ["1"])).toEqual(0);
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([]);
+                expect(await client.lrange(key2, 0, -1)).toEqual([]);
 
                 // Key exists, but is not a list
-                checkSimple(await client.set(key3, "bar"));
+                expect(await client.set(key3, "bar"));
                 await expect(client.lpushx(key3, ["_"])).rejects.toThrow(
                     RequestError,
                 );
@@ -1525,7 +1514,7 @@ export function runBaseTests<Context>(config: {
 
                 expect(await client.llen("nonExistingKey")).toEqual(0);
 
-                checkSimple(await client.set(key2, "foo")).toEqual("OK");
+                expect(await client.set(key2, "foo")).toEqual("OK");
 
                 try {
                     expect(await client.llen(key2)).toThrow();
@@ -1557,7 +1546,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.lpush(key2, lpushArgs2)).toEqual(2);
 
                 // Move from LEFT to LEFT
-                checkSimple(
+                expect(
                     await client.lmove(
                         key1,
                         key2,
@@ -1567,7 +1556,7 @@ export function runBaseTests<Context>(config: {
                 ).toEqual("1");
 
                 // Move from LEFT to RIGHT
-                checkSimple(
+                expect(
                     await client.lmove(
                         key1,
                         key2,
@@ -1576,16 +1565,16 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual("2");
 
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([
+                expect(await client.lrange(key2, 0, -1)).toEqual([
                     "1",
                     "3",
                     "4",
                     "2",
                 ]);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([]);
+                expect(await client.lrange(key1, 0, -1)).toEqual([]);
 
                 // Move from RIGHT to LEFT - non-existing destination key
-                checkSimple(
+                expect(
                     await client.lmove(
                         key2,
                         key1,
@@ -1595,7 +1584,7 @@ export function runBaseTests<Context>(config: {
                 ).toEqual("2");
 
                 // Move from RIGHT to RIGHT
-                checkSimple(
+                expect(
                     await client.lmove(
                         key2,
                         key1,
@@ -1604,14 +1593,8 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual("4");
 
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([
-                    "1",
-                    "3",
-                ]);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([
-                    "2",
-                    "4",
-                ]);
+                expect(await client.lrange(key2, 0, -1)).toEqual(["1", "3"]);
+                expect(await client.lrange(key1, 0, -1)).toEqual(["2", "4"]);
 
                 // Non-existing source key
                 expect(
@@ -1625,7 +1608,7 @@ export function runBaseTests<Context>(config: {
 
                 // Non-list source key
                 const key3 = "{key}-3" + uuidv4();
-                checkSimple(await client.set(key3, "value")).toEqual("OK");
+                expect(await client.set(key3, "value")).toEqual("OK");
                 await expect(
                     client.lmove(
                         key3,
@@ -1676,18 +1659,16 @@ export function runBaseTests<Context>(config: {
                 ).rejects.toThrow(RequestError);
 
                 // assert lset result
-                checkSimple(await client.lset(key, index, element)).toEqual(
-                    "OK",
-                );
-                checkSimple(await client.lrange(key, 0, negativeIndex)).toEqual(
+                expect(await client.lset(key, index, element)).toEqual("OK");
+                expect(await client.lrange(key, 0, negativeIndex)).toEqual(
                     expectedList,
                 );
 
                 // assert lset with a negative index for the last element in the list
-                checkSimple(
-                    await client.lset(key, negativeIndex, element),
-                ).toEqual("OK");
-                checkSimple(await client.lrange(key, 0, negativeIndex)).toEqual(
+                expect(await client.lset(key, negativeIndex, element)).toEqual(
+                    "OK",
+                );
+                expect(await client.lrange(key, 0, negativeIndex)).toEqual(
                     expectedList2,
                 );
 
@@ -1710,17 +1691,17 @@ export function runBaseTests<Context>(config: {
                 const key = uuidv4();
                 const valueList = ["value4", "value3", "value2", "value1"];
                 expect(await client.lpush(key, valueList)).toEqual(4);
-                checkSimple(await client.ltrim(key, 0, 1)).toEqual("OK");
-                checkSimple(await client.lrange(key, 0, -1)).toEqual([
+                expect(await client.ltrim(key, 0, 1)).toEqual("OK");
+                expect(await client.lrange(key, 0, -1)).toEqual([
                     "value1",
                     "value2",
                 ]);
 
                 /// `start` is greater than `end` so the key will be removed.
-                checkSimple(await client.ltrim(key, 4, 2)).toEqual("OK");
+                expect(await client.ltrim(key, 4, 2)).toEqual("OK");
                 expect(await client.lrange(key, 0, -1)).toEqual([]);
 
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
 
                 try {
                     expect(await client.ltrim(key, 0, 1)).toThrow();
@@ -1748,20 +1729,18 @@ export function runBaseTests<Context>(config: {
                 ];
                 expect(await client.lpush(key, valueList)).toEqual(5);
                 expect(await client.lrem(key, 2, "value1")).toEqual(2);
-                checkSimple(await client.lrange(key, 0, -1)).toEqual([
+                expect(await client.lrange(key, 0, -1)).toEqual([
                     "value2",
                     "value2",
                     "value1",
                 ]);
                 expect(await client.lrem(key, -1, "value2")).toEqual(1);
-                checkSimple(await client.lrange(key, 0, -1)).toEqual([
+                expect(await client.lrange(key, 0, -1)).toEqual([
                     "value2",
                     "value1",
                 ]);
                 expect(await client.lrem(key, 0, "value2")).toEqual(1);
-                checkSimple(await client.lrange(key, 0, -1)).toEqual([
-                    "value1",
-                ]);
+                expect(await client.lrange(key, 0, -1)).toEqual(["value1"]);
                 expect(await client.lrem("nonExistingKey", 2, "value")).toEqual(
                     0,
                 );
@@ -1777,8 +1756,8 @@ export function runBaseTests<Context>(config: {
                 const key = uuidv4();
                 const valueList = ["value1", "value2", "value3", "value4"];
                 expect(await client.rpush(key, valueList)).toEqual(4);
-                checkSimple(await client.rpop(key)).toEqual("value4");
-                checkSimple(await client.rpopCount(key, 2)).toEqual([
+                expect(await client.rpop(key)).toEqual("value4");
+                expect(await client.rpopCount(key, 2)).toEqual([
                     "value3",
                     "value2",
                 ]);
@@ -1793,7 +1772,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
 
                 try {
                     expect(await client.rpush(key, ["bar"])).toThrow();
@@ -1825,7 +1804,7 @@ export function runBaseTests<Context>(config: {
 
                 expect(await client.rpush(key1, ["0"])).toEqual(1);
                 expect(await client.rpushx(key1, ["1", "2", "3"])).toEqual(4);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([
+                expect(await client.lrange(key1, 0, -1)).toEqual([
                     "0",
                     "1",
                     "2",
@@ -1833,10 +1812,10 @@ export function runBaseTests<Context>(config: {
                 ]);
 
                 expect(await client.rpushx(key2, ["1"])).toEqual(0);
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([]);
+                expect(await client.lrange(key2, 0, -1)).toEqual([]);
 
                 // Key exists, but is not a list
-                checkSimple(await client.set(key3, "bar"));
+                expect(await client.set(key3, "bar"));
                 await expect(client.rpushx(key3, ["_"])).rejects.toThrow(
                     RequestError,
                 );
@@ -1861,7 +1840,7 @@ export function runBaseTests<Context>(config: {
                     await client.srem(key, ["member3", "nonExistingMember"]),
                 ).toEqual(1);
                 /// compare the 2 sets.
-                checkSimple(await client.smembers(key)).toEqual(
+                expect(await client.smembers(key)).toEqual(
                     new Set(["member1", "member2", "member4"]),
                 );
                 expect(await client.srem(key, ["member1"])).toEqual(1);
@@ -1886,19 +1865,19 @@ export function runBaseTests<Context>(config: {
 
                 // move an element
                 expect(await client.smove(key1, key2, "1"));
-                checkSimple(await client.smembers(key1)).toEqual(
+                expect(await client.smembers(key1)).toEqual(
                     new Set(["2", "3"]),
                 );
-                checkSimple(await client.smembers(key2)).toEqual(
+                expect(await client.smembers(key2)).toEqual(
                     new Set(["1", "2", "3"]),
                 );
 
                 // moved element already exists in the destination set
                 expect(await client.smove(key2, key1, "2"));
-                checkSimple(await client.smembers(key1)).toEqual(
+                expect(await client.smembers(key1)).toEqual(
                     new Set(["2", "3"]),
                 );
-                checkSimple(await client.smembers(key2)).toEqual(
+                expect(await client.smembers(key2)).toEqual(
                     new Set(["1", "3"]),
                 );
 
@@ -1906,43 +1885,29 @@ export function runBaseTests<Context>(config: {
                 expect(await client.smove(non_existing_key, key1, "4")).toEqual(
                     false,
                 );
-                checkSimple(await client.smembers(key1)).toEqual(
+                expect(await client.smembers(key1)).toEqual(
                     new Set(["2", "3"]),
                 );
 
                 // move to a new set
                 expect(await client.smove(key1, key3, "2"));
-                checkSimple(await client.smembers(key1)).toEqual(
-                    new Set(["3"]),
-                );
-                checkSimple(await client.smembers(key3)).toEqual(
-                    new Set(["2"]),
-                );
+                expect(await client.smembers(key1)).toEqual(new Set(["3"]));
+                expect(await client.smembers(key3)).toEqual(new Set(["2"]));
 
                 // attempt to move a missing element
                 expect(await client.smove(key1, key3, "42")).toEqual(false);
-                checkSimple(await client.smembers(key1)).toEqual(
-                    new Set(["3"]),
-                );
-                checkSimple(await client.smembers(key3)).toEqual(
-                    new Set(["2"]),
-                );
+                expect(await client.smembers(key1)).toEqual(new Set(["3"]));
+                expect(await client.smembers(key3)).toEqual(new Set(["2"]));
 
                 // move missing element to missing key
                 expect(
                     await client.smove(key1, non_existing_key, "42"),
                 ).toEqual(false);
-                checkSimple(await client.smembers(key1)).toEqual(
-                    new Set(["3"]),
-                );
-                checkSimple(await client.type(non_existing_key)).toEqual(
-                    "none",
-                );
+                expect(await client.smembers(key1)).toEqual(new Set(["3"]));
+                expect(await client.type(non_existing_key)).toEqual("none");
 
                 // key exists, but it is not a set
-                checkSimple(await client.set(string_key, "value")).toEqual(
-                    "OK",
-                );
+                expect(await client.set(string_key, "value")).toEqual("OK");
                 await expect(
                     client.smove(string_key, key1, "_"),
                 ).rejects.toThrow();
@@ -1972,7 +1937,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
 
                 try {
                     expect(await client.sadd(key, ["bar"])).toThrow();
@@ -2023,7 +1988,7 @@ export function runBaseTests<Context>(config: {
                 // positive test case
                 expect(await client.sadd(key1, member1_list)).toEqual(4);
                 expect(await client.sadd(key2, member2_list)).toEqual(3);
-                checkSimple(await client.sinter([key1, key2])).toEqual(
+                expect(await client.sinter([key1, key2])).toEqual(
                     new Set(["c", "d"]),
                 );
 
@@ -2042,7 +2007,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // non-set key
-                checkSimple(await client.set(key2, "value")).toEqual("OK");
+                expect(await client.set(key2, "value")).toEqual("OK");
 
                 try {
                     expect(await client.sinter([key2])).toThrow();
@@ -2106,7 +2071,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // source key exists, but it is not a set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.sintercard([key1, stringKey]),
                 ).rejects.toThrow(RequestError);
@@ -2132,42 +2097,34 @@ export function runBaseTests<Context>(config: {
 
                 // store in a new key
                 expect(await client.sinterstore(key3, [key1, key2])).toEqual(1);
-                checkSimple(await client.smembers(key3)).toEqual(
-                    new Set(["c"]),
-                );
+                expect(await client.smembers(key3)).toEqual(new Set(["c"]));
 
                 // overwrite existing set, which is also a source set
                 expect(await client.sinterstore(key2, [key2, key3])).toEqual(1);
-                checkSimple(await client.smembers(key2)).toEqual(
-                    new Set(["c"]),
-                );
+                expect(await client.smembers(key2)).toEqual(new Set(["c"]));
 
                 // source set is the same as the existing set
                 expect(await client.sinterstore(key2, [key2])).toEqual(1);
-                checkSimple(await client.smembers(key2)).toEqual(
-                    new Set(["c"]),
-                );
+                expect(await client.smembers(key2)).toEqual(new Set(["c"]));
 
                 // intersection with non-existing key
                 expect(
                     await client.sinterstore(key1, [key2, nonExistingKey]),
                 ).toEqual(0);
-                checkSimple(await client.smembers(key1)).toEqual(new Set());
+                expect(await client.smembers(key1)).toEqual(new Set());
 
                 // invalid argument - key list must not be empty
                 await expect(client.sinterstore(key3, [])).rejects.toThrow();
 
                 // non-set key
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.sinterstore(key3, [stringKey]),
                 ).rejects.toThrow();
 
                 // overwrite non-set key
                 expect(await client.sinterstore(stringKey, [key2])).toEqual(1);
-                checkSimple(await client.smembers(stringKey)).toEqual(
-                    new Set("c"),
-                );
+                expect(await client.smembers(stringKey)).toEqual(new Set("c"));
             }, protocol);
         },
         config.timeout,
@@ -2187,17 +2144,17 @@ export function runBaseTests<Context>(config: {
                 expect(await client.sadd(key1, member1_list)).toEqual(3);
                 expect(await client.sadd(key2, member2_list)).toEqual(3);
 
-                checkSimple(await client.sdiff([key1, key2])).toEqual(
+                expect(await client.sdiff([key1, key2])).toEqual(
                     new Set(["a", "b"]),
                 );
-                checkSimple(await client.sdiff([key2, key1])).toEqual(
+                expect(await client.sdiff([key2, key1])).toEqual(
                     new Set(["d", "e"]),
                 );
 
-                checkSimple(await client.sdiff([key1, nonExistingKey])).toEqual(
+                expect(await client.sdiff([key1, nonExistingKey])).toEqual(
                     new Set(["a", "b", "c"]),
                 );
-                checkSimple(await client.sdiff([nonExistingKey, key1])).toEqual(
+                expect(await client.sdiff([nonExistingKey, key1])).toEqual(
                     new Set(),
                 );
 
@@ -2205,7 +2162,7 @@ export function runBaseTests<Context>(config: {
                 await expect(client.sdiff([])).rejects.toThrow();
 
                 // key exists, but it is not a set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(client.sdiff([stringKey])).rejects.toThrow();
             }, protocol);
         },
@@ -2229,27 +2186,25 @@ export function runBaseTests<Context>(config: {
 
                 // store diff in new key
                 expect(await client.sdiffstore(key3, [key1, key2])).toEqual(2);
-                checkSimple(await client.smembers(key3)).toEqual(
+                expect(await client.smembers(key3)).toEqual(
                     new Set(["a", "b"]),
                 );
 
                 // overwrite existing set
                 expect(await client.sdiffstore(key3, [key2, key1])).toEqual(2);
-                checkSimple(await client.smembers(key3)).toEqual(
+                expect(await client.smembers(key3)).toEqual(
                     new Set(["d", "e"]),
                 );
 
                 // overwrite one of the source sets
                 expect(await client.sdiffstore(key3, [key2, key3])).toEqual(1);
-                checkSimple(await client.smembers(key3)).toEqual(
-                    new Set(["c"]),
-                );
+                expect(await client.smembers(key3)).toEqual(new Set(["c"]));
 
                 // diff between non-empty set and empty set
                 expect(
                     await client.sdiffstore(key3, [key1, nonExistingKey]),
                 ).toEqual(3);
-                checkSimple(await client.smembers(key3)).toEqual(
+                expect(await client.smembers(key3)).toEqual(
                     new Set(["a", "b", "c"]),
                 );
 
@@ -2257,13 +2212,13 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.sdiffstore(key3, [nonExistingKey, key1]),
                 ).toEqual(0);
-                checkSimple(await client.smembers(key3)).toEqual(new Set());
+                expect(await client.smembers(key3)).toEqual(new Set());
 
                 // invalid argument - key list must not be empty
                 await expect(client.sdiffstore(key3, [])).rejects.toThrow();
 
                 // source key exists, but it is not a set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.sdiffstore(key3, [stringKey]),
                 ).rejects.toThrow();
@@ -2272,7 +2227,7 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.sdiffstore(stringKey, [key1, key2]),
                 ).toEqual(2);
-                checkSimple(await client.smembers(stringKey)).toEqual(
+                expect(await client.smembers(stringKey)).toEqual(
                     new Set(["a", "b"]),
                 );
             }, protocol);
@@ -2293,7 +2248,7 @@ export function runBaseTests<Context>(config: {
 
                 expect(await client.sadd(key1, memberList1)).toEqual(3);
                 expect(await client.sadd(key2, memberList2)).toEqual(4);
-                checkSimple(await client.sunion([key1, key2])).toEqual(
+                expect(await client.sunion([key1, key2])).toEqual(
                     new Set(["a", "b", "c", "d", "e"]),
                 );
 
@@ -2301,12 +2256,12 @@ export function runBaseTests<Context>(config: {
                 await expect(client.sunion([])).rejects.toThrow();
 
                 // non-existing key returns the set of existing keys
-                checkSimple(
-                    await client.sunion([key1, nonExistingKey]),
-                ).toEqual(new Set(memberList1));
+                expect(await client.sunion([key1, nonExistingKey])).toEqual(
+                    new Set(memberList1),
+                );
 
                 // key exists, but it is not a set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(client.sunion([stringKey])).rejects.toThrow();
             }, protocol);
         },
@@ -2330,19 +2285,19 @@ export function runBaseTests<Context>(config: {
 
                 // store union in new key
                 expect(await client.sunionstore(key4, [key1, key2])).toEqual(5);
-                checkSimple(await client.smembers(key4)).toEqual(
+                expect(await client.smembers(key4)).toEqual(
                     new Set(["a", "b", "c", "d", "e"]),
                 );
 
                 // overwrite existing set
                 expect(await client.sunionstore(key1, [key4, key2])).toEqual(5);
-                checkSimple(await client.smembers(key1)).toEqual(
+                expect(await client.smembers(key1)).toEqual(
                     new Set(["a", "b", "c", "d", "e"]),
                 );
 
                 // overwrite one of the source keys
                 expect(await client.sunionstore(key2, [key4, key2])).toEqual(5);
-                checkSimple(await client.smembers(key2)).toEqual(
+                expect(await client.smembers(key2)).toEqual(
                     new Set(["a", "b", "c", "d", "e"]),
                 );
 
@@ -2356,7 +2311,7 @@ export function runBaseTests<Context>(config: {
                 await expect(client.sunionstore(key4, [])).rejects.toThrow();
 
                 // key exists, but it is not a set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.sunionstore(key4, [stringKey, key1]),
                 ).rejects.toThrow();
@@ -2365,7 +2320,7 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.sunionstore(stringKey, [key1, key3]),
                 ).toEqual(7);
-                checkSimple(await client.smembers(stringKey)).toEqual(
+                expect(await client.smembers(stringKey)).toEqual(
                     new Set(["a", "b", "c", "d", "e", "f", "g"]),
                 );
             }, protocol);
@@ -2388,7 +2343,7 @@ export function runBaseTests<Context>(config: {
                     await client.sismember("nonExistingKey", "member1"),
                 ).toEqual(false);
 
-                checkSimple(await client.set(key2, "foo")).toEqual("OK");
+                expect(await client.set(key2, "foo")).toEqual("OK");
                 await expect(
                     client.sismember(key2, "member1"),
                 ).rejects.toThrow();
@@ -2425,7 +2380,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // key exists, but it is not a set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.smismember(stringKey, ["a"]),
                 ).rejects.toThrow(RequestError);
@@ -2443,11 +2398,11 @@ export function runBaseTests<Context>(config: {
                 expect(await client.sadd(key, members)).toEqual(3);
 
                 const result1 = await client.spop(key);
-                expect(members).toContain(intoString(result1));
+                expect(members).toContain(result1);
 
                 members = members.filter((item) => item != result1);
                 const result2 = await client.spopCount(key, 2);
-                expect(intoString(result2)).toEqual(intoString(members));
+                expect(result2).toEqual(new Set(members));
                 expect(await client.spop("nonExistingKey")).toEqual(null);
                 expect(await client.spopCount("nonExistingKey", 1)).toEqual(
                     new Set(),
@@ -2464,9 +2419,9 @@ export function runBaseTests<Context>(config: {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
                 const value = uuidv4();
-                checkSimple(await client.set(key1, value)).toEqual("OK");
+                expect(await client.set(key1, value)).toEqual("OK");
                 expect(await client.exists([key1])).toEqual(1);
-                checkSimple(await client.set(key2, value)).toEqual("OK");
+                expect(await client.set(key2, value)).toEqual("OK");
                 expect(
                     await client.exists([key1, "nonExistingKey", key2]),
                 ).toEqual(2);
@@ -2484,9 +2439,9 @@ export function runBaseTests<Context>(config: {
                 const key2 = "{key}" + uuidv4();
                 const key3 = "{key}" + uuidv4();
                 const value = uuidv4();
-                checkSimple(await client.set(key1, value)).toEqual("OK");
-                checkSimple(await client.set(key2, value)).toEqual("OK");
-                checkSimple(await client.set(key3, value)).toEqual("OK");
+                expect(await client.set(key1, value)).toEqual("OK");
+                expect(await client.set(key2, value)).toEqual("OK");
+                expect(await client.set(key3, value)).toEqual("OK");
                 expect(
                     await client.unlink([key1, key2, "nonExistingKey", key3]),
                 ).toEqual(3);
@@ -2500,11 +2455,11 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient, cluster) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(await client.expire(key, 10)).toEqual(true);
                 expect(await client.ttl(key)).toBeLessThanOrEqual(10);
                 /// set command clears the timeout.
-                checkSimple(await client.set(key, "bar")).toEqual("OK");
+                expect(await client.set(key, "bar")).toEqual("OK");
                 const versionLessThan =
                     cluster.checkIfServerVersionLessThan("7.0.0");
 
@@ -2546,7 +2501,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient, cluster) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(
                     await client.expireAt(
                         key,
@@ -2577,7 +2532,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.ttl(key)).toBeLessThanOrEqual(50);
 
                 /// set command clears the timeout.
-                checkSimple(await client.set(key, "bar")).toEqual("OK");
+                expect(await client.set(key, "bar")).toEqual("OK");
 
                 if (!versionLessThan) {
                     expect(
@@ -2598,14 +2553,14 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(await client.ttl(key)).toEqual(-1);
                 expect(await client.expire(key, -10)).toEqual(true);
                 expect(await client.ttl(key)).toEqual(-2);
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(await client.pexpire(key, -10000)).toEqual(true);
                 expect(await client.ttl(key)).toEqual(-2);
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(
                     await client.expireAt(
                         key,
@@ -2613,7 +2568,7 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual(true);
                 expect(await client.ttl(key)).toEqual(-2);
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(
                     await client.pexpireAt(
                         key,
@@ -2659,12 +2614,12 @@ export function runBaseTests<Context>(config: {
                 const key2 = Buffer.from(uuidv4());
 
                 let script = new Script(Buffer.from("return 'Hello'"));
-                checkSimple(await client.invokeScript(script)).toEqual("Hello");
+                expect(await client.invokeScript(script)).toEqual("Hello");
 
                 script = new Script(
                     Buffer.from("return redis.call('SET', KEYS[1], ARGV[1])"),
                 );
-                checkSimple(
+                expect(
                     await client.invokeScript(script, {
                         keys: [key1],
                         args: [Buffer.from("value1")],
@@ -2672,7 +2627,7 @@ export function runBaseTests<Context>(config: {
                 ).toEqual("OK");
 
                 /// Reuse the same script with different parameters.
-                checkSimple(
+                expect(
                     await client.invokeScript(script, {
                         keys: [key2],
                         args: [Buffer.from("value2")],
@@ -2682,11 +2637,11 @@ export function runBaseTests<Context>(config: {
                 script = new Script(
                     Buffer.from("return redis.call('GET', KEYS[1])"),
                 );
-                checkSimple(
+                expect(
                     await client.invokeScript(script, { keys: [key1] }),
                 ).toEqual("value1");
 
-                checkSimple(
+                expect(
                     await client.invokeScript(script, { keys: [key2] }),
                 ).toEqual("value2");
             }, protocol);
@@ -2702,12 +2657,12 @@ export function runBaseTests<Context>(config: {
                 const key2 = uuidv4();
 
                 let script = new Script("return 'Hello'");
-                checkSimple(await client.invokeScript(script)).toEqual("Hello");
+                expect(await client.invokeScript(script)).toEqual("Hello");
 
                 script = new Script(
                     "return redis.call('SET', KEYS[1], ARGV[1])",
                 );
-                checkSimple(
+                expect(
                     await client.invokeScript(script, {
                         keys: [key1],
                         args: ["value1"],
@@ -2715,7 +2670,7 @@ export function runBaseTests<Context>(config: {
                 ).toEqual("OK");
 
                 /// Reuse the same script with different parameters.
-                checkSimple(
+                expect(
                     await client.invokeScript(script, {
                         keys: [key2],
                         args: ["value2"],
@@ -2723,11 +2678,11 @@ export function runBaseTests<Context>(config: {
                 ).toEqual("OK");
 
                 script = new Script("return redis.call('GET', KEYS[1])");
-                checkSimple(
+                expect(
                     await client.invokeScript(script, { keys: [key1] }),
                 ).toEqual("value1");
 
-                checkSimple(
+                expect(
                     await client.invokeScript(script, { keys: [key2] }),
                 ).toEqual("value2");
             }, protocol);
@@ -2937,14 +2892,12 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zadd(key2, entries2)).toEqual(1);
                 expect(await client.zadd(key3, entries3)).toEqual(4);
 
-                checkSimple(await client.zdiff([key1, key2])).toEqual([
+                expect(await client.zdiff([key1, key2])).toEqual([
                     "one",
                     "three",
                 ]);
-                checkSimple(await client.zdiff([key1, key3])).toEqual([]);
-                checkSimple(await client.zdiff([nonExistingKey, key3])).toEqual(
-                    [],
-                );
+                expect(await client.zdiff([key1, key3])).toEqual([]);
+                expect(await client.zdiff([nonExistingKey, key3])).toEqual([]);
 
                 let result = await client.zdiffWithScores([key1, key2]);
                 const expected = {
@@ -2966,7 +2919,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // key exists, but it is not a sorted set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(client.zdiff([stringKey, key1])).rejects.toThrow();
                 await expect(
                     client.zdiffWithScores([stringKey, key1]),
@@ -3047,7 +3000,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // key exists, but it is not a sorted set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.zdiffstore(key4, [stringKey, key1]),
                 ).rejects.toThrow(RequestError);
@@ -3072,7 +3025,7 @@ export function runBaseTests<Context>(config: {
                     await client.zscore("nonExistingKey", "nonExistingMember"),
                 ).toEqual(null);
 
-                checkSimple(await client.set(key2, "foo")).toEqual("OK");
+                expect(await client.set(key2, "foo")).toEqual("OK");
                 await expect(client.zscore(key2, "foo")).rejects.toThrow();
             }, protocol);
         },
@@ -3119,7 +3072,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // key exists, but it is not a sorted set
-                checkSimple(await client.set(stringKey, "foo")).toEqual("OK");
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
                 await expect(
                     client.zmscore(stringKey, ["one"]),
                 ).rejects.toThrow(RequestError);
@@ -3175,7 +3128,7 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual(0);
 
-                checkSimple(await client.set(key2, "foo")).toEqual("OK");
+                expect(await client.set(key2, "foo")).toEqual("OK");
                 await expect(
                     client.zcount(key2, "negativeInfinity", "positiveInfinity"),
                 ).rejects.toThrow();
@@ -3192,9 +3145,9 @@ export function runBaseTests<Context>(config: {
                 const membersScores = { one: 1, two: 2, three: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
-                checkSimple(
-                    await client.zrange(key, { start: 0, stop: 1 }),
-                ).toEqual(["one", "two"]);
+                expect(await client.zrange(key, { start: 0, stop: 1 })).toEqual(
+                    ["one", "two"],
+                );
                 const result = await client.zrangeWithScores(key, {
                     start: 0,
                     stop: -1,
@@ -3207,7 +3160,7 @@ export function runBaseTests<Context>(config: {
                         three: 3.0,
                     }),
                 ).toBe(true);
-                checkSimple(
+                expect(
                     await client.zrange(key, { start: 0, stop: 1 }, true),
                 ).toEqual(["three", "two"]);
                 expect(await client.zrange(key, { start: 3, stop: 1 })).toEqual(
@@ -3229,7 +3182,7 @@ export function runBaseTests<Context>(config: {
                 const membersScores = { one: 1, two: 2, three: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
-                checkSimple(
+                expect(
                     await client.zrange(key, {
                         start: "negativeInfinity",
                         stop: { value: 3, isInclusive: false },
@@ -3249,7 +3202,7 @@ export function runBaseTests<Context>(config: {
                         three: 3.0,
                     }),
                 ).toBe(true);
-                checkSimple(
+                expect(
                     await client.zrange(
                         key,
                         {
@@ -3261,7 +3214,7 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual(["two", "one"]);
 
-                checkSimple(
+                expect(
                     await client.zrange(key, {
                         start: "negativeInfinity",
                         stop: "positiveInfinity",
@@ -3322,7 +3275,7 @@ export function runBaseTests<Context>(config: {
                 const membersScores = { a: 1, b: 2, c: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
-                checkSimple(
+                expect(
                     await client.zrange(key, {
                         start: "negativeInfinity",
                         stop: { value: "c", isInclusive: false },
@@ -3330,7 +3283,7 @@ export function runBaseTests<Context>(config: {
                     }),
                 ).toEqual(["a", "b"]);
 
-                checkSimple(
+                expect(
                     await client.zrange(key, {
                         start: "negativeInfinity",
                         stop: "positiveInfinity",
@@ -3339,7 +3292,7 @@ export function runBaseTests<Context>(config: {
                     }),
                 ).toEqual(["b", "c"]);
 
-                checkSimple(
+                expect(
                     await client.zrange(
                         key,
                         {
@@ -3548,27 +3501,25 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "value")).toEqual("OK");
-                checkSimple(await client.type(key)).toEqual("string");
-                checkSimple(await client.del([key])).toEqual(1);
+                expect(await client.set(key, "value")).toEqual("OK");
+                expect(await client.type(key)).toEqual("string");
+                expect(await client.del([key])).toEqual(1);
 
-                checkSimple(await client.lpush(key, ["value"])).toEqual(1);
-                checkSimple(await client.type(key)).toEqual("list");
-                checkSimple(await client.del([key])).toEqual(1);
+                expect(await client.lpush(key, ["value"])).toEqual(1);
+                expect(await client.type(key)).toEqual("list");
+                expect(await client.del([key])).toEqual(1);
 
-                checkSimple(await client.sadd(key, ["value"])).toEqual(1);
-                checkSimple(await client.type(key)).toEqual("set");
-                checkSimple(await client.del([key])).toEqual(1);
+                expect(await client.sadd(key, ["value"])).toEqual(1);
+                expect(await client.type(key)).toEqual("set");
+                expect(await client.del([key])).toEqual(1);
 
-                checkSimple(await client.zadd(key, { member: 1.0 })).toEqual(1);
-                checkSimple(await client.type(key)).toEqual("zset");
-                checkSimple(await client.del([key])).toEqual(1);
+                expect(await client.zadd(key, { member: 1.0 })).toEqual(1);
+                expect(await client.type(key)).toEqual("zset");
+                expect(await client.del([key])).toEqual(1);
 
-                checkSimple(await client.hset(key, { field: "value" })).toEqual(
-                    1,
-                );
-                checkSimple(await client.type(key)).toEqual("hash");
-                checkSimple(await client.del([key])).toEqual(1);
+                expect(await client.hset(key, { field: "value" })).toEqual(1);
+                expect(await client.type(key)).toEqual("hash");
+                expect(await client.del([key])).toEqual(1);
 
                 await client.customCommand([
                     "XADD",
@@ -3577,9 +3528,9 @@ export function runBaseTests<Context>(config: {
                     "field",
                     "value",
                 ]);
-                checkSimple(await client.type(key)).toEqual("stream");
-                checkSimple(await client.del([key])).toEqual(1);
-                checkSimple(await client.type(key)).toEqual("none");
+                expect(await client.type(key)).toEqual("stream");
+                expect(await client.del([key])).toEqual(1);
+                expect(await client.type(key)).toEqual("none");
             }, protocol);
         },
         config.timeout,
@@ -3590,7 +3541,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const message = uuidv4();
-                checkSimple(await client.echo(message)).toEqual(message);
+                expect(await client.echo(message)).toEqual(message);
             }, protocol);
         },
         config.timeout,
@@ -3603,8 +3554,8 @@ export function runBaseTests<Context>(config: {
                 const key1 = uuidv4();
                 const key1Value = uuidv4();
                 const key1ValueLength = key1Value.length;
-                checkSimple(await client.set(key1, key1Value)).toEqual("OK");
-                checkSimple(await client.strlen(key1)).toEqual(key1ValueLength);
+                expect(await client.set(key1, key1Value)).toEqual("OK");
+                expect(await client.strlen(key1)).toEqual(key1ValueLength);
 
                 expect(await client.strlen("nonExistKey")).toEqual(0);
 
@@ -3638,12 +3589,8 @@ export function runBaseTests<Context>(config: {
                         listKey2Value,
                     ]),
                 ).toEqual(2);
-                checkSimple(await client.lindex(listName, 0)).toEqual(
-                    listKey2Value,
-                );
-                checkSimple(await client.lindex(listName, 1)).toEqual(
-                    listKey1Value,
-                );
+                expect(await client.lindex(listName, 0)).toEqual(listKey2Value);
+                expect(await client.lindex(listName, 1)).toEqual(listKey1Value);
                 expect(await client.lindex("notExsitingList", 1)).toEqual(null);
                 expect(await client.lindex(listName, 3)).toEqual(null);
             }, protocol);
@@ -3678,7 +3625,7 @@ export function runBaseTests<Context>(config: {
                         "3.5",
                     ),
                 ).toEqual(6);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([
+                expect(await client.lrange(key1, 0, -1)).toEqual([
                     "1",
                     "1.5",
                     "2",
@@ -3730,7 +3677,7 @@ export function runBaseTests<Context>(config: {
                     }),
                 ).toBe(true);
                 expect(await client.zpopmin(key)).toEqual({});
-                checkSimple(await client.set(key, "value")).toEqual("OK");
+                expect(await client.set(key, "value")).toEqual("OK");
                 await expect(client.zpopmin(key)).rejects.toThrow();
                 expect(await client.zpopmin("notExsitingKey")).toEqual({});
             }, protocol);
@@ -3754,7 +3701,7 @@ export function runBaseTests<Context>(config: {
                     }),
                 ).toBe(true);
                 expect(await client.zpopmax(key)).toEqual({});
-                checkSimple(await client.set(key, "value")).toEqual("OK");
+                expect(await client.set(key, "value")).toEqual("OK");
                 await expect(client.zpopmax(key)).rejects.toThrow();
                 expect(await client.zpopmax("notExsitingKey")).toEqual({});
             }, protocol);
@@ -3769,7 +3716,7 @@ export function runBaseTests<Context>(config: {
                 const key = uuidv4();
                 expect(await client.pttl(key)).toEqual(-2);
 
-                checkSimple(await client.set(key, "value")).toEqual("OK");
+                expect(await client.set(key, "value")).toEqual("OK");
                 expect(await client.pttl(key)).toEqual(-1);
 
                 expect(await client.expire(key, 10)).toEqual(true);
@@ -3845,7 +3792,7 @@ export function runBaseTests<Context>(config: {
                     null,
                 );
 
-                checkSimple(await client.set(key2, "value")).toEqual("OK");
+                expect(await client.set(key2, "value")).toEqual("OK");
                 await expect(client.zrank(key2, "member")).rejects.toThrow();
             }, protocol);
         },
@@ -3887,7 +3834,7 @@ export function runBaseTests<Context>(config: {
                 ).toBeNull();
 
                 // Key exists, but is not a sorted set
-                checkSimple(await client.set(nonSetKey, "value")).toEqual("OK");
+                expect(await client.set(nonSetKey, "value")).toEqual("OK");
                 await expect(
                     client.zrevrank(nonSetKey, "member"),
                 ).rejects.toThrow();
@@ -3903,7 +3850,7 @@ export function runBaseTests<Context>(config: {
                     await client.rpush("brpop-test", ["foo", "bar", "baz"]),
                 ).toEqual(3);
                 // Test basic usage
-                checkSimple(await client.brpop(["brpop-test"], 0.1)).toEqual([
+                expect(await client.brpop(["brpop-test"], 0.1)).toEqual([
                     "brpop-test",
                     "baz",
                 ]);
@@ -3940,7 +3887,7 @@ export function runBaseTests<Context>(config: {
                     await client.rpush("blpop-test", ["foo", "bar", "baz"]),
                 ).toEqual(3);
                 // Test basic usage
-                checkSimple(await client.blpop(["blpop-test"], 0.1)).toEqual([
+                expect(await client.blpop(["blpop-test"], 0.1)).toEqual([
                     "blpop-test",
                     "foo",
                 ]);
@@ -3974,7 +3921,7 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.set(key, "foo")).toEqual("OK");
+                expect(await client.set(key, "foo")).toEqual("OK");
                 expect(await client.persist(key)).toEqual(false);
 
                 expect(await client.expire(key, 10)).toEqual(true);
@@ -4014,7 +3961,7 @@ export function runBaseTests<Context>(config: {
                     ],
                     { id: "0-1" },
                 );
-                checkSimple(timestamp1).toEqual("0-1");
+                expect(timestamp1).toEqual("0-1");
                 expect(
                     await client.xadd(key, [
                         [field1, "foo2"],
@@ -4211,7 +4158,7 @@ export function runBaseTests<Context>(config: {
                         [timestamp_2_3 as string]: [["bar", "bar3"]],
                     },
                 };
-                checkSimple(result).toEqual(expected);
+                expect(result).toEqual(expected);
             }, ProtocolVersion.RESP2);
         },
         config.timeout,
@@ -4227,7 +4174,7 @@ export function runBaseTests<Context>(config: {
                 await client.set(key, "value");
                 await client.rename(key, newKey);
                 const result = await client.get(newKey);
-                checkSimple(result).toEqual("value");
+                expect(result).toEqual("value");
                 // If key doesn't exist it should throw, it also test that key has successfully been renamed
                 await expect(client.rename(key, newKey)).rejects.toThrow();
             }, protocol);
@@ -4254,13 +4201,13 @@ export function runBaseTests<Context>(config: {
                 await client.set(key1, "key1");
                 await client.set(key3, "key3");
                 // Test that renamenx can rename key1 to key2 (non-existing value)
-                checkSimple(await client.renamenx(key1, key2)).toEqual(true);
+                expect(await client.renamenx(key1, key2)).toEqual(true);
                 // sanity check
-                checkSimple(await client.get(key2)).toEqual("key1");
+                expect(await client.get(key2)).toEqual("key1");
                 // Test that renamenx doesn't rename key2 to key3 (with an existing value)
-                checkSimple(await client.renamenx(key2, key3)).toEqual(false);
+                expect(await client.renamenx(key2, key3)).toEqual(false);
                 // sanity check
-                checkSimple(await client.get(key3)).toEqual("key3");
+                expect(await client.get(key3)).toEqual("key3");
             }, protocol);
         },
         config.timeout,
@@ -4271,13 +4218,13 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                checkSimple(await client.pfadd(key, [])).toEqual(1);
-                checkSimple(await client.pfadd(key, ["one", "two"])).toEqual(1);
-                checkSimple(await client.pfadd(key, ["two"])).toEqual(0);
-                checkSimple(await client.pfadd(key, [])).toEqual(0);
+                expect(await client.pfadd(key, [])).toEqual(1);
+                expect(await client.pfadd(key, ["one", "two"])).toEqual(1);
+                expect(await client.pfadd(key, ["two"])).toEqual(0);
+                expect(await client.pfadd(key, [])).toEqual(0);
 
                 // key exists, but it is not a HyperLogLog
-                checkSimple(await client.set("foo", "value")).toEqual("OK");
+                expect(await client.set("foo", "value")).toEqual("OK");
                 await expect(client.pfadd("foo", [])).rejects.toThrow();
             }, protocol);
         },
@@ -4335,9 +4282,9 @@ export function runBaseTests<Context>(config: {
                 count: 500,
             },
         });
-        checkSimple(setResWithExpirySetMilli).toEqual("OK");
+        expect(setResWithExpirySetMilli).toEqual("OK");
         const getWithExpirySetMilli = await client.get(key);
-        checkSimple(getWithExpirySetMilli).toEqual(value);
+        expect(getWithExpirySetMilli).toEqual(value);
 
         const setResWithExpirySec = await client.set(key, value, {
             expiry: {
@@ -4345,9 +4292,9 @@ export function runBaseTests<Context>(config: {
                 count: 1,
             },
         });
-        checkSimple(setResWithExpirySec).toEqual("OK");
+        expect(setResWithExpirySec).toEqual("OK");
         const getResWithExpirySec = await client.get(key);
-        checkSimple(getResWithExpirySec).toEqual(value);
+        expect(getResWithExpirySec).toEqual(value);
 
         const setWithUnixSec = await client.set(key, value, {
             expiry: {
@@ -4355,59 +4302,59 @@ export function runBaseTests<Context>(config: {
                 count: Math.floor(Date.now() / 1000) + 1,
             },
         });
-        checkSimple(setWithUnixSec).toEqual("OK");
+        expect(setWithUnixSec).toEqual("OK");
         const getWithUnixSec = await client.get(key);
-        checkSimple(getWithUnixSec).toEqual(value);
+        expect(getWithUnixSec).toEqual(value);
 
         const setResWithExpiryKeep = await client.set(key, value, {
             expiry: "keepExisting",
         });
-        checkSimple(setResWithExpiryKeep).toEqual("OK");
+        expect(setResWithExpiryKeep).toEqual("OK");
         const getResWithExpiryKeep = await client.get(key);
-        checkSimple(getResWithExpiryKeep).toEqual(value);
+        expect(getResWithExpiryKeep).toEqual(value);
         // wait for the key to expire base on the previous set
         let sleep = new Promise((resolve) => setTimeout(resolve, 1000));
         await sleep;
         const getResExpire = await client.get(key);
         // key should have expired
-        checkSimple(getResExpire).toEqual(null);
+        expect(getResExpire).toEqual(null);
         const setResWithExpiryWithUmilli = await client.set(key, value, {
             expiry: {
                 type: "unixMilliseconds",
                 count: Date.now() + 1000,
             },
         });
-        checkSimple(setResWithExpiryWithUmilli).toEqual("OK");
+        expect(setResWithExpiryWithUmilli).toEqual("OK");
         // wait for the key to expire
         sleep = new Promise((resolve) => setTimeout(resolve, 1001));
         await sleep;
         const getResWithExpiryWithUmilli = await client.get(key);
         // key should have expired
-        checkSimple(getResWithExpiryWithUmilli).toEqual(null);
+        expect(getResWithExpiryWithUmilli).toEqual(null);
     }
 
     async function setWithOnlyIfExistOptions(client: BaseClient) {
         const key = uuidv4();
         const value = uuidv4();
         const setKey = await client.set(key, value);
-        checkSimple(setKey).toEqual("OK");
+        expect(setKey).toEqual("OK");
         const getRes = await client.get(key);
-        checkSimple(getRes).toEqual(value);
+        expect(getRes).toEqual(value);
         const setExistingKeyRes = await client.set(key, value, {
             conditionalSet: "onlyIfExists",
         });
-        checkSimple(setExistingKeyRes).toEqual("OK");
+        expect(setExistingKeyRes).toEqual("OK");
         const getExistingKeyRes = await client.get(key);
-        checkSimple(getExistingKeyRes).toEqual(value);
+        expect(getExistingKeyRes).toEqual(value);
 
         const notExistingKeyRes = await client.set(key + 1, value, {
             conditionalSet: "onlyIfExists",
         });
         // key does not exist, so it should not be set
-        checkSimple(notExistingKeyRes).toEqual(null);
+        expect(notExistingKeyRes).toEqual(null);
         const getNotExistingKey = await client.get(key + 1);
         // key should not have been set
-        checkSimple(getNotExistingKey).toEqual(null);
+        expect(getNotExistingKey).toEqual(null);
     }
 
     async function setWithOnlyIfNotExistOptions(client: BaseClient) {
@@ -4417,19 +4364,19 @@ export function runBaseTests<Context>(config: {
             conditionalSet: "onlyIfDoesNotExist",
         });
         // key does not exist, so it should be set
-        checkSimple(notExistingKeyRes).toEqual("OK");
+        expect(notExistingKeyRes).toEqual("OK");
         const getNotExistingKey = await client.get(key);
         // key should have been set
-        checkSimple(getNotExistingKey).toEqual(value);
+        expect(getNotExistingKey).toEqual(value);
 
         const existingKeyRes = await client.set(key, value, {
             conditionalSet: "onlyIfDoesNotExist",
         });
         // key exists, so it should not be set
-        checkSimple(existingKeyRes).toEqual(null);
+        expect(existingKeyRes).toEqual(null);
         const getExistingKey = await client.get(key);
         // key should not have been set
-        checkSimple(getExistingKey).toEqual(value);
+        expect(getExistingKey).toEqual(value);
     }
 
     async function setWithGetOldOptions(client: BaseClient) {
@@ -4440,19 +4387,19 @@ export function runBaseTests<Context>(config: {
             returnOldValue: true,
         });
         // key does not exist, so old value should be null
-        checkSimple(setResGetNotExistOld).toEqual(null);
+        expect(setResGetNotExistOld).toEqual(null);
         // key should have been set
         const getResGetNotExistOld = await client.get(key);
-        checkSimple(getResGetNotExistOld).toEqual(value);
+        expect(getResGetNotExistOld).toEqual(value);
 
         const setResGetExistOld = await client.set(key, value, {
             returnOldValue: true,
         });
         // key exists, so old value should be returned
-        checkSimple(setResGetExistOld).toEqual(value);
+        expect(setResGetExistOld).toEqual(value);
         // key should have been set
         const getResGetExistOld = await client.get(key);
-        checkSimple(getResGetExistOld).toEqual(value);
+        expect(getResGetExistOld).toEqual(value);
     }
 
     async function setWithAllOptions(client: BaseClient) {
@@ -4506,14 +4453,14 @@ export function runBaseTests<Context>(config: {
             });
 
             if (exist == false) {
-                checkSimple(setRes).toEqual("OK");
+                expect(setRes).toEqual("OK");
                 exist = true;
             } else {
-                checkSimple(setRes).toEqual(null);
+                expect(setRes).toEqual(null);
             }
 
             const getRes = await client.get(key);
-            checkSimple(getRes).toEqual(value);
+            expect(getRes).toEqual(value);
         }
 
         for (const expiryVal of expiryCombination) {
@@ -4576,37 +4523,31 @@ export function runBaseTests<Context>(config: {
                     null,
                 );
 
-                checkSimple(
+                expect(
                     await client.set(
                         string_key,
                         "a really loooooooooooooooooooooooooooooooooooooooong value",
                     ),
                 ).toEqual("OK");
 
-                checkSimple(await client.objectEncoding(string_key)).toEqual(
-                    "raw",
-                );
+                expect(await client.objectEncoding(string_key)).toEqual("raw");
 
-                checkSimple(await client.set(string_key, "2")).toEqual("OK");
-                checkSimple(await client.objectEncoding(string_key)).toEqual(
-                    "int",
-                );
+                expect(await client.set(string_key, "2")).toEqual("OK");
+                expect(await client.objectEncoding(string_key)).toEqual("int");
 
-                checkSimple(await client.set(string_key, "value")).toEqual(
-                    "OK",
-                );
-                checkSimple(await client.objectEncoding(string_key)).toEqual(
+                expect(await client.set(string_key, "value")).toEqual("OK");
+                expect(await client.objectEncoding(string_key)).toEqual(
                     "embstr",
                 );
 
                 expect(await client.lpush(list_key, ["1"])).toEqual(1);
 
                 if (versionLessThan72) {
-                    checkSimple(await client.objectEncoding(list_key)).toEqual(
+                    expect(await client.objectEncoding(list_key)).toEqual(
                         "quicklist",
                     );
                 } else {
-                    checkSimple(await client.objectEncoding(list_key)).toEqual(
+                    expect(await client.objectEncoding(list_key)).toEqual(
                         "listpack",
                     );
                 }
@@ -4618,23 +4559,23 @@ export function runBaseTests<Context>(config: {
                     ).toEqual(1);
                 }
 
-                checkSimple(await client.objectEncoding(hashtable_key)).toEqual(
+                expect(await client.objectEncoding(hashtable_key)).toEqual(
                     "hashtable",
                 );
 
                 expect(await client.sadd(intset_key, ["1"])).toEqual(1);
-                checkSimple(await client.objectEncoding(intset_key)).toEqual(
+                expect(await client.objectEncoding(intset_key)).toEqual(
                     "intset",
                 );
 
                 expect(await client.sadd(set_listpack_key, ["foo"])).toEqual(1);
 
                 if (versionLessThan72) {
-                    checkSimple(
+                    expect(
                         await client.objectEncoding(set_listpack_key),
                     ).toEqual("hashtable");
                 } else {
-                    checkSimple(
+                    expect(
                         await client.objectEncoding(set_listpack_key),
                     ).toEqual("listpack");
                 }
@@ -4648,20 +4589,20 @@ export function runBaseTests<Context>(config: {
                     ).toEqual(1);
                 }
 
-                checkSimple(
-                    await client.objectEncoding(hash_hashtable_key),
-                ).toEqual("hashtable");
+                expect(await client.objectEncoding(hash_hashtable_key)).toEqual(
+                    "hashtable",
+                );
 
                 expect(
                     await client.hset(hash_listpack_key, { "1": "2" }),
                 ).toEqual(1);
 
                 if (versionLessThan7) {
-                    checkSimple(
+                    expect(
                         await client.objectEncoding(hash_listpack_key),
                     ).toEqual("ziplist");
                 } else {
-                    checkSimple(
+                    expect(
                         await client.objectEncoding(hash_listpack_key),
                     ).toEqual("listpack");
                 }
@@ -4673,7 +4614,7 @@ export function runBaseTests<Context>(config: {
                     ).toEqual(1);
                 }
 
-                checkSimple(await client.objectEncoding(skiplist_key)).toEqual(
+                expect(await client.objectEncoding(skiplist_key)).toEqual(
                     "skiplist",
                 );
 
@@ -4682,11 +4623,11 @@ export function runBaseTests<Context>(config: {
                 ).toEqual(1);
 
                 if (versionLessThan7) {
-                    checkSimple(
+                    expect(
                         await client.objectEncoding(zset_listpack_key),
                     ).toEqual("ziplist");
                 } else {
-                    checkSimple(
+                    expect(
                         await client.objectEncoding(zset_listpack_key),
                     ).toEqual("listpack");
                 }
@@ -4694,7 +4635,7 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.xadd(stream_key, [["field", "value"]]),
                 ).not.toBeNull();
-                checkSimple(await client.objectEncoding(stream_key)).toEqual(
+                expect(await client.objectEncoding(stream_key)).toEqual(
                     "stream",
                 );
             }, protocol);
@@ -4979,7 +4920,7 @@ export function runBaseTests<Context>(config: {
                 const key2 = uuidv4();
                 const value = "foobar";
 
-                checkSimple(await client.set(key1, value)).toEqual("OK");
+                expect(await client.set(key1, value)).toEqual("OK");
                 expect(await client.bitcount(key1)).toEqual(26);
                 expect(
                     await client.bitcount(key1, { start: 1, end: 1 }),
@@ -5218,19 +5159,35 @@ export function runBaseTests<Context>(config: {
                 const expectedResult = [
                     [
                         members[0],
-                        [56.4413, 3479447370796909, membersCoordinates[0]],
+                        [
+                            56.4413,
+                            3479447370796909,
+                            [15.087267458438873, 37.50266842333162],
+                        ],
                     ],
                     [
                         members[1],
-                        [190.4424, 3479099956230698, membersCoordinates[1]],
+                        [
+                            190.4424,
+                            3479099956230698,
+                            [13.361389338970184, 38.1155563954963],
+                        ],
                     ],
                     [
                         members[2],
-                        [279.7403, 3481342659049484, membersCoordinates[2]],
+                        [
+                            279.7403,
+                            3481342659049484,
+                            [17.241510450839996, 38.78813451624225],
+                        ],
                     ],
                     [
                         members[3],
-                        [279.7405, 3479273021651468, membersCoordinates[3]],
+                        [
+                            279.7405,
+                            3479273021651468,
+                            [12.75848776102066, 38.78813451624225],
+                        ],
                     ],
                 ];
 
@@ -5245,7 +5202,7 @@ export function runBaseTests<Context>(config: {
                     { width: 400, height: 400, unit: GeoUnit.KILOMETERS },
                 );
                 // using set to compare, because results are reordrered
-                checkSimple(new Set(searchResult)).toEqual(membersSet);
+                expect(new Set(searchResult)).toEqual(membersSet);
 
                 // order search result
                 searchResult = await client.geosearch(
@@ -5254,7 +5211,7 @@ export function runBaseTests<Context>(config: {
                     { width: 400, height: 400, unit: GeoUnit.KILOMETERS },
                     { sortOrder: SortOrder.ASC },
                 );
-                checkSimple(searchResult).toEqual(members);
+                expect(searchResult).toEqual(members);
 
                 // order and query all extra data
                 searchResult = await client.geosearch(
@@ -5268,7 +5225,7 @@ export function runBaseTests<Context>(config: {
                         withHash: true,
                     },
                 );
-                checkSimple(searchResult).toEqual(expectedResult);
+                expect(searchResult).toEqual(expectedResult);
 
                 // order, query and limit by 1
                 searchResult = await client.geosearch(
@@ -5283,7 +5240,7 @@ export function runBaseTests<Context>(config: {
                         count: 1,
                     },
                 );
-                checkSimple(searchResult).toEqual(expectedResult.slice(0, 1));
+                expect(searchResult).toEqual(expectedResult.slice(0, 1));
 
                 // test search by box, unit: meters, from member, with distance
                 const meters = 400 * 1000;
@@ -5297,7 +5254,7 @@ export function runBaseTests<Context>(config: {
                         sortOrder: SortOrder.DESC,
                     },
                 );
-                checkSimple(searchResult).toEqual([
+                expect(searchResult).toEqual([
                     ["edge2", [236529.1799]],
                     ["Palermo", [166274.1516]],
                     ["Catania", [0.0]],
@@ -5317,7 +5274,7 @@ export function runBaseTests<Context>(config: {
                         count: 2,
                     },
                 );
-                checkSimple(searchResult).toEqual([
+                expect(searchResult).toEqual([
                     ["Palermo", [3479099956230698]],
                     ["edge1", [3479273021651468]],
                 ]);
@@ -5330,9 +5287,7 @@ export function runBaseTests<Context>(config: {
                     { width: miles, height: miles, unit: GeoUnit.MILES },
                     { count: 1, isAny: true },
                 );
-                expect(members.map((m) => Buffer.from(m))).toContainEqual(
-                    searchResult[0],
-                );
+                expect(members).toContainEqual(searchResult[0]);
 
                 // test search by radius, units: feet, from member
                 const feetRadius = 200 * 3280.8399;
@@ -5342,7 +5297,7 @@ export function runBaseTests<Context>(config: {
                     { radius: feetRadius, unit: GeoUnit.FEET },
                     { sortOrder: SortOrder.ASC },
                 );
-                checkSimple(searchResult).toEqual(["Catania", "Palermo"]);
+                expect(searchResult).toEqual(["Catania", "Palermo"]);
 
                 // Test search by radius, unit: meters, from member
                 const metersRadius = 200 * 1000;
@@ -5352,7 +5307,7 @@ export function runBaseTests<Context>(config: {
                     { radius: metersRadius, unit: GeoUnit.METERS },
                     { sortOrder: SortOrder.DESC },
                 );
-                checkSimple(searchResult).toEqual(["Palermo", "Catania"]);
+                expect(searchResult).toEqual(["Palermo", "Catania"]);
 
                 searchResult = await client.geosearch(
                     key,
@@ -5363,7 +5318,7 @@ export function runBaseTests<Context>(config: {
                         withHash: true,
                     },
                 );
-                checkSimple(searchResult).toEqual([
+                expect(searchResult).toEqual([
                     ["Palermo", [3479099956230698]],
                     ["Catania", [3479447370796909]],
                 ]);
@@ -5375,7 +5330,7 @@ export function runBaseTests<Context>(config: {
                     { radius: 175, unit: GeoUnit.MILES },
                     { sortOrder: SortOrder.DESC },
                 );
-                checkSimple(searchResult).toEqual([
+                expect(searchResult).toEqual([
                     "edge1",
                     "edge2",
                     "Palermo",
@@ -5395,7 +5350,7 @@ export function runBaseTests<Context>(config: {
                         withDist: true,
                     },
                 );
-                checkSimple(searchResult).toEqual(expectedResult.slice(0, 2));
+                expect(searchResult).toEqual(expectedResult.slice(0, 2));
 
                 // Test search by radius, unit: kilometers, from a geospatial data, with limited ANY count to 1
                 searchResult = await client.geosearch(
@@ -5411,9 +5366,7 @@ export function runBaseTests<Context>(config: {
                         withHash: true,
                     },
                 );
-                expect(members.map((m) => Buffer.from(m))).toContainEqual(
-                    searchResult[0][0],
-                );
+                expect(members).toContainEqual(searchResult[0][0]);
 
                 // no members within the area
                 searchResult = await client.geosearch(
@@ -5472,10 +5425,10 @@ export function runBaseTests<Context>(config: {
                     2,
                 );
 
-                checkSimple(
+                expect(
                     await client.zmpop([key1, key2], ScoreFilter.MAX),
                 ).toEqual([key1, { b1: 2 }]);
-                checkSimple(
+                expect(
                     await client.zmpop([key2, key1], ScoreFilter.MAX, 10),
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
@@ -5570,10 +5523,10 @@ export function runBaseTests<Context>(config: {
                     2,
                 );
 
-                checkSimple(
+                expect(
                     await client.bzmpop([key1, key2], ScoreFilter.MAX, 0.1),
                 ).toEqual([key1, { b1: 2 }]);
-                checkSimple(
+                expect(
                     await client.bzmpop([key2, key1], ScoreFilter.MAX, 0.1, 10),
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
@@ -5901,7 +5854,7 @@ export function runCommonTests<Context>(config: {
                 const value = "שלום hello 汉字";
                 await client.set(key, value);
                 const result = await client.get(key);
-                checkSimple(result).toEqual(value);
+                expect(result).toEqual(value);
             });
         },
         config.timeout,
@@ -5913,7 +5866,7 @@ export function runCommonTests<Context>(config: {
             await runTest(async (client: Client) => {
                 const result = await client.get(uuidv4());
 
-                checkSimple(result).toEqual(null);
+                expect(result).toEqual(null);
             });
         },
         config.timeout,
@@ -5927,7 +5880,7 @@ export function runCommonTests<Context>(config: {
                 await client.set(key, "");
                 const result = await client.get(key);
 
-                checkSimple(result).toEqual("");
+                expect(result).toEqual("");
             });
         },
         config.timeout,
@@ -5954,7 +5907,7 @@ export function runCommonTests<Context>(config: {
                 await client.set(key, value);
                 const result = await client.get(key);
 
-                checkSimple(result).toEqual(value);
+                expect(result).toEqual(value);
             });
         },
         config.timeout,
@@ -5969,7 +5922,7 @@ export function runCommonTests<Context>(config: {
                         await GetAndSetRandomValue(client);
                     } else {
                         const result = await client.get(uuidv4());
-                        checkSimple(result).toEqual(null);
+                        expect(result).toEqual(null);
                     }
                 };
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -809,7 +809,7 @@ export function runBaseTests<Context>(config: {
                 const overflowGet = new BitFieldGet(u2, offset1);
 
                 // binary value: 01100110 01101111 01101111 01100010 01100001 01110010
-                checkSimple(await client.set(key1, foobar)).toEqual("OK");
+                expect(await client.set(key1, foobar)).toEqual("OK");
 
                 // SET tests
                 expect(
@@ -966,7 +966,7 @@ export function runBaseTests<Context>(config: {
                 );
 
                 // binary value: 01100110 01101111 01101111 01100010 01100001 01110010
-                checkSimple(await client.set(key, foobar)).toEqual("OK");
+                expect(await client.set(key, foobar)).toEqual("OK");
                 expect(
                     await client.bitfieldReadOnly(key, [
                         // Get value in: 0(11)00110 01101111 01101111 01100010 01100001 01110010 00010100

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -380,15 +380,15 @@ export function checkFunctionListResponse(
                 const flags = (
                     functionInfo["flags"] as unknown as Buffer[]
                 ).map((f) => f.toString());
-                checkSimple(functionInfo["description"]).toEqual(
+                expect(functionInfo["description"]).toEqual(
                     functionDescriptions.get(name),
                 );
 
-                checkSimple(flags).toEqual(functionFlags.get(name));
+                expect(flags).toEqual(functionFlags.get(name));
             }
 
             if (libCode) {
-                checkSimple(lib["library_code"]).toEqual(libCode);
+                expect(lib["library_code"]).toEqual(libCode);
             }
 
             break;


### PR DESCRIPTION
Reference PR: https://github.com/valkey-io/valkey-glide/pull/1953

- BaseClient is hardcoded to use the stringDecoder.
- `checkSimple` calls in SharedTests.ts.
- One test is failing and marked as TODO as it needs to be discussed. The test is `bitop test`.