### PR TITLE
Node: Add binary variant to sorted set commands - part 1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Node: Added binary variant to sorted set commands - part 1 ([#2190](https://github.com/valkey-io/valkey-glide/pull/2190))
 * Node: Added binary variant to generic commands ([#2158](https://github.com/valkey-io/valkey-glide/pull/2158))
 * Node: Added binary variant to geo commands ([#2149](https://github.com/valkey-io/valkey-glide/pull/2149))
 * Node: Added binary variant to HYPERLOGLOG commands ([#2176](https://github.com/valkey-io/valkey-glide/pull/2176))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3214,7 +3214,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/ttl/|valkey.io} for details.
      *
      * @param key - The key to return its timeout.
-     * @returns TTL in seconds, -2 if `key` does not exist or -1 if `key` exists but has no associated expire.
+     * @returns TTL in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
      *
      * @example
      * ```typescript
@@ -3370,16 +3370,17 @@ export class BaseClient {
         return this.createWritePromise(createXRevRange(key, end, start, count));
     }
 
-    /** Adds members with their scores to the sorted set stored at `key`.
+    /**
+     * Adds members with their scores to the sorted set stored at `key`.
      * If a member is already a part of the sorted set, its score is updated.
      *
      * @see {@link https://valkey.io/commands/zadd/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @param membersScoresMap - A mapping of members to their corresponding scores.
-     * @param options - The ZAdd options.
+     * @param options - (Optional) The ZAdd options - see {@link ZAddOptions}.
      * @returns The number of elements added to the sorted set.
-     * If `changed` is set, returns the number of elements updated in the sorted set.
+     * If {@link ZAddOptions.changed|changed} is set, returns the number of elements updated in the sorted set.
      *
      * @example
      * ```typescript
@@ -3397,8 +3398,8 @@ export class BaseClient {
      * ```
      */
     public async zadd(
-        key: string,
-        membersScoresMap: Record<string, number>,
+        key: GlideString,
+        membersScoresMap: Record<string, number>, // TODO GlideString in Record
         options?: ZAddOptions,
     ): Promise<number> {
         return this.createWritePromise(
@@ -3472,13 +3473,14 @@ export class BaseClient {
         return this.createWritePromise(createZRem(key, members));
     }
 
-    /** Returns the cardinality (number of elements) of the sorted set stored at `key`.
+    /**
+     * Returns the cardinality (number of elements) of the sorted set stored at `key`.
      *
      * @see {@link https://valkey.io/commands/zcard/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
      * @returns The number of elements in the sorted set.
-     * If `key` does not exist, it is treated as an empty sorted set, and this command returns 0.
+     * If `key` does not exist, it is treated as an empty sorted set, and this command returns `0`.
      *
      * @example
      * ```typescript
@@ -3494,7 +3496,7 @@ export class BaseClient {
      * console.log(result); // Output: 0
      * ```
      */
-    public async zcard(key: string): Promise<number> {
+    public async zcard(key: GlideString): Promise<number> {
         return this.createWritePromise(createZCard(key));
     }
 
@@ -3516,7 +3518,10 @@ export class BaseClient {
      * console.log(cardinality); // Output: 3 - The intersection of the sorted sets at "key1" and "key2" has a cardinality of 3.
      * ```
      */
-    public async zintercard(keys: string[], limit?: number): Promise<number> {
+    public async zintercard(
+        keys: GlideString[],
+        limit?: number,
+    ): Promise<number> {
         return this.createWritePromise(createZInterCard(keys, limit));
     }
 
@@ -3529,6 +3534,7 @@ export class BaseClient {
      * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns An `array` of elements representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
      *
@@ -3541,8 +3547,11 @@ export class BaseClient {
      * console.log(result); // Output: ["member1"] - "member1" is in "zset1" but not "zset2" or "zset3".
      * ```
      */
-    public async zdiff(keys: string[]): Promise<string[]> {
-        return this.createWritePromise(createZDiff(keys));
+    public async zdiff(
+        keys: GlideString[],
+        options?: DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createZDiff(keys), options);
     }
 
     /**
@@ -3554,6 +3563,7 @@ export class BaseClient {
      * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A map of elements and their scores representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
      *
@@ -3567,9 +3577,11 @@ export class BaseClient {
      * ```
      */
     public async zdiffWithScores(
-        keys: string[],
+        keys: GlideString[],
+        options?: DecoderOption,
     ): Promise<Record<string, number>> {
-        return this.createWritePromise(createZDiffWithScores(keys));
+        // TODO GlideString in Record
+        return this.createWritePromise(createZDiffWithScores(keys), options);
     }
 
     /**
@@ -3597,8 +3609,8 @@ export class BaseClient {
      * ```
      */
     public async zdiffstore(
-        destination: string,
-        keys: string[],
+        destination: GlideString,
+        keys: GlideString[],
     ): Promise<number> {
         return this.createWritePromise(createZDiffStore(destination, keys));
     }
@@ -3698,7 +3710,8 @@ export class BaseClient {
         return this.createWritePromise(createZMScore(key, members));
     }
 
-    /** Returns the number of members in the sorted set stored at `key` with scores between `minScore` and `maxScore`.
+    /**
+     * Returns the number of members in the sorted set stored at `key` with scores between `minScore` and `maxScore`.
      *
      * @see {@link https://valkey.io/commands/zcount/|valkey.io} for more details.
      *
@@ -3706,8 +3719,8 @@ export class BaseClient {
      * @param minScore - The minimum score to count from. Can be positive/negative infinity, or specific score and inclusivity.
      * @param maxScore - The maximum score to count up to. Can be positive/negative infinity, or specific score and inclusivity.
      * @returns The number of members in the specified score range.
-     * If `key` does not exist, it is treated as an empty sorted set, and the command returns 0.
-     * If `minScore` is greater than `maxScore`, 0 is returned.
+     * If `key` does not exist, it is treated as an empty sorted set, and the command returns `0`.
+     * If `minScore` is greater than `maxScore`, `0` is returned.
      *
      * @example
      * ```typescript
@@ -3724,7 +3737,7 @@ export class BaseClient {
      * ```
      */
     public async zcount(
-        key: string,
+        key: GlideString,
         minScore: Boundary<number>,
         maxScore: Boundary<number>,
     ): Promise<number> {
@@ -3873,8 +3886,8 @@ export class BaseClient {
      *
      * @param destination - The key of the destination sorted set.
      * @param keys - The keys of the sorted sets with possible formats:
-     *  string[] - for keys only.
-     *  KeyWeight[] - for weighted keys with score multipliers.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with score multipliers.
      * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      * @returns The number of elements in the resulting sorted set stored at `destination`.
@@ -3891,8 +3904,8 @@ export class BaseClient {
      * ```
      */
     public async zinterstore(
-        destination: string,
-        keys: string[] | KeyWeight[],
+        destination: GlideString,
+        keys: GlideString[] | KeyWeight[],
         aggregationType?: AggregationType,
     ): Promise<number> {
         return this.createWritePromise(
@@ -3938,10 +3951,12 @@ export class BaseClient {
      * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets with possible formats:
-     *  - string[] - for keys only.
-     *  - KeyWeight[] - for weighted keys with score multipliers.
-     * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
-     * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with score multipliers.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements.
+     *     If `aggregationType` is not specified, defaults to `AggregationType.SUM`. See {@link AggregationType}.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns The resulting sorted set with scores.
      *
      * @example
@@ -3955,11 +3970,11 @@ export class BaseClient {
      * ```
      */
     public async zinterWithScores(
-        keys: string[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        keys: GlideString[] | KeyWeight[],
+        options?: { aggregationType?: AggregationType } & DecoderOption,
     ): Promise<Record<string, number>> {
         return this.createWritePromise(
-            createZInter(keys, aggregationType, true),
+            createZInter(keys, options?.aggregationType, true),
         );
     }
 
@@ -4216,6 +4231,7 @@ export class BaseClient {
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
      *     `0` will block indefinitely. Since 6.0.0: timeout is interpreted as a double instead of an integer.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns An `array` containing the key where the member was popped out, the member, itself, and the member score.
      *     If no member could be popped and the `timeout` expired, returns `null`.
      *
@@ -4226,10 +4242,11 @@ export class BaseClient {
      * ```
      */
     public async bzpopmin(
-        keys: string[],
+        keys: GlideString[],
         timeout: number,
-    ): Promise<[string, string, number] | null> {
-        return this.createWritePromise(createBZPopMin(keys, timeout));
+        options?: DecoderOption,
+    ): Promise<[GlideString, GlideString, number] | null> {
+        return this.createWritePromise(createBZPopMin(keys, timeout), options);
     }
 
     /** Removes and returns the members with the highest scores from the sorted set stored at `key`.
@@ -4277,6 +4294,7 @@ export class BaseClient {
      * @param keys - The keys of the sorted sets.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of
      *     `0` will block indefinitely. Since 6.0.0: timeout is interpreted as a double instead of an integer.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns An `array` containing the key where the member was popped out, the member, itself, and the member score.
      *     If no member could be popped and the `timeout` expired, returns `null`.
      *
@@ -4287,10 +4305,11 @@ export class BaseClient {
      * ```
      */
     public async bzpopmax(
-        keys: string[],
+        keys: GlideString[],
         timeout: number,
-    ): Promise<[string, string, number] | null> {
-        return this.createWritePromise(createBZPopMax(keys, timeout));
+        options?: DecoderOption,
+    ): Promise<[GlideString, GlideString, number] | null> {
+        return this.createWritePromise(createBZPopMax(keys, timeout), options);
     }
 
     /**
@@ -4299,7 +4318,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/pttl/|valkey.io} for more details.
      *
      * @param key - The key to return its timeout.
-     * @returns TTL in milliseconds. -2 if `key` does not exist, -1 if `key` exists but has no associated expire.
+     * @returns TTL in milliseconds, `-2` if `key` does not exist, `-1` if `key` exists but has no associated expire.
      *
      * @example
      * ```typescript
@@ -6028,7 +6047,9 @@ export class BaseClient {
      *     {@link ScoreFilter.MAX} to pop the member with the lowest/highest score accordingly.
      * @param timeout - The number of seconds to wait for a blocking operation to complete.
      *     A value of 0 will block indefinitely.
-     * @param count - (Optional) The number of elements to pop. If not supplied, only one element will be popped.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count` : the number of elements to pop. If not supplied, only one element will be popped.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A two-element `array` containing the key name of the set from which the element
      *     was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
@@ -6042,13 +6063,15 @@ export class BaseClient {
      * ```
      */
     public async bzmpop(
-        keys: string[],
+        keys: GlideString[],
         modifier: ScoreFilter,
         timeout: number,
-        count?: number,
-    ): Promise<[string, [Record<string, number>]] | null> {
+        options?: { count?: number } & DecoderOption,
+    ): Promise<[GlideString, Record<string, number>] | null> {
+        // TODO GlideString in Record
         return this.createWritePromise(
-            createBZMPop(keys, modifier, timeout, count),
+            createBZMPop(keys, modifier, timeout, options?.count),
+            options,
         );
     }
 
@@ -6078,9 +6101,9 @@ export class BaseClient {
      * ```
      */
     public async zincrby(
-        key: string,
+        key: GlideString,
         increment: number,
-        member: string,
+        member: GlideString,
     ): Promise<number> {
         return this.createWritePromise(createZIncrBy(key, increment, member));
     }

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1390,7 +1390,7 @@ export type ZAddOptions = {
  * @internal
  */
 export function createZAdd(
-    key: string,
+    key: GlideString,
     membersScoresMap: Record<string, number>,
     options?: ZAddOptions,
     incr: boolean = false,
@@ -1437,7 +1437,7 @@ export function createZAdd(
 /**
  * `KeyWeight` - pair of variables represents a weighted key for the `ZINTERSTORE` and `ZUNIONSTORE` sorted sets commands.
  */
-export type KeyWeight = [string, number];
+export type KeyWeight = [GlideString, number];
 /**
  * `AggregationType` - representing aggregation types for `ZINTERSTORE` and `ZUNIONSTORE` sorted set commands.
  */
@@ -1447,8 +1447,8 @@ export type AggregationType = "SUM" | "MIN" | "MAX";
  * @internal
  */
 export function createZInterstore(
-    destination: string,
-    keys: string[] | KeyWeight[],
+    destination: GlideString,
+    keys: GlideString[] | KeyWeight[],
     aggregationType?: AggregationType,
 ): command_request.Command {
     const args = createZCmdArgs(keys, {
@@ -1463,7 +1463,7 @@ export function createZInterstore(
  * @internal
  */
 export function createZInter(
-    keys: string[] | KeyWeight[],
+    keys: GlideString[] | KeyWeight[],
     aggregationType?: AggregationType,
     withScores?: boolean,
 ): command_request.Command {
@@ -1488,14 +1488,14 @@ export function createZUnion(
  * Helper function for Zcommands (ZInter, ZinterStore, ZUnion..) that arranges arguments in the server's required order.
  */
 function createZCmdArgs(
-    keys: string[] | KeyWeight[],
+    keys: GlideString[] | KeyWeight[],
     options: {
         aggregationType?: AggregationType;
         withScores?: boolean;
-        destination?: string;
+        destination?: GlideString;
     },
-): string[] {
-    const args = [];
+): GlideString[] {
+    const args: GlideString[] = [];
 
     const destination = options.destination;
 
@@ -1505,11 +1505,12 @@ function createZCmdArgs(
 
     args.push(keys.length.toString());
 
-    if (typeof keys[0] === "string") {
-        args.push(...(keys as string[]));
+    if (!Array.isArray(keys[0])) {
+        // KeyWeight is an array
+        args.push(...(keys as GlideString[]));
     } else {
         const weightsKeys = keys.map(([key]) => key);
-        args.push(...(weightsKeys as string[]));
+        args.push(...(weightsKeys as GlideString[]));
         const weights = keys.map(([, weight]) => weight.toString());
         args.push("WEIGHTS", ...weights);
     }
@@ -1540,7 +1541,7 @@ export function createZRem(
 /**
  * @internal
  */
-export function createZCard(key: string): command_request.Command {
+export function createZCard(key: GlideString): command_request.Command {
     return createCommand(RequestType.ZCard, [key]);
 }
 
@@ -1548,14 +1549,14 @@ export function createZCard(key: string): command_request.Command {
  * @internal
  */
 export function createZInterCard(
-    keys: string[],
+    keys: GlideString[],
     limit?: number,
 ): command_request.Command {
-    let args: string[] = keys;
+    const args = keys;
     args.unshift(keys.length.toString());
 
     if (limit != undefined) {
-        args = args.concat(["LIMIT", limit.toString()]);
+        args.push("LIMIT", limit.toString());
     }
 
     return createCommand(RequestType.ZInterCard, args);
@@ -1564,8 +1565,8 @@ export function createZInterCard(
 /**
  * @internal
  */
-export function createZDiff(keys: string[]): command_request.Command {
-    const args: string[] = keys;
+export function createZDiff(keys: GlideString[]): command_request.Command {
+    const args = keys;
     args.unshift(keys.length.toString());
     return createCommand(RequestType.ZDiff, args);
 }
@@ -1573,8 +1574,10 @@ export function createZDiff(keys: string[]): command_request.Command {
 /**
  * @internal
  */
-export function createZDiffWithScores(keys: string[]): command_request.Command {
-    const args: string[] = keys;
+export function createZDiffWithScores(
+    keys: GlideString[],
+): command_request.Command {
+    const args = keys;
     args.unshift(keys.length.toString());
     args.push("WITHSCORES");
     return createCommand(RequestType.ZDiff, args);
@@ -1584,10 +1587,10 @@ export function createZDiffWithScores(keys: string[]): command_request.Command {
  * @internal
  */
 export function createZDiffStore(
-    destination: string,
-    keys: string[],
+    destination: GlideString,
+    keys: GlideString[],
 ): command_request.Command {
-    const args: string[] = [destination, keys.length.toString(), ...keys];
+    const args = [destination, keys.length.toString(), ...keys];
     return createCommand(RequestType.ZDiffStore, args);
 }
 
@@ -1806,7 +1809,7 @@ function createZRangeArgs(
  * @internal
  */
 export function createZCount(
-    key: string,
+    key: GlideString,
     minScore: Boundary<number>,
     maxScore: Boundary<number>,
 ): command_request.Command {
@@ -3468,12 +3471,12 @@ export function createZMPop(
  * @internal
  */
 export function createBZMPop(
-    keys: string[],
+    keys: GlideString[],
     modifier: ScoreFilter,
     timeout: number,
     count?: number,
 ): command_request.Command {
-    const args: string[] = [
+    const args = [
         timeout.toString(),
         keys.length.toString(),
         ...keys,
@@ -3492,9 +3495,9 @@ export function createBZMPop(
  * @internal
  */
 export function createZIncrBy(
-    key: string,
+    key: GlideString,
     increment: number,
-    member: string,
+    member: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.ZIncrBy, [
         key,
@@ -3911,7 +3914,7 @@ export function createPubSubShardNumSub(
  * @internal
  */
 export function createBZPopMax(
-    keys: string[],
+    keys: GlideString[],
     timeout: number,
 ): command_request.Command {
     return createCommand(RequestType.BZPopMax, [...keys, timeout.toString()]);
@@ -3921,7 +3924,7 @@ export function createBZPopMax(
  * @internal
  */
 export function createBZPopMin(
-    keys: string[],
+    keys: GlideString[],
     timeout: number,
 ): command_request.Command {
     return createCommand(RequestType.BZPopMin, [...keys, timeout.toString()]);

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1683,26 +1683,28 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key to return its timeout.
      *
-     * Command Response -  TTL in seconds, -2 if `key` does not exist or -1 if `key` exists but has no associated expire.
+     * Command Response - TTL in seconds, `-2` if `key` does not exist or `-1` if `key` exists but has no associated expire.
      */
     public ttl(key: GlideString): T {
         return this.addAndReturn(createTTL(key));
     }
 
-    /** Adds members with their scores to the sorted set stored at `key`.
+    /**
+     * Adds members with their scores to the sorted set stored at `key`.
      * If a member is already a part of the sorted set, its score is updated.
+     *
      * @see {@link https://valkey.io/commands/zadd/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param membersScoresMap - A mapping of members to their corresponding scores.
-     * @param options - The ZAdd options.
+     * @param options - (Optional) The ZAdd options - see {@link ZAddOptions}.
      *
      * Command Response - The number of elements added to the sorted set.
-     * If `changed` is set, returns the number of elements updated in the sorted set.
+     * If {@link ZAddOptions.changed|changed} is set, returns the number of elements updated in the sorted set.
      */
     public zadd(
-        key: string,
-        membersScoresMap: Record<string, number>,
+        key: GlideString,
+        membersScoresMap: Record<string, number>, // TODO GlideString in Record
         options?: ZAddOptions,
     ): T {
         return this.addAndReturn(createZAdd(key, membersScoresMap, options));
@@ -1746,15 +1748,17 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createZRem(key, members));
     }
 
-    /** Returns the cardinality (number of elements) of the sorted set stored at `key`.
+    /**
+     * Returns the cardinality (number of elements) of the sorted set stored at `key`.
+     *
      * @see {@link https://valkey.io/commands/zcard/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      *
      * Command Response - The number of elements in the sorted set.
-     * If `key` does not exist, it is treated as an empty sorted set, and this command returns 0.
+     * If `key` does not exist, it is treated as an empty sorted set, and this command returns `0`.
      */
-    public zcard(key: string): T {
+    public zcard(key: GlideString): T {
         return this.addAndReturn(createZCard(key));
     }
 
@@ -1770,7 +1774,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The cardinality of the intersection of the given sorted sets.
      */
-    public zintercard(keys: string[], limit?: number): T {
+    public zintercard(keys: GlideString[], limit?: number): T {
         return this.addAndReturn(createZInterCard(keys, limit));
     }
 
@@ -1786,7 +1790,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` of elements representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
      */
-    public zdiff(keys: string[]): T {
+    public zdiff(keys: GlideString[]): T {
         return this.addAndReturn(createZDiff(keys));
     }
 
@@ -1802,7 +1806,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A map of elements and their scores representing the difference between the sorted sets.
      * If the first key does not exist, it is treated as an empty sorted set, and the command returns an empty `array`.
      */
-    public zdiffWithScores(keys: string[]): T {
+    public zdiffWithScores(keys: GlideString[]): T {
         return this.addAndReturn(createZDiffWithScores(keys));
     }
 
@@ -1819,7 +1823,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The number of members in the resulting sorted set stored at `destination`.
      */
-    public zdiffstore(destination: string, keys: string[]): T {
+    public zdiffstore(destination: GlideString, keys: GlideString[]): T {
         return this.addAndReturn(createZDiffStore(destination, keys));
     }
 
@@ -1877,7 +1881,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createZMScore(key, members));
     }
 
-    /** Returns the number of members in the sorted set stored at `key` with scores between `minScore` and `maxScore`.
+    /**
+     * Returns the number of members in the sorted set stored at `key` with scores between `minScore` and `maxScore`.
+     *
      * @see {@link https://valkey.io/commands/zcount/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
@@ -1885,11 +1891,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param maxScore - The maximum score to count up to. Can be positive/negative infinity, or specific score and inclusivity.
      *
      * Command Response - The number of members in the specified score range.
-     * If `key` does not exist, it is treated as an empty sorted set, and the command returns 0.
-     * If `minScore` is greater than `maxScore`, 0 is returned.
+     * If `key` does not exist, it is treated as an empty sorted set, and the command returns `0`.
+     * If `minScore` is greater than `maxScore`, `0` is returned.
      */
     public zcount(
-        key: string,
+        key: GlideString,
         minScore: Boundary<number>,
         maxScore: Boundary<number>,
     ): T {
@@ -1977,24 +1983,22 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Computes the intersection of sorted sets given by the specified `keys` and stores the result in `destination`.
      * If `destination` already exists, it is overwritten. Otherwise, a new sorted set will be created.
      *
-     * When in cluster mode, `destination` and all keys in `keys` must map to the same hash slot.
-     *
      * @see {@link https://valkey.io/commands/zinterstore/|valkey.io} for details.
      *
      * @remarks Since Valkey version 6.2.0.
      *
      * @param destination - The key of the destination sorted set.
      * @param keys - The keys of the sorted sets with possible formats:
-     *  string[] - for keys only.
-     *  KeyWeight[] - for weighted keys with score multipliers.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with score multipliers.
      * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - The number of elements in the resulting sorted set stored at `destination`.
      */
     public zinterstore(
-        destination: string,
-        keys: string[] | KeyWeight[],
+        destination: GlideString,
+        keys: GlideString[] | KeyWeight[],
         aggregationType?: AggregationType,
     ): T {
         return this.addAndReturn(
@@ -2015,7 +2019,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The resulting array of intersecting elements.
      */
-    public zinter(keys: string[]): T {
+    public zinter(keys: GlideString[]): T {
         return this.addAndReturn(createZInter(keys));
     }
 
@@ -2029,15 +2033,15 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets with possible formats:
-     *  - string[] - for keys only.
-     *  - KeyWeight[] - for weighted keys with score multipliers.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with score multipliers.
      * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - The resulting sorted set with scores.
      */
     public zinterWithScores(
-        keys: string[] | KeyWeight[],
+        keys: GlideString[] | KeyWeight[],
         aggregationType?: AggregationType,
     ): T {
         return this.addAndReturn(createZInter(keys, aggregationType, true));
@@ -2186,7 +2190,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` containing the key where the member was popped out, the member, itself, and the member score.
      *     If no member could be popped and the `timeout` expired, returns `null`.
      */
-    public bzpopmin(keys: string[], timeout: number): T {
+    public bzpopmin(keys: GlideString[], timeout: number): T {
         return this.addAndReturn(createBZPopMin(keys, timeout));
     }
 
@@ -2221,7 +2225,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` containing the key where the member was popped out, the member, itself, and the member score.
      *     If no member could be popped and the `timeout` expired, returns `null`.
      */
-    public bzpopmax(keys: string[], timeout: number): T {
+    public bzpopmax(keys: GlideString[], timeout: number): T {
         return this.addAndReturn(createBZPopMax(keys, timeout));
     }
 
@@ -2243,7 +2247,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key to return its timeout.
      *
-     * Command Response - TTL in milliseconds. -2 if `key` does not exist, -1 if `key` exists but has no associated expire.
+     * Command Response - TTL in milliseconds, `-2` if `key` does not exist, `-1` if `key` exists but has no associated expire.
      */
     public pttl(key: GlideString): T {
         return this.addAndReturn(createPTTL(key));
@@ -3533,7 +3537,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     If no member could be popped, returns `null`.
      */
     public bzmpop(
-        keys: string[],
+        keys: GlideString[],
         modifier: ScoreFilter,
         timeout: number,
         count?: number,
@@ -3554,7 +3558,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The new score of `member`.
      */
-    public zincrby(key: string, increment: number, member: string): T {
+    public zincrby(
+        key: GlideString,
+        increment: number,
+        member: GlideString,
+    ): T {
         return this.addAndReturn(createZIncrBy(key, increment, member));
     }
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -4974,7 +4974,7 @@ export function runBaseTests(config: {
                 // Intersection results are aggregated by the MAX score of elements
                 const zinterWithScoresResults = await client.zinterWithScores(
                     [key1, key2],
-                    "MAX",
+                    { aggregationType: "MAX" },
                 );
                 const expectedMapMax = {
                     one: 1.5,
@@ -5003,7 +5003,7 @@ export function runBaseTests(config: {
                 // Intersection results are aggregated by the MIN score of elements
                 const zinterWithScoresResults = await client.zinterWithScores(
                     [key1, key2],
-                    "MIN",
+                    { aggregationType: "MIN" },
                 );
                 const expectedMapMin = {
                     one: 1.0,
@@ -5032,7 +5032,7 @@ export function runBaseTests(config: {
                 // Intersection results are aggregated by the SUM score of elements
                 const zinterWithScoresResults = await client.zinterWithScores(
                     [key1, key2],
-                    "SUM",
+                    { aggregationType: "SUM" },
                 );
                 const expectedMapSum = {
                     one: 2.5,
@@ -5064,7 +5064,7 @@ export function runBaseTests(config: {
                         [key1, 3],
                         [key2, 2],
                     ],
-                    "SUM",
+                    { aggregationType: "SUM" },
                 );
                 const expectedMapSum = {
                     one: 6,
@@ -8856,7 +8856,9 @@ export function runBaseTests(config: {
                     await client.bzmpop([key1, key2], ScoreFilter.MAX, 0.1),
                 ).toEqual([key1, { b1: 2 }]);
                 expect(
-                    await client.bzmpop([key2, key1], ScoreFilter.MAX, 0.1, 10),
+                    await client.bzmpop([key2, key1], ScoreFilter.MAX, 0.1, {
+                        count: 10,
+                    }),
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
                 // ensure that command doesn't time out even if timeout > request timeout (250ms by default)
@@ -8868,7 +8870,7 @@ export function runBaseTests(config: {
                         [nonExistingKey],
                         ScoreFilter.MAX,
                         0.55,
-                        1,
+                        { count: 1 },
                     ),
                 ).toBeNull();
 
@@ -8878,22 +8880,24 @@ export function runBaseTests(config: {
                     client.bzmpop([stringKey], ScoreFilter.MAX, 0.1),
                 ).rejects.toThrow(RequestError);
                 await expect(
-                    client.bzmpop([stringKey], ScoreFilter.MAX, 0.1, 1),
+                    client.bzmpop([stringKey], ScoreFilter.MAX, 0.1, {
+                        count: 1,
+                    }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: key list should not be empty
                 await expect(
-                    client.bzmpop([], ScoreFilter.MAX, 0.1, 1),
+                    client.bzmpop([], ScoreFilter.MAX, 0.1, { count: 1 }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: count should be greater than 0
                 await expect(
-                    client.bzmpop([key1], ScoreFilter.MAX, 0.1, 0),
+                    client.bzmpop([key1], ScoreFilter.MAX, 0.1, { count: 0 }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: timeout can not be a negative number
                 await expect(
-                    client.bzmpop([key1], ScoreFilter.MAX, -1, 10),
+                    client.bzmpop([key1], ScoreFilter.MAX, -1, { count: 10 }),
                 ).rejects.toThrow(RequestError);
 
                 // check that order of entries in the response is preserved
@@ -8909,7 +8913,7 @@ export function runBaseTests(config: {
                     [key2],
                     ScoreFilter.MIN,
                     0.1,
-                    10,
+                    { count: 10 },
                 );
 
                 if (result) {


### PR DESCRIPTION
* `BZMPop`
* `BZPopMax`
* `BZPopMin`
* `ZAdd`
* `ZCard`
* `ZCount`
* `ZDiff`
* `ZDiffStore`
* `ZIncrBy`
* `ZInter`
* `ZInterCard`
* `ZInterStore`
