### PR TITLE
Update Valkey version to 8.0.0 in test matrix and version checks

### DIFF
--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -5,6 +5,6 @@
   },
   {
     "type": "valkey",
-    "version": "8.0.0-rc1"
+    "version": "8.0.0"
   }
 ]

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -918,14 +918,10 @@ public class SharedCommandTests {
         assertEquals("", client.getrange(stringKey, -1, -3).get());
 
         // a redis bug, fixed in version 8: https://github.com/redis/redis/issues/13207
-        assertEquals(
-                SERVER_VERSION.isLowerThan("8.0.0") ? "T" : "",
-                client.getrange(stringKey, -200, -100).get());
+        assertEquals("T", client.getrange(stringKey, -200, -100).get());
 
         // empty key (returning null isn't implemented)
-        assertEquals(
-                SERVER_VERSION.isLowerThan("8.0.0") ? "" : null,
-                client.getrange(nonStringKey, 0, -1).get());
+        assertEquals("", client.getrange(nonStringKey, 0, -1).get());
 
         // non-string key
         assertEquals(1, client.lpush(nonStringKey, new String[] {"_"}).get());
@@ -955,14 +951,10 @@ public class SharedCommandTests {
         assertEquals(gs(""), client.getrange(stringKey, -1, -3).get());
 
         // a redis bug, fixed in version 8: https://github.com/redis/redis/issues/13207
-        assertEquals(
-                gs(SERVER_VERSION.isLowerThan("8.0.0") ? "T" : ""),
-                client.getrange(stringKey, -200, -100).get());
+        assertEquals(gs("T"), client.getrange(stringKey, -200, -100).get());
 
         // empty key (returning null isn't implemented)
-        assertEquals(
-                gs(SERVER_VERSION.isLowerThan("8.0.0") ? "" : null),
-                client.getrange(nonStringKey, 0, -1).get());
+        assertEquals(gs(""), client.getrange(nonStringKey, 0, -1).get());
 
         // non-string key
         assertEquals(1, client.lpush(nonStringKey, new GlideString[] {gs("_")}).get());
@@ -3279,7 +3271,7 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void scriptShow_test(BaseClient client) {
-        assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0"));
+        assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"));
 
         String code = "return '" + UUID.randomUUID().toString().substring(0, 5) + "'";
         Script script = new Script(code, false);
@@ -10423,7 +10415,7 @@ public class SharedCommandTests {
                             () -> client.bitcount(key1, 5, 30, BitmapIndexType.BIT).get());
             assertTrue(executionException.getCause() instanceof RequestException);
         }
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             assertEquals(26L, client.bitcount(key1, 0).get());
             assertEquals(4L, client.bitcount(key1, 5).get());
             assertEquals(0L, client.bitcount(key1, 80).get());
@@ -12557,7 +12549,7 @@ public class SharedCommandTests {
     @MethodSource("getClients")
     public void sort_with_pattern(BaseClient client) {
         if (client instanceof GlideClusterClient) {
-            assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0"), "This feature added in version 8");
+            assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"), "This feature added in version 8");
         }
         String setKey1 = "{setKey}1";
         String setKey2 = "{setKey}2";
@@ -12739,7 +12731,7 @@ public class SharedCommandTests {
     @MethodSource("getClients")
     public void sort_with_pattern_binary(BaseClient client) {
         if (client instanceof GlideClusterClient) {
-            assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0"), "This feature added in version 8");
+            assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"), "This feature added in version 8");
         }
 
         GlideString setKey1 = gs("{setKeyGs}1");
@@ -14291,7 +14283,7 @@ public class SharedCommandTests {
         assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> client.sscan(key1, "-1").get());
         } else {
@@ -14432,7 +14424,7 @@ public class SharedCommandTests {
         assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> client.sscan(key1, gs("-1")).get());
         } else {
@@ -14586,7 +14578,7 @@ public class SharedCommandTests {
         assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> client.zscan(key1, "-1").get());
         } else {
@@ -14710,7 +14702,7 @@ public class SharedCommandTests {
         assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
         assertTrue(ArrayUtils.getLength(result[resultCollectionIndex]) >= 0);
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
                     client.zscan(key1, initialCursor, ZScanOptions.builder().noScores(true).build()).get();
             assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
@@ -14788,7 +14780,7 @@ public class SharedCommandTests {
         assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> client.zscan(key1, gs("-1")).get());
         } else {
@@ -14917,7 +14909,7 @@ public class SharedCommandTests {
         assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
         assertTrue(ArrayUtils.getLength(result[resultCollectionIndex]) >= 0);
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
                     client
                             .zscan(key1, initialCursor, ZScanOptionsBinary.builder().noScores(true).build())
@@ -14993,7 +14985,7 @@ public class SharedCommandTests {
         assertDeepEquals(new String[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> client.hscan(key1, "-1").get());
         } else {
@@ -15104,7 +15096,7 @@ public class SharedCommandTests {
         assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
         assertTrue(ArrayUtils.getLength(result[resultCollectionIndex]) >= 0);
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
                     client.hscan(key1, initialCursor, HScanOptions.builder().noValues(true).build()).get();
             assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
@@ -15175,7 +15167,7 @@ public class SharedCommandTests {
         assertDeepEquals(new GlideString[] {}, result[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> client.hscan(key1, gs("-1")).get());
         } else {
@@ -15293,7 +15285,7 @@ public class SharedCommandTests {
         assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
         assertTrue(ArrayUtils.getLength(result[resultCollectionIndex]) >= 0);
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
                     client
                             .hscan(key1, initialCursor, HScanOptionsBinary.builder().noValues(true).build())

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -382,7 +382,7 @@ public class TransactionTestUtilities {
                 .hscan(hashKey2, "0")
                 .hscan(hashKey2, "0", HScanOptions.builder().count(20L).build());
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             transaction
                     .hscan(hashKey2, "0", HScanOptions.builder().count(20L).noValues(false).build())
                     .hscan(hashKey2, "0", HScanOptions.builder().count(20L).noValues(true).build());
@@ -417,7 +417,7 @@ public class TransactionTestUtilities {
                     }, // hscan(hashKey2, "0", HScanOptions.builder().count(20L).build());
                 };
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
                     concatenateArrays(
                             result,
@@ -670,7 +670,7 @@ public class TransactionTestUtilities {
                 .zrandmemberWithCountWithScores(zSetKey2, 1)
                 .zscan(zSetKey2, "0")
                 .zscan(zSetKey2, "0", ZScanOptions.builder().count(20L).build());
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             transaction
                     .zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).noScores(false).build())
                     .zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).noScores(true).build());
@@ -741,7 +741,7 @@ public class TransactionTestUtilities {
                     }, // zscan(zSetKey2, 0, ZScanOptions.builder().count(20L).build())
                 };
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             expectedResults =
                     concatenateArrays(
                             expectedResults,
@@ -1288,7 +1288,7 @@ public class TransactionTestUtilities {
                     .bitpos(key3, 1, 44, 50, BitmapIndexType.BIT);
         }
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             transaction.set(key4, "foobar").bitcount(key4, 0);
         }
 
@@ -1321,7 +1321,7 @@ public class TransactionTestUtilities {
                             });
         }
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             expectedResults =
                     concatenateArrays(
                             expectedResults,

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -311,7 +311,7 @@ public class ClusterTransactionTests {
             transaction.sortReadOnly(key1, SortOptions.builder().orderBy(DESC).build());
         }
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             transaction
                     .hset(key3, Map.of("name", "Alice", "age", "30"))
                     .hset(key4, Map.of("name", "Bob", "age", "25"))
@@ -358,7 +358,7 @@ public class ClusterTransactionTests {
                             );
         }
 
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             expectedResult =
                     concatenateArrays(
                             expectedResult,

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1055,7 +1055,7 @@ public class CommandTests {
         assertEquals(OK, clusterClient.flushall(ASYNC, route).get());
 
         var replicaRoute = new SlotKeyRoute("key", REPLICA);
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             // Since Valkey 8.0.0 flushall can run on replicas
             assertEquals(OK, clusterClient.flushall(route).get());
         } else {
@@ -1650,7 +1650,7 @@ public class CommandTests {
     public void fcall_readonly_function() {
         assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in version 7");
         assumeTrue(
-                !SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0"),
+                !SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"),
                 "Temporary disabeling this test on valkey 8");
 
         String libName = "fcall_readonly_function";
@@ -1708,7 +1708,7 @@ public class CommandTests {
     public void fcall_readonly_binary_function() {
         assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in version 7");
         assumeTrue(
-                !SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0"),
+                !SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"),
                 "Temporary disabeling this test on valkey 8");
 
         String libName = "fcall_readonly_function";

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1176,7 +1176,7 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> regularClient.scan("-1").get());
         } else {
@@ -1235,7 +1235,7 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             ExecutionException executionException =
                     assertThrows(ExecutionException.class, () -> regularClient.scan(gs("-1")).get());
         } else {
@@ -1303,7 +1303,7 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             final ScanOptions finalOptions = options;
             ExecutionException executionException =
                     assertThrows(
@@ -1392,7 +1392,7 @@ public class CommandTests {
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
-        if (SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")) {
+        if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             final ScanOptions finalOptions = options;
             ExecutionException executionException =
                     assertThrows(

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1297,7 +1297,7 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `getrange test_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster) => {
+            await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
                 const nonStringKey = uuidv4();
                 const valueEncoded = Buffer.from("This is a string");
@@ -1337,15 +1337,10 @@ export function runBaseTests(config: {
                 // incorrect range
                 expect(await client.getrange(key, -1, -3)).toEqual("");
 
-                // a bug fixed in version 8: https://github.com/redis/redis/issues/13207
-                expect(await client.getrange(key, -200, -100)).toEqual(
-                    cluster.checkIfServerVersionLessThan("8.0.0") ? "T" : "",
-                );
+                expect(await client.getrange(key, -200, -100)).toEqual("T");
 
                 // empty key (returning null isn't implemented)
-                expect(await client.getrange(nonStringKey, 0, -1)).toEqual(
-                    cluster.checkIfServerVersionLessThan("8.0.0") ? "" : null,
-                );
+                expect(await client.getrange(nonStringKey, 0, -1)).toEqual("");
 
                 // non-string key
                 expect(await client.lpush(nonStringKey, ["_"])).toEqual(1);
@@ -1604,7 +1599,7 @@ export function runBaseTests(config: {
                 expect(result[resultCursorIndex]).not.toEqual(initialCursor);
                 expect(result[resultCollectionIndex].length).toBeGreaterThan(0);
 
-                if (!cluster.checkIfServerVersionLessThan("7.9.0")) {
+                if (!cluster.checkIfServerVersionLessThan("8.0.0")) {
                     const result = await client.hscan(key1, initialCursor, {
                         noValues: true,
                     });
@@ -1645,7 +1640,7 @@ export function runBaseTests(config: {
                     expect(result2[resultCollectionIndex]).toEqual([]);
 
                     // Negative cursor
-                    if (cluster.checkIfServerVersionLessThan("7.9.0")) {
+                    if (cluster.checkIfServerVersionLessThan("8.0.0")) {
                         result = await client.hscan(key1, "-1");
                         expect(result[resultCursorIndex]).toEqual(
                             initialCursor,
@@ -4194,7 +4189,7 @@ export function runBaseTests(config: {
         `script show test_%p`,
         async (protocol) => {
             await runTest(async (client: BaseClient, cluster) => {
-                if (cluster.checkIfServerVersionLessThan("7.9.0")) {
+                if (cluster.checkIfServerVersionLessThan("8.0.0")) {
                     return;
                 }
 
@@ -8921,7 +8916,7 @@ export function runBaseTests(config: {
                     ).rejects.toThrow(RequestError);
                 }
 
-                if (cluster.checkIfServerVersionLessThan("7.9.0")) {
+                if (cluster.checkIfServerVersionLessThan("8.0.0")) {
                     await expect(
                         client.bitcount(key1, {
                             start: 2,
@@ -9755,7 +9750,7 @@ export function runBaseTests(config: {
                     expect(result[resultCollectionIndex]).toEqual([]);
 
                     // Negative cursor
-                    if (cluster.checkIfServerVersionLessThan("7.9.0")) {
+                    if (cluster.checkIfServerVersionLessThan("8.0.0")) {
                         result = await client.zscan(key1, "-1");
                         expect(result[resultCursorIndex]).toEqual(
                             initialCursor,
@@ -9869,7 +9864,7 @@ export function runBaseTests(config: {
                         result[resultCollectionIndex].length,
                     ).toBeGreaterThan(0);
 
-                    if (!cluster.checkIfServerVersionLessThan("7.9.0")) {
+                    if (!cluster.checkIfServerVersionLessThan("8.0.0")) {
                         const result = await client.zscan(key1, initialCursor, {
                             noScores: true,
                         });
@@ -12079,7 +12074,7 @@ export function runBaseTests(config: {
             await runTest(
                 async (client: BaseClient, cluster: ValkeyCluster) => {
                     if (
-                        cluster.checkIfServerVersionLessThan("7.9.0") &&
+                        cluster.checkIfServerVersionLessThan("8.0.0") &&
                         client instanceof GlideClusterClient
                     ) {
                         return;

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -812,7 +812,7 @@ export async function transactionTest(
     baseTransaction.hscan(key4, "0");
     responseData.push(['hscan(key4, "0")', ["0", [field, value]]]);
 
-    if (gte(version, "7.9.0")) {
+    if (gte(version, "8.0.0")) {
         baseTransaction.hscan(key4, "0", { noValues: false });
         responseData.push([
             'hscan(key4, "0", {noValues: false})',
@@ -1081,7 +1081,7 @@ export async function transactionTest(
     baseTransaction.zscan(key12, "0");
     responseData.push(['zscan(key12, "0")', ["0", ["one", "1", "two", "2"]]]);
 
-    if (gte(version, "7.9.0")) {
+    if (gte(version, "8.0.0")) {
         baseTransaction.zscan(key12, "0", { noScores: false });
         responseData.push([
             'zscan(key12, "0", {noScores: false})',
@@ -1463,7 +1463,7 @@ export async function transactionTest(
         ]);
     }
 
-    if (gte(version, "7.9.0")) {
+    if (gte(version, "8.0.0")) {
         baseTransaction.set(key17, "foobar");
         responseData.push(['set(key17, "foobar")', "OK"]);
         baseTransaction.bitcount(key17, {

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -539,14 +539,9 @@ class TestCommands:
         # incorrect range
         assert await glide_client.getrange(key, -1, -3) == b""
 
-        # a redis bug, fixed in version 8: https://github.com/redis/redis/issues/13207
-        if await check_if_server_version_lt(glide_client, "8.0.0"):
-            assert await glide_client.getrange(key, -200, -100) == value[0].encode()
-        else:
-            assert await glide_client.getrange(key, -200, -100) == b""
+        assert await glide_client.getrange(key, -200, -100) == value[0].encode()
 
-        if await check_if_server_version_lt(glide_client, "8.0.0"):
-            assert await glide_client.getrange(non_string_key, 0, -1) == b""
+        assert await glide_client.getrange(non_string_key, 0, -1) == b""
 
         # non-string key
         assert await glide_client.lpush(non_string_key, ["_"]) == 1
@@ -4720,7 +4715,7 @@ class TestCommands:
     ):
         if isinstance(
             glide_client, GlideClusterClient
-        ) and await check_if_server_version_lt(glide_client, "7.9.0"):
+        ) and await check_if_server_version_lt(glide_client, "8.0.0"):
             return pytest.mark.skip(
                 reason=f"Valkey version required in cluster mode>= 8.0.0"
             )
@@ -7133,7 +7128,7 @@ class TestCommands:
                     set_key, OffsetOptions(1, 1, BitmapIndexType.BIT)
                 )
 
-        if await check_if_server_version_lt(glide_client, "7.9.0"):
+        if await check_if_server_version_lt(glide_client, "8.0.0"):
             # exception thrown optional end was implemented after 8.0.0
             with pytest.raises(RequestError):
                 await glide_client.bitcount(
@@ -9835,7 +9830,7 @@ class TestClusterRoutes:
         assert result[result_collection_index] == []
 
         # Negative cursor
-        if await check_if_server_version_lt(glide_client, "7.9.0"):
+        if await check_if_server_version_lt(glide_client, "8.0.0"):
             result = await glide_client.sscan(key1, "-1")
             assert result[result_cursor_index] == initial_cursor.encode()
             assert result[result_collection_index] == []
@@ -9949,7 +9944,7 @@ class TestClusterRoutes:
         assert result[result_collection_index] == []
 
         # Negative cursor
-        if await check_if_server_version_lt(glide_client, "7.9.0"):
+        if await check_if_server_version_lt(glide_client, "8.0.0"):
             result = await glide_client.zscan(key1, "-1")
             assert result[result_cursor_index] == initial_cursor.encode()
             assert result[result_collection_index] == []
@@ -10025,7 +10020,7 @@ class TestClusterRoutes:
         assert len(result[result_collection_index]) >= 0
 
         # Test no_scores option
-        if not await check_if_server_version_lt(glide_client, "7.9.0"):
+        if not await check_if_server_version_lt(glide_client, "8.0.0"):
             result = await glide_client.zscan(key1, initial_cursor, no_scores=True)
             assert result[result_cursor_index] != b"0"
             values_array = cast(List[bytes], result[result_collection_index])
@@ -10076,7 +10071,7 @@ class TestClusterRoutes:
         assert result[result_collection_index] == []
 
         # Negative cursor
-        if await check_if_server_version_lt(glide_client, "7.9.0"):
+        if await check_if_server_version_lt(glide_client, "8.0.0"):
             result = await glide_client.hscan(key1, "-1")
             assert result[result_cursor_index] == initial_cursor.encode()
             assert result[result_collection_index] == []
@@ -10152,7 +10147,7 @@ class TestClusterRoutes:
         assert len(result[result_collection_index]) >= 0
 
         # Test no_values option
-        if not await check_if_server_version_lt(glide_client, "7.9.0"):
+        if not await check_if_server_version_lt(glide_client, "8.0.0"):
             result = await glide_client.hscan(key1, initial_cursor, no_values=True)
             assert result[result_cursor_index] != b"0"
             values_array = cast(List[bytes], result[result_collection_index])
@@ -10487,7 +10482,7 @@ class TestScripts:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_script_show(self, glide_client: TGlideClient):
-        min_version = "7.9.0"
+        min_version = "8.0.0"
         if await check_if_server_version_lt(glide_client, min_version):
             return pytest.mark.skip(reason=f"Valkey version required >= {min_version}")
 

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -308,7 +308,7 @@ async def transaction_test(
     args.append([b"0", [key3.encode(), b"10.5"]])
     transaction.hscan(key4, "0", match="*", count=10)
     args.append([b"0", [key3.encode(), b"10.5"]])
-    if not await check_if_server_version_lt(glide_client, "7.9.0"):
+    if not await check_if_server_version_lt(glide_client, "8.0.0"):
         transaction.hscan(key4, "0", match="*", count=10, no_values=True)
         args.append([b"0", [key3.encode()]])
     transaction.hrandfield(key4)
@@ -463,7 +463,7 @@ async def transaction_test(
     args.append([b"0", [b"three", b"3"]])
     transaction.zscan(key8, "0", match="*", count=20)
     args.append([b"0", [b"three", b"3"]])
-    if not await check_if_server_version_lt(glide_client, "7.9.0"):
+    if not await check_if_server_version_lt(glide_client, "8.0.0"):
         transaction.zscan(key8, "0", match="*", count=20, no_scores=True)
         args.append([b"0", [b"three"]])
     transaction.zpopmax(key8)
@@ -561,7 +561,7 @@ async def transaction_test(
         transaction.bitpos_interval(key20, 1, 44, 50, BitmapIndexType.BIT)
         args.append(46)
 
-    if not await check_if_server_version_lt(glide_client, "7.9.0"):
+    if not await check_if_server_version_lt(glide_client, "8.0.0"):
         transaction.set(key20, "foobar")
         args.append(OK)
         transaction.bitcount(key20, OffsetOptions(0))
@@ -720,7 +720,7 @@ async def transaction_test(
         alpha=True,
     )
     args.append(4)
-    if not await check_if_server_version_lt(glide_client, "7.9.0"):
+    if not await check_if_server_version_lt(glide_client, "8.0.0"):
         transaction.hset(f"{{{keyslot}}}:1", {"name": "Alice", "age": "30"})
         args.append(2)
         transaction.hset(f"{{{keyslot}}}:2", {"name": "Bob", "age": "25"})


### PR DESCRIPTION
instead of testing with valkey8 rc on our ci, we will now test with valkey 8
inn valkey 8 rc the valkey version was 7.9.240, so all the version checks needs to be updated