### PR TITLE
Added `Telemetry` support for GLIDE client (core only)

### DIFF
--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -18,6 +18,7 @@ redis = { path = "./redis-rs/redis", features = [
     "cluster",
     "cluster-async",
 ] }
+telemetrylib = { path = "./telemetry" }
 tokio = { version = "1", features = ["macros", "time"] }
 logger_core = { path = "../logger_core" }
 dispose = "0.5.0"
@@ -37,6 +38,8 @@ once_cell = "1.18.0"
 sha1_smol = "1.0.0"
 nanoid = "0.4.0"
 async-trait = { version = "0.1.24" }
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 
 [features]
 socket-layer = [

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -102,6 +102,8 @@ tracing = "0.1"
 # Optional uuid support
 uuid = { version = "1.6.1", optional = true }
 
+telemetrylib = { path = "../../telemetry" }
+
 [features]
 default = [
     "acl",

--- a/glide-core/redis-rs/redis/src/cluster_async/connections_logic.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_logic.rs
@@ -388,15 +388,15 @@ where
     if is_management {
         glide_connection_options.disconnect_notifier = None;
     }
-    let conn = C::connect(
+    C::connect(
         info,
         response_timeout,
         connection_timeout,
         socket_addr,
         glide_connection_options,
     )
-    .await?;
-    Ok(conn.into())
+    .await
+    .map(|conn| conn.into())
 }
 
 /// The function returns None if the checked connection/s are healthy. Otherwise, it returns the type of the unhealthy connection/s.

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -31,21 +31,22 @@ pub const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2
 pub const DEFAULT_PERIODIC_TOPOLOGY_CHECKS_INTERVAL: Duration = Duration::from_secs(60);
 pub const INTERNAL_CONNECTION_TIMEOUT: Duration = Duration::from_millis(250);
 pub const FINISHED_SCAN_CURSOR: &str = "finished";
-// The value of 1000 for the maximum number of inflight requests is determined based on Little's Law in queuing theory:
-//
-// Expected maximum request rate: 50,000 requests/second
-// Expected response time: 1 millisecond
-//
-// According to Little's Law, the maximum number of inflight requests required to fully utilize the maximum request rate is:
-//   (50,000 requests/second) × (1 millisecond / 1000 milliseconds) = 50 requests
-//
-// The value of 1000 provides a buffer for bursts while still allowing full utilization of the maximum request rate.
+
+/// The value of 1000 for the maximum number of inflight requests is determined based on Little's Law in queuing theory:
+///
+/// Expected maximum request rate: 50,000 requests/second
+/// Expected response time: 1 millisecond
+///
+/// According to Little's Law, the maximum number of inflight requests required to fully utilize the maximum request rate is:
+///   (50,000 requests/second) × (1 millisecond / 1000 milliseconds) = 50 requests
+///
+/// The value of 1000 provides a buffer for bursts while still allowing full utilization of the maximum request rate.
 pub const DEFAULT_MAX_INFLIGHT_REQUESTS: u32 = 1000;
 
-// The connection check interval is currently not exposed to the user via ConnectionRequest,
-// as improper configuration could negatively impact performance or pub/sub resiliency.
-// A 3-second interval provides a reasonable balance between connection validation
-// and performance overhead.
+/// The connection check interval is currently not exposed to the user via ConnectionRequest,
+/// as improper configuration could negatively impact performance or pub/sub resiliency.
+/// A 3-second interval provides a reasonable balance between connection validation
+/// and performance overhead.
 pub const CONNECTION_CHECKS_INTERVAL: Duration = Duration::from_secs(3);
 
 pub(super) fn get_port(address: &NodeAddress) -> u16 {

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -713,8 +713,7 @@ impl Client {
             })
         })
         .await
-        .map_err(|_| ConnectionError::Timeout)
-        .and_then(|res| res)
+        .map_err(|_| ConnectionError::Timeout)?
     }
 }
 

--- a/glide-core/src/lib.rs
+++ b/glide-core/src/lib.rs
@@ -17,3 +17,4 @@ pub mod scripts_container;
 pub use client::ConnectionRequest;
 pub mod cluster_scan_container;
 pub mod request_type;
+pub use telemetrylib::Telemetry;

