### PR TITLE
Node: Ensure client closure in flushAndCloseClient with try-finally

### DIFF
--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -396,19 +396,17 @@ export async function flushAndCloseClient(
     addresses: [string, number][],
     client?: BaseClient,
 ) {
-    await testTeardown(
-        cluster_mode,
-        getClientConfigurationOption(addresses, ProtocolVersion.RESP3, {
-            requestTimeout: 2000,
-        }),
-    );
-
-    // some tests don't initialize a client
-    if (client == undefined) {
-        return;
+    try {
+        await testTeardown(
+            cluster_mode,
+            getClientConfigurationOption(addresses, ProtocolVersion.RESP3, {
+                requestTimeout: 2000,
+            }),
+        );
+    } finally {
+        // some tests don't initialize a client
+        client?.close();
     }
-
-    client.close();
 }
 
 /**


### PR DESCRIPTION
Clients may not be properly closed when FLUSHALL command times out in flushAndCloseClient, despite being handled in afterEach blocks of test suites.

The issue is reproducible by configuring an extremely low random requestTimeout value in ClientConfiguration during [testTeardown execution](https://github.com/jhpung/valkey-glide/blob/b33968cce98c1f4897448841289e0cec3dc75050/node/tests/TestUtilities.ts#L400-L405)

Fixes CI: https://github.com/avifenesh/valkey-glide/actions/runs/11678481691/job/32518075011

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2336

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
