### PR TITLE
Node binary api: blmpop, lrem, lset, ltrim and rpushx  commands updated for binary command inputs

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2325,11 +2325,13 @@ export class BaseClient {
      * ```
      */
     public async lset(
-        key: string,
+        key: GlideString,
         index: number,
-        element: string,
+        element: GlideString,
     ): Promise<"OK"> {
-        return this.createWritePromise(createLSet(key, index, element));
+        return this.createWritePromise(createLSet(key, index, element), {
+            decoder: Decoder.String,
+        });
     }
 
     /** Trim an existing list so that it will contain only the specified range of elements specified.
@@ -2354,8 +2356,14 @@ export class BaseClient {
      * console.log(result); // Output: 'OK' - Indicates that the list has been trimmed to contain elements from 0 to 1.
      * ```
      */
-    public async ltrim(key: string, start: number, end: number): Promise<"OK"> {
-        return this.createWritePromise(createLTrim(key, start, end));
+    public async ltrim(
+        key: GlideString,
+        start: number,
+        end: number,
+    ): Promise<"OK"> {
+        return this.createWritePromise(createLTrim(key, start, end), {
+            decoder: Decoder.String,
+        });
     }
 
     /** Removes the first `count` occurrences of elements equal to `element` from the list stored at `key`.
@@ -2377,9 +2385,9 @@ export class BaseClient {
      * ```
      */
     public async lrem(
-        key: string,
+        key: GlideString,
         count: number,
-        element: string,
+        element: GlideString,
     ): Promise<number> {
         return this.createWritePromise(createLRem(key, count, element));
     }
@@ -2430,7 +2438,10 @@ export class BaseClient {
      * console.log(result);  // Output: 2 - Indicates that the list has two elements.
      * ```
      * */
-    public async rpushx(key: string, elements: string[]): Promise<number> {
+    public async rpushx(
+        key: GlideString,
+        elements: GlideString[],
+    ): Promise<number> {
         return this.createWritePromise(createRPushX(key, elements));
     }
 
@@ -6481,13 +6492,13 @@ export class BaseClient {
      * ```
      */
     public async blmpop(
-        keys: string[],
+        keys: GlideString[],
         direction: ListDirection,
         timeout: number,
         count?: number,
     ): Promise<Record<string, string[]>> {
         return this.createWritePromise(
-            createBLMPop(timeout, keys, direction, count),
+            createBLMPop(keys, direction, timeout, count),
         );
     }
 

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -942,9 +942,9 @@ export function createBLMove(
  * @internal
  */
 export function createLSet(
-    key: string,
+    key: GlideString,
     index: number,
-    element: string,
+    element: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.LSet, [key, index.toString(), element]);
 }
@@ -953,7 +953,7 @@ export function createLSet(
  * @internal
  */
 export function createLTrim(
-    key: string,
+    key: GlideString,
     start: number,
     end: number,
 ): command_request.Command {
@@ -968,9 +968,9 @@ export function createLTrim(
  * @internal
  */
 export function createLRem(
-    key: string,
+    key: GlideString,
     count: number,
-    element: string,
+    element: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.LRem, [key, count.toString(), element]);
 }
@@ -989,8 +989,8 @@ export function createRPush(
  * @internal
  */
 export function createRPushX(
-    key: string,
-    elements: string[],
+    key: GlideString,
+    elements: GlideString[],
 ): command_request.Command {
     return createCommand(RequestType.RPushX, [key].concat(elements));
 }
@@ -3821,12 +3821,12 @@ export function createLMPop(
  * @internal
  */
 export function createBLMPop(
-    timeout: number,
-    keys: string[],
+    keys: GlideString[],
     direction: ListDirection,
+    timeout: number,
     count?: number,
 ): command_request.Command {
-    const args: string[] = [
+    const args: GlideString[] = [
         timeout.toString(),
         keys.length.toString(),
         ...keys,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1190,7 +1190,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - Always "OK".
      */
-    public lset(key: string, index: number, element: string): T {
+    public lset(key: GlideString, index: number, element: GlideString): T {
         return this.addAndReturn(createLSet(key, index, element));
     }
 
@@ -1209,7 +1209,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
      * If `key` does not exist the command will be ignored.
      */
-    public ltrim(key: string, start: number, end: number): T {
+    public ltrim(key: GlideString, start: number, end: number): T {
         return this.addAndReturn(createLTrim(key, start, end));
     }
 
@@ -1225,7 +1225,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - the number of the removed elements.
      * If `key` does not exist, 0 is returned.
      */
-    public lrem(key: string, count: number, element: string): T {
+    public lrem(key: GlideString, count: number, element: string): T {
         return this.addAndReturn(createLRem(key, count, element));
     }
 
@@ -1254,7 +1254,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The length of the list after the push operation.
      */
-    public rpushx(key: string, elements: string[]): T {
+    public rpushx(key: GlideString, elements: GlideString[]): T {
         return this.addAndReturn(createRPushX(key, elements));
     }
 
@@ -3802,12 +3802,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     If no member could be popped and the timeout expired, returns `null`.
      */
     public blmpop(
-        keys: string[],
+        keys: GlideString[],
         direction: ListDirection,
         timeout: number,
         count?: number,
     ): T {
-        return this.addAndReturn(createBLMPop(timeout, keys, direction, count));
+        return this.addAndReturn(createBLMPop(keys, direction, timeout, count));
     }
 
     /**

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2078,7 +2078,6 @@ export function runBaseTests(config: {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
                 const key3 = uuidv4();
-
                 expect(await client.lpush(key1, ["0"])).toEqual(1);
                 expect(await client.lpushx(key1, ["1", "2", "3"])).toEqual(4);
                 expect(await client.lrange(key1, 0, -1)).toEqual([
@@ -2471,6 +2470,17 @@ export function runBaseTests(config: {
                 await expect(client.lset(nonListKey, 0, "b")).rejects.toThrow(
                     RequestError,
                 );
+
+                //test lset for binary key and element values
+                const key2 = uuidv4();
+                expect(await client.lpush(key2, lpushArgs)).toEqual(4);
+                // assert lset result
+                expect(
+                    await client.lset(Buffer.from(key2), index, element),
+                ).toEqual("OK");
+                expect(await client.lrange(key2, 0, negativeIndex)).toEqual(
+                    expectedList,
+                );
             }, protocol);
         },
         config.timeout,
@@ -2502,6 +2512,17 @@ export function runBaseTests(config: {
                         "Operation against a key holding the wrong kind of value",
                     );
                 }
+
+                //test for binary key as input to the command
+                const key2 = uuidv4();
+                expect(await client.lpush(key2, valueList)).toEqual(4);
+                expect(await client.ltrim(Buffer.from(key2), 0, 1)).toEqual(
+                    "OK",
+                );
+                expect(await client.lrange(key2, 0, -1)).toEqual([
+                    "value1",
+                    "value2",
+                ]);
             }, protocol);
         },
         config.timeout,
@@ -2511,7 +2532,7 @@ export function runBaseTests(config: {
         `lrem with existing key and non existing key_%p`,
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
-                const key = uuidv4();
+                const key1 = uuidv4();
                 const valueList = [
                     "value1",
                     "value2",
@@ -2519,23 +2540,39 @@ export function runBaseTests(config: {
                     "value1",
                     "value2",
                 ];
-                expect(await client.lpush(key, valueList)).toEqual(5);
-                expect(await client.lrem(key, 2, "value1")).toEqual(2);
-                expect(await client.lrange(key, 0, -1)).toEqual([
+                expect(await client.lpush(key1, valueList)).toEqual(5);
+                expect(await client.lrem(key1, 2, "value1")).toEqual(2);
+                expect(await client.lrange(key1, 0, -1)).toEqual([
                     "value2",
                     "value2",
                     "value1",
                 ]);
-                expect(await client.lrem(key, -1, "value2")).toEqual(1);
-                expect(await client.lrange(key, 0, -1)).toEqual([
+                expect(await client.lrem(key1, -1, "value2")).toEqual(1);
+                expect(await client.lrange(key1, 0, -1)).toEqual([
                     "value2",
                     "value1",
                 ]);
-                expect(await client.lrem(key, 0, "value2")).toEqual(1);
-                expect(await client.lrange(key, 0, -1)).toEqual(["value1"]);
+                expect(await client.lrem(key1, 0, "value2")).toEqual(1);
+                expect(await client.lrange(key1, 0, -1)).toEqual(["value1"]);
                 expect(await client.lrem("nonExistingKey", 2, "value")).toEqual(
                     0,
                 );
+
+                // test for binary key and element as input to the command
+                const key2 = uuidv4();
+                expect(await client.lpush(key2, valueList)).toEqual(5);
+                expect(
+                    await client.lrem(
+                        Buffer.from(key2),
+                        2,
+                        Buffer.from("value1"),
+                    ),
+                ).toEqual(2);
+                expect(await client.lrange(key2, 0, -1)).toEqual([
+                    "value2",
+                    "value2",
+                    "value1",
+                ]);
             }, protocol);
         },
         config.timeout,
@@ -2633,6 +2670,23 @@ export function runBaseTests(config: {
                 await expect(client.rpushx(key2, [])).rejects.toThrow(
                     RequestError,
                 );
+
+                //test for binary key and elemnts as inputs to the command.
+                const key4 = uuidv4();
+                expect(await client.rpush(key4, ["0"])).toEqual(1);
+                expect(
+                    await client.rpushx(Buffer.from(key4), [
+                        Buffer.from("1"),
+                        Buffer.from("2"),
+                        Buffer.from("3"),
+                    ]),
+                ).toEqual(4);
+                expect(await client.lrange(key4, 0, -1)).toEqual([
+                    "0",
+                    "1",
+                    "2",
+                    "3",
+                ]);
             }, protocol);
         },
         config.timeout,
@@ -10567,6 +10621,44 @@ export function runBaseTests(config: {
                 await expect(
                     client.blmpop([nonListKey], ListDirection.RIGHT, 0.1, 1),
                 ).rejects.toThrow(RequestError);
+
+                // Test with single binary key array as input
+                const key3 = "{key}" + uuidv4();
+                const singleKeyArrayWithKey3 = [Buffer.from(key3)];
+
+                // pushing to the arrays to be popped
+                expect(await client.lpush(key3, lpushArgs)).toEqual(5);
+                const expectedWithKey3 = { [key3]: ["five"] };
+
+                // checking correct result from popping
+                expect(
+                    await client.blmpop(
+                        singleKeyArrayWithKey3,
+                        ListDirection.LEFT,
+                        0.1,
+                    ),
+                ).toEqual(expectedWithKey3);
+
+                // test with multiple binary keys array as input
+                const key4 = "{key}" + uuidv4();
+                const multiKeyArrayWithKey3AndKey4 = [
+                    Buffer.from(key4),
+                    Buffer.from(key3),
+                ];
+
+                // pushing to the arrays to be popped
+                expect(await client.lpush(key4, lpushArgs)).toEqual(5);
+                const expectedWithKey4 = { [key4]: ["one", "two"] };
+
+                // checking correct result from popping
+                expect(
+                    await client.blmpop(
+                        multiKeyArrayWithKey3AndKey4,
+                        ListDirection.RIGHT,
+                        0.1,
+                        2,
+                    ),
+                ).toEqual(expectedWithKey4);
             }, protocol);
         },
         config.timeout,


### PR DESCRIPTION
PR to add node Binary api code changes for the following commands:
1. **blmpop** (https://valkey.io/commands/blmpop/)
2. **lrem** (https://valkey.io/commands/lrem/)
3. **lset** (https://valkey.io/commands/lset/)
4. **ltrim** (https://valkey.io/commands/ltrim/)
5. **rpushx** (https://valkey.io/commands/rpushx/)