### PR TITLE
Node modules test fix

### DIFF
--- a/node/jest.config.js
+++ b/node/jest.config.js
@@ -29,5 +29,5 @@ module.exports = {
             },
         ],
     ],
-    setupFilesAfterEnv: ["./tests/setup.js"],
+    setupFilesAfterEnv: ["./tests/setup.ts"],
 };

--- a/node/package.json
+++ b/node/package.json
@@ -34,7 +34,7 @@
         "fix-protobuf-file": "replace 'this\\.encode\\(message, writer\\)\\.ldelim' 'this.encode(message, writer && writer.len ? writer.fork() : writer).ldelim' src/ProtobufMessage.js",
         "test": "npm run build-test-utils && jest --verbose --testPathIgnorePatterns='ServerModules'",
         "test-minimum": "npm run build-test-utils && jest --verbose --runInBand --testNamePattern='^(.(?!(GlideJson|GlideFt|pubsub|kill)))*$'",
-        "test-modules": "npm run build-test-utils && jest --verbose --testNamePattern='(GlideJson|GlideFt)'",
+        "test-modules": "npm run build-test-utils && jest --verbose --runInBand --testNamePattern='(GlideJson|GlideFt)'",
         "build-test-utils": "cd ../utils && npm i && npm run build",
         "lint:fix": "npm run install-linting && npx eslint -c ../eslint.config.mjs --fix && npm run prettier:format",
         "lint": "npm run install-linting && npx eslint -c ../eslint.config.mjs && npm run prettier:check:ci",
@@ -59,9 +59,9 @@
         "replace": "^1.2.2",
         "semver": "^7.6.3",
         "ts-jest": "^29.2.5",
+        "ts-node": "^10.9.2",
         "typescript": "^5.5.4",
