### PR TITLE
Node: Fix imports for `Script` and `ClusterScanCursor`.

### DIFF
--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -2,8 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { ClusterScanCursor } from "glide-rs";
-import { Script } from "index";
+import { ClusterScanCursor, Script } from "glide-rs";
 import * as net from "net";
 import {
     BaseClient,

--- a/node/tests/ScanTest.test.ts
+++ b/node/tests/ScanTest.test.ts
@@ -3,9 +3,9 @@
  */
 
 import { afterAll, afterEach, beforeAll, describe } from "@jest/globals";
-import { ClusterScanCursor } from "glide-rs";
 import { v4 as uuidv4 } from "uuid";
 import {
+    ClusterScanCursor,
     Decoder,
     GlideClient,
     GlideClusterClient,


### PR DESCRIPTION
Reorganize imports - no real change for a user.