### PR TITLE
Node: fix pubsub IT

### DIFF
--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -5,6 +5,6 @@
   },
   {
     "type": "valkey",
-    "version": "8.0.0"
+    "version": "8.0.0-rc1"
   }
 ]

--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -5,6 +5,6 @@
   },
   {
     "type": "valkey",
-    "version": "8.0.0-rc1"
+    "version": "8.0.0"
   }
 ]

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -4018,7 +4018,7 @@ describe("PubSub", () => {
      *
      * @param clusterMode - Indicates if the test should be run in cluster mode.
      */
-    it.each([true, false])(
+    it.each([true])(
         "test pubsub numsub and shardnumsub separation_%p",
         async (clusterMode) => {
             //const clusterMode = false;
@@ -4070,17 +4070,13 @@ describe("PubSub", () => {
                 });
 
                 // Test pubsubShardnumsub
-                if (clusterMode) {
-                    const shardSubscribers = await (
-                        client2 as GlideClusterClient
-                    ).pubsubShardNumSub([regularChannel, shardChannel]);
-                    expect(
-                        convertGlideRecordToRecord(shardSubscribers),
-                    ).toEqual({
-                        [regularChannel]: 0,
-                        [shardChannel]: 2,
-                    });
-                }
+                const shardSubscribers = await (
+                    client2 as GlideClusterClient
+                ).pubsubShardNumSub([regularChannel, shardChannel]);
+                expect(convertGlideRecordToRecord(shardSubscribers)).toEqual({
+                    [regularChannel]: 0,
+                    [shardChannel]: 2,
+                });
             } finally {
                 if (client1) {
                     await clientCleanup(client1, pubSub!);


### PR DESCRIPTION
Required by #2296
Removing standalone client from a test which checks `numsub` and `shardnumsub` together, because shard commands available on cluster only. Those commands are checked in other tests.

fixes: https://github.com/valkey-io/valkey-glide/issues/2327