### PR TITLE
Added inflight_requests_limit

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -13,6 +13,8 @@ use redis::cluster_routing::{Routable, RoutingInfo, SingleNodeRoutingInfo};
 use redis::{Cmd, ErrorKind, ObjectType, PushInfo, RedisError, RedisResult, ScanStateRC, Value};
 pub use standalone_client::StandaloneClient;
 use std::io;
+use std::sync::atomic::{AtomicIsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 pub use types::*;
 
@@ -29,6 +31,15 @@ pub const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2
 pub const DEFAULT_PERIODIC_TOPOLOGY_CHECKS_INTERVAL: Duration = Duration::from_secs(60);
 pub const INTERNAL_CONNECTION_TIMEOUT: Duration = Duration::from_millis(250);
 pub const FINISHED_SCAN_CURSOR: &str = "finished";
+// The value of 1000 for the maximum number of inflight requests is determined based on Little's Law in queuing theory:
+//
+// Expected maximum request rate: 50,000 requests/second
+// Expected response time: 1 millisecond
+//
+// According to Little's Law, the maximum number of inflight requests required to fully utilize the maximum request rate is:
+//   (50,000 requests/second) × (1 millisecond / 1000 milliseconds) = 50 requests
+//
+// The value of 1000 provides a buffer for bursts while still allowing full utilization of the maximum request rate.
 pub const DEFAULT_MAX_INFLIGHT_REQUESTS: u32 = 1000;
 
 // The connection check interval is currently not exposed to the user via ConnectionRequest,
@@ -103,7 +114,8 @@ pub enum ClientWrapper {
 pub struct Client {
     internal_client: ClientWrapper,
     request_timeout: Duration,
-    inflight_requests_limit: u32,
+    // Setting this counter to limit the inflight requests, in case of any queue is blocked, so we return error to the customer.
+    inflight_requests_allowed: Arc<AtomicIsize>,
 }
 
 async fn run_with_timeout<T>(
@@ -412,8 +424,33 @@ impl Client {
         }
     }
 
-    pub fn get_inflight_requests_limit(&self) -> u32 {
-        self.inflight_requests_limit
+    pub fn reserve_inflight_request(&self) -> bool {
+        // We use this approach of checking the `inflight_requests_allowed` value
+        // twice, before and after decrementing, to prevent it from reaching negative
+        // values. Allowing the `inflight_requests_allowed` value to go below zero
+        // could lead to a race condition where tasks might not be able to run even
+        // when there are available slots.
+        if self.inflight_requests_allowed.load(Ordering::SeqCst) <= 0 {
+            false
+        } else {
+            // The value is being checked again because it might have changed
+            // during the intervening period since the load by other tasks.
+            if self
+                .inflight_requests_allowed
+                .fetch_sub(1, Ordering::SeqCst)
+                <= 0
+            {
+                self.inflight_requests_allowed
+                    .fetch_add(1, Ordering::SeqCst);
+                return false;
+            }
+            true
+        }
+    }
+
+    pub fn release_inflight_request(&self) -> isize {
+        self.inflight_requests_allowed
+            .fetch_add(1, Ordering::SeqCst)
     }
 }
 
@@ -630,6 +667,9 @@ impl Client {
         let inflight_requests_limit = request
             .inflight_requests_limit
             .unwrap_or(DEFAULT_MAX_INFLIGHT_REQUESTS);
+        let inflight_requests_allowed = Arc::new(AtomicIsize::new(
+            inflight_requests_limit.try_into().unwrap(),
+        ));
         tokio::time::timeout(DEFAULT_CLIENT_CREATION_TIMEOUT, async move {
             let internal_client = if request.cluster_mode_enabled {
                 let client = create_cluster_client(request, push_sender)
@@ -647,7 +687,7 @@ impl Client {
             Ok(Self {
                 internal_client,
                 request_timeout,
-                inflight_requests_limit,
+                inflight_requests_allowed,
             })
         })
         .await

--- a/glide-core/src/client/types.rs
+++ b/glide-core/src/client/types.rs
@@ -23,6 +23,7 @@ pub struct ConnectionRequest {
     pub connection_retry_strategy: Option<ConnectionRetryStrategy>,
     pub periodic_checks: Option<PeriodicCheck>,
     pub pubsub_subscriptions: Option<redis::PubSubSubscriptionInfo>,
+    pub inflight_requests_limit: Option<u32>,
 }
 
 pub struct AuthenticationInfo {
@@ -187,6 +188,8 @@ impl From<protobuf::ConnectionRequest> for ConnectionRequest {
             pubsub_subscriptions = Some(redis_pubsub);
         }
 
+        let inflight_requests_limit = none_if_zero(value.inflight_requests_limit);
+
         ConnectionRequest {
             read_from,
             client_name,
@@ -200,6 +203,7 @@ impl From<protobuf::ConnectionRequest> for ConnectionRequest {
             connection_retry_strategy,
             periodic_checks,
             pubsub_subscriptions,
+            inflight_requests_limit,
         }
     }
 }

--- a/glide-core/src/protobuf/connection_request.proto
+++ b/glide-core/src/protobuf/connection_request.proto
@@ -69,6 +69,7 @@ message ConnectionRequest {
         PeriodicChecksDisabled periodic_checks_disabled = 12;
     }
     PubSubSubscriptions pubsub_subscriptions = 13;
+    uint32 inflight_requests_limit = 14;
 }
 
 message ConnectionRetryStrategy {

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -496,7 +496,7 @@ fn handle_request(
             |current_inflight| {
                 if current_inflight as u32 >= client.get_inflight_requests_limit() {
                     // In case counter reached the limit, don't update and return Err.
-                    return None;
+                    None
                 } else {
                     Some(current_inflight + 1)
                 }

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -24,8 +24,6 @@ use redis::cluster_routing::{ResponsePolicy, Routable};
 use redis::{Cmd, PushInfo, RedisError, ScanStateRC, Value};
 use std::cell::Cell;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 use std::{env, str};
 use std::{io, thread};
 use thiserror::Error;
@@ -478,111 +476,88 @@ fn get_route(
     }
 }
 
-fn handle_request(
-    request: CommandRequest,
-    client: Client,
-    writer: Rc<Writer>,
-    inflight_counter: Arc<AtomicUsize>,
-) {
-    let inflight_requests_clone = inflight_counter.clone();
+fn handle_request(request: CommandRequest, client: Client, writer: Rc<Writer>) {
     task::spawn_local(async move {
-        let result;
-        let updated_inflight_counter: bool;
+        let mut updated_inflight_counter = true;
+        let client_clone = client.clone();
 
-        // Check if already reached inflight request limit
-        let fetched_inflight = inflight_requests_clone.fetch_update(
-            Ordering::AcqRel,
-            Ordering::Acquire,
-            |current_inflight| {
-                if current_inflight as u32 >= client.get_inflight_requests_limit() {
-                    // In case counter reached the limit, don't update and return Err.
-                    None
-                } else {
-                    Some(current_inflight + 1)
+        let result = match client.reserve_inflight_request() {
+            false => {
+                updated_inflight_counter = false;
+                Err(ClientUsageError::User(
+                    "Reached maximum inflight requests".to_string(),
+                ))
+            }
+            true => match request.command {
+                Some(action) => match action {
+                    command_request::Command::ClusterScan(cluster_scan_command) => {
+                        cluster_scan(cluster_scan_command, client).await
+                    }
+                    command_request::Command::SingleCommand(command) => {
+                        match get_redis_command(&command) {
+                            Ok(cmd) => match get_route(request.route.0, Some(&cmd)) {
+                                Ok(routes) => send_command(cmd, client, routes).await,
+                                Err(e) => Err(e),
+                            },
+                            Err(e) => Err(e),
+                        }
+                    }
+                    command_request::Command::Transaction(transaction) => {
+                        match get_route(request.route.0, None) {
+                            Ok(routes) => send_transaction(transaction, client, routes).await,
+                            Err(e) => Err(e),
+                        }
+                    }
+                    command_request::Command::ScriptInvocation(script) => {
+                        match get_route(request.route.0, None) {
+                            Ok(routes) => {
+                                invoke_script(
+                                    script.hash,
+                                    Some(script.keys),
+                                    Some(script.args),
+                                    client,
+                                    routes,
+                                )
+                                .await
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                    command_request::Command::ScriptInvocationPointers(script) => {
+                        let keys = script
+                            .keys_pointer
+                            .map(|pointer| *unsafe { Box::from_raw(pointer as *mut Vec<Bytes>) });
+                        let args = script
+                            .args_pointer
+                            .map(|pointer| *unsafe { Box::from_raw(pointer as *mut Vec<Bytes>) });
+                        match get_route(request.route.0, None) {
+                            Ok(routes) => {
+                                invoke_script(script.hash, keys, args, client, routes).await
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                },
+                None => {
+                    log_debug(
+                        "received error",
+                        format!(
+                            "Received empty request for callback {}",
+                            request.callback_idx
+                        ),
+                    );
+                    Err(ClientUsageError::Internal(
+                        "Received empty request".to_string(),
+                    ))
                 }
             },
-        );
+        };
 
-        match fetched_inflight {
-            Err(_) => {
-                updated_inflight_counter = false;
-                result = Err(ClientUsageError::User(
-                    "Reached maximum inflight requests".to_string(),
-                ));
-            }
-            Ok(_) => {
-                updated_inflight_counter = true;
-                result = match request.command {
-                    Some(action) => match action {
-                        command_request::Command::ClusterScan(cluster_scan_command) => {
-                            cluster_scan(cluster_scan_command, client).await
-                        }
-                        command_request::Command::SingleCommand(command) => {
-                            match get_redis_command(&command) {
-                                Ok(cmd) => match get_route(request.route.0, Some(&cmd)) {
-                                    Ok(routes) => send_command(cmd, client, routes).await,
-                                    Err(e) => Err(e),
-                                },
-                                Err(e) => Err(e),
-                            }
-                        }
-                        command_request::Command::Transaction(transaction) => {
-                            match get_route(request.route.0, None) {
-                                Ok(routes) => send_transaction(transaction, client, routes).await,
-                                Err(e) => Err(e),
-                            }
-                        }
-                        command_request::Command::ScriptInvocation(script) => {
-                            match get_route(request.route.0, None) {
-                                Ok(routes) => {
-                                    invoke_script(
-                                        script.hash,
-                                        Some(script.keys),
-                                        Some(script.args),
-                                        client,
-                                        routes,
-                                    )
-                                    .await
-                                }
-                                Err(e) => Err(e),
-                            }
-                        }
-                        command_request::Command::ScriptInvocationPointers(script) => {
-                            let keys = script.keys_pointer.map(|pointer| *unsafe {
-                                Box::from_raw(pointer as *mut Vec<Bytes>)
-                            });
-                            let args = script.args_pointer.map(|pointer| *unsafe {
-                                Box::from_raw(pointer as *mut Vec<Bytes>)
-                            });
-                            match get_route(request.route.0, None) {
-                                Ok(routes) => {
-                                    invoke_script(script.hash, keys, args, client, routes).await
-                                }
-                                Err(e) => Err(e),
-                            }
-                        }
-                    },
-                    None => {
-                        log_debug(
-                            "received error",
-                            format!(
-                                "Received empty request for callback {}",
-                                request.callback_idx
-                            ),
-                        );
-                        Err(ClientUsageError::Internal(
-                            "Received empty request".to_string(),
-                        ))
-                    }
-                };
-            }
+        if updated_inflight_counter {
+            client_clone.release_inflight_request();
         }
 
         let _res = write_result(result, request.callback_idx, &writer).await;
-
-        if updated_inflight_counter {
-            inflight_requests_clone.fetch_sub(1, Ordering::Release);
-        }
     });
 }
 
@@ -590,15 +565,9 @@ async fn handle_requests(
     received_requests: Vec<CommandRequest>,
     client: &Client,
     writer: &Rc<Writer>,
-    inflight_counter: Arc<AtomicUsize>,
 ) {
     for request in received_requests {
-        handle_request(
-            request,
-            client.clone(),
-            writer.clone(),
-            inflight_counter.clone(),
-        );
+        handle_request(request, client.clone(), writer.clone());
     }
     // Yield to ensure that the subtasks aren't starved.
     task::yield_now().await;
@@ -647,23 +616,13 @@ async fn read_values_loop(
     client: &Client,
     writer: Rc<Writer>,
 ) -> ClosingReason {
-    // Setting this counter to limit the inflight requests, in case of any queue is blocked, so we return error
-    // to the customer.
-    let inflight_requests_counter = Arc::new(AtomicUsize::new(0));
-
     loop {
         match client_listener.next_values().await {
             Closed(reason) => {
                 return reason;
             }
             ReceivedValues(received_requests) => {
-                handle_requests(
-                    received_requests,
-                    client,
-                    &writer,
-                    inflight_requests_counter.clone(),
-                )
-                .await;
+                handle_requests(received_requests, client, &writer).await;
             }
         }
     }

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -346,6 +346,23 @@ mod socket_listener {
         )
     }
 
+    fn write_blpop(
+        buffer: &mut Vec<u8>,
+        socket: &mut UnixStream,
+        callback_index: u32,
+        key: &str,
+        timeout: u32,
+    ) {
+        write_command_request(
+            buffer,
+            socket,
+            callback_index,
+            vec![key.to_string().into(), timeout.to_string().into()],
+            RequestType::BLPop.into(),
+            false,
+        )
+    }
+
     fn parse_header(buffer: &[u8]) -> (u32, usize) {
         u32::decode_var(buffer).unwrap()
     }
@@ -1031,6 +1048,41 @@ mod socket_listener {
         for i in 0..NUMBER_OF_THREADS {
             assert_eq!(State::ReceivedValue, results[i]);
         }
+    }
+
+    // This test checks that the inflight requests limit is working. Using the default value (1000),
+    // sending this amount + 1 of blocking commands and assert the +1 request ID to return with error while
+    // the prev requests still block in the server after the first blocking request.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_limiting_inflight_requests(
+        #[values(RedisType::Cluster, RedisType::Standalone)] use_cluster: RedisType,
+    ) {
+        let default_max_inflight_requests = 1000;
+        let test_basics = setup_test_basics(Tls::NoTls, TestServer::Unique, use_cluster);
+
+        let mut write_blpop_socket = test_basics.socket.try_clone().unwrap();
+
+        for i in 0..(default_max_inflight_requests + 1) {
+            let mut buffer = Vec::with_capacity(1);
+            write_blpop(
+                &mut buffer,
+                &mut write_blpop_socket,
+                i as u32,
+                "nonexistingkeylist",
+                0,
+            );
+        }
+
+        // Assert the last request failes with RequestError as glide already reached default_max_inflight_requests
+        let mut buffer = Vec::with_capacity(1);
+        assert_error_response(
+            &mut buffer,
+            &mut write_blpop_socket,
+            default_max_inflight_requests,
+            ResponseType::RequestError,
+        );
     }
 
     #[rstest]

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -1069,7 +1069,7 @@ mod socket_listener {
             write_blpop(
                 &mut buffer,
                 &mut write_blpop_socket,
-                i as u32,
+                i,
                 "nonexistingkeylist",
                 0,
             );

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -389,7 +389,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             This limit is used to control the memory usage and prevent the client from overwhelming the server or getting stuck in case of a queue backlog.
             If not set, a default value will be used.
 
-            
+
 
     Notes:
         Currently, the reconnection strategy in cluster mode is not configurable, and exponential backoff

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -134,6 +134,7 @@ class BaseClientConfiguration:
         request_timeout: Optional[int] = None,
         client_name: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
+        inflight_requests_limit: Optional[int] = None,
     ):
         """
         Represents the configuration settings for a Glide client.
@@ -158,6 +159,10 @@ class BaseClientConfiguration:
                 This duration encompasses sending the request, awaiting for a response from the server, and any required reconnections or retries.
                 If the specified timeout is exceeded for a pending request, it will result in a timeout error. If not set, a default value will be used.
             client_name (Optional[str]): Client name to be used for the client. Will be used with CLIENT SETNAME command during connection establishment.
+            inflight_requests_limit (Optional[int]): The maximum number of concurrent requests allowed to be in-flight (sent but not yet completed).
+                This limit is used to control the memory usage and prevent the client from overwhelming the server or getting stuck in case of a queue backlog.
+                If not set, a default value will be used.
+
         """
         self.addresses = addresses
         self.use_tls = use_tls
@@ -166,6 +171,7 @@ class BaseClientConfiguration:
         self.request_timeout = request_timeout
         self.client_name = client_name
         self.protocol = protocol
+        self.inflight_requests_limit = inflight_requests_limit
 
     def _create_a_protobuf_conn_request(
         self, cluster_mode: bool = False
@@ -196,6 +202,8 @@ class BaseClientConfiguration:
         if self.client_name:
             request.client_name = self.client_name
         request.protocol = self.protocol.value
+        if self.inflight_requests_limit:
+            request.inflight_requests_limit = self.inflight_requests_limit
 
         return request
 
@@ -236,6 +244,10 @@ class GlideClientConfiguration(BaseClientConfiguration):
         protocol (ProtocolVersion): The version of the RESP protocol to communicate with the server.
         pubsub_subscriptions (Optional[GlideClientConfiguration.PubSubSubscriptions]): Pubsub subscriptions to be used for the client.
                 Will be applied via SUBSCRIBE/PSUBSCRIBE commands during connection establishment.
+        inflight_requests_limit (Optional[int]): The maximum number of concurrent requests allowed to be in-flight (sent but not yet completed).
+            This limit is used to control the memory usage and prevent the client from overwhelming the server or getting stuck in case of a queue backlog.
+            If not set, a default value will be used.
+
     """
 
     class PubSubChannelModes(IntEnum):
@@ -280,6 +292,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         client_name: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         pubsub_subscriptions: Optional[PubSubSubscriptions] = None,
+        inflight_requests_limit: Optional[int] = None,
     ):
         super().__init__(
             addresses=addresses,
@@ -289,6 +302,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
             request_timeout=request_timeout,
             client_name=client_name,
             protocol=protocol,
+            inflight_requests_limit=inflight_requests_limit,
         )
         self.reconnect_strategy = reconnect_strategy
         self.database_id = database_id
@@ -371,6 +385,11 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             Defaults to PeriodicChecksStatus.ENABLED_DEFAULT_CONFIGS.
         pubsub_subscriptions (Optional[GlideClusterClientConfiguration.PubSubSubscriptions]): Pubsub subscriptions to be used for the client.
             Will be applied via SUBSCRIBE/PSUBSCRIBE/SSUBSCRIBE commands during connection establishment.
+        inflight_requests_limit (Optional[int]): The maximum number of concurrent requests allowed to be in-flight (sent but not yet completed).
+            This limit is used to control the memory usage and prevent the client from overwhelming the server or getting stuck in case of a queue backlog.
+            If not set, a default value will be used.
+
+            
 
     Notes:
         Currently, the reconnection strategy in cluster mode is not configurable, and exponential backoff
@@ -422,6 +441,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             PeriodicChecksStatus, PeriodicChecksManualInterval
         ] = PeriodicChecksStatus.ENABLED_DEFAULT_CONFIGS,
         pubsub_subscriptions: Optional[PubSubSubscriptions] = None,
+        inflight_requests_limit: Optional[int] = None,
     ):
         super().__init__(
             addresses=addresses,
@@ -431,6 +451,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             request_timeout=request_timeout,
             client_name=client_name,
             protocol=protocol,
+            inflight_requests_limit=inflight_requests_limit,
         )
         self.periodic_checks = periodic_checks
         self.pubsub_subscriptions = pubsub_subscriptions

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -246,7 +246,7 @@ async def create_client(
             protocol=protocol,
             request_timeout=timeout,
             pubsub_subscriptions=cluster_mode_pubsub,
-            inflight_requests_limit=inflight_requests_limit
+            inflight_requests_limit=inflight_requests_limit,
         )
         return await GlideClusterClient.create(cluster_config)
     else:

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -229,6 +229,7 @@ async def create_client(
     standalone_mode_pubsub: Optional[
         GlideClientConfiguration.PubSubSubscriptions
     ] = None,
+    inflight_requests_limit: Optional[int] = None,
 ) -> Union[GlideClient, GlideClusterClient]:
     # Create async socket client
     use_tls = request.config.getoption("--tls")
@@ -245,6 +246,7 @@ async def create_client(
             protocol=protocol,
             request_timeout=timeout,
             pubsub_subscriptions=cluster_mode_pubsub,
+            inflight_requests_limit=inflight_requests_limit
         )
         return await GlideClusterClient.create(cluster_config)
     else:
@@ -260,6 +262,7 @@ async def create_client(
             protocol=protocol,
             request_timeout=timeout,
             pubsub_subscriptions=standalone_mode_pubsub,
+            inflight_requests_limit=inflight_requests_limit,
         )
         return await GlideClient.create(config)
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -311,7 +311,7 @@ class TestCommands:
         assert int(result[b"proto"]) == 2
 
     # Testing the inflight_requests_limit parameter in glide. Sending the allowed amount + 1 of requests
-    # to glide, using blocking commands, and checking the N+1 request returns immediately with error. 
+    # to glide, using blocking commands, and checking the N+1 request returns immediately with error.
     @pytest.mark.parametrize("cluster_mode", [False, True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     @pytest.mark.parametrize("inflight_requests_limit", [5, 100, 1500])
@@ -320,26 +320,29 @@ class TestCommands:
     ):
         key1 = f"{{nonexistinglist}}:1-{get_random_string(10)}"
         test_client = await create_client(
-            request=request, protocol=protocol, cluster_mode=cluster_mode, inflight_requests_limit=inflight_requests_limit
+            request=request,
+            protocol=protocol,
+            cluster_mode=cluster_mode,
+            inflight_requests_limit=inflight_requests_limit,
         )
-        
+
         tasks = []
         for i in range(inflight_requests_limit + 1):
-            tasks.append(test_client.blpop([key1], 0))
+            coro = test_client.blpop([key1], 0)
+            task = asyncio.create_task(coro)
+            tasks.append(task)
 
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
         for task in done:
-            try:
-                result = await task
-                print(f"Completed task: {result}")
-            except Exception as e:
-                assert isinstance(e, RequestError)
-                print(f"Error in task: {e}")
-                break
+            with pytest.raises(RequestError) as e:
+                await task
+            assert "maximum inflight requests" in str(e)
 
         for task in pending:
             task.cancel()
+
+        await test_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])


### PR DESCRIPTION
# Inflight Requests Limit

This PR introduces a new feature that limits the maximum number of concurrent (inflight) requests sent to Valkey through each connection of a Glide client. This feature is implemented in the Glide infrastructure and is currently supported for the Python client, with plans to extend support to other language clients in the future.

## Motivation

Limiting the number of inflight requests per connection can help prevent the queues in the Glide infrastructure from running out of memory (OOM) due to excessive queuing or blocking. When the Glide infrastructure receives more requests than it can handle, it may start queuing requests, leading to increased memory usage and potential OOM situations in the queues. By controlling the number of inflight requests, this feature aims to mitigate the risk of the Glide queues running out of memory and improve overall system stability and reliability.

## Implementation

The inflight requests limit is implemented using an atomic counter mechanism. Each connection in a Glide client has an associated atomic counter that keeps track of the number of inflight requests for that connection.

When a new request is initiated, the client attempts to increment the atomic counter associated with the connection. If the counter value after incrementing exceeds the configured inflight requests limit for that connection, the request is rejected with an error, indicating that the maximum inflight requests limit has been reached.

If the counter value after incrementing is within the limit, the request proceeds, and the counter is decremented when the request is completed.

## Configuration

The inflight requests limit is configurable and has a default value of 1000 requests per connection. This default value can be overridden by client-specific configuration options, which will be documented separately for each language client.

For the Python client, the `inflight_requests_limit` option has been added to the `GlideClusterClientConfiguration` and `GlideClientConfiguration` classes, allowing users to specify the desired limit when creating a new client instance.

## Limitations and Considerations

- The inflight requests limit applies to each individual connection in a Glide client, not to the entire client instance.
- Requests that exceed the inflight requests limit are rejected with an error and are not queued or processed later.
- Setting a low inflight requests limit might negatively impact the client's performance, as it can lead to more requests being rejected.
- It's recommended to set the inflight requests limit based on the expected load, available resources, and the desired balance between performance and resource utilization.

## Future Work

- Extend support for the inflight requests limit feature to other language clients (e.g., Node, Java, etc.).
- Provide monitoring and metrics around the inflight requests limit to help users better understand the client's behavior and tune the configuration accordingly.