### PR TITLE
Node: Add binary variant to sorted set commands - part 2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### Changes
-* Node: Added binary variant to sorted set commands ([#2190](https://github.com/valkey-io/valkey-glide/pull/2190) and [#2210](https://github.com/valkey-io/valkey-glide/pull/2210))
+* Node: Added binary variant to sorted set commands ([#2190](https://github.com/valkey-io/valkey-glide/pull/2190), [#2210](https://github.com/valkey-io/valkey-glide/pull/2210))
 * Node: Added binary variant to HASH commands ([#2194](https://github.com/valkey-io/valkey-glide/pull/2194))
 * Node: Added binary variant to server management commands ([#2179](https://github.com/valkey-io/valkey-glide/pull/2179))
 * Node: Added/updated binary variant to connection management commands and WATCH/UNWATCH ([#2160](https://github.com/valkey-io/valkey-glide/pull/2160))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3992,7 +3992,7 @@ export class BaseClient {
     public async zrange(
         key: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
-        options?: { reverse: boolean } & DecoderOption,
+        options?: { reverse?: boolean } & DecoderOption,
     ): Promise<GlideString[]> {
         return this.createWritePromise(
             createZRange(key, rangeQuery, options?.reverse),
@@ -4043,7 +4043,7 @@ export class BaseClient {
     public async zrangeWithScores(
         key: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
-        options?: { reverse: boolean } & DecoderOption,
+        options?: { reverse?: boolean } & DecoderOption,
     ): Promise<Record<string, number>> {
         return this.createWritePromise(
             createZRangeWithScores(key, rangeQuery, options?.reverse),

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -298,7 +298,7 @@ export type DecoderOption = {
 };
 
 /**
- * Data type which represents how data are returned from sorted sets or insterted there.
+ * Data type which represents sorted sets data, including elements and their respective scores.
  * Similar to `Record<GlideString, number>` - see {@link GlideRecord}.
  */
 export type SortedSetDataType = {
@@ -3816,7 +3816,7 @@ export class BaseClient {
      * @param aggregationType - Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      * @returns The number of elements in the resulting sorted set stored at `destination`.
      *
-     * * @example
+     * @example
      * ```typescript
      * await client.zadd("key1", {"member1": 10.5, "member2": 8.2})
      * await client.zadd("key2", {"member1": 9.5})
@@ -6378,7 +6378,7 @@ export class BaseClient {
      * // Assume "key1" contains a sorted set with multiple members
      * let cursor = "0";
      * do {
-     *      let result = await client.zscan(key1, cursor, {
+     *      const result = await client.zscan(key1, cursor, {
      *          match: "*",
      *          count: 5,
      *      });

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -55,6 +55,7 @@ import {
     StreamTrimOptions,
     TimeUnit,
     ZAddOptions,
+    convertElementsAndScores,
     createAppend,
     createBLMPop,
     createBLMove,
@@ -3540,7 +3541,11 @@ export class BaseClient {
         options?: ZAddOptions,
     ): Promise<number> {
         return this.createWritePromise(
-            createZAdd(key, membersAndScores, options),
+            createZAdd(
+                key,
+                convertElementsAndScores(membersAndScores),
+                options,
+            ),
         );
     }
 
@@ -3826,13 +3831,19 @@ export class BaseClient {
      * // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements.
      * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1}))
      * // Output: {'member1': 20, 'member2': 8.2} - "member1" is now stored in "my_sorted_set" with score of 20 and "member2" with score of 8.2.
+     * ```
      *
+     * @example
+     * ```typescript
      * // use `zunionstore` with default weights
      * console.log(await client.zunionstore("my_sorted_set", ["key1", "key2"], AggregationType.MAX))
      * // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements, and each score is the maximum score between the sets.
      * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1}))
      * // Output: {'member1': 10.5, 'member2': 8.2} - "member1" is now stored in "my_sorted_set" with score of 10.5 and "member2" with score of 8.2.
+     * ```
      *
+     * @example
+     * ```typescript
      * // use `zunionstore` with default aggregation
      * console.log(await client.zunionstore("my_sorted_set", [["key1", 2], ["key2", 1]])) // Output: 2
      * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1})) // Output: { member2: 16.4, member1: 30.5 }
@@ -3941,7 +3952,7 @@ export class BaseClient {
      *              type: "byScore",
      *           }, { reverse: true });
      * console.log(result); // Output: members with scores within the range of negative infinity to 3, in descending order
-     * // ['member3', 'member2']
+     * // ['member2', 'member1']
      * ```
      */
     public async zrange(

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1411,7 +1411,7 @@ export function createZAdd(
 
     if (!Array.isArray(membersAndScores)) {
         // convert Record<string, number> to SortedSetDataType
-        membersAndScores = Object.entries(membersAndScores).map((p) => {
+        membersAndScores = Object.entries(membersAndScores).map((element) => {
             return { element: p[0], score: p[1] };
         });
     }

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1386,7 +1386,7 @@ export function convertElementsAndScores(
 ): SortedSetDataType {
     if (!Array.isArray(membersAndScores)) {
         // convert Record<string, number> to SortedSetDataType
-        membersAndScores = Object.entries(membersAndScores).map((element) => {
+        return Object.entries(membersAndScores).map((element) => {
             return { element: element[0], score: element[1] };
         });
     }

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1372,10 +1372,27 @@ export type ZAddOptions = {
 
 /**
  * @internal
+ * Convert input from `Record` to `SortedSetDataType` to ensure the only one type.
+ */
+export function convertElementsAndScores(
+    membersAndScores: SortedSetDataType | Record<string, number>,
+): SortedSetDataType {
+    if (!Array.isArray(membersAndScores)) {
+        // convert Record<string, number> to SortedSetDataType
+        membersAndScores = Object.entries(membersAndScores).map((element) => {
+            return { element: element[0], score: element[1] };
+        });
+    }
+
+    return membersAndScores;
+}
+
+/**
+ * @internal
  */
 export function createZAdd(
     key: GlideString,
-    membersAndScores: SortedSetDataType | Record<string, number>,
+    membersAndScores: SortedSetDataType,
     options?: ZAddOptions,
     incr: boolean = false,
 ): command_request.Command {
@@ -1407,13 +1424,6 @@ export function createZAdd(
 
     if (incr) {
         args.push("INCR");
-    }
-
-    if (!Array.isArray(membersAndScores)) {
-        // convert Record<string, number> to SortedSetDataType
-        membersAndScores = Object.entries(membersAndScores).map((element) => {
-            return { element: p[0], score: p[1] };
-        });
     }
 
     membersAndScores.forEach((p) => args.push(p.score.toString(), p.element));

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -5,8 +5,12 @@
 import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "glide-rs";
 import Long from "long";
 
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-import { BaseClient, GlideRecord, HashDataType, SortedSetDataType } from "src/BaseClient";
+import {
+    BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars
+    GlideRecord,
+    HashDataType,
+    SortedSetDataType,
+} from "src/BaseClient";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 import { GlideClient } from "src/GlideClient";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1375,7 +1375,7 @@ export type ZAddOptions = {
  */
 export function createZAdd(
     key: GlideString,
-    membersAndScores: SortedSetDataType,
+    membersAndScores: SortedSetDataType | Record<string, number>,
     options?: ZAddOptions,
     incr: boolean = false,
 ): command_request.Command {
@@ -1407,6 +1407,13 @@ export function createZAdd(
 
     if (incr) {
         args.push("INCR");
+    }
+
+    if (!Array.isArray(membersAndScores)) {
+        // convert Record<string, number> to SortedSetDataType
+        membersAndScores = Object.entries(membersAndScores).map((p) => {
+            return { element: p[0], score: p[1] };
+        });
     }
 
     membersAndScores.forEach((p) => args.push(p.score.toString(), p.element));

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -1322,7 +1322,7 @@ export class GlideClusterClient extends BaseClient {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
-     * @param options - (Optional) {@link SortClusterOptions} and {@link DecoderOption}.
+     * @param options - (Optional) See {@link SortClusterOptions} and {@link DecoderOption}.
      * @returns An `Array` of sorted elements
      *
      * @example
@@ -1355,7 +1355,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
-     * @param options - (Optional) {@link SortClusterOptions}.
+     * @param options - (Optional) See {@link SortClusterOptions}.
      * @returns The number of elements in the sorted key stored at `destination`.
      *
      * @example

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -5,7 +5,8 @@
 import {
     BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars
     GlideString,
-    ReadFrom, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ReadFrom,
+    SortedSetDataType, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from "./BaseClient";
 
 import {
@@ -1713,51 +1714,67 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createTTL(key));
     }
 
-    /** Adds members with their scores to the sorted set stored at `key`.
+    /**
+     * Adds members with their scores to the sorted set stored at `key`.
      * If a member is already a part of the sorted set, its score is updated.
+     *
      * @see {@link https://valkey.io/commands/zadd/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
-     * @param membersScoresMap - A mapping of members to their corresponding scores.
-     * @param options - The ZAdd options.
+     * @param membersAndScores - A list of members and their corresponding scores or a mapping of members to their corresponding scores.
+     * @param options - (Optional) The `ZADD` options - see {@link ZAddOptions}.
      *
      * Command Response - The number of elements added to the sorted set.
-     * If `changed` is set, returns the number of elements updated in the sorted set.
+     * If {@link ZAddOptions.changed} is set to `true`, returns the number of elements updated in the sorted set.
      */
     public zadd(
-        key: string,
-        membersScoresMap: Record<string, number>,
+        key: GlideString,
+        membersScoresMap: SortedSetDataType | Record<string, number>,
         options?: ZAddOptions,
     ): T {
+        if (!Array.isArray(membersScoresMap)) {
+            membersScoresMap = Object.entries(membersScoresMap).map((p) => {
+                return { element: p[0], score: p[1] };
+            });
+        }
         return this.addAndReturn(createZAdd(key, membersScoresMap, options));
     }
 
-    /** Increments the score of member in the sorted set stored at `key` by `increment`.
+    /**
+     * Increments the score of member in the sorted set stored at `key` by `increment`.
      * If `member` does not exist in the sorted set, it is added with `increment` as its score (as if its previous score was 0.0).
      * If `key` does not exist, a new sorted set with the specified member as its sole member is created.
+     *
      * @see {@link https://valkey.io/commands/zadd/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
      * @param member - A member in the sorted set to increment.
      * @param increment - The score to increment the member.
-     * @param options - The ZAdd options.
+     * @param options - (Optional) The `ZADD` options - see {@link ZAddOptions}.
      *
      * Command Response - The score of the member.
-     * If there was a conflict with the options, the operation aborts and null is returned.
+     * If there was a conflict with the options, the operation aborts and `null` is returned.
      */
     public zaddIncr(
-        key: string,
-        member: string,
+        key: GlideString,
+        member: GlideString,
         increment: number,
         options?: ZAddOptions,
     ): T {
         return this.addAndReturn(
-            createZAdd(key, { [member]: increment }, options, true),
+            createZAdd(
+                key,
+                [{ element: member, score: increment }],
+                options,
+                true,
+            ),
         );
     }
 
-    /** Removes the specified members from the sorted set stored at `key`.
+    /**
+     * Removes the specified members from the sorted set stored at `key`.
      * Specified members that are not a member of this set are ignored.
+     *
      * @see {@link https://valkey.io/commands/zrem/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
@@ -1766,7 +1783,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The number of members that were removed from the sorted set, not including non-existing members.
      * If `key` does not exist, it is treated as an empty sorted set, and this command returns 0.
      */
-    public zrem(key: string, members: string[]): T {
+    public zrem(key: GlideString, members: GlideString[]): T {
         return this.addAndReturn(createZRem(key, members));
     }
 
@@ -1847,7 +1864,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createZDiffStore(destination, keys));
     }
 
-    /** Returns the score of `member` in the sorted set stored at `key`.
+    /**
+     * Returns the score of `member` in the sorted set stored at `key`.
+     *
      * @see {@link https://valkey.io/commands/zscore/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
@@ -1857,7 +1876,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `member` does not exist in the sorted set, null is returned.
      * If `key` does not exist, null is returned.
      */
-    public zscore(key: string, member: string): T {
+    public zscore(key: GlideString, member: GlideString): T {
         return this.addAndReturn(createZScore(key, member));
     }
 
@@ -1869,15 +1888,15 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @see {@link https://valkey.io/commands/zunionstore/|valkey.io} for details.
      * @param destination - The key of the destination sorted set.
      * @param keys - The keys of the sorted sets with possible formats:
-     *        string[] - for keys only.
-     *        KeyWeight[] - for weighted keys with score multipliers.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with their score multipliers.
      * @param aggregationType - Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      *
      * Command Response - The number of elements in the resulting sorted set stored at `destination`.
      */
     public zunionstore(
-        destination: string,
-        keys: string[] | KeyWeight[],
+        destination: GlideString,
+        keys: GlideString[] | KeyWeight[],
         aggregationType?: AggregationType,
     ): T {
         return this.addAndReturn(
@@ -1897,7 +1916,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` of scores corresponding to `members`.
      * If a member does not exist in the sorted set, the corresponding value in the list will be `null`.
      */
-    public zmscore(key: string, members: string[]): T {
+    public zmscore(key: GlideString, members: GlideString[]): T {
         return this.addAndReturn(createZMScore(key, members));
     }
 
@@ -1920,11 +1939,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createZCount(key, minScore, maxScore));
     }
 
-    /** Returns the specified range of elements in the sorted set stored at `key`.
-     * ZRANGE can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
+    /**
+     * Returns the specified range of elements in the sorted set stored at `key`.
+     * `ZRANGE` can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
+     *
+     * To get the elements with their scores, see {@link zrangeWithScores}.
      *
      * @see {@link https://valkey.io/commands/zrange/|valkey.io} for details.
-     * To get the elements with their scores, see `zrangeWithScores`.
      *
      * @param key - The key of the sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
@@ -1937,15 +1958,17 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns an empty array.
      */
     public zrange(
-        key: string,
+        key: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
         reverse: boolean = false,
     ): T {
         return this.addAndReturn(createZRange(key, rangeQuery, reverse));
     }
 
-    /** Returns the specified range of elements with their scores in the sorted set stored at `key`.
-     * Similar to ZRANGE but with a WITHSCORE flag.
+    /**
+     * Returns the specified range of elements with their scores in the sorted set stored at `key`.
+     * Similar to {@link ZRange} but with a `WITHSCORE` flag.
+     *
      * @see {@link https://valkey.io/commands/zrange/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
@@ -1959,7 +1982,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns an empty map.
      */
     public zrangeWithScores(
-        key: string,
+        key: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
         reverse: boolean = false,
     ): T {
@@ -1987,8 +2010,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The number of elements in the resulting sorted set.
      */
     public zrangeStore(
-        destination: string,
-        source: string,
+        destination: GlideString,
+        source: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
         reverse: boolean = false,
     ): T {
@@ -2069,9 +2092,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /**
      * Computes the union of sorted sets given by the specified `keys` and returns a list of union elements.
-     * To get the scores as well, see {@link zunionWithScores}.
      *
-     * To store the result in a key as a sorted set, see {@link zunionStore}.
+     * To get the scores as well, see {@link zunionWithScores}.
+     * To store the result in a key as a sorted set, see {@link zunionstore}.
      *
      * @remarks Since Valkey version 6.2.0.
      *
@@ -2079,9 +2102,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param keys - The keys of the sorted sets.
      *
-     * Command Response - The resulting array of union elements.
+     * Command Response - The resulting array with a union of sorted set elements.
      */
-    public zunion(keys: string[]): T {
+    public zunion(keys: GlideString[]): T {
         return this.addAndReturn(createZUnion(keys));
     }
 
@@ -2094,15 +2117,15 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets with possible formats:
-     *  - string[] - for keys only.
-     *  - KeyWeight[] - for weighted keys with score multipliers.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with their score multipliers.
      * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - The resulting sorted set with scores.
      */
     public zunionWithScores(
-        keys: string[] | KeyWeight[],
+        keys: GlideString[] | KeyWeight[],
         aggregationType?: AggregationType,
     ): T {
         return this.addAndReturn(createZUnion(keys, aggregationType, true));
@@ -2114,10 +2137,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for details.
      *
      * @param keys - The key of the sorted set.
+     *
      * Command Response - A string representing a random member from the sorted set.
      *     If the sorted set does not exist or is empty, the response will be `null`.
      */
-    public zrandmember(key: string): T {
+    public zrandmember(key: GlideString): T {
         return this.addAndReturn(createZRandMember(key));
     }
 
@@ -2130,10 +2154,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param count - The number of members to return.
      *     If `count` is positive, returns unique members.
      *     If negative, allows for duplicates.
+     *
      * Command Response - An `array` of members from the sorted set.
      *     If the sorted set does not exist or is empty, the response will be an empty `array`.
      */
-    public zrandmemberWithCount(key: string, count: number): T {
+    public zrandmemberWithCount(key: GlideString, count: number): T {
         return this.addAndReturn(createZRandMember(key, count));
     }
 
@@ -2146,11 +2171,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param count - The number of members to return.
      *     If `count` is positive, returns unique members.
      *     If negative, allows for duplicates.
-     * Command Response - A 2D `array` of `[member, score]` `arrays`, where
-     *     member is a `string` and score is a `number`.
+     *
+     * Command Response - A list of {@link KeyWeight} tuples, which store member names and their respective scores.
      *     If the sorted set does not exist or is empty, the response will be an empty `array`.
      */
-    public zrandmemberWithCountWithScores(key: string, count: number): T {
+    public zrandmemberWithCountWithScores(key: GlideString, count: number): T {
         return this.addAndReturn(createZRandMember(key, count, true));
     }
 
@@ -2167,21 +2192,25 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createType(key));
     }
 
-    /** Returns the length of the string value stored at `key`.
+    /**
+     * Returns the length of the string value stored at `key`.
+     *
      * @see {@link https://valkey.io/commands/strlen/|valkey.io} for details.
      *
      * @param key - The `key` to check its length.
      *
      * Command Response - The length of the string value stored at `key`
-     * If `key` does not exist, it is treated as an empty string, and the command returns 0.
+     * If `key` does not exist, it is treated as an empty string, and the command returns `0`.
      */
     public strlen(key: GlideString): T {
         return this.addAndReturn(createStrlen(key));
     }
 
-    /** Removes and returns the members with the lowest scores from the sorted set stored at `key`.
+    /**
+     * Removes and returns the members with the lowest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the lowest scores are removed and returned.
      * Otherwise, only one member with the lowest score is removed and returned.
+     *
      * @see {@link https://valkey.io/commands/zpopmin/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
@@ -2191,7 +2220,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` doesn't exist, it will be treated as an empty sorted set and the command returns an empty map.
      * If `count` is higher than the sorted set's cardinality, returns all members and their scores.
      */
-    public zpopmin(key: string, count?: number): T {
+    public zpopmin(key: GlideString, count?: number): T {
         return this.addAndReturn(createZPopMin(key, count));
     }
 
@@ -2214,9 +2243,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createBZPopMin(keys, timeout));
     }
 
-    /** Removes and returns the members with the highest scores from the sorted set stored at `key`.
+    /**
+     * Removes and returns the members with the highest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the highest scores are removed and returned.
      * Otherwise, only one member with the highest score is removed and returned.
+     *
      * @see {@link https://valkey.io/commands/zpopmax/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
@@ -2226,7 +2257,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` doesn't exist, it will be treated as an empty sorted set and the command returns an empty map.
      * If `count` is higher than the sorted set's cardinality, returns all members and their scores, ordered from highest to lowest.
      */
-    public zpopmax(key: string, count?: number): T {
+    public zpopmax(key: GlideString, count?: number): T {
         return this.addAndReturn(createZPopMax(key, count));
     }
 
@@ -2275,9 +2306,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         return this.addAndReturn(createPTTL(key));
     }
 
-    /** Removes all elements in the sorted set stored at `key` with rank between `start` and `end`.
+    /**
+     * Removes all elements in the sorted set stored at `key` with rank between `start` and `end`.
      * Both `start` and `end` are zero-based indexes with 0 being the element with the lowest score.
      * These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score.
+     *
      * @see {@link https://valkey.io/commands/zremrangebyrank/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
@@ -2289,7 +2322,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `end` exceeds the actual end of the sorted set, the range will stop at the actual end of the sorted set.
      * If `key` does not exist 0 will be returned.
      */
-    public zremRangeByRank(key: string, start: number, end: number): T {
+    public zremRangeByRank(key: GlideString, start: number, end: number): T {
         return this.addAndReturn(createZRemRangeByRank(key, start, end));
     }
 
@@ -2299,34 +2332,36 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @see {@link https://valkey.io/commands/zremrangebylex/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
-     * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
-     * @param maxLex - The maximum lex to count up to. Can be positive/negative infinity, or a specific lex and inclusivity.
+     * @param minLex - The minimum lex to count from. Can be negative infinity, or a specific lex and inclusivity.
+     * @param maxLex - The maximum lex to count up to. Can be positive infinity, or a specific lex and inclusivity.
      *
      * Command Response - The number of members removed.
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns 0.
      * If `minLex` is greater than `maxLex`, 0 is returned.
      */
     public zremRangeByLex(
-        key: string,
-        minLex: Boundary<string>,
-        maxLex: Boundary<string>,
+        key: GlideString,
+        minLex: Boundary<GlideString>,
+        maxLex: Boundary<GlideString>,
     ): T {
         return this.addAndReturn(createZRemRangeByLex(key, minLex, maxLex));
     }
 
-    /** Removes all elements in the sorted set stored at `key` with a score between `minScore` and `maxScore`.
+    /**
+     * Removes all elements in the sorted set stored at `key` with a score between `minScore` and `maxScore`.
+     *
      * @see {@link https://valkey.io/commands/zremrangebyscore/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
-     * @param minScore - The minimum score to remove from. Can be positive/negative infinity, or specific score and inclusivity.
-     * @param maxScore - The maximum score to remove to. Can be positive/negative infinity, or specific score and inclusivity.
+     * @param minScore - The minimum score to remove from. Can be negative infinity, or specific score and inclusivity.
+     * @param maxScore - The maximum score to remove to. Can be positive infinity, or specific score and inclusivity.
      *
      * Command Response - the number of members removed.
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns 0.
      * If `minScore` is greater than `maxScore`, 0 is returned.
      */
     public zremRangeByScore(
-        key: string,
+        key: GlideString,
         minScore: Boundary<number>,
         maxScore: Boundary<number>,
     ): T {
@@ -2341,24 +2376,26 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @see {@link https://valkey.io/commands/zlexcount/|valkey.io} for details.
      *
      * @param key - The key of the sorted set.
-     * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
-     * @param maxLex - The maximum lex to count up to. Can be positive/negative infinity, or a specific lex and inclusivity.
+     * @param minLex - The minimum lex to count from. Can be negative infinity, or a specific lex and inclusivity.
+     * @param maxLex - The maximum lex to count up to. Can be positive infinity, or a specific lex and inclusivity.
      *
      * Command Response - The number of members in the specified lex range.
      * If 'key' does not exist, it is treated as an empty sorted set, and the command returns '0'.
      * If maxLex is less than minLex, '0' is returned.
      */
     public zlexcount(
-        key: string,
-        minLex: Boundary<string>,
-        maxLex: Boundary<string>,
+        key: GlideString,
+        minLex: Boundary<GlideString>,
+        maxLex: Boundary<GlideString>,
     ): T {
         return this.addAndReturn(createZLexCount(key, minLex, maxLex));
     }
 
-    /** Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
+    /**
+     * Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
+     * To get the rank of `member` with its score, see {@link zrankWithScore}.
+     *
      * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
-     * To get the rank of `member` with its score, see `zrankWithScore`.
      *
      * @param key - The key of the sorted set.
      * @param member - The member whose rank is to be retrieved.
@@ -2366,11 +2403,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The rank of `member` in the sorted set.
      * If `key` doesn't exist, or if `member` is not present in the set, null will be returned.
      */
-    public zrank(key: string, member: string): T {
+    public zrank(key: GlideString, member: GlideString): T {
         return this.addAndReturn(createZRank(key, member));
     }
 
-    /** Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
+    /**
+     * Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
      *
      * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
      * @remarks Since Valkey version 7.2.0.
@@ -2381,13 +2419,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A list containing the rank and score of `member` in the sorted set.
      * If `key` doesn't exist, or if `member` is not present in the set, null will be returned.
      */
-    public zrankWithScore(key: string, member: string): T {
+    public zrankWithScore(key: GlideString, member: GlideString): T {
         return this.addAndReturn(createZRank(key, member, true));
     }
 
     /**
      * Returns the rank of `member` in the sorted set stored at `key`, where
-     * scores are ordered from the highest to lowest, starting from 0.
+     * scores are ordered from the highest to lowest, starting from `0`.
      * To get the rank of `member` with its score, see {@link zrevrankWithScore}.
      *
      * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for details.
@@ -2398,13 +2436,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
      *     If `key` doesn't exist, or if `member` is not present in the set, `null` will be returned.
      */
-    public zrevrank(key: string, member: string): T {
+    public zrevrank(key: GlideString, member: GlideString): T {
         return this.addAndReturn(createZRevRank(key, member));
     }
 
     /**
      * Returns the rank of `member` in the sorted set stored at `key` with its
-     * score, where scores are ordered from the highest to lowest, starting from 0.
+     * score, where scores are ordered from the highest to lowest, starting from `0`.
      *
      * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for details.
      * @remarks Since Valkey version 7.2.0.
@@ -2416,7 +2454,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     are ordered from high to low based on scores.
      *     If `key` doesn't exist, or if `member` is not present in the set, `null` will be returned.
      */
-    public zrevrankWithScore(key: string, member: string): T {
+    public zrevrankWithScore(key: GlideString, member: GlideString): T {
         return this.addAndReturn(createZRevRankWithScore(key, member));
     }
 
@@ -3530,7 +3568,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Pops a member-score pair from the first non-empty sorted set, with the given `keys`
+     * Pops member-score pairs from the first non-empty sorted set, with the given `keys`
      * being checked in the order they are provided.
      *
      * @see {@link https://valkey.io/commands/zmpop/|valkey.io} for details.
@@ -3545,7 +3583,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     element was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
      */
-    public zmpop(keys: string[], modifier: ScoreFilter, count?: number): T {
+    public zmpop(
+        keys: GlideString[],
+        modifier: ScoreFilter,
+        count?: number,
+    ): T {
         return this.addAndReturn(createZMPop(keys, modifier, count));
     }
 
@@ -3602,7 +3644,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key of the sorted set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of
      *      the search.
-     * @param options - (Optional) The zscan options.
+     * @param options - (Optional) The `zscan` options - see {@link BaseScanOptions}
      *
      * Command Response - An `Array` of the `cursor` and the subset of the sorted set held by `key`.
      *      The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
@@ -3610,7 +3652,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *      of the sorted set held in `key`. The `Array` in the second element is always a flattened series of
      *      `String` pairs, where the value is at even indices and the score is at odd indices.
      */
-    public zscan(key: string, cursor: string, options?: BaseScanOptions): T {
+    public zscan(
+        key: GlideString,
+        cursor: string,
+        options?: BaseScanOptions,
+    ): T {
         return this.addAndReturn(createZScan(key, cursor, options));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -5,7 +5,7 @@
 import {
     BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars
     GlideString,
-    ReadFrom,
+    ReadFrom, // eslint-disable-line @typescript-eslint/no-unused-vars
     SortedSetDataType, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from "./BaseClient";
 
@@ -1729,15 +1729,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public zadd(
         key: GlideString,
-        membersScoresMap: SortedSetDataType | Record<string, number>,
+        membersAndScores: SortedSetDataType | Record<string, number>,
         options?: ZAddOptions,
     ): T {
-        if (!Array.isArray(membersScoresMap)) {
-            membersScoresMap = Object.entries(membersScoresMap).map((p) => {
-                return { element: p[0], score: p[1] };
-            });
-        }
-        return this.addAndReturn(createZAdd(key, membersScoresMap, options));
+        return this.addAndReturn(createZAdd(key, membersAndScores, options));
     }
 
     /**
@@ -2096,9 +2091,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * To get the scores as well, see {@link zunionWithScores}.
      * To store the result in a key as a sorted set, see {@link zunionstore}.
      *
-     * @remarks Since Valkey version 6.2.0.
-     *
      * @see {@link https://valkey.io/commands/zunion/|valkey.io} for details.
+     * @remarks Since Valkey version 6.2.0.
      *
      * @param keys - The keys of the sorted sets.
      *

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -64,6 +64,7 @@ import {
     StreamTrimOptions,
     TimeUnit,
     ZAddOptions,
+    convertElementsAndScores,
     createAppend,
     createBLMPop,
     createBLMove,
@@ -1736,7 +1737,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         membersAndScores: SortedSetDataType | Record<string, number>,
         options?: ZAddOptions,
     ): T {
-        return this.addAndReturn(createZAdd(key, membersAndScores, options));
+        return this.addAndReturn(
+            createZAdd(
+                key,
+                convertElementsAndScores(membersAndScores),
+                options,
+            ),
+        );
     }
 
     /**

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -8,6 +8,7 @@
 // represents a running server instance. See first 2 test cases as examples.
 
 import { expect, it } from "@jest/globals";
+import { SortedSetDataType } from "src/BaseClient";
 import { v4 as uuidv4 } from "uuid";
 import {
     BaseClientConfiguration,
@@ -3967,8 +3968,15 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
-                const newMembersScores = { one: 2, two: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+                const newMembersScores: SortedSetDataType = [
+                    { element: Buffer.from("one"), score: 2 },
+                    { element: "two", score: 3 },
+                ];
 
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zaddIncr(key, "one", 2)).toEqual(3.0);
@@ -3985,7 +3993,11 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
                 expect(
                     await client.zadd(key, membersScores, {
                         conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
@@ -4021,10 +4033,14 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: -3, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: -3 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
 
                 expect(await client.zadd(key, membersScores)).toEqual(3);
-                membersScores["one"] = 10;
+                membersScores[0].score = 10;
 
                 expect(
                     await client.zadd(key, membersScores, {
@@ -4061,7 +4077,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zrem(key, ["one"])).toEqual(1);
                 expect(await client.zrem(key, ["one", "two", "three"])).toEqual(
@@ -4080,7 +4101,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zcard(key)).toEqual(3);
                 expect(await client.zrem(key, ["one"])).toEqual(1);
@@ -4102,8 +4128,16 @@ export function runBaseTests(config: {
                 const key2 = `{key}:${uuidv4()}`;
                 const stringKey = `{key}:${uuidv4()}`;
                 const nonExistingKey = `{key}:${uuidv4()}`;
-                const memberScores1 = { one: 1, two: 2, three: 3 };
-                const memberScores2 = { two: 2, three: 3, four: 4 };
+                const memberScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+                const memberScores2: SortedSetDataType = [
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                    { element: "four", score: 4 },
+                ];
 
                 expect(await client.zadd(key1, memberScores1)).toEqual(3);
                 expect(await client.zadd(key2, memberScores2)).toEqual(3);
@@ -4147,18 +4181,20 @@ export function runBaseTests(config: {
                 const nonExistingKey = `{key}-${uuidv4()}`;
                 const stringKey = `{key}-${uuidv4()}`;
 
-                const entries1 = {
-                    one: 1.0,
-                    two: 2.0,
-                    three: 3.0,
-                };
-                const entries2 = { two: 2.0 };
-                const entries3 = {
-                    one: 1.0,
-                    two: 2.0,
-                    three: 3.0,
-                    four: 4.0,
-                };
+                const entries1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+                const entries2: SortedSetDataType = [
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const entries3: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                    { element: "four", score: 4 },
+                ];
 
                 expect(await client.zadd(key1, entries1)).toEqual(3);
                 expect(await client.zadd(key2, entries2)).toEqual(1);
@@ -4216,18 +4252,20 @@ export function runBaseTests(config: {
                 const nonExistingKey = `{key}-${uuidv4()}`;
                 const stringKey = `{key}-${uuidv4()}`;
 
-                const entries1 = {
-                    one: 1.0,
-                    two: 2.0,
-                    three: 3.0,
-                };
-                const entries2 = { two: 2.0 };
-                const entries3 = {
-                    one: 1.0,
-                    two: 2.0,
-                    three: 3.0,
-                    four: 4.0,
-                };
+                const entries1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+                const entries2: SortedSetDataType = [
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const entries3: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                    { element: "four", score: 4 },
+                ];
 
                 expect(await client.zadd(key1, entries1)).toEqual(3);
                 expect(await client.zadd(key2, entries2)).toEqual(1);
@@ -4287,7 +4325,12 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient) => {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3 },
+                ];
+
                 expect(await client.zadd(key1, membersScores)).toEqual(3);
                 expect(await client.zscore(key1, "one")).toEqual(1.0);
                 expect(await client.zscore(key1, "nonExistingMember")).toEqual(
@@ -4314,8 +4357,15 @@ export function runBaseTests(config: {
             stop: -1,
         };
 
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 1.5 },
+            { element: Buffer.from("two"), score: 2.5 },
+            { element: "three", score: 3.5 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -4340,8 +4390,15 @@ export function runBaseTests(config: {
             stop: -1,
         };
 
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 1.5 },
+            { element: Buffer.from("two"), score: 2.5 },
+            { element: "three", score: 3.5 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -4366,8 +4423,15 @@ export function runBaseTests(config: {
             stop: -1,
         };
 
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 1.5 },
+            { element: Buffer.from("two"), score: 2.5 },
+            { element: "three", score: 3.5 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -4392,8 +4456,15 @@ export function runBaseTests(config: {
             stop: -1,
         };
 
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 2.0, two: 3.0, three: 4.0 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 2 },
+            { element: Buffer.from("two"), score: 3 },
+            { element: "three", score: 4 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -4416,8 +4487,15 @@ export function runBaseTests(config: {
             start: 0,
             stop: -1,
         };
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 1.5 },
+            { element: Buffer.from("two"), score: 2.5 },
+            { element: "three", score: 3.5 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -4452,7 +4530,10 @@ export function runBaseTests(config: {
             start: 0,
             stop: -1,
         };
-        const membersScores1 = { one: 1.0, two: 2.0 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
 
@@ -4506,11 +4587,12 @@ export function runBaseTests(config: {
                 const nonExistingKey = `{key}-${uuidv4()}`;
                 const stringKey = `{key}-${uuidv4()}`;
 
-                const entries = {
-                    one: 1.0,
-                    two: 2.0,
-                    three: 3.0,
-                };
+                const entries: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key1, entries)).toEqual(3);
 
                 expect(
@@ -4549,7 +4631,12 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient) => {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key1, membersScores)).toEqual(3);
                 expect(
                     await client.zcount(
@@ -4608,7 +4695,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(await client.zrange(key, { start: 0, stop: 1 })).toEqual(
@@ -4645,7 +4737,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
@@ -4738,7 +4835,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { a: 1, b: 2, c: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                    { element: "c", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
@@ -4802,7 +4904,12 @@ export function runBaseTests(config: {
 
                 const key = "{testKey}:1-" + uuidv4();
                 const destkey = "{testKey}:2-" + uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
@@ -4855,7 +4962,12 @@ export function runBaseTests(config: {
                 if (cluster.checkIfServerVersionLessThan("6.2.0")) return;
                 const key = "{testKey}:1-" + uuidv4();
                 const destkey = "{testKey}:2-" + uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
@@ -4942,7 +5054,12 @@ export function runBaseTests(config: {
                 if (cluster.checkIfServerVersionLessThan("6.2.0")) return;
                 const key = "{testKey}:1-" + uuidv4();
                 const destkey = "{testKey}:2-" + uuidv4();
-                const membersScores = { a: 1, b: 2, c: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                    { element: "c", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
@@ -5086,8 +5203,15 @@ export function runBaseTests(config: {
             stop: -1,
         };
 
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 2.0, two: 3.0, three: 4.0 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 2 },
+            { element: Buffer.from("two"), score: 3 },
+            { element: "three", score: 4 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5129,8 +5253,15 @@ export function runBaseTests(config: {
             stop: -1,
         };
 
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 2.0, two: 3.0, three: 4.0 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 2 },
+            { element: Buffer.from("two"), score: 3 },
+            { element: "three", score: 4 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5152,8 +5283,15 @@ export function runBaseTests(config: {
             start: 0,
             stop: -1,
         };
-        const membersScores1 = { one: 1.0, two: 2.0 };
-        const membersScores2 = { one: 2.0, two: 3.0, three: 4.0 };
+        const membersScores1: SortedSetDataType = [
+            { element: "one", score: 1 },
+            { element: Buffer.from("two"), score: 2 },
+        ];
+        const membersScores2: SortedSetDataType = [
+            { element: "one", score: 2 },
+            { element: Buffer.from("two"), score: 3 },
+            { element: "three", score: 4 },
+        ];
 
         expect(await client.zadd(key1, membersScores1)).toEqual(2);
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5219,8 +5357,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5241,8 +5386,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5271,8 +5423,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5300,8 +5459,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5329,8 +5495,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5358,8 +5531,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5420,8 +5600,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5443,8 +5630,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5474,8 +5668,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5504,8 +5705,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5534,8 +5742,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5564,8 +5779,15 @@ export function runBaseTests(config: {
                 const key1 = "{testKey}:1-" + uuidv4();
                 const key2 = "{testKey}:2-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
-                const membersScores2 = { one: 1.5, two: 2.5, three: 3.5 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                ];
+                const membersScores2: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2.5 },
+                    { element: "three", score: 3.5 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
@@ -5596,7 +5818,10 @@ export function runBaseTests(config: {
                 if (cluster.checkIfServerVersionLessThan("6.2.0")) return;
                 const key1 = "{testKey}:1-" + uuidv4();
 
-                const membersScores1 = { one: 1.0, two: 2.0 };
+                const membersScores1: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: "two", score: 2 },
+                ];
 
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
 
@@ -5640,7 +5865,9 @@ export function runBaseTests(config: {
                 expect(await client.type(key)).toEqual("set");
                 expect(await client.del([key])).toEqual(1);
 
-                expect(await client.zadd(key, { member: 1.0 })).toEqual(1);
+                expect(
+                    await client.zadd(key, [{ element: "member", score: 1.0 }]),
+                ).toEqual(1);
                 expect(await client.type(key)).toEqual("zset");
                 expect(await client.del([key])).toEqual(1);
 
@@ -5863,12 +6090,17 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { a: 1, b: 2, c: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                    { element: "c", score: 3 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zpopmin(key)).toEqual({ a: 1.0 });
 
                 expect(
-                    compareMaps(await client.zpopmin(key, 3), {
+                    compareMaps(await client.zpopmin(key, { count: 3 }), {
                         b: 2.0,
                         c: 3.0,
                     }),
@@ -5887,12 +6119,17 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { a: 1, b: 2, c: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                    { element: "c", score: 3 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zpopmax(key)).toEqual({ c: 3.0 });
 
                 expect(
-                    compareMaps(await client.zpopmax(key, 3), {
+                    compareMaps(await client.zpopmax(key, { count: 3 }), {
                         b: 2.0,
                         a: 1.0,
                     }),
@@ -5914,8 +6151,15 @@ export function runBaseTests(config: {
                 const key2 = "{key}-2" + uuidv4();
                 const key3 = "{key}-3" + uuidv4();
 
-                expect(await client.zadd(key1, { a: 1.0, b: 1.5 })).toBe(2);
-                expect(await client.zadd(key2, { c: 2.0 })).toBe(1);
+                expect(
+                    await client.zadd(key1, [
+                        { element: "a", score: 1.0 },
+                        { element: "b", score: 1.5 },
+                    ]),
+                ).toBe(2);
+                expect(
+                    await client.zadd(key2, [{ element: "c", score: 2.0 }]),
+                ).toBe(1);
                 expect(await client.bzpopmax([key1, key2], 0.5)).toEqual([
                     key1,
                     "b",
@@ -5957,8 +6201,15 @@ export function runBaseTests(config: {
                 const key2 = "{key}-2" + uuidv4();
                 const key3 = "{key}-3" + uuidv4();
 
-                expect(await client.zadd(key1, { a: 1.0, b: 1.5 })).toBe(2);
-                expect(await client.zadd(key2, { c: 2.0 })).toBe(1);
+                expect(
+                    await client.zadd(key1, [
+                        { element: "a", score: 1.0 },
+                        { element: "b", score: 1.5 },
+                    ]),
+                ).toBe(2);
+                expect(
+                    await client.zadd(key2, [{ element: "c", score: 2.0 }]),
+                ).toBe(1);
                 expect(await client.bzpopmin([key1, key2], 0.5)).toEqual([
                     key1,
                     "a",
@@ -6033,7 +6284,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zremRangeByRank(key, 2, 1)).toEqual(0);
                 expect(await client.zremRangeByRank(key, 0, 1)).toEqual(2);
@@ -6052,7 +6308,12 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient, cluster) => {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
-                const membersScores = { one: 1.5, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key1, membersScores)).toEqual(3);
                 expect(await client.zrank(key1, "one")).toEqual(0);
 
@@ -6087,7 +6348,12 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient, cluster) => {
                 const key = uuidv4();
                 const nonSetKey = uuidv4();
-                const membersScores = { one: 1.5, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1.5 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zrevrank(key, "three")).toEqual(0);
 
@@ -6553,7 +6819,13 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
                 const stringKey = uuidv4();
-                const membersScores = { a: 1, b: 2, c: 3, d: 4 };
+                const membersScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                    { element: "c", score: 3.0 },
+                    { element: "d", score: 4 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(4);
 
                 expect(
@@ -6608,7 +6880,12 @@ export function runBaseTests(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
-                const membersScores = { one: 1, two: 2, three: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: Buffer.from("two"), score: 2 },
+                    { element: "three", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
@@ -6645,7 +6922,12 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
                 const stringKey = uuidv4();
-                const membersScores = { a: 1, b: 2, c: 3 };
+                const membersScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                    { element: "c", score: 3.0 },
+                ];
+
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 // In range negative to positive infinity.
@@ -7895,7 +8177,9 @@ export function runBaseTests(config: {
                 // The default value of zset-max-listpack-entries is 128
                 for (let i = 0; i < 129; i++) {
                     expect(
-                        await client.zadd(skiplist_key, { [String(i)]: 2.0 }),
+                        await client.zadd(skiplist_key, [
+                            { element: String(i), score: 2.0 },
+                        ]),
                     ).toEqual(1);
                 }
 
@@ -7904,7 +8188,9 @@ export function runBaseTests(config: {
                 );
 
                 expect(
-                    await client.zadd(zset_listpack_key, { "1": 2.0 }),
+                    await client.zadd(zset_listpack_key, [
+                        { element: "1", score: 2.0 },
+                    ]),
                 ).toEqual(1);
 
                 if (versionLessThan7) {
@@ -8932,23 +9218,35 @@ export function runBaseTests(config: {
                 const nonExistingKey = "{key}-0" + uuidv4();
                 const stringKey = "{key}-string" + uuidv4();
 
-                expect(await client.zadd(key1, { a1: 1, b1: 2 })).toEqual(2);
-                expect(await client.zadd(key2, { a2: 0.1, b2: 0.2 })).toEqual(
-                    2,
-                );
+                expect(
+                    await client.zadd(key1, [
+                        { element: "a1", score: 1 },
+                        { element: "b1", score: 2 },
+                    ]),
+                ).toEqual(2);
+                expect(
+                    await client.zadd(key2, [
+                        { element: "a2", score: 0.1 },
+                        { element: "b2", score: 0.2 },
+                    ]),
+                ).toEqual(2);
 
                 expect(
                     await client.zmpop([key1, key2], ScoreFilter.MAX),
                 ).toEqual([key1, { b1: 2 }]);
                 expect(
-                    await client.zmpop([key2, key1], ScoreFilter.MAX, 10),
+                    await client.zmpop([key2, key1], ScoreFilter.MAX, {
+                        count: 10,
+                    }),
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
                 expect(
                     await client.zmpop([nonExistingKey], ScoreFilter.MIN),
                 ).toBeNull();
                 expect(
-                    await client.zmpop([nonExistingKey], ScoreFilter.MIN, 1),
+                    await client.zmpop([nonExistingKey], ScoreFilter.MIN, {
+                        count: 1,
+                    }),
                 ).toBeNull();
 
                 // key exists, but it is not a sorted set
@@ -8957,32 +9255,39 @@ export function runBaseTests(config: {
                     client.zmpop([stringKey], ScoreFilter.MAX),
                 ).rejects.toThrow(RequestError);
                 await expect(
-                    client.zmpop([stringKey], ScoreFilter.MAX, 1),
+                    client.zmpop([stringKey], ScoreFilter.MAX, { count: 1 }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: key list should not be empty
                 await expect(
-                    client.zmpop([], ScoreFilter.MAX, 1),
+                    client.zmpop([], ScoreFilter.MAX, { count: 1 }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: count should be greater than 0
                 await expect(
-                    client.zmpop([key1], ScoreFilter.MAX, 0),
+                    client.zmpop([key1], ScoreFilter.MAX, { count: 0 }),
                 ).rejects.toThrow(RequestError);
 
                 // check that order of entries in the response is preserved
-                const entries: Record<string, number> = {};
+                const entries: SortedSetDataType = [];
 
                 for (let i = 0; i < 10; i++) {
                     // a0 => 0, a1 => 1 etc
-                    entries["a" + i] = i;
+                    entries.push({ element: "a" + i, score: i });
                 }
 
                 expect(await client.zadd(key2, entries)).toEqual(10);
-                const result = await client.zmpop([key2], ScoreFilter.MIN, 10);
+                const result = await client.zmpop([key2], ScoreFilter.MIN, {
+                    count: 10,
+                });
 
                 if (result) {
-                    expect(result[1]).toEqual(entries);
+                    const entriesSImplified: Record<string, number> = {};
+                    entries.forEach(
+                        (e) =>
+                            (entriesSImplified[e.element as string] = e.score),
+                    );
+                    expect(result[1]).toEqual(entriesSImplified);
                 }
             }, protocol);
         },
@@ -9021,7 +9326,7 @@ export function runBaseTests(config: {
         },
         config.timeout,
     );
-
+    /*
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `zscan test_%p`,
         async (protocol) => {
@@ -9179,7 +9484,7 @@ export function runBaseTests(config: {
         },
         config.timeout,
     );
-
+*/
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `bzmpop test_%p`,
         async (protocol) => {
@@ -9190,10 +9495,18 @@ export function runBaseTests(config: {
                 const nonExistingKey = "{key}-0" + uuidv4();
                 const stringKey = "{key}-string" + uuidv4();
 
-                expect(await client.zadd(key1, { a1: 1, b1: 2 })).toEqual(2);
-                expect(await client.zadd(key2, { a2: 0.1, b2: 0.2 })).toEqual(
-                    2,
-                );
+                expect(
+                    await client.zadd(key1, [
+                        { element: "a1", score: 1 },
+                        { element: "b1", score: 2 },
+                    ]),
+                ).toEqual(2);
+                expect(
+                    await client.zadd(key2, [
+                        { element: "a2", score: 0.1 },
+                        { element: "b2", score: 0.2 },
+                    ]),
+                ).toEqual(2);
 
                 expect(
                     await client.bzmpop([key1, key2], ScoreFilter.MAX, 0.1),
@@ -9240,11 +9553,11 @@ export function runBaseTests(config: {
                 ).rejects.toThrow(RequestError);
 
                 // check that order of entries in the response is preserved
-                const entries: Record<string, number> = {};
+                const entries: SortedSetDataType = [];
 
                 for (let i = 0; i < 10; i++) {
                     // a0 => 0, a1 => 1 etc
-                    entries["a" + i] = i;
+                    entries.push({ element: "a" + i, score: i });
                 }
 
                 expect(await client.zadd(key2, entries)).toEqual(10);
@@ -9256,11 +9569,13 @@ export function runBaseTests(config: {
                 );
 
                 if (result) {
-                    expect(result[1]).toEqual(entries);
+                    const entriesSImplified: Record<string, number> = {};
+                    entries.forEach(
+                        (e) =>
+                            (entriesSImplified[e.element as string] = e.score),
+                    );
+                    expect(result[1]).toEqual(entriesSImplified);
                 }
-
-                // TODO: add test case with 0 timeout (no timeout) should never time out,
-                // but we wrap the test with timeout to avoid test failing or stuck forever
             }, protocol);
         },
         config.timeout,
@@ -9493,8 +9808,11 @@ export function runBaseTests(config: {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
 
-                const memberScores = { one: 1.0, two: 2.0 };
-                const elements = ["one", "two"];
+                const memberScores: SortedSetDataType = [
+                    { element: "one", score: 1 },
+                    { element: "two", score: 2 },
+                ];
+                const elements: GlideString[] = ["one", "two"];
                 expect(await client.zadd(key1, memberScores)).toBe(2);
 
                 // check random memember belongs to the set
@@ -9522,7 +9840,10 @@ export function runBaseTests(config: {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
 
-                const memberScores = { one: 1.0, two: 2.0 };
+                const memberScores: SortedSetDataType = [
+                    { element: "a", score: 1 },
+                    { element: Buffer.from("b"), score: 2 },
+                ];
                 expect(await client.zadd(key1, memberScores)).toBe(2);
 
                 // unique values are expected as count is positive
@@ -9569,7 +9890,10 @@ export function runBaseTests(config: {
                 const key1 = uuidv4();
                 const key2 = uuidv4();
 
-                const memberScores = { one: 1.0, two: 2.0 };
+                const memberScores: SortedSetDataType = [
+                    { element: "pne", score: 1 },
+                    { element: "two", score: 2 },
+                ];
                 const memberScoreMap = new Map<string, number>([
                     ["one", 1.0],
                     ["two", 2.0],


### PR DESCRIPTION
* `ZAdd`
* `ZAddIncr`
* `ZLexCount`
* `ZMPop`
* `ZMScore`
* `ZPopMax`
* `ZPopMin`
* `ZRandMember` / `ZRandmemberWithCount` / `ZRandmemberWithCountWithScores`
* `ZRange` / `ZRangeWithScores`
* `ZRangeStore`
* `ZRank` / `ZRankWithScore`
* `ZRem`
* `ZRemRangeByLex`
* `ZRemRangeByRank`
* `ZRemRangeByScore`
* `ZRevRank` / `ZRevrankWithScore`
* `ZScan`
* `ZScore`
* `ZUnion` / `ZUnionWithScores`
* `ZUnionStore`

Notes:
* `ZADD` supports two types of input arguments for better compatibility and UX
* Some commands updated in this PR return `Record<string, ...>` - this remains unchanged and will be fixed in scope of #2207. Even though I added decoder option to these commands, I can't test them with binary decoder yet.