### PR TITLE
Python: Round map values in tests for floating-point comparison

### DIFF
--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -105,6 +105,7 @@ from tests.utils.utils import (
     get_random_string,
     is_single_response,
     parse_info_response,
+    round_values,
 )
 
 
@@ -2687,6 +2688,7 @@ class TestCommands:
         )
         expected_map = {member: value[1] for member, value in result.items()}
         sorted_expected_map = dict(sorted(expected_map.items(), key=lambda x: x[1]))
+        zrange_map = round_values(zrange_map, 10)
         assert compare_maps(zrange_map, sorted_expected_map) is True
 
         # Test storing results of a box search, unit: kilometes, from a geospatial data, with distance
@@ -2706,6 +2708,8 @@ class TestCommands:
         )
         expected_map = {member: value[0] for member, value in result.items()}
         sorted_expected_map = dict(sorted(expected_map.items(), key=lambda x: x[1]))
+        zrange_map = round_values(zrange_map, 10)
+        sorted_expected_map = round_values(sorted_expected_map, 10)
         assert compare_maps(zrange_map, sorted_expected_map) is True
 
         # Test storing results of a box search, unit: kilometes, from a geospatial data, with count
@@ -2746,6 +2750,8 @@ class TestCommands:
             b"Palermo": 166274.15156960033,
             b"edge2": 236529.17986494553,
         }
+        zrange_map = round_values(zrange_map, 9)
+        expected_distances = round_values(expected_distances, 9)
         assert compare_maps(zrange_map, expected_distances) is True
 
         # Test search by box, unit: feet, from a member, with limited ANY count to 2, with hash
@@ -2827,6 +2833,8 @@ class TestCommands:
             b"Catania": 0.0,
             b"Palermo": 166274.15156960033,
         }
+        zrange_map = round_values(zrange_map, 9)
+        expected_distances = round_values(expected_distances, 9)
         assert compare_maps(zrange_map, expected_distances) is True
 
         # Test search by radius, unit: miles, from a geospatial data
@@ -2860,6 +2868,8 @@ class TestCommands:
         )
         expected_map = {member: value[0] for member, value in result.items()}
         sorted_expected_map = dict(sorted(expected_map.items(), key=lambda x: x[1]))
+        zrange_map = round_values(zrange_map, 10)
+        sorted_expected_map = round_values(sorted_expected_map, 10)
         assert compare_maps(zrange_map, sorted_expected_map) is True
 
         # Test storing results of a radius search, unit: kilometers, from a geospatial data, with limited ANY count to 1

--- a/python/python/tests/utils/utils.py
+++ b/python/python/tests/utils/utils.py
@@ -136,6 +136,9 @@ def compare_maps(
         convert_bytes_to_string_object(map2)
     )
 
+def round_values(map_data: dict, decimal_places: int) -> dict:
+    """Round the values in a map to the specified number of decimal places."""
+    return {key: round(value, decimal_places) for key, value in map_data.items()}
 
 def convert_bytes_to_string_object(
     # TODO: remove the str options

--- a/python/python/tests/utils/utils.py
+++ b/python/python/tests/utils/utils.py
@@ -136,9 +136,11 @@ def compare_maps(
         convert_bytes_to_string_object(map2)
     )
 
+
 def round_values(map_data: dict, decimal_places: int) -> dict:
     """Round the values in a map to the specified number of decimal places."""
     return {key: round(value, decimal_places) for key, value in map_data.items()}
+
 
 def convert_bytes_to_string_object(
     # TODO: remove the str options


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): #2594 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
