### PR TITLE
Replace google-api-python-client by protobuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 * Java, Node, Python: Add NOSCORES option to ZSCAN & NOVALUES option to HSCAN (Valkey-8) ([#2174](https://github.com/valkey-io/valkey-glide/pull/2174))
 * Node: Add SCAN command ([#2257](https://github.com/valkey-io/valkey-glide/pull/2257))
 * Java: Add Script commands ([#2261](https://github.com/valkey-io/valkey-glide/pull/2261))
+* Python: Replace google-api-python-client with protobuf ([#2304](https://github.com/valkey-io/valkey-glide/pull/2304))
 
 #### Breaking Changes
 * Java: Update INFO command ([#2274](https://github.com/valkey-io/valkey-glide/pull/2274))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.8"
 dependencies = [
     "async-timeout>=4.0.2",
     "typing-extensions>=4.8.0",
-    "google-api-python-client==2.85.0"
+    "protobuf>=3.20"
 ]
 classifiers = [
     "Topic :: Database",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,4 @@
 async-timeout==4.0.2
-google-api-python-client==2.85.0
 maturin==0.13.0
 protobuf==3.20.*
 pytest==7.1.2


### PR DESCRIPTION
Let me prefix that one by saying that I haven't been testing it extensively, it just seems to be working as expected.

This PR would fix https://github.com/valkey-io/valkey-glide/issues/2298. Can you just trigger the test suite and see what happens? They seem to be passing fine there: https://github.com/Rafiot/valkey-glide/actions/runs/10905533315