### PR TITLE
Node: fix xinfogroups; fix lrem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Node: Fix binary variant for xinfogroups and lrem ([#2324](https://github.com/valkey-io/valkey-glide/pull/2324))
 * Node: Use `options` struct for all optional arguments ([#2287](https://github.com/valkey-io/valkey-glide/pull/2287))
 * Node: Added `invokeScript` API with routing for cluster client ([#2284](https://github.com/valkey-io/valkey-glide/pull/2284))
 * Java: Expanded tests for converting non UTF-8 bytes to Strings ([#2286](https://github.com/valkey-io/valkey-glide/pull/2286))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -5523,7 +5523,7 @@ export class BaseClient {
      * ```
      */
     public async xinfoGroups(
-        key: string,
+        key: GlideString,
         options?: DecoderOption,
     ): Promise<Record<string, GlideString | number | null>[]> {
         return this.createWritePromise<

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2694,7 +2694,7 @@ export function createXInfoStream(
 }
 
 /** @internal */
-export function createXInfoGroups(key: string): command_request.Command {
+export function createXInfoGroups(key: GlideString): command_request.Command {
     return createCommand(RequestType.XInfoGroups, [key]);
 }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1252,7 +1252,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Command Response - the number of the removed elements.
      * If `key` does not exist, 0 is returned.
      */
-    public lrem(key: GlideString, count: number, element: string): T {
+    public lrem(key: GlideString, count: number, element: GlideString): T {
         return this.addAndReturn(createLRem(key, count, element));
     }
 
@@ -2651,7 +2651,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *     attributes of a consumer group for the stream at `key`.
      *     The response comes in format `GlideRecord<GlideString | number | null>[]`, see {@link GlideRecord}.
      */
-    public xinfoGroups(key: string): T {
+    public xinfoGroups(key: GlideString): T {
         return this.addAndReturn(createXInfoGroups(key));
     }
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -10757,7 +10757,7 @@ export function runBaseTests(config: {
                 ).toEqual("OK");
 
                 // one empty group exists
-                expect(await client.xinfoGroups(key)).toEqual(
+                expect(await client.xinfoGroups(Buffer.from(key))).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
                               {


### PR DESCRIPTION
Add support for: 
- The xinfoGroups key argument should take binary keys. 
- lrem for transactions members argument should take binary keys. 

Fixes: https://github.com/valkey-io/valkey-glide/issues/2325