-        "uuid": "^10.0.0",
-        "ts-node": "^10.9.2"
+        "uuid": "^11.0"
     },
     "author": "Valkey GLIDE Maintainers",
     "license": "Apache-2.0",

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -41,7 +41,6 @@ import {
     generateLuaLibCode,
     getClientConfigurationOption,
     getServerVersion,
-    parseCommandLineArgs,
     parseEndpoints,
     transactionTest,
     validateTransactionResponse,
@@ -56,8 +55,7 @@ describe("GlideClient", () => {
     let cluster: ValkeyCluster;
     let client: GlideClient;
     beforeAll(async () => {
-        const standaloneAddresses =
-            parseCommandLineArgs()["standalone-endpoints"];
+        const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
         cluster = standaloneAddresses
             ? await ValkeyCluster.initFromExistingCluster(
                   false,

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -50,7 +50,6 @@ import {
     getServerVersion,
     intoArray,
     intoString,
-    parseCommandLineArgs,
     parseEndpoints,
     transactionTest,
     validateTransactionResponse,
@@ -65,7 +64,7 @@ describe("GlideClusterClient", () => {
     let cluster: ValkeyCluster;
     let client: GlideClusterClient;
     beforeAll(async () => {
-        const clusterAddresses = parseCommandLineArgs()["cluster-endpoints"];
+        const clusterAddresses = global.CLUSTER_ENDPOINTS;
         // Connect to cluster or create a new one based on the parsed addresses
         cluster = clusterAddresses
             ? await ValkeyCluster.initFromExistingCluster(

--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -28,7 +28,6 @@ import ValkeyCluster from "../../utils/TestUtils";
 import {
     flushAndCloseClient,
     getServerVersion,
-    parseCommandLineArgs,
     parseEndpoints,
 } from "./TestUtilities";
 
@@ -60,9 +59,8 @@ describe("PubSub", () => {
     let cmeCluster: ValkeyCluster;
     let cmdCluster: ValkeyCluster;
     beforeAll(async () => {
-        const standaloneAddresses =
-            parseCommandLineArgs()["standalone-endpoints"];
-        const clusterAddresses = parseCommandLineArgs()["cluster-endpoints"];
+        const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
+        const clusterAddresses = global.CLUSTER_ENDPOINTS;
         // Connect to cluster or create a new one based on the parsed addresses
         cmdCluster = standaloneAddresses
             ? await ValkeyCluster.initFromExistingCluster(

--- a/node/tests/ScanTest.test.ts
+++ b/node/tests/ScanTest.test.ts
@@ -18,7 +18,6 @@ import {
     flushAndCloseClient,
     getClientConfigurationOption,
     getServerVersion,
-    parseCommandLineArgs,
     parseEndpoints,
 } from "./TestUtilities";
 
@@ -30,7 +29,7 @@ describe("Scan GlideClusterClient", () => {
     let cluster: ValkeyCluster;
     let client: GlideClusterClient;
     beforeAll(async () => {
-        const clusterAddresses = parseCommandLineArgs()["cluster-endpoints"];
+        const clusterAddresses = global.CLUSTER_ENDPOINTS;
         // Connect to cluster or create a new one based on the parsed addresses
         cluster = clusterAddresses
             ? await ValkeyCluster.initFromExistingCluster(
@@ -385,8 +384,7 @@ describe("Scan GlideClient", () => {
     let cluster: ValkeyCluster;
     let client: GlideClient;
     beforeAll(async () => {
-        const standaloneAddresses =
-            parseCommandLineArgs()["standalone-endpoints"];
+        const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
         cluster = standaloneAddresses
             ? await ValkeyCluster.initFromExistingCluster(
                   false,

--- a/node/tests/ServerModules.test.ts
+++ b/node/tests/ServerModules.test.ts
@@ -45,7 +45,7 @@ describe("Server Module Tests", () => {
             parseEndpoints(clusterAddresses),
             getServerVersion,
         );
-    }, 20000);
+    }, 40000);
 
     afterAll(async () => {
         await cluster.close();

--- a/node/tests/ServerModules.test.ts
+++ b/node/tests/ServerModules.test.ts
@@ -28,7 +28,6 @@ import {
     flushAndCloseClient,
     getClientConfigurationOption,
     getServerVersion,
-    parseCommandLineArgs,
     parseEndpoints,
 } from "./TestUtilities";
 
@@ -39,7 +38,7 @@ describe("Server Module Tests", () => {
     let cluster: ValkeyCluster;
 
     beforeAll(async () => {
-        const clusterAddresses = parseCommandLineArgs()["cluster-endpoints"];
+        const clusterAddresses = global.CLUSTER_ENDPOINTS;
         cluster = await ValkeyCluster.initFromExistingCluster(
             true,
             parseEndpoints(clusterAddresses),

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1594,7 +1594,7 @@ export function runBaseTests(config: {
                 // Test count with match returns a non-empty list
                 result = await client.hscan(key1, initialCursor, {
                     match: "1*",
-                    count: 30,
+                    count: 1000,
                 });
                 expect(result[resultCursorIndex]).not.toEqual(initialCursor);
                 expect(result[resultCollectionIndex].length).toBeGreaterThan(0);
@@ -9842,7 +9842,7 @@ export function runBaseTests(config: {
                     // Test count with match returns a non-empty list
                     result = await client.zscan(key1, initialCursor, {
                         match: "member1*",
-                        count: 20,
+                        count: 1000,
                     });
                     expect(result[resultCursorIndex]).not.toEqual("0");
                     expect(

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -4,7 +4,6 @@
 
 import { expect } from "@jest/globals";
 import { exec } from "child_process";
-import parseArgs from "minimist";
 import { gte } from "semver";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -347,22 +346,6 @@ export async function waitForScriptNotBusy(
     } while (isBusy);
 }
 
-/**
- * Parses the command-line arguments passed to the Node.js process.
- *
- * @returns Parsed command-line arguments.
- *
- * @example
- * ```typescript
- * // Command: node script.js --name="John Doe" --age=30
- * const args = parseCommandLineArgs();
- * // args = { name: 'John Doe', age: 30 }
- * ```
- */
-export function parseCommandLineArgs() {
-    return parseArgs(process.argv.slice(2));
-}
-
 export async function testTeardown(
     cluster_mode: boolean,
     option: BaseClientConfiguration,
@@ -386,7 +369,7 @@ export const getClientConfigurationOption = (
             port,
         })),
         protocol,
-        useTLS: parseCommandLineArgs()["tls"] == "true",
+        useTLS: global.TLS ?? false,
         requestTimeout: 1000,
         ...configOverrides,
     };

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -1273,15 +1273,6 @@ export async function transactionTest(
         "xpending(key9, groupName1)",
         [1, "0-2", "0-2", [[consumer, "1"]]],
     ]);
-    baseTransaction.xpendingWithOptions(key9, groupName1, {
-        start: InfBoundary.NegativeInfinity,
-        end: InfBoundary.PositiveInfinity,
-        count: 10,
-    });
-    responseData.push([
-        "xpendingWithOptions(key9, groupName1, -, +, 10)",
-        [["0-2", consumer, 0, 1]],
-    ]);
     baseTransaction.xclaim(key9, groupName1, consumer, 0, ["0-2"]);
     responseData.push([
         'xclaim(key9, groupName1, consumer, 0, ["0-2"])',

--- a/node/tests/setup.js
+++ b/node/tests/setup.js
@@ -1,7 +1,0 @@
-import { beforeAll } from "@jest/globals";
-import { Logger } from "..";
-
-beforeAll(() => {
-    Logger.init("off");
-    Logger.setLoggerConfig("off");
-});

--- a/node/tests/setup.ts
+++ b/node/tests/setup.ts
@@ -1,0 +1,23 @@
+/* eslint-disable no-var */
+import { beforeAll } from "@jest/globals";
+import minimist from "minimist";
+import { Logger } from "../build-ts";
+
+beforeAll(() => {
+    Logger.init("error", "log.log");
+    // Logger.setLoggerConfig("off");
+});
+
+declare global {
+    var CLI_ARGS: Record<string, string | boolean | number>;
+    var CLUSTER_ENDPOINTS: string;
+    var STAND_ALONE_ENDPOINT: string;
+    var TLS: boolean;
+}
+
+const args = minimist(process.argv.slice(2));
+// Make the arguments available globally
+global.CLI_ARGS = args;
+global.CLUSTER_ENDPOINTS = args["cluster-endpoints"] as string;
+global.STAND_ALONE_ENDPOINT = args["standalone-endpoints"] as string;
+global.TLS = args.tls;

--- a/node/tests/setup.ts
+++ b/node/tests/setup.ts
@@ -20,4 +20,4 @@ const args = minimist(process.argv.slice(2));
 global.CLI_ARGS = args;
 global.CLUSTER_ENDPOINTS = args["cluster-endpoints"] as string;
 global.STAND_ALONE_ENDPOINT = args["standalone-endpoints"] as string;
-global.TLS = args.tls;
+global.TLS = !!args.tls;

--- a/node/tests/tsconfig.json
+++ b/node/tests/tsconfig.json
@@ -3,5 +3,5 @@
     "compilerOptions": {
         "rootDir": "../../"
     },
-    "include": ["*.ts", "./*.test.ts"]
+    "include": ["*.ts", "./*.test.ts", "setup.ts"]
 }

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -22,7 +22,7 @@ function parseOutput(input: string): {
         .map((address) => address.split(":"))
         .map((address) => [address[0], Number(address[1])]) as [
         string,
-        number
+        number,
     ][];
 
     if (clusterFolder === undefined || ports === undefined) {
@@ -43,7 +43,7 @@ export class ValkeyCluster {
     private constructor(
         version: string,
         addresses: [string, number][],
-        clusterFolder?: string
+        clusterFolder?: string,
     ) {
         this.addresses = addresses;
         this.clusterFolder = clusterFolder;
@@ -56,9 +56,9 @@ export class ValkeyCluster {
         replicaCount: number,
         getVersionCallback: (
             addresses: [string, number][],
-            clusterMode: boolean
+            clusterMode: boolean,
         ) => Promise<string>,
-        loadModule?: string[]
+        loadModule?: string[],
     ): Promise<ValkeyCluster> {
         return new Promise<ValkeyCluster>((resolve, reject) => {
             let command = `start -r ${replicaCount} -n ${shardCount}`;
@@ -70,7 +70,7 @@ export class ValkeyCluster {
             if (loadModule) {
                 if (loadModule.length === 0) {
                     throw new Error(
-                        "Please provide the path(s) to the module(s) you want to load."
+                        "Please provide the path(s) to the module(s) you want to load.",
                     );
                 }
 
@@ -94,12 +94,12 @@ export class ValkeyCluster {
                                     new ValkeyCluster(
                                         ver,
                                         addresses,
-                                        clusterFolder
-                                    )
-                            )
+                                        clusterFolder,
+                                    ),
+                            ),
                         );
                     }
-                }
+                },
             );
         });
     }
@@ -109,11 +109,11 @@ export class ValkeyCluster {
         addresses: [string, number][],
         getVersionCallback: (
             addresses: [string, number][],
-            clusterMode: boolean
-        ) => Promise<string>
+            clusterMode: boolean,
+        ) => Promise<string>,
     ): Promise<ValkeyCluster> {
         return getVersionCallback(addresses, cluster_mode).then(
-            (ver) => new ValkeyCluster(ver, addresses, "")
+            (ver) => new ValkeyCluster(ver, addresses, ""),
         );
     }
 

--- a/utils/package.json
+++ b/utils/package.json
@@ -12,9 +12,9 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@types/node": "^20.12.12",
+        "@types/node": "22.9",
         "@types/semver": "^7.5.8",
-        "prettier": "^2.8.8"
+        "prettier": "^3.3"
     },
     "dependencies": {
         "child_process": "^1.0.2",

--- a/utils/release-candidate-testing/node/index.js
+++ b/utils/release-candidate-testing/node/index.js
@@ -4,7 +4,6 @@
 import { GlideClient, GlideClusterClient } from "@valkey/valkey-glide";
 import { ValkeyCluster } from "../../TestUtils.js";
 
-
 async function runCommands(client) {
     console.log("Executing commands");
     // Set a bunch of keys
@@ -41,7 +40,9 @@ async function runCommands(client) {
     // check that the correct number of keys were deleted
     if (deletedKeysNum !== 3) {
         console.log(deletedKeysNum);
-        throw new Error(`Unexpected number of keys deleted, expected 3, got ${deletedKeysNum}`);
+        throw new Error(
+            `Unexpected number of keys deleted, expected 3, got ${deletedKeysNum}`,
+        );
     }
     // check that the keys were deleted
     for (let i = 1; i <= 3; i++) {
@@ -74,7 +75,8 @@ async function clusterTests() {
     try {
         console.log("Testing cluster");
         console.log("Creating cluster");
-        let valkeyCluster = await ValkeyCluster.createCluster(true,
+        let valkeyCluster = await ValkeyCluster.createCluster(
+            true,
             3,
             1,
             getServerVersion,
@@ -82,8 +84,12 @@ async function clusterTests() {
         console.log("Cluster created");
 
         console.log("Connecting to cluster");
-        let addresses = valkeyCluster.getAddresses().map((address) => { return { host: address[0], port: address[1] } });
-        const client = await GlideClusterClient.createClient({ addresses: addresses });
+        let addresses = valkeyCluster.getAddresses().map((address) => {
+            return { host: address[0], port: address[1] };
+        });
+        const client = await GlideClusterClient.createClient({
+            addresses: addresses,
+        });
         console.log("Connected to cluster");
 
         await runCommands(client);
@@ -103,9 +109,10 @@ async function clusterTests() {
 
 async function standaloneTests() {
     try {
-        console.log("Testing standalone Cluster")
+        console.log("Testing standalone Cluster");
         console.log("Creating Cluster");
-        let valkeyCluster = await ValkeyCluster.createCluster(false,
+        let valkeyCluster = await ValkeyCluster.createCluster(
+            false,
             1,
             1,
             getServerVersion,
@@ -113,13 +120,14 @@ async function standaloneTests() {
         console.log("Cluster created");
 
         console.log("Connecting to Cluster");
-        let addresses = valkeyCluster.getAddresses().map((address) => { return { host: address[0], port: address[1] } });
+        let addresses = valkeyCluster.getAddresses().map((address) => {
+            return { host: address[0], port: address[1] };
+        });
         const client = await GlideClient.createClient({ addresses: addresses });
         console.log("Connected to Cluster");
 
         await closeClientAndCluster(client, valkeyCluster);
         console.log("Done");
-
     } catch (error) {
         // Need this part just when running in our self-hosted runner, so if the test fails before closing Clusters we still kill them and clean up
         if (process.platform === "linux" && process.arch in ["arm", "arm64"]) {
@@ -129,7 +137,6 @@ async function standaloneTests() {
         throw error;
     }
 }
-
 
 async function main() {
     await clusterTests();


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
The main reason of this PR is to fix parsing issue with modules tests,

This pull request includes several changes to the `node` and `utils` directories, focusing on improving test configurations, updating dependencies, and refactoring code for better maintainability. The most important changes are grouped into test configuration updates, dependency updates, and code refactoring.

### Test Configuration Updates:

* [`node/jest.config.js`](diffhunk://#diff-3c657330b3b1f8ed84fa9c7ec5cb77162627b38e2a64f3af0c2ddf23c1258d65L32-R32): Updated the `setupFilesAfterEnv` configuration to use `setup.ts` instead of `setup.js`.
* [`node/package.json`](diffhunk://#diff-d6e19f28e97cfeda63a9bd9426f10f1d2454eeed375ee1235e8ba842ceeb46a0L37-R37): Modified the `test-modules` script to run tests in-band for better isolation.
* [`node/tests/setup.ts`](diffhunk://#diff-af7930b381ecf4dc1a220dc1e410e6f8375668edbdb8502ffdff87e495db8668R1-R23): Introduced a new setup file to initialize global variables and configure the logger.
* [`node/tests/tsconfig.json`](diffhunk://#diff-92ce7f03e6d3e22bf55219a96660040138d6dab5b54b49eb22bf70a9171f6698L6-R6): Included `setup.ts` in the TypeScript configuration to ensure it is compiled.

### Dependency Updates:

* [`node/package.json`](diffhunk://#diff-d6e19f28e97cfeda63a9bd9426f10f1d2454eeed375ee1235e8ba842ceeb46a0R62-R64): Added `ts-node` as a new dependency and updated the `uuid` package version.
* [`utils/package.json`](diffhunk://#diff-779d8c2fb842050e3122b7bc967a1815d40eedc071aa966cbe9ec076a8136e6bL15-R17): Updated the `@types/node` and `prettier` dependencies to their latest versions.

### Code Refactoring:

* Removed the `parseCommandLineArgs` function and replaced its usage with global variables in multiple test files (`GlideClient.test.ts`, `GlideClusterClient.test.ts`, `PubSub.test.ts`, `ScanTest.test.ts`, `ServerModules.test.ts`). [[1]](diffhunk://#diff-1a174a764a0a897fb4aa705075c059a00afb07579a5f5320e46784e064d12d53L44) [[2]](diffhunk://#diff-1a174a764a0a897fb4aa705075c059a00afb07579a5f5320e46784e064d12d53L59-R58) [[3]](diffhunk://#diff-5819a9823d0d4e624c1ec4567febd092130caf0b9aa10b036d8e7f602b0758b0L53) [[4]](diffhunk://#diff-5819a9823d0d4e624c1ec4567febd092130caf0b9aa10b036d8e7f602b0758b0L68-R67) [[5]](diffhunk://#diff-b9e67e0fbaf82c9974f42a37f10eccdb13a5a7eca422a52d9377495975bde3cdL31) [[6]](diffhunk://#diff-b9e67e0fbaf82c9974f42a37f10eccdb13a5a7eca422a52d9377495975bde3cdL63-R63) [[7]](diffhunk://#diff-2ee2d2d0dbec17147463683d902a34dd3d146774b9e16e1ccaa192ab72c026c9L21) [[8]](diffhunk://#diff-2ee2d2d0dbec17147463683d902a34dd3d146774b9e16e1ccaa192ab72c026c9L33-R32) [[9]](diffhunk://#diff-2ee2d2d0dbec17147463683d902a34dd3d146774b9e16e1ccaa192ab72c026c9L388-R387) [[10]](diffhunk://#diff-c006fa7b521b546c1dc7a8238e572cb665216d7bcca2c0ebb59f23f2b444ee2dL31) [[11]](diffhunk://#diff-c006fa7b521b546c1dc7a8238e572cb665216d7bcca2c0ebb59f23f2b444ee2dL42-R47) [[12]](diffhunk://#diff-6cc2fb6a9baaaa3fdf3e95bc64aa27155ae36ecf17b6a9f94797a32446ab103aL7) [[13]](diffhunk://#diff-6cc2fb6a9baaaa3fdf3e95bc64aa27155ae36ecf17b6a9f94797a32446ab103aL350-L365) [[14]](diffhunk://#diff-6cc2fb6a9baaaa3fdf3e95bc64aa27155ae36ecf17b6a9f94797a32446ab103aL389-R372) [[15]](diffhunk://#diff-6cc2fb6a9baaaa3fdf3e95bc64aa27155ae36ecf17b6a9f94797a32446ab103aL1276-L1284)
* Refactored `TestUtils.ts` to improve code readability and consistency, including formatting changes. [[1]](diffhunk://#diff-ad8ace7e1c7bd63a56fc4c3cd1b55ecd948db6697c5519b19d845a9536c594f4L25-R25) [[2]](diffhunk://#diff-ad8ace7e1c7bd63a56fc4c3cd1b55ecd948db6697c5519b19d845a9536c594f4L46-R46) [[3]](diffhunk://#diff-ad8ace7e1c7bd63a56fc4c3cd1b55ecd948db6697c5519b19d845a9536c594f4L59-R61) [[4]](diffhunk://#diff-ad8ace7e1c7bd63a56fc4c3cd1b55ecd948db6697c5519b19d845a9536c594f4L73-R73) [[5]](diffhunk://#diff-ad8ace7e1c7bd63a56fc4c3cd1b55ecd948db6697c5519b19d845a9536c594f4L97-R102) [[6]](diffhunk://#diff-ad8ace7e1c7bd63a56fc4c3cd1b55ecd948db6697c5519b19d845a9536c594f4L112-R116)
* Updated `release-candidate-testing/node/index.js` formatting. [[1]](diffhunk://#diff-ffd0435437a5256df6657a09b50c39d8c4b95af38874258d9198c9865ceb31caL7) [[2]](diffhunk://#diff-ffd0435437a5256df6657a09b50c39d8c4b95af38874258d9198c9865ceb31caL44-R45) [[3]](diffhunk://#diff-ffd0435437a5256df6657a09b50c39d8c4b95af38874258d9198c9865ceb31caL77-R92)
### Issue link

This Pull Request is linked to issue #2624

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
