### PR TITLE
Go:Fix benchmarking code and improve response side performance

### DIFF
--- a/go/benchmarks/benchmarking.go
+++ b/go/benchmarks/benchmarking.go
@@ -84,6 +84,8 @@ func executeBenchmarks(runConfig *runConfiguration, connectionSettings *connecti
 	return nil
 }
 
+var key_count int64 = 1
+
 func runSingleBenchmark(config *benchmarkConfig) error {
 	fmt.Printf("Running benchmarking for %s client:\n", config.clientName)
 	fmt.Printf(
@@ -228,13 +230,13 @@ const (
 func getActions(dataSize int) map[string]operations {
 	actions := map[string]operations{
 		getExisting: func(client benchmarkClient) (string, error) {
-			return client.get(keyFromExistingKeyspace())
+			return client.get(keyFromExistingKeyspace(getExisting))
 		},
 		getNonExisting: func(client benchmarkClient) (string, error) {
 			return client.get(keyFromNewKeyspace())
 		},
 		set: func(client benchmarkClient) (string, error) {
-			return client.set(keyFromExistingKeyspace(), strings.Repeat("0", dataSize))
+			return client.set(keyFromExistingKeyspace(set), strings.Repeat("0", dataSize))
 		},
 	}
 
@@ -246,8 +248,15 @@ const (
 	sizeExistingKeyspace = 3000000
 )
 
-func keyFromExistingKeyspace() string {
-	randNum, err := rand.Int(rand.Reader, big.NewInt(sizeExistingKeyspace))
+func keyFromExistingKeyspace(action string) string {
+	if action == set {
+
+		if key_count < sizeNewKeyspace-1 {
+			key_count = key_count + 1
+		}
+		return fmt.Sprint(key_count)
+	}
+	randNum, err := rand.Int(rand.Reader, big.NewInt(key_count))
 	if err != nil {
 		log.Fatal("Error while generating random number for existing keyspace: ", err)
 	}

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -362,30 +362,29 @@ pub unsafe extern "C" fn command(
         let result: RedisResult<Option<CommandResponse>> = match value {
             Value::Nil => Ok(None),
             Value::SimpleString(text) => {
-                let vec = text.chars().map(|b| b as c_char).collect::<Vec<_>>();
+                let vec = text.into_bytes();
                 let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                command_response.string_value = vec_ptr;
+                command_response.string_value = vec_ptr as *mut c_char;
                 command_response.string_value_len = len;
                 Ok(Some(command_response))
             }
             Value::BulkString(text) => {
-                let vec = text.iter().map(|b| *b as c_char).collect::<Vec<_>>();
-                let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                command_response.string_value = vec_ptr;
+                let (vec_ptr, len) = convert_vec_to_pointer(text);
+                command_response.string_value = vec_ptr as *mut c_char;
                 command_response.string_value_len = len;
                 Ok(Some(command_response))
             }
             Value::VerbatimString { format: _, text } => {
-                let vec = text.chars().map(|b| b as c_char).collect::<Vec<_>>();
+                let vec = text.into_bytes();
                 let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                command_response.string_value = vec_ptr;
+                command_response.string_value = vec_ptr as *mut c_char;
                 command_response.string_value_len = len;
                 Ok(Some(command_response))
             }
             Value::Okay => {
-                let vec = "OK".chars().map(|b| b as c_char).collect::<Vec<_>>();
+                let vec = String::from("OK").into_bytes();
                 let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                command_response.string_value = vec_ptr;
+                command_response.string_value = vec_ptr as *mut c_char;
                 command_response.string_value_len = len;
                 Ok(Some(command_response))
             }


### PR DESCRIPTION
- The latency numbers for `get_existing` were off because initially it was not always fetching the existing keys. This PR fixes the same.
- For the response side optimisation, copying of `Value` received from server to `Rust vec` is avoided and the pointer is passed directly to Go.

Benchmarking command:
```
go run . -resultsFile gobenchmarks.json -dataSize "100 1000 10000" -concurrentTasks "10" -clients all -host localhost -port 6379 -clientCount "1"
```
