### PR TITLE
Ignore proc-macro-error lint failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
             - .github/workflows/rust.yml
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/workflows/lint-rust/action.yml
             - .github/json_matrices/build-matrix.json
     pull_request:
         paths:
@@ -21,6 +22,7 @@ on:
             - .github/workflows/rust.yml
             - .github/workflows/install-shared-dependencies/action.yml
             - .github/workflows/install-valkey/action.yml
+            - .github/workflows/lint-rust/action.yml
             - .github/json_matrices/build-matrix.json
     workflow_dispatch:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ on:
             - .github/workflows/install-valkey/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/json_matrices/build-matrix.json
+            - deny.toml
     pull_request:
         paths:
             - logger_core/**
@@ -24,6 +25,7 @@ on:
             - .github/workflows/install-valkey/action.yml
             - .github/workflows/lint-rust/action.yml
             - .github/json_matrices/build-matrix.json
+            - deny.toml
     workflow_dispatch:
 
 concurrency:

--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,8 @@ unsound = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+    # Unmaintained dependency error that needs more attention due to nested dependencies
+    "RUSTSEC-2024-0370"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -358,7 +358,7 @@ pub fn build_keys_and_certs_for_tls(tempdir: &TempDir) -> TlsFilePaths {
             .arg("genrsa")
             .arg("-out")
             .arg(name)
-            .arg(&format!("{size}"))
+            .arg(format!("{size}"))
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::null())
             .spawn()


### PR DESCRIPTION
- We are ignoring the error
  ```
  proc-macro-error 1.0.4 registry+https://github.com/rust-lang/crates.io-index
      │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
  ```
  for now as it is in nested dependencies and requires more discussion.
  
  Reference: https://rustsec.org/advisories/RUSTSEC-2024-0370.html


- Fixed the lint error 
  ```
  error: the borrowed expression implements the required traits
     --> tests/utilities/mod.rs:361:18
      |
  361 |             .arg(&format!("{size}"))
      |                  ^^^^^^^^^^^^^^^^^^ help: change this to: `format!("{size}")`
  ```