### PR TITLE
Java: fix IT

### DIFF
--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1119,6 +1119,7 @@ public class SharedCommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void non_UTF8_GlideString_map_of_arrays(BaseClient client) {
+        assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.0.0"));
         byte[] nonUTF8Bytes = new byte[] {(byte) 0xEE};
         GlideString key = gs(UUID.randomUUID().toString());
         GlideString nonUTF8Key = gs(new byte[] {(byte) 0xFE});


### PR DESCRIPTION
Fixes failure of `non_UTF8_GlideString_map_of_arrays` test on redis 6.2. `lmpop` exists from version 7+
https://github.com/valkey-io/valkey-glide/actions/runs/11440382907/job/31827744171?pr=2051#step:7:35157