### PR TITLE
Rust dep ci issue and warning in transaction py fix

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,8 @@ yanked = "deny"
 ignore = [
     # Unmaintained dependency error that needs more attention due to nested dependencies
     "RUSTSEC-2024-0370",
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0388",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -1033,6 +1033,9 @@ class TestTransaction:
         assert result[5:13] == [2, 2, 2, [b"Bob", b"Alice"], 2, OK, None, 0]
         assert result[13:] == expected
 
+    @pytest.mark.filterwarnings(
+        action="ignore", message="The test <Function test_transaction_clear>"
+    )
     def test_transaction_clear(self):
         transaction = Transaction()
         transaction.info()


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This pull request includes updates to the `deny.toml` file to ignore additional security advisories and adds a warning filter to a test in the `test_transaction.py` file.

Security updates:

* [`deny.toml`](diffhunk://#diff-1040309c64844eb1b6b63d8fd67938adbf9461f1b3c61f12cf738f064a02d3deR27-R28): Added "RUSTSEC-2024-0384" and "RUSTSEC-2024-0388" to the list of ignored advisories.

Test improvements:

* [`python/python/tests/test_transaction.py`](diffhunk://#diff-0e76e703bbbc3d8fba066a7e2d2dfa3d620ca525655886096cf249f92e6d5ab4R1036-R1038): Added a filter to ignore warnings for the `test_transaction_clear` function.

### Issue link

This Pull Request is linked to issue #2669

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
