### PR TITLE
Fix node examples

### DIFF
--- a/examples/node/README.MD
+++ b/examples/node/README.MD
@@ -1,38 +1,19 @@
-## Pre-requirements
--   GCC
--   pkg-config
--   protobuf-compiler (protoc)
--   openssl
--   libssl-dev
-
-Installation for ubuntu:
-`sudo apt install -y gcc pkg-config protobuf-compiler openssl libssl-dev python3`
-
-### node 16 (or newer)
-
-This is required for the NodeJS wrapper, and for running benchmarks.
-
+### Install node 16 (or newer)
 ```
 curl -s https://deb.nodesource.com/setup_16.x | sudo bash
 apt-get install nodejs npm
 npm i -g npm@8
 ```
 
-## Build
-To build GLIDE's Node client, run (on unix based systems):
+## Install GLIDE package and build the example
 ```
-cd valkey-glide/node
-git submodule update --init --recursive
-npm install
-rm -rf build-ts
-npm run build:release
 cd valkey-glide/examples/node
 npm install
 npx tsc
 ```
 
 ## Run
-To run the example:
+To run the example (make sure redis/valkey server is available at the address used in the example):
 ```
 cd valkey-glide/examples/node
 node index.js

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -4,7 +4,7 @@
 
 import { GlideClient, GlideClusterClient, Logger } from "@valkey/valkey-glide";
 
-async function sendPingToNode() {
+async function sendPingToStandAloneNode() {
     // When in Redis is in standalone mode, add address of the primary node, and any replicas you'd like to be able to read from.
     const addresses = [
         {
@@ -64,6 +64,9 @@ function setConsoleLogger() {
 }
 
 setFileLogger();
-await sendPingToNode();
 setConsoleLogger();
-await sendPingToRandomNodeInCluster();
+// Enable for standalone mode
+await sendPingToStandAloneNode();
+
+// Enable for cluster mode
+// await sendPingToRandomNodeInCluster();

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,7 +1,7 @@
 {
     "type": "module",
     "dependencies": {
-        "@valkey/valkey-glide": "^1.1.0",
+        "@valkey/valkey-glide": "latest",
         "@types/node": "^20.4.8"
     },
     "devDependencies": {


### PR DESCRIPTION
 1. Use the latest version from npm.
 2. Clear up the doc.
 3. Comment out the cluster mode in the example, leaving standalone mode by default.