### PR TITLE
Node: Add Binary support for stream commands, part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,8 +101,7 @@
 * Node: Added XACK commands ([#2112](https://github.com/valkey-io/valkey-glide/pull/2112))
 * Node: Added XGROUP SETID command ([#2135]((https://github.com/valkey-io/valkey-glide/pull/2135))
 * Node: Added binary variant to string commands ([#2183](https://github.com/valkey-io/valkey-glide/pull/2183))
-* Node: Added binary variant to stream commands (part 1) ([#2200](https://github.com/valkey-io/valkey-glide/pull/2200))
-* Node: Added binary variant to stream commands (part 2) ([#2222](https://github.com/valkey-io/valkey-glide/pull/2222))
+* Node: Added binary variant to stream commands ([#2200](https://github.com/valkey-io/valkey-glide/pull/2200), [#2222](https://github.com/valkey-io/valkey-glide/pull/2222))
 
 #### Breaking Changes
 * Node: (Refactor) Convert classes to types ([#2005](https://github.com/valkey-io/valkey-glide/pull/2005))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@
 * Node: Added XACK commands ([#2112](https://github.com/valkey-io/valkey-glide/pull/2112))
 * Node: Added XGROUP SETID command ([#2135]((https://github.com/valkey-io/valkey-glide/pull/2135))
 * Node: Added binary variant to string commands ([#2183](https://github.com/valkey-io/valkey-glide/pull/2183))
-* Node: Added binary variant to stream commands ([#2200](https://github.com/valkey-io/valkey-glide/pull/2200))
+* Node: Added binary variant to stream commands (part 1) ([#2200](https://github.com/valkey-io/valkey-glide/pull/2200))
+* Node: Added binary variant to stream commands (part 2) ([#2222](https://github.com/valkey-io/valkey-glide/pull/2222))
 
 #### Breaking Changes
 * Node: (Refactor) Convert classes to types ([#2005](https://github.com/valkey-io/valkey-glide/pull/2005))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -756,17 +756,17 @@ export class BaseClient {
     ) {
         const message = Array.isArray(command)
             ? command_request.CommandRequest.create({
-                  callbackIdx,
-                  transaction: command_request.Transaction.create({
-                      commands: command,
-                  }),
-              })
+                callbackIdx,
+                transaction: command_request.Transaction.create({
+                    commands: command,
+                }),
+            })
             : command instanceof command_request.Command
-              ? command_request.CommandRequest.create({
+                ? command_request.CommandRequest.create({
                     callbackIdx,
                     singleCommand: command,
                 })
-              : command_request.CommandRequest.create({
+                : command_request.CommandRequest.create({
                     callbackIdx,
                     scriptInvocation: command,
                 });
@@ -5007,8 +5007,9 @@ export class BaseClient {
      * ```
      */
     public async xinfoConsumers(
-        key: string,
-        group: string,
+        key: GlideString,
+        group: GlideString,
+        // TODO: change return type to be compatible with GlideString
     ): Promise<Record<string, string | number>[]> {
         return this.createWritePromise(createXInfoConsumers(key, group));
     }
@@ -5420,9 +5421,9 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-        primary: connection_request.ReadFrom.Primary,
-        preferReplica: connection_request.ReadFrom.PreferReplica,
-    };
+            primary: connection_request.ReadFrom.Primary,
+            preferReplica: connection_request.ReadFrom.PreferReplica,
+        };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -6798,11 +6799,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-            "password" in options.credentials
+                "password" in options.credentials
                 ? {
-                      password: options.credentials.password,
-                      username: options.credentials.username,
-                  }
+                    password: options.credentials.password,
+                    username: options.credentials.username,
+                }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -4817,7 +4817,7 @@ export class BaseClient {
      * @returns The number of entries deleted from the stream. If `key` doesn't exist, 0 is returned.
      */
     public async xtrim(
-        key: string,
+        key: GlideString,
         options: StreamTrimOptions,
     ): Promise<number> {
         return this.createWritePromise(createXTrim(key, options));

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -4932,9 +4932,9 @@ export class BaseClient {
      * ```
      */
     public async xpending(
-        key: string,
-        group: string,
-    ): Promise<[number, string, string, [string, number][]]> {
+        key: GlideString,
+        group: GlideString,
+    ): Promise<[number, GlideString, GlideString, [GlideString, number][]]> {
         return this.createWritePromise(createXPending(key, group));
     }
 
@@ -4973,10 +4973,10 @@ export class BaseClient {
      * ```
      */
     public async xpendingWithOptions(
-        key: string,
-        group: string,
+        key: GlideString,
+        group: GlideString,
         options: StreamPendingOptions,
-    ): Promise<[string, string, number, number][]> {
+    ): Promise<[GlideString, GlideString, number, number][]> {
         return this.createWritePromise(createXPending(key, group, options));
     }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -4854,9 +4854,10 @@ export class BaseClient {
     ): Promise<Record<string, Record<string, [string, string][]>>> {
         if (!Array.isArray(keys_and_ids)) {
             keys_and_ids = Object.entries(keys_and_ids).map((e) => {
-                return {key: e[0], value: e[1]}
-            })
+                return { key: e[0], value: e[1] };
+            });
         }
+
         return this.createWritePromise(createXRead(keys_and_ids, options));
     }
 
@@ -4901,9 +4902,10 @@ export class BaseClient {
     > | null> {
         if (!Array.isArray(keys_and_ids)) {
             keys_and_ids = Object.entries(keys_and_ids).map((e) => {
-                return {key: e[0], value: e[1]}
-            })
+                return { key: e[0], value: e[1] };
+            });
         }
+
         return this.createWritePromise(
             createXReadGroup(group, consumer, keys_and_ids, options),
         );

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -328,6 +328,24 @@ export function convertFieldsAndValuesForHset(
 }
 
 /**
+ * This function converts an input from Record or GlideRecord types to GlideRecord.
+ *
+ * @param record - input record in either Record or GlideRecord types.
+ * @returns same data in GlideRecord type.
+ */
+export function convertRecordToGlideRecord(
+    record: Record<string, GlideString> | GlideRecord<GlideString>,
+): GlideRecord<GlideString> {
+    if (!Array.isArray(record)) {
+        return Object.entries(record).map((e) => {
+            return { key: e[0], value: e[1] };
+        });
+    }
+
+    return record;
+}
+
+/**
  * Our purpose in creating PointerResponse type is to mark when response is of number/long pointer response type.
  * Consequently, when the response is returned, we can check whether it is instanceof the PointerResponse type and pass it to the Rust core function with the proper parameters.
  */
@@ -4852,11 +4870,7 @@ export class BaseClient {
         keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
         options?: StreamReadOptions,
     ): Promise<Record<string, Record<string, [string, string][]>>> {
-        if (!Array.isArray(keys_and_ids)) {
-            keys_and_ids = Object.entries(keys_and_ids).map((e) => {
-                return { key: e[0], value: e[1] };
-            });
-        }
+        keys_and_ids = convertRecordToGlideRecord(keys_and_ids);
 
         return this.createWritePromise(createXRead(keys_and_ids, options));
     }
@@ -4900,11 +4914,7 @@ export class BaseClient {
         string,
         Record<string, [string, string][] | null>
     > | null> {
-        if (!Array.isArray(keys_and_ids)) {
-            keys_and_ids = Object.entries(keys_and_ids).map((e) => {
-                return { key: e[0], value: e[1] };
-            });
-        }
+        keys_and_ids = convertRecordToGlideRecord(keys_and_ids);
 
         return this.createWritePromise(
             createXReadGroup(group, consumer, keys_and_ids, options),

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3481,7 +3481,7 @@ export class BaseClient {
      * ```
      */
     public async xrange(
-        key: string,
+        key: GlideString,
         start: Boundary<string>,
         end: Boundary<string>,
         count?: number,

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -4905,7 +4905,7 @@ export class BaseClient {
      * console.log(numEntries); // Output: 2 - "my_stream" contains 2 entries.
      * ```
      */
-    public async xlen(key: string): Promise<number> {
+    public async xlen(key: GlideString): Promise<number> {
         return this.createWritePromise(createXLen(key));
     }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -297,6 +297,14 @@ export type DecoderOption = {
     decoder?: Decoder;
 };
 
+/** A replacement for `Record<GlideString, T>` - array of key-value pairs. */
+export type GlideRecord<T> = {
+    /** The value name. */
+    key: GlideString;
+    /** The value itself. */
+    value: T;
+}[];
+
 /**
  * This function converts an input from HashDataType or Record types to HashDataType.
  *
@@ -4841,9 +4849,14 @@ export class BaseClient {
      * ```
      */
     public async xread(
-        keys_and_ids: Record<string, string>,
+        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
         options?: StreamReadOptions,
     ): Promise<Record<string, Record<string, [string, string][]>>> {
+        if (!Array.isArray(keys_and_ids)) {
+            keys_and_ids = Object.entries(keys_and_ids).map((e) => {
+                return {key: e[0], value: e[1]}
+            })
+        }
         return this.createWritePromise(createXRead(keys_and_ids, options));
     }
 
@@ -4878,14 +4891,19 @@ export class BaseClient {
      * ```
      */
     public async xreadgroup(
-        group: string,
-        consumer: string,
-        keys_and_ids: Record<string, string>,
+        group: GlideString,
+        consumer: GlideString,
+        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
         options?: StreamReadGroupOptions,
     ): Promise<Record<
         string,
         Record<string, [string, string][] | null>
     > | null> {
+        if (!Array.isArray(keys_and_ids)) {
+            keys_and_ids = Object.entries(keys_and_ids).map((e) => {
+                return {key: e[0], value: e[1]}
+            })
+        }
         return this.createWritePromise(
             createXReadGroup(group, consumer, keys_and_ids, options),
         );

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3529,7 +3529,7 @@ export class BaseClient {
      * ```
      */
     public async xrevrange(
-        key: string,
+        key: GlideString,
         end: Boundary<string>,
         start: Boundary<string>,
         count?: number,

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -756,17 +756,17 @@ export class BaseClient {
     ) {
         const message = Array.isArray(command)
             ? command_request.CommandRequest.create({
-                callbackIdx,
-                transaction: command_request.Transaction.create({
-                    commands: command,
-                }),
-            })
+                  callbackIdx,
+                  transaction: command_request.Transaction.create({
+                      commands: command,
+                  }),
+              })
             : command instanceof command_request.Command
-                ? command_request.CommandRequest.create({
+              ? command_request.CommandRequest.create({
                     callbackIdx,
                     singleCommand: command,
                 })
-                : command_request.CommandRequest.create({
+              : command_request.CommandRequest.create({
                     callbackIdx,
                     scriptInvocation: command,
                 });
@@ -5357,7 +5357,7 @@ export class BaseClient {
      * ```
      */
     public async xinfoStream(
-        key: string,
+        key: GlideString,
         fullOptions?: boolean | number,
     ): Promise<ReturnTypeXinfoStream> {
         return this.createWritePromise(
@@ -5421,9 +5421,9 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-            primary: connection_request.ReadFrom.Primary,
-            preferReplica: connection_request.ReadFrom.PreferReplica,
-        };
+        primary: connection_request.ReadFrom.Primary,
+        preferReplica: connection_request.ReadFrom.PreferReplica,
+    };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -6799,11 +6799,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-                "password" in options.credentials
+            "password" in options.credentials
                 ? {
-                    password: options.credentials.password,
-                    username: options.credentials.username,
-                }
+                      password: options.credentials.password,
+                      username: options.credentials.username,
+                  }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2142,7 +2142,7 @@ export function createXTrim(
  * @internal
  */
 export function createXRange(
-    key: string,
+    key: GlideString,
     start: Boundary<string>,
     end: Boundary<string>,
     count?: number,

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2639,7 +2639,7 @@ export function createXInfoGroups(key: string): command_request.Command {
 /**
  * @internal
  */
-export function createXLen(key: string): command_request.Command {
+export function createXLen(key: GlideString): command_request.Command {
     return createCommand(RequestType.XLen, [key]);
 }
 

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -141,10 +141,10 @@ export type SetOptions = {
      * `KEEPTTL` in the Redis API.
      */
     | "keepExisting"
-    | {
-        type: TimeUnit;
-        count: number;
-    };
+        | {
+              type: TimeUnit;
+              count: number;
+          };
 };
 
 /**
@@ -1392,7 +1392,7 @@ export function createZAdd(
         if (options.conditionalChange) {
             if (
                 options.conditionalChange ===
-                ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
+                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
                 options.updateOptions
             ) {
                 throw new Error(
@@ -1640,15 +1640,15 @@ export type Boundary<T> =
      *  Represents a specific boundary.
      */
     | {
-        /**
-         * The comparison value.
-         */
-        value: T;
-        /**
-         * Whether the value is inclusive. Defaults to `true`.
-         */
-        isInclusive?: boolean;
-    };
+          /**
+           * The comparison value.
+           */
+          value: T;
+          /**
+           * Whether the value is inclusive. Defaults to `true`.
+           */
+          isInclusive?: boolean;
+      };
 
 /**
  * Represents a range by index (rank) in a sorted set.
@@ -2015,21 +2015,21 @@ export function createZRank(
 
 export type StreamTrimOptions = (
     | {
-        /**
-         * Trim the stream according to entry ID.
-         * Equivalent to `MINID` in the Redis API.
-         */
-        method: "minid";
-        threshold: GlideString;
-    }
+          /**
+           * Trim the stream according to entry ID.
+           * Equivalent to `MINID` in the Redis API.
+           */
+          method: "minid";
+          threshold: GlideString;
+      }
     | {
-        /**
-         * Trim the stream according to length.
-         * Equivalent to `MAXLEN` in the Redis API.
-         */
-        method: "maxlen";
-        threshold: number;
-    }
+          /**
+           * Trim the stream according to length.
+           * Equivalent to `MAXLEN` in the Redis API.
+           */
+          method: "maxlen";
+          threshold: number;
+      }
 ) & {
     /**
      * If `true`, the stream will be trimmed exactly. Equivalent to `=` in the
@@ -2559,7 +2559,7 @@ function addStreamsArgs(keys_and_ids: GlideRecord<GlideString>): GlideString[] {
     return [
         "STREAMS",
         ...keys_and_ids.map((e) => e.key),
-        ...keys_and_ids.map((e) => e.value)
+        ...keys_and_ids.map((e) => e.value),
     ];
 }
 
@@ -2600,8 +2600,8 @@ export function createXReadGroup(
 // TODO: change return type to be compatible with GlideString
 export type ReturnTypeXinfoStream = {
     [key: string]:
-    | StreamEntries
-    | Record<string, StreamEntries | Record<string, StreamEntries>[]>[];
+        | StreamEntries
+        | Record<string, StreamEntries | Record<string, StreamEntries>[]>[];
 };
 
 /**

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -6,7 +6,7 @@ import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "glide-rs";
 import Long from "long";
 
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-import { BaseClient, HashDataType } from "src/BaseClient";
+import { BaseClient, GlideRecord, HashDataType } from "src/BaseClient";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 import { GlideClient } from "src/GlideClient";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
@@ -2538,7 +2538,7 @@ export type StreamReadGroupOptions = StreamReadOptions & {
 };
 
 /** @internal */
-function addReadOptions(options?: StreamReadOptions): string[] {
+function addReadOptions(options?: StreamReadOptions): GlideString[] {
     const args = [];
 
     if (options?.count !== undefined) {
@@ -2555,11 +2555,11 @@ function addReadOptions(options?: StreamReadOptions): string[] {
 }
 
 /** @internal */
-function addStreamsArgs(keys_and_ids: Record<string, string>): string[] {
+function addStreamsArgs(keys_and_ids: GlideRecord<GlideString>): GlideString[] {
     return [
         "STREAMS",
-        ...Object.keys(keys_and_ids),
-        ...Object.values(keys_and_ids),
+        ...keys_and_ids.map((e) => e.key),
+        ...keys_and_ids.map((e) => e.value)
     ];
 }
 
@@ -2567,23 +2567,22 @@ function addStreamsArgs(keys_and_ids: Record<string, string>): string[] {
  * @internal
  */
 export function createXRead(
-    keys_and_ids: Record<string, string>,
+    keys_and_ids: GlideRecord<GlideString>,
     options?: StreamReadOptions,
 ): command_request.Command {
     const args = addReadOptions(options);
     args.push(...addStreamsArgs(keys_and_ids));
-
     return createCommand(RequestType.XRead, args);
 }
 
 /** @internal */
 export function createXReadGroup(
-    group: string,
-    consumer: string,
-    keys_and_ids: Record<string, string>,
+    group: GlideString,
+    consumer: GlideString,
+    keys_and_ids: GlideRecord<GlideString>,
     options?: StreamReadGroupOptions,
 ): command_request.Command {
-    const args: string[] = ["GROUP", group, consumer];
+    const args: GlideString[] = ["GROUP", group, consumer];
 
     if (options) {
         args.push(...addReadOptions(options));

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2654,13 +2654,13 @@ export type StreamPendingOptions = {
     /** Limit the number of messages returned. */
     count: number;
     /** Filter pending entries by consumer. */
-    consumer?: string;
+    consumer?: GlideString;
 };
 
 /** @internal */
 export function createXPending(
-    key: string,
-    group: string,
+    key: GlideString,
+    group: GlideString,
     options?: StreamPendingOptions,
 ): command_request.Command {
     const args = [key, group];

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2598,6 +2598,7 @@ export function createXReadGroup(
 /**
  * Represents a the return type for XInfo Stream in the response
  */
+// TODO: change return type to be compatible with GlideString
 export type ReturnTypeXinfoStream = {
     [key: string]:
     | StreamEntries
@@ -2613,10 +2614,10 @@ export type StreamEntries = string | number | (string | number | string[])[][];
  * @internal
  */
 export function createXInfoStream(
-    key: string,
+    key: GlideString,
     options: boolean | number,
 ): command_request.Command {
-    const args: string[] = [key];
+    const args: GlideString[] = [key];
 
     if (options != false) {
         args.push("FULL");

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -141,10 +141,10 @@ export type SetOptions = {
      * `KEEPTTL` in the Redis API.
      */
     | "keepExisting"
-        | {
-              type: TimeUnit;
-              count: number;
-          };
+    | {
+        type: TimeUnit;
+        count: number;
+    };
 };
 
 /**
@@ -1392,7 +1392,7 @@ export function createZAdd(
         if (options.conditionalChange) {
             if (
                 options.conditionalChange ===
-                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
+                ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
                 options.updateOptions
             ) {
                 throw new Error(
@@ -1640,15 +1640,15 @@ export type Boundary<T> =
      *  Represents a specific boundary.
      */
     | {
-          /**
-           * The comparison value.
-           */
-          value: T;
-          /**
-           * Whether the value is inclusive. Defaults to `true`.
-           */
-          isInclusive?: boolean;
-      };
+        /**
+         * The comparison value.
+         */
+        value: T;
+        /**
+         * Whether the value is inclusive. Defaults to `true`.
+         */
+        isInclusive?: boolean;
+    };
 
 /**
  * Represents a range by index (rank) in a sorted set.
@@ -2015,21 +2015,21 @@ export function createZRank(
 
 export type StreamTrimOptions = (
     | {
-          /**
-           * Trim the stream according to entry ID.
-           * Equivalent to `MINID` in the Redis API.
-           */
-          method: "minid";
-          threshold: string;
-      }
+        /**
+         * Trim the stream according to entry ID.
+         * Equivalent to `MINID` in the Redis API.
+         */
+        method: "minid";
+        threshold: string;
+    }
     | {
-          /**
-           * Trim the stream according to length.
-           * Equivalent to `MAXLEN` in the Redis API.
-           */
-          method: "maxlen";
-          threshold: number;
-      }
+        /**
+         * Trim the stream according to length.
+         * Equivalent to `MAXLEN` in the Redis API.
+         */
+        method: "maxlen";
+        threshold: number;
+    }
 ) & {
     /**
      * If `true`, the stream will be trimmed exactly. Equivalent to `=` in the
@@ -2600,8 +2600,8 @@ export function createXReadGroup(
  */
 export type ReturnTypeXinfoStream = {
     [key: string]:
-        | StreamEntries
-        | Record<string, StreamEntries | Record<string, StreamEntries>[]>[];
+    | StreamEntries
+    | Record<string, StreamEntries | Record<string, StreamEntries>[]>[];
 };
 
 /**
@@ -2680,8 +2680,8 @@ export function createXPending(
 
 /** @internal */
 export function createXInfoConsumers(
-    key: string,
-    group: string,
+    key: GlideString,
+    group: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.XInfoConsumers, [key, group]);
 }

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2161,7 +2161,7 @@ export function createXRange(
  * @internal
  */
 export function createXRevRange(
-    key: string,
+    key: GlideString,
     start: Boundary<string>,
     end: Boundary<string>,
     count?: number,

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2020,7 +2020,7 @@ export type StreamTrimOptions = (
          * Equivalent to `MINID` in the Redis API.
          */
         method: "minid";
-        threshold: string;
+        threshold: GlideString;
     }
     | {
         /**
@@ -2130,7 +2130,7 @@ export function createXDel(
  * @internal
  */
 export function createXTrim(
-    key: string,
+    key: GlideString,
     options: StreamTrimOptions,
 ): command_request.Command {
     const args = [key];

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2637,7 +2637,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A map of stream entry ids, to an array of entries, or `null` if `count` is non-positive.
      */
     public xrevrange(
-        key: string,
+        key: GlideString,
         end: Boundary<string>,
         start: Boundary<string>,
         count?: number,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2747,7 +2747,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `Array` of `Records`, where each mapping contains the attributes
      *     of a consumer for the given consumer group of the stream at `key`.
      */
-    public xinfoConsumers(key: string, group: string): T {
+    public xinfoConsumers(key: GlideString, group: GlideString): T {
         return this.addAndReturn(createXInfoConsumers(key, group));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2695,7 +2695,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The number of entries in the stream. If `key` does not exist, returns `0`.
      */
-    public xlen(key: string): T {
+    public xlen(key: GlideString): T {
         return this.addAndReturn(createXLen(key));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -4,6 +4,7 @@
 
 import {
     BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars
+    GlideRecord, // eslint-disable-line @typescript-eslint/no-unused-vars
     GlideString,
     HashDataType,
     convertFieldsAndValuesForHset,
@@ -2655,9 +2656,14 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A `Record` of stream keys, each key is mapped to a `Record` of stream ids, to an `Array` of entries.
      */
     public xread(
-        keys_and_ids: Record<string, string>,
+        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
         options?: StreamReadOptions,
     ): T {
+        if (!Array.isArray(keys_and_ids)) {
+            keys_and_ids = Object.entries(keys_and_ids).map((e) => {
+                return {key: e[0], value: e[1]}
+            })
+        }
         return this.addAndReturn(createXRead(keys_and_ids, options));
     }
 
@@ -2676,11 +2682,16 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     Returns `null` if there is no stream that can be served.
      */
     public xreadgroup(
-        group: string,
-        consumer: string,
-        keys_and_ids: Record<string, string>,
+        group: GlideString,
+        consumer: GlideString,
+        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
         options?: StreamReadGroupOptions,
     ): T {
+        if (!Array.isArray(keys_and_ids)) {
+            keys_and_ids = Object.entries(keys_and_ids).map((e) => {
+                return {key: e[0], value: e[1]}
+            })
+        }
         return this.addAndReturn(
             createXReadGroup(group, consumer, keys_and_ids, options),
         );

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -4,7 +4,7 @@
 
 import {
     BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars
-    GlideRecord, // eslint-disable-line @typescript-eslint/no-unused-vars
+    GlideRecord,
     GlideString,
     HashDataType,
     convertFieldsAndValuesForHset,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2661,9 +2661,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     ): T {
         if (!Array.isArray(keys_and_ids)) {
             keys_and_ids = Object.entries(keys_and_ids).map((e) => {
-                return {key: e[0], value: e[1]}
-            })
+                return { key: e[0], value: e[1] };
+            });
         }
+
         return this.addAndReturn(createXRead(keys_and_ids, options));
     }
 
@@ -2689,9 +2690,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     ): T {
         if (!Array.isArray(keys_and_ids)) {
             keys_and_ids = Object.entries(keys_and_ids).map((e) => {
-                return {key: e[0], value: e[1]}
-            })
+                return { key: e[0], value: e[1] };
+            });
         }
+
         return this.addAndReturn(
             createXReadGroup(group, consumer, keys_and_ids, options),
         );

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2556,7 +2556,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A {@link ReturnTypeXinfoStream} of detailed stream information for the given `key`.
      *     See example of {@link BaseClient.xinfoStream} for more details.
      */
-    public xinfoStream(key: string, fullOptions?: boolean | number): T {
+    public xinfoStream(key: GlideString, fullOptions?: boolean | number): T {
         return this.addAndReturn(createXInfoStream(key, fullOptions ?? false));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2607,7 +2607,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - A map of stream entry ids, to an array of entries, or `null` if `count` is non-positive.
      */
     public xrange(
-        key: string,
+        key: GlideString,
         start: Boundary<string>,
         end: Boundary<string>,
         count?: number,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2542,7 +2542,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The number of entries deleted from the stream. If `key` doesn't exist, 0 is returned.
      */
-    public xtrim(key: string, options: StreamTrimOptions): T {
+    public xtrim(key: GlideString, options: StreamTrimOptions): T {
         return this.addAndReturn(createXTrim(key, options));
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -2714,7 +2714,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` that includes the summary of the pending messages.
      * See example of {@link BaseClient.xpending|xpending} for more details.
      */
-    public xpending(key: string, group: string): T {
+    public xpending(key: GlideString, group: GlideString): T {
         return this.addAndReturn(createXPending(key, group));
     }
 
@@ -2731,8 +2731,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * See example of {@link BaseClient.xpendingWithOptions|xpendingWithOptions} for more details.
      */
     public xpendingWithOptions(
-        key: string,
-        group: string,
+        key: GlideString,
+        group: GlideString,
         options: StreamPendingOptions,
     ): T {
         return this.addAndReturn(createXPending(key, group, options));

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -6488,7 +6488,7 @@ export function runBaseTests(config: {
 
                 expect(
                     await client.xrevrange(
-                        key,
+                        Buffer.from(key),
                         InfBoundary.PositiveInfinity,
                         InfBoundary.NegativeInfinity,
                     ),

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -7106,7 +7106,7 @@ export function runBaseTests(config: {
                         id: streamId1_1,
                     }),
                 ).toEqual(streamId1_1);
-                const fullResult = (await client.xinfoStream(key, 1)) as {
+                const fullResult = (await client.xinfoStream(Buffer.from(key), 1)) as {
                     length: number;
                     "radix-tree-keys": number;
                     "radix-tree-nodes": number;

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -6390,7 +6390,7 @@ export function runBaseTests(config: {
                     },
                 );
                 expect(id).not.toBeNull();
-                expect(await client.xlen(key)).toEqual(2);
+                expect(await client.xlen(Buffer.from(key))).toEqual(2);
 
                 // this will trim the 2nd entry.
                 expect(

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -6868,10 +6868,10 @@ export function runBaseTests(config: {
                 ]);
 
                 const result = await client.xread(
-                    {
-                        [key1]: timestamp_1_1 as string,
-                        [key2]: timestamp_2_1 as string,
-                    },
+                    [
+                        {key: Buffer.from(key1), value: timestamp_1_1 as string},
+                        {key: key2, value: Buffer.from(timestamp_2_1 as string)},
+                    ],
                     {
                         block: 1,
                     },
@@ -6955,7 +6955,9 @@ export function runBaseTests(config: {
 
                 // read the entire stream for the consumer and mark messages as pending
                 expect(
-                    await client.xreadgroup(group, consumer, { [key1]: ">" }),
+                    await client.xreadgroup(Buffer.from(group), Buffer.from(consumer), 
+                    [{ key: Buffer.from(key1), value: Buffer.from(">") }]
+                ),
                 ).toEqual({
                     [key1]: {
                         [entry1]: [["a", "b"]],

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -6522,7 +6522,7 @@ export function runBaseTests(config: {
                 if (!cluster.checkIfServerVersionLessThan("6.2.0")) {
                     expect(
                         await client.xrange(
-                            key,
+                            Buffer.from(key),
                             { isInclusive: false, value: streamId2 },
                             { value: "5" },
                             1,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -10452,7 +10452,7 @@ export function runBaseTests(config: {
                 // wait to get some minIdleTime
                 await new Promise((resolve) => setTimeout(resolve, 500));
 
-                expect(await client.xpending(key, group)).toEqual([
+                expect(await client.xpending(Buffer.from(key), group)).toEqual([
                     2,
                     "0-1",
                     "0-2",
@@ -10461,7 +10461,7 @@ export function runBaseTests(config: {
 
                 const result = await client.xpendingWithOptions(
                     key,
-                    group,
+                    Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
                             start: InfBoundary.NegativeInfinity,
@@ -10484,7 +10484,7 @@ export function runBaseTests(config: {
                         start: { value: "0-1", isInclusive: true },
                         end: { value: "0-2", isInclusive: false },
                         count: 12,
-                        consumer: "_",
+                        consumer: Buffer.from("_"),
                     }),
                 ).toEqual([]);
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -354,8 +354,8 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.exec(new Transaction().lastsave())
                         : await client.exec(
-                              new ClusterTransaction().lastsave(),
-                          );
+                            new ClusterTransaction().lastsave(),
+                        );
                 expect(response?.[0]).toBeGreaterThan(yesterday);
             }, protocol);
         },
@@ -7418,13 +7418,13 @@ export function runBaseTests(config: {
                 let response =
                     client instanceof GlideClient
                         ? await client.exec(
-                              new Transaction().dump(key1),
-                              Decoder.Bytes,
-                          )
+                            new Transaction().dump(key1),
+                            Decoder.Bytes,
+                        )
                         : await client.exec(
-                              new ClusterTransaction().dump(key1),
-                              { decoder: Decoder.Bytes },
-                          );
+                            new ClusterTransaction().dump(key1),
+                            { decoder: Decoder.Bytes },
+                        );
                 expect(response?.[0]).not.toBeNull();
                 data = response?.[0] as Buffer;
 
@@ -7432,17 +7432,17 @@ export function runBaseTests(config: {
                 response =
                     client instanceof GlideClient
                         ? await client.exec(
-                              new Transaction()
-                                  .restore(key4, 0, data)
-                                  .get(key4),
-                              Decoder.String,
-                          )
+                            new Transaction()
+                                .restore(key4, 0, data)
+                                .get(key4),
+                            Decoder.String,
+                        )
                         : await client.exec(
-                              new ClusterTransaction()
-                                  .restore(key4, 0, data)
-                                  .get(key4),
-                              { decoder: Decoder.String },
-                          );
+                            new ClusterTransaction()
+                                .restore(key4, 0, data)
+                                .get(key4),
+                            { decoder: Decoder.String },
+                        );
                 expect(response?.[0]).toEqual("OK");
                 expect(response?.[1]).toEqual(value);
 
@@ -7450,17 +7450,17 @@ export function runBaseTests(config: {
                 response =
                     client instanceof GlideClient
                         ? await client.exec(
-                              new Transaction()
-                                  .restore(key5, 0, data)
-                                  .get(key5),
-                              Decoder.Bytes,
-                          )
+                            new Transaction()
+                                .restore(key5, 0, data)
+                                .get(key5),
+                            Decoder.Bytes,
+                        )
                         : await client.exec(
-                              new ClusterTransaction()
-                                  .restore(key5, 0, data)
-                                  .get(key5),
-                              { decoder: Decoder.Bytes },
-                          );
+                            new ClusterTransaction()
+                                .restore(key5, 0, data)
+                                .get(key5),
+                            { decoder: Decoder.Bytes },
+                        );
                 expect(response?.[0]).toEqual("OK");
                 expect(response?.[1]).toEqual(valueEncode);
             }, protocol);
@@ -7847,13 +7847,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                          type:
-                              | TimeUnit.Seconds
-                              | TimeUnit.Milliseconds
-                              | TimeUnit.UnixSeconds
-                              | TimeUnit.UnixMilliseconds;
-                          count: number;
-                      },
+                        type:
+                        | TimeUnit.Seconds
+                        | TimeUnit.Milliseconds
+                        | TimeUnit.UnixSeconds
+                        | TimeUnit.UnixMilliseconds;
+                        count: number;
+                    },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -7873,13 +7873,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                          type:
-                              | TimeUnit.Seconds
-                              | TimeUnit.Milliseconds
-                              | TimeUnit.UnixSeconds
-                              | TimeUnit.UnixMilliseconds;
-                          count: number;
-                      },
+                        type:
+                        | TimeUnit.Seconds
+                        | TimeUnit.Milliseconds
+                        | TimeUnit.UnixSeconds
+                        | TimeUnit.UnixMilliseconds;
+                        count: number;
+                    },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -10087,7 +10087,7 @@ export function runBaseTests(config: {
                 expect(
                     await client.xgroupCreate(key2, groupName1, "0-0"),
                 ).toEqual("OK");
-                expect(await client.xinfoConsumers(key2, groupName1)).toEqual(
+                expect(await client.xinfoConsumers(Buffer.from(key2), groupName1)).toEqual(
                     [],
                 );
             }, protocol);
@@ -10117,23 +10117,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                                  "entries-read": null,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                                "entries-read": null,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 expect(
@@ -10170,23 +10170,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                                  "entries-read": null,
-                                  lag: 3,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                                "entries-read": null,
+                                lag: 3,
+                            },
+                        ],
                 );
 
                 expect(
@@ -10216,23 +10216,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 3,
-                                  "last-delivered-id": streamId3,
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 3,
+                                "last-delivered-id": streamId3,
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 3,
-                                  "last-delivered-id": streamId3,
-                                  "entries-read": 3,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 3,
+                                "last-delivered-id": streamId3,
+                                "entries-read": 3,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 expect(
@@ -10247,23 +10247,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 2,
-                                  "last-delivered-id": streamId3,
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 2,
+                                "last-delivered-id": streamId3,
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 2,
-                                  "last-delivered-id": streamId3,
-                                  "entries-read": 3,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 2,
+                                "last-delivered-id": streamId3,
+                                "entries-read": 3,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 // key exists, but it is not a stream
@@ -10464,16 +10464,16 @@ export function runBaseTests(config: {
                     group,
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                              start: InfBoundary.NegativeInfinity,
-                              end: InfBoundary.PositiveInfinity,
-                              count: 1,
-                          }
+                            start: InfBoundary.NegativeInfinity,
+                            end: InfBoundary.PositiveInfinity,
+                            count: 1,
+                        }
                         : {
-                              start: InfBoundary.NegativeInfinity,
-                              end: InfBoundary.PositiveInfinity,
-                              count: 1,
-                              minIdleTime: 42,
-                          },
+                            start: InfBoundary.NegativeInfinity,
+                            end: InfBoundary.PositiveInfinity,
+                            count: 1,
+                            minIdleTime: 42,
+                        },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -6412,7 +6412,7 @@ export function runBaseTests(config: {
                 expect(await client.xlen(key)).toEqual(2);
 
                 expect(
-                    await client.xtrim(key, {
+                    await client.xtrim(Buffer.from(key), {
                         method: "maxlen",
                         threshold: 1,
                         exact: true,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -354,8 +354,8 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.exec(new Transaction().lastsave())
                         : await client.exec(
-                            new ClusterTransaction().lastsave(),
-                        );
+                              new ClusterTransaction().lastsave(),
+                          );
                 expect(response?.[0]).toBeGreaterThan(yesterday);
             }, protocol);
         },
@@ -6869,8 +6869,14 @@ export function runBaseTests(config: {
 
                 const result = await client.xread(
                     [
-                        {key: Buffer.from(key1), value: timestamp_1_1 as string},
-                        {key: key2, value: Buffer.from(timestamp_2_1 as string)},
+                        {
+                            key: Buffer.from(key1),
+                            value: timestamp_1_1 as string,
+                        },
+                        {
+                            key: key2,
+                            value: Buffer.from(timestamp_2_1 as string),
+                        },
                     ],
                     {
                         block: 1,
@@ -6955,9 +6961,11 @@ export function runBaseTests(config: {
 
                 // read the entire stream for the consumer and mark messages as pending
                 expect(
-                    await client.xreadgroup(Buffer.from(group), Buffer.from(consumer), 
-                    [{ key: Buffer.from(key1), value: Buffer.from(">") }]
-                ),
+                    await client.xreadgroup(
+                        Buffer.from(group),
+                        Buffer.from(consumer),
+                        [{ key: Buffer.from(key1), value: Buffer.from(">") }],
+                    ),
                 ).toEqual({
                     [key1]: {
                         [entry1]: [["a", "b"]],
@@ -7108,7 +7116,10 @@ export function runBaseTests(config: {
                         id: streamId1_1,
                     }),
                 ).toEqual(streamId1_1);
-                const fullResult = (await client.xinfoStream(Buffer.from(key), 1)) as {
+                const fullResult = (await client.xinfoStream(
+                    Buffer.from(key),
+                    1,
+                )) as {
                     length: number;
                     "radix-tree-keys": number;
                     "radix-tree-nodes": number;
@@ -7420,13 +7431,13 @@ export function runBaseTests(config: {
                 let response =
                     client instanceof GlideClient
                         ? await client.exec(
-                            new Transaction().dump(key1),
-                            Decoder.Bytes,
-                        )
+                              new Transaction().dump(key1),
+                              Decoder.Bytes,
+                          )
                         : await client.exec(
-                            new ClusterTransaction().dump(key1),
-                            { decoder: Decoder.Bytes },
-                        );
+                              new ClusterTransaction().dump(key1),
+                              { decoder: Decoder.Bytes },
+                          );
                 expect(response?.[0]).not.toBeNull();
                 data = response?.[0] as Buffer;
 
@@ -7434,17 +7445,17 @@ export function runBaseTests(config: {
                 response =
                     client instanceof GlideClient
                         ? await client.exec(
-                            new Transaction()
-                                .restore(key4, 0, data)
-                                .get(key4),
-                            Decoder.String,
-                        )
+                              new Transaction()
+                                  .restore(key4, 0, data)
+                                  .get(key4),
+                              Decoder.String,
+                          )
                         : await client.exec(
-                            new ClusterTransaction()
-                                .restore(key4, 0, data)
-                                .get(key4),
-                            { decoder: Decoder.String },
-                        );
+                              new ClusterTransaction()
+                                  .restore(key4, 0, data)
+                                  .get(key4),
+                              { decoder: Decoder.String },
+                          );
                 expect(response?.[0]).toEqual("OK");
                 expect(response?.[1]).toEqual(value);
 
@@ -7452,17 +7463,17 @@ export function runBaseTests(config: {
                 response =
                     client instanceof GlideClient
                         ? await client.exec(
-                            new Transaction()
-                                .restore(key5, 0, data)
-                                .get(key5),
-                            Decoder.Bytes,
-                        )
+                              new Transaction()
+                                  .restore(key5, 0, data)
+                                  .get(key5),
+                              Decoder.Bytes,
+                          )
                         : await client.exec(
-                            new ClusterTransaction()
-                                .restore(key5, 0, data)
-                                .get(key5),
-                            { decoder: Decoder.Bytes },
-                        );
+                              new ClusterTransaction()
+                                  .restore(key5, 0, data)
+                                  .get(key5),
+                              { decoder: Decoder.Bytes },
+                          );
                 expect(response?.[0]).toEqual("OK");
                 expect(response?.[1]).toEqual(valueEncode);
             }, protocol);
@@ -7849,13 +7860,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -7875,13 +7886,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -10089,9 +10100,9 @@ export function runBaseTests(config: {
                 expect(
                     await client.xgroupCreate(key2, groupName1, "0-0"),
                 ).toEqual("OK");
-                expect(await client.xinfoConsumers(Buffer.from(key2), groupName1)).toEqual(
-                    [],
-                );
+                expect(
+                    await client.xinfoConsumers(Buffer.from(key2), groupName1),
+                ).toEqual([]);
             }, protocol);
         },
         config.timeout,
@@ -10119,23 +10130,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(
@@ -10172,23 +10183,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 3,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 3,
+                              },
+                          ],
                 );
 
                 expect(
@@ -10218,23 +10229,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(
@@ -10249,23 +10260,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 // key exists, but it is not a stream
@@ -10466,16 +10477,16 @@ export function runBaseTests(config: {
                     Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                        }
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                          }
                         : {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                            minIdleTime: 42,
-                        },
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                              minIdleTime: 42,
+                          },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);


### PR DESCRIPTION
Commands included:

- `XINFO CONSUMERS`
- `XINFO STREAM`
- `XLEN`
- `XPENDING`
- `XRANGE`
- `XREAD`
- `XREADGROUP`
- `XREVRANGE`
- `XTRIM`