### PR TITLE
Add Valkey8 support

### DIFF
--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -2,5 +2,9 @@
   {
     "type": "valkey",
     "version": "7.2.5"
+  },
+  {
+    "type": "valkey",
+    "version": "8.0.0-rc1"
   }
 ]

--- a/.github/workflows/install-valkey/action.yml
+++ b/.github/workflows/install-valkey/action.yml
@@ -62,6 +62,7 @@ runs:
             echo 'export PATH=/usr/local/bin:$PATH' >>~/.bash_profile
 
         - name: Verify Valkey installation and symlinks
+          if: ${{ !contains(inputs.engine-version, '-rc1') }}
           shell: bash
           run: | 
             # In Valkey releases, the engine is built with symlinks from valkey-server and valkey-cli

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,6 +15,7 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+            - .github/json_matrices/engine-matrix.json
 
     pull_request:
         paths:
@@ -29,6 +30,7 @@ on:
             - .github/workflows/lint-rust/action.yml
             - .github/workflows/install-valkey/action.yml
             - .github/json_matrices/build-matrix.json
+            - .github/json_matrices/engine-matrix.json
     workflow_dispatch:
 
 concurrency:

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -103,12 +103,53 @@ tasks.register('startStandalone') {
 
 tasks.register('getServerVersion') {
     doLast {
-        new ByteArrayOutputStream().withStream { os ->
-            exec {
-                commandLine 'redis-server', '-v'
-                standardOutput = os
+        def detectedVersion
+        def output = new ByteArrayOutputStream()
+
+        // Helper method to find the full path of a command
+        def findFullPath = { command ->
+            def pathOutput = new ByteArrayOutputStream()
+            try {
+                exec {
+                    commandLine 'which', command  // Use 'where' for Windows
+                    standardOutput = pathOutput
+                }
+                return pathOutput.toString().trim()
+            } catch (Exception e) {
+                println "Failed to find path for ${command}: ${e.message}"
+                return ""
             }
-            serverVersion = extractServerVersion(os.toString())
+        }
+
+        // Get full paths
+        def valkeyPath = findFullPath('valkey-server')
+        def redisPath = findFullPath('redis-server')
+
+        def tryGetVersion = { serverPath ->
+            try {
+                exec {
+                    commandLine serverPath, '-v'
+                    standardOutput = output
+                }
+                return output.toString()
+            } catch (Exception e) {
+                println "Failed to execute ${serverPath}: ${e.message}"
+                return ""
+            }
+        }
+
+        // Try valkey-server first, then redis-server if it fails
+        def versionOutput = tryGetVersion(valkeyPath)
+        if (versionOutput.isEmpty() && !redisPath.isEmpty()) {
+            versionOutput = tryGetVersion(redisPath)
+        }
+
+        if (!versionOutput.isEmpty()) {
+            detectedVersion = extractServerVersion(versionOutput)
+            println "Detected server version: ${detectedVersion}"
+            serverVersion = detectedVersion
+        } else {
+            throw new GradleException("Failed to retrieve the server version.")
         }
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -13774,9 +13774,14 @@ public class SharedCommandTests {
         assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        result = client.sscan(key1, "-1").get();
-        assertEquals(initialCursor, result[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> client.sscan(key1, "-1").get());
+        } else {
+            result = client.sscan(key1, "-1").get();
+            assertEquals(initialCursor, result[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
+        }
 
         // Result contains the whole set
         assertEquals(charMembers.length, client.sadd(key1, charMembers).get());
@@ -13910,9 +13915,14 @@ public class SharedCommandTests {
         assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        result = client.sscan(key1, gs("-1")).get();
-        assertEquals(initialCursor, gs(result[resultCursorIndex].toString()));
-        assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> client.sscan(key1, gs("-1")).get());
+        } else {
+            result = client.sscan(key1, gs("-1")).get();
+            assertEquals(initialCursor, gs(result[resultCursorIndex].toString()));
+            assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
+        }
 
         // Result contains the whole set
         assertEquals(charMembers.length, client.sadd(key1, charMembers).get());
@@ -14059,9 +14069,14 @@ public class SharedCommandTests {
         assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        result = client.zscan(key1, "-1").get();
-        assertEquals(initialCursor, result[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> client.zscan(key1, "-1").get());
+        } else {
+            result = client.zscan(key1, "-1").get();
+            assertEquals(initialCursor, result[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
+        }
 
         // Result contains the whole set
         assertEquals(charMembers.length, client.zadd(key1, charMap).get());
@@ -14240,9 +14255,14 @@ public class SharedCommandTests {
         assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        result = client.zscan(key1, gs("-1")).get();
-        assertEquals(initialCursor, gs(result[resultCursorIndex].toString()));
-        assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> client.zscan(key1, gs("-1")).get());
+        } else {
+            result = client.zscan(key1, gs("-1")).get();
+            assertEquals(initialCursor, gs(result[resultCursorIndex].toString()));
+            assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
+        }
 
         // Result contains the whole set
         assertEquals(charMembers.length, client.zadd(key1.toString(), charMap_strings).get());
@@ -14425,9 +14445,14 @@ public class SharedCommandTests {
         assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        result = client.hscan(key1, "-1").get();
-        assertEquals(initialCursor, result[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> client.hscan(key1, "-1").get());
+        } else {
+            result = client.hscan(key1, "-1").get();
+            assertEquals(initialCursor, result[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
+        }
 
         // Result contains the whole set
         assertEquals(charMembers.length, client.hset(key1, charMap).get());
@@ -14589,9 +14614,14 @@ public class SharedCommandTests {
         assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        result = client.hscan(key1, gs("-1")).get();
-        assertEquals(initialCursor, gs(result[resultCursorIndex].toString()));
-        assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> client.hscan(key1, gs("-1")).get());
+        } else {
+            result = client.hscan(key1, gs("-1")).get();
+            assertEquals(initialCursor, gs(result[resultCursorIndex].toString()));
+            assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
+        }
 
         // Result contains the whole set
         assertEquals(charMembers.length, client.hset(key1, charMap).get());

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1535,9 +1535,14 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        Object[] negativeResult = regularClient.scan("-1").get();
-        assertEquals(initialCursor, negativeResult[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> regularClient.scan("-1").get());
+        } else {
+            Object[] negativeResult = regularClient.scan("-1").get();
+            assertEquals(initialCursor, negativeResult[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        }
 
         // Add keys to the database using mset
         regularClient.mset(keys).get();
@@ -1589,9 +1594,14 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        Object[] negativeResult = regularClient.scan(gs("-1")).get();
-        assertEquals(initialCursor, negativeResult[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            ExecutionException executionException =
+                    assertThrows(ExecutionException.class, () -> regularClient.scan(gs("-1")).get());
+        } else {
+            Object[] negativeResult = regularClient.scan(gs("-1")).get();
+            assertEquals(initialCursor, negativeResult[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        }
 
         // Add keys to the database using mset
         regularClient.msetBinary(keys).get();
@@ -1652,9 +1662,16 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        Object[] negativeResult = regularClient.scan("-1", options).get();
-        assertEquals(initialCursor, negativeResult[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            final ScanOptions finalOptions = options;
+            ExecutionException executionException =
+                    assertThrows(
+                            ExecutionException.class, () -> regularClient.scan("-1", finalOptions).get());
+        } else {
+            Object[] negativeResult = regularClient.scan("-1", options).get();
+            assertEquals(initialCursor, negativeResult[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        }
 
         // scan for strings by match pattern:
         options =
@@ -1734,9 +1751,16 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        Object[] negativeResult = regularClient.scan(gs("-1"), options).get();
-        assertEquals(initialCursor, negativeResult[resultCursorIndex]);
-        assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            final ScanOptions finalOptions = options;
+            ExecutionException executionException =
+                    assertThrows(
+                            ExecutionException.class, () -> regularClient.scan(gs("-1"), finalOptions).get());
+        } else {
+            Object[] negativeResult = regularClient.scan(gs("-1"), options).get();
+            assertEquals(initialCursor, negativeResult[resultCursorIndex]);
+            assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+        }
 
         // scan for strings by match pattern:
         options =

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -412,7 +412,10 @@ class TestCommands:
         info_res = get_first_result(await glide_client.info([InfoSection.SERVER]))
         info = info_res.decode()
         assert "# Server" in info
-        cluster_mode = parse_info_response(info_res)["redis_mode"]
+        if not await check_if_server_version_lt(glide_client, "7.9.0"):
+            cluster_mode = parse_info_response(info_res)["server_mode"]
+        else:
+            cluster_mode = parse_info_response(info_res)["redis_mode"]
         expected_cluster_mode = isinstance(glide_client, GlideClusterClient)
         assert cluster_mode == "cluster" if expected_cluster_mode else "standalone"
         info = get_first_result(
@@ -9823,9 +9826,13 @@ class TestClusterRoutes:
         assert result[result_collection_index] == []
 
         # Negative cursor
-        result = await glide_client.sscan(key1, "-1")
-        assert result[result_cursor_index] == initial_cursor.encode()
-        assert result[result_collection_index] == []
+        if await check_if_server_version_lt(glide_client, "7.9.0"):
+            result = await glide_client.sscan(key1, "-1")
+            assert result[result_cursor_index] == initial_cursor.encode()
+            assert result[result_collection_index] == []
+        else:
+            with pytest.raises(RequestError):
+                await glide_client.sscan(key2, "-1")
 
         # Result contains the whole set
         assert await glide_client.sadd(key1, char_members) == len(char_members)
@@ -9933,9 +9940,13 @@ class TestClusterRoutes:
         assert result[result_collection_index] == []
 
         # Negative cursor
-        result = await glide_client.zscan(key1, "-1")
-        assert result[result_cursor_index] == initial_cursor.encode()
-        assert result[result_collection_index] == []
+        if await check_if_server_version_lt(glide_client, "7.9.0"):
+            result = await glide_client.zscan(key1, "-1")
+            assert result[result_cursor_index] == initial_cursor.encode()
+            assert result[result_collection_index] == []
+        else:
+            with pytest.raises(RequestError):
+                await glide_client.zscan(key2, "-1")
 
         # Result contains the whole set
         assert await glide_client.zadd(key1, char_map) == len(char_map)
@@ -10046,9 +10057,13 @@ class TestClusterRoutes:
         assert result[result_collection_index] == []
 
         # Negative cursor
-        result = await glide_client.hscan(key1, "-1")
-        assert result[result_cursor_index] == initial_cursor.encode()
-        assert result[result_collection_index] == []
+        if await check_if_server_version_lt(glide_client, "7.9.0"):
+            result = await glide_client.hscan(key1, "-1")
+            assert result[result_cursor_index] == initial_cursor.encode()
+            assert result[result_collection_index] == []
+        else:
+            with pytest.raises(RequestError):
+                await glide_client.hscan(key2, "-1")
 
         # Result contains the whole set
         assert await glide_client.hset(key1, char_map) == len(char_map)

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -842,9 +842,15 @@ class TestTransaction:
         transaction.custom_command(["WATCH", key])
         with pytest.raises(RequestError) as e:
             await self.exec_transaction(glide_client, transaction)
-        assert "WATCH inside MULTI is not allowed" in str(
-            e
-        )  # TODO : add an assert on EXEC ABORT
+        if await check_if_server_version_lt(glide_client, "7.9.0"):
+            assert "WATCH inside MULTI is not allowed" in str(
+                e
+            )  # TODO : add an assert on EXEC ABORT
+
+        else:
+            assert "Command not allowed inside a transaction" in str(
+                e
+            )  # TODO : add an assert on EXEC ABORT
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/python/tests/utils/utils.py
+++ b/python/python/tests/utils/utils.py
@@ -79,6 +79,9 @@ def get_random_string(length):
 async def check_if_server_version_lt(client: TGlideClient, min_version: str) -> bool:
     # TODO: change it to pytest fixture after we'll implement a sync client
     info_str = await client.info([InfoSection.SERVER])
+    valkey_version = parse_info_response(info_str).get("valkey_version")
+    if valkey_version:
+        return version.parse(valkey_version) < version.parse(min_version)
     server_version = parse_info_response(info_str).get("redis_version")
     assert server_version is not None
     return version.parse(server_version) < version.parse(min_version)

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -51,15 +51,23 @@ export class RedisCluster {
     }
 
     private static async detectVersion(): Promise<string> {
-        return new Promise<string>((resolve, reject) =>
-            exec(`redis-server -v`, (error, stdout) => {
+        return new Promise<string>((resolve, reject) => {
+            // First, try with `valkey-server -v`
+            exec("valkey-server -v", (error, stdout) => {
                 if (error) {
-                    reject(error);
-                } else {
-                    resolve(stdout.split("v=")[1].split(" ")[0]);
+                    // If `valkey-server` fails, try `redis-server -v`
+                    exec("redis-server -v", (error, stdout) => {
+                        if (error) {
+                            reject(error);
+                        } else {
+                            resolve(stdout.split("v=")[1].split(" ")[0]);
+                        }
+                    });
                 }
-            })
-        );
+
+                resolve(stdout.split("v=")[1].split(" ")[0]);
+            });
+        });
     }
 
     public static createCluster(


### PR DESCRIPTION
- [x] change test_info_server_replication not to check the "redis_mode". Errors parsing won't be changed - see https://github.com/valkey-io/valkey/pull/306
- [x] adding one command in every wrapper that excepts a sha and returns the script code, we can also add a get_code function to the script object - see https://github.com/valkey-io/valkey/pull/617
- ~~[x] Added new command [CLUSTER SLOT-STATS](https://github.com/valkey-io/valkey/pull/351/files#top) in each of the wrappers for CLUSTER mode only. [PR #351](https://github.com/valkey-io/valkey/pull/351)~~
- [x] add NOSCORES parameter to the the zscan command in every wrapper. for java - add the parameter to ZSCANOptions - see https://github.com/valkey-io/valkey/pull/324
- [ ] Add NOVALUES option to HSCAN command. (Redis#12765)
- [ ] For Valkey 8, change the end param to optional https://github.com/valkey-io/valkey/pull/118
- [ ] Support BY/GET options for SORT/SORT_RO in cluster mode when pattern
implies a single slot.