### PR TITLE
Node: Fixed missing exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Node: Fixed missing exports ([#2301](https://github.com/valkey-io/valkey-glide/pull/2301))
 * Node: Use `options` struct for all optional arguments ([#2287](https://github.com/valkey-io/valkey-glide/pull/2287))
 * Node: Added `invokeScript` API with routing for cluster client ([#2284](https://github.com/valkey-io/valkey-glide/pull/2284))
 * Java: Expanded tests for converting non UTF-8 bytes to Strings ([#2286](https://github.com/valkey-io/valkey-glide/pull/2286))

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -49,7 +49,7 @@ async function sendPingToRandomNodeInCluster() {
         clientName: "test_cluster_client",
     });
     // The empty array signifies that there are no additional arguments.
-    const pong = await client.customCommand(["PING"], "randomNode");
+    const pong = await client.customCommand(["PING"], { route: "randomNode" });
     console.log(pong);
     await send_set_and_get(client);
     client.close();

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,7 +1,7 @@
 {
     "type": "module",
     "dependencies": {
-        "@valkey/valkey-glide": "^1.0.0",
+        "@valkey/valkey-glide": "^1.1.0",
         "@types/node": "^20.4.8"
     },
     "devDependencies": {

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -192,6 +192,12 @@ function initialize() {
         createLeakedMap,
         createLeakedString,
         parseInfoResponse,
+        Script,
+        ObjectType,
+        ClusterScanCursor,
+        BaseClientConfiguration,
+        GlideClusterClientConfiguration,
+        LevelOptions,
     } = nativeBinding;
 
     module.exports = {
@@ -305,6 +311,12 @@ function initialize() {
         createLeakedMap,
         createLeakedString,
         parseInfoResponse,
+        Script,
+        ObjectType,
+        ClusterScanCursor,
+        BaseClientConfiguration,
+        GlideClusterClientConfiguration,
+        LevelOptions,
     };
 
     globalObject = Object.assign(global, nativeBinding);

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -12,7 +12,7 @@ const LEVEL = new Map<LevelOptions | undefined, Level | undefined>([
     ["trace", Level.Trace],
     [undefined, undefined],
 ]);
-type LevelOptions = "error" | "warn" | "info" | "debug" | "trace";
+export type LevelOptions = "error" | "warn" | "info" | "debug" | "trace";
 
 /*
  * A singleton class that allows logging which is consistent with logs from the internal rust core.


### PR DESCRIPTION
Fixed missing exports:
- `Script`
- `ObjectType`
- `ClusterScanCursor`
- `BaseClientConfiguration`
- `GlideClusterClientConfiguration`
- `LevelOptions`
 
This PR will resolve issue https://github.com/valkey-io/valkey-glide/issues/2307