### PR TITLE
Added inflightRequestsLimit client config to Node

### DIFF
--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -44,6 +44,9 @@ pub const DEFAULT_TIMEOUT_IN_MILLISECONDS: u32 =
     glide_core::client::DEFAULT_RESPONSE_TIMEOUT.as_millis() as u32;
 
 #[napi]
+pub const DEFAULT_INFLIGHT_REQUESTS_LIMIT: u32 = glide_core::client::DEFAULT_MAX_INFLIGHT_REQUESTS;
+
+#[napi]
 struct AsyncClient {
     #[allow(dead_code)]
     connection: MultiplexedConnection,

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -1501,12 +1501,6 @@ describe("GlideClient", () => {
         },
     );
 
-    function getRandomString(length: number) {
-        return Math.random()
-            .toString(36)
-            .substring(2, length + 2);
-    }
-
     it.each([
         [ProtocolVersion.RESP2, 5],
         [ProtocolVersion.RESP2, 100],
@@ -1525,7 +1519,7 @@ describe("GlideClient", () => {
             const client = await GlideClient.createClient(config);
 
             try {
-                const key1 = `{nonexistinglist}:1-${getRandomString(10)}`;
+                const key1 = `{nonexistinglist}:1-${uuidv4()}`;
                 const tasks: Promise<[GlideString, GlideString] | null>[] = [];
 
                 // Start inflightRequestsLimit blocking tasks
@@ -1543,13 +1537,8 @@ describe("GlideClient", () => {
                     setTimeout(resolve, 100),
                 );
                 const allTasksStatus = await Promise.race([
-                    Promise.all(
-                        tasks.map((task) =>
-                            task.then(
-                                () => "resolved",
-                                () => "rejected",
-                            ),
-                        ),
+                    Promise.any(
+                        tasks.map((task) => task.then(() => "resolved")),
                     ),
                     timeoutPromise.then(() => "pending"),
                 ]);

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -1501,6 +1501,65 @@ describe("GlideClient", () => {
         },
     );
 
+    function getRandomString(length: number) {
+        return Math.random()
+            .toString(36)
+            .substring(2, length + 2);
+    }
+
+    it.each([
+        [ProtocolVersion.RESP2, 5],
+        [ProtocolVersion.RESP2, 100],
+        [ProtocolVersion.RESP2, 1500],
+        [ProtocolVersion.RESP3, 5],
+        [ProtocolVersion.RESP3, 100],
+        [ProtocolVersion.RESP3, 1500],
+    ])(
+        "test inflight requests limit of %p with protocol %p",
+        async (protocol, inflightRequestsLimit) => {
+            const config = getClientConfigurationOption(
+                cluster.getAddresses(),
+                protocol,
+                { inflightRequestsLimit },
+            );
+            const client = await GlideClient.createClient(config);
+
+            try {
+                const key1 = `{nonexistinglist}:1-${getRandomString(10)}`;
+                const tasks: Promise<[GlideString, GlideString] | null>[] = [];
+
+                // Start inflightRequestsLimit blocking tasks
+                for (let i = 0; i < inflightRequestsLimit; i++) {
+                    tasks.push(client.blpop([key1], 0));
+                }
+
+                // This task should immediately fail due to reaching the limit
+                await expect(client.blpop([key1], 0)).rejects.toThrow(
+                    RequestError,
+                );
+
+                // Verify that all previous tasks are still pending
+                const timeoutPromise = new Promise((resolve) =>
+                    setTimeout(resolve, 100),
+                );
+                const allTasksStatus = await Promise.race([
+                    Promise.all(
+                        tasks.map((task) =>
+                            task.then(
+                                () => "resolved",
+                                () => "rejected",
+                            ),
+                        ),
+                    ),
+                    timeoutPromise.then(() => "pending"),
+                ]);
+                expect(allTasksStatus).toBe("pending");
+            } finally {
+                await client.close();
+            }
+        },
+    );
+
     runBaseTests({
         init: async (protocol, configOverrides) => {
             const config = getClientConfigurationOption(

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -1976,12 +1976,6 @@ describe("GlideClusterClient", () => {
         TIMEOUT,
     );
 
-    function getRandomString(length: number) {
-        return Math.random()
-            .toString(36)
-            .substring(2, length + 2);
-    }
-
     it.each([
         [ProtocolVersion.RESP2, 5],
         [ProtocolVersion.RESP2, 100],
@@ -2000,7 +1994,7 @@ describe("GlideClusterClient", () => {
             const client = await GlideClusterClient.createClient(config);
 
             try {
-                const key1 = `{nonexistinglist}:1-${getRandomString(10)}`;
+                const key1 = `{nonexistinglist}:1-${uuidv4()}`;
                 const tasks: Promise<[GlideString, GlideString] | null>[] = [];
 
                 // Start inflightRequestsLimit blocking tasks
@@ -2018,13 +2012,8 @@ describe("GlideClusterClient", () => {
                     setTimeout(resolve, 100),
                 );
                 const allTasksStatus = await Promise.race([
-                    Promise.all(
-                        tasks.map((task) =>
-                            task.then(
-                                () => "resolved",
-                                () => "rejected",
-                            ),
-                        ),
+                    Promise.any(
+                        tasks.map((task) => task.then(() => "resolved")),
                     ),
                     timeoutPromise.then(() => "pending"),
                 ]);


### PR DESCRIPTION
Adding support for this client config inflightRequestsLimit
The maximum number of concurrent requests allowed to be in-flight (sent but not yet completed).
This limit is used to control the memory usage and prevent the client from overwhelming the server or getting stuck in case of a queue backlog.

If not set, a default value will be used.

Issue link
This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/1253

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one issue.
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added or updated.
* [x] Destination branch is correct - main or release
* [x] Commits will be squashed upon merging.     
