### PR TITLE
Node: add binary support for PubSub commands, part 1

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -6513,7 +6513,9 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/pubsub-channels/|valkey.io} for more details.
      *
      * @param pattern - A glob-style pattern to match active channels.
-     *                  If not provided, all active channels are returned.
+     *     If not provided, all active channels are returned.
+     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
+     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
      * @returns A list of currently active channels matching the given pattern.
      *          If no pattern is specified, all active channels are returned.
      *
@@ -6526,8 +6528,13 @@ export class BaseClient {
      * console.log(newsChannels); // Output: ["news.sports", "news.weather"]
      * ```
      */
-    public async pubsubChannels(pattern?: string): Promise<string[]> {
-        return this.createWritePromise(createPubSubChannels(pattern));
+    public async pubsubChannels(
+        pattern?: GlideString,
+        decoder?: Decoder,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createPubSubChannels(pattern), {
+            decoder,
+        });
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -6512,10 +6512,10 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/pubsub-channels/|valkey.io} for more details.
      *
-     * @param pattern - A glob-style pattern to match active channels.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `pattern`: A glob-style pattern to match active channels.
      *     If not provided, all active channels are returned.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A list of currently active channels matching the given pattern.
      *          If no pattern is specified, all active channels are returned.
      *
@@ -6529,11 +6529,10 @@ export class BaseClient {
      * ```
      */
     public async pubsubChannels(
-        pattern?: GlideString,
-        decoder?: Decoder,
+        options?: { pattern?: GlideString } & DecoderOption,
     ): Promise<GlideString[]> {
-        return this.createWritePromise(createPubSubChannels(pattern), {
-            decoder,
+        return this.createWritePromise(createPubSubChannels(options?.pattern), {
+            decoder: options?.decoder,
         });
     }
 

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2205,8 +2205,8 @@ export function createTime(): command_request.Command {
  * @internal
  */
 export function createPublish(
-    message: string,
-    channel: string,
+    message: GlideString,
+    channel: GlideString,
     sharded: boolean = false,
 ): command_request.Command {
     const request = sharded ? RequestType.SPublish : RequestType.Publish;
@@ -3845,7 +3845,7 @@ export function createBLMPop(
  * @internal
  */
 export function createPubSubChannels(
-    pattern?: string,
+    pattern?: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.PubSubChannels, pattern ? [pattern] : []);
 }
@@ -3870,7 +3870,7 @@ export function createPubSubNumSub(
  * @internal
  */
 export function createPubsubShardChannels(
-    pattern?: string,
+    pattern?: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.PubSubSChannels, pattern ? [pattern] : []);
 }

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -834,7 +834,10 @@ export class GlideClient extends BaseClient {
      * console.log(result); // Output: 1 - This message was posted to 1 subscription which is configured on primary node
      * ```
      */
-    public async publish(message: string, channel: string): Promise<number> {
+    public async publish(
+        message: GlideString,
+        channel: GlideString,
+    ): Promise<number> {
         return this.createWritePromise(createPublish(message, channel));
     }
 

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -1250,9 +1250,7 @@ export class GlideClusterClient extends BaseClient {
     ): Promise<GlideString[]> {
         return this.createWritePromise(
             createPubsubShardChannels(options?.pattern),
-            {
-                decoder: options?.decoder,
-            },
+            { decoder: options?.decoder },
         );
     }
 

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -1212,8 +1212,8 @@ export class GlideClusterClient extends BaseClient {
      * ```
      */
     public async publish(
-        message: string,
-        channel: string,
+        message: GlideString,
+        channel: GlideString,
         sharded: boolean = false,
     ): Promise<number> {
         return this.createWritePromise(
@@ -1228,7 +1228,9 @@ export class GlideClusterClient extends BaseClient {
      * @see {@link https://valkey.io/commands/pubsub-shardchannels/|valkey.io} for details.
      *
      * @param pattern - A glob-style pattern to match active shard channels.
-     *                  If not provided, all active shard channels are returned.
+     *     If not provided, all active shard channels are returned.
+     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
+     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
      * @returns A list of currently active shard channels matching the given pattern.
      *          If no pattern is specified, all active shard channels are returned.
      *
@@ -1241,8 +1243,13 @@ export class GlideClusterClient extends BaseClient {
      * console.log(filteredChannels); // Output: ["channel1", "channel2"]
      * ```
      */
-    public async pubsubShardChannels(pattern?: string): Promise<string[]> {
-        return this.createWritePromise(createPubsubShardChannels(pattern));
+    public async pubsubShardChannels(
+        pattern?: GlideString,
+        decoder?: Decoder,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createPubsubShardChannels(pattern), {
+            decoder,
+        });
     }
 
     /**

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -1227,10 +1227,10 @@ export class GlideClusterClient extends BaseClient {
      *
      * @see {@link https://valkey.io/commands/pubsub-shardchannels/|valkey.io} for details.
      *
-     * @param pattern - A glob-style pattern to match active shard channels.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `pattern`: A glob-style pattern to match active shard channels.
      *     If not provided, all active shard channels are returned.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A list of currently active shard channels matching the given pattern.
      *          If no pattern is specified, all active shard channels are returned.
      *
@@ -1244,12 +1244,16 @@ export class GlideClusterClient extends BaseClient {
      * ```
      */
     public async pubsubShardChannels(
-        pattern?: GlideString,
-        decoder?: Decoder,
+        options?: {
+            pattern?: GlideString;
+        } & DecoderOption,
     ): Promise<GlideString[]> {
-        return this.createWritePromise(createPubsubShardChannels(pattern), {
-            decoder,
-        });
+        return this.createWritePromise(
+            createPubsubShardChannels(options?.pattern),
+            {
+                decoder: options?.decoder,
+            },
+        );
     }
 
     /**

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -3821,7 +3821,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A list of currently active channels matching the given pattern.
      *          If no pattern is specified, all active channels are returned.
      */
-    public pubsubChannels(pattern?: string): T {
+    public pubsubChannels(pattern?: GlideString): T {
         return this.addAndReturn(createPubSubChannels(pattern));
     }
 
@@ -4007,7 +4007,7 @@ export class Transaction extends BaseTransaction<Transaction> {
      * Command Response -  Number of subscriptions in primary node that received the message.
      * Note that this value does not include subscriptions that configured on replicas.
      */
-    public publish(message: string, channel: string): Transaction {
+    public publish(message: GlideString, channel: GlideString): Transaction {
         return this.addAndReturn(createPublish(message, channel));
     }
 }
@@ -4134,8 +4134,8 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Command Response -  Number of subscriptions in primary node that received the message.
      */
     public publish(
-        message: string,
-        channel: string,
+        message: GlideString,
+        channel: GlideString,
         sharded: boolean = false,
     ): ClusterTransaction {
         return this.addAndReturn(createPublish(message, channel, sharded));
@@ -4152,7 +4152,7 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * Command Response - A list of currently active shard channels matching the given pattern.
      *          If no pattern is specified, all active shard channels are returned.
      */
-    public pubsubShardChannels(pattern?: string): ClusterTransaction {
+    public pubsubShardChannels(pattern?: GlideString): ClusterTransaction {
         return this.addAndReturn(createPubsubShardChannels(pattern));
     }
 

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -3353,7 +3353,7 @@ describe("PubSub", () => {
 
                 // Test pubsubChannels with pattern
                 const channelsWithPattern = await client2.pubsubChannels({
-                    pattern: pattern,
+                    pattern,
                 });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
@@ -3697,7 +3697,7 @@ describe("PubSub", () => {
                 // Test pubsubShardchannels with pattern
                 const channelsWithPattern = await (
                     client2 as GlideClusterClient
-                ).pubsubShardChannels({ pattern: pattern });
+                ).pubsubShardChannels({ pattern });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
                 );

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -3353,14 +3353,14 @@ describe("PubSub", () => {
 
                 // Test pubsubChannels with pattern
                 const channelsWithPattern =
-                    await client2.pubsubChannels(pattern);
+                    await client2.pubsubChannels({ pattern: pattern });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
                 );
 
                 // Test with non-matching pattern
                 const nonMatchingChannels =
-                    await client2.pubsubChannels("non_matching_*");
+                    await client2.pubsubChannels({ pattern: "non_matching_*" });
                 expect(nonMatchingChannels.length).toBe(0);
             } finally {
                 if (client1) {
@@ -3695,7 +3695,7 @@ describe("PubSub", () => {
                 // Test pubsubShardchannels with pattern
                 const channelsWithPattern = await (
                     client2 as GlideClusterClient
-                ).pubsubShardChannels(pattern);
+                ).pubsubShardChannels({ pattern: pattern });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
                 );
@@ -3703,7 +3703,7 @@ describe("PubSub", () => {
                 // Test with non-matching pattern
                 const nonMatchingChannels = await (
                     client2 as GlideClusterClient
-                ).pubsubShardChannels("non_matching_*");
+                ).pubsubShardChannels({ pattern: "non_matching_*" });
                 expect(nonMatchingChannels).toEqual([]);
             } finally {
                 if (client1) {

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -3352,15 +3352,17 @@ describe("PubSub", () => {
                 );
 
                 // Test pubsubChannels with pattern
-                const channelsWithPattern =
-                    await client2.pubsubChannels({ pattern: pattern });
+                const channelsWithPattern = await client2.pubsubChannels({
+                    pattern: pattern,
+                });
                 expect(new Set(channelsWithPattern)).toEqual(
                     new Set([channel1, channel2]),
                 );
 
                 // Test with non-matching pattern
-                const nonMatchingChannels =
-                    await client2.pubsubChannels({ pattern: "non_matching_*" });
+                const nonMatchingChannels = await client2.pubsubChannels({
+                    pattern: "non_matching_*",
+                });
                 expect(nonMatchingChannels.length).toBe(0);
             } finally {
                 if (client1) {

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -2970,7 +2970,7 @@ describe("PubSub", () => {
 
                     expect(
                         await (publishingClient as GlideClusterClient).publish(
-                            message,
+                            Buffer.from(message),
                             channel,
                             true,
                         ),
@@ -2979,7 +2979,7 @@ describe("PubSub", () => {
                     expect(
                         await (publishingClient as GlideClusterClient).publish(
                             message2,
-                            channel,
+                            Buffer.from(channel),
                             true,
                         ),
                     ).toEqual(1);


### PR DESCRIPTION
PubSub (part 1):
`Publish`
`SPublish`
`PUBSUB CHANNELS`
`PUBSUB SHARDCHANNELS`
`PUBSUB NUMPAT` - No change required

For the remaining PubSub commands,`Record< >` are used. They will be handled in the next PR.