### PR TITLE
Node: Add binary support to scard smove sismember srandmember

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3003,8 +3003,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/srandmember/|valkey.io} for more details.
      *
      * @param key - The key from which to retrieve the set member.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A random element from the set, or null if `key` does not exist.
      *
      * @example
@@ -3023,11 +3022,9 @@ export class BaseClient {
      */
     public async srandmember(
         key: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createSRandMember(key), {
-            decoder: decoder,
-        });
+        return this.createWritePromise(createSRandMember(key), options);
     }
 
     /**
@@ -3039,6 +3036,7 @@ export class BaseClient {
      * @param count - The number of members to return.
      *                If `count` is positive, returns unique members.
      *                If `count` is negative, allows for duplicates members.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns a list of members from the set. If the set does not exist or is empty, an empty list will be returned.
      *
      * @example
@@ -3056,10 +3054,11 @@ export class BaseClient {
      * ```
      */
     public async srandmemberCount(
-        key: string,
+        key: GlideString,
         count: number,
-    ): Promise<string[]> {
-        return this.createWritePromise(createSRandMember(key, count));
+        options?: DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createSRandMember(key, count), options);
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2659,9 +2659,9 @@ export class BaseClient {
      * ```
      */
     public async smove(
-        source: string,
-        destination: string,
-        member: string,
+        source: GlideString,
+        destination: GlideString,
+        member: GlideString,
     ): Promise<boolean> {
         return this.createWritePromise(
             createSMove(source, destination, member),
@@ -2682,7 +2682,7 @@ export class BaseClient {
      * console.log(result); // Output: 3
      * ```
      */
-    public async scard(key: string): Promise<number> {
+    public async scard(key: GlideString): Promise<number> {
         return this.createWritePromise(createSCard(key));
     }
 
@@ -2900,7 +2900,10 @@ export class BaseClient {
      * console.log(result); // Output: false - Indicates that "non_existing_member" does not exist in the set "my_set".
      * ```
      */
-    public async sismember(key: string, member: string): Promise<boolean> {
+    public async sismember(
+        key: GlideString,
+        member: GlideString,
+    ): Promise<boolean> {
         return this.createWritePromise(createSIsMember(key, member));
     }
 
@@ -2922,8 +2925,8 @@ export class BaseClient {
      * ```
      */
     public async smismember(
-        key: string,
-        members: string[],
+        key: GlideString,
+        members: GlideString[],
     ): Promise<boolean[]> {
         return this.createWritePromise(createSMIsMember(key, members));
     }
@@ -3000,6 +3003,8 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/srandmember/|valkey.io} for more details.
      *
      * @param key - The key from which to retrieve the set member.
+     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
+     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
      * @returns A random element from the set, or null if `key` does not exist.
      *
      * @example
@@ -3016,8 +3021,13 @@ export class BaseClient {
      * console.log(result); // Output: null
      * ```
      */
-    public async srandmember(key: string): Promise<string | null> {
-        return this.createWritePromise(createSRandMember(key));
+    public async srandmember(
+        key: GlideString,
+        decoder?: Decoder,
+    ): Promise<GlideString | null> {
+        return this.createWritePromise(createSRandMember(key), {
+            decoder: decoder,
+        });
     }
 
     /**

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1056,9 +1056,9 @@ export function createSMembers(key: GlideString): command_request.Command {
  * @internal
  */
 export function createSMove(
-    source: string,
-    destination: string,
-    member: string,
+    source: GlideString,
+    destination: GlideString,
+    member: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.SMove, [source, destination, member]);
 }
@@ -1066,7 +1066,7 @@ export function createSMove(
 /**
  * @internal
  */
-export function createSCard(key: string): command_request.Command {
+export function createSCard(key: GlideString): command_request.Command {
     return createCommand(RequestType.SCard, [key]);
 }
 
@@ -1142,8 +1142,8 @@ export function createSUnionStore(
  * @internal
  */
 export function createSIsMember(
-    key: string,
-    member: string,
+    key: GlideString,
+    member: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.SIsMember, [key, member]);
 }
@@ -1152,8 +1152,8 @@ export function createSIsMember(
  * @internal
  */
 export function createSMIsMember(
-    key: string,
-    members: string[],
+    key: GlideString,
+    members: GlideString[],
 ): command_request.Command {
     return createCommand(RequestType.SMIsMember, [key].concat(members));
 }
@@ -1174,10 +1174,11 @@ export function createSPop(
  * @internal
  */
 export function createSRandMember(
-    key: string,
+    key: GlideString,
     count?: number,
 ): command_request.Command {
-    const args: string[] = count == undefined ? [key] : [key, count.toString()];
+    const args: GlideString[] =
+        count == undefined ? [key] : [key, count.toString()];
     return createCommand(RequestType.SRandMember, args);
 }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1348,7 +1348,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - `true` on success, or `false` if the `source` set does not exist or the element is not a member of the source set.
      */
-    public smove(source: string, destination: string, member: string): T {
+    public smove(
+        source: GlideString,
+        destination: GlideString,
+        member: GlideString,
+    ): T {
         return this.addAndReturn(createSMove(source, destination, member));
     }
 
@@ -1359,7 +1363,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - the cardinality (number of elements) of the set, or 0 if key does not exist.
      */
-    public scard(key: string): T {
+    public scard(key: GlideString): T {
         return this.addAndReturn(createSCard(key));
     }
 
@@ -1470,7 +1474,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - `true` if the member exists in the set, `false` otherwise.
      * If `key` doesn't exist, it is treated as an empty set and the command returns `false`.
      */
-    public sismember(key: string, member: string): T {
+    public sismember(key: GlideString, member: GlideString): T {
         return this.addAndReturn(createSIsMember(key, member));
     }
 
@@ -1485,7 +1489,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - An `array` of `boolean` values, each indicating if the respective member exists in the set.
      */
-    public smismember(key: string, members: string[]): T {
+    public smismember(key: GlideString, members: GlideString[]): T {
         return this.addAndReturn(createSMIsMember(key, members));
     }
 
@@ -1522,7 +1526,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key from which to retrieve the set member.
      * Command Response - A random element from the set, or null if `key` does not exist.
      */
-    public srandmember(key: string): T {
+    public srandmember(key: GlideString): T {
         return this.addAndReturn(createSRandMember(key));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1540,7 +1540,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *                If `count` is negative, allows for duplicates members.
      * Command Response - A list of members from the set. If the set does not exist or is empty, an empty list will be returned.
      */
-    public srandmemberCount(key: string, count: number): T {
+    public srandmemberCount(key: GlideString, count: number): T {
         return this.addAndReturn(createSRandMember(key, count));
     }
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2725,6 +2725,7 @@ export function runBaseTests(config: {
                 ).toEqual(
                     new Set([Buffer.from("member4"), Buffer.from("member5")]),
                 );
+                expect(await client.scard(Buffer.from(key))).toEqual(2);
             }, protocol);
         },
         config.timeout,
@@ -2791,6 +2792,18 @@ export function runBaseTests(config: {
                 await expect(
                     client.smove(string_key, key1, "_"),
                 ).rejects.toThrow();
+
+                // source, destination and member as binary buffers
+                expect(
+                    await client.smove(
+                        Buffer.from(key1),
+                        Buffer.from(key3),
+                        Buffer.from("3"),
+                    ),
+                ).toEqual(true);
+                expect(await client.smembers(key3)).toEqual(
+                    new Set(["2", "3"]),
+                );
             }, protocol);
         },
         config.timeout,
@@ -3380,6 +3393,12 @@ export function runBaseTests(config: {
                 expect(await client.sadd(key1, ["member1"])).toEqual(1);
                 expect(await client.sismember(key1, "member1")).toEqual(true);
                 expect(
+                    await client.sismember(
+                        Buffer.from(key1),
+                        Buffer.from("member1"),
+                    ),
+                ).toEqual(true);
+                expect(
                     await client.sismember(key1, "nonExistingMember"),
                 ).toEqual(false);
                 expect(
@@ -3412,6 +3431,13 @@ export function runBaseTests(config: {
                     true,
                     false,
                 ]);
+
+                expect(
+                    await client.smismember(Buffer.from(key), [
+                        Buffer.from("b"),
+                        Buffer.from("c"),
+                    ]),
+                ).toEqual([true, false]);
 
                 expect(await client.smismember(nonExistingKey, ["b"])).toEqual([
                     false,
@@ -3486,6 +3512,11 @@ export function runBaseTests(config: {
 
                 const result2 = await client.srandmember(key);
                 expect(members).toContain(result2);
+                const result3 = await client.srandmember(
+                    Buffer.from(key),
+                    Decoder.Bytes,
+                );
+                expect(members).toContain(result3?.toString());
                 expect(await client.srandmember("nonExistingKey")).toEqual(
                     null,
                 );


### PR DESCRIPTION
Binary support added to commands - 
`SCARD`
`SMOVE`
`SISMEMBER`
`SMISMEMBER`
`SRANDMEMBER`
`SRANDMEMBERCOUNT`