### PR TITLE
Java: Allow to run modules CI on demand.

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -197,9 +197,8 @@ jobs:
               name: lint java rust
 
     test-modules:
-        if: github.event.pull_request.head.repo.owner.login == 'valkey-io'
-        environment: AWS_ACTIONS
-        name: Running Module Tests
+        if: github.repository_owner == 'valkey-io'
+        name: Modules Tests
         runs-on: [self-hosted, linux, ARM64]
         timeout-minutes: 15
         steps:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -198,6 +198,7 @@ jobs:
 
     test-modules:
         if: (github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch') || github.event.pull_request.head.repo.owner.login == 'valkey-io'
+        environment: AWS_ACTIONS
         name: Modules Tests
         runs-on: [self-hosted, linux, ARM64]
         timeout-minutes: 15

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -197,7 +197,7 @@ jobs:
               name: lint java rust
 
     test-modules:
-        if: github.repository_owner == 'valkey-io' && secrets.MEMDB_MODULES_ENDPOINT != ''
+        if: (github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch') || github.event.pull_request.head.repo.owner.login == 'valkey-io'
         name: Modules Tests
         runs-on: [self-hosted, linux, ARM64]
         timeout-minutes: 15

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -197,7 +197,7 @@ jobs:
               name: lint java rust
 
     test-modules:
-        if: github.repository_owner == 'valkey-io'
+        if: github.repository_owner == 'valkey-io' && secrets.MEMDB_MODULES_ENDPOINT != ''
         name: Modules Tests
         runs-on: [self-hosted, linux, ARM64]
         timeout-minutes: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Operational Enhancements
 
+* Java: Add modules CI ([#2388](https://github.com/valkey-io/valkey-glide/pull/2388), [#2404](https://github.com/valkey-io/valkey-glide/pull/2404), [#2416](https://github.com/valkey-io/valkey-glide/pull/2416))
+
 ## 1.1.0 (2024-09-24)
 
 #### Changes


### PR DESCRIPTION
Revert https://github.com/valkey-io/valkey-glide/pull/2404 - allow a developer to run modules CI without creating a PR