### PR TITLE
Node: Fix tests.

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -185,10 +185,11 @@ import {
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 type PromiseFunction = (value?: any) => void;
 type ErrorFunction = (error: RedisError) => void;
-export type ReturnTypeMap = { [key: string]: ReturnType };
+export type ReturnTypeRecord = { [key: string]: ReturnType };
+export type ReturnTypeMap = Map<string, ReturnType>;
 export type ReturnTypeAttribute = {
     value: ReturnType;
-    attributes: ReturnTypeMap;
+    attributes: ReturnTypeRecord;
 };
 export enum ProtocolVersion {
     /** Use RESP2 to communicate with the server nodes. */
@@ -205,6 +206,7 @@ export type ReturnType =
     | bigint
     | Buffer
     | Set<ReturnType>
+    | ReturnTypeRecord
     | ReturnTypeMap
     | ReturnTypeAttribute
     | ReturnType[];

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@jest/globals";
 import { BufferReader, BufferWriter } from "protobufjs";
 import { v4 as uuidv4 } from "uuid";
-import { GlideClient, ProtocolVersion, Transaction , ListDirection } from "..";
+import { GlideClient, ProtocolVersion, Transaction, ListDirection } from "..";
 import { RedisCluster } from "../../utils/TestUtils.js";
 import { FlushMode } from "../build-ts/src/Commands";
 import { command_request } from "../src/ProtobufMessage";

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@jest/globals";
 import { BufferReader, BufferWriter } from "protobufjs";
 import { v4 as uuidv4 } from "uuid";
-import { GlideClient, ProtocolVersion, Transaction } from "..";
+import { GlideClient, ProtocolVersion, Transaction , ListDirection } from "..";
 import { RedisCluster } from "../../utils/TestUtils.js";
 import { FlushMode } from "../build-ts/src/Commands";
 import { command_request } from "../src/ProtobufMessage";
@@ -29,7 +29,6 @@ import {
     transactionTest,
     validateTransactionResponse,
 } from "./TestUtilities";
-import { ListDirection } from "..";
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -282,11 +282,21 @@ export function runBaseTests<Context>(config: {
                 /// we execute set and info so the commandstats will show `cmdstat_set::calls` greater than 1
                 /// after the configResetStat call we initiate an info command and the the commandstats won't contain `cmdstat_set`.
                 await client.set("foo", "bar");
-                const oldResult = await client.info([InfoOptions.Commandstats]);
+                const oldResult =
+                    client instanceof GlideClient
+                        ? await client.info([InfoOptions.Commandstats])
+                        : Object.values(
+                              await client.info([InfoOptions.Commandstats]),
+                          ).join();
                 expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
-                const result = await client.info([InfoOptions.Commandstats]);
+                const result =
+                    client instanceof GlideClient
+                        ? await client.info([InfoOptions.Commandstats])
+                        : Object.values(
+                              await client.info([InfoOptions.Commandstats]),
+                          ).join();
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -45,10 +45,8 @@ import { SingleNodeRoute } from "../build-ts/src/GlideClusterClient";
 import {
     Client,
     GetAndSetRandomValue,
-    checkSimple,
     compareMaps,
     getFirstResult,
-    intoString,
 } from "./TestUtilities";
 
 export type BaseClient = GlideClient | GlideClusterClient;
@@ -285,8 +283,7 @@ export function runBaseTests<Context>(config: {
                 /// after the configResetStat call we initiate an info command and the the commandstats won't contain `cmdstat_set`.
                 await client.set("foo", "bar");
                 const oldResult = await client.info([InfoOptions.Commandstats]);
-                const oldResultAsString = intoString(oldResult);
-                expect(oldResultAsString).toContain("cmdstat_set");
+                expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
                 const result = await client.info([InfoOptions.Commandstats]);
@@ -338,14 +335,14 @@ export function runBaseTests<Context>(config: {
 
                 expect(await client.msetnx(keyValueMap1)).toEqual(true);
 
-                checkSimple(
-                    await client.mget([key1, key2, nonExistingKey]),
-                ).toEqual([value, value, null]);
+                expect(await client.mget([key1, key2, nonExistingKey])).toEqual(
+                    [value, value, null],
+                );
 
                 expect(await client.msetnx(keyValueMap2)).toEqual(false);
 
                 expect(await client.get(key3)).toEqual(null);
-                checkSimple(await client.get(key2)).toEqual(value);
+                expect(await client.get(key2)).toEqual(value);
 
                 // empty map and RequestError is thrown
                 const emptyMap = {};
@@ -1694,7 +1691,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.lpush(key2, lpushArgs2)).toEqual(2);
 
                 // Move from LEFT to LEFT with blocking
-                checkSimple(
+                expect(
                     await client.blmove(
                         key1,
                         key2,
@@ -1705,7 +1702,7 @@ export function runBaseTests<Context>(config: {
                 ).toEqual("1");
 
                 // Move from LEFT to RIGHT with blocking
-                checkSimple(
+                expect(
                     await client.blmove(
                         key1,
                         key2,
@@ -1715,16 +1712,16 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual("2");
 
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([
+                expect(await client.lrange(key2, 0, -1)).toEqual([
                     "1",
                     "3",
                     "4",
                     "2",
                 ]);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([]);
+                expect(await client.lrange(key1, 0, -1)).toEqual([]);
 
                 // Move from RIGHT to LEFT non-existing destination with blocking
-                checkSimple(
+                expect(
                     await client.blmove(
                         key2,
                         key1,
@@ -1734,15 +1731,15 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual("2");
 
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([
+                expect(await client.lrange(key2, 0, -1)).toEqual([
                     "1",
                     "3",
                     "4",
                 ]);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual(["2"]);
+                expect(await client.lrange(key1, 0, -1)).toEqual(["2"]);
 
                 // Move from RIGHT to RIGHT with blocking
-                checkSimple(
+                expect(
                     await client.blmove(
                         key2,
                         key1,
@@ -1752,14 +1749,8 @@ export function runBaseTests<Context>(config: {
                     ),
                 ).toEqual("4");
 
-                checkSimple(await client.lrange(key2, 0, -1)).toEqual([
-                    "1",
-                    "3",
-                ]);
-                checkSimple(await client.lrange(key1, 0, -1)).toEqual([
-                    "2",
-                    "4",
-                ]);
+                expect(await client.lrange(key2, 0, -1)).toEqual(["1", "3"]);
+                expect(await client.lrange(key1, 0, -1)).toEqual(["2", "4"]);
 
                 // Non-existing source key with blocking
                 expect(
@@ -1774,7 +1765,7 @@ export function runBaseTests<Context>(config: {
 
                 // Non-list source key with blocking
                 const key3 = "{key}-3" + uuidv4();
-                checkSimple(await client.set(key3, "value")).toEqual("OK");
+                expect(await client.set(key3, "value")).toEqual("OK");
                 await expect(
                     client.blmove(
                         key3,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -45,7 +45,6 @@ import { SingleNodeRoute } from "../build-ts/src/GlideClusterClient";
 import {
     Client,
     GetAndSetRandomValue,
-    checkSimple,
     compareMaps,
     getFirstResult,
 } from "./TestUtilities";

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -45,6 +45,7 @@ import { SingleNodeRoute } from "../build-ts/src/GlideClusterClient";
 import {
     Client,
     GetAndSetRandomValue,
+    checkSimple,
     compareMaps,
     getFirstResult,
     intoString,


### PR DESCRIPTION
* Fix issue caused by merging #2047 and #2026/#2046 w/o rebase
* Fix pubsub IT to work with already existing clusters
* Removed `Buffer`, `checkSimple` and `intoString` references from tests
* Fix transaction IT response validation to use deep comparison and reporting (#2010)
