### PR TITLE
Node: fix lints

### DIFF
--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -14,6 +14,7 @@ on:
             - node/**
             - benchmarks/utilities/*
             - .github/workflows/lint-ts.yml
+    workflow_dispatch:
 
 concurrency:
     group: node-lint-${{ github.head_ref || github.ref }}

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -9,6 +9,7 @@ import { arch, platform } from "process";
 
 let globalObject = global as unknown;
 
+/* eslint-disable @typescript-eslint/no-require-imports */
 function loadNativeBinding() {
     let nativeBinding = null;
     switch (platform) {

--- a/node/tests/AsyncClient.test.ts
+++ b/node/tests/AsyncClient.test.ts
@@ -7,7 +7,7 @@ import { AsyncClient } from "glide-rs";
 import RedisServer from "redis-server";
 import { runCommonTests } from "./SharedTests";
 import { flushallOnPort } from "./TestUtilities";
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const FreePort = require("find-free-port");
 
 const PORT_NUMBER = 4000;

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -5604,10 +5604,12 @@ export function runBaseTests<Context>(config: {
                     await client.zmpop([key2, key1], ScoreFilter.MAX, 10),
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
-                expect(await client.zmpop([nonExistingKey], ScoreFilter.MIN))
-                    .toBeNull();
-                expect(await client.zmpop([nonExistingKey], ScoreFilter.MIN, 1))
-                    .toBeNull();
+                expect(
+                    await client.zmpop([nonExistingKey], ScoreFilter.MIN),
+                ).toBeNull();
+                expect(
+                    await client.zmpop([nonExistingKey], ScoreFilter.MIN, 1),
+                ).toBeNull();
 
                 // key exists, but it is not a sorted set
                 expect(await client.set(stringKey, "value")).toEqual("OK");

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -5605,9 +5605,9 @@ export function runBaseTests<Context>(config: {
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
                 expect(await client.zmpop([nonExistingKey], ScoreFilter.MIN))
-                    .toBeNull;
+                    .toBeNull();
                 expect(await client.zmpop([nonExistingKey], ScoreFilter.MIN, 1))
-                    .toBeNull;
+                    .toBeNull();
 
                 // key exists, but it is not a sorted set
                 expect(await client.set(stringKey, "value")).toEqual("OK");
@@ -5705,7 +5705,7 @@ export function runBaseTests<Context>(config: {
                 // ensure that command doesn't time out even if timeout > request timeout (250ms by default)
                 expect(
                     await client.bzmpop([nonExistingKey], ScoreFilter.MAX, 0.5),
-                ).toBeNull;
+                ).toBeNull();
                 expect(
                     await client.bzmpop(
                         [nonExistingKey],
@@ -5713,7 +5713,7 @@ export function runBaseTests<Context>(config: {
                         0.55,
                         1,
                     ),
-                ).toBeNull;
+                ).toBeNull();
 
                 // key exists, but it is not a sorted set
                 expect(await client.set(stringKey, "value")).toEqual("OK");

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -411,7 +411,7 @@ export function validateTransactionResponse(
 
         try {
             expect(response?.[i]).toEqual(expectedResponse);
-        } catch (e) {
+        } catch {
             const expected =
                 expectedResponse instanceof Map
                     ? JSON.stringify(Array.from(expectedResponse.entries()))


### PR DESCRIPTION
1. `eslint` probably got new update and started producing new errors, which we never seen before ([CI run](https://github.com/valkey-io/valkey-glide/actions/runs/10185991412/job/28176763111?pr=2057))
2. Update lint CI to allow running in demand according to #1967 

```
/home/runner/work/valkey-glide/valkey-glide/node/npm/glide/index.ts
  20:45  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  23:45  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  26:45  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  33:45  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  36:45  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  39:45  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  52:37  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports
  55:37  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports

/home/runner/work/valkey-glide/valkey-glide/node/tests/AsyncClient.test.ts
  [11](https://github.com/valkey-io/valkey-glide/actions/runs/10185991412/job/28176763111?pr=2057#step:4:12):18  error  A `require()` style import is forbidden  @typescript-eslint/no-require-imports

/home/runner/work/valkey-glide/valkey-glide/node/tests/SharedTests.ts
  5604:17  error  Expected an assignment or function call and instead saw an expression  @typescript-eslint/no-unused-expressions
  5606:17  error  Expected an assignment or function call and instead saw an expression  @typescript-eslint/no-unused-expressions
  5703:17  error  Expected an assignment or function call and instead saw an expression  @typescript-eslint/no-unused-expressions
  5706:17  error  Expected an assignment or function call and instead saw an expression  @typescript-eslint/no-unused-expressions

/home/runner/work/valkey-glide/valkey-glide/node/tests/TestUtilities.ts
  4[14](https://github.com/valkey-io/valkey-glide/actions/runs/10185991412/job/28176763111?pr=2057#step:4:15):18  error  'e' is defined but never used  @typescript-eslint/no-unused-vars

✖ 14 problems (14 errors, 0 warnings)
```