### PR TITLE
Avoid retrying on IO errors when it’s unclear if the server received the request

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -7,7 +7,7 @@ use crate::connection::{
     resp2_is_pub_sub_state_cleared, resp3_is_pub_sub_state_cleared, ConnectionAddr, ConnectionInfo,
     Msg, RedisConnectionInfo,
 };
-#[cfg(any(feature = "tokio-comp"))]
+#[cfg(feature = "tokio-comp")]
 use crate::parser::ValueCodec;
 use crate::types::{ErrorKind, FromRedisValue, RedisError, RedisFuture, RedisResult, Value};
 use crate::{from_owned_redis_value, ProtocolVersion, ToRedisArgs};

--- a/glide-core/redis-rs/redis/src/aio/connection_manager.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection_manager.rs
@@ -78,9 +78,9 @@ macro_rules! reconnect_if_dropped {
     };
 }
 
-/// Handle a connection result. If there's an I/O error, reconnect.
+/// Handle a connection result. If the connection has dropped, reconnect.
 /// Propagate any error.
-macro_rules! reconnect_if_io_error {
+macro_rules! reconnect_if_conn_dropped {
     ($self:expr, $result:expr, $current:expr) => {
         if let Err(e) = $result {
             if e.is_connection_dropped() {
@@ -249,7 +249,7 @@ impl ConnectionManager {
             .clone()
             .await
             .map_err(|e| e.clone_mostly("Reconnecting failed"));
-        reconnect_if_io_error!(self, connection_result, guard);
+        reconnect_if_conn_dropped!(self, connection_result, guard);
         let result = connection_result?.send_packed_command(cmd).await;
         reconnect_if_dropped!(self, &result, guard);
         result
@@ -270,7 +270,7 @@ impl ConnectionManager {
             .clone()
             .await
             .map_err(|e| e.clone_mostly("Reconnecting failed"));
-        reconnect_if_io_error!(self, connection_result, guard);
+        reconnect_if_conn_dropped!(self, connection_result, guard);
         let result = connection_result?
             .send_packed_commands(cmd, offset, count)
             .await;

--- a/glide-core/redis-rs/redis/src/aio/connection_manager.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection_manager.rs
@@ -83,7 +83,7 @@ macro_rules! reconnect_if_dropped {
 macro_rules! reconnect_if_io_error {
     ($self:expr, $result:expr, $current:expr) => {
         if let Err(e) = $result {
-            if e.is_io_error() {
+            if e.is_connection_dropped() {
                 $self.reconnect($current);
             }
             return Err(e);

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -771,7 +771,8 @@ where
                                 .wait_time_for_retry(retries);
                             thread::sleep(sleep_time);
                         }
-                        crate::types::RetryMethod::Reconnect => {
+                        crate::types::RetryMethod::Reconnect
+                        | crate::types::RetryMethod::ReconnectAndRetry => {
                             if *self.auto_reconnect.borrow() {
                                 if let Ok(mut conn) = self.connect(&addr) {
                                     if conn.check_connection() {

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -43,7 +43,9 @@ use std::time::Duration;
 
 use rand::{seq::IteratorRandom, thread_rng};
 
+pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
 use crate::cluster_pipeline::UNROUTABLE_ERROR;
+pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
 use crate::cluster_routing::{
     MultipleNodeRoutingInfo, ResponsePolicy, Routable, SingleNodeRoutingInfo,
 };
@@ -54,16 +56,13 @@ use crate::connection::{
     connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
 };
 use crate::parser::parse_redis_value;
-use crate::types::{ErrorKind, HashMap, RedisError, RedisResult, Value};
+use crate::types::{ErrorKind, HashMap, RedisError, RedisResult, RetryMethod, Value};
 pub use crate::TlsMode; // Pub for backwards compatibility
 use crate::{
     cluster_client::ClusterParams,
     cluster_routing::{Redirect, Route, RoutingInfo},
     IntoConnectionInfo, PushInfo,
 };
-
-pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
-pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
 
 use tokio::sync::mpsc;
 
@@ -749,12 +748,12 @@ where
                     retries += 1;
 
                     match err.retry_method() {
-                        crate::types::RetryMethod::AskRedirect => {
+                        RetryMethod::AskRedirect => {
                             redirected = err
                                 .redirect_node()
                                 .map(|(node, _slot)| Redirect::Ask(node.to_string()));
                         }
-                        crate::types::RetryMethod::MovedRedirect => {
+                        RetryMethod::MovedRedirect => {
                             // Refresh slots.
                             self.refresh_slots()?;
                             // Request again.
@@ -762,8 +761,8 @@ where
                                 .redirect_node()
                                 .map(|(node, _slot)| Redirect::Moved(node.to_string()));
                         }
-                        crate::types::RetryMethod::WaitAndRetryOnPrimaryRedirectOnReplica
-                        | crate::types::RetryMethod::WaitAndRetry => {
+                        RetryMethod::WaitAndRetryOnPrimaryRedirectOnReplica
+                        | RetryMethod::WaitAndRetry => {
                             // Sleep and retry.
                             let sleep_time = self
                                 .cluster_params
@@ -771,8 +770,7 @@ where
                                 .wait_time_for_retry(retries);
                             thread::sleep(sleep_time);
                         }
-                        crate::types::RetryMethod::Reconnect
-                        | crate::types::RetryMethod::ReconnectAndRetry => {
+                        RetryMethod::Reconnect | RetryMethod::ReconnectAndRetry => {
                             if *self.auto_reconnect.borrow() {
                                 if let Ok(mut conn) = self.connect(&addr) {
                                     if conn.check_connection() {
@@ -781,10 +779,10 @@ where
                                 }
                             }
                         }
-                        crate::types::RetryMethod::NoRetry => {
+                        RetryMethod::NoRetry => {
                             return Err(err);
                         }
-                        crate::types::RetryMethod::RetryImmediately => {}
+                        RetryMethod::RetryImmediately => {}
                     }
                 }
             }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -845,6 +845,7 @@ impl<C> Future for Request<C> {
                 let request = this.request.as_mut().unwrap();
                 // TODO - would be nice if we didn't need to repeat this code twice, with & without retries.
                 if request.retry >= this.retry_params.number_of_retries {
+                    let retry_method = err.retry_method();
                     let next = if err.kind() == ErrorKind::AllConnectionsUnavailable {
                         Next::ReconnectToInitialNodes { request: None }.into()
                     } else if matches!(err.retry_method(), crate::types::RetryMethod::MovedRedirect)
@@ -855,7 +856,9 @@ impl<C> Future for Request<C> {
                             sleep_duration: None,
                         }
                         .into()
-                    } else if matches!(err.retry_method(), crate::types::RetryMethod::Reconnect) {
+                    } else if matches!(retry_method, crate::types::RetryMethod::Reconnect)
+                        || matches!(retry_method, crate::types::RetryMethod::ReconnectAndRetry)
+                    {
                         if let OperationTarget::Node { address } = target {
                             Next::Reconnect {
                                 request: None,
@@ -934,13 +937,18 @@ impl<C> Future for Request<C> {
                         });
                         self.poll(cx)
                     }
-                    crate::types::RetryMethod::Reconnect => {
+                    crate::types::RetryMethod::Reconnect
+                    | crate::types::RetryMethod::ReconnectAndRetry => {
                         let mut request = this.request.take().unwrap();
                         // TODO should we reset the redirect here?
                         request.info.reset_routing();
                         warn!("disconnected from {:?}", address);
+                        let should_retry = matches!(
+                            err.retry_method(),
+                            crate::types::RetryMethod::ReconnectAndRetry
+                        );
                         Next::Reconnect {
-                            request: Some(request),
+                            request: should_retry.then_some(request),
                             target: address,
                         }
                         .into()
@@ -1177,8 +1185,11 @@ where
         Ok(connections.0)
     }
 
-    fn reconnect_to_initial_nodes(&mut self) -> impl Future<Output = ()> {
-        let inner = self.inner.clone();
+    // Reconnet to the initial nodes provided by the user in the creation of the client,
+    // and try to refresh the slots based on the initial connections.
+    // Being used when all cluster connections are unavailable.
+    fn reconnect_to_initial_nodes(inner: Arc<InnerCore<C>>) -> impl Future<Output = ()> {
+        let inner = inner.clone();
         async move {
             let connection_map = match Self::create_initial_connections(
                 &inner.initial_nodes,
@@ -1680,7 +1691,9 @@ where
         Self::refresh_slots_inner(inner, curr_retry)
             .await
             .map_err(|err| {
-                if curr_retry > DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES {
+                if curr_retry > DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES
+                    || err.kind() == ErrorKind::AllConnectionsUnavailable
+                {
                     BackoffError::Permanent(err)
                 } else {
                     BackoffError::from(err)
@@ -2073,14 +2086,22 @@ where
             }
             ConnectionCheck::RandomConnection => {
                 let read_guard = core.conn_lock.read().await;
-                let (random_address, random_conn_future) = read_guard
+                read_guard
                     .random_connections(1, ConnectionType::User)
-                    .next()
-                    .ok_or(RedisError::from((
-                        ErrorKind::AllConnectionsUnavailable,
-                        "No random connection found",
-                    )))?;
-                return Ok((random_address, random_conn_future.await));
+                    .and_then(|mut random_connections| {
+                        random_connections.next().map(
+                            |(random_address, random_conn_future)| async move {
+                                (random_address, random_conn_future.await)
+                            },
+                        )
+                    })
+                    .ok_or_else(|| {
+                        RedisError::from((
+                            ErrorKind::AllConnectionsUnavailable,
+                            "No random connection found",
+                        ))
+                    })?
+                    .await
             }
         };
 
@@ -2104,10 +2125,19 @@ where
                 }
                 Err(err) => {
                     trace!("Recover slots failed!");
-                    *future = Box::pin(Self::refresh_slots_and_subscriptions_with_retries(
-                        self.inner.clone(),
-                        &RefreshPolicy::Throttable,
-                    ));
+                    let next_state = if err.kind() == ErrorKind::AllConnectionsUnavailable {
+                        ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
+                            ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
+                        )))
+                    } else {
+                        ConnectionState::Recover(RecoverFuture::RecoverSlots(Box::pin(
+                            Self::refresh_slots_and_subscriptions_with_retries(
+                                self.inner.clone(),
+                                &RefreshPolicy::Throttable,
+                            ),
+                        )))
+                    };
+                    self.state = next_state;
                     Poll::Ready(Err(err))
                 }
             },
@@ -2226,9 +2256,7 @@ where
                         }));
                     }
                 }
-                Next::Reconnect {
-                    request, target, ..
-                } => {
+                Next::Reconnect { request, target } => {
                     poll_flush_action =
                         poll_flush_action.change_state(PollFlushAction::Reconnect(vec![target]));
                     if let Some(request) = request {
@@ -2371,7 +2399,7 @@ where
                 }
                 PollFlushAction::ReconnectFromInitialConnections => {
                     self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
-                        self.reconnect_to_initial_nodes(),
+                        ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
                     )));
                 }
             }
@@ -2413,8 +2441,19 @@ async fn calculate_topology_from_random_nodes<'a, C>(
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
 {
-    let requested_nodes =
-        read_guard.random_connections(num_of_nodes_to_query, ConnectionType::PreferManagement);
+    let requested_nodes = if let Some(random_conns) =
+        read_guard.random_connections(num_of_nodes_to_query, ConnectionType::PreferManagement)
+    {
+        random_conns
+    } else {
+        return (
+            Err(RedisError::from((
+                ErrorKind::AllConnectionsUnavailable,
+                "No available connections to refresh slots from",
+            ))),
+            vec![],
+        );
+    };
     let topology_join_results =
         futures::future::join_all(requested_nodes.map(|(addr, conn)| async move {
             let mut conn: C = conn.await;

--- a/glide-core/redis-rs/redis/tests/test_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_async.rs
@@ -569,7 +569,7 @@ mod basic_async {
                 Err(err) => break err,
             }
         };
-        assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
+        assert_eq!(err.kind(), ErrorKind::IoErrorRetrySafe);
     }
 
     #[tokio::test]

--- a/glide-core/redis-rs/redis/tests/test_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_async.rs
@@ -569,7 +569,7 @@ mod basic_async {
                 Err(err) => break err,
             }
         };
-        assert_eq!(err.kind(), ErrorKind::IoErrorRetrySafe);
+        assert_eq!(err.kind(), ErrorKind::FatalSendError);
     }
 
     #[tokio::test]

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -2542,7 +2542,7 @@ mod cluster_async {
                     6380 => panic!("Node should not be called"),
                     _ => match completed.fetch_add(1, Ordering::SeqCst) {
                         0..=1 => Err(Err(RedisError::from((
-                            ErrorKind::IoErrorRetrySafe,
+                            ErrorKind::FatalSendError,
                             "mock-io-error",
                         )))),
                         _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
@@ -2651,7 +2651,7 @@ mod cluster_async {
                 let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
                 match i {
                     0 => Err(Err(RedisError::from((
-                        ErrorKind::IoErrorRetrySafe,
+                        ErrorKind::FatalSendError,
                         "server didn't receive the request, safe to retry",
                     )))),
                     _ => Err(Ok(Value::Int(1))),
@@ -3988,7 +3988,7 @@ mod cluster_async {
                         panic!("Too many pings!");
                     }
                     Err(Err(RedisError::from((
-                        ErrorKind::IoErrorRetrySafe,
+                        ErrorKind::FatalSendError,
                         "mock-io-error",
                     ))))
                 } else {
@@ -3999,7 +3999,7 @@ mod cluster_async {
                         // Error once with io-error, ensure connection is reestablished w/out calling
                         // other node (i.e., not doing a full slot rebuild)
                         Err(Err(RedisError::from((
-                            ErrorKind::IoErrorRetrySafe,
+                            ErrorKind::FatalSendError,
                             "mock-io-error",
                         ))))
                     } else {

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -172,7 +172,7 @@ mod socket_listener {
     }
 
     fn read_from_socket(buffer: &mut Vec<u8>, socket: &mut UnixStream) -> usize {
-        buffer.resize(100, 0_u8);
+        buffer.resize(300, 0_u8);
         socket.read(buffer).unwrap()
     }
 


### PR DESCRIPTION
### Main Change:
ATM, on I/O errors, we would reconnect to the failed node and retry the request if there were more retries left. This approach had a critical issue: we couldn’t reliably determine if the server had already received the request before the connection was broken. Retrying in such cases could result in duplicate command execution.

**Example:**
1. Client sends `INCR key`.
2. Server receives the request and increments the key (e.g., key = 1).
3. A network issue disconnects the client before the server can respond.
4. The client reconnects and retries the `INCR key`.
5. Server increments the key again (now key = 2). **BAD outcome**.

This PR differentiates between errors where it’s safe to retry and those where it’s not. Specifically, with multiplexed connections, if the `send` function returns an error, it guarantees that the server never received the data, making retries safe (see https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Sender.html#method.send). For other errors, where we can’t be certain, retries are unsafe and will not be automatically attempted. Instead, these errors will now be returned to the user, who must manually retry if they determine it’s safe.

### Test Changes:
Since I/O errors are now returned to the user, tests that previously killed the server now loop to retry the request, simulating the handling of I/O errors on the user side.

### Refresh Slots Change:
While testing this fix, I found that when all connections were unavailable and `refresh_slots` was called, it didn’t raise the expected `allConnectionsUnavailable` error. This has been fixed by updating `random_connections` function to return an `Option`. Now, if no connections are found, `refresh_slots` raises the `allConnectionsUnavailable` error immediately. The state then shifts to reconnecting to the initial nodes, and slot refreshes are attempted using the new connections.

### Out of Scope:
A future PR could introduce a new configuration option to enable retries on connection error, allowing users to control this behavior at the client level.