### PR TITLE
Node: Add tests and docstrings for setrange command

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -6555,23 +6555,23 @@ export class BaseClient {
     }
 
     /**
-     * Overwrites part of the string stored at `key`, starting at the specified `offset`,
-     * for the entire length of `value`. If the `offset` is larger than the current length of the string at `key`,
-     * the string is padded with zero bytes to make `offset` fit. Creates the `key` if it doesn't exist.
+     * Overwrites part of the GlideString stored at `key`, starting at the specified `offset`,
+     * for the entire length of `value`. If the `offset` is larger than the current length of the GlideString at `key`,
+     * the GlideString is padded with zero bytes to make `offset` fit. Creates the `key` if it doesn't exist.
      *
      * @see {@link https://valkey.io/commands/setrange/|valkey.io} for more details.
      *
-     * @param key - The key of the string to update.
-     * @param offset - The position in the string where `value` should be written.
-     * @param value - The string written with `offset`.
-     * @returns The length of the string stored at `key` after it was modified.
+     * @param key - The key of the GlideString to update.
+     * @param offset - The position in the GlideString where `value` should be written.
+     * @param value - The GlideString written with `offset`.
+     * @returns The length of the GlideString stored at `key` after it was modified.
      *
      * @example
      * ```typescript
      * const len = await client.setrange("key", 6, "GLIDE");
      * console.log(len); // Output: 11 - New key was created with length of 11 symbols
      * const value = await client.get("key");
-     * console.log(result); // Output: "\0\0\0\0\0\0GLIDE" - The string was padded with zero bytes
+     * console.log(result); // Output: "\0\0\0\0\0\0GLIDE" - The GlideString was padded with zero bytes
      * ```
      */
     public async setrange(

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -3764,17 +3764,17 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Overwrites part of the string stored at `key`, starting at the specified `offset`,
-     * for the entire length of `value`. If the `offset` is larger than the current length of the string at `key`,
-     * the string is padded with zero bytes to make `offset` fit. Creates the `key` if it doesn't exist.
+     * Overwrites part of the GlideString stored at `key`, starting at the specified `offset`,
+     * for the entire length of `value`. If the `offset` is larger than the current length of the GlideString at `key`,
+     * the GlideString is padded with zero bytes to make `offset` fit. Creates the `key` if it doesn't exist.
      *
      * @see {@link https://valkey.io/commands/setrange/|valkey.io} for details.
      *
-     * @param key - The key of the string to update.
-     * @param offset - The position in the string where `value` should be written.
-     * @param value - The string written with `offset`.
+     * @param key - The key of the GlideString to update.
+     * @param offset - The position in the GlideString where `value` should be written.
+     * @param value - The GlideString written with `offset`.
      *
-     * Command Response - The length of the string stored at `key` after it was modified.
+     * Command Response - The length of the GlideString stored at `key` after it was modified.
      */
     public setrange(key: GlideString, offset: number, value: GlideString): T {
         return this.addAndReturn(createSetRange(key, offset, value));

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -7564,13 +7564,42 @@ export function runBaseTests(config: {
 
                 // new key
                 expect(await client.setrange(key, 0, "Hello World")).toBe(11);
+                expect(
+                    await client.setrange(key, 0, Buffer.from("Hello World")),
+                ).toBe(11);
 
                 // existing key
                 expect(await client.setrange(key, 6, "GLIDE")).toBe(11);
+                expect(
+                    await client.setrange(Buffer.from(key), 6, "GLIDE"),
+                ).toBe(11);
+                expect(
+                    await client.setrange(key, 6, Buffer.from("GLIDE")),
+                ).toBe(11);
+                expect(
+                    await client.setrange(
+                        Buffer.from(key),
+                        6,
+                        Buffer.from("GLIDE"),
+                    ),
+                ).toBe(11);
                 expect(await client.get(key)).toEqual("Hello GLIDE");
 
                 // offset > len
                 expect(await client.setrange(key, 15, "GLIDE")).toBe(20);
+                expect(
+                    await client.setrange(Buffer.from(key), 15, "GLIDE"),
+                ).toBe(20);
+                expect(
+                    await client.setrange(key, 15, Buffer.from("GLIDE")),
+                ).toBe(20);
+                expect(
+                    await client.setrange(
+                        Buffer.from(key),
+                        15,
+                        Buffer.from("GLIDE"),
+                    ),
+                ).toBe(20);
                 expect(await client.get(key)).toEqual(
                     "Hello GLIDE\0\0\0\0GLIDE",
                 );


### PR DESCRIPTION
Add tests for multiple scenarios. 
Update the docstrings with "GlideString" instead of "string".