### PR TITLE
Java: Fix byte GlideString conversion to String bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Java: Add test for GlideString ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
 * Java: Fetch server version using info command ([#2258](https://github.com/valkey-io/valkey-glide/pull/2258))
 * Node: Added binary variant for commands which have `Record` as input or output ([#2207](https://github.com/valkey-io/valkey-glide/pull/2207))
 * Node: Renamed `ReturnType` to `GlideReturnType` ([#2241](https://github.com/valkey-io/valkey-glide/pull/2241))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 #### Changes
-* Java: Add test for GlideString ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
 * Java: Fetch server version using info command ([#2258](https://github.com/valkey-io/valkey-glide/pull/2258))
 * Node: Added binary variant for commands which have `Record` as input or output ([#2207](https://github.com/valkey-io/valkey-glide/pull/2207))
 * Node: Renamed `ReturnType` to `GlideReturnType` ([#2241](https://github.com/valkey-io/valkey-glide/pull/2241))
@@ -121,6 +120,7 @@
 * Core: Change FUNCTION STATS command to return multi node response for standalone mode ([#2117](https://github.com/valkey-io/valkey-glide/pull/2117))
 
 #### Fixes
+* Java: Java: Fix byte conversion to GlideString bug ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
 * Java: Add overloads for XADD to allow duplicate entry keys ([#1970](https://github.com/valkey-io/valkey-glide/pull/1970))
 * Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
 * Java: `XRange`/`XRevRange` should return `null` instead of `GlideException` when given a negative count ([#1920](https://github.com/valkey-io/valkey-glide/pull/1920))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 * Core: Change FUNCTION STATS command to return multi node response for standalone mode ([#2117](https://github.com/valkey-io/valkey-glide/pull/2117))
 
 #### Fixes
-* Java: Fix byte GlideString conversion to String bug ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
+* Java: Fix GlideString conversion from byte to String ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
 * Java: Add overloads for XADD to allow duplicate entry keys ([#1970](https://github.com/valkey-io/valkey-glide/pull/1970))
 * Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
 * Java: `XRange`/`XRevRange` should return `null` instead of `GlideException` when given a negative count ([#1920](https://github.com/valkey-io/valkey-glide/pull/1920))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 * Core: Change FUNCTION STATS command to return multi node response for standalone mode ([#2117](https://github.com/valkey-io/valkey-glide/pull/2117))
 
 #### Fixes
-* Java: Java: Fix byte conversion to GlideString bug ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
+* Java: Fix byte GlideString conversion to String bug ([#2271](https://github.com/valkey-io/valkey-glide/pull/2271))
 * Java: Add overloads for XADD to allow duplicate entry keys ([#1970](https://github.com/valkey-io/valkey-glide/pull/1970))
 * Node: Fix ZADD bug where command could not be called with only the `changed` optional parameter ([#1995](https://github.com/valkey-io/valkey-glide/pull/1995))
 * Java: `XRange`/`XRevRange` should return `null` instead of `GlideException` when given a negative count ([#1920](https://github.com/valkey-io/valkey-glide/pull/1920))

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -35,12 +35,13 @@ public class ArrayTransformUtils {
      * Converts a map of GlideString keys and values of any type in to an array of GlideStrings with
      * alternating keys and values.
      *
-     * @param args Map of GlideString keys to values of any type to convert.
+     * @param args Map of GlideString keys to values of GlideString.
      * @return Array of strings [key1, gs(value1.toString()), key2, gs(value2.toString()), ...].
      */
-    public static GlideString[] convertMapToKeyValueGlideStringArray(Map<GlideString, ?> args) {
+    public static GlideString[] convertMapToKeyValueGlideStringArray(
+            Map<GlideString, GlideString> args) {
         return args.entrySet().stream()
-                .flatMap(entry -> Stream.of(entry.getKey(), GlideString.gs(entry.getValue().toString())))
+                .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
                 .toArray(GlideString[]::new);
     }
 
@@ -78,7 +79,7 @@ public class ArrayTransformUtils {
             }
         }
         return Arrays.stream(args)
-                .flatMap(entry -> Stream.of(entry[0], GlideString.gs(entry[1].toString())))
+                .flatMap(entry -> Stream.of(entry[0], entry[1]))
                 .toArray(GlideString[]::new);
     }
 
@@ -99,10 +100,10 @@ public class ArrayTransformUtils {
      * Converts a map of GlideString keys and values of any type into an array of GlideStrings with
      * alternating values and keys.
      *
-     * @param args Map of GlideString keys to values of any type to convert.
+     * @param args Map of GlideString keys to values of Double type to convert.
      * @return Array of GlideStrings [gs(value1.toString()), key1, gs(value2.toString()), key2, ...].
      */
-    public static GlideString[] convertMapToValueKeyStringArrayBinary(Map<GlideString, ?> args) {
+    public static GlideString[] convertMapToValueKeyStringArrayBinary(Map<GlideString, Double> args) {
         return args.entrySet().stream()
                 .flatMap(entry -> Stream.of(gs(entry.getValue().toString()), entry.getKey()))
                 .toArray(GlideString[]::new);

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -32,8 +32,7 @@ public class ArrayTransformUtils {
     }
 
     /**
-     * Converts a map of GlideString keys and values of any type in to an array of GlideStrings with
-     * alternating keys and values.
+     * Converts a map of GlideString keys and values to an array of GlideStrings.
      *
      * @param args Map of GlideString keys to values of GlideString.
      * @return Array of strings [key1, gs(value1.toString()), key2, gs(value2.toString()), ...].
@@ -65,10 +64,10 @@ public class ArrayTransformUtils {
     }
 
     /**
-     * Converts a nested array of GlideString keys and values of any type in to an array of
-     * GlideStrings with alternating keys and values.
+     * Converts a nested array of GlideString keys and values in to an array of GlideStrings with
+     * alternating keys and values.
      *
-     * @param args Nested array of GlideString keys to values of any type to convert.
+     * @param args Nested array of GlideString keys and values to convert.
      * @return Array of strings [key1, gs(value1.toString()), key2, gs(value2.toString()), ...].
      */
     public static GlideString[] convertNestedArrayToKeyValueGlideStringArray(GlideString[][] args) {

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1004,7 +1004,7 @@ public class SharedCommandTests {
         assertEquals(1, client.hset(hashKey, fieldValueMap).get());
         assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashKey).get());
         assertThrows(
-            ExecutionException.class, () -> client.hget(hashKey.toString(), stringField).get());
+                ExecutionException.class, () -> client.hget(hashKey.toString(), stringField).get());
 
         // Non UTF-8 set key and field value map
         assertEquals(1, client.hset(hashNonUTF8Key, fieldValueMap).get());

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -991,16 +991,25 @@ public class SharedCommandTests {
         byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
         GlideString key = gs(nonUTF8Bytes);
         GlideString hashKey = gs(UUID.randomUUID().toString());
+        GlideString hashNonUTF8Key = gs(new byte[] {(byte) 0xFF});
         GlideString value = gs(nonUTF8Bytes);
         String stringField = "field";
         Map<GlideString, GlideString> fieldValueMap = Map.of(gs(stringField), value);
 
+        // Non UTF-8 key and value
         assertEquals(OK, client.set(key, value).get());
         assertEquals(value, client.get(key).get());
+
+        // Non UTF-8 field value map for a set
         assertEquals(1, client.hset(hashKey, fieldValueMap).get());
         assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashKey).get());
         assertThrows(
-                ExecutionException.class, () -> client.hget(hashKey.toString(), stringField).get());
+            ExecutionException.class, () -> client.hget(hashKey.toString(), stringField).get());
+
+        // Non UTF-8 set key and field value map
+        assertEquals(1, client.hset(hashNonUTF8Key, fieldValueMap).get());
+        assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashNonUTF8Key).get());
+        assertEquals(value, client.hget(hashNonUTF8Key, gs(stringField)).get());
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1009,6 +1009,7 @@ public class SharedCommandTests {
         // Testing keys for a set using byte[] that cannot be converted to UTF-8 Strings returns bytes.
         assertEquals(1, client.hset(hashNonUTF8Key, fieldValueMap).get());
         assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashNonUTF8Key).get());
+        // No error is thrown as GlideString will be returned when arguments are GlideStrings.
         assertEquals(value, client.hget(hashNonUTF8Key, gs(stringField)).get());
 
         // Converting non UTF-8 bytes result to String returns a message.

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -996,20 +996,25 @@ public class SharedCommandTests {
         String stringField = "field";
         Map<GlideString, GlideString> fieldValueMap = Map.of(gs(stringField), value);
 
-        // Non UTF-8 key and value
+        // Testing keys and values using byte[] that cannot be converted to UTF-8 Strings.
         assertEquals(OK, client.set(key, value).get());
         assertEquals(value, client.get(key).get());
 
-        // Non UTF-8 field value map for a set
+        // Testing set values using byte[] that cannot be converted to UTF-8 Strings.
         assertEquals(1, client.hset(hashKey, fieldValueMap).get());
         assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashKey).get());
         assertThrows(
                 ExecutionException.class, () -> client.hget(hashKey.toString(), stringField).get());
 
-        // Non UTF-8 set key and field value map
+        // Testing keys for a set using byte[] that cannot be converted to UTF-8 Strings returns bytes.
         assertEquals(1, client.hset(hashNonUTF8Key, fieldValueMap).get());
         assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashNonUTF8Key).get());
         assertEquals(value, client.hget(hashNonUTF8Key, gs(stringField)).get());
+
+        // Converting non UTF-8 bytes result to String returns a message.
+        assertEquals(
+                "Value not convertible to string: byte[] 13",
+                client.hget(hashNonUTF8Key, gs(stringField)).get().toString());
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -987,6 +987,25 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
+    public void non_UTF8_GlideString_test(BaseClient client) {
+        byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
+        GlideString key = gs(nonUTF8Bytes);
+        GlideString hashKey = gs(UUID.randomUUID().toString());
+        GlideString value = gs(nonUTF8Bytes);
+        String stringField = "field";
+        Map<GlideString, GlideString> fieldValueMap = Map.of(gs(stringField), value);
+
+        assertEquals(OK, client.set(key, value).get());
+        assertEquals(value, client.get(key).get());
+        assertEquals(1, client.hset(hashKey, fieldValueMap).get());
+        assertDeepEquals(new GlideString[] {gs(stringField)}, client.hkeys(hashKey).get());
+        assertThrows(
+                ExecutionException.class, () -> client.hget(hashKey.toString(), stringField).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
     public void hset_hget_binary_existing_fields_non_existing_fields(BaseClient client) {
         GlideString key = gs(UUID.randomUUID().toString());
         GlideString field1 = gs(UUID.randomUUID().toString());


### PR DESCRIPTION
### Description
Fixes a bug that incorrectly converts non UTF-8 bytes GlideString to String with the value `"Value not convertible to string: byte[] "` instead of throwing an exception.

### Affected APIs:
convertMapToKeyValueGlideStringArray:
- `public CompletableFuture<String> msetBinary(@NonNull Map<GlideString, GlideString> keyValueMap)`
- `public CompletableFuture<Long> hset(
            @NonNull GlideString key, @NonNull Map<GlideString, GlideString> fieldValueMap)`
- `public CompletableFuture<GlideString> xadd(
            @NonNull GlideString key,
            @NonNull Map<GlideString, GlideString> values,
            @NonNull StreamAddOptionsBinary options)`
- `public CompletableFuture<Boolean> msetnxBinary(
            @NonNull Map<GlideString, GlideString> keyValueMap)`

convertNestedArrayToKeyValueGlideStringArray:
- `public CompletableFuture<GlideString> xadd(
            @NonNull GlideString key,
            @NonNull GlideString[][] values,
            @NonNull StreamAddOptionsBinary options)`

convertMapToValueKeyStringArrayBinary:
- `public CompletableFuture<Long> zadd(
            @NonNull GlideString key,
            @NonNull Map<GlideString, Double> membersScoresMap,
            @NonNull ZAddOptions options,
            boolean changed)`

### Reproduction steps for the bug:
Run
```
        byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
        GlideString hashKey = gs(UUID.randomUUID().toString());
        GlideString value = gs(nonUTF8Bytes);
        String stringField = "field";
        Map<GlideString, GlideString> fieldValueMap = Map.of(gs(stringField), value);

        assertEquals(1, client.hset(hashKey, fieldValueMap).get());
        System.out.println(client.hget(hashKey.toString(), stringField).get());
```
See the output to be `Value not convertible to string: byte[] 13`

### Expected
We expect an exception to be thrown in order to avoid unintended data to be stored in the server.