### PR TITLE
Node: Clean `since` tags in command documentation

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -916,7 +916,8 @@ export class BaseClient {
     }
 
     /** Get the value associated with the given key, or null if no such value exists.
-     * See https://valkey.io/commands/get/ for details.
+     *
+     * @see {@link https://valkey.io/commands/get/|valkey.io} for details.
      *
      * @param key - The key to retrieve from the database.
      * @param decoder - Optional enum parameter for decoding the response.
@@ -965,7 +966,7 @@ export class BaseClient {
     /**
      * Gets a string value associated with the given `key`and deletes the key.
      *
-     * See https://valkey.io/commands/getdel/ for details.
+     * @see {@link https://valkey.io/commands/getdel/|valkey.io} for details.
      *
      * @param key - The key to retrieve from the database.
      * @returns If `key` exists, returns the `value` of `key`. Otherwise, return `null`.
@@ -989,7 +990,7 @@ export class BaseClient {
      * penultimate and so forth. If `key` does not exist, an empty string is returned. If `start`
      * or `end` are out of range, returns the substring within the valid range of the string.
      *
-     * See https://valkey.io/commands/getrange/ for details.
+     * @see {@link https://valkey.io/commands/getrange/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param start - The starting offset.
@@ -1018,7 +1019,8 @@ export class BaseClient {
     }
 
     /** Set the given key with the given value. Return value is dependent on the passed options.
-     * See https://valkey.io/commands/set/ for details.
+     *
+     * @see {@link https://valkey.io/commands/set/|valkey.io} for details.
      *
      * @param key - The key to store.
      * @param value - The value to store with the given key.
@@ -1055,7 +1057,8 @@ export class BaseClient {
     }
 
     /** Removes the specified keys. A key is ignored if it does not exist.
-     * See https://valkey.io/commands/del/ for details.
+     *
+     * @see {@link https://valkey.io/commands/del/|valkey.io} for details.
      *
      * @param keys - the keys we wanted to remove.
      * @returns the number of keys that were removed.
@@ -1080,7 +1083,8 @@ export class BaseClient {
     }
 
     /** Retrieve the values of multiple keys.
-     * See https://valkey.io/commands/mget/ for details.
+     *
+     * @see {@link https://valkey.io/commands/mget/|valkey.io} for details.
      *
      * @remarks When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
      * @param keys - A list of keys to retrieve values for.
@@ -1101,7 +1105,8 @@ export class BaseClient {
     }
 
     /** Set multiple keys to multiple values in a single operation.
-     * See https://valkey.io/commands/mset/ for details.
+     *
+     * @see {@link https://valkey.io/commands/mset/|valkey.io} for details.
      *
      * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keyValueMap` map to different hash slots.
      * @param keyValueMap - A key-value map consisting of keys and their respective values to set.
@@ -1122,9 +1127,9 @@ export class BaseClient {
      * Sets multiple keys to values if the key does not exist. The operation is atomic, and if one or
      * more keys already exist, the entire operation fails.
      *
-     * See https://valkey.io/commands/msetnx/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/msetnx/|valkey.io} for more details.
      * @remarks When in cluster mode, all keys in `keyValueMap` must map to the same hash slot.
+     *
      * @param keyValueMap - A key-value map consisting of keys and their respective values to set.
      * @returns `true` if all keys were set. `false` if no key was set.
      *
@@ -1142,7 +1147,8 @@ export class BaseClient {
     }
 
     /** Increments the number stored at `key` by one. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/incr/ for details.
+     *
+     * @see {@link https://valkey.io/commands/incr/|valkey.io} for details.
      *
      * @param key - The key to increment its value.
      * @returns the value of `key` after the increment.
@@ -1160,7 +1166,8 @@ export class BaseClient {
     }
 
     /** Increments the number stored at `key` by `amount`. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/incrby/ for details.
+     *
+     * @see {@link https://valkey.io/commands/incrby/|valkey.io} for details.
      *
      * @param key - The key to increment its value.
      * @param amount - The amount to increment.
@@ -1181,7 +1188,8 @@ export class BaseClient {
     /** Increment the string representing a floating point number stored at `key` by `amount`.
      * By using a negative increment value, the result is that the value stored at `key` is decremented.
      * If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/incrbyfloat/ for details.
+     *
+     * @see {@link https://valkey.io/commands/incrbyfloat/|valkey.io} for details.
      *
      * @param key - The key to increment its value.
      * @param amount - The amount to increment.
@@ -1200,7 +1208,8 @@ export class BaseClient {
     }
 
     /** Decrements the number stored at `key` by one. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/decr/ for details.
+     *
+     * @see {@link https://valkey.io/commands/decr/|valkey.io} for details.
      *
      * @param key - The key to decrement its value.
      * @returns the value of `key` after the decrement.
@@ -1218,7 +1227,8 @@ export class BaseClient {
     }
 
     /** Decrements the number stored at `key` by `amount`. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/decrby/ for details.
+     *
+     * @see {@link https://valkey.io/commands/decrby/|valkey.io} for details.
      *
      * @param key - The key to decrement its value.
      * @param amount - The amount to decrement.
@@ -1240,7 +1250,7 @@ export class BaseClient {
      * Perform a bitwise operation between multiple keys (containing string values) and store the result in the
      * `destination`.
      *
-     * See https://valkey.io/commands/bitop/ for more details.
+     * @see {@link https://valkey.io/commands/bitop/|valkey.io} for more details.
      *
      * @remarks When in cluster mode, `destination` and all `keys` must map to the same hash slot.
      * @param operation - The bitwise operation to perform.
@@ -1273,7 +1283,7 @@ export class BaseClient {
      * Returns the bit value at `offset` in the string value stored at `key`. `offset` must be greater than or equal
      * to zero.
      *
-     * See https://valkey.io/commands/getbit/ for more details.
+     * @see {@link https://valkey.io/commands/getbit/|valkey.io} for more details.
      *
      * @param key - The key of the string.
      * @param offset - The index of the bit to return.
@@ -1296,7 +1306,7 @@ export class BaseClient {
      * `2^32` and greater than or equal to `0`. If a key is non-existent then the bit at `offset` is set to `value` and
      * the preceding bits are set to `0`.
      *
-     * See https://valkey.io/commands/setbit/ for more details.
+     * @see {@link https://valkey.io/commands/setbit/|valkey.io} for more details.
      *
      * @param key - The key of the string.
      * @param offset - The index of the bit to be set.
@@ -1323,7 +1333,7 @@ export class BaseClient {
      * The offset can also be a negative number indicating an offset starting at the end of the list, with `-1` being
      * the last byte of the list, `-2` being the penultimate, and so on.
      *
-     * See https://valkey.io/commands/bitpos/ for more details.
+     * @see {@link https://valkey.io/commands/bitpos/|valkey.io} for more details.
      *
      * @param key - The key of the string.
      * @param bit - The bit value to match. Must be `0` or `1`.
@@ -1360,7 +1370,7 @@ export class BaseClient {
      * are assumed. If BIT is specified, `start=0` and `end=2` means to look at the first three bits. If BYTE is
      * specified, `start=0` and `end=2` means to look at the first three bytes.
      *
-     * See https://valkey.io/commands/bitpos/ for more details.
+     * @see {@link https://valkey.io/commands/bitpos/|valkey.io} for more details.
      *
      * @param key - The key of the string.
      * @param bit - The bit value to match. Must be `0` or `1`.
@@ -1398,7 +1408,7 @@ export class BaseClient {
      * Reads or modifies the array of bits representing the string that is held at `key` based on the specified
      * `subcommands`.
      *
-     * See https://valkey.io/commands/bitfield/ for more details.
+     * @see {@link https://valkey.io/commands/bitfield/|valkey.io} for more details.
      *
      * @param key - The key of the string.
      * @param subcommands - The subcommands to be performed on the binary value of the string at `key`, which could be
@@ -1435,9 +1445,9 @@ export class BaseClient {
     /**
      * Reads the array of bits representing the string that is held at `key` based on the specified `subcommands`.
      *
-     * See https://valkey.io/commands/bitfield_ro/ for more details.
+     * @see {@link https://valkey.io/commands/bitfield_ro/|valkey.io} for more details.
      *
-     * Since Valkey version 6.0.0.
+     * @remarks Since Valkey version 6.0.0.
      *
      * @param key - The key of the string.
      * @param subcommands - The {@link BitFieldGet} subcommands to be performed.
@@ -1458,7 +1468,8 @@ export class BaseClient {
     }
 
     /** Retrieve the value associated with `field` in the hash stored at `key`.
-     * See https://valkey.io/commands/hget/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hget/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field in the hash stored at `key` to retrieve from the database.
@@ -1484,7 +1495,8 @@ export class BaseClient {
     }
 
     /** Sets the specified fields to their respective values in the hash stored at `key`.
-     * See https://valkey.io/commands/hset/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hset/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param fieldValueMap - A field-value map consisting of fields and their corresponding values
@@ -1508,7 +1520,8 @@ export class BaseClient {
     /** Sets `field` in the hash stored at `key` to `value`, only if `field` does not yet exist.
      * If `key` does not exist, a new key holding a hash is created.
      * If `field` already exists, this operation has no effect.
-     * See https://valkey.io/commands/hsetnx/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/hsetnx/|valkey.io} for more details.
      *
      * @param key - The key of the hash.
      * @param field - The field to set the value for.
@@ -1539,7 +1552,8 @@ export class BaseClient {
 
     /** Removes the specified fields from the hash stored at `key`.
      * Specified fields that do not exist within this hash are ignored.
-     * See https://valkey.io/commands/hdel/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hdel/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param fields - The fields to remove from the hash stored at `key`.
@@ -1558,7 +1572,8 @@ export class BaseClient {
     }
 
     /** Returns the values associated with the specified fields in the hash stored at `key`.
-     * See https://valkey.io/commands/hmget/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hmget/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param fields - The fields in the hash stored at `key` to retrieve from the database.
@@ -1581,7 +1596,8 @@ export class BaseClient {
     }
 
     /** Returns if `field` is an existing field in the hash stored at `key`.
-     * See https://valkey.io/commands/hexists/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hexists/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field to check in the hash stored at `key`.
@@ -1606,7 +1622,8 @@ export class BaseClient {
     }
 
     /** Returns all fields and values of the hash stored at `key`.
-     * See https://valkey.io/commands/hgetall/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hgetall/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @returns a list of fields and their values stored in the hash. Every field name in the list is followed by its value.
@@ -1626,7 +1643,8 @@ export class BaseClient {
     /** Increments the number stored at `field` in the hash stored at `key` by increment.
      * By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
      * If `field` or `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/hincrby/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hincrby/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param amount - The amount to increment.
@@ -1651,7 +1669,8 @@ export class BaseClient {
     /** Increment the string representing a floating point number stored at `field` in the hash stored at `key` by increment.
      * By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
      * If `field` or `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/hincrbyfloat/ for details.
+     *
+     * @see {@link https://valkey.io/commands/hincrbyfloat/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param amount - The amount to increment.
@@ -1674,7 +1693,8 @@ export class BaseClient {
     }
 
     /** Returns the number of fields contained in the hash stored at `key`.
-     * See https://valkey.io/commands/hlen/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/hlen/|valkey.io} for more details.
      *
      * @param key - The key of the hash.
      * @returns The number of fields in the hash, or 0 when the key does not exist.
@@ -1698,7 +1718,8 @@ export class BaseClient {
     }
 
     /** Returns all values in the hash stored at key.
-     * See https://valkey.io/commands/hvals/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/hvals/|valkey.io} for more details.
      *
      * @param key - The key of the hash.
      * @returns a list of values in the hash, or an empty list when the key does not exist.
@@ -1717,7 +1738,7 @@ export class BaseClient {
     /**
      * Returns the string length of the value associated with `field` in the hash stored at `key`.
      *
-     * See https://valkey.io/commands/hstrlen/ for details.
+     * @see {@link https://valkey.io/commands/hstrlen/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field in the hash.
@@ -1737,9 +1758,8 @@ export class BaseClient {
     /**
      * Returns a random field name from the hash value stored at `key`.
      *
-     * See https://valkey.io/commands/hrandfield/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/hrandfield/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @returns A random field name from the hash stored at `key`, or `null` when
@@ -1802,9 +1822,8 @@ export class BaseClient {
     /**
      * Retrieves up to `count` random field names from the hash value stored at `key`.
      *
-     * See https://valkey.io/commands/hrandfield/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/hrandfield/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -1829,9 +1848,8 @@ export class BaseClient {
      * Retrieves up to `count` random field names along with their values from the hash
      * value stored at `key`.
      *
-     * See https://valkey.io/commands/hrandfield/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/hrandfield/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -1857,7 +1875,8 @@ export class BaseClient {
     /** Inserts all the specified values at the head of the list stored at `key`.
      * `elements` are inserted one after the other to the head of the list, from the leftmost element to the rightmost element.
      * If `key` does not exist, it is created as empty list before performing the push operations.
-     * See https://valkey.io/commands/lpush/ for details.
+     *
+     * @see {@link https://valkey.io/commands/lpush/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the head of the list stored at `key`.
@@ -1885,7 +1904,7 @@ export class BaseClient {
      * Inserts specified values at the head of the `list`, only if `key` already
      * exists and holds a list.
      *
-     * See https://valkey.io/commands/lpushx/ for details.
+     * @see {@link https://valkey.io/commands/lpushx/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the head of the list stored at `key`.
@@ -1902,7 +1921,8 @@ export class BaseClient {
 
     /** Removes and returns the first elements of the list stored at `key`.
      * The command pops a single element from the beginning of the list.
-     * See https://valkey.io/commands/lpop/ for details.
+     *
+     * @see {@link https://valkey.io/commands/lpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @returns The value of the first element.
@@ -1927,7 +1947,8 @@ export class BaseClient {
     }
 
     /** Removes and returns up to `count` elements of the list stored at `key`, depending on the list's length.
-     * See https://valkey.io/commands/lpop/ for details.
+     *
+     * @see {@link https://valkey.io/commands/lpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
@@ -1959,7 +1980,8 @@ export class BaseClient {
      * The offsets `start` and `end` are zero-based indexes, with 0 being the first element of the list, 1 being the next element and so on.
      * These offsets can also be negative numbers indicating offsets starting at the end of the list,
      * with -1 being the last element of the list, -2 being the penultimate, and so on.
-     * See https://valkey.io/commands/lrange/ for details.
+     *
+     * @see {@link https://valkey.io/commands/lrange/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param start - The starting point of the range.
@@ -1999,7 +2021,8 @@ export class BaseClient {
     }
 
     /** Returns the length of the list stored at `key`.
-     * See https://valkey.io/commands/llen/ for details.
+     *
+     * @see {@link https://valkey.io/commands/llen/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @returns the length of the list at `key`.
@@ -2021,9 +2044,8 @@ export class BaseClient {
      * depending on `whereTo`, and pushes the element at the first/last element of the list
      * stored at `destination` depending on `whereFrom`, see {@link ListDirection}.
      *
-     * See https://valkey.io/commands/lmove/ for details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/lmove/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
@@ -2063,13 +2085,11 @@ export class BaseClient {
      * of the list stored at `destination` depending on `whereTo`.
      * `BLMOVE` is the blocking variant of {@link lmove}.
      *
+     * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
      * @remarks
      * 1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
      * 2. `BLMOVE` is a client blocking command, see https://github.com/aws/glide-for-redis/wiki/General-Concepts#blocking-commands for more details and best practices.
-     *
-     * See https://valkey.io/commands/blmove/ for details.
-     *
-     * Since Valkey version 6.2.0.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
@@ -2110,7 +2130,7 @@ export class BaseClient {
      * Negative indices can be used to designate elements starting at the tail of
      * the list. Here, `-1` means the last element, `-2` means the penultimate and so forth.
      *
-     * See https://valkey.io/commands/lset/ for details.
+     * @see {@link https://valkey.io/commands/lset/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param index - The index of the element in the list to be set.
@@ -2136,7 +2156,8 @@ export class BaseClient {
      * The offsets `start` and `end` are zero-based indexes, with 0 being the first element of the list, 1 being the next element and so on.
      * These offsets can also be negative numbers indicating offsets starting at the end of the list,
      * with -1 being the last element of the list, -2 being the penultimate, and so on.
-     * See https://valkey.io/commands/ltrim/ for details.
+     *
+     * @see {@link https://valkey.io/commands/ltrim/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param start - The starting point of the range.
@@ -2186,7 +2207,8 @@ export class BaseClient {
     /** Inserts all the specified values at the tail of the list stored at `key`.
      * `elements` are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
      * If `key` does not exist, it is created as empty list before performing the push operations.
-     * See https://valkey.io/commands/rpush/ for details.
+     *
+     * @see {@link https://valkey.io/commands/rpush/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the tail of the list stored at `key`.
@@ -2214,7 +2236,7 @@ export class BaseClient {
      * Inserts specified values at the tail of the `list`, only if `key` already
      * exists and holds a list.
      *
-     * See https://valkey.io/commands/rpushx/ for details.
+     * @see {@link https://valkey.io/commands/rpushx/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the tail of the list stored at `key`.
@@ -2231,7 +2253,8 @@ export class BaseClient {
 
     /** Removes and returns the last elements of the list stored at `key`.
      * The command pops a single element from the end of the list.
-     * See https://valkey.io/commands/rpop/ for details.
+     *
+     * @see {@link https://valkey.io/commands/rpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @returns The value of the last element.
@@ -2256,7 +2279,8 @@ export class BaseClient {
     }
 
     /** Removes and returns up to `count` elements from the list stored at `key`, depending on the list's length.
-     * See https://valkey.io/commands/rpop/ for details.
+     *
+     * @see {@link https://valkey.io/commands/rpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
@@ -2286,7 +2310,8 @@ export class BaseClient {
 
     /** Adds the specified members to the set stored at `key`. Specified members that are already a member of this set are ignored.
      * If `key` does not exist, a new set is created before adding `members`.
-     * See https://valkey.io/commands/sadd/ for details.
+     *
+     * @see {@link https://valkey.io/commands/sadd/|valkey.io} for details.
      *
      * @param key - The key to store the members to its set.
      * @param members - A list of members to add to the set stored at `key`.
@@ -2304,7 +2329,8 @@ export class BaseClient {
     }
 
     /** Removes the specified members from the set stored at `key`. Specified members that are not a member of this set are ignored.
-     * See https://valkey.io/commands/srem/ for details.
+     *
+     * @see {@link https://valkey.io/commands/srem/|valkey.io} for details.
      *
      * @param key - The key to remove the members from its set.
      * @param members - A list of members to remove from the set stored at `key`.
@@ -2323,7 +2349,8 @@ export class BaseClient {
     }
 
     /** Returns all the members of the set value stored at `key`.
-     * See https://valkey.io/commands/smembers/ for details.
+     *
+     * @see {@link https://valkey.io/commands/smembers/|valkey.io} for details.
      *
      * @param key - The key to return its members.
      * @returns A `Set` containing all members of the set.
@@ -2344,8 +2371,8 @@ export class BaseClient {
 
     /** Moves `member` from the set at `source` to the set at `destination`, removing it from the source set.
      * Creates a new destination set if needed. The operation is atomic.
-     * See https://valkey.io/commands/smove for more details.
      *
+     * @see {@link https://valkey.io/commands/smove/|valkey.io} for more details.
      * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      *
      * @param source - The key of the set to remove the element from.
@@ -2370,7 +2397,8 @@ export class BaseClient {
     }
 
     /** Returns the set cardinality (number of elements) of the set stored at `key`.
-     * See https://valkey.io/commands/scard/ for details.
+     *
+     * @see {@link https://valkey.io/commands/scard/|valkey.io} for details.
      *
      * @param key - The key to return the number of its members.
      * @returns The cardinality (number of elements) of the set, or 0 if key does not exist.
@@ -2387,9 +2415,10 @@ export class BaseClient {
     }
 
     /** Gets the intersection of all the given sets.
-     * See https://valkey.io/docs/latest/commands/sinter/ for more details.
      *
+     * @see {@link https://valkey.io/docs/latest/commands/sinter/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     *
      * @param keys - The `keys` of the sets to get the intersection.
      * @returns - A set of members which are present in all given sets.
      * If one or more sets do not exist, an empty set will be returned.
@@ -2417,11 +2446,10 @@ export class BaseClient {
     /**
      * Gets the cardinality of the intersection of all the given sets.
      *
-     * See https://valkey.io/commands/sintercard/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/sintercard/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sets.
      * @param limit - The limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
      * @returns The cardinality of the intersection result. If one or more sets do not exist, `0` is returned.
@@ -2444,9 +2472,9 @@ export class BaseClient {
     /**
      * Stores the members of the intersection of all given sets specified by `keys` into a new set at `destination`.
      *
-     * See https://valkey.io/commands/sinterstore/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/sinterstore/|valkey.io} for more details.
      * @remarks When in cluster mode, `destination` and all `keys` must map to the same hash slot.
+     *
      * @param destination - The key of the destination set.
      * @param keys - The keys from which to retrieve the set members.
      * @returns The number of elements in the resulting set.
@@ -2467,9 +2495,9 @@ export class BaseClient {
     /**
      * Computes the difference between the first set and all the successive sets in `keys`.
      *
-     * See https://valkey.io/commands/sdiff/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/sdiff/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     *
      * @param keys - The keys of the sets to diff.
      * @returns A `Set` of elements representing the difference between the sets.
      * If a key in `keys` does not exist, it is treated as an empty set.
@@ -2491,9 +2519,9 @@ export class BaseClient {
     /**
      * Stores the difference between the first set and all the successive sets in `keys` into a new set at `destination`.
      *
-     * See https://valkey.io/commands/sdiffstore/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/sdiffstore/|valkey.io} for more details.
      * @remarks When in cluster mode, `destination` and all `keys` must map to the same hash slot.
+     *
      * @param destination - The key of the destination set.
      * @param keys - The keys of the sets to diff.
      * @returns The number of elements in the resulting set.
@@ -2516,9 +2544,9 @@ export class BaseClient {
     /**
      * Gets the union of all the given sets.
      *
-     * See https://valkey.io/commands/sunion/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/sunion/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     *
      * @param keys - The keys of the sets.
      * @returns A `Set` of members which are present in at least one of the given sets.
      * If none of the sets exist, an empty `Set` will be returned.
@@ -2544,9 +2572,9 @@ export class BaseClient {
      * Stores the members of the union of all given sets specified by `keys` into a new set
      * at `destination`.
      *
-     * See https://valkey.io/commands/sunionstore/ for details.
-     *
+     * @see {@link https://valkey.io/commands/sunionstore/|valkey.io} for details.
      * @remarks When in cluster mode, `destination` and all `keys` must map to the same hash slot.
+     *
      * @param destination - The key of the destination set.
      * @param keys - The keys from which to retrieve the set members.
      * @returns The number of elements in the resulting set.
@@ -2565,7 +2593,8 @@ export class BaseClient {
     }
 
     /** Returns if `member` is a member of the set stored at `key`.
-     * See https://valkey.io/commands/sismember/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/sismember/|valkey.io} for more details.
      *
      * @param key - The key of the set.
      * @param member - The member to check for existence in the set.
@@ -2593,9 +2622,8 @@ export class BaseClient {
     /**
      * Checks whether each member is contained in the members of the set stored at `key`.
      *
-     * See https://valkey.io/commands/smismember/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/smismember/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the set to check.
      * @param members - A list of members to check for existence in the set.
@@ -2616,8 +2644,9 @@ export class BaseClient {
     }
 
     /** Removes and returns one random member from the set value store at `key`.
-     * See https://valkey.io/commands/spop/ for details.
-     * To pop multiple members, see `spopCount`.
+     * To pop multiple members, see {@link spopCount}.
+     *
+     * @see {@link https://valkey.io/commands/spop/|valkey.io} for details.
      *
      * @param key - The key of the set.
      * @returns the value of the popped member.
@@ -2642,7 +2671,8 @@ export class BaseClient {
     }
 
     /** Removes and returns up to `count` random members from the set value store at `key`, depending on the set's length.
-     * See https://valkey.io/commands/spop/ for details.
+     *
+     * @see {@link https://valkey.io/commands/spop/|valkey.io} for details.
      *
      * @param key - The key of the set.
      * @param count - The count of the elements to pop from the set.
@@ -2672,7 +2702,7 @@ export class BaseClient {
     /**
      * Returns a random element from the set value stored at `key`.
      *
-     * See https://valkey.io/commands/srandmember for more details.
+     * @see {@link https://valkey.io/commands/srandmember/|valkey.io} for more details.
      *
      * @param key - The key from which to retrieve the set member.
      * @returns A random element from the set, or null if `key` does not exist.
@@ -2698,7 +2728,7 @@ export class BaseClient {
     /**
      * Returns one or more random elements from the set value stored at `key`.
      *
-     * See https://valkey.io/commands/srandmember for more details.
+     * @see {@link https://valkey.io/commands/srandmember/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param count - The number of members to return.
@@ -2728,7 +2758,8 @@ export class BaseClient {
     }
 
     /** Returns the number of keys in `keys` that exist in the database.
-     * See https://valkey.io/commands/exists/ for details.
+     *
+     * @see {@link https://valkey.io/commands/exists/|valkey.io} for details.
      *
      * @param keys - The keys list to check.
      * @returns The number of keys that exist. If the same existing key is mentioned in `keys` multiple times,
@@ -2748,7 +2779,8 @@ export class BaseClient {
     /** Removes the specified keys. A key is ignored if it does not exist.
      * This command, similar to DEL, removes specified keys and ignores non-existent ones.
      * However, this command does not block the server, while [DEL](https://valkey.io/commands/del) does.
-     * See https://valkey.io/commands/unlink/ for details.
+     *
+     * @see {@link https://valkey.io/commands/unlink/|valkey.io} for details.
      *
      * @param keys - The keys we wanted to unlink.
      * @returns The number of keys that were unlinked.
@@ -2768,7 +2800,8 @@ export class BaseClient {
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * If `seconds` is non-positive number, the key will be deleted rather than expired.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/expire/ for details.
+     *
+     * @see {@link https://valkey.io/commands/expire/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param seconds - The timeout in seconds.
@@ -2802,7 +2835,8 @@ export class BaseClient {
      * A timestamp in the past will delete the key immediately. After the timeout has expired, the key will automatically be deleted.
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/expireat/ for details.
+     *
+     * @see {@link https://valkey.io/commands/expireat/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param unixSeconds - The timeout in an absolute Unix timestamp.
@@ -2831,9 +2865,8 @@ export class BaseClient {
      * Returns the absolute Unix timestamp (since January 1, 1970) at which the given `key` will expire, in seconds.
      * To get the expiration with millisecond precision, use {@link pexpiretime}.
      *
-     * See https://valkey.io/commands/expiretime/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/expiretime/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The `key` to determine the expiration value of.
      * @returns The expiration Unix timestamp in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
@@ -2860,7 +2893,8 @@ export class BaseClient {
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * If `milliseconds` is non-positive number, the key will be deleted rather than expired.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/pexpire/ for details.
+     *
+     * @see {@link https://valkey.io/commands/pexpire/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param milliseconds - The timeout in milliseconds.
@@ -2889,7 +2923,8 @@ export class BaseClient {
      * A timestamp in the past will delete the key immediately. After the timeout has expired, the key will automatically be deleted.
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/pexpireat/ for details.
+     *
+     * @see {@link https://valkey.io/commands/pexpireat/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param unixMilliseconds - The timeout in an absolute Unix timestamp.
@@ -2917,9 +2952,8 @@ export class BaseClient {
     /**
      * Returns the absolute Unix timestamp (since January 1, 1970) at which the given `key` will expire, in milliseconds.
      *
-     * See https://valkey.io/commands/pexpiretime/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/pexpiretime/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The `key` to determine the expiration value of.
      * @returns The expiration Unix timestamp in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
@@ -2943,7 +2977,8 @@ export class BaseClient {
     }
 
     /** Returns the remaining time to live of `key` that has a timeout.
-     * See https://valkey.io/commands/ttl/ for details.
+     *
+     * @see {@link https://valkey.io/commands/ttl/|valkey.io} for details.
      *
      * @param key - The key to return its timeout.
      * @returns TTL in seconds, -2 if `key` does not exist or -1 if `key` exists but has no associated expire.
@@ -2977,7 +3012,8 @@ export class BaseClient {
      * This method simplifies the process of invoking scripts on a Redis server by using an object that represents a Lua script.
      * The script loading, argument preparation, and execution will all be handled internally. If the script has not already been loaded,
      * it will be loaded automatically using the Redis `SCRIPT LOAD` command. After that, it will be invoked using the Redis `EVALSHA` command
-     * See https://valkey.io/commands/script-load/ and https://valkey.io/commands/evalsha/ for details.
+     *
+     * @see {@link https://valkey.io/commands/script-load/} and {@link https://valkey.io/commands/evalsha/} for details.
      *
      * @param script - The Lua script to execute.
      * @param options - The script option that contains keys and arguments for the script.
@@ -3063,7 +3099,8 @@ export class BaseClient {
 
     /** Adds members with their scores to the sorted set stored at `key`.
      * If a member is already a part of the sorted set, its score is updated.
-     * See https://valkey.io/commands/zadd/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zadd/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param membersScoresMap - A mapping of members to their corresponding scores.
@@ -3099,7 +3136,8 @@ export class BaseClient {
     /** Increments the score of member in the sorted set stored at `key` by `increment`.
      * If `member` does not exist in the sorted set, it is added with `increment` as its score (as if its previous score was 0.0).
      * If `key` does not exist, a new sorted set with the specified member as its sole member is created.
-     * See https://valkey.io/commands/zadd/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zadd/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param member - A member in the sorted set to increment.
@@ -3135,7 +3173,8 @@ export class BaseClient {
 
     /** Removes the specified members from the sorted set stored at `key`.
      * Specified members that are not a member of this set are ignored.
-     * See https://valkey.io/commands/zrem/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zrem/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param members - A list of members to remove from the sorted set.
@@ -3161,7 +3200,8 @@ export class BaseClient {
     }
 
     /** Returns the cardinality (number of elements) of the sorted set stored at `key`.
-     * See https://valkey.io/commands/zcard/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zcard/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @returns The number of elements in the sorted set.
@@ -3188,11 +3228,10 @@ export class BaseClient {
     /**
      * Returns the cardinality of the intersection of the sorted sets specified by `keys`.
      *
-     * See https://valkey.io/commands/zintercard/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/zintercard/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sorted sets to intersect.
      * @param limit - An optional argument that can be used to specify a maximum number for the
      * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
@@ -3212,11 +3251,10 @@ export class BaseClient {
      * Returns the difference between the first sorted set and all the successive sorted sets.
      * To get the elements with their scores, see {@link zdiffWithScores}.
      *
-     * See https://valkey.io/commands/zdiff/ for more details.
-     *
-     * Since Valkey version 6.2.0.
-     *
+     * @see {@link https://valkey.io/commands/zdiff/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 6.2.0.
+     *
      * @param keys - The keys of the sorted sets.
      * @returns An `array` of elements representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
@@ -3238,11 +3276,10 @@ export class BaseClient {
      * Returns the difference between the first sorted set and all the successive sorted sets, with the associated
      * scores.
      *
-     * See https://valkey.io/commands/zdiff/ for more details.
-     *
-     * Since Valkey version 6.2.0.
-     *
+     * @see {@link https://valkey.io/commands/zdiff/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 6.2.0.
+     *
      * @param keys - The keys of the sorted sets.
      * @returns A map of elements and their scores representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
@@ -3267,11 +3304,10 @@ export class BaseClient {
      * the difference as a sorted set to `destination`, overwriting it if it already exists. Non-existent keys are
      * treated as empty sets.
      *
-     * See https://valkey.io/commands/zdiffstore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
-     *
+     * @see {@link https://valkey.io/commands/zdiffstore/|valkey.io} for more details.
      * @remarks When in cluster mode, all keys in `keys` and `destination` must map to the same hash slot.
+     * @remarks Since Valkey version 6.2.0.
+     *
      * @param destination - The key for the resulting sorted set.
      * @param keys - The keys of the sorted sets to compare.
      * @returns The number of members in the resulting sorted set stored at `destination`.
@@ -3295,7 +3331,8 @@ export class BaseClient {
     }
 
     /** Returns the score of `member` in the sorted set stored at `key`.
-     * See https://valkey.io/commands/zscore/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zscore/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose score is to be retrieved.
@@ -3331,9 +3368,8 @@ export class BaseClient {
     /**
      * Returns the scores associated with the specified `members` in the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zmscore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/zmscore/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the sorted set.
      * @param members - A list of members in the sorted set.
@@ -3354,7 +3390,8 @@ export class BaseClient {
     }
 
     /** Returns the number of members in the sorted set stored at `key` with scores between `minScore` and `maxScore`.
-     * See https://valkey.io/commands/zcount/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zcount/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param minScore - The minimum score to count from. Can be positive/negative infinity, or specific score and inclusivity.
@@ -3388,8 +3425,9 @@ export class BaseClient {
     /** Returns the specified range of elements in the sorted set stored at `key`.
      * ZRANGE can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
      *
-     * See https://valkey.io/commands/zrange/ for more details.
-     * To get the elements with their scores, see `zrangeWithScores`.
+     * To get the elements with their scores, see {@link zrangeWithScores}.
+     *
+     * @see {@link https://valkey.io/commands/zrange/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
@@ -3428,7 +3466,7 @@ export class BaseClient {
     /** Returns the specified range of elements with their scores in the sorted set stored at `key`.
      * Similar to ZRANGE but with a WITHSCORE flag.
      *
-     * See https://valkey.io/commands/zrange/ for more details.
+     * @see {@link https://valkey.io/commands/zrange/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
@@ -3475,11 +3513,10 @@ export class BaseClient {
      * sorted set at `destination`. If `destination` doesn't exist, a new sorted
      * set is created; if it exists, it's overwritten.
      *
-     * See https://valkey.io/commands/zrangestore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
-     *
+     * @see {@link https://valkey.io/commands/zrangestore/|valkey.io} for more details.
      * @remarks When in cluster mode, `destination` and `source` must map to the same hash slot.
+     * @remarks Since Valkey version 6.2.0.
+     *
      * @param destination - The key for the destination sorted set.
      * @param source - The key of the source sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
@@ -3522,9 +3559,8 @@ export class BaseClient {
      * If `destination` already exists, it is overwritten. Otherwise, a new sorted set will be created.
      * To get the result directly, see `zinter_withscores`.
      *
-     * When in cluster mode, `destination` and all keys in `keys` must map to the same hash slot.
-     *
-     * See https://valkey.io/commands/zinterstore/ for more details.
+     * @see {@link https://valkey.io/commands/zinterstore/|valkey.io} for more details.
+     * @remarks When in cluster mode, `destination` and all keys in `keys` must map to the same hash slot.
      *
      * @param destination - The key of the destination sorted set.
      * @param keys - The keys of the sorted sets with possible formats:
@@ -3557,7 +3593,7 @@ export class BaseClient {
     /**
      * Returns a random member from the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zrandmember/ for more details.
+     * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for more details.
      *
      * @param keys - The key of the sorted set.
      * @returns A string representing a random member from the sorted set.
@@ -3582,7 +3618,7 @@ export class BaseClient {
     /**
      * Returns random members from the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zrandmember/ for more details.
+     * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for more details.
      *
      * @param keys - The key of the sorted set.
      * @param count - The number of members to return.
@@ -3613,7 +3649,7 @@ export class BaseClient {
     /**
      * Returns random members with scores from the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zrandmember/ for more details.
+     * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for more details.
      *
      * @param keys - The key of the sorted set.
      * @param count - The number of members to return.
@@ -3643,7 +3679,8 @@ export class BaseClient {
     }
 
     /** Returns the length of the string value stored at `key`.
-     * See https://valkey.io/commands/strlen/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/strlen/|valkey.io} for more details.
      *
      * @param key - The key to check its length.
      * @returns - The length of the string value stored at key
@@ -3669,7 +3706,8 @@ export class BaseClient {
     }
 
     /** Returns the string representation of the type of the value stored at `key`.
-     * See https://valkey.io/commands/type/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/type/|valkey.io} for more details.
      *
      * @param key - The `key` to check its data type.
      * @returns If the `key` exists, the type of the stored value is returned. Otherwise, a "none" string is returned.
@@ -3697,7 +3735,8 @@ export class BaseClient {
     /** Removes and returns the members with the lowest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the lowest scores are removed and returned.
      * Otherwise, only one member with the lowest score is removed and returned.
-     * See https://valkey.io/commands/zpopmin for more details.
+     *
+     * @see {@link https://valkey.io/commands/zpopmin/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
@@ -3732,9 +3771,9 @@ export class BaseClient {
      * are provided.
      * `BZPOPMIN` is the blocking variant of {@link zpopmin}.
      *
-     * See https://valkey.io/commands/bzpopmin/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/bzpopmin/|valkey.io} for more details.
      * @remarks When in cluster mode, `keys` must map to the same hash slot.
+     *
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
      *     `0` will block indefinitely. Since 6.0.0: timeout is interpreted as a double instead of an integer.
@@ -3757,7 +3796,8 @@ export class BaseClient {
     /** Removes and returns the members with the highest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the highest scores are removed and returned.
      * Otherwise, only one member with the highest score is removed and returned.
-     * See https://valkey.io/commands/zpopmax for more details.
+     *
+     * @see {@link https://valkey.io/commands/zpopmax/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
@@ -3792,9 +3832,9 @@ export class BaseClient {
      * are provided.
      * `BZPOPMAX` is the blocking variant of {@link zpopmax}.
      *
-     * See https://valkey.io/commands/zpopmax/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/zpopmax/|valkey.io} for more details.
      * @remarks When in cluster mode, `keys` must map to the same hash slot.
+     *
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
      *     `0` will block indefinitely. Since 6.0.0: timeout is interpreted as a double instead of an integer.
@@ -3815,7 +3855,8 @@ export class BaseClient {
     }
 
     /** Returns the remaining time to live of `key` that has a timeout, in milliseconds.
-     * See https://valkey.io/commands/pttl for more details.
+     *
+     * @see {@link https://valkey.io/commands/pttl/|valkey.io} for more details.
      *
      * @param key - The key to return its timeout.
      * @returns TTL in milliseconds. -2 if `key` does not exist, -1 if `key` exists but has no associated expire.
@@ -3848,7 +3889,8 @@ export class BaseClient {
     /** Removes all elements in the sorted set stored at `key` with rank between `start` and `end`.
      * Both `start` and `end` are zero-based indexes with 0 being the element with the lowest score.
      * These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score.
-     * See https://valkey.io/commands/zremrangebyrank/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zremrangebyrank/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param start - The starting point of the range.
@@ -3876,7 +3918,7 @@ export class BaseClient {
     /**
      * Removes all elements in the sorted set stored at `key` with lexicographical order between `minLex` and `maxLex`.
      *
-     * See https://valkey.io/commands/zremrangebylex/ for more details.
+     * @see {@link https://valkey.io/commands/zremrangebylex/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
@@ -3910,7 +3952,8 @@ export class BaseClient {
     }
 
     /** Removes all elements in the sorted set stored at `key` with a score between `minScore` and `maxScore`.
-     * See https://valkey.io/commands/zremrangebyscore/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/zremrangebyscore/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param minScore - The minimum score to remove from. Can be positive/negative infinity, or specific score and inclusivity.
@@ -3946,7 +3989,7 @@ export class BaseClient {
     /**
      * Returns the number of members in the sorted set stored at 'key' with scores between 'minLex' and 'maxLex'.
      *
-     * See https://valkey.io/commands/zlexcount/ for more details.
+     * @see {@link https://valkey.io/commands/zlexcount/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
@@ -3976,8 +4019,9 @@ export class BaseClient {
     }
 
     /** Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
-     * See https://valkey.io/commands/zrank for more details.
-     * To get the rank of `member` with its score, see `zrankWithScore`.
+     * To get the rank of `member` with its score, see {@link zrankWithScore}.
+     *
+     * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -4004,9 +4048,8 @@ export class BaseClient {
 
     /** Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
      *
-     * See https://valkey.io/commands/zrank for more details.
-     *
-     * Since Valkey version 7.2.0.
+     * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
+     * @remarks Since Valkey version 7.2.0.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -4039,7 +4082,7 @@ export class BaseClient {
      * scores are ordered from the highest to lowest, starting from 0.
      * To get the rank of `member` with its score, see {@link zrevrankWithScore}.
      *
-     * See https://valkey.io/commands/zrevrank/ for more details.
+     * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -4060,9 +4103,8 @@ export class BaseClient {
      * Returns the rank of `member` in the sorted set stored at `key` with its
      * score, where scores are ordered from the highest to lowest, starting from 0.
      *
-     * See https://valkey.io/commands/zrevrank/ for more details.
-     *
-     * Since Valkey version 7.2.0.
+     * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for more details.
+     * @remarks Since Valkey version 7.2.0.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -4085,7 +4127,8 @@ export class BaseClient {
 
     /**
      * Adds an entry to the specified stream stored at `key`. If the `key` doesn't exist, the stream is created.
-     * See https://valkey.io/commands/xadd/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/xadd/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param values - field-value pairs to be added to the entry.
@@ -4103,7 +4146,7 @@ export class BaseClient {
     /**
      * Removes the specified entries by id from a stream, and returns the number of entries deleted.
      *
-     * See https://valkey.io/commands/xdel for more details.
+     * @see {@link https://valkey.io/commands/xdel/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param ids - An array of entry ids.
@@ -4122,7 +4165,8 @@ export class BaseClient {
 
     /**
      * Trims the stream stored at `key` by evicting older entries.
-     * See https://valkey.io/commands/xtrim/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/xtrim/|valkey.io} for more details.
      *
      * @param key - the key of the stream
      * @param options - options detailing how to trim the stream.
@@ -4137,7 +4181,8 @@ export class BaseClient {
 
     /**
      * Reads entries from the given streams.
-     * See https://valkey.io/commands/xread/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/xread/|valkey.io} for more details.
      *
      * @param keys_and_ids - pairs of keys and entry ids to read from. A pair is composed of a stream's key and the id of the entry after which the stream will be read.
      * @param options - options detailing how to read the stream.
@@ -4168,7 +4213,7 @@ export class BaseClient {
     /**
      * Returns the number of entries in the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xlen/ for more details.
+     * @see {@link https://valkey.io/commands/xlen/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @returns The number of entries in the stream. If `key` does not exist, returns `0`.
@@ -4186,7 +4231,7 @@ export class BaseClient {
     /**
      * Returns stream message summary information for pending messages matching a given range of IDs.
      *
-     * See https://valkey.io/commands/xpending/ for more details.
+     * @see {@link https://valkey.io/commands/xpending/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -4215,7 +4260,7 @@ export class BaseClient {
     /**
      * Returns an extended form of stream message information for pending messages matching a given range of IDs.
      *
-     * See https://valkey.io/commands/xpending/ for more details.
+     * @see {@link https://valkey.io/commands/xpending/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -4258,7 +4303,7 @@ export class BaseClient {
      * Returns the list of all consumers and their attributes for the given consumer group of the
      * stream stored at `key`.
      *
-     * See https://valkey.io/commands/xinfo-consumers/ for more details.
+     * @see {@link https://valkey.io/commands/xinfo-consumers/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -4290,7 +4335,7 @@ export class BaseClient {
     /**
      * Changes the ownership of a pending message.
      *
-     * See https://valkey.io/commands/xclaim/ for more details.
+     * @see {@link https://valkey.io/commands/xclaim/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -4445,7 +4490,7 @@ export class BaseClient {
      * Changes the ownership of a pending message. This function returns an `array` with
      * only the message/entry IDs, and is equivalent to using `JUSTID` in the Valkey API.
      *
-     * See https://valkey.io/commands/xclaim/ for more details.
+     * @see {@link https://valkey.io/commands/xclaim/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -4478,7 +4523,7 @@ export class BaseClient {
     /**
      * Creates a new consumer group uniquely identified by `groupname` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-create/ for more details.
+     * @see {@link https://valkey.io/commands/xgroup-create/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param groupName - The newly created consumer group name.
@@ -4506,7 +4551,7 @@ export class BaseClient {
     /**
      * Destroys the consumer group `groupname` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-destroy/ for more details.
+     * @see {@link https://valkey.io/commands/xgroup-destroy/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param groupname - The newly created consumer group name.
@@ -4528,12 +4573,15 @@ export class BaseClient {
     /**
      * Returns information about the stream stored at `key`.
      *
+     * @see {@link https://valkey.io/commands/xinfo-stream/|valkey.io} for more details.
+     *
      * @param key - The key of the stream.
      * @param fullOptions - If `true`, returns verbose information with a limit of the first 10 PEL entries.
      * If `number` is specified, returns verbose information limiting the returned PEL entries.
      * If `0` is specified, returns verbose information with no limit.
      * @returns A {@link ReturnTypeXinfoStream} of detailed stream information for the given `key`. See
      *     the example for a sample response.
+     *
      * @example
      * ```typescript
      * const infoResult = await client.xinfoStream("my_stream");
@@ -4598,7 +4646,7 @@ export class BaseClient {
     /**
      * Creates a consumer named `consumerName` in the consumer group `groupName` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-createconsumer for more details.
+     * @see {@link https://valkey.io/commands/xgroup-createconsumer/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param groupName - The consumer group name.
@@ -4624,7 +4672,7 @@ export class BaseClient {
     /**
      * Deletes a consumer named `consumerName` in the consumer group `groupName` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-delconsumer for more details.
+     * @see {@link https://valkey.io/commands/xgroup-delconsumer/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param groupName - The consumer group name.
@@ -4659,7 +4707,8 @@ export class BaseClient {
      * The index is zero-based, so 0 means the first element, 1 the second element and so on.
      * Negative indices can be used to designate elements starting at the tail of the list.
      * Here, -1 means the last element, -2 means the penultimate and so forth.
-     * See https://valkey.io/commands/lindex/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/lindex/|valkey.io} for more details.
      *
      * @param key - The `key` of the list.
      * @param index - The `index` of the element in the list to retrieve.
@@ -4687,7 +4736,7 @@ export class BaseClient {
     /**
      * Inserts `element` in the list at `key` either before or after the `pivot`.
      *
-     * See https://valkey.io/commands/linsert/ for more details.
+     * @see {@link https://valkey.io/commands/linsert/|valkey.io} for more details.
      *
      * @param key - The key of the list.
      * @param position - The relative position to insert into - either `InsertPosition.Before` or
@@ -4717,7 +4766,8 @@ export class BaseClient {
 
     /** Remove the existing timeout on `key`, turning the key from volatile (a key with an expire set) to
      * persistent (a key that will never expire as no timeout is associated).
-     * See https://valkey.io/commands/persist/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/persist/|valkey.io} for more details.
      *
      * @param key - The key to remove the existing timeout on.
      * @returns `false` if `key` does not exist or does not have an associated timeout, `true` if the timeout has been removed.
@@ -4736,7 +4786,8 @@ export class BaseClient {
     /**
      * Renames `key` to `newkey`.
      * If `newkey` already exists it is overwritten.
-     * See https://valkey.io/commands/rename/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/rename/|valkey.io} for more details.
      *
      * @remarks When in cluster mode, `key` and `newKey` must map to the same hash slot.
      * @param key - The key to rename.
@@ -4757,7 +4808,8 @@ export class BaseClient {
 
     /**
      * Renames `key` to `newkey` if `newkey` does not yet exist.
-     * See https://valkey.io/commands/renamenx/ for more details.
+     *
+     * @see {@link https://valkey.io/commands/renamenx/|valkey.io} for more details.
      *
      * @remarks When in cluster mode, `key` and `newKey` must map to the same hash slot.
      * @param key - The key to rename.
@@ -4781,11 +4833,12 @@ export class BaseClient {
      * Pop an element from the tail of the first list that is non-empty,
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
-     * See https://valkey.io/commands/brpop/ for more details.
      *
+     * @see {@link https://valkey.io/commands/brpop/|valkey.io} for more details.
      * @remarks
      * 1. When in cluster mode, all `keys` must map to the same hash slot.
      * 2. `BRPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
      * @returns - An `array` containing the `key` from which the element was popped and the value of the popped element,
@@ -4809,11 +4862,12 @@ export class BaseClient {
      * Pop an element from the head of the first list that is non-empty,
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
-     * See https://valkey.io/commands/blpop/ for more details.
      *
+     * @see {@link https://valkey.io/commands/blpop/|valkey.io} for more details.
      * @remarks
      * 1. When in cluster mode, all `keys` must map to the same hash slot.
      * 2. `BLPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
      * @returns - An `array` containing the `key` from which the element was popped and the value of the popped element,
@@ -4836,7 +4890,7 @@ export class BaseClient {
      * Creates a new structure if the `key` does not exist.
      * When no elements are provided, and `key` exists and is a HyperLogLog, then no operation is performed.
      *
-     * See https://valkey.io/commands/pfadd/ for more details.
+     * @see {@link https://valkey.io/commands/pfadd/|valkey.io} for more details.
      *
      * @param key - The key of the HyperLogLog data structure to add elements into.
      * @param elements - An array of members to add to the HyperLogLog stored at `key`.
@@ -4857,9 +4911,9 @@ export class BaseClient {
     /** Estimates the cardinality of the data stored in a HyperLogLog structure for a single key or
      * calculates the combined cardinality of multiple keys by merging their HyperLogLogs temporarily.
      *
-     * See https://valkey.io/commands/pfcount/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/pfcount/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     *
      * @param keys - The keys of the HyperLogLog data structures to be analyzed.
      * @returns - The approximated cardinality of given HyperLogLog data structures.
      *     The cardinality of a key that does not exist is `0`.
@@ -4877,9 +4931,9 @@ export class BaseClient {
      * Merges multiple HyperLogLog values into a unique value. If the destination variable exists, it is
      * treated as one of the source HyperLogLog data sets, otherwise a new HyperLogLog is created.
      *
-     * See https://valkey.io/commands/pfmerge/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/pfmerge/|valkey.io} for more details.
      * @remarks When in Cluster mode, all keys in `sourceKeys` and `destination` must map to the same hash slot.
+     *
      * @param destination - The key of the destination HyperLogLog where the merged data sets will be stored.
      * @param sourceKeys - The keys of the HyperLogLog structures to be merged.
      * @returns A simple "OK" response.
@@ -4903,7 +4957,7 @@ export class BaseClient {
 
     /** Returns the internal encoding for the Redis object stored at `key`.
      *
-     * See https://valkey.io/commands/object-encoding for more details.
+     * @see {@link https://valkey.io/commands/object-encoding/|valkey.io} for more details.
      *
      * @param key - The `key` of the object to get the internal encoding of.
      * @returns - If `key` exists, returns the internal encoding of the object stored at `key` as a string.
@@ -4920,7 +4974,7 @@ export class BaseClient {
 
     /** Returns the logarithmic access frequency counter of a Redis object stored at `key`.
      *
-     * See https://valkey.io/commands/object-freq for more details.
+     * @see {@link https://valkey.io/commands/object-freq/|valkey.io} for more details.
      *
      * @param key - The `key` of the object to get the logarithmic access frequency counter of.
      * @returns - If `key` exists, returns the logarithmic access frequency counter of the object
@@ -4938,7 +4992,7 @@ export class BaseClient {
     /**
      * Returns the time in seconds since the last access to the value stored at `key`.
      *
-     * See https://valkey.io/commands/object-idletime/ for more details.
+     * @see {@link https://valkey.io/commands/object-idletime/|valkey.io} for more details.
      *
      * @param key - The key of the object to get the idle time of.
      * @returns If `key` exists, returns the idle time in seconds. Otherwise, returns `null`.
@@ -4956,7 +5010,7 @@ export class BaseClient {
     /**
      * Returns the reference count of the object stored at `key`.
      *
-     * See https://valkey.io/commands/object-refcount/ for more details.
+     * @see {@link https://valkey.io/commands/object-refcount/|valkey.io} for more details.
      *
      * @param key - The `key` of the object to get the reference count of.
      * @returns If `key` exists, returns the reference count of the object stored at `key` as a `number`.
@@ -4975,11 +5029,10 @@ export class BaseClient {
     /**
      * Invokes a previously loaded function.
      *
-     * See https://valkey.io/commands/fcall/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/fcall/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param func - The function name.
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
      *     all names of keys that a function accesses must be explicitly provided as `keys`.
@@ -5003,11 +5056,10 @@ export class BaseClient {
     /**
      * Invokes a previously loaded read-only function.
      *
-     * See https://valkey.io/commands/fcall/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/fcall/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param func - The function name.
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
      *     all names of keys that a function accesses must be explicitly provided as `keys`.
@@ -5034,9 +5086,8 @@ export class BaseClient {
      * match is found, `null` is returned. If the `count` option is specified, then the function returns
      * an `array` of indices of matching elements within the list.
      *
-     * See https://valkey.io/commands/lpos/ for more details.
-     *
-     * Since Valkey version 6.0.6.
+     * @see {@link https://valkey.io/commands/lpos/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.0.6.
      *
      * @param key - The name of the list.
      * @param element - The value to search for within the list.
@@ -5063,7 +5114,7 @@ export class BaseClient {
      * Counts the number of set bits (population counting) in the string stored at `key`. The `options` argument can
      * optionally be provided to count the number of bits in a specific string interval.
      *
-     * See https://valkey.io/commands/bitcount for more details.
+     * @see {@link https://valkey.io/commands/bitcount/|valkey.io} for more details.
      *
      * @param key - The key for the string to count the set bits of.
      * @param options - The offset options.
@@ -5090,7 +5141,7 @@ export class BaseClient {
      * Adds geospatial members with their positions to the specified sorted set stored at `key`.
      * If a member is already a part of the sorted set, its position is updated.
      *
-     * See https://valkey.io/commands/geoadd/ for more details.
+     * @see {@link https://valkey.io/commands/geoadd/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param membersToGeospatialData - A mapping of member names to their corresponding positions - see
@@ -5124,9 +5175,8 @@ export class BaseClient {
      * Returns the members of a sorted set populated with geospatial information using {@link geoadd},
      * which are within the borders of the area specified by a given shape.
      *
-     * See https://valkey.io/commands/geosearch/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/geosearch/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the sorted set.
      * @param searchFrom - The query's center point options, could be one of:
@@ -5206,11 +5256,9 @@ export class BaseClient {
      *
      * To get the result directly, see {@link geosearch}.
      *
-     * See https://valkey.io/commands/geosearchstore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
-     *
+     * @see {@link https://valkey.io/commands/geosearchstore/|valkey.io} for more details.
      * @remarks When in cluster mode, `destination` and `source` must map to the same hash slot.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param destination - The key of the destination sorted set.
      * @param source - The key of the sorted set.
@@ -5281,7 +5329,7 @@ export class BaseClient {
      * Returns the positions (longitude, latitude) of all the specified `members` of the
      * geospatial index represented by the sorted set at `key`.
      *
-     * See https://valkey.io/commands/geopos for more details.
+     * @see {@link https://valkey.io/commands/geopos/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param members - The members for which to get the positions.
@@ -5310,11 +5358,10 @@ export class BaseClient {
      * Pops a member-score pair from the first non-empty sorted set, with the given `keys`
      * being checked in the order they are provided.
      *
-     * See https://valkey.io/commands/zmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/zmpop/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
      *     {@link ScoreFilter.MAX} to pop the member with the lowest/highest score accordingly.
@@ -5344,14 +5391,13 @@ export class BaseClient {
      * checked in the order they are provided. Blocks the connection when there are no members
      * to pop from any of the given sorted sets. `BZMPOP` is the blocking variant of {@link zmpop}.
      *
-     * See https://valkey.io/commands/bzmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/bzmpop/|valkey.io} for more details.
      * @remarks
      *      1. When in cluster mode, all `keys` must map to the same hash slot.
      *      2. `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | the wiki}
      *         for more details and best practices.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
      *     {@link ScoreFilter.MAX} to pop the member with the lowest/highest score accordingly.
@@ -5386,7 +5432,7 @@ export class BaseClient {
      * If `member` does not exist in the sorted set, it is added with `increment` as its score.
      * If `key` does not exist, a new sorted set is created with the specified member as its sole member.
      *
-     * See https://valkey.io/commands/zincrby/ for details.
+     * @see {@link https://valkey.io/commands/zincrby/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param increment - The score increment.
@@ -5417,7 +5463,7 @@ export class BaseClient {
     /**
      * Iterates incrementally over a sorted set.
      *
-     * See https://valkey.io/commands/zscan for more details.
+     * @see {@link https://valkey.io/commands/zscan/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of
@@ -5464,7 +5510,7 @@ export class BaseClient {
     /**
      * Returns the distance between `member1` and `member2` saved in the geospatial index stored at `key`.
      *
-     * See https://valkey.io/commands/geodist/ for more details.
+     * @see {@link https://valkey.io/commands/geodist/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param member1 - The name of the first member.
@@ -5493,7 +5539,7 @@ export class BaseClient {
     /**
      * Returns the `GeoHash` strings representing the positions of all the specified `members` in the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/geohash/ for more details.
+     * @see {@link https://valkey.io/commands/geohash/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param members - The array of members whose `GeoHash` strings are to be retrieved.
@@ -5520,11 +5566,9 @@ export class BaseClient {
     /**
      * Returns all the longest common subsequences combined between strings stored at `key1` and `key2`.
      *
-     * See https://valkey.io/commands/lcs/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/lcs/|valkey.io} for more details.
      * @remarks When in cluster mode, `key1` and `key2` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -5545,11 +5589,9 @@ export class BaseClient {
     /**
      * Returns the total length of all the longest common subsequences between strings stored at `key1` and `key2`.
      *
-     * See https://valkey.io/commands/lcs/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/lcs/|valkey.io} for more details.
      * @remarks When in cluster mode, `key1` and `key2` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -5570,11 +5612,9 @@ export class BaseClient {
      * Returns the indices and lengths of the longest common subsequences between strings stored at
      * `key1` and `key2`.
      *
-     * See https://valkey.io/commands/lcs/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/lcs/|valkey.io} for more details.
      * @remarks When in cluster mode, `key1` and `key2` must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -5625,9 +5665,9 @@ export class BaseClient {
     /**
      * Updates the last access time of the specified keys.
      *
-     * See https://valkey.io/commands/touch/ for more details.
-     *
+     * @see {@link https://valkey.io/commands/touch/|valkey.io} for more details.
      * @remarks When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
+     *
      * @param keys - The keys to update the last access time of.
      * @returns The number of keys that were updated. A key is ignored if it doesn't exist.
      *
@@ -5648,9 +5688,9 @@ export class BaseClient {
      * will only execute commands if the watched keys are not modified before execution of the
      * transaction. Executing a transaction will automatically flush all previously watched keys.
      *
-     * See https://valkey.io/commands/watch/ and https://valkey.io/topics/transactions/#cas for more details.
-     *
+     * @see {@link https://valkey.io/commands/watch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
      * @remarks When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
+     *
      * @param keys - The keys to watch.
      * @returns A simple "OK" response.
      *
@@ -5702,7 +5742,7 @@ export class BaseClient {
      * for the entire length of `value`. If the `offset` is larger than the current length of the string at `key`,
      * the string is padded with zero bytes to make `offset` fit. Creates the `key` if it doesn't exist.
      *
-     * See https://valkey.io/commands/setrange/ for more details.
+     * @see {@link https://valkey.io/commands/setrange/|valkey.io} for more details.
      *
      * @param key - The key of the string to update.
      * @param offset - The position in the string where `value` should be written.
@@ -5729,7 +5769,7 @@ export class BaseClient {
      * Appends a `value` to a `key`. If `key` does not exist it is created and set as an empty string,
      * so `APPEND` will be similar to {@link set} in this special case.
      *
-     * See https://valkey.io/commands/append/ for more details.
+     * @see {@link https://valkey.io/commands/append/|valkey.io} for more details.
      *
      * @param key - The key of the string.
      * @param value - The key of the string.
@@ -5754,11 +5794,10 @@ export class BaseClient {
     /**
      * Pops one or more elements from the first non-empty list from the provided `keys`.
      *
-     * See https://valkey.io/commands/lmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/lmpop/|valkey.io} for more details.
      * @remarks When in cluster mode, all `key`s must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
      * @param count - (Optional) The maximum number of popped elements.
@@ -5784,11 +5823,10 @@ export class BaseClient {
      * Blocks the connection until it pops one or more elements from the first non-empty list from the
      * provided `key`. `BLMPOP` is the blocking variant of {@link lmpop}.
      *
-     * See https://valkey.io/commands/blmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
-     *
+     * @see {@link https://valkey.io/commands/blmpop/|valkey.io} for more details.
      * @remarks When in cluster mode, all `key`s must map to the same hash slot.
+     * @remarks Since Valkey version 7.0.0.
+     *
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of `0` will block indefinitely.
@@ -5819,7 +5857,7 @@ export class BaseClient {
      * Lists the currently active channels.
      * The command is routed to all nodes, and aggregates the response to a single array.
      *
-     * See https://valkey.io/commands/pubsub-channels for more details.
+     * @see {@link https://valkey.io/commands/pubsub-channels/|valkey.io} for more details.
      *
      * @param pattern - A glob-style pattern to match active channels.
      *                  If not provided, all active channels are returned.
@@ -5846,7 +5884,7 @@ export class BaseClient {
      * not the count of clients subscribed to patterns.
      * The command is routed to all nodes, and aggregates the response to the sum of all pattern subscriptions.
      *
-     * See https://valkey.io/commands/pubsub-numpat for more details.
+     * @see {@link https://valkey.io/commands/pubsub-numpat/|valkey.io} for more details.
      *
      * @returns The number of unique patterns.
      *
@@ -5866,7 +5904,7 @@ export class BaseClient {
      * Note that it is valid to call this command without channels. In this case, it will just return an empty map.
      * The command is routed to all nodes, and aggregates the response to a single map of the channels and their number of subscriptions.
      *
-     * See https://valkey.io/commands/pubsub-numsub for more details.
+     * @see {@link https://valkey.io/commands/pubsub-numsub/|valkey.io} for more details.
      *
      * @param channels - The list of channels to query for the number of subscribers.
      *                   If not provided, returns an empty map.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3010,7 +3010,7 @@ export class BaseClient {
      * The script loading, argument preparation, and execution will all be handled internally. If the script has not already been loaded,
      * it will be loaded automatically using the `SCRIPT LOAD` command. After that, it will be invoked using the `EVALSHA` command.
      *
-     * @see {@link https://valkey.io/commands/script-load/} and {@link https://valkey.io/commands/evalsha/} for details.
+     * @see {@link https://valkey.io/commands/script-load/|SCRIPT LOAD} and {@link https://valkey.io/commands/evalsha/|EVALSHA} on valkey.io for details.
      *
      * @param script - The Lua script to execute.
      * @param options - The script option that contains keys and arguments for the script.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -296,12 +296,12 @@ class PointerResponse {
 /** Represents the credentials for connecting to a server. */
 export type RedisCredentials = {
     /**
-     * The username that will be used for authenticating connections to the Redis servers.
+     * The username that will be used for authenticating connections to the Valkey servers.
      * If not supplied, "default" will be used.
      */
     username?: string;
     /**
-     * The password that will be used for authenticating connections to the Redis servers.
+     * The password that will be used for authenticating connections to the Valkey servers.
      */
     password: string;
 };
