### PR TITLE
GO: performance improvement

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,6 @@ jobs:
             fail-fast: false
             matrix:
                 go:
-                    # - '1.18.10'
                     - '1.22.0'
                 engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
                 host:
@@ -130,7 +129,6 @@ jobs:
             fail-fast: false
             matrix:
                 go:
-                    - 1.18.10
                     - 1.22.0
         runs-on: ubuntu-latest
         container: amazonlinux:latest

--- a/go/Makefile
+++ b/go/Makefile
@@ -28,9 +28,24 @@ install-tools: install-tools-go1.22.0
 
 build: build-glide-client generate-protobuf
 	go build ./...
+	cd benchmarks && go build -ldflags="-w" ./...
+
+build-debug: build-glide-client-debug generate-protobuf
+	go build -gcflags "-l -N" ./...
+	cd benchmarks && go build -gcflags "-l -N" ./...
+
+clean:
+	go clean
+	rm -f lib.h
+	rm -f benchmarks/benchmarks
+
 
 build-glide-client:
 	cargo build --release
+	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h
+
+build-glide-client-debug:
+	cargo build
 	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h
 
 generate-protobuf:
@@ -58,7 +73,7 @@ format:
 	golines -w --shorten-comments -m 127 .
 
 test:
-	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.so|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
+	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.so|grep -w release|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
 	go test -v -race ./...
 
 # Note: this task is no longer run by CI because:

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -100,7 +100,6 @@ func (client *baseClient) executeCommand(requestType C.RequestType, args []strin
 	}
 
 	cArgs, argLengths := toCStrings(args)
-	// defer freeCStrings(cArgs)
 
 	resultChannel := make(chan payload)
 	resultChannelPtr := uintptr(unsafe.Pointer(&resultChannel))
@@ -120,14 +119,14 @@ func (client *baseClient) executeCommand(requestType C.RequestType, args []strin
 	return payload.value, nil
 }
 
-// / Convert `s` of type `string` into `[]byte`
+// Convert `s` of type `string` into `[]byte`
 func StringToBytes(s string) []byte {
 	p := unsafe.StringData(s)
 	b := unsafe.Slice(p, len(s))
 	return b
 }
 
-// TODO: Handle passing the arguments as strings without assuming null termination assumption.
+// Zero copying conversion from go's []string into C pointers
 func toCStrings(args []string) ([]C.uintptr_t, []C.ulong) {
 	cStrings := make([]C.uintptr_t, len(args))
 	stringLengths := make([]C.ulong, len(args))
@@ -138,12 +137,6 @@ func toCStrings(args []string) ([]C.uintptr_t, []C.ulong) {
 		stringLengths[i] = C.size_t(len(str))
 	}
 	return cStrings, stringLengths
-}
-
-func freeCStrings(cArgs []*C.char) {
-	for _, arg := range cArgs {
-		C.free(unsafe.Pointer(arg))
-	}
 }
 
 func (client *baseClient) Set(key string, value string) (string, error) {

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -100,7 +100,7 @@ func (client *baseClient) executeCommand(requestType C.RequestType, args []strin
 	}
 
 	cArgs, argLengths := toCStrings(args)
-	defer freeCStrings(cArgs)
+	// defer freeCStrings(cArgs)
 
 	resultChannel := make(chan payload)
 	resultChannelPtr := uintptr(unsafe.Pointer(&resultChannel))
@@ -120,12 +120,21 @@ func (client *baseClient) executeCommand(requestType C.RequestType, args []strin
 	return payload.value, nil
 }
 
+// / Convert `s` of type `string` into `[]byte`
+func StringToBytes(s string) []byte {
+	p := unsafe.StringData(s)
+	b := unsafe.Slice(p, len(s))
+	return b
+}
+
 // TODO: Handle passing the arguments as strings without assuming null termination assumption.
-func toCStrings(args []string) ([]*C.char, []C.ulong) {
-	cStrings := make([]*C.char, len(args))
+func toCStrings(args []string) ([]C.uintptr_t, []C.ulong) {
+	cStrings := make([]C.uintptr_t, len(args))
 	stringLengths := make([]C.ulong, len(args))
 	for i, str := range args {
-		cStrings[i] = C.CString(str)
+		bytes := StringToBytes(str)
+		ptr := uintptr(unsafe.Pointer(&bytes[0]))
+		cStrings[i] = C.uintptr_t(ptr)
 		stringLengths[i] = C.size_t(len(str))
 	}
 	return cStrings, stringLengths

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/valkey-io/valkey-glide/go/glide
 
-go 1.18
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.8.4

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -259,6 +259,12 @@ pub unsafe extern "C" fn free_error_message(error_message: *mut c_char) {
 }
 
 /// Converts a double pointer to a vec.
+///
+/// # Safety
+///
+/// `convert_double_pointer_to_vec` returns a `Vec` of u8 slice which holds pointers of `go`
+/// strings. The returned `Vec<&'a [u8]>` is meant to be copied into Rust code. Storing them
+/// for later use will cause the program to crash as the pointers will be freed by go's gc
 unsafe fn convert_double_pointer_to_vec<'a>(
     data: *const *const c_void,
     len: c_ulong,


### PR DESCRIPTION
- Use the go string internal pointer in Rust code
- Do not copy go string pointers when building Redis command in lib.rs
- Added an option to build the client in debug mode (`make build-debug`)
- Added Makefile target `clean`
- Added Makefile target `build-debug`
- Running `make build` should also build the benchmark app

This PR improves performance of GO client by roughly `~35%`

Go expert: please review :) 