### PR TITLE
Python: remove `async_timeout` and `typing_extensions` dependencies f…

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "maturin"
 name = "valkey-glide"
 requires-python = ">=3.8"
 dependencies = [
-    "async-timeout>=4.0.2",
-    "typing-extensions>=4.8.0",
+    "async-timeout>=4.0.2; python_version < '3.11'",
+    "typing-extensions>=4.8.0; python_version < '3.11'",
     "protobuf>=3.20"
 ]
 classifiers = [

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -5,7 +5,6 @@ import sys
 import threading
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
-import async_timeout
 from glide.async_commands.cluster_commands import ClusterCommands
 from glide.async_commands.command_args import ObjectType
 from glide.async_commands.core import CoreCommands
@@ -27,7 +26,6 @@ from glide.protobuf.connection_request_pb2 import ConnectionRequest
 from glide.protobuf.response_pb2 import RequestErrorType, Response
 from glide.protobuf_codec import PartialMessageException, ProtobufCodec
 from glide.routes import Route, set_protobuf_route
-from typing_extensions import Self
 
 from .glide import (
     DEFAULT_TIMEOUT_IN_MILLISECONDS,
@@ -37,6 +35,13 @@ from .glide import (
     start_socket_listener_external,
     value_from_pointer,
 )
+
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+    from typing import Self
+else:
+    import async_timeout
+    from typing_extensions import Self
 
 
 def get_request_error_class(

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
-async-timeout==4.0.2
+async-timeout==4.0.2;python_version<"3.11"
 maturin==0.13.0
 protobuf==3.20.*
 pytest==7.1.2
 pytest-asyncio==0.19.0
-typing_extensions==4.8.0
+typing_extensions==4.8.0;python_version<"3.11"
 pytest-html


### PR DESCRIPTION
…or Python 3.11 and higher ()

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link
This Pull Request is linked to issue (URL): closes #2401

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one issue.
* [x] Commit message has a detailed description of what changed and why.
* [ ] Tests are added or updated.
* [ ] CHANGELOG.md and documentation files are updated.
* [x] Destination branch is correct - main or release
* [ ] Commits will be squashed upon merging.
      
