### PR TITLE
Node: Use `options` for options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Node: Use `options` struct for all optional arguments ([#2287](https://github.com/valkey-io/valkey-glide/pull/2287))
 * Node: Added `invokeScript` API with routing for cluster client ([#2284](https://github.com/valkey-io/valkey-glide/pull/2284))
 * Python: Replace instances of Redis with Valkey ([#2266](https://github.com/valkey-io/valkey-glide/pull/2266))
 * Java: Replace instances of Redis with Valkey ([#2268](https://github.com/valkey-io/valkey-glide/pull/2268))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -5672,7 +5672,7 @@ export class BaseClient {
      *
      * @example
      * ```typescript
-     * const result = await client.xautoclaim("myStream", "myGroup", "myConsumer", 42, "0-0", 25);
+     * const result = await client.xautoclaim("myStream", "myGroup", "myConsumer", 42, "0-0", { count: 25 });
      * console.log(result); // Output:
      * // [
      * //     "1609338788321-0",                // value to be used as `start` argument

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3081,7 +3081,8 @@ export class BaseClient {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sets.
-     * @param limit - The limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `limit`: the limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
      * @returns The cardinality of the intersection result. If one or more sets do not exist, `0` is returned.
      *
      * @example
@@ -3091,15 +3092,15 @@ export class BaseClient {
      * const result1 = await client.sintercard(["set1", "set2"]);
      * console.log(result1); // Output: 2 - The intersection of "set1" and "set2" contains 2 elements: "b" and "c".
      *
-     * const result2 = await client.sintercard(["set1", "set2"], 1);
+     * const result2 = await client.sintercard(["set1", "set2"], { limit: 1 });
      * console.log(result2); // Output: 1 - The computation stops early as the intersection cardinality reaches the limit of 1.
      * ```
      */
     public async sintercard(
         keys: GlideString[],
-        limit?: number,
+        options?: { limit?: number },
     ): Promise<number> {
-        return this.createWritePromise(createSInterCard(keys, limit));
+        return this.createWritePromise(createSInterCard(keys, options?.limit));
     }
 
     /**
@@ -3470,7 +3471,8 @@ export class BaseClient {
      *
      * @param key - The key to set timeout on it.
      * @param seconds - The timeout in seconds.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      * @returns `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      * or operation skipped due to the provided arguments.
      *
@@ -3484,16 +3486,18 @@ export class BaseClient {
      * @example
      * ```typescript
      * // Example usage of the expire method with exisiting expiry
-     * const result = await client.expire("my_key", 60, ExpireOptions.HasNoExpiry);
+     * const result = await client.expire("my_key", 60, { expireOption: ExpireOptions.HasNoExpiry });
      * console.log(result); // Output: false - Indicates that "my_key" has an existing expiry.
      * ```
      */
     public async expire(
         key: GlideString,
         seconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): Promise<boolean> {
-        return this.createWritePromise(createExpire(key, seconds, option));
+        return this.createWritePromise(
+            createExpire(key, seconds, options?.expireOption),
+        );
     }
 
     /**
@@ -3506,24 +3510,25 @@ export class BaseClient {
      *
      * @param key - The key to set timeout on it.
      * @param unixSeconds - The timeout in an absolute Unix timestamp.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      * @returns `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      * or operation skipped due to the provided arguments.
      *
      * @example
      * ```typescript
      * // Example usage of the expireAt method on a key with no previous expiry
-     * const result = await client.expireAt("my_key", 1672531200, ExpireOptions.HasNoExpiry);
+     * const result = await client.expireAt("my_key", 1672531200, { expireOption: ExpireOptions.HasNoExpiry });
      * console.log(result); // Output: true - Indicates that the expiration time for "my_key" was successfully set.
      * ```
      */
     public async expireAt(
         key: GlideString,
         unixSeconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): Promise<boolean> {
         return this.createWritePromise(
-            createExpireAt(key, unixSeconds, option),
+            createExpireAt(key, unixSeconds, options?.expireOption),
         );
     }
 
@@ -3565,24 +3570,25 @@ export class BaseClient {
      *
      * @param key - The key to set timeout on it.
      * @param milliseconds - The timeout in milliseconds.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      * @returns `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      * or operation skipped due to the provided arguments.
      *
      * @example
      * ```typescript
      * // Example usage of the pexpire method on a key with no previous expiry
-     * const result = await client.pexpire("my_key", 60000, ExpireOptions.HasNoExpiry);
+     * const result = await client.pexpire("my_key", 60000, { expireOption: ExpireOptions.HasNoExpiry });
      * console.log(result); // Output: true - Indicates that a timeout of 60,000 milliseconds has been set for "my_key".
      * ```
      */
     public async pexpire(
         key: GlideString,
         milliseconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): Promise<boolean> {
         return this.createWritePromise(
-            createPExpire(key, milliseconds, option),
+            createPExpire(key, milliseconds, options?.expireOption),
         );
     }
 
@@ -3596,24 +3602,25 @@ export class BaseClient {
      *
      * @param key - The key to set timeout on it.
      * @param unixMilliseconds - The timeout in an absolute Unix timestamp.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      * @returns `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      * or operation skipped due to the provided arguments.
      *
      * @example
      * ```typescript
      * // Example usage of the pexpireAt method on a key with no previous expiry
-     * const result = await client.pexpireAt("my_key", 1672531200000, ExpireOptions.HasNoExpiry);
+     * const result = await client.pexpireAt("my_key", 1672531200000, { expireOption: ExpireOptions.HasNoExpiry });
      * console.log(result); // Output: true - Indicates that the expiration time for "my_key" was successfully set.
      * ```
      */
     public async pexpireAt(
         key: GlideString,
         unixMilliseconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): Promise<number> {
         return this.createWritePromise(
-            createPExpireAt(key, unixMilliseconds, option),
+            createPExpireAt(key, unixMilliseconds, options?.expireOption),
         );
     }
 
@@ -3991,21 +3998,21 @@ export class BaseClient {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets to intersect.
-     * @param limit - An optional argument that can be used to specify a maximum number for the
-     * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `limit`: the limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
      * @returns The cardinality of the intersection of the given sorted sets.
      *
      * @example
      * ```typescript
-     * const cardinality = await client.zintercard(["key1", "key2"], 10);
+     * const cardinality = await client.zintercard(["key1", "key2"], { limit: 10 });
      * console.log(cardinality); // Output: 3 - The intersection of the sorted sets at "key1" and "key2" has a cardinality of 3.
      * ```
      */
     public async zintercard(
         keys: GlideString[],
-        limit?: number,
+        options?: { limit?: number },
     ): Promise<number> {
-        return this.createWritePromise(createZInterCard(keys, limit));
+        return this.createWritePromise(createZInterCard(keys, options?.limit));
     }
 
     /**
@@ -4152,7 +4159,9 @@ export class BaseClient {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - `GlideString[]` - for keys only.
      *  - `KeyWeight[]` - for weighted keys with their score multipliers.
-     * @param aggregationType - Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     *   If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      * @returns The number of elements in the resulting sorted set stored at `destination`.
      *
      * @example
@@ -4170,7 +4179,7 @@ export class BaseClient {
      * @example
      * ```typescript
      * // use `zunionstore` with default weights
-     * console.log(await client.zunionstore("my_sorted_set", ["key1", "key2"], AggregationType.MAX))
+     * console.log(await client.zunionstore("my_sorted_set", ["key1", "key2"], { aggregationType: AggregationType.MAX }))
      * // Output: 2 - Indicates that the sorted set "my_sorted_set" contains two elements, and each score is the maximum score between the sets.
      * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, stop: -1}))
      * // Output: {'member1': 10.5, 'member2': 8.2} - "member1" is now stored in "my_sorted_set" with score of 10.5 and "member2" with score of 8.2.
@@ -4186,10 +4195,10 @@ export class BaseClient {
     public async zunionstore(
         destination: GlideString,
         keys: GlideString[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        options?: { aggregationType?: AggregationType },
     ): Promise<number> {
         return this.createWritePromise(
-            createZUnionStore(destination, keys, aggregationType),
+            createZUnionStore(destination, keys, options?.aggregationType),
         );
     }
 
@@ -4409,8 +4418,9 @@ export class BaseClient {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - `GlideString[]` - for keys only.
      *  - `KeyWeight[]` - for weighted keys with score multipliers.
-     * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
-     * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     *   If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      * @returns The number of elements in the resulting sorted set stored at `destination`.
      *
      * @example
@@ -4425,7 +4435,7 @@ export class BaseClient {
      * // Output: {'member1': 20} - "member1" is now stored in "my_sorted_set" with score of 20.
      *
      * // use `zinterstore` with default weights
-     * console.log(await client.zinterstore("my_sorted_set", ["key1", "key2"] , AggregationType.MAX))
+     * console.log(await client.zinterstore("my_sorted_set", ["key1", "key2"] , { aggregationType: AggregationType.MAX }))
      * // Output: 1 - Indicates that the sorted set "my_sorted_set" contains one element, and it's score is the maximum score between the sets.
      * console.log(await client.zrangeWithScores("my_sorted_set", {start: 0, end: -1}))
      * // Output: {'member1': 10.5} - "member1" is now stored in "my_sorted_set" with score of 10.5.
@@ -4434,10 +4444,10 @@ export class BaseClient {
     public async zinterstore(
         destination: GlideString,
         keys: GlideString[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        options?: { aggregationType?: AggregationType },
     ): Promise<number> {
         return this.createWritePromise(
-            createZInterstore(destination, keys, aggregationType),
+            createZInterstore(destination, keys, options?.aggregationType),
         );
     }
 
@@ -5212,7 +5222,7 @@ export class BaseClient {
      * // Output is 2 since the stream marked 2 entries as deleted.
      * ```
      */
-    public async xdel(key: GlideString, ids: GlideString[]): Promise<number> {
+    public async xdel(key: GlideString, ids: string[]): Promise<number> {
         return this.createWritePromise(createXDel(key, ids));
     }
 
@@ -5264,7 +5274,7 @@ export class BaseClient {
      * ```
      */
     public async xread(
-        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
+        keys_and_ids: Record<string, string> | GlideRecord<string>,
         options?: StreamReadOptions & DecoderOption,
     ): Promise<GlideRecord<StreamEntryDataType> | null> {
         return this.createWritePromise<GlideRecord<
@@ -5325,7 +5335,7 @@ export class BaseClient {
     public async xreadgroup(
         group: GlideString,
         consumer: GlideString,
-        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
+        keys_and_ids: Record<string, string> | GlideRecord<string>,
         options?: StreamReadGroupOptions & DecoderOption,
     ): Promise<GlideRecord<
         Record<string, [GlideString, GlideString][] | null>
@@ -5551,7 +5561,7 @@ export class BaseClient {
         group: GlideString,
         consumer: GlideString,
         minIdleTime: number,
-        ids: GlideString[],
+        ids: string[],
         options?: StreamClaimOptions & DecoderOption,
     ): Promise<StreamEntryDataType> {
         return this.createWritePromise<
@@ -5588,7 +5598,7 @@ export class BaseClient {
      *
      * @example
      * ```typescript
-     * const result = await client.xautoclaim("myStream", "myGroup", "myConsumer", 42, "0-0", 25);
+     * const result = await client.xautoclaim("myStream", "myGroup", "myConsumer", 42, "0-0", { count: 25 });
      * console.log(result); // Output:
      * // [
      * //     "1609338788321-0",                // value to be used as `start` argument
@@ -5611,7 +5621,7 @@ export class BaseClient {
         group: GlideString,
         consumer: GlideString,
         minIdleTime: number,
-        start: GlideString,
+        start: string,
         options?: { count?: number } & DecoderOption,
     ): Promise<[GlideString, StreamEntryDataType, GlideString[]?]> {
         return this.createWritePromise<
@@ -5649,7 +5659,8 @@ export class BaseClient {
      * @param minIdleTime - The minimum idle time for the message to be claimed.
      * @param start - Filters the claimed entries to those that have an ID equal or greater than the
      *     specified value.
-     * @param count - (Optional) Limits the number of claimed entries to the specified value.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count`: limits the number of claimed entries to the specified value.
      * @returns An `array` containing the following elements:
      *   - A stream ID to be used as the start argument for the next call to `XAUTOCLAIM`. This ID is
      *     equivalent to the next ID in the stream after the entries that were scanned, or "0-0" if
@@ -5678,12 +5689,12 @@ export class BaseClient {
      * ```
      */
     public async xautoclaimJustId(
-        key: string,
-        group: string,
-        consumer: string,
+        key: GlideString,
+        group: GlideString,
+        consumer: GlideString,
         minIdleTime: number,
         start: string,
-        count?: number,
+        options?: { count?: number },
     ): Promise<[string, string[], string[]?]> {
         return this.createWritePromise(
             createXAutoClaim(
@@ -5692,9 +5703,10 @@ export class BaseClient {
                 consumer,
                 minIdleTime,
                 start,
-                count,
+                options?.count,
                 true,
             ),
+            { decoder: Decoder.String },
         );
     }
 
@@ -5720,15 +5732,16 @@ export class BaseClient {
      * ```
      */
     public async xclaimJustId(
-        key: string,
-        group: string,
-        consumer: string,
+        key: GlideString,
+        group: GlideString,
+        consumer: GlideString,
         minIdleTime: number,
         ids: string[],
         options?: StreamClaimOptions,
     ): Promise<string[]> {
         return this.createWritePromise(
             createXClaim(key, group, consumer, minIdleTime, ids, options, true),
+            { decoder: Decoder.String },
         );
     }
 
@@ -5752,7 +5765,7 @@ export class BaseClient {
     public async xgroupCreate(
         key: GlideString,
         groupName: GlideString,
-        id: GlideString,
+        id: string,
         options?: StreamGroupOptions,
     ): Promise<"OK"> {
         return this.createWritePromise(
@@ -5951,7 +5964,7 @@ export class BaseClient {
     public async xack(
         key: GlideString,
         group: GlideString,
-        ids: GlideString[],
+        ids: string[],
     ): Promise<number> {
         return this.createWritePromise(createXAck(key, group, ids));
     }
@@ -5963,28 +5976,26 @@ export class BaseClient {
      *
      * @param key - The key of the stream.
      * @param groupName - The consumer group name.
-     * @param id - The stream entry ID that should be set as the last delivered ID for the consumer
-     *     group.
-     * @param entriesRead - (Optional) A value representing the number of stream entries already read by the group.
+     * @param id - The stream entry ID that should be set as the last delivered ID for the consumer group.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `entriesRead`: the number of stream entries already read by the group.
      *     This option can only be specified if you are using Valkey version 7.0.0 or above.
      * @returns `"OK"`.
      *
      * * @example
      * ```typescript
-     * console.log(await client.xgroupSetId("mystream", "mygroup", "0", 1)); // Output is "OK"
+     * console.log(await client.xgroupSetId("mystream", "mygroup", "0", { entriesRead: 1 })); // Output is "OK"
      * ```
      */
     public async xgroupSetId(
         key: GlideString,
         groupName: GlideString,
-        id: GlideString,
-        entriesRead?: number,
+        id: string,
+        options?: { entriesRead?: number },
     ): Promise<"OK"> {
         return this.createWritePromise(
-            createXGroupSetid(key, groupName, id, entriesRead),
-            {
-                decoder: Decoder.String,
-            },
+            createXGroupSetid(key, groupName, id, options?.entriesRead),
+            { decoder: Decoder.String },
         );
     }
 
@@ -6890,13 +6901,15 @@ export class BaseClient {
      * @param key - The key of the sorted set.
      * @param member1 - The name of the first member.
      * @param member2 - The name of the second member.
-     * @param geoUnit - (Optional) The unit of distance measurement - see {@link GeoUnit}. If not specified, the {@link GeoUnit.METERS} is used as a default unit.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `unit`: the unit of distance measurement - see {@link GeoUnit}.
+     *   If not specified, the {@link GeoUnit.METERS} is used as a default unit.
      * @returns The distance between `member1` and `member2`. Returns `null`, if one or both members do not exist,
      *     or if the key does not exist.
      *
      * @example
      * ```typescript
-     * const result = await client.geodist("mySortedSet", "Place1", "Place2", GeoUnit.KILOMETERS);
+     * const result = await client.geodist("mySortedSet", "Place1", "Place2", { unit: GeoUnit.KILOMETERS });
      * console.log(num); // Output: the distance between Place1 and Place2.
      * ```
      */
@@ -6904,10 +6917,10 @@ export class BaseClient {
         key: GlideString,
         member1: GlideString,
         member2: GlideString,
-        geoUnit?: GeoUnit,
+        options?: { unit?: GeoUnit },
     ): Promise<number | null> {
         return this.createWritePromise(
-            createGeoDist(key, member1, member2, geoUnit),
+            createGeoDist(key, member1, member2, options?.unit),
         );
     }
 

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2180,7 +2180,7 @@ export function createXAdd(
  */
 export function createXDel(
     key: GlideString,
-    ids: GlideString[],
+    ids: string[],
 ): command_request.Command {
     return createCommand(RequestType.XDel, [key, ...ids]);
 }
@@ -2582,8 +2582,8 @@ export enum FlushMode {
  * @returns same data in GlideRecord type.
  */
 export function convertKeysAndEntries(
-    record: Record<string, GlideString> | GlideRecord<GlideString>,
-): GlideRecord<GlideString> {
+    record: Record<string, string> | GlideRecord<string>,
+): GlideRecord<string> {
     if (!Array.isArray(record)) {
         return convertRecordToGlideRecord(record);
     }
@@ -2633,7 +2633,7 @@ function addReadOptions(options?: StreamReadOptions): GlideString[] {
 }
 
 /** @internal */
-function addStreamsArgs(keys_and_ids: GlideRecord<GlideString>): GlideString[] {
+function addStreamsArgs(keys_and_ids: GlideRecord<string>): GlideString[] {
     return [
         "STREAMS",
         ...keys_and_ids.map((e) => e.key),
@@ -2645,7 +2645,7 @@ function addStreamsArgs(keys_and_ids: GlideRecord<GlideString>): GlideString[] {
  * @internal
  */
 export function createXRead(
-    keys_and_ids: GlideRecord<GlideString>,
+    keys_and_ids: GlideRecord<string>,
     options?: StreamReadOptions,
 ): command_request.Command {
     const args = addReadOptions(options);
@@ -2657,7 +2657,7 @@ export function createXRead(
 export function createXReadGroup(
     group: GlideString,
     consumer: GlideString,
-    keys_and_ids: GlideRecord<GlideString>,
+    keys_and_ids: GlideRecord<string>,
     options?: StreamReadGroupOptions,
 ): command_request.Command {
     const args: GlideString[] = ["GROUP", group, consumer];
@@ -2788,7 +2788,7 @@ export function createXClaim(
     group: GlideString,
     consumer: GlideString,
     minIdleTime: number,
-    ids: GlideString[],
+    ids: string[],
     options?: StreamClaimOptions,
     justId?: boolean,
 ): command_request.Command {
@@ -2856,7 +2856,7 @@ export interface StreamGroupOptions {
 export function createXGroupCreate(
     key: GlideString,
     groupName: GlideString,
-    id: GlideString,
+    id: string,
     options?: StreamGroupOptions,
 ): command_request.Command {
     const args: GlideString[] = [key, groupName, id];
@@ -4093,7 +4093,7 @@ export function createGetEx(
 export function createXAck(
     key: GlideString,
     group: GlideString,
-    ids: GlideString[],
+    ids: string[],
 ): command_request.Command {
     return createCommand(RequestType.XAck, [key, group, ...ids]);
 }
@@ -4104,7 +4104,7 @@ export function createXAck(
 export function createXGroupSetid(
     key: GlideString,
     groupName: GlideString,
-    id: GlideString,
+    id: string,
     entriesRead?: number,
 ): command_request.Command {
     const args = [key, groupName, id];

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -479,9 +479,10 @@ export class GlideClient extends BaseClient {
      *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
-     * @param destinationDB - (Optional) The alternative logical database index for the destination key.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `destinationDB`: the alternative logical database index for the destination key.
      *     If not provided, the current database will be used.
-     * @param replace - (Optional) If `true`, the `destination` key should be removed before copying the
+     * - (Optional) `replace`: if `true`, the `destination` key should be removed before copying the
      *     value to it. If not provided, no action will be performed if the key already exists.
      * @returns `true` if `source` was copied, `false` if the `source` was not copied.
      *

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -805,23 +805,24 @@ export class GlideClusterClient extends BaseClient {
      *
      * @param source - The key to the source value.
      * @param destination - The key where the value should be copied to.
-     * @param replace - (Optional) If `true`, the `destination` key should be removed before copying the
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `replace`: if `true`, the `destination` key should be removed before copying the
      *     value to it. If not provided, no action will be performed if the key already exists.
      * @returns `true` if `source` was copied, `false` if the `source` was not copied.
      *
      * @example
      * ```typescript
-     * const result = await client.copy("set1", "set2", true);
+     * const result = await client.copy("set1", "set2", { replace: true });
      * console.log(result); // Output: true - "set1" was copied to "set2".
      * ```
      */
     public async copy(
         source: GlideString,
         destination: GlideString,
-        replace?: boolean,
+        options?: { replace?: boolean },
     ): Promise<boolean> {
         return this.createWritePromise(
-            createCopy(source, destination, { replace: replace }),
+            createCopy(source, destination, options),
         );
     }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1418,11 +1418,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sets.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `limit`: the limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
      *
      * Command Response - The cardinality of the intersection result. If one or more sets do not exist, `0` is returned.
      */
-    public sintercard(keys: GlideString[], limit?: number): T {
-        return this.addAndReturn(createSInterCard(keys, limit));
+    public sintercard(keys: GlideString[], options?: { limit?: number }): T {
+        return this.addAndReturn(createSInterCard(keys, options?.limit));
     }
 
     /**
@@ -1614,7 +1616,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key to set timeout on it.
      * @param seconds - The timeout in seconds.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      *
      * Command Response - `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      *     or operation skipped due to the provided arguments.
@@ -1622,9 +1625,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public expire(
         key: GlideString,
         seconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): T {
-        return this.addAndReturn(createExpire(key, seconds, option));
+        return this.addAndReturn(
+            createExpire(key, seconds, options?.expireOption),
+        );
     }
 
     /**
@@ -1637,7 +1642,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key to set timeout on it.
      * @param unixSeconds - The timeout in an absolute Unix timestamp.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      *
      * Command Response - `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      *     or operation skipped due to the provided arguments.
@@ -1645,9 +1651,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public expireAt(
         key: GlideString,
         unixSeconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): T {
-        return this.addAndReturn(createExpireAt(key, unixSeconds, option));
+        return this.addAndReturn(
+            createExpireAt(key, unixSeconds, options?.expireOption),
+        );
     }
 
     /**
@@ -1675,7 +1683,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key to set timeout on it.
      * @param milliseconds - The timeout in milliseconds.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      *
      * Command Response - `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      *     or operation skipped due to the provided arguments.
@@ -1683,9 +1692,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public pexpire(
         key: GlideString,
         milliseconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): T {
-        return this.addAndReturn(createPExpire(key, milliseconds, option));
+        return this.addAndReturn(
+            createPExpire(key, milliseconds, options?.expireOption),
+        );
     }
 
     /**
@@ -1698,7 +1709,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key to set timeout on it.
      * @param unixMilliseconds - The timeout in an absolute Unix timestamp.
-     * @param option - (Optional) The expire option - see {@link ExpireOptions}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `expireOption`: the expire option - see {@link ExpireOptions}.
      *
      * Command Response - `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
      *     or operation skipped due to the provided arguments.
@@ -1706,10 +1718,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public pexpireAt(
         key: GlideString,
         unixMilliseconds: number,
-        option?: ExpireOptions,
+        options?: { expireOption?: ExpireOptions },
     ): T {
         return this.addAndReturn(
-            createPExpireAt(key, unixMilliseconds, option),
+            createPExpireAt(key, unixMilliseconds, options?.expireOption),
         );
     }
 
@@ -1835,13 +1847,13 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets to intersect.
-     * @param limit - An optional argument that can be used to specify a maximum number for the
-     * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `limit`: the limit for the intersection cardinality value. If not specified, or set to `0`, no limit is used.
      *
      * Command Response - The cardinality of the intersection of the given sorted sets.
      */
-    public zintercard(keys: GlideString[], limit?: number): T {
-        return this.addAndReturn(createZInterCard(keys, limit));
+    public zintercard(keys: GlideString[], options?: { limit?: number }): T {
+        return this.addAndReturn(createZInterCard(keys, options?.limit));
     }
 
     /**
@@ -1920,17 +1932,19 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - `GlideString[]` - for keys only.
      *  - `KeyWeight[]` - for weighted keys with their score multipliers.
-     * @param aggregationType - Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     *   If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - The number of elements in the resulting sorted set stored at `destination`.
      */
     public zunionstore(
         destination: GlideString,
         keys: GlideString[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        options?: { aggregationType?: AggregationType },
     ): T {
         return this.addAndReturn(
-            createZUnionStore(destination, keys, aggregationType),
+            createZUnionStore(destination, keys, options?.aggregationType),
         );
     }
 
@@ -2065,18 +2079,19 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - `GlideString[]` - for keys only.
      *  - `KeyWeight[]` - for weighted keys with score multipliers.
-     * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
-     * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     *   If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - The number of elements in the resulting sorted set stored at `destination`.
      */
     public zinterstore(
         destination: GlideString,
         keys: GlideString[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        options?: { aggregationType?: AggregationType },
     ): T {
         return this.addAndReturn(
-            createZInterstore(destination, keys, aggregationType),
+            createZInterstore(destination, keys, options?.aggregationType),
         );
     }
 
@@ -2109,8 +2124,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - `GlideString[]` - for keys only.
      *  - `KeyWeight[]` - for weighted keys with score multipliers.
-     * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
-     * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     *   If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - A list of elements and their scores representing the intersection of the sorted sets.
      *     If a key does not exist, it is treated as an empty sorted set, and the command returns an empty result.
@@ -2118,9 +2134,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public zinterWithScores(
         keys: GlideString[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        options?: { aggregationType?: AggregationType },
     ): T {
-        return this.addAndReturn(createZInter(keys, aggregationType, true));
+        return this.addAndReturn(
+            createZInter(keys, options?.aggregationType, true),
+        );
     }
 
     /**
@@ -2151,17 +2169,20 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param keys - The keys of the sorted sets with possible formats:
      *  - `GlideString[]` - for keys only.
      *  - `KeyWeight[]` - for weighted keys with their score multipliers.
-     * @param aggregationType - (Optional) Specifies the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
-     * If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `aggregationType`: the aggregation strategy to apply when combining the scores of elements. See {@link AggregationType}.
+     *   If `aggregationType` is not specified, defaults to `AggregationType.SUM`.
      *
      * Command Response - A list of elements and their scores representing the intersection of the sorted sets.
      *     The response comes in format `GlideRecord<number>`, see {@link GlideRecord}.
      */
     public zunionWithScores(
         keys: GlideString[] | KeyWeight[],
-        aggregationType?: AggregationType,
+        options?: { aggregationType?: AggregationType },
     ): T {
-        return this.addAndReturn(createZUnion(keys, aggregationType, true));
+        return this.addAndReturn(
+            createZUnion(keys, options?.aggregationType, true),
+        );
     }
 
     /**
@@ -2586,7 +2607,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - The number of entries removed from the stream. This number may be less than the number of entries in
      *      `ids`, if the specified `ids` don't exist in the stream.
      */
-    public xdel(key: GlideString, ids: GlideString[]): T {
+    public xdel(key: GlideString, ids: string[]): T {
         return this.addAndReturn(createXDel(key, ids));
     }
 
@@ -2718,7 +2739,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     The response comes in format `GlideRecord<GlideRecord<[GlideString, GlideString][]>>`, see {@link GlideRecord}.
      */
     public xread(
-        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
+        keys_and_ids: Record<string, string> | GlideRecord<string>,
         options?: StreamReadOptions,
     ): T {
         if (!Array.isArray(keys_and_ids)) {
@@ -2748,7 +2769,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public xreadgroup(
         group: GlideString,
         consumer: GlideString,
-        keys_and_ids: Record<string, GlideString> | GlideRecord<GlideString>,
+        keys_and_ids: Record<string, string> | GlideRecord<string>,
         options?: StreamReadGroupOptions,
     ): T {
         if (!Array.isArray(keys_and_ids)) {
@@ -2844,7 +2865,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         group: GlideString,
         consumer: GlideString,
         minIdleTime: number,
-        ids: GlideString[],
+        ids: string[],
         options?: StreamClaimOptions,
     ): T {
         return this.addAndReturn(
@@ -2868,9 +2889,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - An `array` of message ids claimed by the consumer.
      */
     public xclaimJustId(
-        key: string,
-        group: string,
-        consumer: string,
+        key: GlideString,
+        group: GlideString,
+        consumer: GlideString,
         minIdleTime: number,
         ids: string[],
         options?: StreamClaimOptions,
@@ -2892,7 +2913,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param minIdleTime - The minimum idle time for the message to be claimed.
      * @param start - Filters the claimed entries to those that have an ID equal or greater than the
      *     specified value.
-     * @param count - (Optional) Limits the number of claimed entries to the specified value.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count`: the number of claimed entries.
      *
      * Command Response - An `array` containing the following elements:
      *   - A stream ID to be used as the start argument for the next call to `XAUTOCLAIM`. This ID is
@@ -2910,11 +2932,18 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         group: GlideString,
         consumer: GlideString,
         minIdleTime: number,
-        start: GlideString,
-        count?: number,
+        start: string,
+        options?: { count?: number },
     ): T {
         return this.addAndReturn(
-            createXAutoClaim(key, group, consumer, minIdleTime, start, count),
+            createXAutoClaim(
+                key,
+                group,
+                consumer,
+                minIdleTime,
+                start,
+                options?.count,
+            ),
         );
     }
 
@@ -2930,7 +2959,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param minIdleTime - The minimum idle time for the message to be claimed.
      * @param start - Filters the claimed entries to those that have an ID equal or greater than the
      *     specified value.
-     * @param count - (Optional) Limits the number of claimed entries to the specified value.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `count`: limits the number of claimed entries to the specified value.
      *
      * Command Response - An `array` containing the following elements:
      *   - A stream ID to be used as the start argument for the next call to `XAUTOCLAIM`. This ID is
@@ -2942,12 +2972,12 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     These IDs are deleted from the Pending Entries List.
      */
     public xautoclaimJustId(
-        key: string,
-        group: string,
-        consumer: string,
+        key: GlideString,
+        group: GlideString,
+        consumer: GlideString,
         minIdleTime: number,
         start: string,
-        count?: number,
+        options?: { count?: number },
     ): T {
         return this.addAndReturn(
             createXAutoClaim(
@@ -2956,7 +2986,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
                 consumer,
                 minIdleTime,
                 start,
-                count,
+                options?.count,
                 true,
             ),
         );
@@ -2978,7 +3008,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public xgroupCreate(
         key: GlideString,
         groupName: GlideString,
-        id: GlideString,
+        id: string,
         options?: StreamGroupOptions,
     ): T {
         return this.addAndReturn(
@@ -3054,7 +3084,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * Command Response - The number of messages that were successfully acknowledged.
      */
-    public xack(key: GlideString, group: GlideString, ids: GlideString[]): T {
+    public xack(key: GlideString, group: GlideString, ids: string[]): T {
         return this.addAndReturn(createXAck(key, group, ids));
     }
 
@@ -3066,7 +3096,8 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key of the stream.
      * @param groupName - The consumer group name.
      * @param id - The stream entry ID that should be set as the last delivered ID for the consumer group.
-     * @param entriesRead - (Optional) A value representing the number of stream entries already read by the group.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `entriesRead`: the number of stream entries already read by the group.
      *     This option can only be specified if you are using Valkey version 7.0.0 or above.
      *
      * Command Response - `"OK"`.
@@ -3074,11 +3105,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public xgroupSetId(
         key: GlideString,
         groupName: GlideString,
-        id: GlideString,
-        entriesRead?: number,
+        id: string,
+        options?: { entriesRead?: number },
     ): T {
         return this.addAndReturn(
-            createXGroupSetid(key, groupName, id, entriesRead),
+            createXGroupSetid(key, groupName, id, options?.entriesRead),
         );
     }
 
@@ -3722,7 +3753,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key of the sorted set.
      * @param member1 - The name of the first member.
      * @param member2 - The name of the second member.
-     * @param geoUnit - The unit of distance measurement - see {@link GeoUnit}. If not specified, the default unit is {@link GeoUnit.METERS}.
+     * @param options - (Optional) Additional parameters:
+     * - (Optional) `unit`: the unit of distance measurement - see {@link GeoUnit}.
+     *   If not specified, the {@link GeoUnit.METERS} is used as a default unit.
      *
      * Command Response - The distance between `member1` and `member2`. Returns `null`, if one or both members do not exist,
      *     or if the key does not exist.
@@ -3731,9 +3764,11 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         key: GlideString,
         member1: GlideString,
         member2: GlideString,
-        geoUnit?: GeoUnit,
+        options?: { unit?: GeoUnit },
     ): T {
-        return this.addAndReturn(createGeoDist(key, member1, member2, geoUnit));
+        return this.addAndReturn(
+            createGeoDist(key, member1, member2, options?.unit),
+        );
     }
 
     /**
@@ -4166,11 +4201,9 @@ export class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
     public copy(
         source: GlideString,
         destination: GlideString,
-        replace?: boolean,
+        options?: { replace?: boolean },
     ): ClusterTransaction {
-        return this.addAndReturn(
-            createCopy(source, destination, { replace: replace }),
-        );
+        return this.addAndReturn(createCopy(source, destination, options));
     }
 
     /** Publish a message on pubsub channel.

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -409,7 +409,7 @@ describe("GlideClusterClient", () => {
                     client.zdiff(["abc", "zxy", "lkn"]),
                     client.zdiffWithScores(["abc", "zxy", "lkn"]),
                     client.zdiffstore("abc", ["zxy", "lkn"]),
-                    client.copy("abc", "zxy", true),
+                    client.copy("abc", "zxy", { replace: true }),
                     client.geosearchstore(
                         "abc",
                         "zxy",
@@ -648,7 +648,9 @@ describe("GlideClusterClient", () => {
             const value2 = uuidv4();
 
             // neither key exists
-            expect(await client.copy(source, destination, true)).toEqual(false);
+            expect(
+                await client.copy(source, destination, { replace: true }),
+            ).toEqual(false);
             expect(await client.copy(Buffer.from(source), destination)).toEqual(
                 false,
             );
@@ -656,7 +658,9 @@ describe("GlideClusterClient", () => {
             // source exists, destination does not
             expect(await client.set(source, value1)).toEqual("OK");
             expect(
-                await client.copy(source, Buffer.from(destination), false),
+                await client.copy(source, Buffer.from(destination), {
+                    replace: false,
+                }),
             ).toEqual(true);
             expect(await client.get(destination)).toEqual(value1);
 
@@ -670,21 +674,23 @@ describe("GlideClusterClient", () => {
                     Buffer.from(destination),
                 ),
             ).toEqual(false);
-            expect(await client.copy(source, destination, false)).toEqual(
-                false,
-            );
+            expect(
+                await client.copy(source, destination, { replace: false }),
+            ).toEqual(false);
             expect(await client.get(destination)).toEqual(value1);
 
             // both exists, with REPLACE
             expect(
-                await client.copy(source, Buffer.from(destination), true),
+                await client.copy(source, Buffer.from(destination), {
+                    replace: true,
+                }),
             ).toEqual(true);
             expect(await client.get(destination)).toEqual(value2);
 
             //transaction tests
             const transaction = new ClusterTransaction();
             transaction.set(source, value1);
-            transaction.copy(source, destination, true);
+            transaction.copy(source, destination, { replace: true });
             transaction.get(destination);
             const results = await client.exec(transaction);
 

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -977,8 +977,8 @@ export async function transactionTest(
     if (gte(version, "7.0.0")) {
         baseTransaction.sintercard([key7, key7]);
         responseData.push(["sintercard([key7, key7])", 2]);
-        baseTransaction.sintercard([key7, key7], 1);
-        responseData.push(["sintercard([key7, key7], 1)", 1]);
+        baseTransaction.sintercard([key7, key7], { limit: 1 });
+        responseData.push(["sintercard([key7, key7], { limit: 1 })", 1]);
     }
 
     baseTransaction.sinterstore(key7, [key7, key7]);
@@ -1208,8 +1208,8 @@ export async function transactionTest(
         responseData.push(["zadd(key14, { one: 1.0, two: 2.0 })", 2]);
         baseTransaction.zintercard([key8, key14]);
         responseData.push(["zintercard([key8, key14])", 0]);
-        baseTransaction.zintercard([key8, key14], 1);
-        responseData.push(["zintercard([key8, key14], 1)", 0]);
+        baseTransaction.zintercard([key8, key14], { limit: 1 });
+        responseData.push(["zintercard([key8, key14], { limit: 1 })", 0]);
         baseTransaction.zmpop([key14], ScoreFilter.MAX);
         responseData.push([
             "zmpop([key14], MAX)",
@@ -1354,9 +1354,11 @@ export async function transactionTest(
     ]);
 
     if (gte(version, "6.2.0")) {
-        baseTransaction.xautoclaim(key9, groupName1, consumer, 0, "0-0", 1);
+        baseTransaction.xautoclaim(key9, groupName1, consumer, 0, "0-0", {
+            count: 1,
+        });
         responseData.push([
-            'xautoclaim(key9, groupName1, consumer, 0, "0-0", 1)',
+            'xautoclaim(key9, groupName1, consumer, 0, "0-0", { count: 1 })',
             gte(version, "7.0.0")
                 ? [
                       "0-0",
@@ -1502,9 +1504,11 @@ export async function transactionTest(
     ]);
     baseTransaction.geodist(key18, "Palermo", "Catania");
     responseData.push(['geodist(key18, "Palermo", "Catania")', 166274.1516]);
-    baseTransaction.geodist(key18, "Palermo", "Catania", GeoUnit.KILOMETERS);
+    baseTransaction.geodist(key18, "Palermo", "Catania", {
+        unit: GeoUnit.KILOMETERS,
+    });
     responseData.push([
-        'geodist(key18, "Palermo", "Catania", GeoUnit.KILOMETERS)',
+        'geodist(key18, "Palermo", "Catania", { unit: GeoUnit.KILOMETERS })',
         166.2742,
     ]);
     baseTransaction.geohash(key18, ["Palermo", "Catania", "NonExisting"]);


### PR DESCRIPTION
1. Use `options` struct for all optional args for all commands
2. Fix arg types for some stream commands

Purpose of this change:
1. To align all API, especially across standalone and cluster clients and transaction
2. If we don't release it in 1.1, that will be a breaking change
3. Adding new optional argument won't be a breaking change for existing API