### PR TITLE
Node: add timeout to getMessageByMethod to prevent infinite waiting

### DIFF
--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -186,7 +186,9 @@ describe("PubSub", () => {
         index?: number,
     ) {
         if (method === MethodTesting.Async) {
-            const pubsubMessage = await withPromiseTimeout(client.getPubSubMessage());
+            const pubsubMessage = await withPromiseTimeout(
+                client.getPubSubMessage(),
+            );
             return pubsubMessage;
         } else if (method === MethodTesting.Sync) {
             const pubsubMessage = client.tryGetPubSubMessage();

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -30,6 +30,7 @@ import {
     getServerVersion,
     parseCommandLineArgs,
     parseEndpoints,
+    withPromiseTimeout,
 } from "./TestUtilities";
 
 type TGlideClient = GlideClient | GlideClusterClient;
@@ -185,7 +186,7 @@ describe("PubSub", () => {
         index?: number,
     ) {
         if (method === MethodTesting.Async) {
-            const pubsubMessage = await client.getPubSubMessage();
+            const pubsubMessage = await withPromiseTimeout(client.getPubSubMessage());
             return pubsubMessage;
         } else if (method === MethodTesting.Sync) {
             const pubsubMessage = client.tryGetPubSubMessage();

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -1764,5 +1764,10 @@ export async function withPromiseTimeout<T>(
     promise: Promise<T>,
     timeout = 3000,
 ) {
-    return Promise.race([promise, new Promise((_, reject) => setTimeout(() => reject("Timeout"), timeout))]) as Promise<T>;
+    return Promise.race([
+        promise,
+        new Promise((_, reject) =>
+            setTimeout(() => reject("Timeout"), timeout),
+        ),
+    ]) as Promise<T>;
 }

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -1759,3 +1759,10 @@ export async function getServerVersion(
 
     return version;
 }
+
+export async function withPromiseTimeout<T>(
+    promise: Promise<T>,
+    timeout = 3000,
+) {
+    return Promise.race([promise, new Promise((_, reject) => setTimeout(() => reject("Timeout"), timeout))]) as Promise<T>;
+}


### PR DESCRIPTION
When a publish operation fails or the message does not arrive even though it was published. Any client waiting on getPubSubMessage() will continue to wait indefinitely since:

1. The method has no timeout mechanism
2. It relies on pendingPushNotification to receive messages
3. If publish fails, no message will ever arrive in pendingPushNotification
4. The Promise in getPubSubMessage will never resolve or reject

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2336

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [X] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [X] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
