### PR TITLE
Java: Reduce number of pubsub channels in IT

### DIFF
--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -307,8 +307,8 @@ public class PubSubTests {
     @MethodSource("getTestScenarios")
     public void exact_happy_path_many_channels(boolean standalone, MessageReadMethod method) {
         skipTestsOnMac();
-        int numChannels = 256;
-        int messagesPerChannel = 256;
+        int numChannels = 16;
+        int messagesPerChannel = 16;
         var messages = new ArrayList<PubSubMessage>(numChannels * messagesPerChannel);
         ChannelMode mode = exact(standalone);
         Map<? extends ChannelMode, Set<GlideString>> subscriptions = Map.of(mode, new HashSet<>());
@@ -366,8 +366,8 @@ public class PubSubTests {
         assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in version 7");
         skipTestsOnMac();
 
-        int numChannels = 256;
-        int pubsubMessagesPerChannel = 256;
+        int numChannels = 16;
+        int pubsubMessagesPerChannel = 16;
         var pubsubMessages = new ArrayList<PubSubMessage>(numChannels * pubsubMessagesPerChannel);
         PubSubClusterChannelMode mode = PubSubClusterChannelMode.SHARDED;
         Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions = Map.of(mode, new HashSet<>());
@@ -444,8 +444,8 @@ public class PubSubTests {
         skipTestsOnMac();
         String prefix = "channel.";
         GlideString pattern = gs(prefix + "*");
-        int numChannels = 256;
-        int messagesPerChannel = 256;
+        int numChannels = 16;
+        int messagesPerChannel = 16;
         ChannelMode mode = standalone ? PubSubChannelMode.PATTERN : PubSubClusterChannelMode.PATTERN;
         var messages = new ArrayList<PubSubMessage>(numChannels * messagesPerChannel);
         var subscriptions = Map.of(mode, Set.of(pattern));
@@ -482,8 +482,8 @@ public class PubSubTests {
         skipTestsOnMac();
         String prefix = "channel.";
         GlideString pattern = gs(prefix + "*");
-        int numChannels = 256;
-        int messagesPerChannel = 256;
+        int numChannels = 16;
+        int messagesPerChannel = 16;
         var messages = new ArrayList<PubSubMessage>(numChannels * messagesPerChannel);
         ChannelMode mode = standalone ? PubSubChannelMode.EXACT : PubSubClusterChannelMode.EXACT;
         Map<? extends ChannelMode, Set<GlideString>> subscriptions =
@@ -533,7 +533,7 @@ public class PubSubTests {
         skipTestsOnMac();
         String prefix = "channel.";
         GlideString pattern = gs(prefix + "*");
-        int numChannels = 256;
+        int numChannels = 16;
         var messages = new ArrayList<PubSubMessage>(numChannels * 2);
         ChannelMode mode = exact(standalone);
         Map<? extends ChannelMode, Set<GlideString>> subscriptions = Map.of(mode, new HashSet<>());
@@ -604,7 +604,7 @@ public class PubSubTests {
         String prefix = "channel.";
         GlideString pattern = gs(prefix + "*");
         String shardPrefix = "{shard}";
-        int numChannels = 256;
+        int numChannels = 16;
         var messages = new ArrayList<PubSubMessage>(numChannels * 2);
         var shardedMessages = new ArrayList<PubSubMessage>(numChannels);
         Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions =
@@ -660,7 +660,7 @@ public class PubSubTests {
         String prefix = "channel.";
         String pattern = prefix + "*";
         String shardPrefix = "{shard}";
-        int numChannels = 256;
+        int numChannels = 16;
         var messages = new ArrayList<PubSubMessage>(numChannels * 2);
         var shardedMessages = new ArrayList<PubSubMessage>(numChannels);
         Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions =
@@ -742,7 +742,7 @@ public class PubSubTests {
         String prefix = "channel.";
         GlideString pattern = gs(prefix + "*");
         String shardPrefix = "{shard}";
-        int numChannels = 256;
+        int numChannels = 16;
         var exactMessages = new ArrayList<PubSubMessage>(numChannels);
         var patternMessages = new ArrayList<PubSubMessage>(numChannels);
         var shardedMessages = new ArrayList<PubSubMessage>(numChannels);


### PR DESCRIPTION
Speed up pubsub IT. A test with 65k messages takes ~15 sec, now it should be less than 1 sec.