--- a/glide-core/telemetry/Cargo.toml
+++ b/glide-core/telemetry/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "telemetrylib"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Valkey GLIDE Maintainers"]
+
+[dependencies]
+lazy_static = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/glide-core/telemetry/src/lib.rs
+++ b/glide-core/telemetry/src/lib.rs
@@ -1,0 +1,68 @@
+use lazy_static::lazy_static;
+use serde::Serialize;
+use std::sync::RwLock as StdRwLock;
+
+#[derive(Default, Serialize)]
+#[allow(dead_code)]
+pub struct Telemetry {
+    /// Total number of connections opened to Valkey
+    total_connections: usize,
+    /// Total number of GLIDE clients
+    total_clients: usize,
+}
+
+lazy_static! {
+    static ref TELEMETRY: StdRwLock<Telemetry> = StdRwLock::<Telemetry>::default();
+}
+
+const MUTEX_WRITE_ERR: &str = "Failed to obtain write lock for mutex. Poisoned mutex";
+const MUTEX_READ_ERR: &str = "Failed to obtain read lock for mutex. Poisoned mutex";
+
+impl Telemetry {
+    /// Increment the total number of connections by `incr_by`
+    /// Return the number of total connections after the increment
+    pub fn incr_total_connections(incr_by: usize) -> usize {
+        let mut t = TELEMETRY.write().expect(MUTEX_WRITE_ERR);
+        t.total_connections = t.total_connections.saturating_add(incr_by);
+        t.total_connections
+    }
+
+    /// Decrease the total number of connections by `decr_by`
+    /// Return the number of total connections after the decrease
+    pub fn decr_total_connections(decr_by: usize) -> usize {
+        let mut t = TELEMETRY.write().expect(MUTEX_WRITE_ERR);
+        t.total_connections = t.total_connections.saturating_sub(decr_by);
+        t.total_connections
+    }
+
+    /// Increment the total number of clients by `incr_by`
+    /// Return the number of total clients after the increment
+    pub fn incr_total_clients(incr_by: usize) -> usize {
+        let mut t = TELEMETRY.write().expect(MUTEX_WRITE_ERR);
+        t.total_clients = t.total_clients.saturating_add(incr_by);
+        t.total_clients
+    }
+
+    /// Decrease the total number of clients by `decr_by`
+    /// Return the number of total clients after the decrease
+    pub fn decr_total_clients(decr_by: usize) -> usize {
+        let mut t = TELEMETRY.write().expect(MUTEX_WRITE_ERR);
+        t.total_clients = t.total_clients.saturating_sub(decr_by);
+        t.total_clients
+    }
+
+    /// Return the number of active connections
+    pub fn total_connections() -> usize {
+        TELEMETRY.read().expect(MUTEX_READ_ERR).total_connections
+    }
+
+    /// Return the number of active clients
+    pub fn total_clients() -> usize {
+        TELEMETRY.read().expect(MUTEX_READ_ERR).total_clients
+    }
+
+    /// Reset the telemetry collected thus far
+    pub fn reset() {
+        *TELEMETRY.write().expect(MUTEX_WRITE_ERR) = Telemetry::default();
+    }
+}

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3,8 +3,27 @@
  */
 mod utilities;
 
+#[macro_export]
+/// Compare `$expected` with `$actual`. This macro, will exit the test process
+/// if the assertion fails. Unlike `assert_eq!` - this also works in tasks
+macro_rules! async_assert_eq {
+    ($expected:expr, $actual:expr) => {{
+        if $actual != $expected {
+            println!(
+                "{}:{}: Expected: {:?} != Actual: {:?}",
+                file!(),
+                line!(),
+                $actual,
+                $expected
+            );
+            std::process::exit(1);
+        }
+    }};
+}
+
 #[cfg(test)]
 pub(crate) mod shared_client_tests {
+    use glide_core::Telemetry;
     use std::collections::HashMap;
 
     use super::*;
@@ -44,7 +63,9 @@ pub(crate) mod shared_client_tests {
                 })
                 .await
             }
-            BackingServer::Cluster(cluster) => create_cluster_client(cluster, configuration).await,
+            BackingServer::Cluster(cluster) => {
+                create_cluster_client(cluster.as_ref(), configuration).await
+            }
         }
     }
 
