### PR TITLE
Fix python CI: fix linter installation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -216,9 +216,9 @@ jobs:
 
             - name: Install dependencies
               if: always()
-              working-directory: ./python
-              run: |
-                  sudo apt install -y python3-pip python3 flake8 isort black
+              uses: threeal/pipx-install-action@latest
+              with:
+                  packages: flake8 isort black
 
             - name: Lint python with isort
               if: always()


### PR DESCRIPTION
Replay #2444 which was reverted by #2456
Fixes CI failures:
https://github.com/valkey-io/valkey-glide/actions/runs/11364202422/job/31638558098
```
Run black --check --diff .
Usage: black [OPTIONS] SRC ...
Try 'black -h' for help.

Error: Invalid value for '-t' / '--target-version': 'py311' is not one of 'py27', 'py33', 'py34', 'py35', 'py36', 'py37', 'py38', 'py39', 'py310'.
Error: Process completed with exit code 2.
```

Incorrect version of `black` was installed