### PR TITLE
Feature/replace credes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -115,6 +115,7 @@ jobs:
               working-directory: ./python
               run: |
                   source .env/bin/activate
+                  pip install -r dev_requirements.txt
                   cd python/tests/
                   pytest --asyncio-mode=auto --html=pytest_report.html --self-contained-html
 
@@ -177,6 +178,7 @@ jobs:
               working-directory: ./python
               run: |
                   source .env/bin/activate
+                  pip install -r dev_requirements.txt
                   cd python/tests/
                   pytest --asyncio-mode=auto -k test_pubsub --html=pytest_report.html --self-contained-html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### Changes
-* Node, Python, Java, Go: Adding support for replacing connection configured password ([#2651](https://github.com/valkey-io/valkey-glide/pull/2651))
+* Node, Python: Adding support for replacing connection configured password ([#2651](https://github.com/valkey-io/valkey-glide/pull/2651))
 * Node: Add FT._ALIASLIST command([#2652](https://github.com/valkey-io/valkey-glide/pull/2652))
 * Python: Python: `FT._ALIASLIST` command added([#2638](https://github.com/valkey-io/valkey-glide/pull/2638))
 * Node: alias commands added: FT.ALIASADD, FT.ALIADDEL, FT.ALIASUPDATE([#2596](https://github.com/valkey-io/valkey-glide/pull/2596))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Node, Python, Java, Go: Adding support for replacing connection configured password ([#2651](https://github.com/valkey-io/valkey-glide/pull/2651))
 * Node: Add FT._ALIASLIST command([#2652](https://github.com/valkey-io/valkey-glide/pull/2652))
 * Python: Python: `FT._ALIASLIST` command added([#2638](https://github.com/valkey-io/valkey-glide/pull/2638))
 * Node: alias commands added: FT.ALIASADD, FT.ALIADDEL, FT.ALIASUPDATE([#2596](https://github.com/valkey-io/valkey-glide/pull/2596))

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -47,7 +47,6 @@ pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["rt", "net", "time", "sync"] }
 socket2 = { version = "0.5", features = ["all"], optional = true }
-fast-math = { version = "0.1.1", optional = true }
 dispose = { version = "0.5.0", optional = true }
 
 # Only needed for the connection manager
@@ -125,7 +124,6 @@ aio = [
     "tokio-util/codec",
     "combine/tokio",
     "async-trait",
-    "fast-math",
     "dispose",
 ]
 geospatial = []

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.67"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
@@ -67,7 +67,7 @@ dashmap = { version = "6.0", optional = true }
 async-trait = { version = "0.1.24", optional = true }
 
 # Only needed for tokio support
-tokio-retry2 = {version = "0.5", features = ["jitter"], optional = true}
+tokio-retry2 = { version = "0.5", features = ["jitter"], optional = true }
 
 # Only needed for native tls
 native-tls = { version = "0.2", optional = true }

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -31,6 +31,9 @@ use std::time::Duration;
 #[cfg(feature = "tokio-comp")]
 use tokio_util::codec::Decoder;
 
+// Default connection timeout in seconds
+const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
+
 // Senders which the result of a single request are sent through
 type PipelineOutput = oneshot::Sender<RedisResult<Value>>;
 
@@ -76,7 +79,7 @@ struct PipelineMessage<S> {
 /// interface provided by `Pipeline` an easy interface of request to response, hiding the `Stream`
 /// and `Sink`.
 #[derive(Clone)]
-struct Pipeline<SinkItem> {
+pub struct Pipeline<SinkItem> {
     sender: mpsc::Sender<PipelineMessage<SinkItem>>,
     push_manager: Arc<ArcSwap<PushManager>>,
     is_stream_closed: Arc<AtomicBool>,
@@ -399,6 +402,7 @@ where
         self.push_manager.store(Arc::new(push_manager));
     }
 
+    /// Checks if the pipeline is closed.
     pub fn is_closed(&self) -> bool {
         self.is_stream_closed.load(Ordering::Relaxed)
     }
@@ -413,6 +417,7 @@ pub struct MultiplexedConnection {
     response_timeout: Duration,
     protocol: ProtocolVersion,
     push_manager: PushManager,
+    password: Option<String>,
 }
 
 impl Debug for MultiplexedConnection {
@@ -455,35 +460,29 @@ impl MultiplexedConnection {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
-        fn boxed(
-            f: impl Future<Output = ()> + Send + 'static,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
-            Box::pin(f)
-        }
-
-        #[cfg(not(feature = "tokio-comp"))]
-        compile_error!("tokio-comp feature is required for aio feature");
-
-        let redis_connection_info = &connection_info.redis;
         let codec = ValueCodec::default()
             .framed(stream)
             .and_then(|msg| async move { msg });
         let (mut pipeline, driver) =
             Pipeline::new(codec, glide_connection_options.disconnect_notifier);
-        let driver = boxed(driver);
+        let driver = Box::pin(driver);
         let pm = PushManager::default();
         if let Some(sender) = glide_connection_options.push_sender {
             pm.replace_sender(sender);
         }
 
         pipeline.set_push_manager(pm.clone()).await;
-        let mut con = MultiplexedConnection {
-            pipeline,
-            db: connection_info.redis.db,
-            response_timeout,
-            push_manager: pm,
-            protocol: redis_connection_info.protocol,
-        };
+
+        let mut con = MultiplexedConnection::builder()
+            .with_pipeline(pipeline)
+            .with_db(connection_info.redis.db)
+            .with_response_timeout(response_timeout)
+            .with_push_manager(pm)
+            .with_protocol(connection_info.redis.protocol)
+            .with_password(connection_info.redis.password.clone())
+            .build()
+            .await?;
+
         let driver = {
             let auth = setup_connection(&connection_info.redis, &mut con);
 
@@ -502,6 +501,7 @@ impl MultiplexedConnection {
                 }
             }
         };
+
         Ok((con, driver))
     }
 
@@ -574,6 +574,97 @@ impl MultiplexedConnection {
     pub async fn set_push_manager(&mut self, push_manager: PushManager) {
         self.push_manager = push_manager.clone();
         self.pipeline.set_push_manager(push_manager).await;
+    }
+
+    /// Replace password of connection
+    pub async fn update_connection_password(
+        &mut self,
+        password: Option<String>,
+    ) -> RedisResult<Value> {
+        self.password = password;
+        Ok(Value::Okay)
+    }
+
+    /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
+    pub fn builder() -> MultiplexedConnectionBuilder {
+        MultiplexedConnectionBuilder::default()
+    }
+}
+
+#[derive(Default)]
+/// A builder for creating `MultiplexedConnection` instances.
+pub struct MultiplexedConnectionBuilder {
+    pipeline: Option<Pipeline<Vec<u8>>>,
+    db: Option<i64>,
+    response_timeout: Option<Duration>,
+    push_manager: Option<PushManager>,
+    protocol: Option<ProtocolVersion>,
+    password: Option<Option<String>>,
+}
+
+impl MultiplexedConnectionBuilder {
+    /// Sets the pipeline for the `MultiplexedConnectionBuilder`.
+    pub fn with_pipeline(mut self, pipeline: Pipeline<Vec<u8>>) -> Self {
+        self.pipeline = Some(pipeline);
+        self
+    }
+
+    /// Sets the database index for the `MultiplexedConnectionBuilder`.
+    pub fn with_db(mut self, db: i64) -> Self {
+        self.db = Some(db);
+        self
+    }
+
+    /// Sets the response timeout for the `MultiplexedConnectionBuilder`.
+    pub fn with_response_timeout(mut self, timeout: Duration) -> Self {
+        self.response_timeout = Some(timeout);
+        self
+    }
+
+    /// Sets the push manager for the `MultiplexedConnectionBuilder`.
+    pub fn with_push_manager(mut self, push_manager: PushManager) -> Self {
+        self.push_manager = Some(push_manager);
+        self
+    }
+
+    /// Sets the protocol version for the `MultiplexedConnectionBuilder`.
+    pub fn with_protocol(mut self, protocol: ProtocolVersion) -> Self {
+        self.protocol = Some(protocol);
+        self
+    }
+
+    /// Sets the password for the `MultiplexedConnectionBuilder`.
+    pub fn with_password(mut self, password: Option<String>) -> Self {
+        self.password = Some(password);
+        self
+    }
+
+    /// Builds and returns a new `MultiplexedConnection` instance using the configured settings.
+    pub async fn build(self) -> RedisResult<MultiplexedConnection> {
+        let pipeline = self.pipeline.ok_or_else(|| {
+            RedisError::from((
+                crate::ErrorKind::InvalidClientConfig,
+                "Pipeline is required",
+            ))
+        })?;
+        let db = self.db.unwrap_or_default();
+        let response_timeout = self
+            .response_timeout
+            .unwrap_or(DEFAULT_CONNECTION_ATTEMPT_TIMEOUT);
+        let push_manager = self.push_manager.unwrap_or_default();
+        let protocol = self.protocol.unwrap_or_default();
+        let password = self.password.unwrap_or_default();
+
+        let con = MultiplexedConnection {
+            pipeline,
+            db,
+            response_timeout,
+            push_manager,
+            protocol,
+            password,
+        };
+
+        Ok(con)
     }
 }
 

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -31,8 +31,8 @@ use std::time::Duration;
 #[cfg(feature = "tokio-comp")]
 use tokio_util::codec::Decoder;
 
-// Default connection timeout in seconds
-const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
+// Default connection timeout in ms
+const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(250);
 
 // Senders which the result of a single request are sent through
 type PipelineOutput = oneshot::Sender<RedisResult<Value>>;
@@ -79,7 +79,7 @@ struct PipelineMessage<S> {
 /// interface provided by `Pipeline` an easy interface of request to response, hiding the `Stream`
 /// and `Sink`.
 #[derive(Clone)]
-pub struct Pipeline<SinkItem> {
+pub(crate) struct Pipeline<SinkItem> {
     sender: mpsc::Sender<PipelineMessage<SinkItem>>,
     push_manager: Arc<ArcSwap<PushManager>>,
     is_stream_closed: Arc<AtomicBool>,
@@ -473,8 +473,7 @@ impl MultiplexedConnection {
 
         pipeline.set_push_manager(pm.clone()).await;
 
-        let mut con = MultiplexedConnection::builder()
-            .with_pipeline(pipeline)
+        let mut con = MultiplexedConnection::builder(pipeline)
             .with_db(connection_info.redis.db)
             .with_response_timeout(response_timeout)
             .with_push_manager(pm)
@@ -576,7 +575,8 @@ impl MultiplexedConnection {
         self.pipeline.set_push_manager(push_manager).await;
     }
 
-    /// Replace password of connection
+    /// Replace the password used to authenticate with the server.
+    /// If `None` is provided, the password will be removed.
     pub async fn update_connection_password(
         &mut self,
         password: Option<String>,
@@ -586,27 +586,32 @@ impl MultiplexedConnection {
     }
 
     /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
-    pub fn builder() -> MultiplexedConnectionBuilder {
-        MultiplexedConnectionBuilder::default()
+    pub(crate) fn builder(pipeline: Pipeline<Vec<u8>>) -> MultiplexedConnectionBuilder {
+        MultiplexedConnectionBuilder::new(pipeline)
     }
 }
 
-#[derive(Default)]
 /// A builder for creating `MultiplexedConnection` instances.
 pub struct MultiplexedConnectionBuilder {
-    pipeline: Option<Pipeline<Vec<u8>>>,
+    pipeline: Pipeline<Vec<u8>>,
     db: Option<i64>,
     response_timeout: Option<Duration>,
     push_manager: Option<PushManager>,
     protocol: Option<ProtocolVersion>,
-    password: Option<Option<String>>,
+    password: Option<String>,
 }
 
 impl MultiplexedConnectionBuilder {
-    /// Sets the pipeline for the `MultiplexedConnectionBuilder`.
-    pub fn with_pipeline(mut self, pipeline: Pipeline<Vec<u8>>) -> Self {
-        self.pipeline = Some(pipeline);
-        self
+    /// Creates a new builder with the required pipeline
+    pub(crate) fn new(pipeline: Pipeline<Vec<u8>>) -> Self {
+        Self {
+            pipeline,
+            db: None,
+            response_timeout: None,
+            push_manager: None,
+            protocol: None,
+            password: None,
+        }
     }
 
     /// Sets the database index for the `MultiplexedConnectionBuilder`.
@@ -635,28 +640,22 @@ impl MultiplexedConnectionBuilder {
 
     /// Sets the password for the `MultiplexedConnectionBuilder`.
     pub fn with_password(mut self, password: Option<String>) -> Self {
-        self.password = Some(password);
+        self.password = password;
         self
     }
 
     /// Builds and returns a new `MultiplexedConnection` instance using the configured settings.
     pub async fn build(self) -> RedisResult<MultiplexedConnection> {
-        let pipeline = self.pipeline.ok_or_else(|| {
-            RedisError::from((
-                crate::ErrorKind::InvalidClientConfig,
-                "Pipeline is required",
-            ))
-        })?;
         let db = self.db.unwrap_or_default();
         let response_timeout = self
             .response_timeout
             .unwrap_or(DEFAULT_CONNECTION_ATTEMPT_TIMEOUT);
         let push_manager = self.push_manager.unwrap_or_default();
         let protocol = self.protocol.unwrap_or_default();
-        let password = self.password.unwrap_or_default();
+        let password = self.password;
 
         let con = MultiplexedConnection {
-            pipeline,
+            pipeline: self.pipeline,
             db,
             response_timeout,
             push_manager,

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -784,6 +784,7 @@ where
                             return Err(err);
                         }
                         RetryMethod::RetryImmediately => {}
+                        RetryMethod::ReAuthenticate => {}
                     }
                 }
             }

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -306,7 +306,7 @@ where
 
     /// Returns the connection status.
     ///
-    /// The connection is open until any `read_response` call recieved an
+    /// The connection is open until any `read_response` call received an
     /// invalid response from the server (most likely a closed or dropped
     /// connection, otherwise a Redis protocol error). When using unix
     /// sockets the connection is open until writing a command failed with a
@@ -808,7 +808,7 @@ where
         self.refresh_slots()?;
 
         // Given that there are commands that need to be retried, it means something in the cluster
-        // topology changed. Execute each command seperately to take advantage of the existing
+        // topology changed. Execute each command separately to take advantage of the existing
         // retry logic that handles these cases.
         for retry_idx in to_retry {
             let cmd = &cmds[retry_idx];

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -784,7 +784,6 @@ where
                             return Err(err);
                         }
                         RetryMethod::RetryImmediately => {}
-                        RetryMethod::ReAuthenticate => {}
                     }
                 }
             }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -389,7 +389,7 @@ where
         let (sender, receiver) = oneshot::channel();
         self.0
             .send(Message {
-                cmd: CmdArg::OperationRequest { operation_request },
+                cmd: CmdArg::OperationRequest(operation_request),
                 sender,
             })
             .await
@@ -2107,7 +2107,7 @@ where
                     Err(err) => Err((OperationTarget::FanOut, err)),
                 }
             }
-            CmdArg::OperationRequest { operation_request } => match operation_request {
+            CmdArg::OperationRequest(operation_request) => match operation_request {
                 Operation::UpdateConnectionPassword(password) => {
                     core.set_cluster_param(|params| params.password = password)
                         .expect(MUTEX_WRITE_ERR);

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -332,8 +332,7 @@ where
             })
             .map(|response| match response {
                 Response::Single(value) => value,
-                Response::Multiple(_) => unreachable!(),
-                Response::ClusterScanResult(_, _) => unreachable!(),
+                _ => unreachable!(),
             })
     }
 
@@ -656,8 +655,7 @@ fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> 
 }
 
 fn boxed_sleep(duration: Duration) -> BoxFuture<'static, ()> {
-    #[cfg(feature = "tokio-comp")]
-    return Box::pin(tokio::time::sleep(duration));
+    Box::pin(tokio::time::sleep(duration))
 }
 
 pub(crate) enum Response {

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -57,8 +57,8 @@ impl<'a, T: FromRedisValue> Iterator for Iter<'a, T> {
                 return None;
             }
 
-            let pcmd = self.cmd.get_packed_command_with_cursor(self.cursor)?;
-            let rv = self.con.req_packed_command(&pcmd).ok()?;
+            let packed_cmd = self.cmd.get_packed_command_with_cursor(self.cursor)?;
+            let rv = self.con.req_packed_command(&packed_cmd).ok()?;
             let (cur, batch): (u64, Vec<T>) = from_owned_redis_value(rv).ok()?;
 
             self.cursor = cur;
@@ -204,14 +204,14 @@ fn args_len<'a, I>(args: I, cursor: u64) -> usize
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + ExactSizeIterator,
 {
-    let mut totlen = 1 + countdigits(args.len()) + 2;
+    let mut total_len = 1 + countdigits(args.len()) + 2;
     for item in args {
-        totlen += bulklen(match item {
+        total_len += bulklen(match item {
             Arg::Cursor => countdigits(cursor as usize),
             Arg::Simple(val) => val.len(),
         });
     }
-    totlen
+    total_len
 }
 
 pub(crate) fn cmd_len(cmd: &Cmd) -> usize {
@@ -231,9 +231,9 @@ fn write_command_to_vec<'a, I>(cmd: &mut Vec<u8>, args: I, cursor: u64)
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,
 {
-    let totlen = args_len(args.clone(), cursor);
+    let total_len = args_len(args.clone(), cursor);
 
-    cmd.reserve(totlen);
+    cmd.reserve(total_len);
 
     write_command(cmd, args, cursor).unwrap()
 }
@@ -287,7 +287,7 @@ impl Default for Cmd {
 }
 
 /// A command acts as a builder interface to creating encoded redis
-/// requests.  This allows you to easiy assemble a packed command
+/// requests.  This allows you to easy assemble a packed command
 /// by chaining arguments together.
 ///
 /// Basic example:
@@ -324,7 +324,7 @@ impl Cmd {
         }
     }
 
-    /// Creates a new empty command, with at least the requested capcity.
+    /// Creates a new empty command, with at least the requested capacity.
     pub fn with_capacity(arg_count: usize, size_of_data: usize) -> Cmd {
         Cmd {
             data: Vec::with_capacity(size_of_data),
@@ -448,7 +448,7 @@ impl Cmd {
     ///
     /// This is useful for commands such as `SSCAN`, `SCAN` and others.
     ///
-    /// One speciality of this function is that it will check if the response
+    /// One specialty of this function is that it will check if the response
     /// looks like a cursor or not and always just looks at the payload.
     /// This way you can use the function the same for responses in the
     /// format of `KEYS` (just a list) as well as `SSCAN` (which returns a
@@ -481,7 +481,7 @@ impl Cmd {
     ///
     /// This is useful for commands such as `SSCAN`, `SCAN` and others in async contexts.
     ///
-    /// One speciality of this function is that it will check if the response
+    /// One specialty of this function is that it will check if the response
     /// looks like a cursor or not and always just looks at the payload.
     /// This way you can use the function the same for responses in the
     /// format of `KEYS` (just a list) as well as `SSCAN` (which returns a

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -204,7 +204,7 @@ fn args_len<'a, I>(args: I, cursor: u64) -> usize
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + ExactSizeIterator,
 {
-    let mut total_len = 1 + countdigits(args.len()) + 2;
+    let mut total_len = countdigits(args.len()).saturating_add(3);
     for item in args {
         total_len += bulklen(match item {
             Arg::Cursor => countdigits(cursor as usize),
@@ -287,7 +287,7 @@ impl Default for Cmd {
 }
 
 /// A command acts as a builder interface to creating encoded redis
-/// requests.  This allows you to easy assemble a packed command
+/// requests.  This allows you to easily assemble a packed command
 /// by chaining arguments together.
 ///
 /// Basic example:

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -633,11 +633,11 @@ mod tests {
 
     #[test]
     fn decode_resp3_push() {
-        let val = parse_redis_value(b">3\r\n+message\r\n+somechannel\r\n+this is the message\r\n")
+        let val = parse_redis_value(b">3\r\n+message\r\n+some_channel\r\n+this is the message\r\n")
             .unwrap();
         if let Value::Push { ref kind, ref data } = val {
             assert_eq!(&PushKind::Message, kind);
-            assert_eq!(Value::SimpleString("somechannel".to_string()), data[0]);
+            assert_eq!(Value::SimpleString("some_channel".to_string()), data[0]);
             assert_eq!(
                 Value::SimpleString("this is the message".to_string()),
                 data[1]

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -39,7 +39,6 @@ fn err_parser(line: &str) -> ServerError {
         "MASTERDOWN" => ServerErrorKind::MasterDown,
         "READONLY" => ServerErrorKind::ReadOnly,
         "NOTBUSY" => ServerErrorKind::NotBusy,
-        "NOAUTH" => ServerErrorKind::NoAuth,
         code => {
             return ServerError::ExtensionError {
                 code: code.to_string(),

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -39,6 +39,7 @@ fn err_parser(line: &str) -> ServerError {
         "MASTERDOWN" => ServerErrorKind::MasterDown,
         "READONLY" => ServerErrorKind::ReadOnly,
         "NOTBUSY" => ServerErrorKind::NotBusy,
+        "NOAUTH" => ServerErrorKind::NoAuth,
         code => {
             return ServerError::ExtensionError {
                 code: code.to_string(),

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -153,9 +153,6 @@ pub enum ErrorKind {
 
     /// Not all slots are covered by the cluster
     NotAllSlotsCovered,
-
-    /// The server requires authentication
-    NoAuth,
 }
 
 #[derive(PartialEq, Debug)]
@@ -172,7 +169,6 @@ pub(crate) enum ServerErrorKind {
     MasterDown,
     ReadOnly,
     NotBusy,
-    NoAuth,
 }
 
 #[derive(PartialEq, Debug)]
@@ -213,7 +209,6 @@ impl From<ServerError> for RedisError {
                     ServerErrorKind::MasterDown => ErrorKind::MasterDown,
                     ServerErrorKind::ReadOnly => ErrorKind::ReadOnly,
                     ServerErrorKind::NotBusy => ErrorKind::NotBusy,
-                    ServerErrorKind::NoAuth => ErrorKind::NoAuth,
                 };
                 match detail {
                     Some(detail) => RedisError::from((kind, desc, detail)),
@@ -825,7 +820,6 @@ pub(crate) enum RetryMethod {
     AskRedirect,
     MovedRedirect,
     WaitAndRetryOnPrimaryRedirectOnReplica,
-    ReAuthenticate,
 }
 
 /// Indicates a general failure in the library.
@@ -864,7 +858,6 @@ impl RedisError {
             ErrorKind::MasterDown => Some("MASTERDOWN"),
             ErrorKind::ReadOnly => Some("READONLY"),
             ErrorKind::NotBusy => Some("NOTBUSY"),
-            ErrorKind::NoAuth => Some("NOAUTH"),
             _ => match self.repr {
                 ErrorRepr::ExtensionError(ref code, _) => Some(code),
                 _ => None,
@@ -907,7 +900,6 @@ impl RedisError {
             ErrorKind::RESP3NotSupported => "resp3 is not supported by server",
             ErrorKind::ParseError => "parse error",
             ErrorKind::NotAllSlotsCovered => "not all slots are covered",
-            ErrorKind::NoAuth => "authentication required",
         }
     }
 
@@ -994,7 +986,6 @@ impl RedisError {
             RetryMethod::AskRedirect => false,
             RetryMethod::MovedRedirect => false,
             RetryMethod::WaitAndRetryOnPrimaryRedirectOnReplica => false,
-            RetryMethod::ReAuthenticate => false,
         }
     }
 
@@ -1104,7 +1095,6 @@ impl RedisError {
             ErrorKind::NotAllSlotsCovered => RetryMethod::NoRetry,
             ErrorKind::FatalReceiveError => RetryMethod::Reconnect,
             ErrorKind::FatalSendError => RetryMethod::ReconnectAndRetry,
-            ErrorKind::NoAuth => RetryMethod::ReAuthenticate,
         }
     }
 }

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -8,10 +8,7 @@ use std::io;
 use std::str::{from_utf8, Utf8Error};
 use std::string::FromUtf8Error;
 
-#[cfg(feature = "ahash")]
-pub(crate) use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use num_bigint::BigInt;
-#[cfg(not(feature = "ahash"))]
 pub(crate) use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 
@@ -139,7 +136,7 @@ pub enum ErrorKind {
     NoValidReplicasFoundBySentinel,
     /// At least one sentinel connection info is required
     EmptySentinelList,
-    /// Attempted to kill a script/function while they werent' executing
+    /// Attempted to kill a script/function while they weren't executing
     NotBusy,
     /// Used when no valid node connections remain in the cluster connection
     AllConnectionsUnavailable,
@@ -983,7 +980,6 @@ impl RedisError {
         match self.retry_method() {
             RetryMethod::Reconnect => true,
             RetryMethod::ReconnectAndRetry => true,
-
             RetryMethod::NoRetry => false,
             RetryMethod::RetryImmediately => false,
             RetryMethod::WaitAndRetry => false,
@@ -1149,9 +1145,9 @@ impl InfoDict {
     /// the INFO command.  Each line is a key, value pair with the
     /// key and value separated by a colon (`:`).  Lines starting with a
     /// hash (`#`) are ignored.
-    pub fn new(kvpairs: &str) -> InfoDict {
+    pub fn new(key_val_pairs: &str) -> InfoDict {
         let mut map = HashMap::new();
-        for line in kvpairs.lines() {
+        for line in key_val_pairs.lines() {
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
@@ -1179,7 +1175,7 @@ impl InfoDict {
         self.map.get(*key)
     }
 
-    /// Checks if a key is contained in the info dicf.
+    /// Checks if a key is contained in the info dict.
     pub fn contains_key(&self, key: &&str) -> bool {
         self.find(key).is_some()
     }
@@ -1255,7 +1251,7 @@ pub trait ToRedisArgs: Sized {
         NumericBehavior::NonNumeric
     }
 
-    /// Returns an indiciation if the value contained is exactly one
+    /// Returns an indication if the value contained is exactly one
     /// argument.  It returns false if it's zero or more than one.  This
     /// is used in some high level functions to intelligently switch
     /// between `GET` and `MGET` variants.
@@ -1401,7 +1397,7 @@ ryu_based_to_redis_impl!(f64, NumericBehavior::NumberIsFloat);
     feature = "bigdecimal",
     feature = "num-bigint"
 ))]
-macro_rules! bignum_to_redis_impl {
+macro_rules! big_num_to_redis_impl {
     ($t:ty) => {
         impl ToRedisArgs for $t {
             fn write_redis_args<W>(&self, out: &mut W)
@@ -1415,13 +1411,13 @@ macro_rules! bignum_to_redis_impl {
 }
 
 #[cfg(feature = "rust_decimal")]
-bignum_to_redis_impl!(rust_decimal::Decimal);
+big_num_to_redis_impl!(rust_decimal::Decimal);
 #[cfg(feature = "bigdecimal")]
-bignum_to_redis_impl!(bigdecimal::BigDecimal);
+big_num_to_redis_impl!(bigdecimal::BigDecimal);
 #[cfg(feature = "num-bigint")]
-bignum_to_redis_impl!(num_bigint::BigInt);
+big_num_to_redis_impl!(num_bigint::BigInt);
 #[cfg(feature = "num-bigint")]
-bignum_to_redis_impl!(num_bigint::BigUint);
+big_num_to_redis_impl!(num_bigint::BigUint);
 
 impl ToRedisArgs for bool {
     fn write_redis_args<W>(&self, out: &mut W)
@@ -1969,7 +1965,7 @@ impl FromRedisValue for String {
 /// Implement `FromRedisValue` for `$Type` (which should use the generic parameter `$T`).
 ///
 /// The implementation parses the value into a vec, and then passes the value through `$convert`.
-/// If `$convert` is ommited, it defaults to `Into::into`.
+/// If `$convert` is omitted, it defaults to `Into::into`.
 macro_rules! from_vec_from_redis_value {
     (<$T:ident> $Type:ty) => {
         from_vec_from_redis_value!(<$T> $Type; Into::into);
@@ -2169,16 +2165,16 @@ where
 {
     fn from_redis_value(v: &Value) -> RedisResult<BTreeSet<T>> {
         let v = get_inner_value(v);
-        let items = v
-            .as_sequence()
-            .ok_or_else(|| invalid_type_error_inner!(v, "Response type not btreeset compatible"))?;
+        let items = v.as_sequence().ok_or_else(|| {
+            invalid_type_error_inner!(v, "Response type not btree_set compatible")
+        })?;
         items.iter().map(|item| from_redis_value(item)).collect()
     }
     fn from_owned_redis_value(v: Value) -> RedisResult<BTreeSet<T>> {
         let v = get_owned_inner_value(v);
         let items = v
             .into_sequence()
-            .map_err(|v| invalid_type_error_inner!(v, "Response type not btreeset compatible"))?;
+            .map_err(|v| invalid_type_error_inner!(v, "Response type not btree_set compatible"))?;
         items
             .into_iter()
             .map(|item| from_owned_redis_value(item))

--- a/glide-core/redis-rs/redis/tests/auth.rs
+++ b/glide-core/redis-rs/redis/tests/auth.rs
@@ -1,0 +1,315 @@
+mod support;
+
+#[cfg(test)]
+mod auth {
+    use crate::support::*;
+    use redis::{
+        aio::MultiplexedConnection,
+        cluster::ClusterClientBuilder,
+        cluster_async::ClusterConnection,
+        cluster_routing::{MultipleNodeRoutingInfo, ResponsePolicy, RoutingInfo},
+        cmd, ConnectionInfo, GlideConnectionOptions, RedisConnectionInfo, RedisResult, Value,
+    };
+
+    const ALL_SUCCESS_ROUTE: RoutingInfo = RoutingInfo::MultiNode((
+        MultipleNodeRoutingInfo::AllNodes,
+        Some(ResponsePolicy::AllSucceeded),
+    ));
+
+    const PASSWORD: &str = "password";
+    const NEW_PASSWORD: &str = "new_password";
+
+    enum ConnectionType {
+        Cluster,
+        Standalone,
+    }
+
+    enum Connection {
+        Cluster(ClusterConnection),
+        Standalone(MultiplexedConnection),
+    }
+
+    async fn create_connection(
+        password: Option<String>,
+        connection_type: ConnectionType,
+        cluster_context: Option<&TestClusterContext>,
+        standalone_context: Option<&TestContext>,
+    ) -> RedisResult<Connection> {
+        match connection_type {
+            ConnectionType::Cluster => {
+                let cluster_context =
+                    cluster_context.expect("ClusterContext is required for Cluster connection");
+                let builder = get_builder(cluster_context, password);
+                let connection = builder.build()?.get_async_connection(None).await?;
+                Ok(Connection::Cluster(connection))
+            }
+            ConnectionType::Standalone => {
+                let standalone_context =
+                    standalone_context.expect("TestContext is required for Standalone connection");
+                let info = get_connection_info(standalone_context, password);
+                let client = redis::Client::open(info)?;
+                let connection = client
+                    .get_multiplexed_tokio_connection(GlideConnectionOptions::default())
+                    .await?;
+                Ok(Connection::Standalone(connection))
+            }
+        }
+    }
+
+    fn get_connection_info(cluster: &TestContext, password: Option<String>) -> ConnectionInfo {
+        let addr = cluster.server.connection_info().addr.clone();
+        ConnectionInfo {
+            addr,
+            redis: RedisConnectionInfo {
+                password,
+                ..Default::default()
+            },
+        }
+    }
+
+    fn get_builder(cluster: &TestClusterContext, password: Option<String>) -> ClusterClientBuilder {
+        let mut builder = ClusterClientBuilder::new(cluster.nodes.clone());
+        if let Some(password) = password {
+            builder = builder.password(password);
+        }
+        builder
+    }
+
+    async fn set_password(password: &str, conn: &mut Connection) -> RedisResult<()> {
+        let mut set_auth_cmd = cmd("config");
+        set_auth_cmd.arg("set").arg("requirepass").arg(password);
+        match conn {
+            Connection::Cluster(cluster_conn) => cluster_conn
+                .route_command(&set_auth_cmd, ALL_SUCCESS_ROUTE)
+                .await
+                .map(|_| ()),
+            Connection::Standalone(standalone_conn) => set_auth_cmd
+                .query_async::<_, ()>(standalone_conn)
+                .await
+                .map(|_| ()),
+        }
+    }
+
+    async fn kill_all_connections_but_caller(con: &mut ClusterConnection) {
+        let mut kill_cmd = cmd("client");
+        kill_cmd
+            .arg("kill")
+            .arg("type")
+            .arg("normal")
+            .arg("skipme")
+            .arg("yes");
+        con.route_command(&kill_cmd, ALL_SUCCESS_ROUTE)
+            .await
+            .unwrap();
+    }
+
+    async fn reset_connection_standalone(con: &mut MultiplexedConnection) {
+        let _: () = cmd("reset").query_async(con).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_replace_password_cluster() {
+        let cluster_context = TestClusterContext::new(3, 0);
+
+        // Create a management connection to set the password
+        let mut management_connection =
+            match create_connection(None, ConnectionType::Cluster, Some(&cluster_context), None)
+                .await
+                .unwrap()
+            {
+                Connection::Cluster(conn) => conn,
+                _ => panic!("Expected ClusterConnection"),
+            };
+
+        // Set the password using the unified function
+        let mut management_conn = Connection::Cluster(management_connection.clone());
+        set_password(PASSWORD, &mut management_conn).await.unwrap();
+
+        // Test that we can't connect without password
+        let connection_should_fail =
+            create_connection(None, ConnectionType::Cluster, Some(&cluster_context), None).await;
+        assert!(connection_should_fail.is_err());
+        let err = connection_should_fail.err().unwrap();
+        assert!(err.to_string().contains("NoAuth: Authentication required."));
+
+        // Test that we can connect with password
+        let mut connection_should_succeed = match create_connection(
+            Some(PASSWORD.to_string()),
+            ConnectionType::Cluster,
+            Some(&cluster_context),
+            None,
+        )
+        .await
+        .unwrap()
+        {
+            Connection::Cluster(conn) => conn,
+            _ => panic!("Expected ClusterConnection"),
+        };
+
+        let res: RedisResult<Value> = cmd("set")
+            .arg("foo")
+            .arg("bar")
+            .query_async(&mut connection_should_succeed)
+            .await;
+        assert_eq!(res.unwrap(), Value::Okay);
+
+        // Verify that we can retrieve the set value
+        let res: RedisResult<Value> = cmd("get")
+            .arg("foo")
+            .query_async(&mut connection_should_succeed)
+            .await;
+        assert_eq!(res.unwrap(), Value::BulkString(b"bar".to_vec()));
+
+        // Kill the connection to force reconnection
+        kill_all_connections_but_caller(&mut management_connection).await;
+
+        // Attempt to get the value again to ensure reconnection works
+        let should_be_ok: RedisResult<Value> = cmd("get")
+            .arg("foo")
+            .query_async(&mut connection_should_succeed)
+            .await;
+        assert_eq!(should_be_ok.unwrap(), Value::BulkString(b"bar".to_vec()));
+
+        // Reset the password in the connection
+        connection_should_succeed
+            .update_connection_password(Some(NEW_PASSWORD.to_string()))
+            .await
+            .unwrap();
+
+        // Update the password on the server
+        let mut management_conn = Connection::Cluster(management_connection.clone());
+        set_password(NEW_PASSWORD, &mut management_conn)
+            .await
+            .unwrap();
+
+        // Test that we can't connect with the old password
+        let connection_should_fail = create_connection(
+            Some(PASSWORD.to_string()),
+            ConnectionType::Cluster,
+            Some(&cluster_context),
+            None,
+        )
+        .await;
+        assert!(connection_should_fail.is_err());
+        let err = connection_should_fail.err().unwrap();
+        let detail = err.detail().unwrap();
+        assert!(detail.contains("AuthenticationFailed"));
+
+        // Kill the connection to force reconnection
+        kill_all_connections_but_caller(&mut management_connection).await;
+
+        // Verify that the connection with new password still works
+        let result_should_succeed: RedisResult<Value> = cmd("get")
+            .arg("foo")
+            .query_async(&mut connection_should_succeed)
+            .await;
+        assert!(result_should_succeed.is_ok());
+        assert_eq!(
+            result_should_succeed.unwrap(),
+            Value::BulkString(b"bar".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_replace_password_standalone() {
+        let standalone_context = TestContext::new();
+
+        // Create a management connection to set the password
+        let mut management_connection = match create_connection(
+            None,
+            ConnectionType::Standalone,
+            None,
+            Some(&standalone_context),
+        )
+        .await
+        .unwrap()
+        {
+            Connection::Standalone(conn) => conn,
+            _ => panic!("Expected Standalone connection"),
+        };
+
+        // Set the password using the unified function
+        let mut management_conn = Connection::Standalone(management_connection.clone());
+        set_password(PASSWORD, &mut management_conn).await.unwrap();
+
+        // Test that we can't send commands with new connection without password
+        let connection_should_fail = create_connection(
+            None,
+            ConnectionType::Standalone,
+            None,
+            Some(&standalone_context),
+        )
+        .await;
+        let res_should_fail: RedisResult<Value> = match connection_should_fail.unwrap() {
+            Connection::Cluster(mut conn) => cmd("get").arg("foo").query_async(&mut conn).await,
+            Connection::Standalone(mut conn) => cmd("get").arg("foo").query_async(&mut conn).await,
+        };
+        assert!(res_should_fail.is_err());
+
+        // Test that we can connect with password
+        let mut connection_should_succeed = match create_connection(
+            Some(PASSWORD.to_string()),
+            ConnectionType::Standalone,
+            None,
+            Some(&standalone_context),
+        )
+        .await
+        .unwrap()
+        {
+            Connection::Standalone(conn) => conn,
+            _ => panic!("Expected Standalone connection"),
+        };
+
+        let res: RedisResult<Value> = cmd("set")
+            .arg("foo")
+            .arg("bar")
+            .query_async(&mut connection_should_succeed)
+            .await;
+        assert_eq!(res.unwrap(), Value::Okay);
+
+        // Reset the password in the connection
+        connection_should_succeed
+            .update_connection_password(Some(NEW_PASSWORD.to_string()))
+            .await
+            .unwrap();
+
+        // Update the password on the server
+        let mut management_conn = Connection::Standalone(management_connection.clone());
+        set_password(NEW_PASSWORD, &mut management_conn)
+            .await
+            .unwrap();
+
+        // Reset the management connection
+        reset_connection_standalone(&mut management_connection).await;
+
+        // Test that we can't connect with the old password
+        let connection_should_fail = create_connection(
+            Some(PASSWORD.to_string()),
+            ConnectionType::Standalone,
+            None,
+            Some(&standalone_context),
+        )
+        .await;
+        assert!(connection_should_fail.is_err());
+
+        // Verify that the management connection can't perform operations after reset
+        let result_should_fail: RedisResult<Value> = cmd("get")
+            .arg("foo")
+            .query_async(&mut management_connection)
+            .await;
+        assert!(result_should_fail.is_err());
+
+        // Verify that the connection with new password still works
+        let result_should_succeed: RedisResult<Value> = cmd("get")
+            .arg("foo")
+            .query_async(&mut connection_should_succeed)
+            .await;
+        assert!(result_should_succeed.is_ok());
+        assert_eq!(
+            result_should_succeed.unwrap(),
+            Value::BulkString(b"bar".to_vec())
+        );
+    }
+}

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -477,7 +477,7 @@ impl Client {
             .fetch_add(1, Ordering::SeqCst)
     }
 
-    /// Reset the password used to authenticate with the servers.
+    /// Update the password used to authenticate with the servers.
     /// If None is passed, the password will be removed.
     /// If `re_auth` is true, the new password will be used to re-authenticate with all of the nodes.
     pub async fn update_connection_password(

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -259,9 +259,9 @@ impl Client {
                         if let Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) =
                             routing
                         {
-                            let cmdname = cmd.command().unwrap_or_default();
-                            let cmdname = String::from_utf8_lossy(&cmdname);
-                            if redis::cluster_routing::is_readonly_cmd(cmdname.as_bytes()) {
+                            let cmd_name = cmd.command().unwrap_or_default();
+                            let cmd_name = String::from_utf8_lossy(&cmd_name);
+                            if redis::cluster_routing::is_readonly_cmd(cmd_name.as_bytes()) {
                                 // A read-only command, go ahead and send it to a random node
                                 RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)
                             } else {
@@ -270,7 +270,7 @@ impl Client {
                                 log_warn(
                                     "send_command",
                                     format!(
-                                        "User provided 'Random' routing which is not suitable for the writeable command '{cmdname}'. Changing it to 'RandomPrimary'"
+                                        "User provided 'Random' routing which is not suitable for the writeable command '{cmd_name}'. Changing it to 'RandomPrimary'"
                                     ),
                                 );
                                 RoutingInfo::SingleNode(SingleNodeRoutingInfo::RandomPrimary)

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -470,6 +470,18 @@ impl StandaloneClient {
             }
         });
     }
+
+    /// Replace password of the multiplexed connection.
+    pub async fn update_connection_password(
+        &mut self,
+        password: Option<String>,
+    ) -> RedisResult<Value> {
+        self.get_connection(false)
+            .get_connection()
+            .await?
+            .update_connection_password(password.clone())
+            .await
+    }
 }
 
 async fn get_connection_and_replication_info(

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -471,7 +471,8 @@ impl StandaloneClient {
         });
     }
 
-    /// Replace password of the multiplexed connection.
+    /// Update the password used to authenticate with the servers.
+    /// If the password is `None`, the password will be removed.
     pub async fn update_connection_password(
         &mut self,
         password: Option<String>,

--- a/glide-core/src/protobuf/command_request.proto
+++ b/glide-core/src/protobuf/command_request.proto
@@ -517,6 +517,7 @@ message CommandRequest {
         ScriptInvocation script_invocation = 4;
         ScriptInvocationPointers script_invocation_pointers = 5;
         ClusterScan cluster_scan = 6;
+        UpdateConnectionPassword update_connection_password = 7;
     }
     Routes route = 7;
 }

--- a/glide-core/src/protobuf/command_request.proto
+++ b/glide-core/src/protobuf/command_request.proto
@@ -508,6 +508,11 @@ message ClusterScan {
     optional string object_type = 4;
 }
 
+message UpdateConnectionPassword {
+    optional string password = 1;
+    bool re_auth = 2;
+}
+
 message CommandRequest {
     uint32 callback_idx = 1;
 
@@ -519,5 +524,5 @@ message CommandRequest {
         ClusterScan cluster_scan = 6;
         UpdateConnectionPassword update_connection_password = 7;
     }
-    Routes route = 7;
+    Routes route = 8;
 }

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -375,7 +375,7 @@ async fn invoke_script(
 
 async fn send_transaction(
     request: Transaction,
-    mut client: Client,
+    client: &mut Client,
     routing: Option<RoutingInfo>,
 ) -> ClientUsageResult<Value> {
     let mut pipeline = redis::Pipeline::with_capacity(request.commands.capacity());
@@ -461,7 +461,7 @@ fn get_route(
     }
 }
 
-fn handle_request(request: CommandRequest, client: Client, writer: Rc<Writer>) {
+fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer>) {
     task::spawn_local(async move {
         let mut updated_inflight_counter = true;
         let client_clone = client.clone();
@@ -489,7 +489,7 @@ fn handle_request(request: CommandRequest, client: Client, writer: Rc<Writer>) {
                     }
                     command_request::Command::Transaction(transaction) => {
                         match get_route(request.route.0, None) {
-                            Ok(routes) => send_transaction(transaction, client, routes).await,
+                            Ok(routes) => send_transaction(transaction, &mut client, routes).await,
                             Err(e) => Err(e),
                         }
                     }
@@ -522,6 +522,17 @@ fn handle_request(request: CommandRequest, client: Client, writer: Rc<Writer>) {
                             Err(e) => Err(e),
                         }
                     }
+                    command_request::Command::UpdateConnectionPassword(
+                        update_connection_password_command,
+                    ) => client
+                        .update_connection_password(
+                            update_connection_password_command
+                                .password
+                                .map(|chars| chars.to_string()),
+                            update_connection_password_command.re_auth,
+                        )
+                        .await
+                        .map_err(|err| err.into()),
                 },
                 None => {
                     log_debug(

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -673,7 +673,7 @@ function toProtobufRoute(
             if (split.length !== 2) {
                 throw new RequestError(
                     "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                        host,
+                    host,
                 );
             }
 
@@ -990,25 +990,30 @@ export class BaseClient {
     ) {
         const message = Array.isArray(command)
             ? command_request.CommandRequest.create({
-                  callbackIdx,
-                  transaction: command_request.Transaction.create({
-                      commands: command,
-                  }),
-              })
+                callbackIdx,
+                transaction: command_request.Transaction.create({
+                    commands: command,
+                }),
+            })
             : command instanceof command_request.Command
-              ? command_request.CommandRequest.create({
+                ? command_request.CommandRequest.create({
                     callbackIdx,
                     singleCommand: command,
                 })
-              : command instanceof command_request.ClusterScan
-                ? command_request.CommandRequest.create({
-                      callbackIdx,
-                      clusterScan: command,
-                  })
-                : command_request.CommandRequest.create({
-                      callbackIdx,
-                      scriptInvocation: command,
-                  });
+                : command instanceof command_request.ClusterScan
+                    ? command_request.CommandRequest.create({
+                        callbackIdx,
+                        clusterScan: command,
+                    })
+                    : command instanceof command_request.UpdateConnectionPassword
+                        ? command_request.CommandRequest.create({
+                            callbackIdx,
+                            updateConnectionPassword: command,
+                        })
+                        : command_request.CommandRequest.create({
+                            callbackIdx,
+                            scriptInvocation: command,
+                        });
         message.route = route;
 
         this.writeOrBufferRequest(
@@ -5984,9 +5989,9 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-        primary: connection_request.ReadFrom.Primary,
-        preferReplica: connection_request.ReadFrom.PreferReplica,
-    };
+            primary: connection_request.ReadFrom.Primary,
+            preferReplica: connection_request.ReadFrom.PreferReplica,
+        };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -7295,8 +7300,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                      return { key: r.key, elements: r.value };
-                  })[0],
+                    return { key: r.key, elements: r.value };
+                })[0],
         );
     }
 
@@ -7338,8 +7343,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                      return { key: r.key, elements: r.value };
-                  })[0],
+                    return { key: r.key, elements: r.value };
+                })[0],
         );
     }
 
@@ -7546,11 +7551,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-            "password" in options.credentials
+                "password" in options.credentials
                 ? {
-                      password: options.credentials.password,
-                      username: options.credentials.username,
-                  }
+                    password: options.credentials.password,
+                    username: options.credentials.username,
+                }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -12240,6 +12240,161 @@ export function runBaseTests(config: {
         },
         config.timeout,
     );
+
+    describe.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "update_connection_password_%p",
+        (protocol) => {
+            const NEW_PASSWORD = "new_password";
+            const WRONG_PASSWORD = "wrong_password";
+            /**
+             * Test replacing the connection password without immediate re-authentication.
+             * Verifies that:
+             * 1. The client can update its internal password
+             * 2. The client remains connected with current auth
+             * 3. The client can reconnect using the new password after server password change
+             * Currently, this test is only supported for cluster mode,
+             * since standalone mode dont have retry mechanism.
+             */
+            it("test_update_connection_password", async () => {
+                await runTest(async (client: BaseClient) => {
+                    try {
+                        if (client instanceof GlideClient) {
+                            return;
+                        }
+
+                        const result = await client.updateConnectionPassword(
+                            NEW_PASSWORD,
+                            false,
+                        );
+                        expect(result).toEqual("OK");
+
+                        await client.set("test_key", "test_value");
+                        const value = await client.get("test_key");
+                        expect(value).toEqual("test_value");
+                        await expect(
+                            client.configSet({
+                                requirepass: NEW_PASSWORD,
+                            }),
+                        ).resolves.toBe("OK");
+                        await client.customCommand([
+                            "CLIENT",
+                            "KILL",
+                            "TYPE",
+                            "normal",
+                            "skipme",
+                            "no",
+                        ]);
+                        await client.set("test_key2", "test_value2");
+                        const value2 = await client.get("test_key2");
+                        expect(value2).toEqual("test_value2");
+                        await client.configSet({
+                            requirepass: "",
+                        });
+                    } finally {
+                        client?.close();
+                    }
+                }, protocol);
+            });
+
+            /**
+             * Test that immediate re-authentication fails when no server password is set.
+             * This verifies proper error handling when trying to re-authenticate with a
+             * password when the server has no password set.
+             */
+            it("test_update_connection_password_no_server_auth", async () => {
+                await runTest(async (client: BaseClient) => {
+                    try {
+                        await expect(
+                            client.updateConnectionPassword(NEW_PASSWORD, true),
+                        ).rejects.toThrow(RequestError);
+                    } finally {
+                        client?.close();
+                    }
+                }, protocol);
+            });
+
+            /**
+             * Test replacing connection password with a long password string.
+             * Verifies that the client can handle long passwords (1000 characters).
+             */
+            it("test_update_connection_password_long", async () => {
+                await runTest(async (client: BaseClient) => {
+                    try {
+                        const longPassword = "p".repeat(1000);
+                        await expect(
+                            client.updateConnectionPassword(
+                                longPassword,
+                                false,
+                            ),
+                        ).resolves.toBe("OK");
+                        await client.configSet({
+                            requirepass: "",
+                        });
+                    } finally {
+                        client?.close();
+                    }
+                }, protocol);
+            });
+
+            /**
+             * Test that re-authentication fails when using wrong password.
+             * Verifies proper error handling when immediate re-authentication is attempted
+             * with a password that doesn't match the server's password.
+             */
+            it("test_replace_password_reauth_wrong_password", async () => {
+                await runTest(async (client: BaseClient) => {
+                    try {
+                        await client.configSet({
+                            requirepass: NEW_PASSWORD,
+                        });
+
+                        await expect(
+                            client.updateConnectionPassword(
+                                WRONG_PASSWORD,
+                                true,
+                            ),
+                        ).rejects.toThrow(RequestError);
+                        await client.updateConnectionPassword(
+                            NEW_PASSWORD,
+                            true,
+                        );
+                        await client.configSet({
+                            requirepass: "",
+                        });
+                    } finally {
+                        client?.close();
+                    }
+                }, protocol);
+            });
+            /**
+             * Test replacing connection password with immediate re-authentication.
+             * Verifies that:
+             * 1. The client can update its password and re-authenticate immediately
+             * 2. The client remains operational after re-authentication
+             */
+            it("test_update_connection_password_with_reauth", async () => {
+                await runTest(async (client: BaseClient) => {
+                    try {
+                        await client.configSet({
+                            requirepass: NEW_PASSWORD,
+                        });
+
+                        await expect(
+                            client.updateConnectionPassword(NEW_PASSWORD, true),
+                        ).resolves.toBe("OK");
+                        await client.set("test_key", "test_value");
+                        const value = await client.get("test_key");
+                        expect(value).toEqual("test_value");
+                        await client.configSet({
+                            requirepass: "",
+                        });
+                    } finally {
+                        client?.close();
+                    }
+                }, protocol);
+            });
+        },
+    );
 }
 
 export function runCommonTests(config: {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
         "eslint-config-prettier": "^9.1.0",
         "prettier": "^3.3.3",
         "typescript": "^5.6.2",
-        "typescript-eslint": "^8.5.0"
+        "typescript-eslint": "^8.13"
     }
 }

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -4,3 +4,4 @@ isort == 5.10
 mypy == 1.2
 mypy-protobuf == 3.5
 packaging >= 22.0
+pyrsistent

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -260,7 +260,7 @@ __all__ = [
     "TrimByMaxLen",
     "TrimByMinId",
     "UpdateOptions",
-    "ClusterScanCursor"
+    "ClusterScanCursor",
     # PubSub
     "PubSubMsg",
     # Json

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -392,6 +392,38 @@ class CoreCommands(Protocol):
         type: Optional[ObjectType] = ...,
     ) -> TResult: ...
 
+    async def _replace_connection_password(
+        self, password: str, re_auth: bool
+    ) -> TResult: ...
+
+    async def replace_connection_password(self, password: str, re_auth: bool) -> TOK:
+        """
+        Replace the current connection password with a new password.
+
+        **Note:** This method updates the client's internal password configuration and does
+        not perform password rotation on the server side.
+
+        This method is useful in scenarios where the server password has changed or when
+        utilizing short-lived passwords for enhanced security. It allows the client to
+        update its password to reconnect upon disconnection without the need to recreate
+        the client instance. This ensures that the internal reconnection mechanism can
+        handle reconnection seamlessly, preventing the loss of in-flight commands.
+
+        Args:
+            password (str): The new password to replace the current password.
+            re_auth (bool):
+                - `True`: The client will re-authenticate immediately with the new password.
+                - `False`: The new password will be used for the next connection attempt.
+
+        Returns:
+            TOK: A simple OK response.
+
+        Example:
+            >>> await client.replace_connection_password("new_password", re_auth=True)
+            'OK'
+        """
+        return cast(TOK, await self._replace_connection_password(password, re_auth))
+
     async def set(
         self,
         key: TEncodable,

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -392,13 +392,15 @@ class CoreCommands(Protocol):
         type: Optional[ObjectType] = ...,
     ) -> TResult: ...
 
-    async def _replace_connection_password(
-        self, password: str, re_auth: bool
+    async def _update_connection_password(
+        self, password: Optional[str], re_auth: bool
     ) -> TResult: ...
 
-    async def replace_connection_password(self, password: str, re_auth: bool) -> TOK:
+    async def update_connection_password(
+        self, password: Optional[str], re_auth: bool
+    ) -> TOK:
         """
-        Replace the current connection password with a new password.
+        Update the current connection password with a new password.
 
         **Note:** This method updates the client's internal password configuration and does
         not perform password rotation on the server side.
@@ -410,7 +412,8 @@ class CoreCommands(Protocol):
         handle reconnection seamlessly, preventing the loss of in-flight commands.
 
         Args:
-            password (str): The new password to replace the current password.
+            password (Optional[str]): The new password to use for the connection,
+            if `None` the password will be removed.
             re_auth (bool):
                 - `True`: The client will re-authenticate immediately with the new password.
                 - `False`: The new password will be used for the next connection attempt.
@@ -419,10 +422,10 @@ class CoreCommands(Protocol):
             TOK: A simple OK response.
 
         Example:
-            >>> await client.replace_connection_password("new_password", re_auth=True)
+            >>> await client.update_connection_password("new_password", re_auth=True)
             'OK'
         """
-        return cast(TOK, await self._replace_connection_password(password, re_auth))
+        return cast(TOK, await self._update_connection_password(password, re_auth))
 
     async def set(
         self,

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -9,7 +9,7 @@ from glide.async_commands.cluster_commands import ClusterCommands
 from glide.async_commands.command_args import ObjectType
 from glide.async_commands.core import CoreCommands
 from glide.async_commands.standalone_commands import StandaloneCommands
-from glide.config import BaseClientConfiguration
+from glide.config import BaseClientConfiguration, ServerCredentials
 from glide.constants import DEFAULT_READ_BYTES_SIZE, OK, TEncodable, TRequest, TResult
 from glide.exceptions import (
     ClosingError,
@@ -26,6 +26,7 @@ from glide.protobuf.connection_request_pb2 import ConnectionRequest
 from glide.protobuf.response_pb2 import RequestErrorType, Response
 from glide.protobuf_codec import PartialMessageException, ProtobufCodec
 from glide.routes import Route, set_protobuf_route
+from pyrsistent import optional
 
 from .glide import (
     DEFAULT_TIMEOUT_IN_MILLISECONDS,
@@ -532,19 +533,19 @@ class BaseClient(CoreCommands):
                 else:
                     await self._process_response(response=response)
 
-    async def _replace_connection_password(
-        self, password: str, re_auth: bool
+    async def _update_connection_password(
+        self, password: Optional[str], re_auth: bool
     ) -> TResult:
         request = CommandRequest()
         request.callback_idx = self._get_callback_index()
-        request.replace_connection_password.password = password
-        request.replace_connection_password.re_auth = re_auth
+        request.update_connection_password.password = password
+        request.update_connection_password.re_auth = re_auth
         response = await self._write_request_await_response(request)
         # Update the client binding side password if managed to change core configuration password
         if response is OK:
             if self.config.credentials is None:
-                self.config.credentials = ServerCredentials(password=password)
-                self.config.credentials.password = password
+                self.config.credentials = ServerCredentials(password=password or "")
+                self.config.credentials.password = password or ""
         return response
 
 

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -532,6 +532,21 @@ class BaseClient(CoreCommands):
                 else:
                     await self._process_response(response=response)
 
+    async def _replace_connection_password(
+        self, password: str, re_auth: bool
+    ) -> TResult:
+        request = CommandRequest()
+        request.callback_idx = self._get_callback_index()
+        request.replace_connection_password.password = password
+        request.replace_connection_password.re_auth = re_auth
+        response = await self._write_request_await_response(request)
+        # Update the client binding side password if managed to change core configuration password
+        if response is OK:
+            if self.config.credentials is None:
+                self.config.credentials = ServerCredentials(password=password)
+                self.config.credentials.password = password
+        return response
+
 
 class GlideClusterClient(BaseClient, ClusterCommands):
     """

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -185,7 +185,7 @@ class TestGlideClients:
                 ["CONFIG", "SET", "requirepass", password]
             )
 
-            with pytest.raises(ClosingError, match="NOAUTH"):
+            with pytest.raises(ClosingError, match="NoAuth"):
                 # Creation of a new client without password should fail
                 await create_client(
                     request,

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -185,7 +185,7 @@ class TestGlideClients:
                 ["CONFIG", "SET", "requirepass", password]
             )
 
-            with pytest.raises(ClosingError, match="NoAuth"):
+            with pytest.raises(ClosingError, match="NOAUTH"):
                 # Creation of a new client without password should fail
                 await create_client(
                     request,

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -63,7 +63,7 @@ class TestAuthCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_replace_connection_password(self, glide_client: TGlideClient):
+    async def test_update_connection_password(self, glide_client: TGlideClient):
         """
         Test replacing the connection password without immediate re-authentication.
         Verifies that:
@@ -73,7 +73,7 @@ class TestAuthCommands:
         Currently, this test is only supported for cluster mode,
         since standalone mode dont have retry mechanism.
         """
-        result = await glide_client.replace_connection_password(
+        result = await glide_client.update_connection_password(
             NEW_PASSWORD, re_auth=False
         )
         assert result == OK
@@ -89,7 +89,7 @@ class TestAuthCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_replace_connection_password_no_server_auth(
+    async def test_update_connection_password_no_server_auth(
         self, glide_client: TGlideClient
     ):
         """
@@ -98,17 +98,17 @@ class TestAuthCommands:
         password when the server has no password set.
         """
         with pytest.raises(RequestError):
-            await glide_client.replace_connection_password(WRONG_PASSWORD, re_auth=True)
+            await glide_client.update_connection_password(WRONG_PASSWORD, re_auth=True)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_replace_connection_password_long(self, glide_client: TGlideClient):
+    async def test_update_connection_password_long(self, glide_client: TGlideClient):
         """
         Test replacing connection password with a long password string.
         Verifies that the client can handle long passwords (1000 characters).
         """
         long_password = "p" * 1000
-        result = await glide_client.replace_connection_password(
+        result = await glide_client.update_connection_password(
             long_password, re_auth=False
         )
         assert result == OK
@@ -125,11 +125,11 @@ class TestAuthCommands:
         """
         await config_set_new_password(glide_client, NEW_PASSWORD)
         with pytest.raises(RequestError):
-            await glide_client.replace_connection_password(WRONG_PASSWORD, re_auth=True)
+            await glide_client.update_connection_password(WRONG_PASSWORD, re_auth=True)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_replace_connection_password_with_reauth(
+    async def test_update_connection_password_with_reauth(
         self, glide_client: TGlideClient
     ):
         """
@@ -139,7 +139,7 @@ class TestAuthCommands:
         2. The client remains operational after re-authentication
         """
         await config_set_new_password(glide_client, NEW_PASSWORD)
-        result = await glide_client.replace_connection_password(
+        result = await glide_client.update_connection_password(
             NEW_PASSWORD, re_auth=True
         )
         assert result == OK

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -1,0 +1,149 @@
+import pytest
+from glide.config import ProtocolVersion
+from glide.constants import OK
+from glide.exceptions import RequestError
+from glide.glide_client import GlideClient, GlideClusterClient, TGlideClient
+from glide.routes import AllNodes
+
+NEW_PASSWORD = "new_secure_password"
+WRONG_PASSWORD = "wrong_password"
+
+
+async def auth_client(client: TGlideClient, password):
+    """
+    Authenticates the given TGlideClient server connected.
+    """
+    if isinstance(client, GlideClient):
+        await client.custom_command(["AUTH", password])
+    if isinstance(client, GlideClusterClient):
+        await client.custom_command(["AUTH", password], route=AllNodes())
+
+
+async def config_set_new_password(client: TGlideClient, password):
+    """
+    Sets a new password for the given TGlideClient server connected.
+    This function updates the server to require a new password.
+    """
+    if isinstance(client, GlideClient):
+        await client.config_set({"requirepass": password})
+    if isinstance(client, GlideClusterClient):
+        await client.config_set({"requirepass": password}, route=AllNodes())
+
+
+async def reset_connections(client: TGlideClient):
+    """
+    Resets the connections for the given TGlideClient server connected.
+    """
+    if isinstance(client, GlideClient):
+        await client.custom_command(["RESET"])
+    if isinstance(client, GlideClusterClient):
+        await client.custom_command(["RESET"], route=AllNodes())
+
+
+@pytest.mark.asyncio
+class TestAuthCommands:
+    """Test cases for password authentication and management"""
+
+    @pytest.fixture(autouse=True)
+    async def setup(self, glide_client: TGlideClient):
+        """
+        Teardown the test environment, make sure that theres no password set on the server side
+        """
+        try:
+            await auth_client(glide_client, NEW_PASSWORD)
+            await config_set_new_password(glide_client, "")
+        except RequestError:
+            pass
+        yield
+        try:
+            await auth_client(glide_client, NEW_PASSWORD)
+            await config_set_new_password(glide_client, "")
+        except RequestError:
+            pass
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_replace_connection_password(self, glide_client: TGlideClient):
+        """
+        Test replacing the connection password without immediate re-authentication.
+        Verifies that:
+        1. The client can update its internal password
+        2. The client remains connected with current auth
+        3. The client can reconnect using the new password after server password change
+        Currently, this test is only supported for cluster mode,
+        since standalone mode dont have retry mechanism.
+        """
+        result = await glide_client.replace_connection_password(
+            NEW_PASSWORD, re_auth=False
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert await glide_client.set("test_key", "test_value") == OK
+        value = await glide_client.get("test_key")
+        assert value == b"test_value"
+        await config_set_new_password(glide_client, NEW_PASSWORD)
+        await reset_connections(glide_client)
+        # Verify that the client is able to reconnect with the new password
+        value = await glide_client.get("test_key")
+        assert value == b"test_value"
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_replace_connection_password_no_server_auth(
+        self, glide_client: TGlideClient
+    ):
+        """
+        Test that immediate re-authentication fails when no server password is set.
+        This verifies proper error handling when trying to re-authenticate with a
+        password when the server has no password set.
+        """
+        with pytest.raises(RequestError):
+            await glide_client.replace_connection_password(WRONG_PASSWORD, re_auth=True)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_replace_connection_password_long(self, glide_client: TGlideClient):
+        """
+        Test replacing connection password with a long password string.
+        Verifies that the client can handle long passwords (1000 characters).
+        """
+        long_password = "p" * 1000
+        result = await glide_client.replace_connection_password(
+            long_password, re_auth=False
+        )
+        assert result == OK
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_replace_password_reauth_wrong_password(
+        self, glide_client: TGlideClient
+    ):
+        """
+        Test that re-authentication fails when using wrong password.
+        Verifies proper error handling when immediate re-authentication is attempted
+        with a password that doesn't match the server's password.
+        """
+        await config_set_new_password(glide_client, NEW_PASSWORD)
+        with pytest.raises(RequestError):
+            await glide_client.replace_connection_password(WRONG_PASSWORD, re_auth=True)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_replace_connection_password_with_reauth(
+        self, glide_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication.
+        Verifies that:
+        1. The client can update its password and re-authenticate immediately
+        2. The client remains operational after re-authentication
+        """
+        await config_set_new_password(glide_client, NEW_PASSWORD)
+        result = await glide_client.replace_connection_password(
+            NEW_PASSWORD, re_auth=True
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert await glide_client.set("test_key", "test_value") == OK
+        value = await glide_client.get("test_key")
+        assert value == b"test_value"

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -30,14 +30,18 @@ async def config_set_new_password(client: TGlideClient, password):
         await client.config_set({"requirepass": password}, route=AllNodes())
 
 
-async def reset_connections(client: TGlideClient):
+async def kill_connections(client: TGlideClient):
     """
-    Resets the connections for the given TGlideClient server connected.
+    Kills all connections to the given TGlideClient server connected.
     """
     if isinstance(client, GlideClient):
-        await client.custom_command(["RESET"])
+        await client.custom_command(
+            ["CLIENT", "KILL", "TYPE", "normal", "skipme", "no"]
+        )
     if isinstance(client, GlideClusterClient):
-        await client.custom_command(["RESET"], route=AllNodes())
+        await client.custom_command(
+            ["CLIENT", "KILL", "TYPE", "normal", "skipme", "no"], route=AllNodes()
+        )
 
 
 @pytest.mark.asyncio
@@ -82,7 +86,7 @@ class TestAuthCommands:
         value = await glide_client.get("test_key")
         assert value == b"test_value"
         await config_set_new_password(glide_client, NEW_PASSWORD)
-        await reset_connections(glide_client)
+        await kill_connections(glide_client)
         # Verify that the client is able to reconnect with the new password
         value = await glide_client.get("test_key")
         assert value == b"test_value"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 async-timeout==4.0.2;python_version<"3.11"
 maturin==0.13.0
 protobuf==3.20.*
-pytest==7.1.2
-pytest-asyncio==0.19.0
+pytest
+pytest-asyncio
 typing_extensions==4.8.0;python_version<"3.11"
 pytest-html


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This pull request is centered around setting an option to replace the password configured for connection.
The feature introduced the need for major changes in the core functionality of the core, and introduced a new platform in the core for performing management operation on the cluster connection.

The pull request includes various updates and improvements across different parts of the codebase, including workflow updates, dependency changes, and enhancements to the server connection handling. The most important changes include adding support for replacing connection passwords, updating dependencies, and introducing a builder pattern for `MultiplexedConnection`.

### Workflow Updates:
* [`.github/workflows/python.yml`](diffhunk://#diff-092659a9bd0068791326fb1d08f005532e5aeb983b999a7bd32c51deee0a71d5R118): Added `pip install -r dev_requirements.txt` to ensure development dependencies are installed before running tests. [[1]](diffhunk://#diff-092659a9bd0068791326fb1d08f005532e5aeb983b999a7bd32c51deee0a71d5R118) [[2]](diffhunk://#diff-092659a9bd0068791326fb1d08f005532e5aeb983b999a7bd32c51deee0a71d5R181)

### Dependency Updates:
* [`glide-core/redis-rs/redis/Cargo.toml`](diffhunk://#diff-db00c63100e23e5d2ff73b34acb690c3d749c7ac8a94982361594ce7589c7bb8L11-R11): Updated Rust version from 1.65 to 1.67 and removed `fast-math` dependency. [[1]](diffhunk://#diff-db00c63100e23e5d2ff73b34acb690c3d749c7ac8a94982361594ce7589c7bb8L11-R11) [[2]](diffhunk://#diff-db00c63100e23e5d2ff73b34acb690c3d749c7ac8a94982361594ce7589c7bb8L50) [[3]](diffhunk://#diff-db00c63100e23e5d2ff73b34acb690c3d749c7ac8a94982361594ce7589c7bb8L128)

### Changelog Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR2): Added an entry for the new feature that supports replacing connection passwords for multiple languages.

### Server Connection Enhancements:
* [`glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs`](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fR34-R36): Introduced a builder pattern for `MultiplexedConnection`, added a method to update the connection password, and made `Pipeline` struct public within the crate. [[1]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fR34-R36) [[2]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fL79-R82) [[3]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fR405) [[4]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fR420) [[5]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fL458-R484) [[6]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fR503) [[7]](diffhunk://#diff-e69eca9fc5f947ebc7c06b822e358d5486c5f94aa7154c6cc8fa200936b1bd0fR577-R667)
* [`glide-core/redis-rs/redis/src/cluster_async/mod.rs`](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bR58): Added support for updating the connection password across all cluster servers and improved error handling. [[1]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bR58) [[2]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bR110-R113) [[3]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL297-R298) [[4]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL335-R335) [[5]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL360-R409) [[6]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL413-R454) [[7]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bR469-R491) [[8]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bR682-R689) [[9]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL659-R741) [[10]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL682-R755) [[11]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bR816-R819)

### Typo Fixes:
* [`glide-core/redis-rs/redis/src/cluster.rs`](diffhunk://#diff-674bbf4bd1a8994b912e9942ca6c01cb462ae7a883f522800a489df9b59a13e7L309-R309): Fixed typos in comments. [[1]](diffhunk://#diff-674bbf4bd1a8994b912e9942ca6c01cb462ae7a883f522800a489df9b59a13e7L309-R309) [[2]](diffhunk://#diff-674bbf4bd1a8994b912e9942ca6c01cb462ae7a883f522800a489df9b59a13e7L811-R811)

This PR is a great cooperation between the greatest @jhpung, the one and only @umit, and myself, and created a ton of joy of working together as a team.
### Issue link

This Pull Request is linked to issue: #2360 

To-Do:
- [x] Protobuf message for the interaction of the new API which is different from CMD API – @avifenesh 
- [x] Node.js binding implementation and tests — @jhpung 
- [x] Python binding implementation and tests — @avifenesh 
- [x] Java binding implementation and tests — @acarbonetto Do we have someone with the capacity to take it, or support me when I'm struggling around?
- [x] Go binding and tests — @umit
- [x] Changelog — @avifenesh 
- [ ] General docs section — @avifenesh 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
