### PR TITLE
Add decoder options to get() command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### Changes
-* Node: Added binary variant to sorted set commands - part 1 ([#2190](https://github.com/valkey-io/valkey-glide/pull/2190))
+* Node: Added binary variant to sorted set commands ([#2190](https://github.com/valkey-io/valkey-glide/pull/2190), [#2210](https://github.com/valkey-io/valkey-glide/pull/2210))
 * Node: Added binary variant to HASH commands ([#2194](https://github.com/valkey-io/valkey-glide/pull/2194))
 * Node: Added binary variant to server management commands ([#2179](https://github.com/valkey-io/valkey-glide/pull/2179))
 * Node: Added/updated binary variant to connection management commands and WATCH/UNWATCH ([#2160](https://github.com/valkey-io/valkey-glide/pull/2160))

--- a/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
@@ -3,7 +3,9 @@ package glide.api.commands;
 
 import glide.api.models.GlideString;
 import glide.api.models.commands.scan.HScanOptions;
+import glide.api.models.commands.scan.HScanOptions.HScanOptionsBuilder;
 import glide.api.models.commands.scan.HScanOptionsBinary;
+import glide.api.models.commands.scan.HScanOptionsBinary.HScanOptionsBinaryBuilder;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -695,8 +697,10 @@ public interface HashBaseCommands {
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
      *     </code> returned on the last iteration of the result. The second element is always an
      *     <code>Array</code> of the subset of the hash held in <code>key</code>. The array in the
-     *     second element is always a flattened series of <code>String</code> pairs, where the key is
-     *     at even indices and the value is at odd indices.
+     *     second element is a flattened series of <code>String</code> pairs, where the key is at even
+     *     indices and the value is at odd indices. If {@link HScanOptionsBuilder#noValues} is set to
+     *     <code>true
+     *     </code>, the second element will only contain the fields without the values.
      * @example
      *     <pre>{@code
      * // Assume key contains a set with 200 member-score pairs
@@ -731,8 +735,10 @@ public interface HashBaseCommands {
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
      *     </code> returned on the last iteration of the result. The second element is always an
      *     <code>Array</code> of the subset of the hash held in <code>key</code>. The array in the
-     *     second element is always a flattened series of <code>String</code> pairs, where the key is
-     *     at even indices and the value is at odd indices.
+     *     second element is a flattened series of <code>String</code> pairs, where the key is at even
+     *     indices and the value is at odd indices. If {@link HScanOptionsBinaryBuilder#noValues} is
+     *     set to <code>true
+     *     </code>, the second element will only contain the fields without the values.
      * @example
      *     <pre>{@code
      * // Assume key contains a set with 200 member-score pairs

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -22,7 +22,9 @@ import glide.api.models.commands.WeightAggregateOptions.KeysOrWeightedKeysBinary
 import glide.api.models.commands.WeightAggregateOptions.WeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.scan.ZScanOptions;
+import glide.api.models.commands.scan.ZScanOptions.ZScanOptionsBuilder;
 import glide.api.models.commands.scan.ZScanOptionsBinary;
+import glide.api.models.commands.scan.ZScanOptionsBinary.ZScanOptionsBinaryBuilder;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -2789,8 +2791,10 @@ public interface SortedSetBaseCommands {
      *     </code> returned on the last iteration of the sorted set. The second element is always an
      *     <code>
      *     Array</code> of the subset of the sorted set held in <code>key</code>. The array in the
-     *     second element is always a flattened series of <code>String</code> pairs, where the value
-     *     is at even indices and the score is at odd indices.
+     *     second element is a flattened series of <code>String</code> pairs, where the value is at
+     *     even indices and the score is at odd indices. If {@link ZScanOptionsBuilder#noScores} is to
+     *     <code>true
+     *     </code>, the second element will only contain the members without scores.
      * @example
      *     <pre>{@code
      * // Assume key contains a set with 200 member-score pairs
@@ -2826,8 +2830,10 @@ public interface SortedSetBaseCommands {
      *     </code> returned on the last iteration of the sorted set. The second element is always an
      *     <code>
      *     Array</code> of the subset of the sorted set held in <code>key</code>. The array in the
-     *     second element is always a flattened series of <code>String</code> pairs, where the value
-     *     is at even indices and the score is at odd indices.
+     *     second element is a flattened series of <code>String</code> pairs, where the value is at
+     *     even indices and the score is at odd indices. If {@link ZScanOptionsBinaryBuilder#noScores}
+     *     is to <code>true
+     *     </code>, the second element will only contain the members without scores.
      * @example
      *     <pre>{@code
      * // Assume key contains a set with 200 member-score pairs

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -282,8 +282,10 @@ import glide.api.models.commands.geospatial.GeoSearchStoreOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.scan.HScanOptions;
+import glide.api.models.commands.scan.HScanOptions.HScanOptionsBuilder;
 import glide.api.models.commands.scan.SScanOptions;
 import glide.api.models.commands.scan.ZScanOptions;
+import glide.api.models.commands.scan.ZScanOptions.ZScanOptionsBuilder;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamAddOptions.StreamAddOptionsBuilder;
 import glide.api.models.commands.stream.StreamClaimOptions;
@@ -7054,8 +7056,10 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be
      *     the <code>cursor</code> returned on the last iteration of the sorted set. The second
      *     element is always an <code>Array</code> of the subset of the sorted set held in <code>key
-     *     </code>. The array in the second element is always a flattened series of <code>String
-     *     </code> pairs, where the value is at even indices and the score is at odd indices.
+     *     </code>. The array in the second element is a flattened series of <code>String
+     *     </code> pairs, where the value is at even indices and the score is at odd indices. If
+     *     {@link ZScanOptionsBuilder#noScores} is to <code>true</code>, the second element will only
+     *     contain the members without scores.
      */
     public <ArgType> T zscan(
             @NonNull ArgType key, @NonNull ArgType cursor, @NonNull ZScanOptions zScanOptions) {
@@ -7101,8 +7105,10 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be
      *     the <code>cursor</code> returned on the last iteration of the result. The second element is
      *     always an <code>Array</code> of the subset of the hash held in <code>key</code>. The array
-     *     in the second element is always a flattened series of <code>String</code> pairs, where the
-     *     key is at even indices and the value is at odd indices.
+     *     in the second element is a flattened series of <code>String</code> pairs, where the key is
+     *     at even indices and the value is at odd indices. If {@link HScanOptionsBuilder#noValues} is
+     *     set to <code>true</code>, the second element will only contain the fields without the
+     *     values.
      */
     public <ArgType> T hscan(
             @NonNull ArgType key, @NonNull ArgType cursor, @NonNull HScanOptions hScanOptions) {

--- a/java/client/src/main/java/glide/api/models/commands/scan/HScanOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/HScanOptions.java
@@ -2,6 +2,11 @@
 package glide.api.models.commands.scan;
 
 import glide.api.commands.HashBaseCommands;
+import glide.api.models.GlideString;
+import glide.utils.ArgsBuilder;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -10,4 +15,43 @@ import lombok.experimental.SuperBuilder;
  * @see <a href="https://valkey.io/commands/hscan/">valkey.io</a>
  */
 @SuperBuilder
-public class HScanOptions extends BaseScanOptions {}
+@EqualsAndHashCode(callSuper = false)
+public class HScanOptions extends BaseScanOptions {
+
+    /** Option string to include in the HSCAN command when values are not included. */
+    public static final String NO_VALUES_API = "NOVALUES";
+
+    /**
+     * When set to true, the command will not include values in the results. This option is available
+     * from Valkey version 8.0.0 and above.
+     */
+    @Builder.Default protected boolean noValues = false;
+
+    @Override
+    public String[] toArgs() {
+        return Arrays.stream(toGlideStringArgs()).map(GlideString::getString).toArray(String[]::new);
+    }
+
+    /**
+     * Creates the arguments to be used in <code>HSCAN</code> commands.
+     *
+     * @return a GlideString array that holds the options and their arguments.
+     */
+    @Override
+    public GlideString[] toGlideStringArgs() {
+        ArgsBuilder builder = new ArgsBuilder();
+
+        // Add options from the superclass
+        GlideString[] superArgs = super.toGlideStringArgs();
+        for (GlideString arg : superArgs) {
+            builder.add(arg);
+        }
+
+        // Add the noValues option if applicable
+        if (noValues) {
+            builder.add(NO_VALUES_API);
+        }
+
+        return builder.toArray();
+    }
+}

--- a/java/client/src/main/java/glide/api/models/commands/scan/HScanOptionsBinary.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/HScanOptionsBinary.java
@@ -1,7 +1,13 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.commands.scan;
 
+import static glide.api.models.GlideString.gs;
+
 import glide.api.commands.HashBaseCommands;
+import glide.api.models.GlideString;
+import glide.utils.ArgsBuilder;
+import java.util.Arrays;
+import lombok.Builder;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -11,4 +17,36 @@ import lombok.experimental.SuperBuilder;
  * @see <a href="https://valkey.io/commands/hscan/">valkey.io</a>
  */
 @SuperBuilder
-public class HScanOptionsBinary extends BaseScanOptionsBinary {}
+public class HScanOptionsBinary extends BaseScanOptionsBinary {
+    /** Option string to include in the HSCAN command when values are not included. */
+    public static final GlideString NO_VALUES_API = gs("NOVALUES");
+
+    /**
+     * When set to true, the command will not include values in the results. This option is available
+     * from Valkey version 8.0.0 and above.
+     */
+    @Builder.Default protected boolean noValues = false;
+
+    /**
+     * Creates the arguments to be used in <code>ZSCAN</code> commands.
+     *
+     * @return a String array that holds the options and their arguments.
+     */
+    @Override
+    public String[] toArgs() {
+        ArgsBuilder builder = new ArgsBuilder();
+
+        // Add options from the superclass
+        String[] superArgs = super.toArgs();
+        for (String arg : superArgs) {
+            builder.add(arg);
+        }
+
+        // Add the noValues option if applicable
+        if (noValues) {
+            builder.add(NO_VALUES_API.toString());
+        }
+
+        return Arrays.stream(builder.toArray()).map(GlideString::getString).toArray(String[]::new);
+    }
+}

--- a/java/client/src/main/java/glide/api/models/commands/scan/ZScanOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/ZScanOptions.java
@@ -2,6 +2,11 @@
 package glide.api.models.commands.scan;
 
 import glide.api.commands.SortedSetBaseCommands;
+import glide.api.models.GlideString;
+import glide.utils.ArgsBuilder;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -10,4 +15,43 @@ import lombok.experimental.SuperBuilder;
  * @see <a href="https://valkey.io/commands/zscan/">valkey.io</a>
  */
 @SuperBuilder
-public class ZScanOptions extends BaseScanOptions {}
+@EqualsAndHashCode(callSuper = false)
+public class ZScanOptions extends BaseScanOptions {
+
+    /** Option string to include in the ZSCAN command when scores are not included. */
+    public static final String NO_SCORES_API = "NOSCORES";
+
+    /**
+     * When set to true, the command will not include scores in the results. This option is available
+     * from Valkey version 8.0.0 and above.
+     */
+    @Builder.Default protected boolean noScores = false;
+
+    @Override
+    public String[] toArgs() {
+        return Arrays.stream(toGlideStringArgs()).map(GlideString::getString).toArray(String[]::new);
+    }
+
+    /**
+     * Creates the arguments to be used in <code>ZSCAN</code> commands.
+     *
+     * @return a GlideString array that holds the options and their arguments.
+     */
+    @Override
+    public GlideString[] toGlideStringArgs() {
+        ArgsBuilder builder = new ArgsBuilder();
+
+        // Add options from the superclass
+        GlideString[] superArgs = super.toGlideStringArgs();
+        for (GlideString arg : superArgs) {
+            builder.add(arg);
+        }
+
+        // Add the noScores option if applicable
+        if (noScores) {
+            builder.add(NO_SCORES_API);
+        }
+
+        return builder.toArray();
+    }
+}

--- a/java/client/src/main/java/glide/api/models/commands/scan/ZScanOptionsBinary.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/ZScanOptionsBinary.java
@@ -1,7 +1,14 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.commands.scan;
 
+import static glide.api.models.GlideString.gs;
+
 import glide.api.commands.SortedSetBaseCommands;
+import glide.api.models.GlideString;
+import glide.utils.ArgsBuilder;
+import java.util.Arrays;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -11,4 +18,37 @@ import lombok.experimental.SuperBuilder;
  * @see <a href="https://valkey.io/commands/zscan/">valkey.io</a>
  */
 @SuperBuilder
-public class ZScanOptionsBinary extends BaseScanOptionsBinary {}
+@EqualsAndHashCode(callSuper = false)
+public class ZScanOptionsBinary extends BaseScanOptionsBinary {
+    /** Option string to include in the ZSCAN command when scores are not included. */
+    public static final GlideString NO_SCORES_API = gs("NOSCORES");
+
+    /**
+     * When set to true, the command will not include scores in the results. This option is available
+     * from Redis version 8.0.0 and above.
+     */
+    @Builder.Default protected boolean noScores = false;
+
+    /**
+     * Creates the arguments to be used in <code>ZSCAN</code> commands.
+     *
+     * @return a String array that holds the options and their arguments.
+     */
+    @Override
+    public String[] toArgs() {
+        ArgsBuilder builder = new ArgsBuilder();
+
+        // Add options from the superclass
+        String[] superArgs = super.toArgs();
+        for (String arg : superArgs) {
+            builder.add(arg);
+        }
+
+        // Add the noScores option if applicable
+        if (noScores) {
+            builder.add(NO_SCORES_API.toString());
+        }
+
+        return Arrays.stream(builder.toArray()).map(GlideString::getString).toArray(String[]::new);
+    }
+}

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -382,33 +382,54 @@ public class TransactionTestUtilities {
                 .hscan(hashKey2, "0")
                 .hscan(hashKey2, "0", HScanOptions.builder().count(20L).build());
 
-        return new Object[] {
-            2L, // hset(hashKey1, Map.of(field1, value1, field2, value2))
-            value1, // hget(hashKey1, field1)
-            2L, // hlen(hashKey1)
-            true, // hexists(hashKey1, field2)
-            false, // hsetnx(hashKey1, field1, value1)
-            new String[] {value1, null, value2}, // hmget(hashKey1, new String[] {...})
-            Map.of(field1, value1, field2, value2), // hgetall(hashKey1)
-            1L, // hdel(hashKey1, new String[] {field1})
-            new String[] {value2}, // hvals(hashKey1)
-            field2, // hrandfield(hashKey1)
-            new String[] {field2}, // hrandfieldWithCount(hashKey1, 2)
-            new String[] {field2, field2}, // hrandfieldWithCount(hashKey1, -2)
-            new String[][] {{field2, value2}}, // hrandfieldWithCountWithValues(hashKey1, 2)
-            new String[][] {
-                {field2, value2}, {field2, value2}
-            }, // hrandfieldWithCountWithValues(hashKey1, -2)
-            5L, // hincrBy(hashKey1, field3, 5)
-            10.5, // hincrByFloat(hashKey1, field3, 5.5)
-            new String[] {field2, field3}, // hkeys(hashKey1)
-            (long) value2.length(), // hstrlen(hashKey1, field2)
-            1L, // hset(hashKey2, Map.of(field1, value1))
-            new Object[] {"0", new Object[] {field1, value1}}, // hscan(hashKey2, "0")
-            new Object[] {
-                "0", new Object[] {field1, value1}
-            }, // hscan(hashKey2, "0", HScanOptions.builder().count(20L).build());
-        };
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            transaction
+                    .hscan(hashKey2, "0", HScanOptions.builder().count(20L).noValues(false).build())
+                    .hscan(hashKey2, "0", HScanOptions.builder().count(20L).noValues(true).build());
+        }
+
+        var result =
+                new Object[] {
+                    2L, // hset(hashKey1, Map.of(field1, value1, field2, value2))
+                    value1, // hget(hashKey1, field1)
+                    2L, // hlen(hashKey1)
+                    true, // hexists(hashKey1, field2)
+                    false, // hsetnx(hashKey1, field1, value1)
+                    new String[] {value1, null, value2}, // hmget(hashKey1, new String[] {...})
+                    Map.of(field1, value1, field2, value2), // hgetall(hashKey1)
+                    1L, // hdel(hashKey1, new String[] {field1})
+                    new String[] {value2}, // hvals(hashKey1)
+                    field2, // hrandfield(hashKey1)
+                    new String[] {field2}, // hrandfieldWithCount(hashKey1, 2)
+                    new String[] {field2, field2}, // hrandfieldWithCount(hashKey1, -2)
+                    new String[][] {{field2, value2}}, // hrandfieldWithCountWithValues(hashKey1, 2)
+                    new String[][] {
+                        {field2, value2}, {field2, value2}
+                    }, // hrandfieldWithCountWithValues(hashKey1, -2)
+                    5L, // hincrBy(hashKey1, field3, 5)
+                    10.5, // hincrByFloat(hashKey1, field3, 5.5)
+                    new String[] {field2, field3}, // hkeys(hashKey1)
+                    (long) value2.length(), // hstrlen(hashKey1, field2)
+                    1L, // hset(hashKey2, Map.of(field1, value1))
+                    new Object[] {"0", new Object[] {field1, value1}}, // hscan(hashKey2, "0")
+                    new Object[] {
+                        "0", new Object[] {field1, value1}
+                    }, // hscan(hashKey2, "0", HScanOptions.builder().count(20L).build());
+                };
+
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            result =
+                    concatenateArrays(
+                            result,
+                            new Object[] {
+                                new Object[] {"0", new Object[] {field1, value1}}, // hscan(hashKey2, "0",
+                                // HScanOptions.builder().count(20L).noValues(false).build());
+                                new Object[] {"0", new Object[] {field1}}, // hscan(hashKey2, "0",
+                                // HScanOptions.builder().count(20L).noValues(true).build());
+                            });
+        }
+
+        return result;
     }
 
     private static Object[] listCommands(BaseTransaction<?> transaction) {
@@ -648,8 +669,14 @@ public class TransactionTestUtilities {
                 .zrandmemberWithCount(zSetKey2, 1)
                 .zrandmemberWithCountWithScores(zSetKey2, 1)
                 .zscan(zSetKey2, "0")
-                .zscan(zSetKey2, "0", ZScanOptions.builder().count(20L).build())
-                .bzpopmin(new String[] {zSetKey2}, .1);
+                .zscan(zSetKey2, "0", ZScanOptions.builder().count(20L).build());
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            transaction
+                    .zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).noScores(false).build())
+                    .zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).noScores(true).build());
+        }
+
+        transaction.bzpopmin(new String[] {zSetKey2}, .1);
         // zSetKey2 is now empty
 
         if (SERVER_VERSION.isGreaterThanOrEqualTo("6.2.0")) {
@@ -712,9 +739,28 @@ public class TransactionTestUtilities {
                     new Object[] {
                         "0", new String[] {"one", "1"}
                     }, // zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).build())
-                    new Object[] {zSetKey2, "one", 1.0}, // bzpopmin(new String[] { zsetKey2 }, .1)
                 };
 
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+            expectedResults =
+                    concatenateArrays(
+                            expectedResults,
+                            new Object[] {
+                                new Object[] {
+                                    "0", new String[] {"one", "1"}
+                                }, // zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).noScores(false).build())
+                                new Object[] {
+                                    "0", new String[] {"one"}
+                                }, // zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).noScores(true).build())
+                            });
+        }
+
+        expectedResults =
+                concatenateArrays(
+                        expectedResults,
+                        new Object[] {
+                            new Object[] {zSetKey2, "one", 1.0}, // bzpopmin(new String[] { zsetKey2 }, .1)
+                        });
         if (SERVER_VERSION.isGreaterThanOrEqualTo("6.2.0")) {
             expectedResults =
                     concatenateArrays(
@@ -751,6 +797,7 @@ public class TransactionTestUtilities {
                                 2L, // zintercard(new String[] {zSetKey4, zSetKey3}, 2)
                             });
         }
+
         return expectedResults;
     }
 

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -118,7 +118,7 @@ Before starting this step, make sure you've installed all software requirments.
 
 ### Troubleshooting
 
--   If the build fails after running `npx tsc` because `redis-rs` isn't found, check if your npm version is in the range 9.0.0-9.4.1, and if so, upgrade it. 9.4.2 contains a fix to a change introduced in 9.0.0 that is required in order to build the library.
+-   If the build fails after running `npx tsc` because `glide-rs` isn't found, check if your npm version is in the range 9.0.0-9.4.1, and if so, upgrade it. 9.4.2 contains a fix to a change introduced in 9.0.0 that is required in order to build the library.
 
 ### Test
 

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -77,6 +77,8 @@ function initialize() {
     const {
         AggregationType,
         BaseScanOptions,
+        ZScanOptions,
+        HScanOptions,
         BitEncoding,
         BitFieldGet,
         BitFieldIncrBy,
@@ -185,6 +187,8 @@ function initialize() {
     module.exports = {
         AggregationType,
         BaseScanOptions,
+        HScanOptions,
+        ZScanOptions,
         BitEncoding,
         BitFieldGet,
         BitFieldIncrBy,

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -33,6 +33,7 @@ import {
     GeoSearchStoreResultOptions,
     GeoUnit,
     GeospatialData,
+    HScanOptions,
     InsertPosition,
     KeyWeight,
     LPosOptions,
@@ -55,6 +56,7 @@ import {
     StreamTrimOptions,
     TimeUnit,
     ZAddOptions,
+    ZScanOptions,
     convertElementsAndScores,
     createAppend,
     createBLMPop,
@@ -2051,12 +2053,13 @@ export class BaseClient {
      *
      * @param key - The key of the set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of the search.
-     * @param options - (Optional) The {@link BaseScanOptions}.
+     * @param options - (Optional) The {@link HScanOptions}.
      * @returns An array of the `cursor` and the subset of the hash held by `key`.
      * The first element is always the `cursor` for the next iteration of results. `"0"` will be the `cursor`
      * returned on the last iteration of the hash. The second element is always an array of the subset of the
-     * hash held in `key`. The array in the second element is always a flattened series of string pairs,
+     * hash held in `key`. The array in the second element is a flattened series of string pairs,
      * where the value is at even indices and the value is at odd indices.
+     * If `options.noValues` is set to `true`, the second element will only contain the fields without the values.
      *
      * @example
      * ```typescript
@@ -2078,13 +2081,36 @@ export class BaseClient {
      * // Cursor:  39
      * // Members:  ['field 63', 'value 63', 'field 293', 'value 293', 'field 162', 'value 162']
      * // Cursor:  0
-     * // Members:  ['value 55', '55', 'value 24', '24', 'value 90', '90', 'value 113', '113']
+     * // Members:  ['field 55', 'value 55', 'field 24', 'value 24', 'field 90', 'value 90', 'field 113', 'value 113']
+     * ```
+     * @example
+     * ```typescript
+     * // Hscan with noValues
+     * let newCursor = "0";
+     * let result = [];
+     * do {
+     *      result = await client.hscan(key1, newCursor, {
+     *          match: "*",
+     *          count: 3,
+     *          noValues: true,
+     *      });
+     *      newCursor = result[0];
+     *      console.log("Cursor: ", newCursor);
+     *      console.log("Members: ", result[1]);
+     * } while (newCursor !== "0");
+     * // The output of the code above is something similar to:
+     * // Cursor:  31
+     * // Members:  ['field 79', 'field 20', 'field 115']
+     * // Cursor:  39
+     * // Members:  ['field 63', 'field 293', 'field 162']
+     * // Cursor:  0
+     * // Members:  ['field 55', 'field 24', 'field 90', 'field 113']
      * ```
      */
     public async hscan(
         key: string,
         cursor: string,
-        options?: BaseScanOptions,
+        options?: HScanOptions,
     ): Promise<[string, string[]]> {
         return this.createWritePromise(createHScan(key, cursor, options));
     }
@@ -6444,12 +6470,13 @@ export class BaseClient {
      * @param key - The key of the sorted set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of
      *      the search.
-     * @param options - (Optional) The `zscan` options - see {@link BaseScanOptions} and {@link DecoderOption}.
+     * @param options - (Optional) The `zscan` options - see {@link ZScanOptions} and {@link DecoderOption}.
      * @returns An `Array` of the `cursor` and the subset of the sorted set held by `key`.
      *      The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
      *      returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
-     *      of the sorted set held in `key`. The `Array` in the second element is always a flattened series of
+     *      of the sorted set held in `key`. The `Array` in the second element is a flattened series of
      *      `string` pairs, where the value is at even indices and the score is at odd indices.
+     *      If `options.noScores` is to `true`, the second element will only contain the members without scores.
      *
      * @example
      * ```typescript
@@ -6472,11 +6499,36 @@ export class BaseClient {
      * // Cursor:  0
      * // Members:  ['value 55', '55', 'value 24', '24', 'value 90', '90', 'value 113', '113']
      * ```
+     *
+     * @example
+     * ```typescript
+     * // Zscan with no scores
+     * let newCursor = "0";
+     * let result = [];
+     *
+     * do {
+     *      result = await client.zscan(key1, newCursor, {
+     *          match: "*",
+     *          count: 5,
+     *          noScores: true,
+     *      });
+     *      newCursor = result[0];
+     *      console.log("Cursor: ", newCursor);
+     *      console.log("Members: ", result[1]);
+     * } while (newCursor !== "0");
+     * // The output of the code above is something similar to:
+     * // Cursor:  123
+     * // Members:  ['value 163', 'value 114', 'value 25', 'value 82', 'value 64']
+     * // Cursor:  47
+     * // Members:  ['value 39', 'value 127', 'value 43', 'value 139', 'value 211']
+     * // Cursor:  0
+     * // Members:  ['value 55', 'value 24' 'value 90', 'value 113']
+     * ```
      */
     public async zscan(
         key: GlideString,
         cursor: string,
-        options?: BaseScanOptions & DecoderOption,
+        options?: ZScanOptions & DecoderOption,
     ): Promise<[string, GlideString[]]> {
         return this.createWritePromise<[GlideString, GlideString[]]>(
             createZScan(key, cursor, options),

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -55,6 +55,7 @@ import {
     StreamTrimOptions,
     TimeUnit,
     ZAddOptions,
+    convertElementsAndScores,
     createAppend,
     createBLMPop,
     createBLMove,
@@ -303,6 +304,17 @@ export type GlideRecord<T> = {
     key: GlideString;
     /** The value itself. */
     value: T;
+}[];
+
+/**
+ * Data type which represents sorted sets data, including elements and their respective scores.
+ * Similar to `Record<GlideString, number>` - see {@link GlideRecord}.
+ */
+export type SortedSetDataType = {
+    /** The sorted set element name. */
+    element: GlideString;
+    /** The element score. */
+    score: number;
 }[];
 
 /**
@@ -3564,15 +3576,16 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/zadd/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param membersScoresMap - A mapping of members to their corresponding scores.
-     * @param options - (Optional) The ZAdd options - see {@link ZAddOptions}.
+     * @param membersAndScores - A list of members and their corresponding scores or a mapping of members to their corresponding scores.
+     * @param options - (Optional) The `ZADD` options - see {@link ZAddOptions}.
      * @returns The number of elements added to the sorted set.
-     * If {@link ZAddOptions.changed|changed} is set, returns the number of elements updated in the sorted set.
+     * If {@link ZAddOptions.changed} is set to `true`, returns the number of elements updated in the sorted set.
      *
      * @example
      * ```typescript
      * // Example usage of the zadd method to add elements to a sorted set
-     * const result = await client.zadd("my_sorted_set", { "member1": 10.5, "member2": 8.2 });
+     * const data = [{ element: "member1", score: 10.5 }, { element: "member2", score: 8.2 }]
+     * const result = await client.zadd("my_sorted_set", data);
      * console.log(result); // Output: 2 - Indicates that two elements have been added to the sorted set "my_sorted_set."
      * ```
      *
@@ -3580,17 +3593,21 @@ export class BaseClient {
      * ```typescript
      * // Example usage of the zadd method to update scores in an existing sorted set
      * const options = { conditionalChange: ConditionalChange.ONLY_IF_EXISTS, changed: true };
-     * const result = await client.zadd("existing_sorted_set", { member1: 15.0, member2: 5.5 }, options);
+     * const result = await client.zadd("existing_sorted_set", { "member1": 10.5, "member2": 8.2 }, options);
      * console.log(result); // Output: 2 - Updates the scores of two existing members in the sorted set "existing_sorted_set."
      * ```
      */
     public async zadd(
-        key: string,
-        membersScoresMap: Record<string, number>,
+        key: GlideString,
+        membersAndScores: SortedSetDataType | Record<string, number>,
         options?: ZAddOptions,
     ): Promise<number> {
         return this.createWritePromise(
-            createZAdd(key, membersScoresMap, options),
+            createZAdd(
+                key,
+                convertElementsAndScores(membersAndScores),
+                options,
+            ),
         );
     }
 
@@ -3602,11 +3619,11 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/zadd/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param member - A member in the sorted set to increment.
+     * @param member - A member in the sorted set to increment score to.
      * @param increment - The score to increment the member.
-     * @param options - (Optional) The ZAdd options - see {@link ZAddOptions}.
+     * @param options - (Optional) The `ZADD` options - see {@link ZAddOptions}.
      * @returns The score of the member.
-     * If there was a conflict with the options, the operation aborts and null is returned.
+     * If there was a conflict with the options, the operation aborts and `null` is returned.
      *
      * @example
      * ```typescript
@@ -3618,22 +3635,28 @@ export class BaseClient {
      * @example
      * ```typescript
      * // Example usage of the zaddIncr method to add or update a member with a score in an existing sorted set
-     * const result = await client.zaddIncr("existing_sorted_set", member, "3.0", { UpdateOptions: "ScoreLessThanCurrent" });
+     * const result = await client.zaddIncr("existing_sorted_set", member, "3.0", { updateOptions: UpdateByScore.LESS_THAN });
      * console.log(result); // Output: null - Indicates that the member in the sorted set haven't been updated.
      * ```
      */
     public async zaddIncr(
-        key: string,
-        member: string,
+        key: GlideString,
+        member: GlideString,
         increment: number,
         options?: ZAddOptions,
     ): Promise<number | null> {
         return this.createWritePromise(
-            createZAdd(key, { [member]: increment }, options, true),
+            createZAdd(
+                key,
+                [{ element: member, score: increment }],
+                options,
+                true,
+            ),
         );
     }
 
-    /** Removes the specified members from the sorted set stored at `key`.
+    /**
+     * Removes the specified members from the sorted set stored at `key`.
      * Specified members that are not a member of this set are ignored.
      *
      * @see {@link https://valkey.io/commands/zrem/|valkey.io} for more details.
@@ -3657,7 +3680,10 @@ export class BaseClient {
      * console.log(result); // Output: 0 - Indicates that no members were removed as the sorted set "non_existing_sorted_set" does not exist.
      * ```
      */
-    public async zrem(key: string, members: string[]): Promise<number> {
+    public async zrem(
+        key: GlideString,
+        members: GlideString[],
+    ): Promise<number> {
         return this.createWritePromise(createZRem(key, members));
     }
 
@@ -3803,7 +3829,8 @@ export class BaseClient {
         return this.createWritePromise(createZDiffStore(destination, keys));
     }
 
-    /** Returns the score of `member` in the sorted set stored at `key`.
+    /**
+     * Returns the score of `member` in the sorted set stored at `key`.
      *
      * @see {@link https://valkey.io/commands/zscore/|valkey.io} for more details.
      *
@@ -3834,7 +3861,10 @@ export class BaseClient {
      * console.log(result); // Output: null
      * ```
      */
-    public async zscore(key: string, member: string): Promise<number | null> {
+    public async zscore(
+        key: GlideString,
+        member: GlideString,
+    ): Promise<number | null> {
         return this.createWritePromise(createZScore(key, member));
     }
 
@@ -3845,28 +3875,45 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/zunionstore/|valkey.io} for details.
      * @remarks When in cluster mode, `destination` and all keys in `keys` both must map to the same hash slot.
+     *
      * @param destination - The key of the destination sorted set.
      * @param keys - The keys of the sorted sets with possible formats:
-     *         string[] - for keys only.
-     *         KeyWeight[] - for weighted keys with score multipliers.
+     *  - `GlideString[]` - for keys only.
+     *  - `KeyWeight[]` - for weighted keys with their score multipliers.
      * @param aggregationType - Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
      * @returns The number of elements in the resulting sorted set stored at `destination`.
      *
-     * * @example
+     * @example
      * ```typescript
-     * // Example usage of zunionstore command with an existing key
      * await client.zadd("key1", {"member1": 10.5, "member2": 8.2})
      * await client.zadd("key2", {"member1": 9.5})
-     * await client.zunionstore("my_sorted_set", ["key1", "key2"]) // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements.
-     * await client.zrangeWithScores("my_sorted_set", RangeByIndex(0, -1)) // Output: {'member1': 20, 'member2': 8.2}  - "member1"  is now stored in "my_sorted_set" with score of 20 and "member2" with score of 8.2.
-     * await client.zunionstore("my_sorted_set", ["key1", "key2"] , AggregationType.MAX ) // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements, and each score is the maximum score between the sets.
-     * await client.zrangeWithScores("my_sorted_set", RangeByIndex(0, -1)) // Output: {'member1': 10.5, 'member2': 8.2}  - "member1"  is now stored in "my_sorted_set" with score of 10.5 and "member2" with score of 8.2.
-     * await client.zunionstore("my_sorted_set", ["key1, "key2], {weights: [2, 1]}) // Output: 46
+     *
+     * // use `zunionstore` with default aggregation and weights
+     * console.log(await client.zunionstore("my_sorted_set", ["key1", "key2"]))
+     * // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements.
+     * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1}))
+     * // Output: {'member1': 20, 'member2': 8.2} - "member1" is now stored in "my_sorted_set" with score of 20 and "member2" with score of 8.2.
+     * ```
+     *
+     * @example
+     * ```typescript
+     * // use `zunionstore` with default weights
+     * console.log(await client.zunionstore("my_sorted_set", ["key1", "key2"], AggregationType.MAX))
+     * // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements, and each score is the maximum score between the sets.
+     * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1}))
+     * // Output: {'member1': 10.5, 'member2': 8.2} - "member1" is now stored in "my_sorted_set" with score of 10.5 and "member2" with score of 8.2.
+     * ```
+     *
+     * @example
+     * ```typescript
+     * // use `zunionstore` with default aggregation
+     * console.log(await client.zunionstore("my_sorted_set", [["key1", 2], ["key2", 1]])) // Output: 2
+     * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1})) // Output: { member2: 16.4, member1: 30.5 }
      * ```
      */
     public async zunionstore(
-        destination: string,
-        keys: string[] | KeyWeight[],
+        destination: GlideString,
+        keys: GlideString[] | KeyWeight[],
         aggregationType?: AggregationType,
     ): Promise<number> {
         return this.createWritePromise(
@@ -3892,8 +3939,8 @@ export class BaseClient {
      * ```
      */
     public async zmscore(
-        key: string,
-        members: string[],
+        key: GlideString,
+        members: GlideString[],
     ): Promise<(number | null)[]> {
         return this.createWritePromise(createZMScore(key, members));
     }
@@ -3932,8 +3979,9 @@ export class BaseClient {
         return this.createWritePromise(createZCount(key, minScore, maxScore));
     }
 
-    /** Returns the specified range of elements in the sorted set stored at `key`.
-     * ZRANGE can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
+    /**
+     * Returns the specified range of elements in the sorted set stored at `key`.
+     * `ZRANGE` can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
      *
      * To get the elements with their scores, see {@link zrangeWithScores}.
      *
@@ -3944,7 +3992,9 @@ export class BaseClient {
      * - For range queries by index (rank), use {@link RangeByIndex}.
      * - For range queries by lexicographical order, use {@link RangeByLex}.
      * - For range queries by score, use {@link RangeByScore}.
-     * @param reverse - If `true`, reverses the sorted set, with index `0` as the element with the highest score.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `reverse`: if `true`, reverses the sorted set, with index `0` as the element with the highest score.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A list of elements within the specified range.
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns an empty array.
      *
@@ -3952,29 +4002,35 @@ export class BaseClient {
      * ```typescript
      * // Example usage of zrange method to retrieve all members of a sorted set in ascending order
      * const result = await client.zrange("my_sorted_set", { start: 0, stop: -1 });
-     * console.log(result1); // Output: ['member1', 'member2', 'member3'] - Returns all members in ascending order.
+     * console.log(result1); // Output: all members in ascending order
+     * // ['member1', 'member2', 'member3']
      * ```
      * @example
      * ```typescript
-     * // Example usage of zrange method to retrieve members within a score range in ascending order
+     * // Example usage of zrange method to retrieve members within a score range in descending order
      * const result = await client.zrange("my_sorted_set", {
      *              start: InfBoundary.NegativeInfinity,
      *              stop: { value: 3, isInclusive: false },
      *              type: "byScore",
-     *           });
-     * console.log(result); // Output: ['member2', 'member3'] - Returns members with scores within the range of negative infinity to 3, in ascending order.
+     *           }, { reverse: true });
+     * console.log(result); // Output: members with scores within the range of negative infinity to 3, in descending order
+     * // ['member2', 'member1']
      * ```
      */
     public async zrange(
-        key: string,
+        key: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
-        reverse: boolean = false,
-    ): Promise<string[]> {
-        return this.createWritePromise(createZRange(key, rangeQuery, reverse));
+        options?: { reverse?: boolean } & DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(
+            createZRange(key, rangeQuery, options?.reverse),
+            options,
+        );
     }
 
-    /** Returns the specified range of elements with their scores in the sorted set stored at `key`.
-     * Similar to ZRANGE but with a WITHSCORE flag.
+    /**
+     * Returns the specified range of elements with their scores in the sorted set stored at `key`.
+     * Similar to {@link ZRange} but with a `WITHSCORE` flag.
      *
      * @see {@link https://valkey.io/commands/zrange/|valkey.io} for more details.
      *
@@ -3983,7 +4039,9 @@ export class BaseClient {
      * - For range queries by index (rank), use {@link RangeByIndex}.
      * - For range queries by lexicographical order, use {@link RangeByLex}.
      * - For range queries by score, use {@link RangeByScore}.
-     * @param reverse - If `true`, reverses the sorted set, with index `0` as the element with the highest score.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `reverse`: if `true`, reverses the sorted set, with index `0` as the element with the highest score.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A map of elements and their scores within the specified range.
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns an empty map.
      *
@@ -3995,7 +4053,8 @@ export class BaseClient {
      *              stop: { value: 20, isInclusive: false },
      *              type: "byScore",
      *           });
-     * console.log(result); // Output: {'member1': 10.5, 'member2': 15.2} - Returns members with scores between 10 and 20 with their scores.
+     * console.log(result); // Output: members with scores between 10 and 20 with their scores
+     * // {'member1': 10.5, 'member2': 15.2}
      * ```
      * @example
      * ```typescript
@@ -4004,17 +4063,19 @@ export class BaseClient {
      *              start: InfBoundary.NegativeInfinity,
      *              stop: { value: 3, isInclusive: false },
      *              type: "byScore",
-     *           });
-     * console.log(result); // Output: {'member4': -2.0, 'member7': 1.5} - Returns members with scores within the range of negative infinity to 3, with their scores.
+     *           }, { reverse: true });
+     * console.log(result); // Output: members with scores within the range of negative infinity to 3, with their scores in descending order
+     * // {'member7': 1.5, 'member4': -2.0}
      * ```
      */
     public async zrangeWithScores(
-        key: string,
+        key: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
-        reverse: boolean = false,
+        options?: { reverse?: boolean } & DecoderOption,
     ): Promise<Record<string, number>> {
         return this.createWritePromise(
-            createZRangeWithScores(key, rangeQuery, reverse),
+            createZRangeWithScores(key, rangeQuery, options?.reverse),
+            options,
         );
     }
 
@@ -4054,11 +4115,11 @@ export class BaseClient {
      * ```
      */
     public async zrangeStore(
-        destination: string,
-        source: string,
+        destination: GlideString,
+        source: GlideString,
         rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
         reverse: boolean = false,
-    ): Promise<string[]> {
+    ): Promise<number> {
         return this.createWritePromise(
             createZRangeStore(destination, source, rangeQuery, reverse),
         );
@@ -4181,17 +4242,16 @@ export class BaseClient {
 
     /**
      * Computes the union of sorted sets given by the specified `keys` and returns a list of union elements.
-     * To get the scores as well, see {@link zunionWithScores}.
      *
+     * To get the scores as well, see {@link zunionWithScores}.
      * To store the result in a key as a sorted set, see {@link zunionStore}.
      *
+     * @see {@link https://valkey.io/commands/zunion/|valkey.io} for details.
      * @remarks When in cluster mode, all keys in `keys` must map to the same hash slot.
-     *
      * @remarks Since Valkey version 6.2.0.
      *
-     * @see {@link https://valkey.io/commands/zunion/|valkey.io} for details.
-     *
      * @param keys - The keys of the sorted sets.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The resulting array of union elements.
      *
      * @example
@@ -4202,8 +4262,11 @@ export class BaseClient {
      * console.log(result); // Output: ['member1', 'member2']
      * ```
      */
-    public async zunion(keys: string[]): Promise<string[]> {
-        return this.createWritePromise(createZUnion(keys));
+    public async zunion(
+        keys: GlideString[],
+        options?: DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createZUnion(keys), options);
     }
 
     /**
@@ -4219,8 +4282,10 @@ export class BaseClient {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - string[] - for keys only.
      *  - KeyWeight[] - for weighted keys with score multipliers.
-     * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
-     * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements.
+     *     If `aggregationType` is not specified, defaults to `AggregationType.SUM`. See {@link AggregationType}.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns The resulting sorted set with scores.
      *
      * @example
@@ -4234,11 +4299,12 @@ export class BaseClient {
      * ```
      */
     public async zunionWithScores(
-        keys: string[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        keys: GlideString[] | KeyWeight[],
+        options?: { aggregationType?: AggregationType } & DecoderOption,
     ): Promise<Record<string, number>> {
         return this.createWritePromise(
-            createZUnion(keys, aggregationType, true),
+            createZUnion(keys, options?.aggregationType, true),
+            options,
         );
     }
 
@@ -4248,6 +4314,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/zrandmember/|valkey.io} for more details.
      *
      * @param keys - The key of the sorted set.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A string representing a random member from the sorted set.
      *     If the sorted set does not exist or is empty, the response will be `null`.
      *
@@ -4263,8 +4330,11 @@ export class BaseClient {
      * console.log(payload2); // Output: null since the sorted set does not exist.
      * ```
      */
-    public async zrandmember(key: string): Promise<string | null> {
-        return this.createWritePromise(createZRandMember(key));
+    public async zrandmember(
+        key: GlideString,
+        options?: DecoderOption,
+    ): Promise<GlideString | null> {
+        return this.createWritePromise(createZRandMember(key), options);
     }
 
     /**
@@ -4276,6 +4346,7 @@ export class BaseClient {
      * @param count - The number of members to return.
      *     If `count` is positive, returns unique members.
      *     If negative, allows for duplicates.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns An `array` of members from the sorted set.
      *     If the sorted set does not exist or is empty, the response will be an empty `array`.
      *
@@ -4292,10 +4363,11 @@ export class BaseClient {
      * ```
      */
     public async zrandmemberWithCount(
-        key: string,
+        key: GlideString,
         count: number,
-    ): Promise<string[]> {
-        return this.createWritePromise(createZRandMember(key, count));
+        options?: DecoderOption,
+    ): Promise<GlideString[]> {
+        return this.createWritePromise(createZRandMember(key, count), options);
     }
 
     /**
@@ -4307,8 +4379,8 @@ export class BaseClient {
      * @param count - The number of members to return.
      *     If `count` is positive, returns unique members.
      *     If negative, allows for duplicates.
-     * @returns A 2D `array` of `[member, score]` `arrays`, where
-     *     member is a `string` and score is a `number`.
+     * @param options - (Optional) See {@link DecoderOption}.
+     * @returns A list of {@link KeyWeight} tuples, which store member names and their respective scores.
      *     If the sorted set does not exist or is empty, the response will be an empty `array`.
      *
      * @example
@@ -4324,19 +4396,24 @@ export class BaseClient {
      * ```
      */
     public async zrandmemberWithCountWithScores(
-        key: string,
+        key: GlideString,
         count: number,
-    ): Promise<[string, number][]> {
-        return this.createWritePromise(createZRandMember(key, count, true));
+        options?: DecoderOption,
+    ): Promise<KeyWeight[]> {
+        return this.createWritePromise(
+            createZRandMember(key, count, true),
+            options,
+        );
     }
 
-    /** Returns the length of the string value stored at `key`.
+    /**
+     * Returns the length of the string value stored at `key`.
      *
      * @see {@link https://valkey.io/commands/strlen/|valkey.io} for more details.
      *
      * @param key - The key to check its length.
-     * @returns - The length of the string value stored at key
-     * If `key` does not exist, it is treated as an empty string, and the command returns 0.
+     * @returns The length of the string value stored at key
+     * If `key` does not exist, it is treated as an empty string, and the command returns `0`.
      *
      * @example
      * ```typescript
@@ -4387,14 +4464,17 @@ export class BaseClient {
         });
     }
 
-    /** Removes and returns the members with the lowest scores from the sorted set stored at `key`.
+    /**
+     * Removes and returns the members with the lowest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the lowest scores are removed and returned.
      * Otherwise, only one member with the lowest score is removed and returned.
      *
      * @see {@link https://valkey.io/commands/zpopmin/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count`: the number of elements to pop. If not supplied, only one element will be popped.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A map of the removed members and their scores, ordered from the one with the lowest score to the one with the highest.
      * If `key` doesn't exist, it will be treated as an empty sorted set and the command returns an empty map.
      * If `count` is higher than the sorted set's cardinality, returns all members and their scores.
@@ -4414,10 +4494,14 @@ export class BaseClient {
      * ```
      */
     public async zpopmin(
-        key: string,
-        count?: number,
+        key: GlideString,
+        options?: { count?: number } & DecoderOption,
     ): Promise<Record<string, number>> {
-        return this.createWritePromise(createZPopMin(key, count));
+        // TODO GlideString in Record, add tests with binary decoder
+        return this.createWritePromise(
+            createZPopMin(key, options?.count),
+            options,
+        );
     }
 
     /**
@@ -4450,14 +4534,17 @@ export class BaseClient {
         return this.createWritePromise(createBZPopMin(keys, timeout), options);
     }
 
-    /** Removes and returns the members with the highest scores from the sorted set stored at `key`.
+    /**
+     * Removes and returns the members with the highest scores from the sorted set stored at `key`.
      * If `count` is provided, up to `count` members with the highest scores are removed and returned.
      * Otherwise, only one member with the highest score is removed and returned.
      *
      * @see {@link https://valkey.io/commands/zpopmax/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count`: the number of elements to pop. If not supplied, only one element will be popped.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A map of the removed members and their scores, ordered from the one with the highest score to the one with the lowest.
      * If `key` doesn't exist, it will be treated as an empty sorted set and the command returns an empty map.
      * If `count` is higher than the sorted set's cardinality, returns all members and their scores, ordered from highest to lowest.
@@ -4477,10 +4564,14 @@ export class BaseClient {
      * ```
      */
     public async zpopmax(
-        key: string,
-        count?: number,
+        key: GlideString,
+        options?: { count?: number } & DecoderOption,
     ): Promise<Record<string, number>> {
-        return this.createWritePromise(createZPopMax(key, count));
+        // TODO GlideString in Record, add tests with binary decoder
+        return this.createWritePromise(
+            createZPopMax(key, options?.count),
+            options,
+        );
     }
 
     /**
@@ -4546,7 +4637,8 @@ export class BaseClient {
         return this.createWritePromise(createPTTL(key));
     }
 
-    /** Removes all elements in the sorted set stored at `key` with rank between `start` and `end`.
+    /**
+     * Removes all elements in the sorted set stored at `key` with rank between `start` and `end`.
      * Both `start` and `end` are zero-based indexes with 0 being the element with the lowest score.
      * These indexes can be negative numbers, where they indicate offsets starting at the element with the highest score.
      *
@@ -4568,7 +4660,7 @@ export class BaseClient {
      * ```
      */
     public async zremRangeByRank(
-        key: string,
+        key: GlideString,
         start: number,
         end: number,
     ): Promise<number> {
@@ -4581,8 +4673,8 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/zremrangebylex/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
-     * @param maxLex - The maximum lex to count up to. Can be positive/negative infinity, or a specific lex and inclusivity.
+     * @param minLex - The minimum lex to count from. Can be negative infinity, or a specific lex and inclusivity.
+     * @param maxLex - The maximum lex to count up to. Can be positive infinity, or a specific lex and inclusivity.
      * @returns The number of members removed.
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns 0.
      * If `minLex` is greater than `maxLex`, 0 is returned.
@@ -4602,23 +4694,24 @@ export class BaseClient {
      * ```
      */
     public async zremRangeByLex(
-        key: string,
-        minLex: Boundary<string>,
-        maxLex: Boundary<string>,
+        key: GlideString,
+        minLex: Boundary<GlideString>,
+        maxLex: Boundary<GlideString>,
     ): Promise<number> {
         return this.createWritePromise(
             createZRemRangeByLex(key, minLex, maxLex),
         );
     }
 
-    /** Removes all elements in the sorted set stored at `key` with a score between `minScore` and `maxScore`.
+    /**
+     * Removes all elements in the sorted set stored at `key` with a score between `minScore` and `maxScore`.
      *
      * @see {@link https://valkey.io/commands/zremrangebyscore/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param minScore - The minimum score to remove from. Can be positive/negative infinity, or specific score and inclusivity.
-     * @param maxScore - The maximum score to remove to. Can be positive/negative infinity, or specific score and inclusivity.
-     * @returns the number of members removed.
+     * @param minScore - The minimum score to remove from. Can be negative infinity, or specific score and inclusivity.
+     * @param maxScore - The maximum score to remove to. Can be positive infinity, or specific score and inclusivity.
+     * @returns The number of members removed.
      * If `key` does not exist, it is treated as an empty sorted set, and the command returns 0.
      * If `minScore` is greater than `maxScore`, 0 is returned.
      *
@@ -4637,7 +4730,7 @@ export class BaseClient {
      * ```
      */
     public async zremRangeByScore(
-        key: string,
+        key: GlideString,
         minScore: Boundary<number>,
         maxScore: Boundary<number>,
     ): Promise<number> {
@@ -4652,8 +4745,8 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/zlexcount/|valkey.io} for more details.
      *
      * @param key - The key of the sorted set.
-     * @param minLex - The minimum lex to count from. Can be positive/negative infinity, or a specific lex and inclusivity.
-     * @param maxLex - The maximum lex to count up to. Can be positive/negative infinity, or a specific lex and inclusivity.
+     * @param minLex - The minimum lex to count from. Can be negative infinity, or a specific lex and inclusivity.
+     * @param maxLex - The maximum lex to count up to. Can be positive infinity, or a specific lex and inclusivity.
      * @returns The number of members in the specified lex range.
      * If 'key' does not exist, it is treated as an empty sorted set, and the command returns '0'.
      * If maxLex is less than minLex, '0' is returned.
@@ -4671,14 +4764,15 @@ export class BaseClient {
      * ```
      */
     public async zlexcount(
-        key: string,
-        minLex: Boundary<string>,
-        maxLex: Boundary<string>,
+        key: GlideString,
+        minLex: Boundary<GlideString>,
+        maxLex: Boundary<GlideString>,
     ): Promise<number> {
         return this.createWritePromise(createZLexCount(key, minLex, maxLex));
     }
 
-    /** Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
+    /**
+     * Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
      * To get the rank of `member` with its score, see {@link zrankWithScore}.
      *
      * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
@@ -4702,11 +4796,15 @@ export class BaseClient {
      * console.log(result); // Output: null - Indicates that "non_existing_member" is not present in the sorted set "my_sorted_set".
      * ```
      */
-    public async zrank(key: string, member: string): Promise<number | null> {
+    public async zrank(
+        key: GlideString,
+        member: GlideString,
+    ): Promise<number | null> {
         return this.createWritePromise(createZRank(key, member));
     }
 
-    /** Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
+    /**
+     * Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
      *
      * @see {@link https://valkey.io/commands/zrank/|valkey.io} for more details.
      * @remarks Since Valkey version 7.2.0.
@@ -4731,15 +4829,15 @@ export class BaseClient {
      * ```
      */
     public async zrankWithScore(
-        key: string,
-        member: string,
-    ): Promise<number[] | null> {
+        key: GlideString,
+        member: GlideString,
+    ): Promise<[number, number] | null> {
         return this.createWritePromise(createZRank(key, member, true));
     }
 
     /**
      * Returns the rank of `member` in the sorted set stored at `key`, where
-     * scores are ordered from the highest to lowest, starting from 0.
+     * scores are ordered from the highest to lowest, starting from `0`.
      * To get the rank of `member` with its score, see {@link zrevrankWithScore}.
      *
      * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for more details.
@@ -4755,13 +4853,16 @@ export class BaseClient {
      * console.log(result); // Output: 1 - Indicates that "member2" has the second-highest score in the sorted set "my_sorted_set".
      * ```
      */
-    public async zrevrank(key: string, member: string): Promise<number | null> {
+    public async zrevrank(
+        key: GlideString,
+        member: GlideString,
+    ): Promise<number | null> {
         return this.createWritePromise(createZRevRank(key, member));
     }
 
     /**
      * Returns the rank of `member` in the sorted set stored at `key` with its
-     * score, where scores are ordered from the highest to lowest, starting from 0.
+     * score, where scores are ordered from the highest to lowest, starting from `0`.
      *
      * @see {@link https://valkey.io/commands/zrevrank/|valkey.io} for more details.
      * @remarks Since Valkey version 7.2.0.
@@ -4779,9 +4880,9 @@ export class BaseClient {
      * ```
      */
     public async zrevrankWithScore(
-        key: string,
-        member: string,
-    ): Promise<(number[] | null)[]> {
+        key: GlideString,
+        member: GlideString,
+    ): Promise<[number, number] | null> {
         return this.createWritePromise(createZRevRankWithScore(key, member));
     }
 
@@ -6222,7 +6323,7 @@ export class BaseClient {
     }
 
     /**
-     * Pops a member-score pair from the first non-empty sorted set, with the given `keys`
+     * Pops member-score pairs from the first non-empty sorted set, with the given `keys`
      * being checked in the order they are provided.
      *
      * @see {@link https://valkey.io/commands/zmpop/|valkey.io} for more details.
@@ -6232,7 +6333,9 @@ export class BaseClient {
      * @param keys - The keys of the sorted sets.
      * @param modifier - The element pop criteria - either {@link ScoreFilter.MIN} or
      *     {@link ScoreFilter.MAX} to pop the member with the lowest/highest score accordingly.
-     * @param count - (Optional) The number of elements to pop. If not supplied, only one element will be popped.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count`: the number of elements to pop. If not supplied, only one element will be popped.
+     * - (Optional) `decoder`: see {@link DecoderOption}.
      * @returns A two-element `array` containing the key name of the set from which the element
      *     was popped, and a member-score `Record` of the popped element.
      *     If no member could be popped, returns `null`.
@@ -6246,11 +6349,15 @@ export class BaseClient {
      * ```
      */
     public async zmpop(
-        keys: string[],
+        keys: GlideString[],
         modifier: ScoreFilter,
-        count?: number,
-    ): Promise<[string, [Record<string, number>]] | null> {
-        return this.createWritePromise(createZMPop(keys, modifier, count));
+        options?: { count?: number } & DecoderOption,
+    ): Promise<[string, Record<string, number>] | null> {
+        // TODO GlideString in Record, add tests with binary decoder
+        return this.createWritePromise(
+            createZMPop(keys, modifier, options?.count),
+            options,
+        );
     }
 
     /**
@@ -6337,28 +6444,26 @@ export class BaseClient {
      * @param key - The key of the sorted set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of
      *      the search.
-     * @param options - (Optional) The zscan options.
+     * @param options - (Optional) The `zscan` options - see {@link BaseScanOptions} and {@link DecoderOption}.
      * @returns An `Array` of the `cursor` and the subset of the sorted set held by `key`.
      *      The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
      *      returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
      *      of the sorted set held in `key`. The `Array` in the second element is always a flattened series of
-     *      `String` pairs, where the value is at even indices and the score is at odd indices.
+     *      `string` pairs, where the value is at even indices and the score is at odd indices.
      *
      * @example
      * ```typescript
-     * // Assume "key" contains a sorted set with multiple members
-     * let newCursor = "0";
-     * let result = [];
-     *
+     * // Assume "key1" contains a sorted set with multiple members
+     * let cursor = "0";
      * do {
-     *      result = await client.zscan(key1, newCursor, {
+     *      const result = await client.zscan(key1, cursor, {
      *          match: "*",
      *          count: 5,
      *      });
-     *      newCursor = result[0];
-     *      console.log("Cursor: ", newCursor);
+     *      cursor = result[0];
+     *      console.log("Cursor: ", cursor);
      *      console.log("Members: ", result[1]);
-     * } while (newCursor !== "0");
+     * } while (cursor !== "0");
      * // The output of the code above is something similar to:
      * // Cursor:  123
      * // Members:  ['value 163', '163', 'value 114', '114', 'value 25', '25', 'value 82', '82', 'value 64', '64']
@@ -6369,11 +6474,14 @@ export class BaseClient {
      * ```
      */
     public async zscan(
-        key: string,
+        key: GlideString,
         cursor: string,
-        options?: BaseScanOptions,
-    ): Promise<[string, string[]]> {
-        return this.createWritePromise(createZScan(key, cursor, options));
+        options?: BaseScanOptions & DecoderOption,
+    ): Promise<[string, GlideString[]]> {
+        return this.createWritePromise<[GlideString, GlideString[]]>(
+            createZScan(key, cursor, options),
+            options,
+        ).then((res) => [res[0].toString(), res[1]]); // convert cursor back to string
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1034,9 +1034,11 @@ export class BaseClient {
      */
     public async get(
         key: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createGet(key), { decoder: decoder });
+        return this.createWritePromise(createGet(key), {
+            decoder: options?.decoder,
+        });
     }
 
     /**

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -3669,12 +3669,16 @@ export function createHRandField(
 export function createHScan(
     key: string,
     cursor: string,
-    options?: BaseScanOptions,
+    options?: HScanOptions,
 ): command_request.Command {
     let args: GlideString[] = [key, cursor];
 
     if (options) {
         args = args.concat(convertBaseScanOptionsToArgsArray(options));
+
+        if (options.noValues) {
+            args.push("NOVALUES");
+        }
     }
 
     return createCommand(RequestType.HScan, args);
@@ -3764,9 +3768,8 @@ export function createWait(
 }
 
 /**
- * This base class represents the common set of optional arguments for the `SCAN` family of commands.
- * Concrete implementations of this class are tied to specific SCAN commands (`SCAN`, `HSCAN`, `SSCAN`,
- * and `ZSCAN`).
+ * This base class represents the common set of optional arguments for the SCAN family of commands.
+ * Concrete implementations of this class are tied to specific SCAN commands (`SCAN`, `SSCAN`).
  */
 export type BaseScanOptions = {
     /**
@@ -3782,7 +3785,29 @@ export type BaseScanOptions = {
      * sorted set. `COUNT` could be ignored until the sorted set is large enough for the `SCAN` commands to
      * represent the results as compact single-allocation packed encoding.
      */
-    count?: number;
+    readonly count?: number;
+};
+
+/**
+ * Options specific to the ZSCAN command, extending from the base scan options.
+ */
+export type ZScanOptions = BaseScanOptions & {
+    /**
+     * If true, the scores are not included in the results.
+     * Supported from Valkey 8.0.0 and above.
+     */
+    readonly noScores?: boolean;
+};
+
+/**
+ * Options specific to the HSCAN command, extending from the base scan options.
+ */
+export type HScanOptions = BaseScanOptions & {
+    /**
+     * If true, the values of the fields are not included in the results.
+     * Supported from Valkey 8.0.0 and above.
+     */
+    readonly noValues?: boolean;
 };
 
 /**
@@ -3810,12 +3835,16 @@ function convertBaseScanOptionsToArgsArray(
 export function createZScan(
     key: GlideString,
     cursor: string,
-    options?: BaseScanOptions,
+    options?: ZScanOptions,
 ): command_request.Command {
     let args = [key, cursor];
 
     if (options) {
         args = args.concat(convertBaseScanOptionsToArgsArray(options));
+
+        if (options.noScores) {
+            args.push("NOSCORES");
+        }
     }
 
     return createCommand(RequestType.ZScan, args);

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -5,8 +5,12 @@
 import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "glide-rs";
 import Long from "long";
 
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-import { BaseClient, GlideRecord, HashDataType } from "src/BaseClient";
+import {
+    BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars
+    GlideRecord,
+    HashDataType,
+    SortedSetDataType,
+} from "src/BaseClient";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 import { GlideClient } from "src/GlideClient";
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
@@ -1379,14 +1383,31 @@ export type ZAddOptions = {
 
 /**
  * @internal
+ * Convert input from `Record` to `SortedSetDataType` to ensure the only one type.
+ */
+export function convertElementsAndScores(
+    membersAndScores: SortedSetDataType | Record<string, number>,
+): SortedSetDataType {
+    if (!Array.isArray(membersAndScores)) {
+        // convert Record<string, number> to SortedSetDataType
+        return Object.entries(membersAndScores).map((element) => {
+            return { element: element[0], score: element[1] };
+        });
+    }
+
+    return membersAndScores;
+}
+
+/**
+ * @internal
  */
 export function createZAdd(
-    key: string,
-    membersScoresMap: Record<string, number>,
+    key: GlideString,
+    membersAndScores: SortedSetDataType,
     options?: ZAddOptions,
     incr: boolean = false,
 ): command_request.Command {
-    let args = [key];
+    const args = [key];
 
     if (options) {
         if (options.conditionalChange) {
@@ -1416,12 +1437,7 @@ export function createZAdd(
         args.push("INCR");
     }
 
-    args = args.concat(
-        Object.entries(membersScoresMap).flatMap(([key, value]) => [
-            value.toString(),
-            key,
-        ]),
-    );
+    membersAndScores.forEach((p) => args.push(p.score.toString(), p.element));
     return createCommand(RequestType.ZAdd, args);
 }
 
@@ -1466,7 +1482,7 @@ export function createZInter(
  * @internal
  */
 export function createZUnion(
-    keys: string[] | KeyWeight[],
+    keys: GlideString[] | KeyWeight[],
     aggregationType?: AggregationType,
     withScores?: boolean,
 ): command_request.Command {
@@ -1486,7 +1502,7 @@ function createZCmdArgs(
         destination?: GlideString;
     },
 ): GlideString[] {
-    const args: GlideString[] = [];
+    const args = [];
 
     const destination = options.destination;
 
@@ -1523,8 +1539,8 @@ function createZCmdArgs(
  * @internal
  */
 export function createZRem(
-    key: string,
-    members: string[],
+    key: GlideString,
+    members: GlideString[],
 ): command_request.Command {
     return createCommand(RequestType.ZRem, [key].concat(members));
 }
@@ -1589,8 +1605,8 @@ export function createZDiffStore(
  * @internal
  */
 export function createZScore(
-    key: string,
-    member: string,
+    key: GlideString,
+    member: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.ZScore, [key, member]);
 }
@@ -1599,8 +1615,8 @@ export function createZScore(
  * @internal
  */
 export function createZUnionStore(
-    destination: string,
-    keys: string[] | KeyWeight[],
+    destination: GlideString,
+    keys: GlideString[] | KeyWeight[],
     aggregationType?: AggregationType,
 ): command_request.Command {
     const args = createZCmdArgs(keys, { destination, aggregationType });
@@ -1611,8 +1627,8 @@ export function createZUnionStore(
  * @internal
  */
 export function createZMScore(
-    key: string,
-    members: string[],
+    key: GlideString,
+    members: GlideString[],
 ): command_request.Command {
     return createCommand(RequestType.ZMScore, [key, ...members]);
 }
@@ -1656,7 +1672,7 @@ export type Boundary<T> =
  */
 export type RangeByIndex = {
     /**
-     *  The start index of the range.
+     * The start index of the range.
      */
     start: number;
     /**
@@ -1700,12 +1716,10 @@ type SortedSetRange<T> = {
 };
 
 export type RangeByScore = SortedSetRange<number> & { type: "byScore" };
-export type RangeByLex = SortedSetRange<string> & { type: "byLex" };
+export type RangeByLex = SortedSetRange<GlideString> & { type: "byLex" };
 
 /** Returns a string representation of a score boundary as a command argument. */
-function getScoreBoundaryArg(
-    score: Boundary<number> | Boundary<string>,
-): string {
+function getScoreBoundaryArg(score: Boundary<number>): string {
     if (typeof score === "string") {
         // InfBoundary
         return score + "inf";
@@ -1719,23 +1733,25 @@ function getScoreBoundaryArg(
 }
 
 /** Returns a string representation of a lex boundary as a command argument. */
-function getLexBoundaryArg(score: Boundary<number> | Boundary<string>): string {
+function getLexBoundaryArg(score: Boundary<GlideString>): GlideString {
     if (typeof score === "string") {
         // InfBoundary
         return score;
     }
 
     if (score.isInclusive == false) {
-        return "(" + score.value;
+        return typeof score.value === "string"
+            ? "(" + score.value
+            : Buffer.concat([Buffer.from("("), score.value]);
     }
 
-    return "[" + score.value;
+    return typeof score.value === "string"
+        ? "[" + score.value
+        : Buffer.concat([Buffer.from("["), score.value]);
 }
 
 /** Returns a string representation of a stream boundary as a command argument. */
-function getStreamBoundaryArg(
-    boundary: Boundary<number> | Boundary<string>,
-): string {
+function getStreamBoundaryArg(boundary: Boundary<string>): string {
     if (typeof boundary === "string") {
         // InfBoundary
         return boundary;
@@ -1749,12 +1765,12 @@ function getStreamBoundaryArg(
 }
 
 function createZRangeArgs(
-    key: string,
+    key: GlideString,
     rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
     reverse: boolean,
     withScores: boolean,
-): string[] {
-    const args: string[] = [key];
+): GlideString[] {
+    const args: GlideString[] = [key];
 
     if (typeof rangeQuery.start != "number") {
         rangeQuery = rangeQuery as RangeByScore | RangeByLex;
@@ -1816,7 +1832,7 @@ export function createZCount(
  * @internal
  */
 export function createZRange(
-    key: string,
+    key: GlideString,
     rangeQuery: RangeByIndex | RangeByScore | RangeByLex,
     reverse: boolean = false,
 ): command_request.Command {
@@ -1828,7 +1844,7 @@ export function createZRange(
  * @internal
  */
 export function createZRangeWithScores(
-    key: string,
+    key: GlideString,
     rangeQuery: RangeByIndex | RangeByScore | RangeByLex,
     reverse: boolean = false,
 ): command_request.Command {
@@ -1840,8 +1856,8 @@ export function createZRangeWithScores(
  * @internal
  */
 export function createZRangeStore(
-    destination: string,
-    source: string,
+    destination: GlideString,
+    source: GlideString,
     rangeQuery: RangeByIndex | RangeByScore | RangeByLex,
     reverse: boolean = false,
 ): command_request.Command {
@@ -1906,10 +1922,10 @@ export function createLInsert(
  * @internal
  */
 export function createZPopMin(
-    key: string,
+    key: GlideString,
     count?: number,
 ): command_request.Command {
-    const args: string[] = count == undefined ? [key] : [key, count.toString()];
+    const args = count == undefined ? [key] : [key, count.toString()];
     return createCommand(RequestType.ZPopMin, args);
 }
 
@@ -1917,10 +1933,10 @@ export function createZPopMin(
  * @internal
  */
 export function createZPopMax(
-    key: string,
+    key: GlideString,
     count?: number,
 ): command_request.Command {
-    const args: string[] = count == undefined ? [key] : [key, count.toString()];
+    const args = count == undefined ? [key] : [key, count.toString()];
     return createCommand(RequestType.ZPopMax, args);
 }
 
@@ -1942,7 +1958,7 @@ export function createPTTL(key: GlideString): command_request.Command {
  * @internal
  */
 export function createZRemRangeByRank(
-    key: string,
+    key: GlideString,
     start: number,
     stop: number,
 ): command_request.Command {
@@ -1957,9 +1973,9 @@ export function createZRemRangeByRank(
  * @internal
  */
 export function createZRemRangeByLex(
-    key: string,
-    minLex: Boundary<string>,
-    maxLex: Boundary<string>,
+    key: GlideString,
+    minLex: Boundary<GlideString>,
+    maxLex: Boundary<GlideString>,
 ): command_request.Command {
     const args = [key, getLexBoundaryArg(minLex), getLexBoundaryArg(maxLex)];
     return createCommand(RequestType.ZRemRangeByLex, args);
@@ -1969,7 +1985,7 @@ export function createZRemRangeByLex(
  * @internal
  */
 export function createZRemRangeByScore(
-    key: string,
+    key: GlideString,
     minScore: Boundary<number>,
     maxScore: Boundary<number>,
 ): command_request.Command {
@@ -1990,9 +2006,9 @@ export function createPersist(key: GlideString): command_request.Command {
  * @internal
  */
 export function createZLexCount(
-    key: string,
-    minLex: Boundary<string>,
-    maxLex: Boundary<string>,
+    key: GlideString,
+    minLex: Boundary<GlideString>,
+    maxLex: Boundary<GlideString>,
 ): command_request.Command {
     const args = [key, getLexBoundaryArg(minLex), getLexBoundaryArg(maxLex)];
     return createCommand(RequestType.ZLexCount, args);
@@ -2000,8 +2016,8 @@ export function createZLexCount(
 
 /** @internal */
 export function createZRank(
-    key: string,
-    member: string,
+    key: GlideString,
+    member: GlideString,
     withScores?: boolean,
 ): command_request.Command {
     const args = [key, member];
@@ -3415,8 +3431,8 @@ function convertGeoSearchOptionsToArgs(
  * @internal
  */
 export function createZRevRank(
-    key: string,
-    member: string,
+    key: GlideString,
+    member: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.ZRevRank, [key, member]);
 }
@@ -3425,8 +3441,8 @@ export function createZRevRank(
  * @internal
  */
 export function createZRevRankWithScore(
-    key: string,
-    member: string,
+    key: GlideString,
+    member: GlideString,
 ): command_request.Command {
     return createCommand(RequestType.ZRevRank, [key, member, "WITHSCORE"]);
 }
@@ -3446,11 +3462,12 @@ export enum ScoreFilter {
  * @internal
  */
 export function createZMPop(
-    keys: string[],
+    keys: GlideString[],
     modifier: ScoreFilter,
     count?: number,
 ): command_request.Command {
-    const args: string[] = [keys.length.toString()].concat(keys);
+    const args = keys;
+    args.unshift(keys.length.toString());
     args.push(modifier);
 
     if (count !== undefined) {
@@ -3654,7 +3671,7 @@ export function createHScan(
     cursor: string,
     options?: BaseScanOptions,
 ): command_request.Command {
-    let args: string[] = [key, cursor];
+    let args: GlideString[] = [key, cursor];
 
     if (options) {
         args = args.concat(convertBaseScanOptionsToArgsArray(options));
@@ -3667,7 +3684,7 @@ export function createHScan(
  * @internal
  */
 export function createZRandMember(
-    key: string,
+    key: GlideString,
     count?: number,
     withscores?: boolean,
 ): command_request.Command {
@@ -3747,9 +3764,9 @@ export function createWait(
 }
 
 /**
- * This base class represents the common set of optional arguments for the SCAN family of commands.
- * Concrete implementations of this class are tied to specific SCAN commands (SCAN, HSCAN, SSCAN,
- * and ZSCAN).
+ * This base class represents the common set of optional arguments for the `SCAN` family of commands.
+ * Concrete implementations of this class are tied to specific SCAN commands (`SCAN`, `HSCAN`, `SSCAN`,
+ * and `ZSCAN`).
  */
 export type BaseScanOptions = {
     /**
@@ -3759,20 +3776,22 @@ export type BaseScanOptions = {
      * items that match the pattern specified. This is due to the default `COUNT` being `10` which indicates
      * that it will only fetch and match `10` items from the list.
      */
-    readonly match?: string;
+    match?: GlideString;
     /**
      * `COUNT` is a just a hint for the command for how many elements to fetch from the
      * sorted set. `COUNT` could be ignored until the sorted set is large enough for the `SCAN` commands to
      * represent the results as compact single-allocation packed encoding.
      */
-    readonly count?: number;
+    count?: number;
 };
 
 /**
  * @internal
  */
-function convertBaseScanOptionsToArgsArray(options: BaseScanOptions): string[] {
-    const args: string[] = [];
+function convertBaseScanOptionsToArgsArray(
+    options: BaseScanOptions,
+): GlideString[] {
+    const args: GlideString[] = [];
 
     if (options.match) {
         args.push("MATCH", options.match);
@@ -3789,11 +3808,11 @@ function convertBaseScanOptionsToArgsArray(options: BaseScanOptions): string[] {
  * @internal
  */
 export function createZScan(
-    key: string,
+    key: GlideString,
     cursor: string,
     options?: BaseScanOptions,
 ): command_request.Command {
-    let args: string[] = [key, cursor];
+    let args = [key, cursor];
 
     if (options) {
         args = args.concat(convertBaseScanOptionsToArgsArray(options));

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -1331,7 +1331,7 @@ export class GlideClusterClient extends BaseClient {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
-     * @param options - (Optional) {@link SortClusterOptions} and {@link DecoderOption}.
+     * @param options - (Optional) See {@link SortClusterOptions} and {@link DecoderOption}.
      * @returns An `Array` of sorted elements
      *
      * @example
@@ -1364,7 +1364,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * @param key - The key of the list, set, or sorted set to be sorted.
      * @param destination - The key where the sorted result will be stored.
-     * @param options - (Optional) {@link SortClusterOptions}.
+     * @param options - (Optional) See {@link SortClusterOptions}.
      * @returns The number of elements in the sorted key stored at `destination`.
      *
      * @example

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -41,6 +41,7 @@ import {
     GeoSearchStoreResultOptions,
     GeoUnit,
     GeospatialData,
+    HScanOptions,
     InfoOptions,
     InsertPosition,
     KeyWeight,
@@ -67,6 +68,7 @@ import {
     StreamTrimOptions,
     TimeUnit,
     ZAddOptions,
+    ZScanOptions,
     convertElementsAndScores,
     createAppend,
     createBLMPop,
@@ -996,15 +998,16 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key of the set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of the search.
-     * @param options - (Optional) The {@link BaseScanOptions}.
+     * @param options - (Optional) The {@link HScanOptions}.
      *
-     * Command Response -  An array of the `cursor` and the subset of the hash held by `key`.
+     * Command Response - An array of the `cursor` and the subset of the hash held by `key`.
      * The first element is always the `cursor` for the next iteration of results. `"0"` will be the `cursor`
      * returned on the last iteration of the hash. The second element is always an array of the subset of the
-     * hash held in `key`. The array in the second element is always a flattened series of string pairs,
+     * hash held in `key`. The array in the second element is a flattened series of string pairs,
      * where the value is at even indices and the value is at odd indices.
+     * If `options.noValues` is set to `true`, the second element will only contain the fields without the values.
      */
-    public hscan(key: string, cursor: string, options?: BaseScanOptions): T {
+    public hscan(key: string, cursor: string, options?: HScanOptions): T {
         return this.addAndReturn(createHScan(key, cursor, options));
     }
 
@@ -3675,19 +3678,16 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key of the sorted set.
      * @param cursor - The cursor that points to the next iteration of results. A value of `"0"` indicates the start of
      *      the search.
-     * @param options - (Optional) The `zscan` options - see {@link BaseScanOptions}
+     * @param options - (Optional) The `zscan` options - see {@link ZScanOptions}
      *
      * Command Response - An `Array` of the `cursor` and the subset of the sorted set held by `key`.
      *      The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
      *      returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
-     *      of the sorted set held in `key`. The `Array` in the second element is always a flattened series of
+     *      of the sorted set held in `key`. The `Array` in the second element is a flattened series of
      *      `String` pairs, where the value is at even indices and the score is at odd indices.
+     *      If `options.noScores` is to `true`, the second element will only contain the members without scores.
      */
-    public zscan(
-        key: GlideString,
-        cursor: string,
-        options?: BaseScanOptions,
-    ): T {
+    public zscan(key: GlideString, cursor: string, options?: ZScanOptions): T {
         return this.addAndReturn(createZScan(key, cursor, options));
     }
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -7343,10 +7343,12 @@ export function runBaseTests(config: {
 
                 // Restore to a new key without option
                 expect(await client.restore(key2, 0, data)).toEqual("OK");
-                expect(await client.get(key2, Decoder.String)).toEqual(value);
-                expect(await client.get(key2, Decoder.Bytes)).toEqual(
-                    valueEncode,
-                );
+                expect(
+                    await client.get(key2, { decoder: Decoder.String }),
+                ).toEqual(value);
+                expect(
+                    await client.get(key2, { decoder: Decoder.Bytes }),
+                ).toEqual(valueEncode);
 
                 // Restore to an existing key
                 await expect(client.restore(key2, 0, data)).rejects.toThrow(
@@ -7649,9 +7651,9 @@ export function runBaseTests(config: {
                 expect(await client.append(key3, valueEncoded)).toBe(
                     valueEncoded.length * 2,
                 );
-                expect(await client.get(key3, Decoder.Bytes)).toEqual(
-                    Buffer.concat([valueEncoded, valueEncoded]),
-                );
+                expect(
+                    await client.get(key3, { decoder: Decoder.Bytes }),
+                ).toEqual(Buffer.concat([valueEncoded, valueEncoded]));
             }, protocol);
         },
         config.timeout,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -42,7 +42,9 @@ import {
     ScoreFilter,
     Script,
     SignedEncoding,
+    SingleNodeRoute,
     SortOrder,
+    SortedSetDataType,
     TimeUnit,
     Transaction,
     UnsignedEncoding,
@@ -50,7 +52,6 @@ import {
     parseInfoResponse,
 } from "../";
 import { RedisCluster } from "../../utils/TestUtils";
-import { SingleNodeRoute } from "../build-ts/src/GlideClusterClient";
 import {
     Client,
     GetAndSetRandomValue,
@@ -4036,7 +4037,10 @@ export function runBaseTests(config: {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
                 const membersScores = { one: 1, two: 2, three: 3 };
-                const newMembersScores = { one: 2, two: 3 };
+                const newMembersScores: SortedSetDataType = [
+                    { element: "one", score: 2 },
+                    { element: Buffer.from("two"), score: 3 },
+                ];
 
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zaddIncr(key, "one", 2)).toEqual(3.0);
@@ -4068,7 +4072,7 @@ export function runBaseTests(config: {
                 ).toEqual(3);
 
                 expect(
-                    await client.zaddIncr(key, "one", 5.0, {
+                    await client.zaddIncr(key, Buffer.from("one"), 5.0, {
                         conditionalChange:
                             ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
                     }),
@@ -4131,10 +4135,14 @@ export function runBaseTests(config: {
                 const key = uuidv4();
                 const membersScores = { one: 1, two: 2, three: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
-                expect(await client.zrem(key, ["one"])).toEqual(1);
-                expect(await client.zrem(key, ["one", "two", "three"])).toEqual(
-                    2,
-                );
+                expect(await client.zrem(Buffer.from(key), ["one"])).toEqual(1);
+                expect(
+                    await client.zrem(key, [
+                        "one",
+                        Buffer.from("two"),
+                        "three",
+                    ]),
+                ).toEqual(2);
                 expect(
                     await client.zrem("non_existing_set", ["member"]),
                 ).toEqual(0);
@@ -4377,6 +4385,9 @@ export function runBaseTests(config: {
                 const membersScores = { one: 1, two: 2, three: 3 };
                 expect(await client.zadd(key1, membersScores)).toEqual(3);
                 expect(await client.zscore(key1, "one")).toEqual(1.0);
+                expect(
+                    await client.zscore(Buffer.from(key1), Buffer.from("one")),
+                ).toEqual(1.0);
                 expect(await client.zscore(key1, "nonExistingMember")).toEqual(
                     null,
                 );
@@ -4408,7 +4419,9 @@ export function runBaseTests(config: {
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
 
         // Union results are aggregated by the MAX score of elements
-        expect(await client.zunionstore(key3, [key1, key2], "MAX")).toEqual(3);
+        expect(
+            await client.zunionstore(key3, [key1, Buffer.from(key2)], "MAX"),
+        ).toEqual(3);
         const zunionstoreMapMax = await client.zrangeWithScores(key3, range);
         const expectedMapMax = {
             one: 1.5,
@@ -4434,7 +4447,9 @@ export function runBaseTests(config: {
         expect(await client.zadd(key2, membersScores2)).toEqual(3);
 
         // Union results are aggregated by the MIN score of elements
-        expect(await client.zunionstore(key3, [key1, key2], "MIN")).toEqual(3);
+        expect(
+            await client.zunionstore(Buffer.from(key3), [key1, key2], "MIN"),
+        ).toEqual(3);
         const zunionstoreMapMin = await client.zrangeWithScores(key3, range);
         const expectedMapMin = {
             one: 1.0,
@@ -4515,7 +4530,7 @@ export function runBaseTests(config: {
                 key3,
                 [
                     [key1, 2.0],
-                    [key2, 2.0],
+                    [Buffer.from(key2), 2.0],
                 ],
                 "SUM",
             ),
@@ -4601,11 +4616,15 @@ export function runBaseTests(config: {
                 expect(await client.zadd(key1, entries)).toEqual(3);
 
                 expect(
-                    await client.zmscore(key1, ["one", "three", "two"]),
+                    await client.zmscore(Buffer.from(key1), [
+                        "one",
+                        "three",
+                        "two",
+                    ]),
                 ).toEqual([1.0, 3.0, 2.0]);
                 expect(
                     await client.zmscore(key1, [
-                        "one",
+                        Buffer.from("one"),
                         "nonExistingMember",
                         "two",
                         "nonExistingMember",
@@ -4718,8 +4737,12 @@ export function runBaseTests(config: {
                     }),
                 ).toBe(true);
                 expect(
-                    await client.zrange(key, { start: 0, stop: 1 }, true),
-                ).toEqual(["three", "two"]);
+                    await client.zrange(
+                        Buffer.from(key),
+                        { start: 0, stop: 1 },
+                        { reverse: true, decoder: Decoder.Bytes },
+                    ),
+                ).toEqual([Buffer.from("three"), Buffer.from("two")]);
                 expect(await client.zrange(key, { start: 3, stop: 1 })).toEqual(
                     [],
                 );
@@ -4746,7 +4769,7 @@ export function runBaseTests(config: {
                         type: "byScore",
                     }),
                 ).toEqual(["one", "two"]);
-                const result = await client.zrangeWithScores(key, {
+                const result = await client.zrangeWithScores(Buffer.from(key), {
                     start: InfBoundary.NegativeInfinity,
                     stop: InfBoundary.PositiveInfinity,
                     type: "byScore",
@@ -4767,17 +4790,21 @@ export function runBaseTests(config: {
                             stop: InfBoundary.NegativeInfinity,
                             type: "byScore",
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual(["two", "one"]);
 
                 expect(
-                    await client.zrange(key, {
-                        start: InfBoundary.NegativeInfinity,
-                        stop: InfBoundary.PositiveInfinity,
-                        limit: { offset: 1, count: 2 },
-                        type: "byScore",
-                    }),
+                    await client.zrange(
+                        key,
+                        {
+                            start: InfBoundary.NegativeInfinity,
+                            stop: InfBoundary.PositiveInfinity,
+                            limit: { offset: 1, count: 2 },
+                            type: "byScore",
+                        },
+                        { reverse: false },
+                    ),
                 ).toEqual(["two", "three"]);
 
                 expect(
@@ -4788,7 +4815,7 @@ export function runBaseTests(config: {
                             stop: { value: 3, isInclusive: false },
                             type: "byScore",
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual([]);
 
@@ -4808,7 +4835,7 @@ export function runBaseTests(config: {
                             stop: { value: 3, isInclusive: false },
                             type: "byScore",
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual({});
 
@@ -4833,21 +4860,25 @@ export function runBaseTests(config: {
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
-                    await client.zrange(key, {
+                    await client.zrange(Buffer.from(key), {
                         start: InfBoundary.NegativeInfinity,
-                        stop: { value: "c", isInclusive: false },
+                        stop: { value: Buffer.from("c"), isInclusive: false },
                         type: "byLex",
                     }),
                 ).toEqual(["a", "b"]);
 
                 expect(
-                    await client.zrange(key, {
-                        start: InfBoundary.NegativeInfinity,
-                        stop: InfBoundary.PositiveInfinity,
-                        limit: { offset: 1, count: 2 },
-                        type: "byLex",
-                    }),
-                ).toEqual(["b", "c"]);
+                    await client.zrange(
+                        key,
+                        {
+                            start: InfBoundary.PositiveInfinity,
+                            stop: InfBoundary.NegativeInfinity,
+                            limit: { offset: 1, count: 2 },
+                            type: "byLex",
+                        },
+                        { reverse: true, decoder: Decoder.Bytes },
+                    ),
+                ).toEqual([Buffer.from("b"), Buffer.from("a")]);
 
                 expect(
                     await client.zrange(
@@ -4857,7 +4888,7 @@ export function runBaseTests(config: {
                             stop: InfBoundary.NegativeInfinity,
                             type: "byLex",
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual(["b", "a"]);
 
@@ -4869,7 +4900,7 @@ export function runBaseTests(config: {
                             stop: { value: "c", isInclusive: false },
                             type: "byLex",
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual([]);
 
@@ -4897,7 +4928,7 @@ export function runBaseTests(config: {
                 expect(await client.zadd(key, membersScores)).toEqual(3);
 
                 expect(
-                    await client.zrangeStore(destkey, key, {
+                    await client.zrangeStore(destkey, Buffer.from(key), {
                         start: 0,
                         stop: 1,
                     }),
@@ -4911,7 +4942,7 @@ export function runBaseTests(config: {
 
                 expect(
                     await client.zrangeStore(
-                        destkey,
+                        Buffer.from(destkey),
                         key,
                         { start: 0, stop: 1 },
                         true,
@@ -4924,7 +4955,7 @@ export function runBaseTests(config: {
                             start: 0,
                             stop: -1,
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual(["three", "two"]);
 
@@ -4982,7 +5013,7 @@ export function runBaseTests(config: {
                             start: 0,
                             stop: -1,
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual(["two", "one"]);
 
@@ -5039,7 +5070,7 @@ export function runBaseTests(config: {
                 expect(
                     await client.zrangeStore(destkey, key, {
                         start: InfBoundary.NegativeInfinity,
-                        stop: { value: "c", isInclusive: false },
+                        stop: { value: Buffer.from("c"), isInclusive: false },
                         type: "byLex",
                     }),
                 ).toEqual(2);
@@ -5084,7 +5115,7 @@ export function runBaseTests(config: {
                             start: 0,
                             stop: -1,
                         },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual(["b", "a"]);
 
@@ -5531,10 +5562,18 @@ export function runBaseTests(config: {
                 expect(await client.zadd(key1, membersScores1)).toEqual(2);
                 expect(await client.zadd(key2, membersScores2)).toEqual(3);
 
-                const resultZunion = await client.zunion([key1, key2]);
-                const expectedZunion = ["one", "two", "three"];
+                const expectedZunion = ["one", "two", "three"].sort();
 
-                expect(resultZunion.sort()).toEqual(expectedZunion.sort());
+                expect(
+                    (await client.zunion([key1, Buffer.from(key2)])).sort(),
+                ).toEqual(expectedZunion);
+                expect(
+                    (
+                        await client.zunion([key1, key2], {
+                            decoder: Decoder.Bytes,
+                        })
+                    ).sort(),
+                ).toEqual(expectedZunion.map(Buffer.from));
             }, protocol);
         },
         config.timeout,
@@ -5587,8 +5626,8 @@ export function runBaseTests(config: {
 
                 // Union results are aggregated by the MAX score of elements
                 const zunionWithScoresResults = await client.zunionWithScores(
-                    [key1, key2],
-                    "MAX",
+                    [key1, Buffer.from(key2)],
+                    { aggregationType: "MAX" },
                 );
                 const expectedMapMax = {
                     one: 1.5,
@@ -5618,7 +5657,7 @@ export function runBaseTests(config: {
                 // Union results are aggregated by the MIN score of elements
                 const zunionWithScoresResults = await client.zunionWithScores(
                     [key1, key2],
-                    "MIN",
+                    { aggregationType: "MIN" },
                 );
                 const expectedMapMin = {
                     one: 1.0,
@@ -5648,7 +5687,7 @@ export function runBaseTests(config: {
                 // Union results are aggregated by the SUM score of elements
                 const zunionWithScoresResults = await client.zunionWithScores(
                     [key1, key2],
-                    "SUM",
+                    { aggregationType: "SUM" },
                 );
                 const expectedMapSum = {
                     one: 2.5,
@@ -5679,9 +5718,9 @@ export function runBaseTests(config: {
                 const zunionWithScoresResults = await client.zunionWithScores(
                     [
                         [key1, 3],
-                        [key2, 2],
+                        [Buffer.from(key2), 2],
                     ],
-                    "SUM",
+                    { aggregationType: "SUM" },
                 );
                 const expectedMapSum = {
                     one: 6,
@@ -5970,10 +6009,12 @@ export function runBaseTests(config: {
                 const key = uuidv4();
                 const membersScores = { a: 1, b: 2, c: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
-                expect(await client.zpopmin(key)).toEqual({ a: 1.0 });
+                expect(await client.zpopmin(Buffer.from(key))).toEqual({
+                    a: 1.0,
+                });
 
                 expect(
-                    compareMaps(await client.zpopmin(key, 3), {
+                    compareMaps(await client.zpopmin(key, { count: 3 }), {
                         b: 2.0,
                         c: 3.0,
                     }),
@@ -5994,10 +6035,12 @@ export function runBaseTests(config: {
                 const key = uuidv4();
                 const membersScores = { a: 1, b: 2, c: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
-                expect(await client.zpopmax(key)).toEqual({ c: 3.0 });
+                expect(await client.zpopmax(Buffer.from(key))).toEqual({
+                    c: 3.0,
+                });
 
                 expect(
-                    compareMaps(await client.zpopmax(key, 3), {
+                    compareMaps(await client.zpopmax(key, { count: 3 }), {
                         b: 2.0,
                         a: 1.0,
                     }),
@@ -6149,7 +6192,9 @@ export function runBaseTests(config: {
                 const membersScores = { one: 1, two: 2, three: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zremRangeByRank(key, 2, 1)).toEqual(0);
-                expect(await client.zremRangeByRank(key, 0, 1)).toEqual(2);
+                expect(
+                    await client.zremRangeByRank(Buffer.from(key), 0, 1),
+                ).toEqual(2);
                 expect(await client.zremRangeByRank(key, 0, 10)).toEqual(1);
                 expect(
                     await client.zremRangeByRank("nonExistingKey", 0, -1),
@@ -6168,11 +6213,20 @@ export function runBaseTests(config: {
                 const membersScores = { one: 1.5, two: 2, three: 3 };
                 expect(await client.zadd(key1, membersScores)).toEqual(3);
                 expect(await client.zrank(key1, "one")).toEqual(0);
+                expect(
+                    await client.zrank(Buffer.from(key1), Buffer.from("one")),
+                ).toEqual(0);
 
                 if (!cluster.checkIfServerVersionLessThan("7.2.0")) {
                     expect(await client.zrankWithScore(key1, "one")).toEqual([
                         0, 1.5,
                     ]);
+                    expect(
+                        await client.zrankWithScore(
+                            Buffer.from(key1),
+                            Buffer.from("one"),
+                        ),
+                    ).toEqual([0, 1.5]);
                     expect(
                         await client.zrankWithScore(key1, "nonExistingMember"),
                     ).toEqual(null);
@@ -6203,11 +6257,23 @@ export function runBaseTests(config: {
                 const membersScores = { one: 1.5, two: 2, three: 3 };
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zrevrank(key, "three")).toEqual(0);
+                expect(
+                    await client.zrevrank(
+                        Buffer.from(key),
+                        Buffer.from("three"),
+                    ),
+                ).toEqual(0);
 
                 if (!cluster.checkIfServerVersionLessThan("7.2.0")) {
                     expect(await client.zrevrankWithScore(key, "one")).toEqual([
                         2, 1.5,
                     ]);
+                    expect(
+                        await client.zrevrankWithScore(
+                            Buffer.from(key),
+                            Buffer.from("one"),
+                        ),
+                    ).toEqual([2, 1.5]);
                     expect(
                         await client.zrevrankWithScore(
                             key,
@@ -6672,14 +6738,14 @@ export function runBaseTests(config: {
                 expect(
                     await client.zremRangeByLex(
                         key,
-                        { value: "a", isInclusive: false },
+                        { value: Buffer.from("a"), isInclusive: false },
                         { value: "c" },
                     ),
                 ).toEqual(2);
 
                 expect(
                     await client.zremRangeByLex(
-                        key,
+                        Buffer.from(key),
                         { value: "d" },
                         InfBoundary.PositiveInfinity,
                     ),
@@ -6689,7 +6755,7 @@ export function runBaseTests(config: {
                 expect(
                     await client.zremRangeByLex(
                         key,
-                        { value: "a" },
+                        { value: Buffer.from("a") },
                         InfBoundary.NegativeInfinity,
                     ),
                 ).toEqual(0);
@@ -6726,7 +6792,7 @@ export function runBaseTests(config: {
 
                 expect(
                     await client.zremRangeByScore(
-                        key,
+                        Buffer.from(key),
                         { value: 1, isInclusive: false },
                         { value: 2 },
                     ),
@@ -6773,7 +6839,7 @@ export function runBaseTests(config: {
                 // In range a (exclusive) to positive infinity
                 expect(
                     await client.zlexcount(
-                        key,
+                        Buffer.from(key),
                         { value: "a", isInclusive: false },
                         InfBoundary.PositiveInfinity,
                     ),
@@ -6782,7 +6848,7 @@ export function runBaseTests(config: {
                 // In range negative infinity to c (inclusive)
                 expect(
                     await client.zlexcount(key, InfBoundary.NegativeInfinity, {
-                        value: "c",
+                        value: Buffer.from("c"),
                         isInclusive: true,
                     }),
                 ).toEqual(3);
@@ -8759,7 +8825,7 @@ export function runBaseTests(config: {
                     await client.zrangeWithScores(
                         key2,
                         { start: 0, stop: -1 },
-                        true,
+                        { reverse: true },
                     ),
                 ).toEqual({
                     edge2: 236529.17986494553,
@@ -8871,7 +8937,11 @@ export function runBaseTests(config: {
                     ),
                 ).toEqual(2);
                 expect(
-                    await client.zrange(key2, { start: 0, stop: -1 }, true),
+                    await client.zrange(
+                        key2,
+                        { start: 0, stop: -1 },
+                        { reverse: true },
+                    ),
                 ).toEqual(searchResult);
 
                 searchResult = await client.geosearch(
@@ -8912,7 +8982,11 @@ export function runBaseTests(config: {
                     ),
                 ).toEqual(4);
                 expect(
-                    await client.zrange(key2, { start: 0, stop: -1 }, true),
+                    await client.zrange(
+                        key2,
+                        { start: 0, stop: -1 },
+                        { reverse: true },
+                    ),
                 ).toEqual(searchResult);
 
                 // Test search by radius, unit: kilometers, from a geospatial data, with limited count to 2
@@ -9078,14 +9152,20 @@ export function runBaseTests(config: {
                     await client.zmpop([key1, key2], ScoreFilter.MAX),
                 ).toEqual([key1, { b1: 2 }]);
                 expect(
-                    await client.zmpop([key2, key1], ScoreFilter.MAX, 10),
+                    await client.zmpop(
+                        [Buffer.from(key2), key1],
+                        ScoreFilter.MAX,
+                        { count: 10 },
+                    ),
                 ).toEqual([key2, { a2: 0.1, b2: 0.2 }]);
 
                 expect(
                     await client.zmpop([nonExistingKey], ScoreFilter.MIN),
                 ).toBeNull();
                 expect(
-                    await client.zmpop([nonExistingKey], ScoreFilter.MIN, 1),
+                    await client.zmpop([nonExistingKey], ScoreFilter.MIN, {
+                        count: 1,
+                    }),
                 ).toBeNull();
 
                 // key exists, but it is not a sorted set
@@ -9094,17 +9174,17 @@ export function runBaseTests(config: {
                     client.zmpop([stringKey], ScoreFilter.MAX),
                 ).rejects.toThrow(RequestError);
                 await expect(
-                    client.zmpop([stringKey], ScoreFilter.MAX, 1),
+                    client.zmpop([stringKey], ScoreFilter.MAX, { count: 1 }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: key list should not be empty
                 await expect(
-                    client.zmpop([], ScoreFilter.MAX, 1),
+                    client.zmpop([], ScoreFilter.MAX, { count: 1 }),
                 ).rejects.toThrow(RequestError);
 
                 // incorrect argument: count should be greater than 0
                 await expect(
-                    client.zmpop([key1], ScoreFilter.MAX, 0),
+                    client.zmpop([key1], ScoreFilter.MAX, { count: 0 }),
                 ).rejects.toThrow(RequestError);
 
                 // check that order of entries in the response is preserved
@@ -9116,7 +9196,9 @@ export function runBaseTests(config: {
                 }
 
                 expect(await client.zadd(key2, entries)).toEqual(10);
-                const result = await client.zmpop([key2], ScoreFilter.MIN, 10);
+                const result = await client.zmpop([key2], ScoreFilter.MIN, {
+                    count: 10,
+                });
 
                 if (result) {
                     expect(result[1]).toEqual(entries);
@@ -9200,29 +9282,27 @@ export function runBaseTests(config: {
                     expect(result[resultCursorIndex]).toEqual(initialCursor);
                     expect(result[resultCollectionIndex]).toEqual([]);
                 } else {
-                    try {
-                        expect(await client.zscan(key1, "-1")).toThrow();
-                    } catch (e) {
-                        expect((e as Error).message).toMatch(
-                            "ResponseError: invalid cursor",
-                        );
-                    }
+                    await expect(client.zscan(key1, "-1")).rejects.toThrow(
+                        "ResponseError: invalid cursor",
+                    );
                 }
 
                 // Result contains the whole set
                 expect(await client.zadd(key1, charMap)).toEqual(
                     charMembers.length,
                 );
-                result = await client.zscan(key1, initialCursor);
+                result = await client.zscan(key1, initialCursor, {
+                    decoder: Decoder.Bytes,
+                });
                 expect(result[resultCursorIndex]).toEqual(initialCursor);
                 expect(result[resultCollectionIndex].length).toEqual(
                     expectedCharMapArray.length,
                 );
                 expect(result[resultCollectionIndex]).toEqual(
-                    expectedCharMapArray,
+                    expectedCharMapArray.map(Buffer.from),
                 );
 
-                result = await client.zscan(key1, initialCursor, {
+                result = await client.zscan(Buffer.from(key1), initialCursor, {
                     match: "a",
                 });
                 expect(result[resultCursorIndex]).toEqual(initialCursor);
@@ -9236,7 +9316,7 @@ export function runBaseTests(config: {
                 result = await client.zscan(key1, initialCursor);
                 let resultCursor = result[resultCursorIndex];
                 let resultIterationCollection = result[resultCollectionIndex];
-                let fullResultMapArray: string[] = resultIterationCollection;
+                let fullResultMapArray = resultIterationCollection;
                 let nextResult;
                 let nextResultCursor;
 
@@ -9268,9 +9348,9 @@ export function runBaseTests(config: {
                 );
 
                 for (let i = 0; i < fullResultMapArray.length; i += 2) {
-                    expect(fullResultMapArray[i] in expectedFullMap).toEqual(
-                        true,
-                    );
+                    expect(
+                        (fullResultMapArray[i] as string) in expectedFullMap,
+                    ).toEqual(true);
                 }
 
                 // Test match pattern
@@ -9406,9 +9486,6 @@ export function runBaseTests(config: {
                 if (result) {
                     expect(result[1]).toEqual(entries);
                 }
-
-                // TODO: add test case with 0 timeout (no timeout) should never time out,
-                // but we wrap the test with timeout to avoid test failing or stuck forever
             }, protocol);
         },
         config.timeout,
@@ -9642,11 +9719,11 @@ export function runBaseTests(config: {
                 const key2 = uuidv4();
 
                 const memberScores = { one: 1.0, two: 2.0 };
-                const elements = ["one", "two"];
+                const elements: GlideString[] = ["one", "two"];
                 expect(await client.zadd(key1, memberScores)).toBe(2);
 
                 // check random memember belongs to the set
-                const randmember = await client.zrandmember(key1);
+                const randmember = await client.zrandmember(Buffer.from(key1));
 
                 if (randmember !== null) {
                     expect(elements.includes(randmember)).toEqual(true);
@@ -9657,7 +9734,9 @@ export function runBaseTests(config: {
 
                 // Key exists, but is not a set
                 expect(await client.set(key2, "foo")).toBe("OK");
-                await expect(client.zrandmember(key2)).rejects.toThrow();
+                await expect(client.zrandmember(key2)).rejects.toThrow(
+                    RequestError,
+                );
             }, protocol);
         },
         config.timeout,
@@ -9679,7 +9758,10 @@ export function runBaseTests(config: {
                 expect(randMembers.length).toEqual(new Set(randMembers).size);
 
                 // Duplicate values are expected as count is negative
-                randMembers = await client.zrandmemberWithCount(key1, -4);
+                randMembers = await client.zrandmemberWithCount(
+                    Buffer.from(key1),
+                    -4,
+                );
                 expect(randMembers.length).toBe(4);
                 const randMemberSet = new Set<string>();
 
@@ -9726,7 +9808,7 @@ export function runBaseTests(config: {
 
                 // unique values are expected as count is positive
                 let randMembers = await client.zrandmemberWithCountWithScores(
-                    key1,
+                    Buffer.from(key1),
                     4,
                 );
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1415,7 +1415,7 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hscan test_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient) => {
+            await runTest(async (client: BaseClient, cluster) => {
                 const key1 = "{key}-1" + uuidv4();
                 const initialCursor = "0";
                 const defaultCount = 20;
@@ -1556,6 +1556,22 @@ export function runBaseTests(config: {
                 });
                 expect(result[resultCursorIndex]).not.toEqual(initialCursor);
                 expect(result[resultCollectionIndex].length).toBeGreaterThan(0);
+
+                if (!cluster.checkIfServerVersionLessThan("7.9.0")) {
+                    const result = await client.hscan(key1, initialCursor, {
+                        noValues: true,
+                    });
+                    const resultCursor = result[resultCursorIndex];
+                    const fieldsArray = result[
+                        resultCollectionIndex
+                    ] as string[];
+
+                    // Verify that the cursor is not "0" and values are not included
+                    expect(resultCursor).not.toEqual("0");
+                    expect(
+                        fieldsArray.every((field) => !field.startsWith("num")),
+                    ).toBeTruthy();
+                }
             }, protocol);
         },
         config.timeout,
@@ -9258,7 +9274,7 @@ export function runBaseTests(config: {
                 const numberMap: Record<string, number> = {};
 
                 for (let i = 0; i < 50000; i++) {
-                    numberMap[i.toString()] = i;
+                    numberMap["member" + i.toString()] = i;
                 }
 
                 const charMembers = ["a", "b", "c", "d", "e"];
@@ -9371,11 +9387,29 @@ export function runBaseTests(config: {
 
                 // Test count with match returns a non-empty list
                 result = await client.zscan(key1, initialCursor, {
-                    match: "1*",
+                    match: "member1*",
                     count: 20,
                 });
                 expect(result[resultCursorIndex]).not.toEqual("0");
                 expect(result[resultCollectionIndex].length).toBeGreaterThan(0);
+
+                if (!cluster.checkIfServerVersionLessThan("7.9.0")) {
+                    const result = await client.zscan(key1, initialCursor, {
+                        noScores: true,
+                    });
+                    const resultCursor = result[resultCursorIndex];
+                    const fieldsArray = result[
+                        resultCollectionIndex
+                    ] as string[];
+
+                    // Verify that the cursor is not "0" and values are not included
+                    expect(resultCursor).not.toEqual("0");
+                    expect(
+                        fieldsArray.every((field) =>
+                            field.startsWith("member"),
+                        ),
+                    ).toBeTruthy();
+                }
 
                 // Exceptions
                 // Non-set key

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -766,6 +766,24 @@ export async function transactionTest(
     responseData.push(["hset(key4, { [field]: value })", 1]);
     baseTransaction.hscan(key4, "0");
     responseData.push(['hscan(key4, "0")', ["0", [field, value]]]);
+
+    if (gte(version, "7.9.0")) {
+        baseTransaction.hscan(key4, "0", { noValues: false });
+        responseData.push([
+            'hscan(key4, "0", {noValues: false})',
+            ["0", [field, value]],
+        ]);
+        baseTransaction.hscan(key4, "0", {
+            match: "*",
+            count: 20,
+            noValues: true,
+        });
+        responseData.push([
+            'hscan(key4, "0", {match: "*", count: 20, noValues:true})',
+            ["0", [field]],
+        ]);
+    }
+
     baseTransaction.hscan(key4, "0", { match: "*", count: 20 });
     responseData.push([
         'hscan(key4, "0", {match: "*", count: 20})',
@@ -1009,6 +1027,25 @@ export async function transactionTest(
     responseData.push(["zadd(key12, { one: 1, two: 2 })", 2]);
     baseTransaction.zscan(key12, "0");
     responseData.push(['zscan(key12, "0")', ["0", ["one", "1", "two", "2"]]]);
+
+    if (gte(version, "7.9.0")) {
+        baseTransaction.zscan(key12, "0", { noScores: false });
+        responseData.push([
+            'zscan(key12, "0", {noScores: false})',
+            ["0", ["one", "1", "two", "2"]],
+        ]);
+
+        baseTransaction.zscan(key12, "0", {
+            match: "*",
+            count: 20,
+            noScores: true,
+        });
+        responseData.push([
+            'zscan(key12, "0", {match: "*", count: 20, noScores:true})',
+            ["0", ["one", "two"]],
+        ]);
+    }
+
     baseTransaction.zscan(key12, "0", { match: "*", count: 20 });
     responseData.push([
         'zscan(key12, "0", {match: "*", count: 20})',

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -6117,6 +6117,7 @@ class CoreCommands(Protocol):
         cursor: TEncodable,
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
+        no_scores: bool = False,
     ) -> List[Union[bytes, List[bytes]]]:
         """
         Iterates incrementally over a sorted set.
@@ -6135,13 +6136,15 @@ class CoreCommands(Protocol):
             count (Optional[int]): `COUNT` is a just a hint for the command for how many elements to fetch from the
                 sorted set. `COUNT` could be ignored until the sorted set is large enough for the `SCAN` commands to
                 represent the results as compact single-allocation packed encoding.
+            no_scores (bool): If `True`, the command will not return scores associated with the members. Since Valkey "8.0.0".
 
         Returns:
             List[Union[bytes, List[bytes]]]: An `Array` of the `cursor` and the subset of the sorted set held by `key`.
-                The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
-                returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
-                of the sorted set held in `key`. The `Array` in the second element is always a flattened series of
-                `String` pairs, where the value is at even indices and the score is at odd indices.
+            The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
+            returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
+            of the sorted set held in `key`. The `Array` in the second element is a flattened series of
+            `String` pairs, where the value is at even indices and the score is at odd indices.
+            If `no_scores` is set to`True`, the second element will only contain the members without scores.
 
         Examples:
             # Assume "key" contains a sorted set with multiple members
@@ -6160,12 +6163,31 @@ class CoreCommands(Protocol):
             Members: [b'value 39', b'39', b'value 127', b'127', b'value 43', b'43', b'value 139', b'139', b'value 211', b'211']
             Cursor: 0
             Members: [b'value 55', b'55', b'value 24', b'24', b'value 90', b'90', b'value 113', b'113']
+
+            # Using no-score
+            >>> result_cursor = "0"
+            >>> while True:
+            ...     result = await client.zscan("key", "0", match="*", count=5, no_scores=True)
+            ...     new_cursor = str(result[0])
+            ...     print("Cursor: ", new_cursor)
+            ...     print("Members: ", result[1])
+            ...     if new_cursor == "0":
+            ...         break
+            ...     result_cursor = new_cursor
+            Cursor: 123
+            Members: [b'value 163', b'value 114', b'value 25', b'value 82', b'value 64']
+            Cursor: 47
+            Members: [b'value 39', b'value 127', b'value 43', b'value 139', b'value 211']
+            Cursor: 0
+            Members: [b'value 55', b'value 24', b'value 90', b'value 113']
         """
         args: List[TEncodable] = [key, cursor]
         if match is not None:
             args += ["MATCH", match]
         if count is not None:
             args += ["COUNT", str(count)]
+        if no_scores:
+            args.append("NOSCORES")
 
         return cast(
             List[Union[bytes, List[bytes]]],
@@ -6178,6 +6200,7 @@ class CoreCommands(Protocol):
         cursor: TEncodable,
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
+        no_values: bool = False,
     ) -> List[Union[bytes, List[bytes]]]:
         """
         Iterates incrementally over a hash.
@@ -6196,13 +6219,15 @@ class CoreCommands(Protocol):
             count (Optional[int]): `COUNT` is a just a hint for the command for how many elements to fetch from the hash.
                 `COUNT` could be ignored until the hash is large enough for the `SCAN` commands to represent the results
                 as compact single-allocation packed encoding.
+            no_values (bool): If `True`, the command will not return values the fields in the hash. Since Valkey "8.0.0".
 
         Returns:
             List[Union[bytes, List[bytes]]]: An `Array` of the `cursor` and the subset of the hash held by `key`.
                 The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
                 returned on the last iteration of the hash. The second element is always an `Array` of the subset of the
-                hash held in `key`. The `Array` in the second element is always a flattened series of `String` pairs,
+                hash held in `key`. The `Array` in the second element is a flattened series of `String` pairs,
                 where the value is at even indices and the score is at odd indices.
+                If `no_values` is set to `True`, the second element will only contain the fields without the values.
 
         Examples:
             # Assume "key" contains a hash with multiple members
@@ -6221,12 +6246,31 @@ class CoreCommands(Protocol):
             Members: [b'field 63', b'value 63', b'field 293', b'value 293', b'field 162', b'value 162']
             Cursor: 0
             Members: [b'field 420', b'value 420', b'field 221', b'value 221']
+
+            # Use no-values
+            >>> result_cursor = "0"
+            >>> while True:
+            ...     result = await client.hscan("key", "0", match="*", count=3, no_values=True)
+            ...     new_cursor = str(result [0])
+            ...     print("Cursor: ", new_cursor)
+            ...     print("Members: ", result[1])
+            ...     if new_cursor == "0":
+            ...         break
+            ...     result_cursor = new_cursor
+            Cursor: 1
+            Members: [b'field 79',b'field 20', b'field 115']
+            Cursor: 39
+            Members: [b'field 63', b'field 293', b'field 162']
+            Cursor: 0
+            Members: [b'field 420', b'field 221']
         """
         args: List[TEncodable] = [key, cursor]
         if match is not None:
             args += ["MATCH", match]
         if count is not None:
             args += ["COUNT", str(count)]
+        if no_values:
+            args.append("NOVALUES")
 
         return cast(
             List[Union[bytes, List[bytes]]],

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -4463,6 +4463,7 @@ class BaseTransaction:
         cursor: TEncodable,
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
+        no_scores: bool = False,
     ) -> TTransaction:
         """
         Iterates incrementally over a sorted set.
@@ -4474,26 +4475,30 @@ class BaseTransaction:
             cursor (TEncodable): The cursor that points to the next iteration of results. A value of "0" indicates the start of
                 the search.
             match (Optional[TEncodable]): The match filter is applied to the result of the command and will only include
-                strings or byte string that match the pattern specified. If the sorted set is large enough for scan commands to return
+                strings or byte strings that match the pattern specified. If the sorted set is large enough for scan commands to return
                 only a subset of the sorted set then there could be a case where the result is empty although there are
                 items that match the pattern specified. This is due to the default `COUNT` being `10` which indicates
                 that it will only fetch and match `10` items from the list.
             count (Optional[int]): `COUNT` is a just a hint for the command for how many elements to fetch from the
                 sorted set. `COUNT` could be ignored until the sorted set is large enough for the `SCAN` commands to
                 represent the results as compact single-allocation packed encoding.
+            no_scores (bool): If `True`, the command will not return scores associated with the members. Since Valkey "8.0.0".
 
         Returns:
             List[Union[bytes, List[bytes]]]: An `Array` of the `cursor` and the subset of the sorted set held by `key`.
-                The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
-                returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
-                of the sorted set held in `key`. The `Array` in the second element is always a flattened series of
-                `String` pairs, where the value is at even indices and the score is at odd indices.
+            The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
+            returned on the last iteration of the sorted set. The second element is always an `Array` of the subset
+            of the sorted set held in `key`. The `Array` in the second element is a flattened series of
+            `String` pairs, where the value is at even indices and the score is at odd indices.
+            If `no_scores` is set to`True`, the second element will only contain the members without scores.
         """
         args = [key, cursor]
         if match is not None:
             args += ["MATCH", match]
         if count is not None:
             args += ["COUNT", str(count)]
+        if no_scores:
+            args.append("NOSCORES")
 
         return self.append_command(RequestType.ZScan, args)
 
@@ -4503,6 +4508,7 @@ class BaseTransaction:
         cursor: TEncodable,
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
+        no_values: bool = False,
     ) -> TTransaction:
         """
         Iterates incrementally over a hash.
@@ -4514,26 +4520,30 @@ class BaseTransaction:
             cursor (TEncodable): The cursor that points to the next iteration of results. A value of "0" indicates the start of
                 the search.
             match (Optional[TEncodable]): The match filter is applied to the result of the command and will only include
-                strings or bytes strings that match the pattern specified. If the hash is large enough for scan commands to return only a
+                strings or byte strings that match the pattern specified. If the hash is large enough for scan commands to return only a
                 subset of the hash then there could be a case where the result is empty although there are items that
                 match the pattern specified. This is due to the default `COUNT` being `10` which indicates that it will
                 only fetch and match `10` items from the list.
             count (Optional[int]): `COUNT` is a just a hint for the command for how many elements to fetch from the hash.
                 `COUNT` could be ignored until the hash is large enough for the `SCAN` commands to represent the results
                 as compact single-allocation packed encoding.
+            no_values (bool): If `True`, the command will not return values the fields in the hash. Since Valkey "8.0.0".
 
         Returns:
             List[Union[bytes, List[bytes]]]: An `Array` of the `cursor` and the subset of the hash held by `key`.
                 The first element is always the `cursor` for the next iteration of results. `0` will be the `cursor`
                 returned on the last iteration of the hash. The second element is always an `Array` of the subset of the
-                hash held in `key`. The `Array` in the second element is always a flattened series of `String` pairs,
+                hash held in `key`. The `Array` in the second element is a flattened series of `String` pairs,
                 where the value is at even indices and the score is at odd indices.
+                If `no_values` is set to `True`, the second element will only contain the fields without the values.
         """
         args = [key, cursor]
         if match is not None:
             args += ["MATCH", match]
         if count is not None:
             args += ["COUNT", str(count)]
+        if no_values:
+            args.append("NOVALUES")
 
         return self.append_command(RequestType.HScan, args)
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -10020,6 +10020,16 @@ class TestClusterRoutes:
         assert result[result_cursor_index] != b"0"
         assert len(result[result_collection_index]) >= 0
 
+        # Test no_scores option
+        if not await check_if_server_version_lt(glide_client, "7.9.0"):
+            result = await glide_client.zscan(key1, initial_cursor, no_scores=True)
+            assert result[result_cursor_index] != b"0"
+            values_array = cast(List[bytes], result[result_collection_index])
+            # Verify that scores are not included
+            assert all(
+                item.startswith(b"value") and item.isascii() for item in values_array
+            )
+
         # Exceptions
         # Non-set key
         assert await glide_client.set(key2, "test") == OK
@@ -10136,6 +10146,16 @@ class TestClusterRoutes:
         result = await glide_client.hscan(key1, initial_cursor, match="1*", count=20)
         assert result[result_cursor_index] != b"0"
         assert len(result[result_collection_index]) >= 0
+
+        # Test no_values option
+        if not await check_if_server_version_lt(glide_client, "7.9.0"):
+            result = await glide_client.hscan(key1, initial_cursor, no_values=True)
+            assert result[result_cursor_index] != b"0"
+            values_array = cast(List[bytes], result[result_collection_index])
+            # Verify that values are not included
+            assert all(
+                item.startswith(b"field") and item.isascii() for item in values_array
+            )
 
         # Exceptions
         # Non-hash key

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -306,6 +306,9 @@ async def transaction_test(
     args.append([b"0", [key3.encode(), b"10.5"]])
     transaction.hscan(key4, "0", match="*", count=10)
     args.append([b"0", [key3.encode(), b"10.5"]])
+    if not await check_if_server_version_lt(glide_client, "7.9.0"):
+        transaction.hscan(key4, "0", match="*", count=10, no_values=True)
+        args.append([b"0", [key3.encode()]])
     transaction.hrandfield(key4)
     args.append(key3_bytes)
     transaction.hrandfield_count(key4, 1)
@@ -458,6 +461,9 @@ async def transaction_test(
     args.append([b"0", [b"three", b"3"]])
     transaction.zscan(key8, "0", match="*", count=20)
     args.append([b"0", [b"three", b"3"]])
+    if not await check_if_server_version_lt(glide_client, "7.9.0"):
+        transaction.zscan(key8, "0", match="*", count=20, no_scores=True)
+        args.append([b"0", [b"three"]])
     transaction.zpopmax(key8)
     args.append({b"three": 3.0})
     transaction.zpopmin(key8)


### PR DESCRIPTION
Updated decoder to decoderOption for the following commands:
1. get (https://valkey.io/commands/get/)
2. 