### PR TITLE
Core/Cluster mode: Added default retries to the cluster client builder

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -23,7 +23,7 @@ mod value_conversion;
 use tokio::sync::mpsc;
 
 pub const HEARTBEAT_SLEEP_DURATION: Duration = Duration::from_secs(1);
-
+pub const DEFAULT_RETRIES: u32 = 3;
 pub const DEFAULT_RESPONSE_TIMEOUT: Duration = Duration::from_millis(250);
 pub const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(250);
 pub const DEFAULT_PERIODIC_CHECKS_INTERVAL: Duration = Duration::from_secs(60);
@@ -450,7 +450,8 @@ async fn create_cluster_client(
         None => Some(DEFAULT_PERIODIC_CHECKS_INTERVAL),
     };
     let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes)
-        .connection_timeout(INTERNAL_CONNECTION_TIMEOUT);
+        .connection_timeout(INTERNAL_CONNECTION_TIMEOUT)
+        .retries(DEFAULT_RETRIES);
     if read_from_replicas {
         builder = builder.read_from_replicas();
     }


### PR DESCRIPTION
Cluster mode: ATM we're using redis-rs default retries which is 16, which is A LOT and with exponential backoff between retries it takes more than 15 seconds to finish all retries. In glide we're wrapping the command execution futures with timeout so we'll drop the future after the given timeout and response back to the user with timeout error. However, once request is added to redis-rs's pending requests queue, it won't stop to run it until the retries are exceeded. That means that we can see old requests being sent long long after we've responded with timeout error back to the user.
We shall provide a solid fix where dropped requests/timed out requests will be dropped also in redis-rs. 
This PR introduce only a fix to minimze the delta between glide's timeout to the actual completion of the request in redis-rs.
We do not have retries option for the standalone client, it should be added too. Moreover, we shall export the retries configuration to all wrappers so it can be modified by the user. 
 
Created relevant issues:
https://github.com/valkey-io/valkey-glide/issues/2138
https://github.com/valkey-io/valkey-glide/issues/2139
https://github.com/valkey-io/valkey-glide/issues/2140