### PR TITLE
Improve retry logic and update unmaintained dependencies for Rust lint CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 * Core: Add support for sending multi-slot JSON.MSET and JSON.MGET commands ([#2587]https://github.com/valkey-io/valkey-glide/pull/2587)
 * Node: Add `JSON.DEBUG` command ([#2572](https://github.com/valkey-io/valkey-glide/pull/2572))
 * Node: Add `JSON.NUMINCRBY` and `JSON.NUMMULTBY` command ([#2555](https://github.com/valkey-io/valkey-glide/pull/2555))
+* Core: Improve retry logic and update unmaintained dependencies for Rust lint CI ([#2673](https://github.com/valkey-io/valkey-glide/pull/2643))
 
 #### Breaking Changes
 

--- a/benchmarks/rust/Cargo.toml
+++ b/benchmarks/rust/Cargo.toml
@@ -15,7 +15,6 @@ redis = { path = "../../glide-core/redis-rs/redis", features = ["aio"] }
 futures = "0.3.28"
 rand = "0.8.5"
 itoa = "1.0.6"
-futures-time = "^3.0.0"
 clap = { version = "4.3.8", features = ["derive"] }
 chrono = "0.4.26"
 serde_json = "1.0.99"

--- a/deny.toml
+++ b/deny.toml
@@ -57,6 +57,7 @@ allow = [
     "Unicode-DFS-2016",
     "ISC",
     "OpenSSL",
+    "MPL-2.0"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/deny.toml
+++ b/deny.toml
@@ -24,8 +24,6 @@ yanked = "deny"
 ignore = [
     # Unmaintained dependency error that needs more attention due to nested dependencies
     "RUSTSEC-2024-0370",
-    "RUSTSEC-2024-0384",
-    "RUSTSEC-2024-0388",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/deny.toml
+++ b/deny.toml
@@ -59,7 +59,6 @@ allow = [
     "Unicode-DFS-2016",
     "ISC",
     "OpenSSL",
-    "MPL-2.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -24,7 +24,8 @@ logger_core = { path = "../logger_core" }
 dispose = "0.5.0"
 tokio-util = { version = "^0.7", features = ["rt"], optional = true }
 num_cpus = { version = "^1.15", optional = true }
-tokio-retry = "0.3.0"
+tokio-retry2 = {version = "0.5", features = ["jitter"]}
+
 protobuf = { version = "3", features = [
     "bytes",
     "with-bytes",

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -61,7 +61,6 @@ r2d2 = { version = "0.8.8", optional = true }
 # Only needed for cluster
 crc16 = { version = "0.4", optional = true }
 rand = { version = "0.8", optional = true }
-derivative = { version = "2.2.0", optional = true }
 
 # Only needed for async cluster
 dashmap = { version = "6.0", optional = true }
@@ -134,7 +133,7 @@ aio = [
 ]
 geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
-cluster = ["crc16", "rand", "derivative"]
+cluster = ["crc16", "rand"]
 script = ["sha1_smol"]
 tls-native-tls = ["native-tls"]
 tls-rustls = [

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -53,7 +53,6 @@ dispose = { version = "0.5.0", optional = true }
 # Only needed for the connection manager
 arc-swap = { version = "1.7.1" }
 futures = { version = "0.3.3", optional = true }
-tokio-retry = { version = "0.3.0", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
@@ -68,9 +67,7 @@ dashmap = { version = "6.0", optional = true }
 async-trait = { version = "0.1.24", optional = true }
 
 # Only needed for tokio support
-backoff-tokio = { package = "backoff", version = "0.4.0", optional = true, features = [
-    "tokio",
-] }
+tokio-retry2 = {version = "0.5", features = ["jitter"], optional = true}
 
 # Only needed for native tls
 native-tls = { version = "0.2", optional = true }
@@ -144,10 +141,10 @@ tls-rustls = [
 ]
 tls-rustls-insecure = ["tls-rustls"]
 tls-rustls-webpki-roots = ["tls-rustls", "webpki-roots"]
-tokio-comp = ["aio", "tokio/net", "backoff-tokio"]
+tokio-comp = ["aio", "tokio/net", "tokio-retry2"]
 tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
-connection-manager = ["futures", "aio", "tokio-retry"]
+connection-manager = ["futures", "aio", "tokio-retry2"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "dashmap"]
 keep-alive = ["socket2"]

--- a/glide-core/redis-rs/redis/src/cluster_topology.rs
+++ b/glide-core/redis-rs/redis/src/cluster_topology.rs
@@ -8,7 +8,6 @@ use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap};
 use crate::{cluster::TlsMode, ErrorKind, RedisError, RedisResult, Value};
 #[cfg(all(feature = "cluster-async", not(feature = "tokio-comp")))]
 use async_std::sync::RwLock;
-use derivative::Derivative;
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::AtomicBool;
@@ -58,16 +57,20 @@ impl SlotRefreshState {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(PartialEq, Eq)]
 #[derive(Debug)]
 pub(crate) struct TopologyView {
     pub(crate) hash_value: TopologyHash,
-    #[derivative(PartialEq = "ignore")]
     pub(crate) nodes_count: u16,
-    #[derivative(PartialEq = "ignore")]
     slots_and_count: (u16, Vec<Slot>),
 }
+
+impl PartialEq for TopologyView {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash_value == other.hash_value
+    }
+}
+
+impl Eq for TopologyView {}
 
 pub(crate) fn slot(key: &[u8]) -> u16 {
     crc16::State::<crc16::XMODEM>::calculate(key) % SLOT_SIZE

--- a/glide-core/redis-rs/redis/src/cluster_topology.rs
+++ b/glide-core/redis-rs/redis/src/cluster_topology.rs
@@ -20,11 +20,10 @@ use tracing::info;
 // Exponential backoff constants for retrying a slot refresh
 /// The default number of refresh topology retries in the same call
 pub const DEFAULT_NUMBER_OF_REFRESH_SLOTS_RETRIES: usize = 3;
-/// The default maximum interval between two retries of the same call for topology refresh
-pub const DEFAULT_REFRESH_SLOTS_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(1);
-/// The default initial interval for retrying topology refresh
-pub const DEFAULT_REFRESH_SLOTS_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(500);
-
+/// The default base duration for retrying topology refresh
+pub const DEFAULT_REFRESH_SLOTS_RETRY_BASE_DURATION_MILLIS: u64 = 500;
+/// The default base factor for retrying topology refresh
+pub const DEFAULT_REFRESH_SLOTS_RETRY_BASE_FACTOR: f64 = 1.5;
 // Constants for the intervals between two independent consecutive refresh slots calls
 /// The default wait duration between two consecutive refresh slots calls
 #[cfg(feature = "cluster-async")]

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -124,7 +124,7 @@ async fn create_connection(
     let action = || async {
         get_multiplexed_connection(client, &connection_options)
             .await
-            .map_err(|err| RetryError::transient(err))
+            .map_err(RetryError::transient)
     };
 
     match Retry::spawn(retry_strategy.get_iterator(), action).await {

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -17,7 +17,7 @@ use telemetrylib::Telemetry;
 use tokio::sync::{mpsc, Notify};
 use tokio::task;
 use tokio::time::timeout;
-use tokio_retry::Retry;
+use tokio_retry2::{Retry, RetryError};
 
 use super::{run_with_timeout, DEFAULT_CONNECTION_ATTEMPT_TIMEOUT};
 
@@ -121,7 +121,11 @@ async fn create_connection(
             TokioDisconnectNotifier::new(),
         )),
     };
-    let action = || get_multiplexed_connection(client, &connection_options);
+    let action = || async {
+        get_multiplexed_connection(client, &connection_options)
+            .await
+            .map_err(|err| RetryError::transient(err))
+    };
 
     match Retry::spawn(retry_strategy.get_iterator(), action).await {
         Ok(connection) => {

--- a/glide-core/src/retry_strategies.rs
+++ b/glide-core/src/retry_strategies.rs
@@ -3,7 +3,7 @@
  */
 use crate::client::ConnectionRetryStrategy;
 use std::time::Duration;
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
+use tokio_retry2::strategy::{jitter_range, ExponentialBackoff};
 
 #[derive(Clone, Debug)]
 pub(super) struct RetryStrategy {
@@ -27,7 +27,7 @@ impl RetryStrategy {
     pub(super) fn get_iterator(&self) -> impl Iterator<Item = Duration> {
         ExponentialBackoff::from_millis(self.exponent_base as u64)
             .factor(self.factor as u64)
-            .map(jitter)
+            .map(jitter_range(0.8, 1.2))
             .take(self.number_of_retries as usize)
     }
 }
@@ -78,23 +78,39 @@ mod tests {
         let mut counter = 0;
         for duration in intervals {
             counter += 1;
-            assert!(duration.as_millis() <= interval_duration as u128);
+            let upper_limit = (interval_duration as f32 * 1.2) as u128;
+            let lower_limit = (interval_duration as f32 * 0.8) as u128;
+            assert!(
+                lower_limit <= duration.as_millis() || duration.as_millis() <= upper_limit,
+                "{:?}ms <= {:?}ms <= {:?}ms",
+                lower_limit,
+                duration.as_millis(),
+                upper_limit
+            );
         }
         assert_eq!(counter, retries);
     }
 
     #[test]
     fn test_exponential_backoff_with_jitter() {
-        let retries = 3;
-        let base = 10;
-        let factor = 5;
+        let retries = 5;
+        let base = 2;
+        let factor = 100;
         let intervals = get_exponential_backoff(base, factor, retries).get_iterator();
 
         let mut counter = 0;
         for duration in intervals {
             counter += 1;
             let unjittered_duration = factor * (base.pow(counter));
-            assert!(duration.as_millis() <= unjittered_duration as u128);
+            let upper_limit = (unjittered_duration as f32 * 1.2) as u128;
+            let lower_limit = (unjittered_duration as f32 * 0.8) as u128;
+            assert!(
+                lower_limit <= duration.as_millis() || duration.as_millis() <= upper_limit,
+                "{:?}ms <= {:?}ms <= {:?}ms",
+                lower_limit,
+                duration.as_millis(),
+                upper_limit
+            );
         }
 
         assert_eq!(counter, retries);

--- a/go/Cargo.toml
+++ b/go/Cargo.toml
@@ -13,7 +13,6 @@ redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp"
 glide-core = { path = "../glide-core", features = ["socket-layer"] }
 tokio = { version = "^1", features = ["rt", "macros", "rt-multi-thread", "time"] }
 protobuf = { version = "3.3.0", features = [] }
-derivative = "2.2.0"
 
 [profile.release]
 lto = true

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -16,7 +16,7 @@ use std::{
     ffi::{c_void, CString},
     mem,
     os::raw::{c_char, c_double, c_long, c_ulong},
-    ptr
+    ptr,
 };
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -3,7 +3,6 @@
 */
 
 #![deny(unsafe_op_in_unsafe_fn)]
-use derivative::Derivative;
 use glide_core::client::Client as GlideClient;
 use glide_core::connection_request;
 use glide_core::errors;
@@ -17,6 +16,7 @@ use std::{
     ffi::{c_void, CString},
     mem,
     os::raw::{c_char, c_double, c_long, c_ulong},
+    ptr
 };
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;
@@ -28,8 +28,7 @@ use tokio::runtime::Runtime;
 /// The struct is freed by the external caller by using `free_command_response` to avoid memory leaks.
 /// TODO: Add a type enum to validate what type of response is being sent in the CommandResponse.
 #[repr(C)]
-#[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derive(Debug)]
 pub struct CommandResponse {
     response_type: ResponseType,
     int_value: c_long,
@@ -39,24 +38,37 @@ pub struct CommandResponse {
     /// Below two values are related to each other.
     /// `string_value` represents the string.
     /// `string_value_len` represents the length of the string.
-    #[derivative(Default(value = "std::ptr::null_mut()"))]
     string_value: *mut c_char,
     string_value_len: c_long,
 
     /// Below two values are related to each other.
     /// `array_value` represents the array of CommandResponse.
     /// `array_value_len` represents the length of the array.
-    #[derivative(Default(value = "std::ptr::null_mut()"))]
     array_value: *mut CommandResponse,
     array_value_len: c_long,
 
     /// Below two values represent the Map structure inside CommandResponse.
     /// The map is transformed into an array of (map_key: CommandResponse, map_value: CommandResponse) and passed to Go.
     /// These are represented as pointers as the map can be null (optionally present).
-    #[derivative(Default(value = "std::ptr::null_mut()"))]
     map_key: *mut CommandResponse,
-    #[derivative(Default(value = "std::ptr::null_mut()"))]
     map_value: *mut CommandResponse,
+}
+
+impl Default for CommandResponse {
+    fn default() -> Self {
+        CommandResponse {
+            response_type: ResponseType::default(),
+            int_value: 0,
+            float_value: 0.0,
+            bool_value: false,
+            string_value: ptr::null_mut(),
+            string_value_len: 0,
+            array_value: ptr::null_mut(),
+            array_value_len: 0,
+            map_key: ptr::null_mut(),
+            map_value: ptr::null_mut(),
+        }
+    }
 }
 
 #[repr(C)]


### PR DESCRIPTION
**PR Description:**

This PR enhances the retry strategy and addresses dependency maintenance issues in the Rust lint CI:

- **Replaced Unmaintained Crates**: Removed the `backoff`, `tokio-retry`, `futures-time` and `Derivative` crates due to limited functionality and lack of maintenance. Previously, the project used both `backoff` (unmaintained) and `tokio-retry` (last updated 3 years ago). These have been replaced with `tokio-retry2`, which offers enhanced features for exponential backoff. Additionally, `Derivative` was removed as it is no longer maintained.

- **Improved Retry Functionality**: The new `tokio-retry2` crate includes better jitter control, ensuring consistent exponential backoff intervals without erratic timings. The previous implementation produced inconsistent retry intervals (e.g., 192ms, 110ms, 900ms). With `tokio-retry2`, the jitter range is controlled, maintaining a steady exponential backoff. For slot refresh retries, the strategy has been updated to `ExponentialFactorBackoff`, resulting in attempts with intervals such as `[0ms, 400-600ms, 800-1200ms]`.


### Issue link

This Pull Request is linked to issue (URL): closes #2669 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Commits will be squashed upon merging.
