### PR TITLE
Integrate passive disconnect handling and automatic reconnect functionality

### DIFF
--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.18.0"
 arcstr = "1.1.5"
 sha1_smol = "1.0.0"
 nanoid = "0.4.0"
+async-trait = { version = "0.1.24" }
 
 [features]
 socket-layer = ["directories", "integer-encoding", "num_cpus", "protobuf", "tokio-util"]

--- a/glide-core/benches/connections_benchmark.rs
+++ b/glide-core/benches/connections_benchmark.rs
@@ -7,7 +7,8 @@ use redis::{
     aio::{ConnectionLike, ConnectionManager, MultiplexedConnection},
     cluster::ClusterClientBuilder,
     cluster_async::ClusterConnection,
-    AsyncCommands, ConnectionAddr, ConnectionInfo, RedisConnectionInfo, RedisResult, Value,
+    AsyncCommands, ConnectionAddr, ConnectionInfo, GlideConnectionOptions, RedisConnectionInfo,
+    RedisResult, Value,
 };
 use std::env;
 use tokio::runtime::{Builder, Runtime};
@@ -83,7 +84,12 @@ fn get_connection_info(address: ConnectionAddr) -> redis::ConnectionInfo {
 fn multiplexer_benchmark(c: &mut Criterion, address: ConnectionAddr, group: &str) {
     benchmark(c, address, "multiplexer", group, |address, runtime| {
         let client = redis::Client::open(get_connection_info(address)).unwrap();
-        runtime.block_on(async { client.get_multiplexed_tokio_connection(None).await.unwrap() })
+        runtime.block_on(async {
+            client
+                .get_multiplexed_tokio_connection(GlideConnectionOptions::default())
+                .await
+                .unwrap()
+        })
     });
 }
 

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 use rand::{distributions::Alphanumeric, Rng};
 use redis::{
     cluster_routing::{MultipleNodeRoutingInfo, RoutingInfo},
-    ConnectionAddr, PushInfo, RedisConnectionInfo, RedisResult, Value,
+    ConnectionAddr, GlideConnectionOptions, PushInfo, RedisConnectionInfo, RedisResult, Value,
 };
 use socket2::{Domain, Socket, Type};
 use std::{
@@ -457,7 +457,10 @@ pub async fn wait_for_server_to_become_ready(server_address: &ConnectionAddr) {
     })
     .unwrap();
     loop {
-        match client.get_multiplexed_async_connection(None).await {
+        match client
+            .get_multiplexed_async_connection(GlideConnectionOptions::default())
+            .await
+        {
             Err(err) => {
                 if err.is_connection_refusal() {
                     tokio::time::sleep(millisecond).await;
@@ -593,9 +596,13 @@ pub async fn setup_acl(addr: &ConnectionAddr, connection_info: &RedisConnectionI
         redis: RedisConnectionInfo::default(),
     })
     .unwrap();
-    let mut connection =
-        repeat_try_create(|| async { client.get_multiplexed_async_connection(None).await.ok() })
-            .await;
+    let mut connection = repeat_try_create(|| async {
+        client
+            .get_multiplexed_async_connection(GlideConnectionOptions::default())
+            .await
+            .ok()
+    })
+    .await;
 
     let password = connection_info.password.clone().unwrap();
     let username = connection_info

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1,3 +1,4 @@
+use redis::GlideConnectionOptions;
 /**
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
@@ -69,7 +70,9 @@ impl AsyncClient {
         let _runtime_handle = runtime.enter();
         let client = to_js_result(redis::Client::open(connection_address))?;
         let connection =
-            to_js_result(runtime.block_on(client.get_multiplexed_async_connection(None)))?;
+            to_js_result(runtime.block_on(
+                client.get_multiplexed_async_connection(GlideConnectionOptions::default()),
+            ))?;
         Ok(AsyncClient {
             connection,
             runtime,


### PR DESCRIPTION
Maintaining a continuous connection to the server(s) is crucial, especially in PubSub contexts, where undetected disconnects can render the listener inoperable.
Additionally, immediately attempting to reestablish a closed connection reduces latency for the next command.

This functionality is implemented differently for standalone and cluster modes:
- In standalone mode, it utilizes the reconnect functionality, triggered immediately upon detecting a disconnect, without waiting for the next command.
- In cluster mode, it relies on the changes introduced in https://github.com/amazon-contributing/redis-rs/commit/2c7faec028d3ab4a751c309f6af9d6c706e79864.

The validation processes are lightweight in terms of performance and run every 3 seconds.