@@ -1085,8 +1085,8 @@ export class BaseClient {
     /** Retrieve the values of multiple keys.
      *
      * @see {@link https://valkey.io/commands/mget/|valkey.io} for details.
-     *
      * @remarks When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
+     *
      * @param keys - A list of keys to retrieve values for.
      * @returns A list of values corresponding to the provided keys. If a key is not found,
      * its corresponding value in the list will be null.
@@ -1107,8 +1107,8 @@ export class BaseClient {
     /** Set multiple keys to multiple values in a single operation.
      *
      * @see {@link https://valkey.io/commands/mset/|valkey.io} for details.
-     *
      * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keyValueMap` map to different hash slots.
+     *
      * @param keyValueMap - A key-value map consisting of keys and their respective values to set.
      * @returns always "OK".
      *
@@ -1251,8 +1251,8 @@ export class BaseClient {
      * `destination`.
      *
      * @see {@link https://valkey.io/commands/bitop/|valkey.io} for more details.
-     *
      * @remarks When in cluster mode, `destination` and all `keys` must map to the same hash slot.
+     *
      * @param operation - The bitwise operation to perform.
      * @param destination - The key that will store the resulting string.
      * @param keys - The list of keys to perform the bitwise operation on.
@@ -1446,7 +1446,6 @@ export class BaseClient {
      * Reads the array of bits representing the string that is held at `key` based on the specified `subcommands`.
      *
      * @see {@link https://valkey.io/commands/bitfield_ro/|valkey.io} for more details.
-     *
      * @remarks Since Valkey version 6.0.0.
      *
      * @param key - The key of the string.
@@ -2086,9 +2085,8 @@ export class BaseClient {
      * `BLMOVE` is the blocking variant of {@link lmove}.
      *
      * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
-     * @remarks
-     * 1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
-     * 2. `BLMOVE` is a client blocking command, see https://github.com/aws/glide-for-redis/wiki/General-Concepts#blocking-commands for more details and best practices.
+     * @remarks When in cluster mode, both `source` and `destination` must map to the same hash slot.
+     * @remarks `BLMOVE` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Valkey Glide Wiki} for more details and best practices.
      * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source list.
@@ -3009,9 +3007,9 @@ export class BaseClient {
     }
 
     /** Invokes a Lua script with its keys and arguments.
-     * This method simplifies the process of invoking scripts on a Redis server by using an object that represents a Lua script.
+     * This method simplifies the process of invoking scripts on a Valkey server by using an object that represents a Lua script.
      * The script loading, argument preparation, and execution will all be handled internally. If the script has not already been loaded,
-     * it will be loaded automatically using the Redis `SCRIPT LOAD` command. After that, it will be invoked using the Redis `EVALSHA` command
+     * it will be loaded automatically using the `SCRIPT LOAD` command. After that, it will be invoked using the `EVALSHA` command.
      *
      * @see {@link https://valkey.io/commands/script-load/} and {@link https://valkey.io/commands/evalsha/} for details.
      *
@@ -4788,8 +4786,8 @@ export class BaseClient {
      * If `newkey` already exists it is overwritten.
      *
      * @see {@link https://valkey.io/commands/rename/|valkey.io} for more details.
-     *
      * @remarks When in cluster mode, `key` and `newKey` must map to the same hash slot.
+     *
      * @param key - The key to rename.
      * @param newKey - The new name of the key.
      * @returns - If the `key` was successfully renamed, return "OK". If `key` does not exist, an error is thrown.
@@ -4810,8 +4808,8 @@ export class BaseClient {
      * Renames `key` to `newkey` if `newkey` does not yet exist.
      *
      * @see {@link https://valkey.io/commands/renamenx/|valkey.io} for more details.
-     *
      * @remarks When in cluster mode, `key` and `newKey` must map to the same hash slot.
+     *
      * @param key - The key to rename.
      * @param newKey - The new name of the key.
      * @returns - If the `key` was successfully renamed, returns `true`. Otherwise, returns `false`.
@@ -4835,9 +4833,8 @@ export class BaseClient {
      * Blocks the connection when there are no elements to pop from any of the given lists.
      *
      * @see {@link https://valkey.io/commands/brpop/|valkey.io} for more details.
-     * @remarks
-     * 1. When in cluster mode, all `keys` must map to the same hash slot.
-     * 2. `BRPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks `BRPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -4864,9 +4861,8 @@ export class BaseClient {
      * Blocks the connection when there are no elements to pop from any of the given lists.
      *
      * @see {@link https://valkey.io/commands/blpop/|valkey.io} for more details.
-     * @remarks
-     * 1. When in cluster mode, all `keys` must map to the same hash slot.
-     * 2. `BLPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks `BLPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -4955,7 +4951,7 @@ export class BaseClient {
         return this.createWritePromise(createPfMerge(destination, sourceKeys));
     }
 
-    /** Returns the internal encoding for the Redis object stored at `key`.
+    /** Returns the internal encoding for the Valkey object stored at `key`.
      *
      * @see {@link https://valkey.io/commands/object-encoding/|valkey.io} for more details.
      *
@@ -4972,7 +4968,7 @@ export class BaseClient {
         return this.createWritePromise(createObjectEncoding(key));
     }
 
-    /** Returns the logarithmic access frequency counter of a Redis object stored at `key`.
+    /** Returns the logarithmic access frequency counter of a Valkey object stored at `key`.
      *
      * @see {@link https://valkey.io/commands/object-freq/|valkey.io} for more details.
      *
@@ -5392,10 +5388,8 @@ export class BaseClient {
      * to pop from any of the given sorted sets. `BZMPOP` is the blocking variant of {@link zmpop}.
      *
      * @see {@link https://valkey.io/commands/bzmpop/|valkey.io} for more details.
-     * @remarks
-     *      1. When in cluster mode, all `keys` must map to the same hash slot.
-     *      2. `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | the wiki}
-     *         for more details and best practices.
+     * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | Valkey Glide Wiki} for more details and best practices.
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1775,7 +1775,7 @@ export class BaseClient {
     /**
      * Iterates incrementally over a hash.
      *
-     * @see {@link https://valkey.io/commands//|valkey.io} for more details.
+     * @see {@link https://valkey.io/commands/hscan/|valkey.io} for more details.
      *
      * @param key - The key of the set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of the search.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -51,6 +51,7 @@ import {
     StreamPendingOptions,
     StreamReadOptions,
     StreamTrimOptions,
+    TimeUnit,
     ZAddOptions,
     createAppend,
     createBLMPop,
@@ -206,7 +207,6 @@ import {
     createZRevRankWithScore,
     createZScan,
     createZScore,
-    TimeUnit,
 } from "./Commands";
 import {
     ClosingError,
@@ -940,15 +940,14 @@ export class BaseClient {
     /**
      * Get the value of `key` and optionally set its expiration. `GETEX` is similar to {@link get}.
      *
-     * See https://valkey.io/commands/getex for more details.
+     * @see {@link https://valkey.io/commands/getex/|valkey.op} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key to retrieve from the database.
      * @param options - (Optional) Set expiriation to the given key.
      *                  "persist" will retain the time to live associated with the key. Equivalent to `PERSIST` in the VALKEY API.
      *                  Otherwise, a {@link TimeUnit} and duration of the expire time should be specified.
      * @returns If `key` exists, returns the value of `key` as a `string`. Otherwise, return `null`.
-     *
-     * since - Valkey 6.2.0 and above.
      *
      * @example
      * ```typescript
@@ -1776,7 +1775,7 @@ export class BaseClient {
     /**
      * Iterates incrementally over a hash.
      *
-     * See https://valkey.io/commands/hscan for more details.
+     * @see {@link https://valkey.io/commands//|valkey.io} for more details.
      *
      * @param key - The key of the set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of the search.
@@ -4369,9 +4368,8 @@ export class BaseClient {
     /**
      * Transfers ownership of pending stream entries that match the specified criteria.
      *
-     * See https://valkey.io/commands/xautoclaim/ for more details.
-     *
-     * since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/xautoclaim/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -4425,9 +4423,8 @@ export class BaseClient {
     /**
      * Transfers ownership of pending stream entries that match the specified criteria.
      *
-     * See https://valkey.io/commands/xautoclaim/ for more details.
-     *
-     * since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/xautoclaim/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -5714,7 +5711,7 @@ export class BaseClient {
      * acknowledged by at least `numreplicas` of replicas. If `timeout` is reached, the command returns
      * the number of replicas that were not yet reached.
      *
-     * See https://valkey.io/commands/wait/ for more details.
+     * @see {@link https://valkey.io/commands/wait/|valkey.io} for more details.
      *
      * @param numreplicas - The number of replicas to reach.
      * @param timeout - The timeout value specified in milliseconds. A value of 0 will block indefinitely.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1437,11 +1437,11 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/bitfield_ro/ for more details.
      *
+     * Since Valkey version 6.0.0.
+     *
      * @param key - The key of the string.
      * @param subcommands - The {@link BitFieldGet} subcommands to be performed.
      * @returns An array of results from the {@link BitFieldGet} subcommands.
-     *
-     * since Valkey version 6.0.0.
      *
      * @example
      * ```typescript
@@ -1739,7 +1739,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/hrandfield/ for more details.
      *
-     * since Valkey version 6.2.0.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @returns A random field name from the hash stored at `key`, or `null` when
@@ -1804,7 +1804,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/hrandfield/ for more details.
      *
-     * since Valkey version 6.2.0.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -1831,7 +1831,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/hrandfield/ for more details.
      *
-     * since Valkey version 6.2.0.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -2023,13 +2023,13 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/lmove/ for details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
      * @param whereFrom - The {@link ListDirection} to remove the element from.
      * @param whereTo - The {@link ListDirection} to add the element to.
      * @returns The popped element, or `null` if `source` does not exist.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -2069,14 +2069,14 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/blmove/ for details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
      * @param whereFrom - The {@link ListDirection} to remove the element from.
      * @param whereTo - The {@link ListDirection} to add the element to.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of `0` will block indefinitely.
      * @returns The popped element, or `null` if `source` does not exist or if the operation timed-out.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -2419,12 +2419,12 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/sintercard/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param keys - The keys of the sets.
      * @param limit - The limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
      * @returns The cardinality of the intersection result. If one or more sets do not exist, `0` is returned.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript
@@ -2595,11 +2595,11 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/smismember/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param key - The key of the set to check.
      * @param members - A list of members to check for existence in the set.
      * @returns An `array` of `boolean` values, each indicating if the respective member exists in the set.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -2833,10 +2833,10 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/expiretime/ for details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param key - The `key` to determine the expiration value of.
      * @returns The expiration Unix timestamp in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript
@@ -2919,10 +2919,10 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/pexpiretime/ for details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param key - The `key` to determine the expiration value of.
      * @returns The expiration Unix timestamp in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript
@@ -3190,13 +3190,13 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zintercard/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param keys - The keys of the sorted sets to intersect.
      * @param limit - An optional argument that can be used to specify a maximum number for the
      * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
      * @returns The cardinality of the intersection of the given sorted sets.
-     *
-     * since - Redis version 7.0.0.
      *
      * @example
      * ```typescript
@@ -3214,12 +3214,12 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zdiff/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param keys - The keys of the sorted sets.
      * @returns An `array` of elements representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -3240,12 +3240,12 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zdiff/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param keys - The keys of the sorted sets.
      * @returns A map of elements and their scores representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -3269,12 +3269,12 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zdiffstore/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @remarks When in cluster mode, all keys in `keys` and `destination` must map to the same hash slot.
      * @param destination - The key for the resulting sorted set.
      * @param keys - The keys of the sorted sets to compare.
      * @returns The number of members in the resulting sorted set stored at `destination`.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -3333,12 +3333,12 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zmscore/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param key - The key of the sorted set.
      * @param members - A list of members in the sorted set.
      * @returns An `array` of scores corresponding to `members`.
      * If a member does not exist in the sorted set, the corresponding value in the list will be `null`.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -3427,6 +3427,7 @@ export class BaseClient {
 
     /** Returns the specified range of elements with their scores in the sorted set stored at `key`.
      * Similar to ZRANGE but with a WITHSCORE flag.
+     *
      * See https://valkey.io/commands/zrange/ for more details.
      *
      * @param key - The key of the sorted set.
@@ -3476,6 +3477,8 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zrangestore/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @remarks When in cluster mode, `destination` and `source` must map to the same hash slot.
      * @param destination - The key for the destination sorted set.
      * @param source - The key of the source sorted set.
@@ -3485,8 +3488,6 @@ export class BaseClient {
      * - For range queries by score, use {@link RangeByScore}.
      * @param reverse - If `true`, reverses the sorted set, with index `0` as the element with the highest score.
      * @returns The number of elements in the resulting sorted set.
-     *
-     * since - Redis version 6.2.0.
      *
      * @example
      * ```typescript
@@ -4002,14 +4003,15 @@ export class BaseClient {
     }
 
     /** Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
+     *
      * See https://valkey.io/commands/zrank for more details.
+     *
+     * Since Valkey version 7.2.0.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
      * @returns A list containing the rank and score of `member` in the sorted set.
      * If `key` doesn't exist, or if `member` is not present in the set, null will be returned.
-     *
-     * since - Redis version 7.2.0.
      *
      * @example
      * ```typescript
@@ -4060,13 +4062,13 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zrevrank/ for more details.
      *
+     * Since Valkey version 7.2.0.
+     *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
      * @returns A list containing the rank and score of `member` in the sorted set, where ranks
      *     are ordered from high to low based on scores.
      *     If `key` doesn't exist, or if `member` is not present in the set, `null` will be returned.
-     *
-     * since - Valkey version 7.2.0.
      *
      * @example
      * ```typescript
@@ -4975,7 +4977,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/fcall/ for more details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param func - The function name.
@@ -5003,7 +5005,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/fcall/ for more details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param func - The function name.
@@ -5034,13 +5036,13 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/lpos/ for more details.
      *
+     * Since Valkey version 6.0.6.
+     *
      * @param key - The name of the list.
      * @param element - The value to search for within the list.
      * @param options - The LPOS options.
      * @returns The index of `element`, or `null` if `element` is not in the list. If the `count` option
      * is specified, then the function returns an `array` of indices of matching elements within the list.
-     *
-     * since - Valkey version 6.0.6.
      *
      * @example
      * ```typescript
@@ -5124,7 +5126,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/geosearch/ for more details.
      *
-     * since - Valkey 6.2.0 and above.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the sorted set.
      * @param searchFrom - The query's center point options, could be one of:
@@ -5206,7 +5208,7 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/geosearchstore/ for more details.
      *
-     * since - Valkey 6.2.0 and above.
+     * Since Valkey version 6.2.0.
      *
      * @remarks When in cluster mode, `destination` and `source` must map to the same hash slot.
      *
@@ -5310,6 +5312,8 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/zmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
@@ -5318,8 +5322,6 @@ export class BaseClient {
      * @returns A two-element `array` containing the key name of the set from which the element
      *     was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript
@@ -5344,6 +5346,8 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/bzmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks
      *      1. When in cluster mode, all `keys` must map to the same hash slot.
      *      2. `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | the wiki}
@@ -5357,8 +5361,6 @@ export class BaseClient {
      * @returns A two-element `array` containing the key name of the set from which the element
      *     was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript
@@ -5518,11 +5520,11 @@ export class BaseClient {
     /**
      * Returns all the longest common subsequences combined between strings stored at `key1` and `key2`.
      *
-     * since Valkey version 7.0.0.
+     * See https://valkey.io/commands/lcs/ for more details.
+     *
+     * Since Valkey version 7.0.0.
      *
      * @remarks When in cluster mode, `key1` and `key2` must map to the same hash slot.
-     *
-     * See https://valkey.io/commands/lcs/ for more details.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -5543,11 +5545,11 @@ export class BaseClient {
     /**
      * Returns the total length of all the longest common subsequences between strings stored at `key1` and `key2`.
      *
-     * since Valkey version 7.0.0.
+     * See https://valkey.io/commands/lcs/ for more details.
+     *
+     * Since Valkey version 7.0.0.
      *
      * @remarks When in cluster mode, `key1` and `key2` must map to the same hash slot.
-     *
-     * See https://valkey.io/commands/lcs/ for more details.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -5568,11 +5570,11 @@ export class BaseClient {
      * Returns the indices and lengths of the longest common subsequences between strings stored at
      * `key1` and `key2`.
      *
-     * since Valkey version 7.0.0.
+     * See https://valkey.io/commands/lcs/ for more details.
+     *
+     * Since Valkey version 7.0.0.
      *
      * @remarks When in cluster mode, `key1` and `key2` must map to the same hash slot.
-     *
-     * See https://valkey.io/commands/lcs/ for more details.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -5754,13 +5756,13 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/lmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks When in cluster mode, all `key`s must map to the same hash slot.
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
      * @param count - (Optional) The maximum number of popped elements.
      * @returns A `Record` of key-name mapped array of popped elements.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript
@@ -5784,6 +5786,8 @@ export class BaseClient {
      *
      * See https://valkey.io/commands/blmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks When in cluster mode, all `key`s must map to the same hash slot.
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
@@ -5791,8 +5795,6 @@ export class BaseClient {
      * @param count - (Optional) The maximum number of popped elements.
      * @returns - A `Record` of `key` name mapped array of popped elements.
      *     If no member could be popped and the timeout expired, returns `null`.
-     *
-     * since Valkey version 7.0.0.
      *
      * @example
      * ```typescript

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3058,7 +3058,7 @@ export class BaseClient {
     /**
      * Returns stream entries matching a given range of entry IDs.
      *
-     * See https://valkey.io/commands/xrange for more details.
+     * @see {@link https://valkey.io/commands/xrange/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param start - The starting stream entry ID bound for the range.

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -289,7 +289,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Rewrite the configuration file with the current configuration.
-     * @see {@link https://valkey.io/commands/config-rewrite/|valkey.io}for details.
+     * @see {@link https://valkey.io/commands/config-rewrite/|valkey.io} for details.
      *
      * @returns "OK" when the configuration was rewritten properly. Otherwise, an error is thrown.
      *
@@ -305,6 +305,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
+     * 
      * @see {@link https://valkey.io/commands/config-resetstat/|valkey.io} for details.
      *
      * @returns always "OK".

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -131,8 +131,8 @@ export type GlideClientConfiguration = BaseClientConfiguration & {
 
 /**
  * Client used for connection to standalone Redis servers.
- * For full documentation,
- * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#standalone|Valkey Glide Wiki}
+ *
+ * @see For full documentation refer to {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#standalone|Valkey Glide Wiki}.
  */
 export class GlideClient extends BaseClient {
     /**
@@ -171,6 +171,7 @@ export class GlideClient extends BaseClient {
 
     /**
      * Execute a transaction by processing the queued commands.
+     *
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey Glide Wiki} for details on Valkey Transactions.
      *
      * @param transaction - A Transaction object containing a list of commands to be executed.
@@ -200,7 +201,7 @@ export class GlideClient extends BaseClient {
      *
      * Note: An error will occur if the string decoder is used with commands that return only bytes as a response.
      *
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.     *
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.
      *
      * @example
      * ```typescript

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -305,7 +305,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-     * 
+     *
      * @see {@link https://valkey.io/commands/config-resetstat/|valkey.io} for details.
      *
      * @returns always "OK".

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -58,7 +58,7 @@ import { Transaction } from "./Transaction";
 export namespace GlideClientConfiguration {
     /**
      * Enum representing pubsub subscription modes.
-     * See [Valkey PubSub Documentation](https://valkey.io/docs/topics/pubsub/) for more details.
+     * @see {@link  https://valkey.io/docs/topics/pubsub/|Valkey PubSub Documentation} for more details.
      */
     export enum PubSubChannelModes {
         /**
@@ -131,8 +131,8 @@ export type GlideClientConfiguration = BaseClientConfiguration & {
 
 /**
  * Client used for connection to standalone Redis servers.
- * For full documentation, see
- * https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#standalone
+ * For full documentation,
+ * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#standalone|Valkey Glide Wiki}
  */
 export class GlideClient extends BaseClient {
     /**
@@ -169,8 +169,9 @@ export class GlideClient extends BaseClient {
         );
     }
 
-    /** Execute a transaction by processing the queued commands.
-     *   See https://redis.io/topics/Transactions/ for details on Redis Transactions.
+    /**
+     * Execute a transaction by processing the queued commands.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey Glide Wiki} for details on Valkey Transactions.
      *
      * @param transaction - A Transaction object containing a list of commands to be executed.
      * @param decoder - An optional parameter to decode all commands in the transaction. If not set, 'Decoder.String' will be used.
@@ -199,8 +200,7 @@ export class GlideClient extends BaseClient {
      *
      * Note: An error will occur if the string decoder is used with commands that return only bytes as a response.
      *
-     * See the [Glide for Redis Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
-     * for details on the restrictions and limitations of the custom command API.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.     *
      *
      * @example
      * ```typescript
@@ -219,7 +219,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Ping the Redis server.
-     * See https://valkey.io/commands/ping/ for details.
+     * @see {@link https://valkey.io/commands/ping/|valkey.io} for details.
      *
      * @param message - An optional message to include in the PING command.
      * If not provided, the server will respond with "PONG".
@@ -245,7 +245,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Get information and statistics about the Redis server.
-     *  See https://valkey.io/commands/info/ for details.
+     * @see {@link https://valkey.io/commands/info/|valkey.io} for details.
      *
      * @param options - A list of InfoSection values specifying which sections of information to retrieve.
      *  When no parameter is provided, the default option is assumed.
@@ -256,7 +256,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Change the currently selected Redis database.
-     * See https://valkey.io/commands/select/ for details.
+     * @see {@link https://valkey.io/commands/select/|valkey.io} for details.
      *
      * @param index - The index of the database to select.
      * @returns A simple OK response.
@@ -273,7 +273,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Get the name of the primary's connection.
-     *  See https://valkey.io/commands/client-getname/ for more details.
+     * @see {@link https://valkey.io/commands/client-getname/|valkey.io} for more details.
      *
      * @returns the name of the client connection as a string if a name is set, or null if no name is assigned.
      *
@@ -289,7 +289,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Rewrite the configuration file with the current configuration.
-     * See https://valkey.io/commands/config-rewrite/ for details.
+     * @see {@link https://valkey.io/commands/config-rewrite/|valkey.io}for details.
      *
      * @returns "OK" when the configuration was rewritten properly. Otherwise, an error is thrown.
      *
@@ -305,7 +305,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-     * See https://valkey.io/commands/config-resetstat/ for details.
+     * @see {@link https://valkey.io/commands/config-resetstat/|valkey.io} for details.
      *
      * @returns always "OK".
      *
@@ -321,7 +321,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Returns the current connection id.
-     * See https://valkey.io/commands/client-id/ for details.
+     * @see {@link https://valkey.io/commands/client-id/|valkey.io} for details.
      *
      * @returns the id of the client.
      */
@@ -330,7 +330,8 @@ export class GlideClient extends BaseClient {
     }
 
     /** Reads the configuration parameters of a running Redis server.
-     *  See https://valkey.io/commands/config-get/ for details.
+     *
+     * @see {@link https://valkey.io/commands/config-get/|valkey.io} for details.
      *
      * @param parameters - A list of configuration parameter names to retrieve values for.
      *
@@ -349,11 +350,11 @@ export class GlideClient extends BaseClient {
         return this.createWritePromise(createConfigGet(parameters));
     }
 
-    /** Set configuration parameters to the specified values.
-     *   See https://valkey.io/commands/config-set/ for details.
+    /**
+     * Set configuration parameters to the specified values.
      *
+     * @see {@link  https://valkey.io/commands/config-set/|valkey.io} for details.
      * @param parameters - A List of keyValuePairs consisting of configuration parameters and their respective values to set.
-     *
      * @returns "OK" when the configuration was set properly. Otherwise an error is thrown.
      *
      * @example
@@ -368,7 +369,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Echoes the provided `message` back.
-     * See https://valkey.io/commands/echo for more details.
+     * @see {@link https://valkey.io/commands/echo|valkey.io} for more details.
      *
      * @param message - The message to be echoed back.
      * @returns The provided `message`.
@@ -385,7 +386,7 @@ export class GlideClient extends BaseClient {
     }
 
     /** Returns the server time
-     * See https://valkey.io/commands/time/ for details.
+     * @see {@link https://valkey.io/commands/time/|valkey.io} for details.
      *
      * @returns - The current server time as a two items `array`:
      * A Unix timestamp and the amount of microseconds already elapsed in the current second.
@@ -408,9 +409,8 @@ export class GlideClient extends BaseClient {
      * When `replace` is true, removes the `destination` key first if it already exists, otherwise performs
      * no action.
      *
-     * See https://valkey.io/commands/copy/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/copy/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
@@ -447,7 +447,7 @@ export class GlideClient extends BaseClient {
     /**
      * Move `key` from the currently selected database to the database specified by `dbIndex`.
      *
-     * See https://valkey.io/commands/move/ for more details.
+     * @see {@link https://valkey.io/commands/move/|valkey.io} for more details.
      *
      * @param key - The key to move.
      * @param dbIndex - The index of the database to move `key` to.
@@ -467,7 +467,7 @@ export class GlideClient extends BaseClient {
     /**
      * Displays a piece of generative computer art and the server version.
      *
-     * See https://valkey.io/commands/lolwut/ for more details.
+     * @see {@link https://valkey.io/commands/lolwut/|valkey.io} for more details.
      *
      * @param options - The LOLWUT options
      * @returns A piece of generative computer art along with the current server version.
@@ -485,9 +485,8 @@ export class GlideClient extends BaseClient {
     /**
      * Deletes a library and all its functions.
      *
-     * See https://valkey.io/commands/function-delete/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-delete/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param libraryCode - The library name to delete.
      * @returns A simple OK response.
@@ -505,9 +504,8 @@ export class GlideClient extends BaseClient {
     /**
      * Loads a library to Valkey.
      *
-     * See https://valkey.io/commands/function-load/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-load/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param libraryCode - The source code that implements the library.
      * @param replace - Whether the given library should overwrite a library with the same name if it
@@ -533,9 +531,8 @@ export class GlideClient extends BaseClient {
     /**
      * Deletes all function libraries.
      *
-     * See https://valkey.io/commands/function-flush/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-flush/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @returns A simple OK response.
@@ -553,9 +550,8 @@ export class GlideClient extends BaseClient {
     /**
      * Returns information about the functions and libraries.
      *
-     * See https://valkey.io/commands/function-list/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-list/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param options - Parameters to filter and request additional info.
      * @returns Info about all or selected libraries and their functions in {@link FunctionListResponse} format.
@@ -589,15 +585,13 @@ export class GlideClient extends BaseClient {
      * Returns information about the function that's currently running and information about the
      * available execution engines.
      *
-     * See https://valkey.io/commands/function-stats/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-stats/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @returns A `Record` with two keys:
      *     - `"running_script"` with information about the running script.
      *     - `"engines"` with information about available engines and their stats.
-     *
-     * See example for more details.
+     *     - see example for more details.
      *
      * @example
      * ```typescript
@@ -658,7 +652,7 @@ export class GlideClient extends BaseClient {
     /**
      * Deletes all the keys of all the existing databases. This command never fails.
      *
-     * See https://valkey.io/commands/flushall/ for more details.
+     * @see {@link https://valkey.io/commands/flushall/|valkey.io} for more details.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @returns `OK`.
@@ -676,7 +670,7 @@ export class GlideClient extends BaseClient {
     /**
      * Deletes all the keys of the currently selected database. This command never fails.
      *
-     * See https://valkey.io/commands/flushdb/ for more details.
+     * @see {@link https://valkey.io/commands/flushdb/|valkey.io} for more details.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @returns `OK`.
@@ -694,7 +688,7 @@ export class GlideClient extends BaseClient {
     /**
      * Returns the number of keys in the currently selected database.
      *
-     * See https://valkey.io/commands/dbsize/ for more details.
+     * @see {@link https://valkey.io/commands/dbsize/|valkey.io} for more details.
      *
      * @returns The number of keys in the currently selected database.
      *
@@ -710,7 +704,7 @@ export class GlideClient extends BaseClient {
 
     /** Publish a message on pubsub channel.
      *
-     * See https://valkey.io/commands/publish for more details.
+     * @see {@link https://valkey.io/commands/publish/|valkey.io} for more details.
      *
      * @param message - Message to publish.
      * @param channel - Channel to publish the message on.
@@ -736,7 +730,7 @@ export class GlideClient extends BaseClient {
      *
      * To store the result into a new key, see {@link sortStore}.
      *
-     * See https://valkey.io/commands/sort for more details.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - The {@link SortOptions}.
@@ -766,7 +760,8 @@ export class GlideClient extends BaseClient {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - The {@link SortOptions}.
@@ -797,9 +792,9 @@ export class GlideClient extends BaseClient {
      *
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
-     * See https://valkey.io/commands/sort for more details.
-     *
+     * @see {@link https://valkey.io/commands/sort|valkey.io} for more details.
      * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
+     *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
      * @param options - The {@link SortOptions}.
@@ -827,7 +822,7 @@ export class GlideClient extends BaseClient {
      * Returns `UNIX TIME` of the last DB save timestamp or startup timestamp if no save
      * was made since then.
      *
-     * See https://valkey.io/commands/lastsave/ for more details.
+     * @see {@link https://valkey.io/commands/lastsave/|valkey.io} for more details.
      *
      * @returns `UNIX TIME` of the last DB save executed with success.
      * @example
@@ -843,7 +838,7 @@ export class GlideClient extends BaseClient {
     /**
      * Returns a random existing key name from the currently selected database.
      *
-     * See https://valkey.io/commands/randomkey/ for more details.
+     * @see {@link https://valkey.io/commands/randomkey/|valkey.io} for more details.
      *
      * @returns A random existing key name from the currently selected database.
      *
@@ -861,7 +856,7 @@ export class GlideClient extends BaseClient {
      * Flushes all the previously watched keys for a transaction. Executing a transaction will
      * automatically flush all previously watched keys.
      *
-     * See https://valkey.io/commands/unwatch/ and https://valkey.io/topics/transactions/#cas for more details.
+     * @see {@link https://valkey.io/commands/unwatch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
      *
      * @returns A simple "OK" response.
      *

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -410,6 +410,8 @@ export class GlideClient extends BaseClient {
      *
      * See https://valkey.io/commands/copy/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
      * @param destinationDB - (Optional) The alternative logical database index for the destination key.
@@ -417,8 +419,6 @@ export class GlideClient extends BaseClient {
      * @param replace - (Optional) If `true`, the `destination` key should be removed before copying the
      *     value to it. If not provided, no action will be performed if the key already exists.
      * @returns `true` if `source` was copied, `false` if the `source` was not copied.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -487,7 +487,7 @@ export class GlideClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-delete/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param libraryCode - The library name to delete.
      * @returns A simple OK response.
@@ -507,7 +507,7 @@ export class GlideClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-load/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param libraryCode - The source code that implements the library.
      * @param replace - Whether the given library should overwrite a library with the same name if it
@@ -535,7 +535,7 @@ export class GlideClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-flush/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @returns A simple OK response.
@@ -555,7 +555,7 @@ export class GlideClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-list/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param options - Parameters to filter and request additional info.
      * @returns Info about all or selected libraries and their functions in {@link FunctionListResponse} format.
@@ -591,7 +591,7 @@ export class GlideClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-stats/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @returns A `Record` with two keys:
      *     - `"running_script"` with information about the running script.
@@ -766,7 +766,7 @@ export class GlideClient extends BaseClient {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - The {@link SortOptions}.

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -672,14 +672,14 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/copy/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
      * @param replace - (Optional) If `true`, the `destination` key should be removed before copying the
      *     value to it. If not provided, no action will be performed if the key already exists.
      * @returns `true` if `source` was copied, `false` if the `source` was not copied.
-     *
-     * since Valkey version 6.2.0.
      *
      * @example
      * ```typescript
@@ -728,7 +728,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/fcall/ for more details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param args - A list of `function` arguments and it should not represent names of keys.
@@ -757,7 +757,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/fcall/ for more details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param args - A list of `function` arguments and it should not represent names of keys.
@@ -787,7 +787,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-delete/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param libraryCode - The library name to delete.
      * @param route - The command will be routed to all primary node, unless `route` is provided, in which
@@ -814,7 +814,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-load/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param libraryCode - The source code that implements the library.
      * @param replace - Whether the given library should overwrite a library with the same name if it
@@ -846,7 +846,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-flush/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @param route - The command will be routed to all primary nodes, unless `route` is provided, in which
@@ -873,7 +873,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-list/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param options - Parameters to filter and request additional info.
      * @param route - The client will route the command to the nodes defined by `route`.
@@ -914,7 +914,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * See https://valkey.io/commands/function-stats/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param route - The client will route the command to the nodes defined by `route`.
      *     If not defined, the command will be routed to all primary nodes.
@@ -1177,7 +1177,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortClusterOptions}.

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -88,7 +88,7 @@ export type PeriodicChecks =
 export namespace GlideClusterClientConfiguration {
     /**
      * Enum representing pubsub subscription modes.
-     * See [Valkey PubSub Documentation](https://valkey.io/docs/topics/pubsub/) for more details.
+     * @see {@link https://valkey.io/docs/topics/pubsub/|Valkey PubSub Documentation} for more details.
      */
     export enum PubSubChannelModes {
         /**
@@ -285,8 +285,7 @@ function toProtobufRoute(
 
 /**
  * Client used for connection to cluster Redis servers.
- * For full documentation, see
- * https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#cluster
+ * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#cluster|Valkey Glide Wiki} for full documentation.
  */
 export class GlideClusterClient extends BaseClient {
     /**
@@ -346,8 +345,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * Note: An error will occur if the string decoder is used with commands that return only bytes as a response.
      *
-     * See the [Glide for Valkey Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
-     * for details on the restrictions and limitations of the custom command API.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Glide for Valkey Wiki} for details on the restrictions and limitations of the custom command API.
      *
      * @example
      * ```typescript
@@ -367,8 +365,9 @@ export class GlideClusterClient extends BaseClient {
         });
     }
 
-    /** Execute a transaction by processing the queued commands.
-     *   See https://redis.io/topics/Transactions/ for details on Redis Transactions.
+    /**
+     * Execute a transaction by processing the queued commands.
+     * @see {@link https://redis.io/topics/Transactions/|Valkey Glide Wiki} for details on Redis Transactions.
      *
      * @param transaction - A ClusterTransaction object containing a list of commands to be executed.
      * @param route - If `route` is not provided, the transaction will be routed to the slot owner of the first key found in the transaction.
@@ -401,7 +400,8 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Ping the Redis server.
-     * See https://valkey.io/commands/ping/ for details.
+     *
+     * @see {@link https://valkey.io/commands/ping/|valkey.io} for details.
      *
      * @param message - An optional message to include in the PING command.
      * If not provided, the server will respond with "PONG".
@@ -431,7 +431,7 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Get information and statistics about the Redis server.
-     *  See https://valkey.io/commands/info/ for details.
+     * @see {@link https://valkey.io/commands/info/|valkey.io} for details.
      *
      * @param options - A list of InfoSection values specifying which sections of information to retrieve.
      *  When no parameter is provided, the default option is assumed.
@@ -451,7 +451,7 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Get the name of the connection to which the request is routed.
-     *  See https://valkey.io/commands/client-getname/ for more details.
+     * @see {@link https://valkey.io/commands/client-getname/|valkey.io} for details.
      *
      * @param route - The command will be routed a random node, unless `route` is provided, in which
      *   case the client will route the command to the nodes defined by `route`.
@@ -484,11 +484,10 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Rewrite the configuration file with the current configuration.
-     * See https://valkey.io/commands/config-rewrite/ for details.
+     * @see {@link https://valkey.io/commands/config-rewrite/|valkey.io} for details.
      *
      * @param route - The command will be routed to all nodes, unless `route` is provided, in which
      *   case the client will route the command to the nodes defined by `route`.
-     *
      * @returns "OK" when the configuration was rewritten properly. Otherwise, an error is thrown.
      *
      * @example
@@ -505,11 +504,10 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-     * See https://valkey.io/commands/config-resetstat/ for details.
+     * @see {@link https://valkey.io/commands/config-resetstat/|valkey.io} for details.
      *
      * @param route - The command will be routed to all nodes, unless `route` is provided, in which
      *   case the client will route the command to the nodes defined by `route`.
-     *
      * @returns always "OK".
      *
      * @example
@@ -526,7 +524,7 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Returns the current connection id.
-     * See https://valkey.io/commands/client-id/ for details.
+     * @see {@link https://valkey.io/commands/client-id/|valkey.io} for details.
      *
      * @param route - The command will be routed to a random node, unless `route` is provided, in which
      *   case the client will route the command to the nodes defined by `route`.
@@ -541,7 +539,7 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Reads the configuration parameters of a running Redis server.
-     *  See https://valkey.io/commands/config-get/ for details.
+     * @see {@link https://valkey.io/commands/config-get/|valkey.io} for details.
      *
      * @param parameters - A list of configuration parameter names to retrieve values for.
      * @param route - The command will be routed to a random node, unless `route` is provided, in which
@@ -576,13 +574,12 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Set configuration parameters to the specified values.
-     *   See https://valkey.io/commands/config-set/ for details.
+     * @see {@link https://valkey.io/commands/config-set/|valkey.io} for details.
      *
      * @param parameters - A List of keyValuePairs consisting of configuration parameters and their respective values to set.
      * @param route - The command will be routed to all nodes, unless `route` is provided, in which
      *   case the client will route the command to the nodes defined by `route`.
      *   If `route` is not provided, the command will be sent to the all nodes.
-     *
      * @returns "OK" when the configuration was set properly. Otherwise an error is thrown.
      *
      * @example
@@ -602,7 +599,7 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Echoes the provided `message` back.
-     * See https://valkey.io/commands/echo for more details.
+     * @see {@link https://valkey.io/commands/echo/|valkey.io} for details.
      *
      * @param message - The message to be echoed back.
      * @param route - The command will be routed to a random node, unless `route` is provided, in which
@@ -633,7 +630,7 @@ export class GlideClusterClient extends BaseClient {
     }
 
     /** Returns the server time.
-     * See https://valkey.io/commands/time/ for details.
+     * @see {@link https://valkey.io/commands/time/|valkey.io} for details.
      *
      * @param route - The command will be routed to a random node, unless `route` is provided, in which
      *  case the client will route the command to the nodes defined by `route`.
@@ -670,9 +667,8 @@ export class GlideClusterClient extends BaseClient {
      * Copies the value stored at the `source` to the `destination` key. When `replace` is `true`,
      * removes the `destination` key first if it already exists, otherwise performs no action.
      *
-     * See https://valkey.io/commands/copy/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/copy/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @param source - The key to the source value.
@@ -700,7 +696,7 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Displays a piece of generative computer art and the server version.
      *
-     * See https://valkey.io/commands/lolwut/ for more details.
+     * @see {@link https://valkey.io/commands/lolwut/|valkey.io} for details.
      *
      * @param options - The LOLWUT options.
      * @param route - The command will be routed to a random node, unless `route` is provided, in which
@@ -726,9 +722,8 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Invokes a previously loaded function.
      *
-     * See https://valkey.io/commands/fcall/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/fcall/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param args - A list of `function` arguments and it should not represent names of keys.
@@ -755,9 +750,8 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Invokes a previously loaded read-only function.
      *
-     * See https://valkey.io/commands/fcall/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/fcall/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param args - A list of `function` arguments and it should not represent names of keys.
@@ -785,9 +779,8 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Deletes a library and all its functions.
      *
-     * See https://valkey.io/commands/function-delete/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-delete/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param libraryCode - The library name to delete.
      * @param route - The command will be routed to all primary node, unless `route` is provided, in which
@@ -812,9 +805,8 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Loads a library to Valkey.
      *
-     * See https://valkey.io/commands/function-load/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-load/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param libraryCode - The source code that implements the library.
      * @param replace - Whether the given library should overwrite a library with the same name if it
@@ -844,9 +836,8 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Deletes all function libraries.
      *
-     * See https://valkey.io/commands/function-flush/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-flush/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @param route - The command will be routed to all primary nodes, unless `route` is provided, in which
@@ -871,9 +862,8 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Returns information about the functions and libraries.
      *
-     * See https://valkey.io/commands/function-list/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-list/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param options - Parameters to filter and request additional info.
      * @param route - The client will route the command to the nodes defined by `route`.
@@ -912,17 +902,15 @@ export class GlideClusterClient extends BaseClient {
      * Returns information about the function that's currently running and information about the
      * available execution engines.
      *
-     * See https://valkey.io/commands/function-stats/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-stats/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param route - The client will route the command to the nodes defined by `route`.
      *     If not defined, the command will be routed to all primary nodes.
      * @returns A `Record` with two keys:
      *     - `"running_script"` with information about the running script.
      *     - `"engines"` with information about available engines and their stats.
-     *
-     * See example for more details.
+     *     - See example for more details.
      *
      * @example
      * ```typescript
@@ -991,7 +979,7 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Deletes all the keys of all the existing databases. This command never fails.
      *
-     * See https://valkey.io/commands/flushall/ for more details.
+     * @see {@link https://valkey.io/commands/flushall/|valkey.io} for details.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @param route - The command will be routed to all primary nodes, unless `route` is provided, in which
@@ -1013,7 +1001,7 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Deletes all the keys of the currently selected database. This command never fails.
      *
-     * See https://valkey.io/commands/flushdb/ for more details.
+     * @see {@link https://valkey.io/commands/flushdb/|valkey.io} for details.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * @param route - The command will be routed to all primary nodes, unless `route` is provided, in which
@@ -1035,7 +1023,7 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Returns the number of keys in the database.
      *
-     * See https://valkey.io/commands/dbsize/ for more details.
+     * @see {@link https://valkey.io/commands/dbsize/|valkey.io} for details.
 
      * @param route - The command will be routed to all primary nodes, unless `route` is provided, in which
      *     case the client will route the command to the nodes defined by `route`.
@@ -1059,7 +1047,7 @@ export class GlideClusterClient extends BaseClient {
      * The mode is selected using the 'sharded' parameter.
      * For both sharded and non-sharded mode, request is routed using hashed channel as key.
      *
-     * See https://valkey.io/commands/publish and https://valkey.io/commands/spublish for more details.
+     * @see {@link https://valkey.io/commands/publish} and {@link https://valkey.io/commands/spublish} for more details.
      *
      * @param message - Message to publish.
      * @param channel - Channel to publish the message on.
@@ -1094,7 +1082,7 @@ export class GlideClusterClient extends BaseClient {
      * Lists the currently active shard channels.
      * The command is routed to all nodes, and aggregates the response to a single array.
      *
-     * See https://valkey.io/commands/pubsub-shardchannels for more details.
+     * @see {@link https://valkey.io/commands/pubsub-shardchannels/|valkey.io} for details.
      *
      * @param pattern - A glob-style pattern to match active shard channels.
      *                  If not provided, all active shard channels are returned.
@@ -1120,7 +1108,7 @@ export class GlideClusterClient extends BaseClient {
      * Note that it is valid to call this command without channels. In this case, it will just return an empty map.
      * The command is routed to all nodes, and aggregates the response to a single map of the channels and their number of subscriptions.
      *
-     * See https://valkey.io/commands/pubsub-shardnumsub for more details.
+     * @see {@link https://valkey.io/commands/pubsub-shardnumsub/|valkey.io} for details.
      *
      * @param channels - The list of shard channels to query for the number of subscribers.
      *                   If not provided, returns an empty map.
@@ -1149,7 +1137,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * To store the result into a new key, see {@link sortStore}.
      *
-     * See https://valkey.io/commands/sort for more details.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for details.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortClusterOptions}.
@@ -1177,7 +1165,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * Since Valkey version 7.0.0.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortClusterOptions}.
@@ -1206,9 +1194,9 @@ export class GlideClusterClient extends BaseClient {
      *
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
-     * See https://valkey.io/commands/sort for more details.
-     *
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for details.
      * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
+     *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
      * @param options - (Optional) {@link SortClusterOptions}.
@@ -1234,7 +1222,7 @@ export class GlideClusterClient extends BaseClient {
      * Returns `UNIX TIME` of the last DB save timestamp or startup timestamp if no save
      * was made since then.
      *
-     * See https://valkey.io/commands/lastsave/ for more details.
+     * @see {@link https://valkey.io/commands/lastsave/|valkey.io} for details.
      *
      * @param route - (Optional) The command will be routed to a random node, unless `route` is provided, in which
      *     case the client will route the command to the nodes defined by `route`.
@@ -1254,7 +1242,7 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Returns a random existing key name.
      *
-     * See https://valkey.io/commands/randomkey/ for more details.
+     * @see {@link https://valkey.io/commands/randomkey/|valkey.io} for details.
      *
      * @param route - (Optional) The command will be routed to all primary nodes, unless `route` is provided,
      *      in which case the client will route the command to the nodes defined by `route`.
@@ -1276,7 +1264,7 @@ export class GlideClusterClient extends BaseClient {
      * Flushes all the previously watched keys for a transaction. Executing a transaction will
      * automatically flush all previously watched keys.
      *
-     * See https://valkey.io/commands/unwatch/ and https://valkey.io/topics/transactions/#cas for more details.
+     * @see {@link https://valkey.io/commands/unwatch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
      *
      * @param route - (Optional) The command will be routed to all primary nodes, unless `route` is provided,
      *      in which case the client will route the command to the nodes defined by `route`.

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -285,7 +285,8 @@ function toProtobufRoute(
 
 /**
  * Client used for connection to cluster Redis servers.
- * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#cluster|Valkey Glide Wiki} for full documentation.
+ *
+ * @see For full documentation refer to {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#cluster|Valkey Glide Wiki}.
  */
 export class GlideClusterClient extends BaseClient {
     /**

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -958,13 +958,13 @@ export class GlideClusterClient extends BaseClient {
      * Kills a function that is currently executing.
      * `FUNCTION KILL` terminates read-only functions only.
      *
-     * See https://valkey.io/commands/function-kill/ for details.
-     *
-     * since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-kill/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param route - (Optional) The client will route the command to the nodes defined by `route`.
      *     If not defined, the command will be routed to all primary nodes.
      * @returns `OK` if function is terminated. Otherwise, throws an error.
+     *
      * @example
      * ```typescript
      * await client.functionKill();

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -668,9 +668,9 @@ export class GlideClusterClient extends BaseClient {
      * removes the `destination` key first if it already exists, otherwise performs no action.
      *
      * @see {@link https://valkey.io/commands/copy/|valkey.io} for details.
+     * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @remarks Since Valkey version 6.2.0.
      *
-     * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
      * @param replace - (Optional) If `true`, the `destination` key should be removed before copying the

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -893,7 +893,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Iterates incrementally over a hash.
      *
-     * @see {@link https://valkey.io/commands//|valkey.io} for more details.
+     * @see {@link https://valkey.io/commands/hscan/|valkey.io} for more details.
      *
      * @param key - The key of the set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of the search.

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -58,6 +58,7 @@ import {
     StreamPendingOptions,
     StreamReadOptions,
     StreamTrimOptions,
+    TimeUnit,
     ZAddOptions,
     createAppend,
     createBLMPop,
@@ -242,7 +243,6 @@ import {
     createZRevRankWithScore,
     createZScan,
     createZScore,
-    TimeUnit,
 } from "./Commands";
 import { command_request } from "./ProtobufMessage";
 
@@ -308,14 +308,14 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Get the value of `key` and optionally set its expiration. `GETEX` is similar to {@link get}.
-     * See https://valkey.io/commands/getex for more details.
+     *
+     * @see {@link https://valkey.io/commands/getex/|valkey.op} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key to retrieve from the database.
      * @param options - (Optional) set expiriation to the given key.
      *                  "persist" will retain the time to live associated with the key. Equivalent to `PERSIST` in the VALKEY API.
      *                  Otherwise, a {@link TimeUnit} and duration of the expire time should be specified.
-     *
-     * since - Valkey 6.2.0 and above.
      *
      * Command Response - If `key` exists, returns the value of `key` as a `string`. Otherwise, return `null`.
      */
@@ -893,7 +893,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Iterates incrementally over a hash.
      *
-     * See https://valkey.io/commands/hscan for more details.
+     * @see {@link https://valkey.io/commands//|valkey.io} for more details.
      *
      * @param key - The key of the set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of the search.
@@ -2192,8 +2192,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Executes a single command, without checking inputs. Every part of the command, including subcommands,
      *  should be added as a separate value in args.
      *
-     * See the [Glide for Redis Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
-     * for details on the restrictions and limitations of the custom command API.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.
      *
      * Command Response - A response from Redis with an `Object`.
      */
@@ -2315,7 +2314,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns stream entries matching a given range of entry IDs.
      *
-     * See https://valkey.io/commands/xrange for more details.
+     * @see {@link https://valkey.io/commands/xrange/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param start - The starting stream entry ID bound for the range.
@@ -2479,9 +2478,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Transfers ownership of pending stream entries that match the specified criteria.
      *
-     * See https://valkey.io/commands/xautoclaim/ for more details.
-     *
-     * since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/xautoclaim/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -2516,9 +2514,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Transfers ownership of pending stream entries that match the specified criteria.
      *
-     * See https://valkey.io/commands/xautoclaim/ for more details.
-     *
-     * since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/xautoclaim/|valkey.io} for more details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -2643,10 +2640,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `newkey` already exists it is overwritten.
      * In Cluster mode, both `key` and `newkey` must be in the same hash slot,
      * meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
+     *
      * @see {@link https://valkey.io/commands/rename/|valkey.io} for details.
      *
      * @param key - The key to rename.
      * @param newKey - The new name of the key.
+     *
      * Command Response - If the `key` was successfully renamed, return "OK". If `key` does not exist, an error is thrown.
      */
     public rename(key: string, newKey: string): T {
@@ -2657,6 +2656,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Renames `key` to `newkey` if `newkey` does not yet exist.
      * In Cluster mode, both `key` and `newkey` must be in the same hash slot,
      * meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
+     *
      * @see {@link https://valkey.io/commands/renamenx/|valkey.io} for details.
      *
      * @param key - The key to rename.
@@ -2672,12 +2672,15 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pop an element from the tail of the first list that is non-empty,
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
+     *
+     * Note: `BRPOP` is a blocking command.
+     *
      * @see {@link https://valkey.io/commands/brpop/|valkey.io} for details.
-     * Note: `BRPOP` is a blocking command,
-     * see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Blocking Commands} for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
+     *
      * Command Response - An `array` containing the `key` from which the element was popped and the value of the popped element,
      * formatted as [key, value]. If no element could be popped and the timeout expired, returns `null`.
      */
@@ -2689,12 +2692,15 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pop an element from the head of the first list that is non-empty,
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
+     *
+     * Note: `BLPOP` is a blocking command.
+     *
      * @see {@link https://valkey.io/commands/blpop/|valkey.io} for details.
-     * Note: `BLPOP` is a blocking command,
-     * see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Blocking Commands} for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
+     *
      * Command Response - An `array` containing the `key` from which the element was popped and the value of the popped element,
      * formatted as [key, value]. If no element could be popped and the timeout expired, returns `null`.
      */
@@ -2813,7 +2819,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * acknowledged by at least `numreplicas` of replicas. If `timeout` is reached, the command returns
      * the number of replicas that were not yet reached.
      *
-     * See https://valkey.io/commands/wait/ for more details.
+     * @see {@link https://valkey.io/commands/wait/|valkey.io} for more details.
      *
      * @param numreplicas - The number of replicas to reach.
      * @param timeout - The timeout value specified in milliseconds. A value of 0 will block indefinitely.

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -296,8 +296,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Get the value associated with the given key, or null if no such value exists.
-     *
-     * See https://valkey.io/commands/get/ for details.
+     * @see {@link https://valkey.io/commands/get/|valkey.io} for details.
      *
      * @param key - The key to retrieve from the database.
      *
@@ -330,7 +329,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Gets a string value associated with the given `key`and deletes the key.
      *
-     * See https://valkey.io/commands/getdel/ for details.
+     * @see {@link https://valkey.io/commands/getdel/|valkey.io} for details.
      *
      * @param key - The key to retrieve from the database.
      *
@@ -347,7 +346,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * penultimate and so forth. If `key` does not exist, an empty string is returned. If `start`
      * or `end` are out of range, returns the substring within the valid range of the string.
      *
-     * See https://valkey.io/commands/getrange/ for details.
+     * @see {@link https://valkey.io/commands/getrange/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param start - The starting offset.
@@ -360,7 +359,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Set the given key with the given value. Return value is dependent on the passed options.
-     * See https://valkey.io/commands/set/ for details.
+     * @see {@link https://valkey.io/commands/set/|valkey.io} for details.
      *
      * @param key - The key to store.
      * @param value - The value to store with the given key.
@@ -375,7 +374,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Ping the Redis server.
-     * See https://valkey.io/commands/ping/ for details.
+     * @see {@link https://valkey.io/commands/ping/|valkey.io} for details.
      *
      * @param message - An optional message to include in the PING command.
      * If not provided, the server will respond with "PONG".
@@ -388,7 +387,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Get information and statistics about the Redis server.
-     * See https://valkey.io/commands/info/ for details.
+     * @see {@link https://valkey.io/commands/info/|valkey.io} for details.
      *
      * @param options - A list of InfoSection values specifying which sections of information to retrieve.
      * When no parameter is provided, the default option is assumed.
@@ -400,7 +399,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Remove the specified keys. A key is ignored if it does not exist.
-     * See https://valkey.io/commands/del/ for details.
+     * @see {@link https://valkey.io/commands/del/|valkey.io} for details.
      *
      * @param keys - A list of keys to be deleted from the database.
      *
@@ -411,7 +410,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Get the name of the connection on which the transaction is being executed.
-     * See https://valkey.io/commands/client-getname/ for more details.
+     * @see {@link https://valkey.io/commands/client-getname/|valkey.io} for details.
      *
      * Command Response - the name of the client connection as a string if a name is set, or null if no name is assigned.
      */
@@ -420,7 +419,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Rewrite the configuration file with the current configuration.
-     * See https://valkey.io/commands/select/ for details.
+     * @see {@link https://valkey.io/commands/select/|valkey.io} for details.
      *
      * Command Response - "OK" when the configuration was rewritten properly. Otherwise, the transaction fails with an error.
      */
@@ -429,7 +428,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-     * See https://valkey.io/commands/config-resetstat/ for details.
+     * @see {@link https://valkey.io/commands/config-resetstat/|valkey.io} for details.
      *
      * Command Response - always "OK".
      */
@@ -438,7 +437,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Retrieve the values of multiple keys.
-     * See https://valkey.io/commands/mget/ for details.
+     * @see {@link https://valkey.io/commands/mget/|valkey.io} for details.
      *
      * @param keys - A list of keys to retrieve values for.
      *
@@ -450,7 +449,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Set multiple keys to multiple values in a single atomic operation.
-     * See https://valkey.io/commands/mset/ for details.
+     * @see {@link https://valkey.io/commands/mset/|valkey.io} for details.
      *
      * @param keyValueMap - A key-value map consisting of keys and their respective values to set.
      *
@@ -464,7 +463,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Sets multiple keys to values if the key does not exist. The operation is atomic, and if one or
      * more keys already exist, the entire operation fails.
      *
-     * See https://valkey.io/commands/msetnx/ for more details.
+     * @see {@link https://valkey.io/commands/msetnx/|valkey.io} for details.
      *
      * @param keyValueMap - A key-value map consisting of keys and their respective values to set.
      * Command Response - `true` if all keys were set. `false` if no key was set.
@@ -474,7 +473,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Increments the number stored at `key` by one. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/incr/ for details.
+     * @see {@link https://valkey.io/commands/incr/|valkey.io} for details.
      *
      * @param key - The key to increment its value.
      *
@@ -485,7 +484,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Increments the number stored at `key` by `amount`. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/incrby/ for details.
+     * @see {@link https://valkey.io/commands/incrby/|valkey.io} for details.
      *
      * @param key - The key to increment its value.
      * @param amount - The amount to increment.
@@ -499,7 +498,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Increment the string representing a floating point number stored at `key` by `amount`.
      * By using a negative amount value, the result is that the value stored at `key` is decremented.
      * If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/incrbyfloat/ for details.
+     * @see {@link https://valkey.io/commands/incrbyfloat/|valkey.io} for details.
      *
      * @param key - The key to increment its value.
      * @param amount - The amount to increment.
@@ -512,7 +511,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the current connection id.
-     * See https://valkey.io/commands/client-id/ for details.
+     * @see {@link https://valkey.io/commands/client-id/|valkey.io} for details.
      *
      * Command Response - the id of the client.
      */
@@ -521,7 +520,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Decrements the number stored at `key` by one. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/decr/ for details.
+     * @see {@link https://valkey.io/commands/decr/|valkey.io} for details.
      *
      * @param key - The key to decrement its value.
      *
@@ -532,7 +531,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Decrements the number stored at `key` by `amount`. If `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/decrby/ for details.
+     * @see {@link https://valkey.io/commands/decrby/|valkey.io} for details.
      *
      * @param key - The key to decrement its value.
      * @param amount - The amount to decrement.
@@ -547,7 +546,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Perform a bitwise operation between multiple keys (containing string values) and store the result in the
      * `destination`.
      *
-     * See https://valkey.io/commands/bitop/ for more details.
+     * @see {@link https://valkey.io/commands/bitop/|valkey.io} for details.
      *
      * @param operation - The bitwise operation to perform.
      * @param destination - The key that will store the resulting string.
@@ -567,7 +566,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the bit value at `offset` in the string value stored at `key`. `offset` must be greater than or equal
      * to zero.
      *
-     * See https://valkey.io/commands/getbit/ for more details.
+     * @see {@link https://valkey.io/commands/getbit/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param offset - The index of the bit to return.
@@ -585,7 +584,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * `2^32` and greater than or equal to `0`. If a key is non-existent then the bit at `offset` is set to `value` and
      * the preceding bits are set to `0`.
      *
-     * See https://valkey.io/commands/setbit/ for more details.
+     * @see {@link https://valkey.io/commands/setbit/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param offset - The index of the bit to be set.
@@ -603,7 +602,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * The offset can also be a negative number indicating an offset starting at the end of the list, with `-1` being
      * the last byte of the list, `-2` being the penultimate, and so on.
      *
-     * See https://valkey.io/commands/bitpos/ for more details.
+     * @see {@link https://valkey.io/commands/bitpos/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param bit - The bit value to match. Must be `0` or `1`.
@@ -627,7 +626,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * are assumed. If BIT is specified, `start=0` and `end=2` means to look at the first three bits. If BYTE is
      * specified, `start=0` and `end=2` means to look at the first three bytes.
      *
-     * See https://valkey.io/commands/bitpos/ for more details.
+     * @see {@link https://valkey.io/commands/bitpos/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param bit - The bit value to match. Must be `0` or `1`.
@@ -654,7 +653,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Reads or modifies the array of bits representing the string that is held at `key` based on the specified
      * `subcommands`.
      *
-     * See https://valkey.io/commands/bitfield/ for more details.
+     * @see {@link https://valkey.io/commands/bitfield/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param subcommands - The subcommands to be performed on the binary value of the string at `key`, which could be
@@ -681,9 +680,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Reads the array of bits representing the string that is held at `key` based on the specified `subcommands`.
      *
-     * See https://valkey.io/commands/bitfield_ro/ for more details.
-     *
-     * Since Valkey version 6.0.0.
+     * @see {@link https://valkey.io/commands/bitfield_ro/|valkey.io} for details.
+     * @remarks Since Valkey version 6.0.0.
      *
      * @param key - The key of the string.
      * @param subcommands - The {@link BitFieldGet} subcommands to be performed.
@@ -696,7 +694,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Reads the configuration parameters of a running Redis server.
-     * See https://valkey.io/commands/config-get/ for details.
+     * @see {@link https://valkey.io/commands/config-get/|valkey.io} for details.
      *
      * @param parameters - A list of configuration parameter names to retrieve values for.
      *
@@ -708,7 +706,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Set configuration parameters to the specified values.
-     * See https://valkey.io/commands/config-set/ for details.
+     * @see {@link https://valkey.io/commands/config-set/|valkey.io} for details.
      *
      * @param parameters - A List of keyValuePairs consisting of configuration parameters and their respective values to set.
      *
@@ -719,7 +717,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Retrieve the value associated with `field` in the hash stored at `key`.
-     * See https://valkey.io/commands/hget/ for details.
+     * @see {@link https://valkey.io/commands/hget/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field in the hash stored at `key` to retrieve from the database.
@@ -731,7 +729,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Sets the specified fields to their respective values in the hash stored at `key`.
-     * See https://valkey.io/commands/hset/ for details.
+     * @see {@link https://valkey.io/commands/hset/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param fieldValueMap - A field-value map consisting of fields and their corresponding values
@@ -746,7 +744,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Sets `field` in the hash stored at `key` to `value`, only if `field` does not yet exist.
      * If `key` does not exist, a new key holding a hash is created.
      * If `field` already exists, this operation has no effect.
-     * See https://valkey.io/commands/hsetnx/ for more details.
+     * @see {@link https://valkey.io/commands/hsetnx/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field to set the value for.
@@ -760,7 +758,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Removes the specified fields from the hash stored at `key`.
      * Specified fields that do not exist within this hash are ignored.
-     * See https://valkey.io/commands/hdel/ for details.
+     * @see {@link https://valkey.io/commands/hdel/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param fields - The fields to remove from the hash stored at `key`.
@@ -773,7 +771,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the values associated with the specified fields in the hash stored at `key`.
-     * See https://valkey.io/commands/hmget/ for details.
+     * @see {@link https://valkey.io/commands/hmget/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param fields - The fields in the hash stored at `key` to retrieve from the database.
@@ -787,7 +785,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns if `field` is an existing field in the hash stored at `key`.
-     * See https://valkey.io/commands/hexists/ for details.
+     * @see {@link https://valkey.io/commands/hexists/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field to check in the hash stored at `key`.
@@ -800,7 +798,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns all fields and values of the hash stored at `key`.
-     * See https://valkey.io/commands/hgetall/ for details.
+     * @see {@link https://valkey.io/commands/hgetall/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      *
@@ -814,7 +812,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Increments the number stored at `field` in the hash stored at `key` by `increment`.
      * By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
      * If `field` or `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/hincrby/ for details.
+     * @see {@link https://valkey.io/commands/hincrby/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param amount - The amount to increment.
@@ -829,7 +827,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Increment the string representing a floating point number stored at `field` in the hash stored at `key` by `increment`.
      * By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
      * If `field` or `key` does not exist, it is set to 0 before performing the operation.
-     * See https://valkey.io/commands/hincrbyfloat/ for details.
+     * @see {@link https://valkey.io/commands/hincrbyfloat/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param amount - The amount to increment.
@@ -842,7 +840,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the number of fields contained in the hash stored at `key`.
-     * See https://valkey.io/commands/hlen/ for more details.
+     * @see {@link https://valkey.io/commands/hlen/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      *
@@ -853,7 +851,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns all values in the hash stored at key.
-     * See https://valkey.io/commands/hvals/ for more details.
+     * @see {@link https://valkey.io/commands/hvals/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      *
@@ -866,7 +864,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the string length of the value associated with `field` in the hash stored at `key`.
      *
-     * See https://valkey.io/commands/hstrlen/ for details.
+     * @see {@link https://valkey.io/commands/hstrlen/|valkey.io} for details.
      *
      * @param key - The key of the hash.
      * @param field - The field in the hash.
@@ -880,9 +878,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns a random field name from the hash value stored at `key`.
      *
-     * See https://valkey.io/commands/hrandfield/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/hrandfield/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      *
@@ -915,9 +912,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Retrieves up to `count` random field names from the hash value stored at `key`.
      *
-     * See https://valkey.io/commands/hrandfield/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/hrandfield/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -935,9 +931,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Retrieves up to `count` random field names along with their values from the hash
      * value stored at `key`.
      *
-     * See https://valkey.io/commands/hrandfield/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/hrandfield/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -955,7 +950,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Inserts all the specified values at the head of the list stored at `key`.
      * `elements` are inserted one after the other to the head of the list, from the leftmost element to the rightmost element.
      * If `key` does not exist, it is created as empty list before performing the push operations.
-     * See https://valkey.io/commands/lpush/ for details.
+     * @see {@link https://valkey.io/commands/lpush/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the head of the list stored at `key`.
@@ -970,7 +965,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Inserts specified values at the head of the `list`, only if `key` already
      * exists and holds a list.
      *
-     * See https://valkey.io/commands/lpushx/ for details.
+     * @see {@link https://valkey.io/commands/lpushx/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the head of the list stored at `key`.
@@ -983,7 +978,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Removes and returns the first elements of the list stored at `key`.
      * The command pops a single element from the beginning of the list.
-     * See https://valkey.io/commands/lpop/ for details.
+     * @see {@link https://valkey.io/commands/lpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      *
@@ -995,7 +990,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Removes and returns up to `count` elements of the list stored at `key`, depending on the list's length.
-     * See https://valkey.io/commands/lpop/ for details.
+     * @see {@link https://valkey.io/commands/lpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
@@ -1011,7 +1006,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * The offsets `start` and `end` are zero-based indexes, with 0 being the first element of the list, 1 being the next element and so on.
      * These offsets can also be negative numbers indicating offsets starting at the end of the list,
      * with -1 being the last element of the list, -2 being the penultimate, and so on.
-     * See https://valkey.io/commands/lrange/ for details.
+     * @see {@link https://valkey.io/commands/lrange/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param start - The starting point of the range.
@@ -1027,7 +1022,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the length of the list stored at `key`.
-     * See https://valkey.io/commands/llen/ for details.
+     * @see {@link https://valkey.io/commands/llen/|valkey.io} for details.
      *
      * @param key - The key of the list.
      *
@@ -1043,9 +1038,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * depending on `whereFrom`, and pushes the element at the first/last element of the list
      * stored at `destination` depending on `whereTo`, see {@link ListDirection}.
      *
-     * See https://valkey.io/commands/lmove/ for details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/lmove/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
@@ -1072,9 +1066,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * of the list stored at `destination` depending on `whereTo`.
      * `BLMOVE` is the blocking variant of {@link lmove}.
      *
-     * See https://valkey.io/commands/blmove/ for details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @remarks
      * 1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
@@ -1106,7 +1099,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Negative indices can be used to designate elements starting at the tail of
      * the list. Here, `-1` means the last element, `-2` means the penultimate and so forth.
      *
-     * See https://valkey.io/commands/lset/ for details.
+     * @see {@link https://valkey.io/commands/lset/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param index - The index of the element in the list to be set.
@@ -1122,7 +1115,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * The offsets `start` and `end` are zero-based indexes, with 0 being the first element of the list, 1 being the next element and so on.
      * These offsets can also be negative numbers indicating offsets starting at the end of the list,
      * with -1 being the last element of the list, -2 being the penultimate, and so on.
-     * See https://valkey.io/commands/ltrim/ for details.
+     * @see {@link https://valkey.io/commands/ltrim/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param start - The starting point of the range.
@@ -1156,7 +1149,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Inserts all the specified values at the tail of the list stored at `key`.
      * `elements` are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
      * If `key` does not exist, it is created as empty list before performing the push operations.
-     * See https://valkey.io/commands/rpush/ for details.
+     * @see {@link https://valkey.io/commands/rpush/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the tail of the list stored at `key`.
@@ -1171,7 +1164,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Inserts specified values at the tail of the `list`, only if `key` already
      * exists and holds a list.
      *
-     * See https://valkey.io/commands/rpushx/ for details.
+     * @see {@link https://valkey.io/commands/rpushx/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param elements - The elements to insert at the tail of the list stored at `key`.
@@ -1184,7 +1177,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Removes and returns the last elements of the list stored at `key`.
      * The command pops a single element from the end of the list.
-     * See https://valkey.io/commands/rpop/ for details.
+     * @see {@link https://valkey.io/commands/rpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      *
@@ -1196,7 +1189,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Removes and returns up to `count` elements from the list stored at `key`, depending on the list's length.
-     * See https://valkey.io/commands/rpop/ for details.
+     * @see {@link https://valkey.io/commands/rpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
@@ -1210,7 +1203,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Adds the specified members to the set stored at `key`. Specified members that are already a member of this set are ignored.
      * If `key` does not exist, a new set is created before adding `members`.
-     * See https://valkey.io/commands/sadd/ for details.
+     * @see {@link https://valkey.io/commands/sadd/|valkey.io} for details.
      *
      * @param key - The key to store the members to its set.
      * @param members - A list of members to add to the set stored at `key`.
@@ -1222,7 +1215,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Removes the specified members from the set stored at `key`. Specified members that are not a member of this set are ignored.
-     * See https://valkey.io/commands/srem/ for details.
+     * @see {@link https://valkey.io/commands/srem/|valkey.io} for details.
      *
      * @param key - The key to remove the members from its set.
      * @param members - A list of members to remove from the set stored at `key`.
@@ -1235,7 +1228,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns all the members of the set value stored at `key`.
-     * See https://valkey.io/commands/smembers/ for details.
+     * @see {@link https://valkey.io/commands/smembers/|valkey.io} for details.
      *
      * @param key - The key to return its members.
      *
@@ -1248,7 +1241,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Moves `member` from the set at `source` to the set at `destination`, removing it from the source set.
      * Creates a new destination set if needed. The operation is atomic.
-     * See https://valkey.io/commands/smove for more details.
+     * @see {@link https://valkey.io/commands/smove/|valkey.io} for more details.
      *
      * @param source - The key of the set to remove the element from.
      * @param destination - The key of the set to add the element to.
@@ -1261,7 +1254,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the set cardinality (number of elements) of the set stored at `key`.
-     * See https://valkey.io/commands/scard/ for details.
+     * @see {@link https://valkey.io/commands/scard/|valkey.io} for details.
      *
      * @param key - The key to return the number of its members.
      *
@@ -1273,7 +1266,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Gets the intersection of all the given sets.
      * When in cluster mode, all `keys` must map to the same hash slot.
-     * See https://valkey.io/docs/latest/commands/sinter/ for more details.
+     * @see {@link https://valkey.io/commands/sinter/|valkey.io} for details.
      *
      * @param keys - The `keys` of the sets to get the intersection.
      *
@@ -1287,9 +1280,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Gets the cardinality of the intersection of all the given sets.
      *
-     * See https://valkey.io/commands/sintercard/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/sintercard/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sets.
      *
@@ -1302,7 +1294,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Stores the members of the intersection of all given sets specified by `keys` into a new set at `destination`.
      *
-     * See https://valkey.io/commands/sinterstore/ for more details.
+     * @see {@link https://valkey.io/commands/sinterstore/|valkey.io} for details.
      *
      * @param destination - The key of the destination set.
      * @param keys - The keys from which to retrieve the set members.
@@ -1316,7 +1308,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Computes the difference between the first set and all the successive sets in `keys`.
      *
-     * See https://valkey.io/commands/sdiff/ for more details.
+     * @see {@link https://valkey.io/commands/sdiff/|valkey.io} for details.
      *
      * @param keys - The keys of the sets to diff.
      *
@@ -1330,7 +1322,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Stores the difference between the first set and all the successive sets in `keys` into a new set at `destination`.
      *
-     * See https://valkey.io/commands/sdiffstore/ for more details.
+     * @see {@link https://valkey.io/commands/sdiffstore/|valkey.io} for details.
      *
      * @param destination - The key of the destination set.
      * @param keys - The keys of the sets to diff.
@@ -1344,7 +1336,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Gets the union of all the given sets.
      *
-     * See https://valkey.io/commands/sunion/ for more details.
+     * @see {@link https://valkey.io/commands/sunion/|valkey.io} for details.
      *
      * @param keys - The keys of the sets.
      *
@@ -1359,7 +1351,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Stores the members of the union of all given sets specified by `keys` into a new set
      * at `destination`.
      *
-     * See https://valkey.io/commands/sunionstore/ for details.
+     * @see {@link https://valkey.io/commands/sunionstore/|valkey.io} for details.
      *
      * @param destination - The key of the destination set.
      * @param keys - The keys from which to retrieve the set members.
@@ -1371,7 +1363,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns if `member` is a member of the set stored at `key`.
-     * See https://valkey.io/commands/sismember/ for more details.
+     * @see {@link https://valkey.io/commands/sismember/|valkey.io} for details.
      *
      * @param key - The key of the set.
      * @param member - The member to check for existence in the set.
@@ -1386,9 +1378,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Checks whether each member is contained in the members of the set stored at `key`.
      *
-     * See https://valkey.io/commands/smismember/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/smismember/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the set to check.
      * @param members - A list of members to check for existence in the set.
@@ -1400,7 +1391,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Removes and returns one random member from the set value store at `key`.
-     * See https://valkey.io/commands/spop/ for details.
+     * @see {@link https://valkey.io/commands/spop/|valkey.io} for details.
      * To pop multiple members, see `spopCount`.
      *
      * @param key - The key of the set.
@@ -1413,7 +1404,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Removes and returns up to `count` random members from the set value store at `key`, depending on the set's length.
-     * See https://valkey.io/commands/spop/ for details.
+     * @see {@link https://valkey.io/commands/spop/|valkey.io} for details.
      *
      * @param key - The key of the set.
      * @param count - The count of the elements to pop from the set.
@@ -1427,7 +1418,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns a random element from the set value stored at `key`.
      *
-     * See https://valkey.io/commands/srandmember for more details.
+     * @see {@link https://valkey.io/commands/srandmember/|valkey.io} for more details.
      *
      * @param key - The key from which to retrieve the set member.
      * Command Response - A random element from the set, or null if `key` does not exist.
@@ -1438,7 +1429,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns one or more random elements from the set value stored at `key`.
      *
-     * See https://valkey.io/commands/srandmember for more details.
+     * @see {@link https://valkey.io/commands/srandmember/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param count - The number of members to return.
@@ -1451,7 +1442,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the number of keys in `keys` that exist in the database.
-     * See https://valkey.io/commands/exists/ for details.
+     * @see {@link https://valkey.io/commands/exists/|valkey.io} for details.
      *
      * @param keys - The keys list to check.
      *
@@ -1465,7 +1456,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Removes the specified keys. A key is ignored if it does not exist.
      * This command, similar to DEL, removes specified keys and ignores non-existent ones.
      * However, this command does not block the server, while [DEL](https://valkey.io/commands/del) does.
-     * See https://valkey.io/commands/unlink/ for details.
+     * @see {@link https://valkey.io/commands/unlink/|valkey.io} for details.
      *
      * @param keys - The keys we wanted to unlink.
      *
@@ -1479,7 +1470,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * If `seconds` is non-positive number, the key will be deleted rather than expired.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/expire/ for details.
+     * @see {@link https://valkey.io/commands/expire/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param seconds - The timeout in seconds.
@@ -1496,7 +1487,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * A timestamp in the past will delete the key immediately. After the timeout has expired, the key will automatically be deleted.
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/expireat/ for details.
+     * @see {@link https://valkey.io/commands/expireat/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param unixSeconds - The timeout in an absolute Unix timestamp.
@@ -1517,9 +1508,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the absolute Unix timestamp (since January 1, 1970) at which the given `key` will expire, in seconds.
      * To get the expiration with millisecond precision, use {@link pexpiretime}.
      *
-     * See https://valkey.io/commands/expiretime/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/expiretime/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The `key` to determine the expiration value of.
      *
@@ -1533,7 +1523,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * If `milliseconds` is non-positive number, the key will be deleted rather than expired.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/pexpire/ for details.
+     * @see {@link https://valkey.io/commands/pexpire/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param milliseconds - The timeout in milliseconds.
@@ -1554,7 +1544,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * A timestamp in the past will delete the key immediately. After the timeout has expired, the key will automatically be deleted.
      * If `key` already has an existing expire set, the time to live is updated to the new value.
      * The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-     * See https://valkey.io/commands/pexpireat/ for details.
+     * @see {@link https://valkey.io/commands/pexpireat/|valkey.io} for details.
      *
      * @param key - The key to set timeout on it.
      * @param unixMilliseconds - The timeout in an absolute Unix timestamp.
@@ -1576,9 +1566,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the absolute Unix timestamp (since January 1, 1970) at which the given `key` will expire, in milliseconds.
      *
-     * See https://valkey.io/commands/pexpiretime/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/pexpiretime/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The `key` to determine the expiration value of.
      *
@@ -1589,7 +1578,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the remaining time to live of `key` that has a timeout.
-     * See https://valkey.io/commands/ttl/ for details.
+     * @see {@link https://valkey.io/commands/ttl/|valkey.io} for details.
      *
      * @param key - The key to return its timeout.
      *
@@ -1601,7 +1590,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Adds members with their scores to the sorted set stored at `key`.
      * If a member is already a part of the sorted set, its score is updated.
-     * See https://valkey.io/commands/zadd/ for more details.
+     * @see {@link https://valkey.io/commands/zadd/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param membersScoresMap - A mapping of members to their corresponding scores.
@@ -1621,7 +1610,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Increments the score of member in the sorted set stored at `key` by `increment`.
      * If `member` does not exist in the sorted set, it is added with `increment` as its score (as if its previous score was 0.0).
      * If `key` does not exist, a new sorted set with the specified member as its sole member is created.
-     * See https://valkey.io/commands/zadd/ for more details.
+     * @see {@link https://valkey.io/commands/zadd/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param member - A member in the sorted set to increment.
@@ -1644,7 +1633,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Removes the specified members from the sorted set stored at `key`.
      * Specified members that are not a member of this set are ignored.
-     * See https://valkey.io/commands/zrem/ for more details.
+     * @see {@link https://valkey.io/commands/zrem/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param members - A list of members to remove from the sorted set.
@@ -1657,7 +1646,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the cardinality (number of elements) of the sorted set stored at `key`.
-     * See https://valkey.io/commands/zcard/ for more details.
+     * @see {@link https://valkey.io/commands/zcard/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      *
@@ -1671,9 +1660,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the cardinality of the intersection of the sorted sets specified by `keys`.
      *
-     * See https://valkey.io/commands/zintercard/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/zintercard/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets to intersect.
      * @param limit - An optional argument that can be used to specify a maximum number for the
@@ -1689,9 +1677,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the difference between the first sorted set and all the successive sorted sets.
      * To get the elements with their scores, see {@link zdiffWithScores}.
      *
-     * See https://valkey.io/commands/zdiff/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/zdiff/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets.
      *
@@ -1706,9 +1693,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the difference between the first sorted set and all the successive sorted sets, with the associated
      * scores.
      *
-     * See https://valkey.io/commands/zdiff/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/zdiff/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets.
      *
@@ -1724,9 +1710,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * the difference as a sorted set to `destination`, overwriting it if it already exists. Non-existent keys are
      * treated as empty sets.
      *
-     * See https://valkey.io/commands/zdiffstore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/zdiffstore/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param destination - The key for the resulting sorted set.
      * @param keys - The keys of the sorted sets to compare.
@@ -1738,7 +1723,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the score of `member` in the sorted set stored at `key`.
-     * See https://valkey.io/commands/zscore/ for more details.
+     * @see {@link https://valkey.io/commands/zscore/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose score is to be retrieved.
@@ -1754,9 +1739,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the scores associated with the specified `members` in the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zmscore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/zmscore/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the sorted set.
      * @param members - A list of members in the sorted set.
@@ -1769,7 +1753,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the number of members in the sorted set stored at `key` with scores between `minScore` and `maxScore`.
-     * See https://valkey.io/commands/zcount/ for more details.
+     * @see {@link https://valkey.io/commands/zcount/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param minScore - The minimum score to count from. Can be positive/negative infinity, or specific score and inclusivity.
@@ -1790,7 +1774,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Returns the specified range of elements in the sorted set stored at `key`.
      * ZRANGE can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
      *
-     * See https://valkey.io/commands/zrange/ for more details.
+     * @see {@link https://valkey.io/commands/zrange/|valkey.io} for details.
      * To get the elements with their scores, see `zrangeWithScores`.
      *
      * @param key - The key of the sorted set.
@@ -1813,7 +1797,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the specified range of elements with their scores in the sorted set stored at `key`.
      * Similar to ZRANGE but with a WITHSCORE flag.
-     * See https://valkey.io/commands/zrange/ for more details.
+     * @see {@link https://valkey.io/commands/zrange/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
@@ -1840,9 +1824,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * sorted set at `destination`. If `destination` doesn't exist, a new sorted
      * set is created; if it exists, it's overwritten.
      *
-     * See https://valkey.io/commands/zrangestore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/zrangestore/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param destination - The key for the destination sorted set.
      * @param source - The key of the source sorted set.
@@ -1871,7 +1854,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * When in cluster mode, `destination` and all keys in `keys` must map to the same hash slot.
      *
-     * See https://valkey.io/commands/zinterstore/ for more details.
+     * @see {@link https://valkey.io/commands/zinterstore/|valkey.io} for details.
      *
      * @param destination - The key of the destination sorted set.
      * @param keys - The keys of the sorted sets with possible formats:
@@ -1893,7 +1876,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns a random member from the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zrandmember/ for more details.
+     * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for details.
      *
      * @param keys - The key of the sorted set.
      * Command Response - A string representing a random member from the sorted set.
@@ -1906,7 +1889,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns random members from the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zrandmember/ for more details.
+     * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for details.
      *
      * @param keys - The key of the sorted set.
      * @param count - The number of members to return.
@@ -1922,7 +1905,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns random members with scores from the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/zrandmember/ for more details.
+     * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for details.
      *
      * @param keys - The key of the sorted set.
      * @param count - The number of members to return.
@@ -1937,7 +1920,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the string representation of the type of the value stored at `key`.
-     * See https://valkey.io/commands/type/ for more details.
+     * @see {@link https://valkey.io/commands/type/|valkey.io} for details.
      *
      * @param key - The key to check its data type.
      *
@@ -1948,7 +1931,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the length of the string value stored at `key`.
-     * See https://valkey.io/commands/strlen/ for more details.
+     * @see {@link https://valkey.io/commands/strlen/|valkey.io} for details.
      *
      * @param key - The `key` to check its length.
      *
@@ -1962,7 +1945,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Removes and returns the members with the lowest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the lowest scores are removed and returned.
      * Otherwise, only one member with the lowest score is removed and returned.
-     * See https://valkey.io/commands/zpopmin for more details.
+     * @see {@link https://valkey.io/commands/zpopmin/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
@@ -1981,7 +1964,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * are provided.
      * `BZPOPMIN` is the blocking variant of {@link zpopmin}.
      *
-     * See https://valkey.io/commands/bzpopmin/ for more details.
+     * @see {@link https://valkey.io/commands/bzpopmin/|valkey.io} for details.
      *
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
@@ -1997,7 +1980,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Removes and returns the members with the highest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the highest scores are removed and returned.
      * Otherwise, only one member with the highest score is removed and returned.
-     * See https://valkey.io/commands/zpopmax for more details.
+     * @see {@link https://valkey.io/commands/zpopmax/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
@@ -2016,7 +1999,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * are provided.
      * `BZPOPMAX` is the blocking variant of {@link zpopmax}.
      *
-     * See https://valkey.io/commands/bzpopmax/ for more details.
+     * @see {@link https://valkey.io/commands/bzpopmax/|valkey.io} for details.
      *
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
@@ -2030,7 +2013,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Echoes the provided `message` back.
-     * See https://valkey.io/commands/echo for more details.
+     * @see {@link https://valkey.io/commands/echo/|valkey.io} for more details.
      *
      * @param message - The message to be echoed back.
      *
@@ -2041,7 +2024,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the remaining time to live of `key` that has a timeout, in milliseconds.
-     * See https://valkey.io/commands/pttl for more details.
+     * @see {@link https://valkey.io/commands/pttl/|valkey.io} for more details.
      *
      * @param key - The key to return its timeout.
      *
@@ -2054,7 +2037,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Removes all elements in the sorted set stored at `key` with rank between `start` and `end`.
      * Both `start` and `end` are zero-based indexes with 0 being the element with the lowest score.
      * These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score.
-     * See https://valkey.io/commands/zremrangebyrank/ for more details.
+     * @see {@link https://valkey.io/commands/zremrangebyrank/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param start - The starting point of the range.
@@ -2072,7 +2055,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Removes all elements in the sorted set stored at `key` with lexicographical order between `minLex` and `maxLex`.
      *
-     * See https://valkey.io/commands/zremrangebylex/ for more details.
+     * @see {@link https://valkey.io/commands/zremrangebylex/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
@@ -2091,7 +2074,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Removes all elements in the sorted set stored at `key` with a score between `minScore` and `maxScore`.
-     * See https://valkey.io/commands/zremrangebyscore/ for more details.
+     * @see {@link https://valkey.io/commands/zremrangebyscore/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param minScore - The minimum score to remove from. Can be positive/negative infinity, or specific score and inclusivity.
@@ -2114,7 +2097,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the number of members in the sorted set stored at 'key' with scores between 'minLex' and 'maxLex'.
      *
-     * See https://valkey.io/commands/zlexcount/ for more details.
+     * @see {@link https://valkey.io/commands/zlexcount/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
@@ -2133,7 +2116,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
-     * See https://valkey.io/commands/zrank for more details.
+     * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
      * To get the rank of `member` with its score, see `zrankWithScore`.
      *
      * @param key - The key of the sorted set.
@@ -2148,9 +2131,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
      *
-     * See https://valkey.io/commands/zrank for more details.
-     *
-     * Since Valkey version 7.2.0.
+     * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
+     * @remarks Since Valkey version 7.2.0.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -2167,7 +2149,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * scores are ordered from the highest to lowest, starting from 0.
      * To get the rank of `member` with its score, see {@link zrevrankWithScore}.
      *
-     * See https://valkey.io/commands/zrevrank/ for more details.
+     * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -2183,9 +2165,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the rank of `member` in the sorted set stored at `key` with its
      * score, where scores are ordered from the highest to lowest, starting from 0.
      *
-     * See https://valkey.io/commands/zrevrank/ for more details.
-     *
-     * Since Valkey version 7.2.0.
+     * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for details.
+     * @remarks Since Valkey version 7.2.0.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -2200,7 +2181,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Remove the existing timeout on `key`, turning the key from volatile (a key with an expire set) to
      * persistent (a key that will never expire as no timeout is associated).
-     * See https://valkey.io/commands/persist/ for more details.
+     * @see {@link https://valkey.io/commands/persist/|valkey.io} for details.
      *
      * @param key - The key to remove the existing timeout on.
      *
@@ -2226,7 +2207,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * The index is zero-based, so 0 means the first element, 1 the second element and so on.
      * Negative indices can be used to designate elements starting at the tail of the list.
      * Here, -1 means the last element, -2 means the penultimate and so forth.
-     * See https://valkey.io/commands/lindex/ for more details.
+     * @see {@link https://valkey.io/commands/lindex/|valkey.io} for details.
      *
      * @param key - The `key` of the list.
      * @param index - The `index` of the element in the list to retrieve.
@@ -2240,7 +2221,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Inserts `element` in the list at `key` either before or after the `pivot`.
      *
-     * See https://valkey.io/commands/linsert/ for more details.
+     * @see {@link https://valkey.io/commands/linsert/|valkey.io} for details.
      *
      * @param key - The key of the list.
      * @param position - The relative position to insert into - either `InsertPosition.Before` or
@@ -2263,7 +2244,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Adds an entry to the specified stream stored at `key`. If the `key` doesn't exist, the stream is created.
-     * See https://valkey.io/commands/xadd/ for more details.
+     * @see {@link https://valkey.io/commands/xadd/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param values - field-value pairs to be added to the entry.
@@ -2282,7 +2263,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Removes the specified entries by id from a stream, and returns the number of entries deleted.
      *
-     * See https://valkey.io/commands/xdel for more details.
+     * @see {@link https://valkey.io/commands/xdel/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param ids - An array of entry ids.
@@ -2296,7 +2277,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Trims the stream stored at `key` by evicting older entries.
-     * See https://valkey.io/commands/xtrim/ for more details.
+     * @see {@link https://valkey.io/commands/xtrim/|valkey.io} for details.
      *
      * @param key - the key of the stream
      * @param options - options detailing how to trim the stream.
@@ -2323,7 +2304,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the server time.
-     * See https://valkey.io/commands/time/ for details.
+     * @see {@link https://valkey.io/commands/time/|valkey.io} for details.
      *
      * Command Response - The current server time as a two items `array`:
      * A Unix timestamp and the amount of microseconds already elapsed in the current second.
@@ -2363,7 +2344,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Reads entries from the given streams.
-     * See https://valkey.io/commands/xread/ for more details.
+     * @see {@link https://valkey.io/commands/xread/|valkey.io} for details.
      *
      * @param keys_and_ids - pairs of keys and entry ids to read from. A pair is composed of a stream's key and the id of the entry after which the stream will be read.
      * @param options - options detailing how to read the stream.
@@ -2380,7 +2361,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the number of entries in the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xlen/ for more details.
+     * @see {@link https://valkey.io/commands/xlen/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      *
@@ -2393,11 +2374,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns stream message summary information for pending messages matching a given range of IDs.
      *
-     * See https://valkey.io/commands/xpending/ for more details.
+     * @see {@link https://valkey.io/commands/xpending/|valkey.io} for details.
      * Returns the list of all consumers and their attributes for the given consumer group of the
      * stream stored at `key`.
      *
-     * See https://valkey.io/commands/xinfo-consumers/ for more details.
+     * @see {@link https://valkey.io/commands/xinfo-consumers/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -2412,7 +2393,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns stream message summary information for pending messages matching a given range of IDs.
      *
-     * See https://valkey.io/commands/xpending/ for more details.
+     * @see {@link https://valkey.io/commands/xpending/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -2433,7 +2414,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the list of all consumers and their attributes for the given consumer group of the
      * stream stored at `key`.
      *
-     * See https://valkey.io/commands/xinfo-consumers/ for more details.
+     * @see {@link https://valkey.io/commands/xinfo-consumers/|valkey.io} for details.
      *
      * Command Response - An `Array` of `Records`, where each mapping contains the attributes
      *     of a consumer for the given consumer group of the stream at `key`.
@@ -2445,7 +2426,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Changes the ownership of a pending message.
      *
-     * See https://valkey.io/commands/xclaim/ for more details.
+     * @see {@link https://valkey.io/commands/xclaim/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -2473,7 +2454,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Changes the ownership of a pending message. This function returns an `array` with
      * only the message/entry IDs, and is equivalent to using `JUSTID` in the Valkey API.
      *
-     * See https://valkey.io/commands/xclaim/ for more details.
+     * @see {@link https://valkey.io/commands/xclaim/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param group - The consumer group name.
@@ -2583,7 +2564,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Creates a new consumer group uniquely identified by `groupname` for the stream
      * stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-create/ for more details.
+     * @see {@link https://valkey.io/commands/xgroup-create/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param groupName - The newly created consumer group name.
@@ -2606,7 +2587,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Destroys the consumer group `groupname` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-destroy/ for more details.
+     * @see {@link https://valkey.io/commands/xgroup-destroy/|valkey.io} for details.
      *
      * @param key - The key of the stream.
      * @param groupname - The newly created consumer group name.
@@ -2620,7 +2601,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Creates a consumer named `consumerName` in the consumer group `groupName` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-createconsumer for more details.
+     * @see {@link https://valkey.io/commands/xgroup-createconsumer/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param groupName - The consumer group name.
@@ -2641,7 +2622,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Deletes a consumer named `consumerName` in the consumer group `groupName` for the stream stored at `key`.
      *
-     * See https://valkey.io/commands/xgroup-delconsumer for more details.
+     * @see {@link https://valkey.io/commands/xgroup-delconsumer/|valkey.io} for more details.
      *
      * @param key - The key of the stream.
      * @param groupName - The consumer group name.
@@ -2664,7 +2645,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `newkey` already exists it is overwritten.
      * In Cluster mode, both `key` and `newkey` must be in the same hash slot,
      * meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
-     * See https://valkey.io/commands/rename/ for more details.
+     * @see {@link https://valkey.io/commands/rename/|valkey.io} for details.
      *
      * @param key - The key to rename.
      * @param newKey - The new name of the key.
@@ -2678,7 +2659,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Renames `key` to `newkey` if `newkey` does not yet exist.
      * In Cluster mode, both `key` and `newkey` must be in the same hash slot,
      * meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
-     * See https://valkey.io/commands/renamenx/ for more details.
+     * @see {@link https://valkey.io/commands/renamenx/|valkey.io} for details.
      *
      * @param key - The key to rename.
      * @param newKey - The new name of the key.
@@ -2693,7 +2674,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pop an element from the tail of the first list that is non-empty,
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
-     * See https://valkey.io/commands/brpop/ for more details.
+     * @see {@link https://valkey.io/commands/brpop/|valkey.io} for details.
      * Note: `BRPOP` is a blocking command,
      * see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
      *
@@ -2710,7 +2691,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pop an element from the head of the first list that is non-empty,
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
-     * See https://valkey.io/commands/blpop/ for more details.
+     * @see {@link https://valkey.io/commands/blpop/|valkey.io} for details.
      * Note: `BLPOP` is a blocking command,
      * see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
      *
@@ -2727,7 +2708,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Creates a new structure if the `key` does not exist.
      * When no elements are provided, and `key` exists and is a HyperLogLog, then no operation is performed.
      *
-     * See https://valkey.io/commands/pfadd/ for more details.
+     * @see {@link https://valkey.io/commands/pfadd/|valkey.io} for details.
      *
      * @param key - The key of the HyperLogLog data structure to add elements into.
      * @param elements - An array of members to add to the HyperLogLog stored at `key`.
@@ -2741,7 +2722,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Estimates the cardinality of the data stored in a HyperLogLog structure for a single key or
      * calculates the combined cardinality of multiple keys by merging their HyperLogLogs temporarily.
      *
-     * See https://valkey.io/commands/pfcount/ for more details.
+     * @see {@link https://valkey.io/commands/pfcount/|valkey.io} for details.
      *
      * @param keys - The keys of the HyperLogLog data structures to be analyzed.
      * Command Response - The approximated cardinality of given HyperLogLog data structures.
@@ -2755,7 +2736,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Merges multiple HyperLogLog values into a unique value. If the destination variable exists, it is
      * treated as one of the source HyperLogLog data sets, otherwise a new HyperLogLog is created.
      *
-     * See https://valkey.io/commands/pfmerge/ for more details.
+     * @see {@link https://valkey.io/commands/pfmerge/|valkey.io} for details.
      *
      * @param destination - The key of the destination HyperLogLog where the merged data sets will be stored.
      * @param sourceKeys - The keys of the HyperLogLog structures to be merged.
@@ -2767,7 +2748,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the internal encoding for the Redis object stored at `key`.
      *
-     * See https://valkey.io/commands/object-encoding for more details.
+     * @see {@link https://valkey.io/commands/object-encoding/|valkey.io} for more details.
      *
      * @param key - The `key` of the object to get the internal encoding of.
      * Command Response - If `key` exists, returns the internal encoding of the object stored at `key` as a string.
@@ -2779,7 +2760,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the logarithmic access frequency counter of a Redis object stored at `key`.
      *
-     * See https://valkey.io/commands/object-freq for more details.
+     * @see {@link https://valkey.io/commands/object-freq/|valkey.io} for more details.
      *
      * @param key - The `key` of the object to get the logarithmic access frequency counter of.
      * Command Response - If `key` exists, returns the logarithmic access frequency counter of
@@ -2792,7 +2773,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the time in seconds since the last access to the value stored at `key`.
      *
-     * See https://valkey.io/commands/object-idletime/ for more details.
+     * @see {@link https://valkey.io/commands/object-idletime/|valkey.io} for details.
      *
      * @param key - The key of the object to get the idle time of.
      *
@@ -2805,7 +2786,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the reference count of the object stored at `key`.
      *
-     * See https://valkey.io/commands/object-refcount/ for more details.
+     * @see {@link https://valkey.io/commands/object-refcount/|valkey.io} for details.
      *
      * @param key - The `key` of the object to get the reference count of.
      *
@@ -2819,7 +2800,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Displays a piece of generative computer art and the server version.
      *
-     * See https://valkey.io/commands/lolwut/ for more details.
+     * @see {@link https://valkey.io/commands/lolwut/|valkey.io} for details.
      *
      * @param options - The LOLWUT options.
      *
@@ -2849,9 +2830,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Invokes a previously loaded function.
      *
-     * See https://valkey.io/commands/fcall/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/fcall/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
@@ -2867,9 +2847,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Invokes a previously loaded read-only function.
      *
-     * See https://valkey.io/commands/fcall/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/fcall/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
@@ -2885,9 +2864,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Deletes a library and all its functions.
      *
-     * See https://valkey.io/commands/function-delete/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-delete/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param libraryCode - The library name to delete.
      *
@@ -2900,9 +2878,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Loads a library to Valkey.
      *
-     * See https://valkey.io/commands/function-load/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-load/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param libraryCode - The source code that implements the library.
      * @param replace - Whether the given library should overwrite a library with the same name if it
@@ -2917,9 +2894,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Deletes all function libraries.
      *
-     * See https://valkey.io/commands/function-flush/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-flush/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * Command Response - `OK`.
@@ -2931,9 +2907,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns information about the functions and libraries.
      *
-     * See https://valkey.io/commands/function-list/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-list/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param options - Parameters to filter and request additional info.
      *
@@ -2947,9 +2922,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns information about the function that's currently running and information about the
      * available execution engines.
      *
-     * See https://valkey.io/commands/function-stats/ for details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/function-stats/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * Command Response - A `Record` of type {@link FunctionStatsResponse} with two keys:
      *
@@ -2963,7 +2937,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Deletes all the keys of all the existing databases. This command never fails.
      *
-     * See https://valkey.io/commands/flushall/ for more details.
+     * @see {@link https://valkey.io/commands/flushall/|valkey.io} for details.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      *
@@ -2976,7 +2950,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Deletes all the keys of the currently selected database. This command never fails.
      *
-     * See https://valkey.io/commands/flushdb/ for more details.
+     * @see {@link https://valkey.io/commands/flushdb/|valkey.io} for details.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      *
@@ -2991,9 +2965,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * match is found, `null` is returned. If the `count` option is specified, then the function returns
      * an `array` of indices of matching elements within the list.
      *
-     * See https://valkey.io/commands/lpos/ for more details.
-     *
-     * Since Valkey version 6.0.6.
+     * @see {@link https://valkey.io/commands/lpos/|valkey.io} for details.
+     * @remarks Since Valkey version 6.0.6.
      *
      * @param key - The name of the list.
      * @param element - The value to search for within the list.
@@ -3009,7 +2982,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the number of keys in the currently selected database.
      *
-     * See https://valkey.io/commands/dbsize/ for more details.
+     * @see {@link https://valkey.io/commands/dbsize/|valkey.io} for details.
      *
      * Command Response - The number of keys in the currently selected database.
      */
@@ -3021,7 +2994,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Counts the number of set bits (population counting) in the string stored at `key`. The `options` argument can
      * optionally be provided to count the number of bits in a specific string interval.
      *
-     * See https://valkey.io/commands/bitcount for more details.
+     * @see {@link https://valkey.io/commands/bitcount/|valkey.io} for more details.
      *
      * @param key - The key for the string to count the set bits of.
      * @param options - The offset options.
@@ -3038,7 +3011,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Adds geospatial members with their positions to the specified sorted set stored at `key`.
      * If a member is already a part of the sorted set, its position is updated.
      *
-     * See https://valkey.io/commands/geoadd/ for more details.
+     * @see {@link https://valkey.io/commands/geoadd/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param membersToGeospatialData - A mapping of member names to their corresponding positions - see
@@ -3063,9 +3036,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the members of a sorted set populated with geospatial information using {@link geoadd},
      * which are within the borders of the area specified by a given shape.
      *
-     * See https://valkey.io/commands/geosearch/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/geosearch/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key of the sorted set.
      * @param searchFrom - The query's center point options, could be one of:
@@ -3110,9 +3082,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * To get the result directly, see {@link geosearch}.
      *
-     * See https://valkey.io/commands/geosearchstore/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/geosearchstore/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param destination - The key of the destination sorted set.
      * @param source - The key of the sorted set.
@@ -3148,7 +3119,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the positions (longitude, latitude) of all the specified `members` of the
      * geospatial index represented by the sorted set at `key`.
      *
-     * See https://valkey.io/commands/geopos for more details.
+     * @see {@link https://valkey.io/commands/geopos/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param members - The members for which to get the positions.
@@ -3165,9 +3136,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pops a member-score pair from the first non-empty sorted set, with the given `keys`
      * being checked in the order they are provided.
      *
-     * See https://valkey.io/commands/zmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/zmpop/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
@@ -3187,9 +3157,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * checked in the order they are provided. Blocks the connection when there are no members
      * to pop from any of the given sorted sets. `BZMPOP` is the blocking variant of {@link zmpop}.
      *
-     * See https://valkey.io/commands/bzmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/bzmpop/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | the wiki}
      * for more details and best practices.
@@ -3217,7 +3186,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `member` does not exist in the sorted set, it is added with `increment` as its score.
      * If `key` does not exist, a new sorted set is created with the specified member as its sole member.
      *
-     * See https://valkey.io/commands/zincrby/ for details.
+     * @see {@link https://valkey.io/commands/zincrby/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param increment - The score increment.
@@ -3232,7 +3201,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Iterates incrementally over a sorted set.
      *
-     * See https://valkey.io/commands/zscan for more details.
+     * @see {@link https://valkey.io/commands/zscan/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of
@@ -3252,7 +3221,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the distance between `member1` and `member2` saved in the geospatial index stored at `key`.
      *
-     * See https://valkey.io/commands/geodist/ for more details.
+     * @see {@link https://valkey.io/commands/geodist/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param member1 - The name of the first member.
@@ -3274,7 +3243,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the `GeoHash` strings representing the positions of all the specified `members` in the sorted set stored at `key`.
      *
-     * See https://valkey.io/commands/geohash/ for more details.
+     * @see {@link https://valkey.io/commands/geohash/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param members - The array of members whose `GeoHash` strings are to be retrieved.
@@ -3290,7 +3259,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns `UNIX TIME` of the last DB save timestamp or startup timestamp if no save
      * was made since then.
      *
-     * See https://valkey.io/commands/lastsave/ for more details.
+     * @see {@link https://valkey.io/commands/lastsave/|valkey.io} for details.
      *
      * Command Response - `UNIX TIME` of the last DB save executed with success.
      */
@@ -3301,9 +3270,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns all the longest common subsequences combined between strings stored at `key1` and `key2`.
      *
-     * Since Valkey version 7.0.0.
-     *
-     * See https://valkey.io/commands/lcs/ for more details.
+     * @see {@link https://valkey.io/commands/lcs/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -3318,9 +3286,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the total length of all the longest common subsequences between strings stored at `key1` and `key2`.
      *
-     * Since Valkey version 7.0.0.
-     *
-     * See https://valkey.io/commands/lcs/ for more details.
+     * @see {@link https://valkey.io/commands/lcs/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -3335,9 +3302,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the indices and lengths of the longest common subsequences between strings stored at
      * `key1` and `key2`.
      *
-     * Since Valkey version 7.0.0.
-     *
-     * See https://valkey.io/commands/lcs/ for more details.
+     * @see {@link https://valkey.io/commands/lcs/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key1 - The key that stores the first string.
      * @param key2 - The key that stores the second string.
@@ -3364,7 +3330,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Updates the last access time of the specified keys.
      *
-     * See https://valkey.io/commands/touch/ for more details.
+     * @see {@link https://valkey.io/commands/touch/|valkey.io} for details.
      *
      * @param keys - The keys to update the last access time of.
      *
@@ -3377,7 +3343,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns a random existing key name from the currently selected database.
      *
-     * See https://valkey.io/commands/randomkey/ for more details.
+     * @see {@link https://valkey.io/commands/randomkey/|valkey.io} for details.
      *
      * Command Response - A random existing key name from the currently selected database.
      */
@@ -3390,7 +3356,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * for the entire length of `value`. If the `offset` is larger than the current length of the string at `key`,
      * the string is padded with zero bytes to make `offset` fit. Creates the `key` if it doesn't exist.
      *
-     * See https://valkey.io/commands/setrange/ for more details.
+     * @see {@link https://valkey.io/commands/setrange/|valkey.io} for details.
      *
      * @param key - The key of the string to update.
      * @param offset - The position in the string where `value` should be written.
@@ -3406,7 +3372,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Appends a `value` to a `key`. If `key` does not exist it is created and set as an empty string,
      * so `APPEND` will be similar to {@link set} in this special case.
      *
-     * See https://valkey.io/commands/append/ for more details.
+     * @see {@link https://valkey.io/commands/append/|valkey.io} for details.
      *
      * @param key - The key of the string.
      * @param value - The key of the string.
@@ -3420,9 +3386,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Pops one or more elements from the first non-empty list from the provided `keys`.
      *
-     * See https://valkey.io/commands/lmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/lmpop/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @param keys - An array of keys to lists.
@@ -3439,9 +3404,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Blocks the connection until it pops one or more elements from the first non-empty list from the
      * provided `key`. `BLMPOP` is the blocking variant of {@link lmpop}.
      *
-     * See https://valkey.io/commands/blmpop/ for more details.
-     *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/blmpop/|valkey.io} for details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
@@ -3465,7 +3429,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Lists the currently active channels.
      * The command is routed to all nodes, and aggregates the response to a single array.
      *
-     * See https://valkey.io/commands/pubsub-channels for more details.
+     * @see {@link https://valkey.io/commands/pubsub-channels/|valkey.io} for more details.
      *
      * @param pattern - A glob-style pattern to match active channels.
      *                  If not provided, all active channels are returned.
@@ -3483,7 +3447,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * not the count of clients subscribed to patterns.
      * The command is routed to all nodes, and aggregates the response to the sum of all pattern subscriptions.
      *
-     * See https://valkey.io/commands/pubsub-numpat for more details.
+     * @see {@link https://valkey.io/commands/pubsub-numpat/|valkey.io} for more details.
      *
      * Command Response - The number of unique patterns.
      */
@@ -3497,7 +3461,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Note that it is valid to call this command without channels. In this case, it will just return an empty map.
      * The command is routed to all nodes, and aggregates the response to a single map of the channels and their number of subscriptions.
      *
-     * See https://valkey.io/commands/pubsub-numsub for more details.
+     * @see {@link https://valkey.io/commands/pubsub-numsub/|valkey.io} for more details.
      *
      * @param channels - The list of channels to query for the number of subscribers.
      *                   If not provided, returns an empty map.
@@ -3532,7 +3496,7 @@ export class Transaction extends BaseTransaction<Transaction> {
     /// TODO: add MOVE, SLAVEOF and all SENTINEL commands
 
     /** Change the currently selected Redis database.
-     * See https://valkey.io/commands/select/ for details.
+     * @see {@link https://valkey.io/commands/select/|valkey.io} for details.
      *
      * @param index - The index of the database to select.
      *
@@ -3550,7 +3514,7 @@ export class Transaction extends BaseTransaction<Transaction> {
      *
      * To store the result into a new key, see {@link sortStore}.
      *
-     * See https://valkey.io/commands/sort for more details.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortOptions}.
@@ -3569,7 +3533,7 @@ export class Transaction extends BaseTransaction<Transaction> {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * Since Valkey version 7.0.0.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortOptions}.
@@ -3589,7 +3553,7 @@ export class Transaction extends BaseTransaction<Transaction> {
      *
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
-     * See https://valkey.io/commands/sort for more details.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
      *
      * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
      * @param key - The key of the list, set, or sorted set to be sorted.
@@ -3612,9 +3576,8 @@ export class Transaction extends BaseTransaction<Transaction> {
      * When `replace` is true, removes the `destination` key first if it already exists, otherwise performs
      * no action.
      *
-     * See https://valkey.io/commands/copy/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/copy/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
@@ -3636,7 +3599,7 @@ export class Transaction extends BaseTransaction<Transaction> {
     /**
      * Move `key` from the currently selected database to the database specified by `dbIndex`.
      *
-     * See https://valkey.io/commands/move/ for more details.
+     * @see {@link https://valkey.io/commands/move/|valkey.io} for details.
      *
      * @param key - The key to move.
      * @param dbIndex - The index of the database to move `key` to.
@@ -3650,7 +3613,7 @@ export class Transaction extends BaseTransaction<Transaction> {
 
     /** Publish a message on pubsub channel.
      *
-     * See https://valkey.io/commands/publish for more details.
+     * @see {@link https://valkey.io/commands/publish/|valkey.io} for more details.
      *
      * @param message - Message to publish.
      * @param channel - Channel to publish the message on.
@@ -3685,7 +3648,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      *
      * To store the result into a new key, see {@link sortStore}.
      *
-     * See https://valkey.io/commands/sort for more details.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortClusterOptions}.
@@ -3704,7 +3667,8 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * Since Valkey version 7.0.0.
+     * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
+     * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortClusterOptions}.
@@ -3727,7 +3691,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      *
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
-     * See https://valkey.io/commands/sort for more details.
+     * @see {@link https://valkey.io/commands/sort|valkey.io} for more details.
      *
      * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
      * @param key - The key of the list, set, or sorted set to be sorted.
@@ -3748,9 +3712,8 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Copies the value stored at the `source` to the `destination` key. When `replace` is true,
      * removes the `destination` key first if it already exists, otherwise performs no action.
      *
-     * See https://valkey.io/commands/copy/ for more details.
-     *
-     * Since Valkey version 6.2.0.
+     * @see {@link https://valkey.io/commands/copy/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
@@ -3774,7 +3737,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * The mode is selected using the 'sharded' parameter.
      * For both sharded and non-sharded mode, request is routed using hashed channel as key.
      *
-     * See https://valkey.io/commands/publish and https://valkey.io/commands/spublish for more details.
+     * @see {@link https://valkey.io/commands/publish} and {@link https://valkey.io/commands/spublish} for more details.
      *
      * @param message - Message to publish.
      * @param channel - Channel to publish the message on.
@@ -3794,7 +3757,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Lists the currently active shard channels.
      * The command is routed to all nodes, and aggregates the response to a single array.
      *
-     * See https://valkey.io/commands/pubsub-shardchannels for more details.
+     * @see {@link https://valkey.io/commands/pubsub-shardchannels|valkey.io} for more details.
      *
      * @param pattern - A glob-style pattern to match active shard channels.
      *                  If not provided, all active shard channels are returned.
@@ -3811,7 +3774,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Note that it is valid to call this command without channels. In this case, it will just return an empty map.
      * The command is routed to all nodes, and aggregates the response to a single map of the channels and their number of subscriptions.
      *
-     * See https://valkey.io/commands/pubsub-shardnumsub for more details.
+     * @see {@link https://valkey.io/commands/pubsub-shardnumsub|valkey.io} for more details.
      *
      * @param channels - The list of shard channels to query for the number of subscribers.
      *                   If not provided, returns an empty map.

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -309,7 +309,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Get the value of `key` and optionally set its expiration. `GETEX` is similar to {@link get}.
      *
-     * @see {@link https://valkey.io/commands/getex/|valkey.op} for more details.
+     * @see {@link https://valkey.io/commands/getex/|valkey.io} for more details.
      * @remarks Since Valkey version 6.2.0.
      *
      * @param key - The key to retrieve from the database.
@@ -2673,10 +2673,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
      *
-     * Note: `BRPOP` is a blocking command.
-     *
      * @see {@link https://valkey.io/commands/brpop/|valkey.io} for details.
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Blocking Commands} for more details and best practices.
+     * @remarks `BRPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -2693,10 +2691,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * with the given `keys` being checked in the order that they are given.
      * Blocks the connection when there are no elements to pop from any of the given lists.
      *
-     * Note: `BLPOP` is a blocking command.
-     *
      * @see {@link https://valkey.io/commands/blpop/|valkey.io} for details.
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Blocking Commands} for more details and best practices.
+     * @remarks `BLPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -3390,7 +3386,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pops one or more elements from the first non-empty list from the provided `keys`.
      *
      * @see {@link https://valkey.io/commands/lmpop/|valkey.io} for details.
-     * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - An array of keys to lists.
@@ -3557,7 +3552,6 @@ export class Transaction extends BaseTransaction<Transaction> {
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
      * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
-     * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
@@ -3695,7 +3689,6 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
      * @see {@link https://valkey.io/commands/sort|valkey.io} for more details.
-     * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -683,12 +683,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/bitfield_ro/ for more details.
      *
+     * Since Valkey version 6.0.0.
+     *
      * @param key - The key of the string.
      * @param subcommands - The {@link BitFieldGet} subcommands to be performed.
      *
      * Command Response - An array of results from the {@link BitFieldGet} subcommands.
      *
-     * since Valkey version 6.0.0.
      */
     public bitfieldReadOnly(key: string, subcommands: BitFieldGet[]): T {
         return this.addAndReturn(createBitField(key, subcommands, true));
@@ -881,7 +882,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/hrandfield/ for more details.
      *
-     * since Valkey version 6.2.0.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      *
@@ -916,7 +917,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/hrandfield/ for more details.
      *
-     * since Valkey version 6.2.0.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -936,7 +937,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/hrandfield/ for more details.
      *
-     * since Valkey version 6.2.0.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the hash.
      * @param count - The number of field names to return.
@@ -1044,14 +1045,14 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/lmove/ for details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
      * @param whereFrom - The {@link ListDirection} to remove the element from.
      * @param whereTo - The {@link ListDirection} to add the element to.
      *
      * Command Response - The popped element, or `null` if `source` does not exist.
-     *
-     * since Valkey version 6.2.0.
      */
     public lmove(
         source: string,
@@ -1071,11 +1072,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * of the list stored at `destination` depending on `whereTo`.
      * `BLMOVE` is the blocking variant of {@link lmove}.
      *
+     * See https://valkey.io/commands/blmove/ for details.
+     *
+     * Since Valkey version 6.2.0.
+     *
      * @remarks
      * 1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
      * 2. `BLMOVE` is a client blocking command, see https://github.com/aws/glide-for-redis/wiki/General-Concepts#blocking-commands for more details and best practices.
-     *
-     * See https://valkey.io/commands/blmove/ for details.
      *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
@@ -1084,8 +1087,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of `0` will block indefinitely.
      *
      * Command Response - The popped element, or `null` if `source` does not exist or if the operation timed-out.
-     *
-     * since Valkey version 6.2.0.
      */
     public blmove(
         source: string,
@@ -1288,11 +1289,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/sintercard/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sets.
      *
      * Command Response - The cardinality of the intersection result. If one or more sets do not exist, `0` is returned.
-     *
-     * since Valkey version 7.0.0.
      */
     public sintercard(keys: string[], limit?: number): T {
         return this.addAndReturn(createSInterCard(keys, limit));
@@ -1387,12 +1388,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/smismember/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param key - The key of the set to check.
      * @param members - A list of members to check for existence in the set.
      *
      * Command Response - An `array` of `boolean` values, each indicating if the respective member exists in the set.
-     *
-     * since Valkey version 6.2.0.
      */
     public smismember(key: string, members: string[]): T {
         return this.addAndReturn(createSMIsMember(key, members));
@@ -1518,11 +1519,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/expiretime/ for details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param key - The `key` to determine the expiration value of.
      *
      * Command Response - The expiration Unix timestamp in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
-     *
-     * since Valkey version 7.0.0.
      */
     public expireTime(key: string): T {
         return this.addAndReturn(createExpireTime(key));
@@ -1577,11 +1578,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/pexpiretime/ for details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param key - The `key` to determine the expiration value of.
      *
      * Command Response - The expiration Unix timestamp in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
-     *
-     * since Valkey version 7.0.0.
      */
     public pexpireTime(key: string): T {
         return this.addAndReturn(createPExpireTime(key));
@@ -1672,13 +1673,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zintercard/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sorted sets to intersect.
      * @param limit - An optional argument that can be used to specify a maximum number for the
      * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
      *
      * Command Response - The cardinality of the intersection of the given sorted sets.
-     *
-     * since - Redis version 7.0.0.
      */
     public zintercard(keys: string[], limit?: number): T {
         return this.addAndReturn(createZInterCard(keys, limit));
@@ -1690,12 +1691,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zdiff/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param keys - The keys of the sorted sets.
      *
      * Command Response - An `array` of elements representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
-     *
-     * since Valkey version 6.2.0.
      */
     public zdiff(keys: string[]): T {
         return this.addAndReturn(createZDiff(keys));
@@ -1707,12 +1708,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zdiff/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param keys - The keys of the sorted sets.
      *
      * Command Response - A map of elements and their scores representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
-     *
-     * since Valkey version 6.2.0.
      */
     public zdiffWithScores(keys: string[]): T {
         return this.addAndReturn(createZDiffWithScores(keys));
@@ -1725,12 +1726,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zdiffstore/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param destination - The key for the resulting sorted set.
      * @param keys - The keys of the sorted sets to compare.
      *
      * Command Response - The number of members in the resulting sorted set stored at `destination`.
-     *
-     * since Valkey version 6.2.0.
      */
     public zdiffstore(destination: string, keys: string[]): T {
         return this.addAndReturn(createZDiffStore(destination, keys));
@@ -1755,13 +1756,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zmscore/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param key - The key of the sorted set.
      * @param members - A list of members in the sorted set.
      *
      * Command Response - An `array` of scores corresponding to `members`.
      * If a member does not exist in the sorted set, the corresponding value in the list will be `null`.
-     *
-     * since Valkey version 6.2.0.
      */
     public zmscore(key: string, members: string[]): T {
         return this.addAndReturn(createZMScore(key, members));
@@ -1841,6 +1842,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zrangestore/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param destination - The key for the destination sorted set.
      * @param source - The key of the source sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
@@ -1850,8 +1853,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param reverse - If `true`, reverses the sorted set, with index `0` as the element with the highest score.
      *
      * Command Response - The number of elements in the resulting sorted set.
-     *
-     * since - Redis version 6.2.0.
      */
     public zrangeStore(
         destination: string,
@@ -1984,7 +1985,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
-     *     `0` will block indefinitely. Since 6.0.0: timeout is interpreted as a double instead of an integer.
+     *     `0` will block indefinitely. Since Valkey version 6.0.0: timeout is interpreted as a double instead of an integer.
      *
      * Command Response - An `array` containing the key where the member was popped out, the member, itself, and the member score.
      *     If no member could be popped and the `timeout` expired, returns `null`.
@@ -2146,15 +2147,16 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /** Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
+     *
      * See https://valkey.io/commands/zrank for more details.
+     *
+     * Since Valkey version 7.2.0.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
      *
      * Command Response - A list containing the rank and score of `member` in the sorted set.
      * If `key` doesn't exist, or if `member` is not present in the set, null will be returned.
-     *
-     * since - Redis version 7.2.0.
      */
     public zrankWithScore(key: string, member: string): T {
         return this.addAndReturn(createZRank(key, member, true));
@@ -2183,14 +2185,14 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zrevrank/ for more details.
      *
+     * Since Valkey version 7.2.0.
+     *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
      *
      * Command Response -  A list containing the rank and score of `member` in the sorted set, where ranks
      *     are ordered from high to low based on scores.
      *     If `key` doesn't exist, or if `member` is not present in the set, `null` will be returned.
-     *
-     * since - Valkey version 7.2.0.
      */
     public zrevrankWithScore(key: string, member: string): T {
         return this.addAndReturn(createZRevRankWithScore(key, member));
@@ -2849,7 +2851,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/fcall/ for more details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
@@ -2867,7 +2869,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/fcall/ for more details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param func - The function name.
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
@@ -2885,7 +2887,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/function-delete/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param libraryCode - The library name to delete.
      *
@@ -2900,7 +2902,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/function-load/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param libraryCode - The source code that implements the library.
      * @param replace - Whether the given library should overwrite a library with the same name if it
@@ -2917,7 +2919,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/function-flush/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param mode - The flushing mode, could be either {@link FlushMode.SYNC} or {@link FlushMode.ASYNC}.
      * Command Response - `OK`.
@@ -2931,7 +2933,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/function-list/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param options - Parameters to filter and request additional info.
      *
@@ -2947,7 +2949,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/function-stats/ for details.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * Command Response - A `Record` of type {@link FunctionStatsResponse} with two keys:
      *
@@ -2991,14 +2993,14 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/lpos/ for more details.
      *
+     * Since Valkey version 6.0.6.
+     *
      * @param key - The name of the list.
      * @param element - The value to search for within the list.
      * @param options - The LPOS options.
      *
      * Command Response - The index of `element`, or `null` if `element` is not in the list. If the `count`
      * option is specified, then the function returns an `array` of indices of matching elements within the list.
-     *
-     * since - Valkey version 6.0.6.
      */
     public lpos(key: string, element: string, options?: LPosOptions): T {
         return this.addAndReturn(createLPos(key, element, options));
@@ -3063,7 +3065,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/geosearch/ for more details.
      *
-     * since - Valkey 6.2.0 and above.
+     * Since Valkey version 6.2.0.
      *
      * @param key - The key of the sorted set.
      * @param searchFrom - The query's center point options, could be one of:
@@ -3110,7 +3112,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/geosearchstore/ for more details.
      *
-     * since - Valkey 6.2.0 and above.
+     * Since Valkey version 6.2.0.
      *
      * @param destination - The key of the destination sorted set.
      * @param source - The key of the sorted set.
@@ -3165,6 +3167,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/zmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
      *     {@link ScoreFilter.MAX} to pop the member with the lowest/highest score accordingly.
@@ -3173,8 +3177,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A two-element `array` containing the key name of the set from which the
      *     element was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
-     *
-     * since Valkey version 7.0.0.
      */
     public zmpop(keys: string[], modifier: ScoreFilter, count?: number): T {
         return this.addAndReturn(createZMPop(keys, modifier, count));
@@ -3187,6 +3189,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/bzmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | the wiki}
      * for more details and best practices.
      * @param keys - The keys of the sorted sets.
@@ -3198,8 +3202,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A two-element `array` containing the key name of the set from which the element
      *     was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
-     *
-     * since Valkey version 7.0.0.
      */
     public bzmpop(
         keys: string[],
@@ -3299,7 +3301,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns all the longest common subsequences combined between strings stored at `key1` and `key2`.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * See https://valkey.io/commands/lcs/ for more details.
      *
@@ -3316,7 +3318,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns the total length of all the longest common subsequences between strings stored at `key1` and `key2`.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * See https://valkey.io/commands/lcs/ for more details.
      *
@@ -3333,7 +3335,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Returns the indices and lengths of the longest common subsequences between strings stored at
      * `key1` and `key2`.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * See https://valkey.io/commands/lcs/ for more details.
      *
@@ -3420,14 +3422,14 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/lmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
      * @param count - (Optional) The maximum number of popped elements.
      *
      * Command Response - A `Record` of `key` name mapped array of popped elements.
-     *
-     * since Valkey version 7.0.0.
      */
     public lmpop(keys: string[], direction: ListDirection, count?: number): T {
         return this.addAndReturn(createLMPop(keys, direction, count));
@@ -3439,6 +3441,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * See https://valkey.io/commands/blmpop/ for more details.
      *
+     * Since Valkey version 7.0.0.
+     *
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
@@ -3447,8 +3451,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - A `Record` of `key` name mapped array of popped elements.
      *     If no member could be popped and the timeout expired, returns `null`.
-     *
-     * since Valkey version 7.0.0.
      */
     public blmpop(
         keys: string[],
@@ -3567,7 +3569,7 @@ export class Transaction extends BaseTransaction<Transaction> {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortOptions}.
@@ -3612,6 +3614,8 @@ export class Transaction extends BaseTransaction<Transaction> {
      *
      * See https://valkey.io/commands/copy/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
      * @param destinationDB - (Optional) The alternative logical database index for the destination key.
@@ -3620,8 +3624,6 @@ export class Transaction extends BaseTransaction<Transaction> {
      *     value to it. If not provided, no action will be performed if the key already exists.
      *
      * Command Response - `true` if `source` was copied, `false` if the `source` was not copied.
-     *
-     * since Valkey version 6.2.0.
      */
     public copy(
         source: string,
@@ -3702,7 +3704,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      *
      * This command is routed depending on the client's {@link ReadFrom} strategy.
      *
-     * since Valkey version 7.0.0.
+     * Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param options - (Optional) {@link SortClusterOptions}.
@@ -3748,14 +3750,14 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      *
      * See https://valkey.io/commands/copy/ for more details.
      *
+     * Since Valkey version 6.2.0.
+     *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
      * @param replace - (Optional) If `true`, the `destination` key should be removed before copying the
      *     value to it. If not provided, no action will be performed if the key already exists.
      *
      * Command Response - `true` if `source` was copied, `false` if the `source` was not copied.
-     *
-     * since Valkey version 6.2.0.
      */
     public copy(
         source: string,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1067,11 +1067,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * `BLMOVE` is the blocking variant of {@link lmove}.
      *
      * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
+     * @remarks When in cluster mode, both `source` and `destination` must map to the same hash slot.
+     * @remarks `BLMOVE` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Valkey Glide Wiki} for more details and best practices.
      * @remarks Since Valkey version 6.2.0.
-     *
-     * @remarks
-     * 1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
-     * 2. `BLMOVE` is a client blocking command, see https://github.com/aws/glide-for-redis/wiki/General-Concepts#blocking-commands for more details and best practices.
      *
      * @param source - The key to the source list.
      * @param destination - The key to the destination list.
@@ -3158,10 +3156,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * to pop from any of the given sorted sets. `BZMPOP` is the blocking variant of {@link zmpop}.
      *
      * @see {@link https://valkey.io/commands/bzmpop/|valkey.io} for details.
+     * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | Valkey Glide Wiki} for more details and best practices.
      * @remarks Since Valkey version 7.0.0.
      *
-     * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | the wiki}
-     * for more details and best practices.
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
      *     {@link ScoreFilter.MAX} to pop the member with the lowest/highest score accordingly.
@@ -3387,9 +3384,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Pops one or more elements from the first non-empty list from the provided `keys`.
      *
      * @see {@link https://valkey.io/commands/lmpop/|valkey.io} for details.
+     * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @remarks Since Valkey version 7.0.0.
      *
-     * @remarks When in cluster mode, `source` and `destination` must map to the same hash slot.
      * @param keys - An array of keys to lists.
      * @param direction - The direction based on which elements are popped from - see {@link ListDirection}.
      * @param count - (Optional) The maximum number of popped elements.
@@ -3554,8 +3551,8 @@ export class Transaction extends BaseTransaction<Transaction> {
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
      * @see {@link https://valkey.io/commands/sort/|valkey.io} for more details.
-     *
      * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
+     *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
      * @param options - (Optional) {@link SortOptions}.
@@ -3692,8 +3689,8 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * To get the sort result without storing it into a key, see {@link sort} or {@link sortReadOnly}.
      *
      * @see {@link https://valkey.io/commands/sort|valkey.io} for more details.
-     *
      * @remarks When in cluster mode, `destination` and `key` must map to the same hash slot.
+     *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
      * @param options - (Optional) {@link SortClusterOptions}.


### PR DESCRIPTION
Updates javadoc on all node commands to use `@see` and `@remarks` to help document links and remarks. 

Example - see and remarks can be grouped together: 
```
     * @see {@link https://valkey.io/commands/mget/|valkey.io} for details.
     * @remarks When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
```

multiple remarks - also the "Since" comment is updated to a `@remark` to format it correctly:
```
     * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
     * @remarks When in cluster mode, both `source` and `destination` must map to the same hash slot.
     * @remarks `BLMOVE` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Valkey Glide Wiki} for more details and best practices.
     * @remarks Since Valkey version 6.2.0.
```