@@ -537,6 +558,83 @@ pub(crate) mod shared_client_tests {
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 }
             }
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_client_telemetry_standalone() {
+        Telemetry::reset();
+        block_on_all(async move {
+            // create a server with 2 clients
+            let server_config = TestConfiguration {
+                use_tls: false,
+                ..Default::default()
+            };
+
+            let test_basics = utilities::setup_test_basics_internal(&server_config).await;
+            let server = BackingServer::Standalone(test_basics.server);
+
+            // setup_test_basics_internal internally, starts a single client connection
+            assert_eq!(Telemetry::total_connections(), 1);
+            assert_eq!(Telemetry::total_clients(), 1);
+
+            {
+                // Create 2 more clients, confirm that they are tracked
+                let _client1 = create_client(&server, server_config.clone()).await;
+                let _client2 = create_client(&server, server_config).await;
+
+                // Each client maintains a single connection
+                assert_eq!(Telemetry::total_connections(), 3);
+                assert_eq!(Telemetry::total_clients(), 3);
+
+                // Connections are dropped here
+            }
+
+            // Confirm 1 connection & client remain
+            assert_eq!(Telemetry::total_connections(), 1);
+            assert_eq!(Telemetry::total_clients(), 1);
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_client_telemetry_cluster() {
+        Telemetry::reset();
+        block_on_all(async {
+            let local_set = tokio::task::LocalSet::default();
+            let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+            // We use 2 tasks to let "dispose" be called. In addition, the task that checks for the cleanup
+            // does not start until the cluster is up and running. We use a channel to communicate this between
+            // the tasks
+            local_set.spawn_local(async move {
+                let cluster = cluster::setup_default_cluster().await;
+                async_assert_eq!(Telemetry::total_connections(), 0);
+                async_assert_eq!(Telemetry::total_clients(), 0);
+
+                // Each client opens 12 connections
+                println!("Creating 1st cluster client...");
+                let _c1 = cluster::setup_default_client(&cluster).await;
+                async_assert_eq!(Telemetry::total_connections(), 12);
+                async_assert_eq!(Telemetry::total_clients(), 1);
+
+                println!("Creating 2nd cluster client...");
+                let _c2 = cluster::setup_default_client(&cluster).await;
+                async_assert_eq!(Telemetry::total_connections(), 24);
+                async_assert_eq!(Telemetry::total_clients(), 2);
+
+                let _ = tx.send(1).await;
+                // client is dropped and eventually disposed here
+            });
+
+            local_set.spawn_local(async move {
+                let _ = rx.recv().await;
+                println!("Cluster terminated. Wait for the telemetry to clear");
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                assert_eq!(Telemetry::total_connections(), 0);
+                assert_eq!(Telemetry::total_clients(), 0);
+            });
+            local_set.await;
         });
     }
 

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -230,11 +230,11 @@ async fn setup_acl_for_cluster(
 }
 
 pub async fn create_cluster_client(
-    cluster: &Option<RedisCluster>,
+    cluster: Option<&RedisCluster>,
     mut configuration: TestConfiguration,
 ) -> Client {
     let addresses = if !configuration.shared_server {
-        cluster.as_ref().unwrap().get_server_addresses()
+        cluster.unwrap().get_server_addresses()
     } else {
         get_shared_cluster_addresses(configuration.use_tls)
     };
@@ -263,8 +263,18 @@ pub async fn setup_test_basics_internal(configuration: TestConfiguration) -> Clu
     } else {
         None
     };
-    let client = create_cluster_client(&cluster, configuration).await;
+    let client = create_cluster_client(cluster.as_ref(), configuration).await;
     ClusterTestBasics { cluster, client }
+}
+
+pub async fn setup_default_cluster() -> RedisCluster {
+    let test_config = TestConfiguration::default();
+    RedisCluster::new(false, &test_config.connection_info, None, None)
+}
+
+pub async fn setup_default_client(cluster: &RedisCluster) -> Client {
+    let test_config = TestConfiguration::default();
+    create_cluster_client(Some(cluster), test_config).await
 }
 
 pub async fn setup_test_basics(use_tls: bool) -> ClusterTestBasics {


### PR DESCRIPTION
With this PR, `glide-core` + `redis-rs` adds the ability to count for active connections + clients (this is done per process and **not** per client).

Exposing this functionality to the end user will be done in separate PRs.

Related issue: https://github.com/valkey-io/valkey-glide/issues/2376