### PR TITLE
Go: Implement incr and decr commands

### DIFF
--- a/go/api/commands.go
+++ b/go/api/commands.go
@@ -12,8 +12,14 @@ type StringCommands interface {
 	//
 	// See [valkey.io] for details.
 	//
-	// For example:
+	// Parameters:
+	//  key   - The key to store.
+	//  value - The value to store with the given key.
 	//
+	// Return value:
+	//  A simple "OK" response on success.
+	//
+	// For example:
 	//	result, err := client.Set("key", "value")
 	//
 	// [valkey.io]: https://valkey.io/commands/set/
@@ -26,8 +32,17 @@ type StringCommands interface {
 	//
 	// See [valkey.io] for details.
 	//
-	// For example:
+	// Parameters:
+	//  key     - The key to store.
+	//  value   - The value to store with the given key.
+	//  options - The Set options.
 	//
+	// Return value:
+	//  If the value is successfully set, return "OK".
+	//  If value isn't set because of ConditionalSet.OnlyIfExists or ConditionalSet.OnlyIfDoesNotExist conditions, return ("").
+	//  If SetOptions.returnOldValue is set, return the old value as a String.
+	//
+	// For example:
 	//  result, err := client.SetWithOptions("key", "value", &api.SetOptions{
 	//      ConditionalSet: api.OnlyIfExists,
 	//      Expiry: &api.Expiry{
@@ -39,14 +54,104 @@ type StringCommands interface {
 	// [valkey.io]: https://valkey.io/commands/set/
 	SetWithOptions(key string, value string, options *SetOptions) (string, error)
 
-	// Get string value associated with the given key, or an empty string is returned ("") if no such value exists
+	// Get string value associated with the given key, or an empty string is returned ("") if no such value exists.
 	//
 	// See [valkey.io] for details.
 	//
-	// For example:
+	// Parameters:
+	//  key - The key to be retrieved from the database.
 	//
+	// Return value:
+	//  If key exists, returns the value of key as a String. Otherwise, return ("").
+	//
+	// For example:
 	//	result, err := client.Get("key")
 	//
 	// [valkey.io]: https://valkey.io/commands/get/
 	Get(key string) (string, error)
+
+	// Increments the number stored at key by one. If key does not exist, it is set to 0 before performing the operation.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//  key - The key to increment its value.
+	//
+	// Return value:
+	//  The value of key after the increment.
+	//
+	// For example:
+	//  result, err := client.Incr("key");
+	//
+	// [valkey.io]: https://valkey.io/commands/incr/
+	Incr(key string) (int64, error)
+
+	// Increments the number stored at key by amount. If key does not exist, it is set to 0 before performing the operation.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//  key    - The key to increment its value.
+	//  amount - The amount to increment.
+	//
+	// Return value:
+	//  The value of key after the increment.
+	//
+	// For example:
+	//  result, err := client.IncrBy("key", 2);
+	//
+	// [valkey.io]: https://valkey.io/commands/incrby/
+	IncrBy(key string, amount int64) (int64, error)
+
+	// Increments the string representing a floating point number stored at key by amount. By using a negative increment value,
+	// the result is that the value stored at key is decremented. If key does not exist, it is set to 0 before performing the
+	// operation.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//  key    - The key to increment its value.
+	//  amount - The amount to increment.
+	//
+	// Return value:
+	//  The value of key after the increment.
+	//
+	// For example:
+	//  result, err := client.IncrBy("key", 0.5);
+	//
+	// [valkey.io]: https://valkey.io/commands/incrbyfloat/
+	IncrByFloat(key string, amount float64) (float64, error)
+
+	// Decrements the number stored at key by one. If key does not exist, it is set to 0 before performing the operation.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//  key - The key to decrement its value.
+	//
+	// Return value:
+	//  The value of key after the decrement.
+	//
+	// For example:
+	//  result, err := client.Decr("key");
+	//
+	// [valkey.io]: https://valkey.io/commands/decr/
+	Decr(key string) (int64, error)
+
+	// Decrements the number stored at code by amount. If key does not exist, it is set to 0 before performing the operation.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//  key    - The key to decrement its value.
+	//  amount - The amount to decrement.
+	//
+	// Return value:
+	//  The value of key after the decrement.
+	//
+	// For example:
+	//  result, err := client.Decr("key");
+	//
+	// [valkey.io]: https://valkey.io/commands/decrby/
+	DecrBy(key string, amount int64) (int64, error)
 }

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -30,3 +30,13 @@ func handleStringOrNullResponse(response *C.struct_CommandResponse) string {
 	}
 	return handleStringResponse(response)
 }
+
+func handleLongResponse(response *C.struct_CommandResponse) int64 {
+	defer C.free_command_response(response)
+	return int64(response.int_value)
+}
+
+func handleDoubleResponse(response *C.struct_CommandResponse) float64 {
+	defer C.free_command_response(response)
+	return float64(response.float_value)
+}

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -371,6 +371,14 @@ pub unsafe extern "C" fn command(
                 command_response.string_value_len = len;
                 Ok(Some(command_response))
             }
+            Value::Int(num) => {
+                command_response.int_value = num;
+                Ok(Some(command_response))
+            }
+            Value::Double(num) => {
+                command_response.float_value = num;
+                Ok(Some(command_response))
+            }
             // TODO: Add support for other return types.
             _ => todo!(),
         };

--- a/go/utils/transform_utils.go
+++ b/go/utils/transform_utils.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"strconv"
+	"unsafe"
+)
+
+// Convert `s` of type `string` into `[]byte`
+func StringToBytes(s string) []byte {
+	p := unsafe.StringData(s)
+	b := unsafe.Slice(p, len(s))
+	return b
+}
+
+func IntToString(value int64) string {
+	return strconv.FormatInt(value, 10 /*base*/)
+}
+
+func FloatToString(value float64) string {
+	return strconv.FormatFloat(value, 'g', -1 /*precision*/, 64 /*bit*/)
+}


### PR DESCRIPTION
Implementing the following 5 string commands:
- Incr
- IncrBy
- IncrByFloat
- Decr
- DecrBy