### PR TITLE
Node: replace `decoder` by `DecoderOption` and `route` by `RouteOption` in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Changes
 * Node: Added binary variant to HSCAN command ([#2240](https://github.com/valkey-io/valkey-glide/pull/2240))
+* Node: replace decoder by DecoderOption and route by RouteOption in API([#2234](https://github.com/valkey-io/valkey-glide/pull/2234/))
 * Node: Added binary variant to sorted set commands ([#2190](https://github.com/valkey-io/valkey-glide/pull/2190), [#2210](https://github.com/valkey-io/valkey-glide/pull/2210))
 * Node: Added binary variant for MSET, MSETNX commands ([#2229](https://github.com/valkey-io/valkey-glide/pull/2229))
 * Node: Added binary variant to HASH commands ([#2194](https://github.com/valkey-io/valkey-glide/pull/2194))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -479,7 +479,7 @@ export type BaseClientConfiguration = {
     defaultDecoder?: Decoder;
 };
 
-export type ScriptOption = {
+export type ScriptOptions = {
     /**
      * The keys that are used in the script.
      */
@@ -3523,7 +3523,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/script-load/|SCRIPT LOAD} and {@link https://valkey.io/commands/evalsha/|EVALSHA} on valkey.io for details.
      *
      * @param script - The Lua script to execute.
-     * @param options - (Optional) See {@link ScriptOption} and {@link DecoderOption}.
+     * @param options - (Optional) See {@link ScriptOptions} and {@link DecoderOption}.
      * @returns A value that depends on the script that was executed.
      *
      * @example
@@ -3539,7 +3539,7 @@ export class BaseClient {
      */
     public async invokeScript(
         script: Script,
-        options?: ScriptOption & DecoderOption,
+        options?: ScriptOptions & DecoderOption,
     ): Promise<ReturnType> {
         const scriptInvocation = command_request.ScriptInvocation.create({
             hash: script.getHash(),

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -479,7 +479,7 @@ export type BaseClientConfiguration = {
     defaultDecoder?: Decoder;
 };
 
-export type ScriptOptions = {
+export type ScriptOption = {
     /**
      * The keys that are used in the script.
      */
@@ -488,10 +488,6 @@ export type ScriptOptions = {
      * The arguments for the script.
      */
     args?: GlideString[];
-    /**
-     * {@link Decoder} type which defines how to handle the responses. If not set, the default decoder from the client config will be used.
-     */
-    decoder?: Decoder;
 };
 
 function getRequestErrorClass(
@@ -3527,7 +3523,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/script-load/|SCRIPT LOAD} and {@link https://valkey.io/commands/evalsha/|EVALSHA} on valkey.io for details.
      *
      * @param script - The Lua script to execute.
-     * @param options - The script option that contains keys and arguments for the script.
+     * @param options - (Optional) See {@link ScriptOption} and {@link DecoderOption}.
      * @returns A value that depends on the script that was executed.
      *
      * @example
@@ -3543,11 +3539,11 @@ export class BaseClient {
      */
     public async invokeScript(
         script: Script,
-        option?: ScriptOptions,
+        options?: ScriptOption & DecoderOption,
     ): Promise<ReturnType> {
         const scriptInvocation = command_request.ScriptInvocation.create({
             hash: script.getHash(),
-            keys: option?.keys?.map((item) => {
+            keys: options?.keys?.map((item) => {
                 if (typeof item === "string") {
                     // Convert the string to a Buffer
                     return Buffer.from(item);
@@ -3556,7 +3552,7 @@ export class BaseClient {
                     return item;
                 }
             }),
-            args: option?.args?.map((item) => {
+            args: options?.args?.map((item) => {
                 if (typeof item === "string") {
                     // Convert the string to a Buffer
                     return Buffer.from(item);
@@ -3567,7 +3563,7 @@ export class BaseClient {
             }),
         });
         return this.createWritePromise(scriptInvocation, {
-            decoder: option?.decoder,
+            decoder: options?.decoder,
         });
     }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1155,9 +1155,10 @@ export class BaseClient {
             expiry: "persist" | { type: TimeUnit; duration: number };
         } & DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createGetEx(key, options?.expiry), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(
+            createGetEx(key, options?.expiry),
+            options,
+        );
     }
 
     /**
@@ -1259,9 +1260,7 @@ export class BaseClient {
         value: GlideString,
         options?: SetOptions & DecoderOption,
     ): Promise<"OK" | GlideString | null> {
-        return this.createWritePromise(createSet(key, value, options), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(createSet(key, value, options), options);
     }
 
     /**
@@ -3571,9 +3570,7 @@ export class BaseClient {
                 }
             }),
         });
-        return this.createWritePromise(scriptInvocation, {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(scriptInvocation, options);
     }
 
     /**
@@ -6280,7 +6277,7 @@ export class BaseClient {
     ): Promise<[GlideString, [number?, number?, [number, number]?]?][]> {
         return this.createWritePromise(
             createGeoSearch(key, searchFrom, searchBy, options),
-            { decoder: options?.decoder },
+            options,
         );
     }
 
@@ -6975,9 +6972,10 @@ export class BaseClient {
     public async pubsubChannels(
         options?: { pattern?: GlideString } & DecoderOption,
     ): Promise<GlideString[]> {
-        return this.createWritePromise(createPubSubChannels(options?.pattern), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(
+            createPubSubChannels(options?.pattern),
+            options,
+        );
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1032,7 +1032,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/get/|valkey.io} for details.
      *
      * @param key - The key to retrieve from the database.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
+     * @param options - (Optional) See {@link DecoderOption}.
      *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
      * @returns If `key` exists, returns the value of `key`. Otherwise, return null.
      *
@@ -1092,8 +1092,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/getdel/|valkey.io} for details.
      *
      * @param key - The key to retrieve from the database.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns If `key` exists, returns the `value` of `key`. Otherwise, return `null`.
      *
      * @example
@@ -1125,8 +1124,7 @@ export class BaseClient {
      * @param key - The key of the string.
      * @param start - The starting offset.
      * @param end - The ending offset.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A substring extracted from the value stored at `key`.
      *
      * @example
@@ -1301,8 +1299,7 @@ export class BaseClient {
      * @remarks When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
      *
      * @param keys - A list of keys to retrieve values for.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A list of values corresponding to the provided keys. If a key is not found,
      * its corresponding value in the list will be null.
      *
@@ -2238,8 +2235,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/lpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The value of the first element.
      * If `key` does not exist null will be returned.
      *
@@ -2272,8 +2268,7 @@ export class BaseClient {
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A list of the popped elements will be returned depending on the list's length.
      * If `key` does not exist null will be returned.
      *
@@ -2311,8 +2306,7 @@ export class BaseClient {
      * @param key - The key of the list.
      * @param start - The starting point of the range.
      * @param end - The end of the range.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns list of elements in the specified range.
      * If `start` exceeds the end of the list, or if `start` is greater than `end`, an empty list will be returned.
      * If `end` exceeds the actual end of the list, the range will stop at the actual end of the list.
@@ -2381,8 +2375,7 @@ export class BaseClient {
      * @param destination - The key to the destination list.
      * @param whereFrom - The {@link ListDirection} to remove the element from.
      * @param whereTo - The {@link ListDirection} to add the element to.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The popped element, or `null` if `source` does not exist.
      *
      * @example
@@ -2429,8 +2422,7 @@ export class BaseClient {
      * @param whereFrom - The {@link ListDirection} to remove the element from.
      * @param whereTo - The {@link ListDirection} to add the element to.
      * @param timeout - The number of seconds to wait for a blocking operation to complete. A value of `0` will block indefinitely.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The popped element, or `null` if `source` does not exist or if the operation timed-out.
      *
      * @example
@@ -2608,8 +2600,7 @@ export class BaseClient {
      * @see {@link https://valkey.io/commands/rpop/|valkey.io} for details.
      *
      * @param key - The key of the list.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The value of the last element.
      * If `key` does not exist null will be returned.
      *
@@ -2642,8 +2633,7 @@ export class BaseClient {
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A list of popped elements will be returned depending on the list's length.
      * If `key` does not exist null will be returned.
      *
@@ -5663,8 +5653,7 @@ export class BaseClient {
      *
      * @param key - The `key` of the list.
      * @param index - The `index` of the element in the list to retrieve.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns - The element at `index` in the list stored at `key`.
      * If `index` is out of range or if `key` does not exist, null is returned.
      *
@@ -5805,8 +5794,7 @@ export class BaseClient {
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns - An `array` containing the `key` from which the element was popped and the value of the popped element,
      * formatted as [key, value]. If no element could be popped and the timeout expired, returns `null`.
      *
@@ -5838,8 +5826,7 @@ export class BaseClient {
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns - An `array` containing the `key` from which the element was popped and the value of the popped element,
      * formatted as [key, value]. If no element could be popped and the timeout expired, returns `null`.
      *
@@ -6021,8 +6008,7 @@ export class BaseClient {
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
      *     all names of keys that a function accesses must be explicitly provided as `keys`.
      * @param args - A list of `function` arguments and it should not represent names of keys.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The invoked function's return value.
      *
      * @example
@@ -6053,8 +6039,7 @@ export class BaseClient {
      * @param keys - A list of `keys` accessed by the function. To ensure the correct execution of functions,
      *     all names of keys that a function accesses must be explicitly provided as `keys`.
      * @param args - A list of `function` arguments and it should not represent names of keys.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The invoked function's return value.
      *
      * @example

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -572,7 +572,7 @@ function toProtobufRoute(
             if (split.length !== 2) {
                 throw new RequestError(
                     "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                    host,
+                        host,
                 );
             }
 
@@ -867,17 +867,17 @@ export class BaseClient {
     ) {
         const message = Array.isArray(command)
             ? command_request.CommandRequest.create({
-                callbackIdx,
-                transaction: command_request.Transaction.create({
-                    commands: command,
-                }),
-            })
+                  callbackIdx,
+                  transaction: command_request.Transaction.create({
+                      commands: command,
+                  }),
+              })
             : command instanceof command_request.Command
-                ? command_request.CommandRequest.create({
+              ? command_request.CommandRequest.create({
                     callbackIdx,
                     singleCommand: command,
                 })
-                : command_request.CommandRequest.create({
+              : command_request.CommandRequest.create({
                     callbackIdx,
                     scriptInvocation: command,
                 });
@@ -5634,9 +5634,9 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-            primary: connection_request.ReadFrom.Primary,
-            preferReplica: connection_request.ReadFrom.PreferReplica,
-        };
+        primary: connection_request.ReadFrom.Primary,
+        preferReplica: connection_request.ReadFrom.PreferReplica,
+    };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -7033,11 +7033,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-                "password" in options.credentials
+            "password" in options.credentials
                 ? {
-                    password: options.credentials.password,
-                    username: options.credentials.username,
-                }
+                      password: options.credentials.password,
+                      username: options.credentials.username,
+                  }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1048,9 +1048,11 @@ export class BaseClient {
      */
     public async get(
         key: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createGet(key), { decoder: decoder });
+        return this.createWritePromise(createGet(key), {
+            decoder: options?.decoder,
+        });
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -612,7 +612,8 @@ export type PubSubMsg = {
 
 /**
  * @internal
- *
+ * A type to combine RouterOption and DecoderOption to be used for creating write promises for the command.
+ * See - {@link DecoderOption} and {@link RouteOption}
  */
 export type WritePromiseOptions = RouteOption & DecoderOption;
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1033,7 +1033,6 @@ export class BaseClient {
      *
      * @param key - The key to retrieve from the database.
      * @param options - (Optional) See {@link DecoderOption}.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
      * @returns If `key` exists, returns the value of `key`. Otherwise, return null.
      *
      * @example

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1106,9 +1106,11 @@ export class BaseClient {
      */
     public async getdel(
         key: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createGetDel(key), { decoder: decoder });
+        return this.createWritePromise(createGetDel(key), {
+            decoder: options?.decoder,
+        });
     }
 
     /**
@@ -1144,10 +1146,10 @@ export class BaseClient {
         key: GlideString,
         start: number,
         end: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
         return this.createWritePromise(createGetRange(key, start, end), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -1315,9 +1317,11 @@ export class BaseClient {
      */
     public async mget(
         keys: GlideString[],
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<(GlideString | null)[]> {
-        return this.createWritePromise(createMGet(keys), { decoder: decoder });
+        return this.createWritePromise(createMGet(keys), {
+            decoder: options?.decoder,
+        });
     }
 
     /** Set multiple keys to multiple values in a single operation.
@@ -2255,9 +2259,11 @@ export class BaseClient {
      */
     public async lpop(
         key: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createLPop(key), { decoder: decoder });
+        return this.createWritePromise(createLPop(key), {
+            decoder: options?.decoder,
+        });
     }
 
     /** Removes and returns up to `count` elements of the list stored at `key`, depending on the list's length.
@@ -2288,10 +2294,10 @@ export class BaseClient {
     public async lpopCount(
         key: GlideString,
         count: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString[] | null> {
         return this.createWritePromise(createLPop(key, count), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -2337,10 +2343,10 @@ export class BaseClient {
         key: GlideString,
         start: number,
         end: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString[]> {
         return this.createWritePromise(createLRange(key, start, end), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -2399,11 +2405,11 @@ export class BaseClient {
         destination: GlideString,
         whereFrom: ListDirection,
         whereTo: ListDirection,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
         return this.createWritePromise(
             createLMove(source, destination, whereFrom, whereTo),
-            { decoder: decoder },
+            { decoder: options?.decoder },
         );
     }
 
@@ -2447,11 +2453,11 @@ export class BaseClient {
         whereFrom: ListDirection,
         whereTo: ListDirection,
         timeout: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
         return this.createWritePromise(
             createBLMove(source, destination, whereFrom, whereTo, timeout),
-            { decoder: decoder },
+            { decoder: options?.decoder },
         );
     }
 
@@ -2623,9 +2629,11 @@ export class BaseClient {
      */
     public async rpop(
         key: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
-        return this.createWritePromise(createRPop(key), { decoder: decoder });
+        return this.createWritePromise(createRPop(key), {
+            decoder: options?.decoder,
+        });
     }
 
     /** Removes and returns up to `count` elements from the list stored at `key`, depending on the list's length.
@@ -2656,10 +2664,10 @@ export class BaseClient {
     public async rpopCount(
         key: GlideString,
         count: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString[] | null> {
         return this.createWritePromise(createRPop(key, count), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -5677,10 +5685,10 @@ export class BaseClient {
     public async lindex(
         key: GlideString,
         index: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString | null> {
         return this.createWritePromise(createLIndex(key, index), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -5812,10 +5820,10 @@ export class BaseClient {
     public async brpop(
         keys: GlideString[],
         timeout: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<[GlideString, GlideString] | null> {
         return this.createWritePromise(createBRPop(keys, timeout), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -5844,10 +5852,10 @@ export class BaseClient {
     public async blpop(
         keys: GlideString[],
         timeout: number,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<[GlideString, GlideString] | null> {
         return this.createWritePromise(createBLPop(keys, timeout), {
-            decoder: decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -6027,10 +6035,10 @@ export class BaseClient {
         func: GlideString,
         keys: GlideString[],
         args: GlideString[],
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<ReturnType> {
         return this.createWritePromise(createFCall(func, keys, args), {
-            decoder,
+            decoder: options?.decoder,
         });
     }
 
@@ -6060,10 +6068,10 @@ export class BaseClient {
         func: GlideString,
         keys: GlideString[],
         args: GlideString[],
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<ReturnType> {
         return this.createWritePromise(createFCallReadOnly(func, keys, args), {
-            decoder,
+            decoder: options?.decoder,
         });
     }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -235,7 +235,11 @@ import {
     TimeoutError,
 } from "./Errors";
 import { GlideClientConfiguration } from "./GlideClient";
-import { GlideClusterClientConfiguration, Routes } from "./GlideClusterClient";
+import {
+    GlideClusterClientConfiguration,
+    RouteOption,
+    Routes,
+} from "./GlideClusterClient";
 import { Logger } from "./Logger";
 import {
     command_request,
@@ -592,10 +596,12 @@ export type PubSubMsg = {
     pattern?: string | null;
 };
 
-export type WritePromiseOptions = {
-    decoder?: Decoder;
-    route?: Routes;
-};
+/**
+ * @internal
+ *
+ */
+export type WritePromiseOptions = RouteOption & DecoderOption;
+
 export class BaseClient {
     private socket: net.Socket;
     private readonly promiseCallbackFunctions: [
@@ -810,9 +816,9 @@ export class BaseClient {
             | command_request.ScriptInvocation,
         options: WritePromiseOptions = {},
     ): Promise<T> {
-        const decoder = options?.decoder ?? this.defaultDecoder;
         const route = toProtobufRoute(options?.route);
-        const stringDecoder = decoder === Decoder.String ? true : false;
+        const stringDecoder: boolean =
+            (options?.decoder ?? this.defaultDecoder) === Decoder.String;
 
         if (this.isClosed) {
             throw new ClosingError(

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -512,10 +512,13 @@ function getRequestErrorClass(
     return RequestError;
 }
 
+/**
+ * @internal
+ */
 function toProtobufRoute(
     route: Routes | undefined,
 ): command_request.Routes | undefined {
-    if (route === undefined) {
+    if (!route) {
         return undefined;
     }
 
@@ -569,7 +572,7 @@ function toProtobufRoute(
             if (split.length !== 2) {
                 throw new RequestError(
                     "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                        host,
+                    host,
                 );
             }
 
@@ -864,17 +867,17 @@ export class BaseClient {
     ) {
         const message = Array.isArray(command)
             ? command_request.CommandRequest.create({
-                  callbackIdx,
-                  transaction: command_request.Transaction.create({
-                      commands: command,
-                  }),
-              })
+                callbackIdx,
+                transaction: command_request.Transaction.create({
+                    commands: command,
+                }),
+            })
             : command instanceof command_request.Command
-              ? command_request.CommandRequest.create({
+                ? command_request.CommandRequest.create({
                     callbackIdx,
                     singleCommand: command,
                 })
-              : command_request.CommandRequest.create({
+                : command_request.CommandRequest.create({
                     callbackIdx,
                     scriptInvocation: command,
                 });
@@ -5631,9 +5634,9 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-        primary: connection_request.ReadFrom.Primary,
-        preferReplica: connection_request.ReadFrom.PreferReplica,
-    };
+            primary: connection_request.ReadFrom.Primary,
+            preferReplica: connection_request.ReadFrom.PreferReplica,
+        };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -7030,11 +7033,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-            "password" in options.credentials
+                "password" in options.credentials
                 ? {
-                      password: options.credentials.password,
-                      username: options.credentials.username,
-                  }
+                    password: options.credentials.password,
+                    username: options.credentials.username,
+                }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -207,9 +207,9 @@ export class GlideClient extends BaseClient {
      *
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.
      *
-     * @param args - A list of `function` arguments and it should not represent names of keys.
+     * @param args - A list including the command name and arguments for the custom command.
      * @param options - (Optional) See {@link DecoderOption}.
-     * @returns The invoked function's return value.
+     * @returns The executed custom command return value.
      *
      * @example
      * ```typescript
@@ -664,7 +664,6 @@ export class GlideClient extends BaseClient {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param options - (Optional) See {@link DecoderOption}.
-     *
      * @returns A Record where the key is the node address and the value is a Record with two keys:
      *          - `"running_script"`: Information about the running script, or `null` if no script is running.
      *          - `"engines"`: Information about available engines and their stats.

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -207,6 +207,10 @@ export class GlideClient extends BaseClient {
      *
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.
      *
+     * @param args - A list of `function` arguments and it should not represent names of keys.
+     * @param options - (Optional) See {@link DecoderOption}.
+     * @returns The invoked function's return value.
+     *
      * @example
      * ```typescript
      * // Example usage of customCommand method to retrieve pub/sub clients

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -179,8 +179,7 @@ export class GlideClient extends BaseClient {
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey Glide Wiki} for details on Valkey Transactions.
      *
      * @param transaction - A {@link Transaction} object containing a list of commands to be executed.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A list of results corresponding to the execution of each command in the transaction.
      *     If a command returns a value, it will be included in the list. If a command doesn't return a value,
      *     the list entry will be `null`.
@@ -188,11 +187,11 @@ export class GlideClient extends BaseClient {
      */
     public async exec(
         transaction: Transaction,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<ReturnType[] | null> {
         return this.createWritePromise<ReturnType[] | null>(
             transaction.commands,
-            { decoder: decoder },
+            options,
         ).then((result) =>
             this.processResultWithSetCommands(
                 result,
@@ -217,11 +216,9 @@ export class GlideClient extends BaseClient {
      */
     public async customCommand(
         args: GlideString[],
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<ReturnType> {
-        return this.createWritePromise(createCustomCommand(args), {
-            decoder: decoder,
-        });
+        return this.createWritePromise(createCustomCommand(args), options);
     }
 
     /**
@@ -301,8 +298,7 @@ export class GlideClient extends BaseClient {
      *
      * @see {@link https://valkey.io/commands/client-getname/|valkey.io} for more details.
      *
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The name of the client connection as a string if a name is set, or `null` if no name is assigned.
      *
      * @example
@@ -312,10 +308,10 @@ export class GlideClient extends BaseClient {
      * console.log(result); // Output: 'Client Name'
      * ```
      */
-    public async clientGetName(decoder?: Decoder): Promise<GlideString | null> {
-        return this.createWritePromise(createClientGetName(), {
-            decoder: decoder,
-        });
+    public async clientGetName(
+        options?: DecoderOption,
+    ): Promise<GlideString | null> {
+        return this.createWritePromise(createClientGetName(), options);
     }
 
     /**
@@ -381,8 +377,7 @@ export class GlideClient extends BaseClient {
      * @see {@link https://valkey.io/commands/config-get/|valkey.io} for details.
      *
      * @param parameters - A list of configuration parameter names to retrieve values for.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      *
      * @returns A map of values corresponding to the configuration parameters.
      *
@@ -395,11 +390,9 @@ export class GlideClient extends BaseClient {
      */
     public async configGet(
         parameters: string[],
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<Record<string, GlideString>> {
-        return this.createWritePromise(createConfigGet(parameters), {
-            decoder: decoder,
-        });
+        return this.createWritePromise(createConfigGet(parameters), options);
     }
 
     /**
@@ -430,8 +423,7 @@ export class GlideClient extends BaseClient {
      * @see {@link https://valkey.io/commands/echo|valkey.io} for more details.
      *
      * @param message - The message to be echoed back.
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns The provided `message`.
      *
      * @example
@@ -443,11 +435,9 @@ export class GlideClient extends BaseClient {
      */
     public async echo(
         message: GlideString,
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<GlideString> {
-        return this.createWritePromise(createEcho(message), {
-            decoder,
-        });
+        return this.createWritePromise(createEcho(message), options);
     }
 
     /**
@@ -669,8 +659,8 @@ export class GlideClient extends BaseClient {
      * @see {@link https://valkey.io/commands/function-stats/|valkey.io} for details.
      * @remarks Since Valkey version 7.0.0.
      *
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
+     *
      * @returns A Record where the key is the node address and the value is a Record with two keys:
      *          - `"running_script"`: Information about the running script, or `null` if no script is running.
      *          - `"engines"`: Information about available engines and their stats.
@@ -706,11 +696,9 @@ export class GlideClient extends BaseClient {
      * ```
      */
     public async functionStats(
-        decoder?: Decoder,
+        options?: DecoderOption,
     ): Promise<FunctionStatsFullResponse> {
-        return this.createWritePromise(createFunctionStats(), {
-            decoder,
-        });
+        return this.createWritePromise(createFunctionStats(), options);
     }
 
     /**

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -256,9 +256,7 @@ export class GlideClient extends BaseClient {
             message?: GlideString;
         } & DecoderOption,
     ): Promise<GlideString> {
-        return this.createWritePromise(createPing(options?.message), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(createPing(options?.message), options);
     }
 
     /**
@@ -592,7 +590,7 @@ export class GlideClient extends BaseClient {
     ): Promise<GlideString> {
         return this.createWritePromise(
             createFunctionLoad(libraryCode, options?.replace),
-            { decoder: options?.decoder },
+            options,
         );
     }
 
@@ -648,9 +646,7 @@ export class GlideClient extends BaseClient {
     public async functionList(
         options?: FunctionListOptions & DecoderOption,
     ): Promise<FunctionListResponse> {
-        return this.createWritePromise(createFunctionList(options), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(createFunctionList(options), options);
     }
 
     /**
@@ -877,9 +873,7 @@ export class GlideClient extends BaseClient {
         key: GlideString,
         options?: SortOptions & DecoderOption,
     ): Promise<(GlideString | null)[]> {
-        return this.createWritePromise(createSort(key, options), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(createSort(key, options), options);
     }
 
     /**
@@ -910,9 +904,10 @@ export class GlideClient extends BaseClient {
         key: GlideString,
         options?: SortOptions & DecoderOption,
     ): Promise<(GlideString | null)[]> {
-        return this.createWritePromise(createSortReadOnly(key, options), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(
+            createSortReadOnly(key, options),
+            options,
+        );
     }
 
     /**
@@ -972,9 +967,7 @@ export class GlideClient extends BaseClient {
      * Returns a random existing key name from the currently selected database.
      *
      * @see {@link https://valkey.io/commands/randomkey/|valkey.io} for more details.
-     *
-     * @param decoder - (Optional) {@link Decoder} type which defines how to handle the response.
-     *     If not set, the {@link BaseClientConfiguration.defaultDecoder|default decoder} will be used.
+     * @param options - (Optional) See {@link DecoderOption}.
      * @returns A random existing key name from the currently selected database.
      *
      * @example
@@ -983,8 +976,10 @@ export class GlideClient extends BaseClient {
      * console.log(result); // Output: "key12" - "key12" is a random existing key name from the currently selected database.
      * ```
      */
-    public async randomKey(decoder?: Decoder): Promise<GlideString | null> {
-        return this.createWritePromise(createRandomKey(), { decoder: decoder });
+    public async randomKey(
+        options?: DecoderOption,
+    ): Promise<GlideString | null> {
+        return this.createWritePromise(createRandomKey(), options);
     }
 
     /**

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -290,7 +290,7 @@ export class GlideClusterClient extends BaseClient {
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Glide for Valkey Wiki} for details on the restrictions and limitations of the custom command API.
      *
      * @param args - A list including the command name and arguments for the custom command.
-     * @param options - (Optional) See {@link DecoderOption}.
+     * @param options - (Optional) See {@link RouteOption} and {@link DecoderOption}
      * @returns The executed custom command return value.
      *
      * @example

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -400,7 +400,7 @@ export class GlideClusterClient extends BaseClient {
     ): Promise<ClusterResponse<string>> {
         return this.createWritePromise<ClusterResponse<string>>(
             createInfo(options?.sections),
-            { route: options?.route, decoder: Decoder.String },
+            { decoder: Decoder.String, ...options },
         );
     }
 

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -9,7 +9,8 @@ import {
     Decoder,
     DecoderOption,
     GlideString,
-    PubSubMsg, // eslint-disable-line @typescript-eslint/no-unused-vars
+    PubSubMsg,
+    ReadFrom, // eslint-disable-line @typescript-eslint/no-unused-vars
     ReturnType,
 } from "./BaseClient";
 import {
@@ -288,9 +289,9 @@ export class GlideClusterClient extends BaseClient {
      *
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Glide for Valkey Wiki} for details on the restrictions and limitations of the custom command API.
      *
-     * @param args - A list of `function` arguments and it should not represent names of keys.
-     * @param options - (Optional) See {@link RouteOption} and {@link DecoderOption}.
-     * @returns The invoked function's return value.
+     * @param args - A list including the command name and arguments for the custom command.
+     * @param options - (Optional) See {@link DecoderOption}.
+     * @returns The executed custom command return value.
      *
      * @example
      * ```typescript
@@ -321,7 +322,9 @@ export class GlideClusterClient extends BaseClient {
      */
     public async exec(
         transaction: ClusterTransaction,
-        options?: RouteOption & DecoderOption,
+        options?: {
+            route?: SingleNodeRoute;
+        } & DecoderOption,
     ): Promise<ReturnType[] | null> {
         return this.createWritePromise<ReturnType[] | null>(
             transaction.commands,
@@ -369,10 +372,7 @@ export class GlideClusterClient extends BaseClient {
         } & RouteOption &
             DecoderOption,
     ): Promise<GlideString> {
-        return this.createWritePromise(createPing(options?.message), {
-            route: options?.route,
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(createPing(options?.message), options);
     }
 
     /**

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -459,8 +459,8 @@ export class GlideClusterClient extends BaseClient {
      */
     public async configRewrite(options?: RouteOption): Promise<"OK"> {
         return this.createWritePromise(createConfigRewrite(), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -483,8 +483,8 @@ export class GlideClusterClient extends BaseClient {
      */
     public async configResetStat(options?: RouteOption): Promise<"OK"> {
         return this.createWritePromise(createConfigResetStat(), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -571,8 +571,8 @@ export class GlideClusterClient extends BaseClient {
         options?: RouteOption,
     ): Promise<"OK"> {
         return this.createWritePromise(createConfigSet(parameters), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -642,8 +642,8 @@ export class GlideClusterClient extends BaseClient {
         options?: RouteOption,
     ): Promise<ClusterResponse<[string, string]>> {
         return this.createWritePromise(createTime(), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -697,8 +697,8 @@ export class GlideClusterClient extends BaseClient {
         options?: LolwutOptions & RouteOption,
     ): Promise<ClusterResponse<string>> {
         return this.createWritePromise(createLolwut(options), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -778,8 +778,8 @@ export class GlideClusterClient extends BaseClient {
         options?: RouteOption,
     ): Promise<"OK"> {
         return this.createWritePromise(createFunctionDelete(libraryCode), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -813,10 +813,7 @@ export class GlideClusterClient extends BaseClient {
     ): Promise<GlideString> {
         return this.createWritePromise(
             createFunctionLoad(libraryCode, options?.replace),
-            {
-                route: options?.route,
-                decoder: options?.decoder,
-            },
+            options,
         );
     }
 
@@ -843,8 +840,8 @@ export class GlideClusterClient extends BaseClient {
         } & RouteOption,
     ): Promise<"OK"> {
         return this.createWritePromise(createFunctionFlush(options?.mode), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -880,8 +877,8 @@ export class GlideClusterClient extends BaseClient {
         options?: FunctionListOptions & DecoderOption & RouteOption,
     ): Promise<ClusterResponse<FunctionListResponse>> {
         return this.createWritePromise(createFunctionList(options), {
-            route: options?.route,
             decoder: options?.decoder,
+            ...options,
         });
     }
 
@@ -955,8 +952,8 @@ export class GlideClusterClient extends BaseClient {
      */
     public async functionKill(options?: RouteOption): Promise<"OK"> {
         return this.createWritePromise(createFunctionKill(), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -979,8 +976,8 @@ export class GlideClusterClient extends BaseClient {
         options?: RouteOption,
     ): Promise<ClusterResponse<Buffer>> {
         return this.createWritePromise(createFunctionDump(), {
-            route: options?.route,
             decoder: Decoder.Bytes,
+            ...options,
         });
     }
 
@@ -1008,10 +1005,7 @@ export class GlideClusterClient extends BaseClient {
     ): Promise<"OK"> {
         return this.createWritePromise(
             createFunctionRestore(payload, options?.policy),
-            {
-                route: options?.route,
-                decoder: Decoder.String,
-            },
+            { decoder: Decoder.String, ...options },
         );
     }
 
@@ -1039,8 +1033,8 @@ export class GlideClusterClient extends BaseClient {
         } & RouteOption,
     ): Promise<"OK"> {
         return this.createWritePromise(createFlushAll(options?.mode), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -1068,8 +1062,8 @@ export class GlideClusterClient extends BaseClient {
         } & RouteOption,
     ): Promise<"OK"> {
         return this.createWritePromise(createFlushDB(options?.mode), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 
@@ -1161,7 +1155,7 @@ export class GlideClusterClient extends BaseClient {
     ): Promise<GlideString[]> {
         return this.createWritePromise(
             createPubsubShardChannels(options?.pattern),
-            { decoder: options?.decoder },
+            options,
         );
     }
 
@@ -1217,9 +1211,7 @@ export class GlideClusterClient extends BaseClient {
         key: GlideString,
         options?: SortClusterOptions & DecoderOption,
     ): Promise<GlideString[]> {
-        return this.createWritePromise(createSort(key, options), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(createSort(key, options), options);
     }
 
     /**
@@ -1247,9 +1239,10 @@ export class GlideClusterClient extends BaseClient {
         key: GlideString,
         options?: SortClusterOptions & DecoderOption,
     ): Promise<GlideString[]> {
-        return this.createWritePromise(createSortReadOnly(key, options), {
-            decoder: options?.decoder,
-        });
+        return this.createWritePromise(
+            createSortReadOnly(key, options),
+            options,
+        );
     }
 
     /**
@@ -1351,8 +1344,8 @@ export class GlideClusterClient extends BaseClient {
      */
     public async unwatch(options?: RouteOption): Promise<"OK"> {
         return this.createWritePromise(createUnWatch(), {
-            route: options?.route,
             decoder: Decoder.String,
+            ...options,
         });
     }
 }

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -319,7 +319,7 @@ export class GlideClusterClient extends BaseClient {
      * - (Optional) `route`: If `route` is not provided, the transaction will be routed to the slot owner of the first key found in the transaction.
      *     If no key is found, the command will be sent to a random node.
      *     If `route` is provided, the client will route the command to the nodes defined by `route`.
-     * - (Optional) `decoder`: See {@link DecoderOption}.  dddd
+     * - (Optional) `decoder`: See {@link DecoderOption}.
      * @returns A list of results corresponding to the execution of each command in the transaction.
      *     If a command returns a value, it will be included in the list. If a command doesn't return a value,
      *     the list entry will be `null`.

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -314,7 +314,12 @@ export class GlideClusterClient extends BaseClient {
      * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey Glide Wiki} for details on Valkey Transactions.
      *
      * @param transaction - A {@link ClusterTransaction} object containing a list of commands to be executed.
-     * @param options - (Optional) See {@link RouteOption} and {@link DecoderOption}.
+     *
+     * @param options - (Optional) See {@link DecoderOption} and (Optional) Additional parameters:
+     * - (Optional) `route`: If `route` is not provided, the transaction will be routed to the slot owner of the first key found in the transaction.
+     *     If no key is found, the command will be sent to a random node.
+     *     If `route` is provided, the client will route the command to the nodes defined by `route`.
+     *
      * @returns A list of results corresponding to the execution of each command in the transaction.
      *     If a command returns a value, it will be included in the list. If a command doesn't return a value,
      *     the list entry will be `null`.

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -315,11 +315,11 @@ export class GlideClusterClient extends BaseClient {
      *
      * @param transaction - A {@link ClusterTransaction} object containing a list of commands to be executed.
      *
-     * @param options - (Optional) See {@link DecoderOption} and (Optional) Additional parameters:
+     *  @param options - (Optional) Additional parameters:
      * - (Optional) `route`: If `route` is not provided, the transaction will be routed to the slot owner of the first key found in the transaction.
      *     If no key is found, the command will be sent to a random node.
      *     If `route` is provided, the client will route the command to the nodes defined by `route`.
-     *
+     * - (Optional) `decoder`: See {@link DecoderOption}.  dddd
      * @returns A list of results corresponding to the execution of each command in the transaction.
      *     If a command returns a value, it will be included in the list. If a command doesn't return a value,
      *     the list entry will be `null`.

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -876,10 +876,7 @@ export class GlideClusterClient extends BaseClient {
     public async functionList(
         options?: FunctionListOptions & DecoderOption & RouteOption,
     ): Promise<ClusterResponse<FunctionListResponse>> {
-        return this.createWritePromise(createFunctionList(options), {
-            decoder: options?.decoder,
-            ...options,
-        });
+        return this.createWritePromise(createFunctionList(options), options);
     }
 
     /**

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -244,7 +244,9 @@ describe("GlideClient", () => {
             const transaction = new Transaction();
             const expectedRes = await encodedTransactionTest(transaction);
             transaction.select(0);
-            const result = await client.exec(transaction, Decoder.Bytes);
+            const result = await client.exec(transaction, {
+                decoder: Decoder.Bytes,
+            });
             expectedRes.push(["select(0)", "OK"]);
 
             validateTransactionResponse(result, expectedRes);
@@ -264,7 +266,9 @@ describe("GlideClient", () => {
                 Buffer.from("value"),
             );
             bytesTransaction.select(0);
-            const result = await client.exec(bytesTransaction, Decoder.Bytes);
+            const result = await client.exec(bytesTransaction, {
+                decoder: Decoder.Bytes,
+            });
             expectedBytesRes.push(["select(0)", "OK"]);
 
             validateTransactionResponse(result, expectedBytesRes);
@@ -275,7 +279,7 @@ describe("GlideClient", () => {
 
             // Since DUMP gets binary results, we cannot use the string decoder here, so we expected to get an error.
             await expect(
-                client.exec(stringTransaction, Decoder.String),
+                client.exec(stringTransaction, { decoder: Decoder.String }),
             ).rejects.toThrowError(
                 "invalid utf-8 sequence of 1 bytes from index 9",
             );
@@ -1145,7 +1149,9 @@ describe("GlideClient", () => {
 
                 // Verify functionDump
                 let transaction = new Transaction().functionDump();
-                const result = await client.exec(transaction, Decoder.Bytes);
+                const result = await client.exec(transaction, {
+                    decoder: Decoder.Bytes,
+                });
                 const data = result?.[0] as Buffer;
 
                 // Verify functionRestore

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -1438,7 +1438,7 @@ describe("GlideClient", () => {
             // `key` should be the only key in the database
             expect(await client.randomKey()).toEqual(key);
             // test binary decoder
-            expect(await client.randomKey(Decoder.Bytes)).toEqual(
+            expect(await client.randomKey({ decoder: Decoder.Bytes })).toEqual(
                 Buffer.from(key),
             );
 

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -177,8 +177,12 @@ describe("GlideClient", () => {
             expect(result).toEqual("OK");
 
             expect(await client.get(key)).toEqual(valueEncoded);
-            expect(await client.get(key, Decoder.String)).toEqual(value);
-            expect(await client.get(key, Decoder.Bytes)).toEqual(valueEncoded);
+            expect(await client.get(key, { decoder: Decoder.String })).toEqual(
+                value,
+            );
+            expect(await client.get(key, { decoder: Decoder.Bytes })).toEqual(
+                valueEncoded,
+            );
             client.close();
         },
     );
@@ -201,8 +205,12 @@ describe("GlideClient", () => {
             expect(result).toEqual("OK");
 
             expect(await client.get(key)).toEqual(value);
-            expect(await client.get(key, Decoder.String)).toEqual(value);
-            expect(await client.get(key, Decoder.Bytes)).toEqual(valueEncoded);
+            expect(await client.get(key, { decoder: Decoder.String })).toEqual(
+                value,
+            );
+            expect(await client.get(key, { decoder: Decoder.Bytes })).toEqual(
+                valueEncoded,
+            );
             client.close();
         },
     );
@@ -671,7 +679,7 @@ describe("GlideClient", () => {
                         Buffer.from(funcName),
                         [],
                         [Buffer.from("one"), "two"],
-                        Decoder.Bytes,
+                        { decoder: Decoder.Bytes },
                     ),
                 ).toEqual(Buffer.from("one"));
                 expect(
@@ -679,7 +687,7 @@ describe("GlideClient", () => {
                         Buffer.from(funcName),
                         [],
                         ["one", Buffer.from("two")],
-                        Decoder.Bytes,
+                        { decoder: Decoder.Bytes },
                     ),
                 ).toEqual(Buffer.from("one"));
 

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -310,7 +310,7 @@ describe("SocketConnectionInternals", () => {
                         },
                     );
                 });
-                const result = await connection.get("foo", Decoder.String);
+                const result = await connection.get("foo", { decoder: Decoder.String });
                 expect(result).toEqual(expected);
             });
         };
@@ -696,8 +696,8 @@ describe("SocketConnectionInternals", () => {
                 } else {
                     throw new Error(
                         "unexpected command: [" +
-                            request.singleCommand!.argsArray!.args!.at(0) +
-                            "]",
+                        request.singleCommand!.argsArray!.args!.at(0) +
+                        "]",
                     );
                 }
 

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -310,7 +310,9 @@ describe("SocketConnectionInternals", () => {
                         },
                     );
                 });
-                const result = await connection.get("foo", { decoder: Decoder.String });
+                const result = await connection.get("foo", {
+                    decoder: Decoder.String,
+                });
                 expect(result).toEqual(expected);
             });
         };
@@ -696,8 +698,8 @@ describe("SocketConnectionInternals", () => {
                 } else {
                     throw new Error(
                         "unexpected command: [" +
-                        request.singleCommand!.argsArray!.args!.at(0) +
-                        "]",
+                            request.singleCommand!.argsArray!.args!.at(0) +
+                            "]",
                     );
                 }
 

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -260,9 +260,9 @@ describe("GlideClusterClient", () => {
                 ).toEqual("OK");
                 // check the restore
                 expect(await client.get(key)).toEqual(value);
-                expect(await client.get(key, Decoder.Bytes)).toEqual(
-                    valueEncoded,
-                );
+                expect(
+                    await client.get(key, { decoder: Decoder.Bytes }),
+                ).toEqual(valueEncoded);
             }
         },
         TIMEOUT,

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -1182,7 +1182,9 @@ describe("GlideClusterClient", () => {
 
                                 // Delete the function
                                 expect(
-                                    await client.functionDelete(libName, route),
+                                    await client.functionDelete(libName, {
+                                        route,
+                                    }),
                                 ).toEqual("OK");
 
                                 functionList = await client.functionList({
@@ -1198,7 +1200,7 @@ describe("GlideClusterClient", () => {
 
                                 // Delete a non-existing library
                                 await expect(
-                                    client.functionDelete(libName, route),
+                                    client.functionDelete(libName, { route }),
                                 ).rejects.toThrow(`Library not found`);
                             } finally {
                                 expect(await client.functionFlush()).toEqual(
@@ -1247,7 +1249,7 @@ describe("GlideClusterClient", () => {
 
                                 // nothing to kill
                                 await expect(
-                                    client.functionKill(route),
+                                    client.functionKill({ route }),
                                 ).rejects.toThrow(/notbusy/i);
 
                                 // load the lib
@@ -1279,9 +1281,9 @@ describe("GlideClusterClient", () => {
                                     while (timeout >= 0) {
                                         try {
                                             expect(
-                                                await client.functionKill(
+                                                await client.functionKill({
                                                     route,
-                                                ),
+                                                }),
                                             ).toEqual("OK");
                                             killed = true;
                                             break;
@@ -1333,7 +1335,7 @@ describe("GlideClusterClient", () => {
 
                         try {
                             // dumping an empty lib
-                            let response = await client.functionDump(route);
+                            let response = await client.functionDump({ route });
 
                             if (singleNodeRoute) {
                                 expect(response.byteLength).toBeGreaterThan(0);
@@ -1365,7 +1367,7 @@ describe("GlideClusterClient", () => {
                                 withCode: true,
                                 route: route,
                             });
-                            response = await client.functionDump(route);
+                            response = await client.functionDump({ route });
                             const dump = (
                                 singleNodeRoute
                                     ? response
@@ -1519,7 +1521,7 @@ describe("GlideClusterClient", () => {
 
                         // nothing to kill
                         await expect(
-                            client.functionKill(route),
+                            client.functionKill({ route }),
                         ).rejects.toThrow(/notbusy/i);
 
                         // load the lib
@@ -1546,7 +1548,7 @@ describe("GlideClusterClient", () => {
                                 try {
                                     // valkey kills a function with 5 sec delay
                                     // but this will always throw an error in the test
-                                    await client.functionKill(route);
+                                    await client.functionKill({ route });
                                 } catch (err) {
                                     // looking for an error with "unkillable" in the message
                                     // at that point we can break the loop

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1665,18 +1665,22 @@ export function runBaseTests(config: {
 
                 expect(await client.set(key, value)).toEqual("OK");
                 expect(await client.get(key)).toEqual(value);
-                expect(await client.get(key, Decoder.Bytes)).toEqual(
-                    valueEncoded,
-                );
-                expect(await client.get(key, Decoder.String)).toEqual(value);
+                expect(
+                    await client.get(key, { decoder: Decoder.Bytes }),
+                ).toEqual(valueEncoded);
+                expect(
+                    await client.get(key, { decoder: Decoder.String }),
+                ).toEqual(value);
 
                 // Setting the encoded value. Should behave as the previous test since the default is String decoding.
                 expect(await client.set(key, valueEncoded)).toEqual("OK");
                 expect(await client.get(key)).toEqual(value);
-                expect(await client.get(key, Decoder.Bytes)).toEqual(
-                    valueEncoded,
-                );
-                expect(await client.get(key, Decoder.String)).toEqual(value);
+                expect(
+                    await client.get(key, { decoder: Decoder.Bytes }),
+                ).toEqual(valueEncoded);
+                expect(
+                    await client.get(key, { decoder: Decoder.String }),
+                ).toEqual(value);
             }, protocol);
         },
         config.timeout,
@@ -7425,10 +7429,12 @@ export function runBaseTests(config: {
 
                 // Restore to a new key without option
                 expect(await client.restore(key2, 0, data)).toEqual("OK");
-                expect(await client.get(key2, Decoder.String)).toEqual(value);
-                expect(await client.get(key2, Decoder.Bytes)).toEqual(
-                    valueEncode,
-                );
+                expect(
+                    await client.get(key2, { decoder: Decoder.String }),
+                ).toEqual(value);
+                expect(
+                    await client.get(key2, { decoder: Decoder.Bytes }),
+                ).toEqual(valueEncode);
 
                 // Restore to an existing key
                 await expect(client.restore(key2, 0, data)).rejects.toThrow(
@@ -7731,9 +7737,9 @@ export function runBaseTests(config: {
                 expect(await client.append(key3, valueEncoded)).toBe(
                     valueEncoded.length * 2,
                 );
-                expect(await client.get(key3, Decoder.Bytes)).toEqual(
-                    Buffer.concat([valueEncoded, valueEncoded]),
-                );
+                expect(
+                    await client.get(key3, { decoder: Decoder.Bytes }),
+                ).toEqual(Buffer.concat([valueEncoded, valueEncoded]));
             }, protocol);
         },
         config.timeout,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -386,10 +386,9 @@ export function runBaseTests(config: {
                 //mget with binary buffers
                 expect(await client.mset(keyValueList)).toEqual("OK");
                 expect(
-                    await client.mget(
-                        [key1, key2, "nonExistingKey", key3],
-                        Decoder.Bytes,
-                    ),
+                    await client.mget([key1, key2, "nonExistingKey", key3], {
+                        decoder: Decoder.Bytes,
+                    }),
                 ).toEqual([valueEncoded, valueEncoded, null, valueEncoded]);
             }, protocol);
         },
@@ -1256,10 +1255,12 @@ export function runBaseTests(config: {
                 expect(await client.getdel(key1)).toEqual(null);
 
                 expect(await client.set(key1, value1)).toEqual("OK");
-                expect(await client.getdel(key1, Decoder.Bytes)).toEqual(
-                    value1Encoded,
-                );
-                expect(await client.getdel(key1, Decoder.Bytes)).toEqual(null);
+                expect(
+                    await client.getdel(key1, { decoder: Decoder.Bytes }),
+                ).toEqual(value1Encoded);
+                expect(
+                    await client.getdel(key1, { decoder: Decoder.Bytes }),
+                ).toEqual(null);
 
                 // key isn't a string
                 expect(await client.sadd(key2, ["a"])).toEqual(1);
@@ -1286,14 +1287,20 @@ export function runBaseTests(config: {
 
                 // range of binary buffer
                 expect(await client.set(key, "This is a string")).toEqual("OK");
-                expect(await client.getrange(key, 0, 3, Decoder.Bytes)).toEqual(
-                    valueEncoded.subarray(0, 4),
-                );
                 expect(
-                    await client.getrange(key, -3, -1, Decoder.Bytes),
+                    await client.getrange(key, 0, 3, {
+                        decoder: Decoder.Bytes,
+                    }),
+                ).toEqual(valueEncoded.subarray(0, 4));
+                expect(
+                    await client.getrange(key, -3, -1, {
+                        decoder: Decoder.Bytes,
+                    }),
                 ).toEqual(valueEncoded.subarray(-3, valueEncoded.length));
                 expect(
-                    await client.getrange(key, 0, -1, Decoder.Bytes),
+                    await client.getrange(key, 0, -1, {
+                        decoder: Decoder.Bytes,
+                    }),
                 ).toEqual(valueEncoded.subarray(0, valueEncoded.length));
 
                 // out of range
@@ -2106,21 +2113,23 @@ export function runBaseTests(config: {
                 );
                 expect(await client.lpop("nonExistingKey")).toEqual(null);
                 expect(await client.lpush(key2, valueList2)).toEqual(3);
-                expect(await client.lpop(key2, Decoder.Bytes)).toEqual(
-                    Buffer.from("value5"),
-                );
-                expect(await client.lrange(key2, 0, -1, Decoder.Bytes)).toEqual(
-                    encodedValues,
-                );
-                expect(await client.lpopCount(key2, 2, Decoder.Bytes)).toEqual(
-                    encodedValues,
-                );
+                expect(
+                    await client.lpop(key2, { decoder: Decoder.Bytes }),
+                ).toEqual(Buffer.from("value5"));
+                expect(
+                    await client.lrange(key2, 0, -1, {
+                        decoder: Decoder.Bytes,
+                    }),
+                ).toEqual(encodedValues);
+                expect(
+                    await client.lpopCount(key2, 2, { decoder: Decoder.Bytes }),
+                ).toEqual(encodedValues);
                 expect(
                     await client.lpush(key2, [Buffer.from("value8")]),
                 ).toEqual(1);
-                expect(await client.lpop(key2, Decoder.Bytes)).toEqual(
-                    Buffer.from("value8"),
-                );
+                expect(
+                    await client.lpop(key2, { decoder: Decoder.Bytes }),
+                ).toEqual(Buffer.from("value8"));
             }, protocol);
         },
         config.timeout,
@@ -2318,7 +2327,7 @@ export function runBaseTests(config: {
                         key2,
                         ListDirection.RIGHT,
                         ListDirection.LEFT,
-                        Decoder.Bytes,
+                        { decoder: Decoder.Bytes },
                     ),
                 ).toEqual(Buffer.from("4"));
 
@@ -2459,7 +2468,7 @@ export function runBaseTests(config: {
                         ListDirection.RIGHT,
                         ListDirection.LEFT,
                         0.1,
-                        Decoder.Bytes,
+                        { decoder: Decoder.Bytes },
                     ),
                 ).toEqual(Buffer.from("4"));
 
@@ -2685,19 +2694,18 @@ export function runBaseTests(config: {
                 expect(await client.rpop("nonExistingKey")).toEqual(null);
 
                 expect(await client.rpush(key2, valueList2)).toEqual(3);
-                expect(await client.rpop(key2, Decoder.Bytes)).toEqual(
-                    Buffer.from("value7"),
-                );
-                expect(await client.rpopCount(key2, 2, Decoder.Bytes)).toEqual([
-                    Buffer.from("value6"),
-                    Buffer.from("value5"),
-                ]);
+                expect(
+                    await client.rpop(key2, { decoder: Decoder.Bytes }),
+                ).toEqual(Buffer.from("value7"));
+                expect(
+                    await client.rpopCount(key2, 2, { decoder: Decoder.Bytes }),
+                ).toEqual([Buffer.from("value6"), Buffer.from("value5")]);
                 expect(
                     await client.rpush(key2, [Buffer.from("value8")]),
                 ).toEqual(1);
-                expect(await client.rpop(key2, Decoder.Bytes)).toEqual(
-                    Buffer.from("value8"),
-                );
+                expect(
+                    await client.rpop(key2, { decoder: Decoder.Bytes }),
+                ).toEqual(Buffer.from("value8"));
             }, protocol);
         },
         config.timeout,
@@ -5914,12 +5922,16 @@ export function runBaseTests(config: {
                 expect(await client.lindex(listName, 1)).toEqual(listKey1Value);
                 expect(await client.lindex("notExsitingList", 1)).toEqual(null);
                 expect(await client.lindex(listName, 3)).toEqual(null);
-                expect(await client.lindex(listName, 0, Decoder.Bytes)).toEqual(
-                    Buffer.from(listKey2Value),
-                );
-                expect(await client.lindex(listName, 1, Decoder.Bytes)).toEqual(
-                    Buffer.from(listKey1Value),
-                );
+                expect(
+                    await client.lindex(listName, 0, {
+                        decoder: Decoder.Bytes,
+                    }),
+                ).toEqual(Buffer.from(listKey2Value));
+                expect(
+                    await client.lindex(listName, 1, {
+                        decoder: Decoder.Bytes,
+                    }),
+                ).toEqual(Buffer.from(listKey1Value));
                 expect(await client.lindex(encodedListName, 0)).toEqual(
                     listKey2Value,
                 );
@@ -6338,7 +6350,9 @@ export function runBaseTests(config: {
                 ]);
                 // Test encoded value
                 expect(
-                    await client.brpop(["brpop-test"], 0.1, Decoder.Bytes),
+                    await client.brpop(["brpop-test"], 0.1, {
+                        decoder: Decoder.Bytes,
+                    }),
                 ).toEqual([Buffer.from("brpop-test"), Buffer.from("bar")]);
                 // Delete all values from list
                 expect(await client.del(["brpop-test"])).toEqual(1);
@@ -6379,7 +6393,9 @@ export function runBaseTests(config: {
                 ]);
                 // Test decoded value
                 expect(
-                    await client.blpop(["blpop-test"], 0.1, Decoder.Bytes),
+                    await client.blpop(["blpop-test"], 0.1, {
+                        decoder: Decoder.Bytes,
+                    }),
                 ).toEqual([Buffer.from("blpop-test"), Buffer.from("bar")]);
                 // Delete all values from list
                 expect(await client.del(["blpop-test"])).toEqual(1);

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -396,9 +396,12 @@ export function runBaseTests(config: {
 
                 expect(await client.mset(keyValueListEncoded)).toEqual("OK");
                 expect(
-                    await client.mget([key1Encoded, key2, "nonExistingKey", key3Encoded], {
-                        decoder: Decoder.Bytes,
-                    }),
+                    await client.mget(
+                        [key1Encoded, key2, "nonExistingKey", key3Encoded],
+                        {
+                            decoder: Decoder.Bytes,
+                        },
+                    ),
                 ).toEqual([valueEncoded, valueEncoded, null, valueEncoded]);
             }, protocol);
         },

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -169,7 +169,9 @@ export function runBaseTests(config: {
 
                     if (client instanceof GlideClient) {
                         expect(
-                            await client.clientGetName(Decoder.Bytes),
+                            await client.clientGetName({
+                                decoder: Decoder.Bytes,
+                            }),
                         ).toEqual(Buffer.from("TEST_CLIENT"));
                     } else {
                         expect(
@@ -5837,24 +5839,25 @@ export function runBaseTests(config: {
                 expect(await client.echo(message)).toEqual(message);
                 expect(
                     client instanceof GlideClient
-                        ? await client.echo(message, Decoder.String)
+                        ? await client.echo(message, {
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(message, {
                               decoder: Decoder.String,
                           }),
                 ).toEqual(message);
                 expect(
                     client instanceof GlideClient
-                        ? await client.echo(message, Decoder.Bytes)
+                        ? await client.echo(message, { decoder: Decoder.Bytes })
                         : await client.echo(message, {
                               decoder: Decoder.Bytes,
                           }),
                 ).toEqual(Buffer.from(message));
                 expect(
                     client instanceof GlideClient
-                        ? await client.echo(
-                              Buffer.from(message),
-                              Decoder.String,
-                          )
+                        ? await client.echo(Buffer.from(message), {
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(Buffer.from(message), {
                               decoder: Decoder.String,
                           }),
@@ -7534,10 +7537,9 @@ export function runBaseTests(config: {
                 // Transaction tests
                 let response =
                     client instanceof GlideClient
-                        ? await client.exec(
-                              new Transaction().dump(key1),
-                              Decoder.Bytes,
-                          )
+                        ? await client.exec(new Transaction().dump(key1), {
+                              decoder: Decoder.Bytes,
+                          })
                         : await client.exec(
                               new ClusterTransaction().dump(key1),
                               { decoder: Decoder.Bytes },
@@ -7552,7 +7554,7 @@ export function runBaseTests(config: {
                               new Transaction()
                                   .restore(key4, 0, data)
                                   .get(key4),
-                              Decoder.String,
+                              { decoder: Decoder.String },
                           )
                         : await client.exec(
                               new ClusterTransaction()
@@ -7570,7 +7572,7 @@ export function runBaseTests(config: {
                               new Transaction()
                                   .restore(key5, 0, data)
                                   .get(key5),
-                              Decoder.Bytes,
+                              { decoder: Decoder.Bytes },
                           )
                         : await client.exec(
                               new ClusterTransaction()


### PR DESCRIPTION
Change log:
1. Updated decoder to DecoderOption, router to RouterOption in GlideClient.ts, GlideClusterClient.ts and BaseClient.ts.
2. Update test cases based on the changes in point 1.
3. Moved toProtobufRoute to BaseClient.

In BaseClient.ts, replaced decoder with decoderOption for the following commands:
1. get (https://valkey.io/commands/get/)
2. getdel(https://valkey.io/commands/getdel/)
4. getrange (https://valkey.io/commands/getrange/)
5. mget (https://valkey.io/commands/mget/)
6. lpop (https://valkey.io/commands/lpop/)
7. lpopCount (https://valkey.io/commands/lpopCount/)
8. lrange (https://valkey.io/commands/lrange/)
9. lmove (https://valkey.io/commands/lmove/)
10. blmove (https://valkey.io/commands/blmove/)
11. rpop (https://valkey.io/commands/rpop/)
12. rpopCount (https://valkey.io/commands/rpopCount/)
13. lindex (https://valkey.io/commands/lindex/)
14. brpop (https://valkey.io/commands/brpop/)
15. blpop (https://valkey.io/commands/blpop/)
16. fcall (https://valkey.io/commands/fcall/)
17. fcallReadonly


In GlideClient.ts updated following commands:
1. exec (https://valkey.io/commands/exec/)
2. customCommand
3. clientGetName
4. configGet
5. echo
6. functionStats

Documentation updated for all commands
