### PR TITLE
Java: Expanded tests for converting non UTF-8 bytes to Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Changes
 * Node: Added `invokeScript` API with routing for cluster client ([#2284](https://github.com/valkey-io/valkey-glide/pull/2284))
+* Java: Expanded tests for converting non UTF-8 bytes to Strings ([#2286](https://github.com/valkey-io/valkey-glide/pull/2286))
 * Python: Replace instances of Redis with Valkey ([#2266](https://github.com/valkey-io/valkey-glide/pull/2266))
 * Java: Replace instances of Redis with Valkey ([#2268](https://github.com/valkey-io/valkey-glide/pull/2268))
 * Node: Replace instances of Redis with Valkey ([#2260](https://github.com/valkey-io/valkey-glide/pull/2260))

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -86,10 +86,10 @@ public class ArrayTransformUtils {
      * Converts a map of string keys and values of any type into an array of strings with alternating
      * values and keys.
      *
-     * @param args Map of string keys to values of any type to convert.
+     * @param args Map of string keys to values of Double type to convert.
      * @return Array of strings [value1.toString(), key1, value2.toString(), key2, ...].
      */
-    public static String[] convertMapToValueKeyStringArray(Map<String, ?> args) {
+    public static String[] convertMapToValueKeyStringArray(Map<String, Double> args) {
         return args.entrySet().stream()
                 .flatMap(entry -> Stream.of(entry.getValue().toString(), entry.getKey()))
                 .toArray(String[]::new);

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -996,7 +996,7 @@ public class SharedCommandTests {
         byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
         GlideString key = gs(nonUTF8Bytes);
         GlideString hashKey = gs(UUID.randomUUID().toString());
-        GlideString hashNonUTF8Key = gs(new byte[] {(byte) 0xFF});
+        GlideString hashNonUTF8Key = gs(new byte[] {(byte) 0xDD});
         GlideString value = gs(nonUTF8Bytes);
         String stringField = "field";
         Map<GlideString, GlideString> fieldValueMap = Map.of(gs(stringField), value);
@@ -1029,7 +1029,7 @@ public class SharedCommandTests {
     public void non_UTF8_GlideString_map_with_double(BaseClient client) {
         byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
         GlideString key = gs(UUID.randomUUID().toString());
-        GlideString nonUTF8Key = gs(new byte[] {(byte) 0xFF});
+        GlideString nonUTF8Key = gs(new byte[] {(byte) 0xEF});
         Map<GlideString, Double> membersScores =
                 Map.of(gs(nonUTF8Bytes), 1.0, gs("two"), 2.0, gs("three"), 3.0);
 
@@ -1095,7 +1095,7 @@ public class SharedCommandTests {
     public void non_UTF8_GlideString_map_with_geospatial(BaseClient client) {
         byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
         GlideString key = gs(UUID.randomUUID().toString());
-        GlideString nonUTF8Key = gs(new byte[] {(byte) 0xFF});
+        GlideString nonUTF8Key = gs(new byte[] {(byte) 0xDF});
         Map<GlideString, GeospatialData> membersToCoordinates = new HashMap<>();
         membersToCoordinates.put(gs(nonUTF8Bytes), new GeospatialData(13.361389, 38.115556));
         membersToCoordinates.put(gs("Catania"), new GeospatialData(15.087269, 37.502669));
@@ -1145,7 +1145,7 @@ public class SharedCommandTests {
     public void non_UTF8_GlideString_map_of_arrays(BaseClient client) {
         byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
         GlideString key = gs(UUID.randomUUID().toString());
-        GlideString nonUTF8Key = gs(new byte[] {(byte) 0xFF});
+        GlideString nonUTF8Key = gs(new byte[] {(byte) 0xFE});
         GlideString[] lpushArgs = {gs(nonUTF8Bytes), gs("two")};
 
         // Testing map of arrays using byte[] that cannot be converted to UTF-8 Strings.

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1151,20 +1151,20 @@ public class SharedCommandTests {
         // Testing map of arrays using byte[] that cannot be converted to UTF-8 Strings.
         assertEquals(2, client.lpush(key, lpushArgs).get());
         assertThrows(
-            ExecutionException.class,
-            () -> client.lmpop(new String[] {key.toString()}, ListDirection.RIGHT).get());
+                ExecutionException.class,
+                () -> client.lmpop(new String[] {key.toString()}, ListDirection.RIGHT).get());
 
         // Testing map of arrays using byte[] that cannot be converted to UTF-8 Strings returns bytes.
         assertEquals(2, client.lpush(nonUTF8Key, lpushArgs).get());
         // No error is thrown as GlideString will be returned when arguments are GlideStrings.
         assertDeepEquals(
-            Map.of(nonUTF8Key, new GlideString[] {gs(nonUTF8Bytes)}),
-            client.lmpop(new GlideString[]{nonUTF8Key}, ListDirection.RIGHT).get());
+                Map.of(nonUTF8Key, new GlideString[] {gs(nonUTF8Bytes)}),
+                client.lmpop(new GlideString[] {nonUTF8Key}, ListDirection.RIGHT).get());
 
         // Converting non UTF-8 bytes result to String returns a message.
         assertEquals(
-            "Value not convertible to string: byte[] 13",
-            client.lmpop(new GlideString[]{nonUTF8Key}, ListDirection.RIGHT).get().get(nonUTF8Key)[0]);
+                "Value not convertible to string: byte[] 13",
+                client.lmpop(new GlideString[] {nonUTF8Key}, ListDirection.RIGHT).get().get(nonUTF8Key)[0]);
     }
 
     @SneakyThrows


### PR DESCRIPTION
Expands on testing for https://github.com/valkey-io/valkey-glide/pull/2271.

Tests were included for stream, sorted set, list,  and geospatial data types.
Also specified `?` type to `double` for `convertMapToValueKeyStringArray`'s parameter. This function affects 
```
CompletableFuture<Long> zadd(
            @NonNull String key,
            @NonNull Map<String, Double> membersScoresMap,
            @NonNull ZAddOptions options,
            boolean changed)
```