### PR TITLE
Fix benchmark CI error MISCONF

### DIFF
--- a/.github/workflows/test-benchmark/action.yml
+++ b/.github/workflows/test-benchmark/action.yml
@@ -11,7 +11,8 @@ runs:
 
     steps:
         - shell: bash
-          run: redis-server &
+          # Disable RDB snapshots to avoid configuration errors
+          run: redis-server --save "" --daemonize "yes"
 
         - shell: bash
           working-directory: ./benchmarks


### PR DESCRIPTION
Fix test-benchmark CI error MISCONF by disabling the RDB snapshots on the server (with `--save ""`):
> [ErrorReply: MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-writes-on-bgsave-error option). Please check the Redis logs for details about the RDB error.]

https://github.com/valkey-io/valkey-glide/actions/runs/11643552677/job/32424425430#step:8:2