### PR TITLE
Java: fix logger test

### DIFF
--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -72,9 +72,6 @@ public class LoggerTests {
         // Initialize a new logger to force closing of existing files
         String dummyFilename = "dummy.txt";
         Logger.setLoggerConfig(Logger.Level.DEFAULT, dummyFilename);
-        File[] dummyLogFiles = logFolder.listFiles((dir, name) -> name.startsWith(dummyFilename + "."));
-        assertNotNull(dummyLogFiles);
-        File dummyLogFile = dummyLogFiles[0];
 
         File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith(filename + "."));
         assertNotNull(logFiles);

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -93,7 +93,6 @@ public class LoggerTests {
             assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
         } finally {
             logFile.delete();
-            dummyLogFile.delete();
             logFolder.delete();
         }
     }


### PR DESCRIPTION
Since #2391 log file isn't created if no writes requested. Test "LoggerTests > log to file" starts to fail on `main` branch.