### PR TITLE
Downgrade and fix cargo-deny version

### DIFF
--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -42,7 +42,7 @@ runs:
 
         - run: |
               cargo update
-              cargo install cargo-deny
+              cargo install --locked --version 0.15.1 cargo-deny
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash


### PR DESCRIPTION
This should fix the lint-rust CI workflow.  This is the second time this has happened.  I added `--locked` because we did not do this last time and it is the recommended option by the maintainers of `cargo-deny`: https://github.com/EmbarkStudios/cargo-deny/issues/641#issuecomment-2016478168