### PR TITLE
Core: Refactored the connection container lock to use a sync RwLock

### DIFF
--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -184,6 +184,7 @@ once_cell = "1"
 anyhow = "1"
 sscanf = "0.4.1"
 serial_test = "2"
+versions = "6.3"
 
 [[test]]
 name = "test_async"

--- a/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
@@ -297,7 +297,7 @@ where
         &self,
         amount: usize,
         conn_type: ConnectionType,
-    ) -> Option<impl Iterator<Item = ConnectionAndAddress<Connection>> + '_> {
+    ) -> Option<Vec<ConnectionAndAddress<Connection>>> {
         (!self.connection_map.is_empty()).then_some({
             self.connection_map
                 .iter()
@@ -308,6 +308,7 @@ where
                     let conn = node.get_connection(&conn_type);
                     (address.clone(), conn)
                 })
+                .collect::<Vec<_>>()
         })
     }
 
@@ -693,6 +694,7 @@ mod tests {
         let random_connections: HashSet<_> = container
             .random_connections(3, ConnectionType::User)
             .expect("No connections found")
+            .into_iter()
             .map(|pair| pair.1)
             .collect();
 
@@ -723,6 +725,7 @@ mod tests {
         let random_connections: Vec<_> = container
             .random_connections(1, ConnectionType::User)
             .expect("No connections found")
+            .into_iter()
             .collect();
 
         assert_eq!(vec![(address, 4)], random_connections);
@@ -734,6 +737,7 @@ mod tests {
         let mut random_connections: Vec<_> = container
             .random_connections(1000, ConnectionType::User)
             .expect("No connections found")
+            .into_iter()
             .map(|pair| pair.1)
             .collect();
         random_connections.sort();
@@ -747,6 +751,7 @@ mod tests {
         let mut random_connections: Vec<_> = container
             .random_connections(1000, ConnectionType::PreferManagement)
             .expect("No connections found")
+            .into_iter()
             .map(|pair| pair.1)
             .collect();
         random_connections.sort();

--- a/glide-core/redis-rs/redis/src/commands/cluster_scan.rs
+++ b/glide-core/redis-rs/redis/src/commands/cluster_scan.rs
@@ -1,7 +1,7 @@
 use crate::aio::ConnectionLike;
 use crate::cluster_async::{
     ClusterConnInner, Connect, Core, InternalRoutingInfo, InternalSingleNodeRouting, RefreshPolicy,
-    Response,
+    Response, MUTEX_READ_ERR,
 };
 use crate::cluster_routing::SlotAddr;
 use crate::cluster_topology::SLOT_SIZE;
@@ -385,7 +385,9 @@ where
         }
     }
     async fn are_all_slots_covered(&self) -> bool {
-        ClusterConnInner::<C>::check_if_all_slots_covered(&self.conn_lock.read().await.slot_map)
+        ClusterConnInner::<C>::check_if_all_slots_covered(
+            &self.conn_lock.read().expect(MUTEX_READ_ERR).slot_map,
+        )
     }
     async fn refresh_if_topology_changed(&self) {
         ClusterConnInner::check_topology_and_refresh_if_diff(

--- a/glide-core/redis-rs/redis/tests/support/util.rs
+++ b/glide-core/redis-rs/redis/tests/support/util.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use versions::Versioning;
 
 use super::TestContext;
 
@@ -25,21 +26,10 @@ pub fn parse_client_info(client_info: &str) -> HashMap<String, String> {
 }
 
 pub fn version_greater_or_equal(ctx: &TestContext, version: &str) -> bool {
-    // Parse the provided version string into major, minor, and patch
-    let parsed_version: Vec<&str> = version.split('.').collect();
-    if parsed_version.len() != 3 {
-        panic!("Version string must be in the format 'major.minor.patch'");
-    }
-
-    let major: u16 = parsed_version[0].parse().expect("Failed to parse version");
-    let minor: u16 = parsed_version[1].parse().expect("Failed to parse version");
-    let patch: u16 = parsed_version[2].parse().expect("Failed to parse version");
-
     // Get the server version
-    let server_version = ctx.get_version();
-
+    let (major, minor, patch) = ctx.get_version();
+    let server_version = Versioning::new(format!("{major}.{minor}.{patch}")).unwrap();
+    let compared_version = Versioning::new(version).unwrap();
     // Compare server version with the specified version
-    (server_version.0 > major)
-        || (server_version.0 == major && server_version.1 > minor)
-        || (server_version.0 == major && server_version.1 == minor && server_version.2 >= patch)
+    server_version >= compared_version
 }

--- a/glide-core/redis-rs/redis/tests/support/util.rs
+++ b/glide-core/redis-rs/redis/tests/support/util.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use super::TestContext;
+
 #[macro_export]
 macro_rules! assert_args {
     ($value:expr, $($args:expr),+) => {
@@ -20,4 +22,24 @@ pub fn parse_client_info(client_info: &str) -> HashMap<String, String> {
     }
 
     res
+}
+
+pub fn version_greater_or_equal(ctx: &TestContext, version: &str) -> bool {
+    // Parse the provided version string into major, minor, and patch
+    let parsed_version: Vec<&str> = version.split('.').collect();
+    if parsed_version.len() != 3 {
+        panic!("Version string must be in the format 'major.minor.patch'");
+    }
+
+    let major: u16 = parsed_version[0].parse().expect("Failed to parse version");
+    let minor: u16 = parsed_version[1].parse().expect("Failed to parse version");
+    let patch: u16 = parsed_version[2].parse().expect("Failed to parse version");
+
+    // Get the server version
+    let server_version = ctx.get_version();
+
+    // Compare server version with the specified version
+    (server_version.0 > major)
+        || (server_version.0 == major && server_version.1 > minor)
+        || (server_version.0 == major && server_version.1 == minor && server_version.2 >= patch)
 }

--- a/glide-core/redis-rs/redis/tests/test_basic.rs
+++ b/glide-core/redis-rs/redis/tests/test_basic.rs
@@ -783,6 +783,10 @@ mod basic {
     #[serial_test::serial]
     fn test_pubsub_unsubscribe_no_subs() {
         let ctx = TestContext::new();
+        if version_greater_or_equal(&ctx, "7.2.4") {
+            // Skip for versions 7.2.4 and above
+            return;
+        }
         let mut con = ctx.connection();
 
         {
@@ -799,6 +803,10 @@ mod basic {
     #[serial_test::serial]
     fn test_pubsub_unsubscribe_one_sub() {
         let ctx = TestContext::new();
+        if version_greater_or_equal(&ctx, "7.2.4") {
+            // Skip for versions 7.2.4 and above
+            return;
+        }
         let mut con = ctx.connection();
 
         {
@@ -834,6 +842,10 @@ mod basic {
     #[serial_test::serial]
     fn scoped_pubsub() {
         let ctx = TestContext::new();
+        if version_greater_or_equal(&ctx, "7.2.4") {
+            // Skip for versions 7.2.4 and above
+            return;
+        }
         let mut con = ctx.connection();
 
         // Connection for subscriber api


### PR DESCRIPTION
## Core: Refactored the Connection Container Lock to Use a Synchronous RwLock

This PR refactors the connection container lock to use a synchronous RwLock instead of an asynchronous one, ensuring that the lock is held only briefly and not across await points. This change addresses potential deadlocks and improves overall lock acquisition time.

### Background

In the redis-rs implementation, the entire request pipeline is blocked while the cluster client is in a recovery state. Specifically, when poll_flush calls poll_recover, the system waits for the recovery future to complete before processing other tasks. During this recovery period, some in-flight requests may already be running but remain pending. This creates a risk of deadlock if a request holds the connection container lock while the recovery future is waiting for it.

### Why the Change was Made

Switching to a synchronous lock ensures that the recovery state cannot be entered while the connection container lock is held, thus preventing the recovery future from getting stuck. By preventing requests from holding the lock across await points, we reduce the risk of deadlocks.