### PR TITLE
Node - Add binary support to transaction commands

### DIFF
--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -219,6 +219,7 @@ import {
     createXGroupCreateConsumer,
     createXGroupDelConsumer,
     createXGroupDestroy,
+    createXGroupSetid,
     createXInfoConsumers,
     createXInfoGroups,
     createXInfoStream,
@@ -259,7 +260,6 @@ import {
     createZScore,
     createZUnion,
     createZUnionStore,
-    createXGroupSetid,
 } from "./Commands";
 import { command_request } from "./ProtobufMessage";
 
@@ -371,7 +371,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - substring extracted from the value stored at `key`.
      */
-    public getrange(key: string, start: number, end: number): T {
+    public getrange(key: GlideString, start: number, end: number): T {
         return this.addAndReturn(createGetRange(key, start, end));
     }
 
@@ -498,7 +498,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A list of values corresponding to the provided keys. If a key is not found,
      * its corresponding value in the list will be null.
      */
-    public mget(keys: string[]): T {
+    public mget(keys: GlideString[]): T {
         return this.addAndReturn(createMGet(keys));
     }
 
@@ -778,7 +778,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - the value associated with `field`, or null when `field` is not present in the hash or `key` does not exist.
      */
-    public hget(key: string, field: string): T {
+    public hget(key: GlideString, field: GlideString): T {
         return this.addAndReturn(createHGet(key, field));
     }
 
@@ -924,7 +924,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - a list of values in the hash, or an empty list when the key does not exist.
      */
-    public hvals(key: string): T {
+    public hvals(key: GlideString): T {
         return this.addAndReturn(createHVals(key));
     }
 
@@ -1024,7 +1024,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - the length of the list after the push operations.
      */
-    public lpush(key: string, elements: string[]): T {
+    public lpush(key: GlideString, elements: GlideString[]): T {
         return this.addAndReturn(createLPush(key, elements));
     }
 
@@ -1052,7 +1052,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The value of the first element.
      * If `key` does not exist null will be returned.
      */
-    public lpop(key: string): T {
+    public lpop(key: GlideString): T {
         return this.addAndReturn(createLPop(key));
     }
 
@@ -1065,7 +1065,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A list of the popped elements will be returned depending on the list's length.
      * If `key` does not exist null will be returned.
      */
-    public lpopCount(key: string, count: number): T {
+    public lpopCount(key: GlideString, count: number): T {
         return this.addAndReturn(createLPop(key, count));
     }
 
@@ -1084,7 +1084,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `end` exceeds the actual end of the list, the range will stop at the actual end of the list.
      * If `key` does not exist an empty list will be returned.
      */
-    public lrange(key: string, start: number, end: number): T {
+    public lrange(key: GlideString, start: number, end: number): T {
         return this.addAndReturn(createLRange(key, start, end));
     }
 
@@ -1096,7 +1096,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - the length of the list at `key`.
      * If `key` does not exist, it is interpreted as an empty list and 0 is returned.
      */
-    public llen(key: string): T {
+    public llen(key: GlideString): T {
         return this.addAndReturn(createLLen(key));
     }
 
@@ -1116,8 +1116,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The popped element, or `null` if `source` does not exist.
      */
     public lmove(
-        source: string,
-        destination: string,
+        source: GlideString,
+        destination: GlideString,
         whereFrom: ListDirection,
         whereTo: ListDirection,
     ): T {
@@ -1147,8 +1147,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The popped element, or `null` if `source` does not exist or if the operation timed-out.
      */
     public blmove(
-        source: string,
-        destination: string,
+        source: GlideString,
+        destination: GlideString,
         whereFrom: ListDirection,
         whereTo: ListDirection,
         timeout: number,
@@ -1221,7 +1221,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - the length of the list after the push operations.
      */
-    public rpush(key: string, elements: string[]): T {
+    public rpush(key: GlideString, elements: GlideString[]): T {
         return this.addAndReturn(createRPush(key, elements));
     }
 
@@ -1249,7 +1249,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The value of the last element.
      * If `key` does not exist null will be returned.
      */
-    public rpop(key: string): T {
+    public rpop(key: GlideString): T {
         return this.addAndReturn(createRPop(key));
     }
 
@@ -1262,7 +1262,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A list of popped elements will be returned depending on the list's length.
      * If `key` does not exist null will be returned.
      */
-    public rpopCount(key: string, count: number): T {
+    public rpopCount(key: GlideString, count: number): T {
         return this.addAndReturn(createRPop(key, count));
     }
 
@@ -2404,7 +2404,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The element at index in the list stored at `key`.
      * If `index` is out of range or if `key` does not exist, null is returned.
      */
-    public lindex(key: string, index: number): T {
+    public lindex(key: GlideString, index: number): T {
         return this.addAndReturn(createLIndex(key, index));
     }
 
@@ -2424,10 +2424,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If the `pivot` wasn't found, returns `0`.
      */
     public linsert(
-        key: string,
+        key: GlideString,
         position: InsertPosition,
-        pivot: string,
-        element: string,
+        pivot: GlideString,
+        element: GlideString,
     ): T {
         return this.addAndReturn(createLInsert(key, position, pivot, element));
     }
@@ -2984,7 +2984,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` containing the `key` from which the element was popped and the value of the popped element,
      * formatted as [key, value]. If no element could be popped and the timeout expired, returns `null`.
      */
-    public brpop(keys: string[], timeout: number): T {
+    public brpop(keys: GlideString[], timeout: number): T {
         return this.addAndReturn(createBRPop(keys, timeout));
     }
 
@@ -3002,7 +3002,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` containing the `key` from which the element was popped and the value of the popped element,
      * formatted as [key, value]. If no element could be popped and the timeout expired, returns `null`.
      */
-    public blpop(keys: string[], timeout: number): T {
+    public blpop(keys: GlideString[], timeout: number): T {
         return this.addAndReturn(createBLPop(keys, timeout));
     }
 
@@ -3710,7 +3710,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The length of the string after appending the value.
      */
-    public append(key: string, value: string): T {
+    public append(key: GlideString, value: GlideString): T {
         return this.addAndReturn(createAppend(key, value));
     }
 


### PR DESCRIPTION
Added binary support to these transaction commands, for which the binary option was already merged - 
*append
*getrange
*hget
*mget
*hvals
*lpush
*lpop
*lpopcount
*lrange
*lindex
*lmove
*blmove
*linsert
*llen
*rpush
*rpop
*rpopcount
*blpop
*brpop