### PR TITLE
Java: log failed tests

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -40,6 +40,24 @@ subprojects {
         // TODO: add jacoco with code coverage
         // finalizedBy jacocoTestReport, jacocoTestCoverageVerification
     }
+
+    ext.failedTests = []
+
+    tasks.withType(Test) {
+        afterTest { TestDescriptor descriptor, TestResult result ->
+            if (result.resultType == TestResult.ResultType.FAILURE) {
+                failedTests << "${descriptor.className}.${descriptor.name}"
+            }
+        }
+    }
+
+    gradle.buildFinished {
+        if (!failedTests.empty) {
+            println "\nFailed tests for `:${project.name}`:"
+            failedTests.each { failedTest -> println failedTest }
+            println ""
+        }
+    }
 }
 
 // JaCoCo section (code coverage by unit tests)


### PR DESCRIPTION
Additional logging of failed tests at the end of each test run. No need to search in big output for failures.
Example of message:
```
Failed tests for `:client`:
glide.ExceptionHandlingTests.verify_future_pipeline_abortion()

Failed tests for `:integTest`:
glide.cluster.CommandTests.flushall()
glide.cluster.CommandTests.fcall_readonly_binary_function()
glide.cluster.CommandTests.fcall_readonly_function()
```

<details>

```
...
TransactionTests > sort and sortReadOnly PASSED

TransactionTests > test transaction dump restore STARTED
glide.standalone.TransactionTests.test_transaction_dump_restore(): SUCCESS 0.001s

TransactionTests > test transaction dump restore PASSED

328 tests completed, 3 failed, 6 skipped

> Task :integTest:test FAILED

> Task :integTest:stopAllAfterTests
INFO:root:## Executing cluster_manager.py with the following args:
  Namespace(host='127.0.0.1', tls=False, auth=None, log='info', logfile=None, action='stop', folder_path='/mnt/c/GitHub/babushka/utils/clusters', prefix='redis-cluster', cluster_folder=None, keep_folder=True)
INFO:root:2024-10-04 01:14:51.159227+00:00 Stopping script for cluster/s redis-cluster* in /mnt/c/GitHub/babushka/utils/clusters
INFO:root:Cluster stopped in 0.1149 seconds
LOG_FILE=/mnt/c/GitHub/babushka/utils/clusters/redis-cluster-2024-10-04T01-12-56Z-BHMOkM/cluster_manager.log

Failed tests for `:client`:
glide.ExceptionHandlingTests.verify_future_pipeline_abortion()


Failed tests for `:integTest`:
glide.cluster.CommandTests.flushall()
glide.cluster.CommandTests.fcall_readonly_binary_function()
glide.cluster.CommandTests.fcall_readonly_function()


FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':client:test'.
> There were failing tests. See the report at: file:///mnt/c/GitHub/babushka/java/client/build/reports/tests/test/index.html

* Try:
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':integTest:test'.
> There were failing tests. See the report at: file:///mnt/c/GitHub/babushka/java/integTest/build/reports/tests/test/index.html

* Try:
> Run with --scan to get full insights.
==============================================================================

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 2m 39s
36 actionable tasks: 9 executed, 27 up-to-date
```
</details>