### PR TITLE
Bump valkey 8 wait timeout

### DIFF
--- a/java/integTest/src/test/java/glide/SharedClientTests.java
+++ b/java/integTest/src/test/java/glide/SharedClientTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@Timeout(25) // seconds
+@Timeout(35) // seconds
 public class SharedClientTests {
 
     private static GlideClient standaloneClient = null;

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -107,7 +107,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@Timeout(10) // seconds
+@Timeout(30) // seconds
 public class CommandTests {
 
     private static GlideClusterClient clusterClient = null;
@@ -1660,7 +1660,7 @@ public class CommandTests {
 
         assertEquals(libName, clusterClient.functionLoad(code, false).get());
         // let replica sync with the primary node
-        assertEquals(1L, clusterClient.wait(1L, 3000L).get());
+        assertEquals(1L, clusterClient.wait(1L, 4000L).get());
 
         // fcall on a replica node should fail, because a function isn't guaranteed to be RO
         var executionException =


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): Fixes #2619 and #2618

Raised Timeouts to add flexibility on some tests and avoid time outs for tests:
* `glide.SharedClientTests.send_and_receive_large_values`
* `glide.cluster.CommandTests.fcall_readonly_function`
Fixes CI run: https://github.com/valkey-io/valkey-glide/actions/runs/11691408118 (note: modules test was rejected - hence the red 'X')

### Checklist

Before submitting the PR make sure the following are checked:

-   N/A This Pull Request is related to one issue - fixes similar bugs.
-   N/A Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   N/A CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
