### PR TITLE
Reduce glide_rs.so size (for Java)

### DIFF
--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -21,7 +21,7 @@ bytes = { version = "1.6.0" }
 
 [profile.release]
 lto = true
-debug = true
+strip = "symbols"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ffi_test)'] }


### PR DESCRIPTION
This PR strips debugging symbols from the compiled Rust shared object (`libglide_rs.so`)
and reduces its size from `59MB` down to `4.4MB`

Closes: https://github.com/valkey-io/valkey-glide/issues/2039

Before:

```bash
$ ls -lh ./target/release/deps/libglide_rs.so
-rwxrwxr-x 2 ubuntu ubuntu 59M Sep 29 11:15 ./target/release/deps/libglide_rs.so
```

After:

```bash
$ ls -lh ./target/release/deps/libglide_rs.so
-rwxrwxr-x 2 ubuntu ubuntu 4.4M Sep 29 11:51 ./target/release/deps/libglide_rs.so
```
