### PR TITLE
Java: Fix script kill IT

### DIFF
--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -399,7 +399,7 @@ public class TestUtilities {
     /**
      * Lock test until server completes a script/function execution.
      *
-     * @param lambda Client api reference to use for checking the server.
+     * @param lambda Client api reference to use for terminating the script/function on the server.
      */
     public static void waitForNotBusy(Supplier<CompletableFuture<?>> lambda) {
         // If function wasn't killed, and it didn't time out - it blocks the server and cause rest

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -397,32 +399,19 @@ public class TestUtilities {
     /**
      * Lock test until server completes a script/function execution.
      *
-     * @param function true if need to kill a function, false to kill a script.
+     * @param lambda Client api reference to use for checking the server.
      */
-    @SneakyThrows
-    public static void waitForNotBusy(BaseClient client, boolean function) {
+    public static void waitForNotBusy(Supplier<CompletableFuture<?>> lambda) {
         // If function wasn't killed, and it didn't time out - it blocks the server and cause rest
         // test to fail.
         boolean isBusy = true;
-        int timeout = 10000; // 10 sec - to avoid infinite locking
         do {
-            if (timeout <= 0) fail();
             try {
-                if (client instanceof GlideClusterClient) {
-                    if (function) ((GlideClusterClient) client).functionKill().get();
-                    else ((GlideClusterClient) client).scriptKill().get();
-                } else if (client instanceof GlideClient) {
-                    if (function) ((GlideClient) client).functionKill().get();
-                    else ((GlideClient) client).scriptKill().get();
-                }
-                timeout -= 100;
+                lambda.get().get();
             } catch (Exception busy) {
                 // should throw `notbusy` error, because the function should be killed before
                 if (busy.getMessage().toLowerCase().contains("notbusy")) {
                     isBusy = false;
-                } else {
-                    Thread.sleep(100);
-                    timeout -= 100;
                 }
             }
         } while (isBusy);

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1808,7 +1808,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient, true);
+                waitForNotBusy(clusterClient::functionKill);
             }
         }
     }
@@ -1863,7 +1863,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient, true);
+                waitForNotBusy(clusterClient::functionKill);
             }
         }
     }
@@ -1915,7 +1915,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient, true);
+                waitForNotBusy(clusterClient::functionKill);
             }
         }
     }
@@ -1969,7 +1969,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient, true);
+                waitForNotBusy(clusterClient::functionKill);
             }
         }
     }
@@ -3276,7 +3276,7 @@ public class CommandTests {
 
                 assertTrue(scriptKilled);
             } finally {
-                waitForNotBusy(clusterClient, false);
+                waitForNotBusy(clusterClient::scriptKill);
             }
         }
 
@@ -3297,7 +3297,7 @@ public class CommandTests {
         String key = UUID.randomUUID().toString();
         RequestRoutingConfiguration.Route route =
                 new RequestRoutingConfiguration.SlotKeyRoute(key, PRIMARY);
-        String code = createLongRunningLuaScript(5, false);
+        String code = createLongRunningLuaScript(6, false);
         Script script = new Script(code, false);
 
         CompletableFuture<Object> promise = new CompletableFuture<>();

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1808,7 +1808,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient);
+                waitForNotBusy(clusterClient, true);
             }
         }
     }
@@ -1863,7 +1863,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient);
+                waitForNotBusy(clusterClient, true);
             }
         }
     }
@@ -1915,7 +1915,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient);
+                waitForNotBusy(clusterClient, true);
             }
         }
     }
@@ -1969,7 +1969,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(clusterClient);
+                waitForNotBusy(clusterClient, true);
             }
         }
     }
@@ -3276,7 +3276,7 @@ public class CommandTests {
 
                 assertTrue(scriptKilled);
             } finally {
-                waitForNotBusy(clusterClient);
+                waitForNotBusy(clusterClient, false);
             }
         }
 

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -784,7 +784,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(regularClient);
+                waitForNotBusy(regularClient, true);
             }
         }
     }
@@ -835,7 +835,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(regularClient);
+                waitForNotBusy(regularClient, true);
             }
         }
     }
@@ -1681,7 +1681,7 @@ public class CommandTests {
 
                 assertTrue(scriptKilled);
             } finally {
-                waitForNotBusy(regularClient);
+                waitForNotBusy(regularClient, false);
             }
         }
 

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -784,7 +784,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(regularClient, true);
+                waitForNotBusy(regularClient::functionKill);
             }
         }
     }
@@ -835,7 +835,7 @@ public class CommandTests {
 
                 assertTrue(functionKilled);
             } finally {
-                waitForNotBusy(regularClient, true);
+                waitForNotBusy(regularClient::functionKill);
             }
         }
     }
@@ -1681,7 +1681,7 @@ public class CommandTests {
 
                 assertTrue(scriptKilled);
             } finally {
-                waitForNotBusy(regularClient, false);
+                waitForNotBusy(regularClient::scriptKill);
             }
         }
 
@@ -1700,7 +1700,7 @@ public class CommandTests {
     @Test
     public void scriptKill_unkillable() {
         String key = UUID.randomUUID().toString();
-        String code = createLongRunningLuaScript(5, false);
+        String code = createLongRunningLuaScript(6, false);
         Script script = new Script(code, false);
 
         CompletableFuture<Object> promise = new CompletableFuture<>();


### PR DESCRIPTION
Fix failure of the following IT
```
glide.cluster.CommandTests.scriptKill_with_route()
glide.cluster.CommandTests.scriptKill_unkillable()
glide.standalone.CommandTests.scriptKill()
glide.standalone.CommandTests.scriptKill_unkillable()
```
especially on redis 6, which has no `function kill`.
ref #2524