### PR TITLE
CI: fix amazon linux job

### DIFF
--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -63,7 +63,7 @@ runs:
           shell: bash
           if: "${{ inputs.os == 'amazon-linux' }}"
           run: |
-              yum install -y gcc pkgconfig openssl openssl-devel which curl gettext --allowerasing
+              yum install -y gcc pkgconfig openssl openssl-devel which curl gettext tar --allowerasing
 
         - name: Install Rust toolchain and protoc
           if: "${{ !contains(inputs.target, 'musl') }}"


### PR DESCRIPTION
This fixes the following error ([example](https://github.com/valkey-io/valkey-glide/actions/runs/10373323035/job/28718163220?pr=2114#step:7:538)):
```
Warning: Failed to restore: Unable to locate executable file: tar. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```