### PR TITLE
Go: Handling generic arrays instead of only string arrays

### DIFF
--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -33,11 +33,9 @@ func handleStringOrNullResponse(response *C.struct_CommandResponse) string {
 
 func handleStringArrayResponse(response *C.struct_CommandResponse) []string {
 	defer C.free_command_response(response)
-	var len []C.long
-	len = append(len, unsafe.Slice(response.array_elements_len, response.array_value_len)...)
 	var slice []string
-	for k, v := range unsafe.Slice(response.array_value, response.array_value_len) {
-		slice = append(slice, convertCharArrayToString(v, len[k]))
+	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
+		slice = append(slice, convertCharArrayToString(v.string_value, v.string_value_len))
 	}
 	return slice
 }


### PR DESCRIPTION
Initially the code was handling Array of Strings. With this change, Rust code will support all kinds of arrays.