### PR TITLE
Added inflightRequestsLimit client config to java

### DIFF
--- a/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
@@ -66,4 +66,12 @@ public abstract class BaseClientConfiguration {
     private final ThreadPoolResource threadPoolResource;
 
     public abstract BaseSubscriptionConfiguration getSubscriptionConfiguration();
+
+    /**
+     * The maximum number of concurrent requests allowed to be in-flight (sent but not yet completed).
+     * This limit is used to control the memory usage and prevent the client from overwhelming the
+     * server or getting stuck in case of a queue backlog. If not set, a default value of 1000 will be
+     * used.
+     */
+    private final Integer inflightRequestsLimit;
 }

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClientConfiguration.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
  *         .databaseId(1)
  *         .clientName("GLIDE")
  *         .subscriptionConfiguration(subscriptionConfiguration)
+ *         .inflightRequestsLimit(1000)
  *         .build();
  * }</pre>
  */

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
@@ -22,6 +22,7 @@ import lombok.experimental.SuperBuilder;
  *         .requestTimeout(2000)
  *         .clientName("GLIDE")
  *         .subscriptionConfiguration(subscriptionConfiguration)
+ *         .inflightRequestsLimit(1000)
  *         .build();
  * }</pre>
  */

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -118,6 +118,10 @@ public class ConnectionManager {
             connectionRequestBuilder.setClientName(configuration.getClientName());
         }
 
+        if (configuration.getInflightRequestsLimit() != null) {
+            connectionRequestBuilder.setInflightRequestsLimit(configuration.getInflightRequestsLimit());
+        }
+
         return connectionRequestBuilder;
     }
 

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -64,6 +64,8 @@ public class ConnectionManagerTest {
 
     private static final String CLIENT_NAME = "ClientName";
 
+    private static final int INFLIGHT_REQUESTS_LIMIT = 1000;
+
     @BeforeEach
     public void setUp() {
         channel = mock(ChannelHandler.class);
@@ -149,6 +151,7 @@ public class ConnectionManagerTest {
                                         .subscription(EXACT, gs("channel_2"))
                                         .subscription(PATTERN, gs("*chatRoom*"))
                                         .build())
+                        .inflightRequestsLimit(INFLIGHT_REQUESTS_LIMIT)
                         .build();
         ConnectionRequest expectedProtobufConnectionRequest =
                 ConnectionRequest.newBuilder()
@@ -193,6 +196,7 @@ public class ConnectionManagerTest {
                                                                                 ByteString.copyFrom(gs("*chatRoom*").getBytes()))
                                                                         .build()))
                                         .build())
+                        .setInflightRequestsLimit(INFLIGHT_REQUESTS_LIMIT)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
         Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();


### PR DESCRIPTION
Adding support for this client config inflightRequestsLimit
The maximum number of concurrent requests allowed to be in-flight (sent but not yet completed).
This limit is used to control the memory usage and prevent the client from overwhelming the server or getting stuck in case of a queue backlog.

If not set, a default value will be used.

Issue link
This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/1253

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one issue.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.
* [x] Destination branch is correct - main or release
* [x] Commits will be squashed upon merging.
      
