### PR TITLE
Java: move pubsub IT to another suite

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -132,6 +132,56 @@ jobs:
                       benchmarks/results/**
                       java/client/build/reports/spotbugs/**
 
+    test-pubsub:
+        needs: get-matrices
+        timeout-minutes: 35
+        strategy:
+            fail-fast: false
+            matrix:
+                java: ${{ fromJson(needs.get-matrices.outputs.version-matrix-output) }}
+                engine: ${{ fromJson(needs.get-matrices.outputs.engine-matrix-output) }}
+                host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
+        runs-on: ${{ matrix.host.RUNNER }}
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+
+            - name: Set up JDK ${{ matrix.java }}
+              uses: actions/setup-java@v4
+              with:
+                  distribution: "temurin"
+                  java-version: ${{ matrix.java }}
+
+            - name: Install shared software dependencies
+              uses: ./.github/workflows/install-shared-dependencies
+              with:
+                  os: ${{ matrix.host.OS }}
+                  target: ${{ matrix.host.TARGET }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  engine-version: ${{ matrix.engine.version }}
+
+            - name: Install protoc (protobuf)
+              uses: arduino/setup-protoc@v3
+              with:
+                  version: "29.1"
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Test pubsub
+              working-directory: java
+              run: ./gradlew :integTest:pubsubTest
+
+            - name: Upload test & spotbugs reports
+              if: always()
+              continue-on-error: true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: test-reports-pubsub-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  path: |
+                      java/integTest/build/reports/**
+                      utils/clusters/**
+
     get-containers:
         runs-on: ubuntu-latest
         if: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -145,8 +145,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              with:
-                  submodules: recursive
 
             - name: Set up JDK ${{ matrix.java }}
               uses: actions/setup-java@v4

--- a/java/DEVELOPER.md
+++ b/java/DEVELOPER.md
@@ -227,6 +227,12 @@ To run end-to-end tests, use the following command:
 ./gradlew :integTest:test
 ```
 
+To run integration tests for pubsub feature:
+
+```bash
+./gradlew :integTest:pubsubTest
+```
+
 IT suite start the server for testing - standalone and cluster installation using `cluster_manager` script.
 By default, it starts servers without TLS; to activate TLS add `-Dtls=true` to the command line:
 ```bash

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -106,6 +106,8 @@ tasks.register('startClusterForAz') {
     }
 }
 
+tasks.register('beforeTests') {}
+tasks.register('afterTests') {}
 tasks.register('startStandalone') {
     doLast {
         if (System.getProperty("standalone-endpoints") == null) {
@@ -125,15 +127,19 @@ tasks.register('startStandalone') {
     }
 }
 
-test.dependsOn 'stopAllBeforeTests'
+beforeTests.dependsOn 'stopAllBeforeTests'
 stopAllBeforeTests.finalizedBy 'clearDirs'
 clearDirs.finalizedBy 'startStandalone'
 clearDirs.finalizedBy 'startCluster'
 clearDirs.finalizedBy 'startClusterForAz'
-test.finalizedBy 'stopAllAfterTests'
+afterTests.finalizedBy 'stopAllAfterTests'
 compileTestJava.dependsOn ':client:publishToMavenLocal'
 
 tasks.withType(Test) {
+    useJUnitPlatform()
+    dependsOn 'beforeTests'
+    finalizedBy 'afterTests'
+
     doFirst {
         systemProperty 'test.server.standalone', standaloneHosts
         systemProperty 'test.server.cluster', clusterHosts
@@ -157,7 +163,14 @@ tasks.withType(Test) {
 
 test {
     filter {
+        excludeTestsMatching 'glide.PubSubTests'
         excludeTestsMatching 'glide.modules.*'
+    }
+}
+
+tasks.register('pubsubTest', Test) {
+    filter {
+        includeTestsMatching 'glide.PubSubTests'
     }
 }
 


### PR DESCRIPTION
Now `./gradlew build` and `./gradlew :integTest:test` don't include pubsub IT.
To run it do `./gradlew :integTest:pubsubTest`