### PR TITLE
Core: SlotMap refactor - Added NodesMap, Update the slot map upon MOVED errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * Node: Add `JSON.NUMINCRBY` and `JSON.NUMMULTBY` command ([#2555](https://github.com/valkey-io/valkey-glide/pull/2555))
 * Core: Improve retry logic and update unmaintained dependencies for Rust lint CI ([#2673](https://github.com/valkey-io/valkey-glide/pull/2643))
 * Core: Release the read lock while creating connections in `refresh_connections` ([#2630](https://github.com/valkey-io/valkey-glide/issues/2630))
+* Core: SlotMap refactor - Added NodesMap, Update the slot map upon MOVED errors  ([#2682](https://github.com/valkey-io/valkey-glide/issues/2682))
 
 #### Breaking Changes
 

--- a/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
@@ -1,11 +1,12 @@
 use crate::cluster_async::ConnectionFuture;
-use crate::cluster_routing::{Route, SlotAddr};
+use crate::cluster_routing::{Route, ShardAddrs, SlotAddr};
 use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap, SlotMapValue};
 use crate::cluster_topology::TopologyHash;
 use dashmap::DashMap;
 use futures::FutureExt;
 use rand::seq::IteratorRandom;
 use std::net::IpAddr;
+use std::sync::Arc;
 use telemetrylib::Telemetry;
 
 /// Count the number of connections in a connections_map object
@@ -175,6 +176,16 @@ where
         }
     }
 
+    /// Returns an iterator over the nodes in the `slot_map`, yielding pairs of the node address and its associated shard addresses.
+    pub(crate) fn slot_map_nodes(
+        &self,
+    ) -> impl Iterator<Item = (Arc<String>, Arc<ShardAddrs>)> + '_ {
+        self.slot_map
+            .nodes_map()
+            .iter()
+            .map(|item| (item.key().clone(), item.value().clone()))
+    }
+
     // Extends the current connection map with the provided one
     pub(crate) fn extend_connection_map(
         &mut self,
@@ -189,11 +200,7 @@ where
 
     /// Returns true if the address represents a known primary node.
     pub(crate) fn is_primary(&self, address: &String) -> bool {
-        self.connection_for_address(address).is_some()
-            && self
-                .slot_map
-                .values()
-                .any(|slot_addrs| slot_addrs.primary.as_str() == address)
+        self.connection_for_address(address).is_some() && self.slot_map.is_primary(address)
     }
 
     fn round_robin_read_from_replica(
@@ -202,19 +209,20 @@ where
     ) -> Option<ConnectionAndAddress<Connection>> {
         let addrs = &slot_map_value.addrs;
         let initial_index = slot_map_value
-            .latest_used_replica
+            .last_used_replica
             .load(std::sync::atomic::Ordering::Relaxed);
         let mut check_count = 0;
         loop {
             check_count += 1;
 
             // Looped through all replicas, no connected replica was found.
-            if check_count > addrs.replicas.len() {
-                return self.connection_for_address(addrs.primary.as_str());
+            if check_count > addrs.replicas().len() {
+                return self.connection_for_address(addrs.primary().as_str());
             }
-            let index = (initial_index + check_count) % addrs.replicas.len();
-            if let Some(connection) = self.connection_for_address(addrs.replicas[index].as_str()) {
-                let _ = slot_map_value.latest_used_replica.compare_exchange_weak(
+            let index = (initial_index + check_count) % addrs.replicas().len();
+            if let Some(connection) = self.connection_for_address(addrs.replicas()[index].as_str())
+            {
+                let _ = slot_map_value.last_used_replica.compare_exchange_weak(
                     initial_index,
                     index,
                     std::sync::atomic::Ordering::Relaxed,
@@ -228,15 +236,15 @@ where
     fn lookup_route(&self, route: &Route) -> Option<ConnectionAndAddress<Connection>> {
         let slot_map_value = self.slot_map.slot_value_for_route(route)?;
         let addrs = &slot_map_value.addrs;
-        if addrs.replicas.is_empty() {
-            return self.connection_for_address(addrs.primary.as_str());
+        if addrs.replicas().is_empty() {
+            return self.connection_for_address(addrs.primary().as_str());
         }
 
         match route.slot_addr() {
-            SlotAddr::Master => self.connection_for_address(addrs.primary.as_str()),
+            SlotAddr::Master => self.connection_for_address(addrs.primary().as_str()),
             SlotAddr::ReplicaOptional => match self.read_from_replica_strategy {
                 ReadFromReplicaStrategy::AlwaysFromPrimary => {
-                    self.connection_for_address(addrs.primary.as_str())
+                    self.connection_for_address(addrs.primary().as_str())
                 }
                 ReadFromReplicaStrategy::RoundRobin => {
                     self.round_robin_read_from_replica(slot_map_value)
@@ -274,7 +282,7 @@ where
         self.slot_map
             .addresses_for_all_primaries()
             .into_iter()
-            .flat_map(|addr| self.connection_for_address(addr))
+            .flat_map(|addr| self.connection_for_address(&addr))
     }
 
     pub(crate) fn node_for_address(&self, address: &str) -> Option<ClusterNode<Connection>> {

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -1969,8 +1969,6 @@ where
     }
 
     /// Handles MOVED errors by updating the client's slot and node mappings based on the new primary's role:
-    /// /// Updates the slot and node mappings in response to a MOVED error.
-    /// This function handles various scenarios based on the new primary's role:
     ///
     /// 1. **No Change**: If the new primary is already the current slot owner, no updates are needed.
     /// 2. **Failover**: If the new primary is a replica within the same shard (indicating a failover),
@@ -2550,7 +2548,7 @@ where
                     if let Some(future) = future {
                         self.in_flight_requests.push(Box::pin(Request {
                             retry_params,
-                            request: Some(request),
+                            request,
                             future,
                         }));
                     }

--- a/glide-core/redis-rs/redis/src/cluster_slotmap.rs
+++ b/glide-core/redis-rs/redis/src/cluster_slotmap.rs
@@ -1,26 +1,23 @@
+use std::sync::Arc;
 use std::{
     collections::{BTreeMap, HashSet},
     fmt::Display,
     sync::atomic::AtomicUsize,
 };
 
-use crate::cluster_routing::{Route, Slot, SlotAddr, SlotAddrs};
+use dashmap::DashMap;
+
+use crate::cluster_routing::{Route, ShardAddrs, Slot, SlotAddr};
+use crate::ErrorKind;
+use crate::RedisError;
+use crate::RedisResult;
+pub(crate) type NodesMap = DashMap<Arc<String>, Arc<ShardAddrs>>;
 
 #[derive(Debug)]
 pub(crate) struct SlotMapValue {
     pub(crate) start: u16,
-    pub(crate) addrs: SlotAddrs,
-    pub(crate) latest_used_replica: AtomicUsize,
-}
-
-impl SlotMapValue {
-    fn from_slot(slot: Slot) -> Self {
-        Self {
-            start: slot.start(),
-            addrs: SlotAddrs::from_slot(slot),
-            latest_used_replica: AtomicUsize::new(0),
-        }
-    }
+    pub(crate) addrs: Arc<ShardAddrs>,
+    pub(crate) last_used_replica: Arc<AtomicUsize>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Copy)]
@@ -33,6 +30,7 @@ pub(crate) enum ReadFromReplicaStrategy {
 #[derive(Debug, Default)]
 pub(crate) struct SlotMap {
     pub(crate) slots: BTreeMap<u16, SlotMapValue>,
+    nodes_map: NodesMap,
     read_from_replica: ReadFromReplicaStrategy,
 }
 
@@ -40,34 +38,79 @@ fn get_address_from_slot(
     slot: &SlotMapValue,
     read_from_replica: ReadFromReplicaStrategy,
     slot_addr: SlotAddr,
-) -> &str {
-    if slot_addr == SlotAddr::Master || slot.addrs.replicas.is_empty() {
-        return slot.addrs.primary.as_str();
+) -> Arc<String> {
+    let addrs = &slot.addrs;
+    if slot_addr == SlotAddr::Master || addrs.replicas().is_empty() {
+        return addrs.primary();
     }
     match read_from_replica {
-        ReadFromReplicaStrategy::AlwaysFromPrimary => slot.addrs.primary.as_str(),
+        ReadFromReplicaStrategy::AlwaysFromPrimary => addrs.primary(),
         ReadFromReplicaStrategy::RoundRobin => {
             let index = slot
-                .latest_used_replica
+                .last_used_replica
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                % slot.addrs.replicas.len();
-            slot.addrs.replicas[index].as_str()
+                % addrs.replicas().len();
+            addrs.replicas()[index].clone()
         }
     }
 }
 
 impl SlotMap {
-    pub(crate) fn new(slots: Vec<Slot>, read_from_replica: ReadFromReplicaStrategy) -> Self {
-        let mut this = Self {
+    pub(crate) fn new_with_read_strategy(read_from_replica: ReadFromReplicaStrategy) -> Self {
+        SlotMap {
             slots: BTreeMap::new(),
+            nodes_map: DashMap::new(),
             read_from_replica,
-        };
-        this.slots.extend(
-            slots
-                .into_iter()
-                .map(|slot| (slot.end(), SlotMapValue::from_slot(slot))),
-        );
-        this
+        }
+    }
+
+    pub(crate) fn new(slots: Vec<Slot>, read_from_replica: ReadFromReplicaStrategy) -> Self {
+        let mut slot_map = SlotMap::new_with_read_strategy(read_from_replica);
+        let mut shard_id = 0;
+        for slot in slots {
+            let primary = Arc::new(slot.master);
+            // Get the shard addresses if the primary is already in nodes_map;
+            // otherwise, create a new ShardAddrs and add it
+            let shard_addrs_arc = slot_map
+                .nodes_map
+                .entry(primary.clone())
+                .or_insert_with(|| {
+                    shard_id += 1;
+                    let replicas: Vec<Arc<String>> =
+                        slot.replicas.into_iter().map(Arc::new).collect();
+                    Arc::new(ShardAddrs::new(primary, replicas))
+                })
+                .clone();
+
+            // Add all replicas to nodes_map with a reference to the same ShardAddrs if not already present
+            shard_addrs_arc.replicas().iter().for_each(|replica| {
+                slot_map
+                    .nodes_map
+                    .entry(replica.clone())
+                    .or_insert(shard_addrs_arc.clone());
+            });
+
+            // Insert the slot value into the slots map
+            slot_map.slots.insert(
+                slot.end,
+                SlotMapValue {
+                    addrs: shard_addrs_arc.clone(),
+                    start: slot.start,
+                    last_used_replica: Arc::new(AtomicUsize::new(0)),
+                },
+            );
+        }
+        slot_map
+    }
+
+    pub(crate) fn nodes_map(&self) -> &NodesMap {
+        &self.nodes_map
+    }
+
+    pub fn is_primary(&self, address: &String) -> bool {
+        self.nodes_map
+            .get(address)
+            .map_or(false, |shard_addrs| *shard_addrs.primary() == *address)
     }
 
     pub fn slot_value_for_route(&self, route: &Route) -> Option<&SlotMapValue> {
@@ -84,40 +127,45 @@ impl SlotMap {
             })
     }
 
-    pub fn slot_addr_for_route(&self, route: &Route) -> Option<&str> {
+    pub fn slot_addr_for_route(&self, route: &Route) -> Option<Arc<String>> {
         self.slot_value_for_route(route).map(|slot_value| {
             get_address_from_slot(slot_value, self.read_from_replica, route.slot_addr())
         })
     }
 
-    pub fn values(&self) -> impl Iterator<Item = &SlotAddrs> {
-        self.slots.values().map(|slot_value| &slot_value.addrs)
+    /// Retrieves the shard addresses (`ShardAddrs`) for the specified `slot` by looking it up in the `slots` tree,
+    /// returning a reference to the stored shard addresses if found.
+    pub(crate) fn shard_addrs_for_slot(&self, slot: u16) -> Option<Arc<ShardAddrs>> {
+        self.slots
+            .range(slot..)
+            .next()
+            .map(|(_, slot_value)| slot_value.addrs.clone())
     }
 
-    fn all_unique_addresses(&self, only_primaries: bool) -> HashSet<&str> {
-        let mut addresses = HashSet::new();
-        for slot in self.values() {
-            addresses.insert(slot.primary.as_str());
-            if !only_primaries {
-                addresses.extend(slot.replicas.iter().map(|str| str.as_str()));
-            }
-        }
-
-        addresses
+    pub fn addresses_for_all_primaries(&self) -> HashSet<Arc<String>> {
+        self.nodes_map
+            .iter()
+            .map(|map_item| {
+                let shard_addrs = map_item.value();
+                shard_addrs.primary().clone()
+            })
+            .collect()
     }
 
-    pub fn addresses_for_all_primaries(&self) -> HashSet<&str> {
-        self.all_unique_addresses(true)
-    }
-
-    pub fn addresses_for_all_nodes(&self) -> HashSet<&str> {
-        self.all_unique_addresses(false)
+    pub fn all_node_addresses(&self) -> HashSet<Arc<String>> {
+        self.nodes_map
+            .iter()
+            .map(|map_item| {
+                let node_addr = map_item.key();
+                node_addr.clone()
+            })
+            .collect()
     }
 
     pub fn addresses_for_multi_slot<'a, 'b>(
         &'a self,
         routes: &'b [(Route, Vec<usize>)],
-    ) -> impl Iterator<Item = Option<&'a str>> + 'a
+    ) -> impl Iterator<Item = Option<Arc<String>>> + 'a
     where
         'b: 'a,
     {
@@ -127,14 +175,12 @@ impl SlotMap {
     }
 
     // Returns the slots that are assigned to the given address.
-    pub(crate) fn get_slots_of_node(&self, node_address: &str) -> Vec<u16> {
-        let node_address = node_address.to_string();
+    pub(crate) fn get_slots_of_node(&self, node_address: Arc<String>) -> Vec<u16> {
         self.slots
             .iter()
             .filter_map(|(end, slot_value)| {
-                if slot_value.addrs.primary == node_address
-                    || slot_value.addrs.replicas.contains(&node_address)
-                {
+                let addrs = &slot_value.addrs;
+                if addrs.primary() == node_address || addrs.replicas().contains(&node_address) {
                     Some(slot_value.start..(*end + 1))
                 } else {
                     None
@@ -148,17 +194,251 @@ impl SlotMap {
         &self,
         slot: u16,
         slot_addr: SlotAddr,
-    ) -> Option<String> {
+    ) -> Option<Arc<String>> {
         self.slots.range(slot..).next().and_then(|(_, slot_value)| {
             if slot_value.start <= slot {
-                Some(
-                    get_address_from_slot(slot_value, self.read_from_replica, slot_addr)
-                        .to_string(),
-                )
+                Some(get_address_from_slot(
+                    slot_value,
+                    self.read_from_replica,
+                    slot_addr,
+                ))
             } else {
                 None
             }
         })
+    }
+
+    /// Inserts a single slot into the `slots` map, associating it with a new `SlotMapValue`
+    /// that contains the shard addresses (`shard_addrs`) and represents a range of just the given slot.
+    ///
+    /// # Returns
+    /// * `Option<SlotMapValue>` - Returns the previous `SlotMapValue` if a slot already existed for the given key,
+    ///   or `None` if the slot was newly inserted.
+    fn insert_single_slot(
+        &mut self,
+        slot: u16,
+        shard_addrs: Arc<ShardAddrs>,
+    ) -> Option<SlotMapValue> {
+        self.slots.insert(
+            slot,
+            SlotMapValue {
+                start: slot,
+                addrs: shard_addrs,
+                last_used_replica: Arc::new(AtomicUsize::new(0)),
+            },
+        )
+    }
+
+    /// Creats a new shard addresses that contain only the primary node, adds it to the nodes map
+    /// and updates the slots tree for the given `slot` to point to the new primary.
+    pub(crate) fn add_new_primary(&mut self, slot: u16, node_addr: Arc<String>) -> RedisResult<()> {
+        let shard_addrs = Arc::new(ShardAddrs::new_with_primary(node_addr.clone()));
+        self.nodes_map.insert(node_addr, shard_addrs.clone());
+        self.update_slot_range(slot, shard_addrs)
+    }
+
+    fn shard_addrs_equal(shard1: &Arc<ShardAddrs>, shard2: &Arc<ShardAddrs>) -> bool {
+        Arc::ptr_eq(shard1, shard2)
+    }
+
+    /// Updates the end of an existing slot range in the `slots` tree. This function removes the slot entry
+    /// associated with the current end (`curr_end`) and reinserts it with a new end value (`new_end`).
+    ///
+    /// The operation effectively shifts the range's end boundary from `curr_end` to `new_end`, while keeping the
+    /// rest of the slot's data (e.g., shard addresses) unchanged.
+    ///
+    /// # Parameters:
+    /// - `curr_end`: The current end of the slot range that will be removed.
+    /// - `new_end`: The new end of the slot range where the slot data will be reinserted.
+    fn update_end_range(&mut self, curr_end: u16, new_end: u16) -> RedisResult<()> {
+        if let Some(curr_slot_val) = self.slots.remove(&curr_end) {
+            self.slots.insert(new_end, curr_slot_val);
+            return Ok(());
+        }
+        Err(RedisError::from((
+            ErrorKind::ClientError,
+            "Couldn't find slot range with end: {curr_end:?} in the slot map",
+        )))
+    }
+
+    /// Attempts to merge the current `slot` with the next slot range in the `slots` map, if they are consecutive
+    /// and share the same shard addresses. If the next slot's starting position is exactly `slot + 1`
+    /// and the shard addresses match, the next slot's starting point is moved to `slot`, effectively merging
+    /// the slot to the existing range.
+    ///
+    /// # Parameters:
+    /// - `slot`: The slot to attempt to merge with the next slot.
+    /// - `new_addrs`: The shard addresses to compare with the next slot's shard addresses.
+    ///
+    /// # Returns:
+    /// - `bool`: Returns `true` if the merge was successful, otherwise `false`.
+    fn try_merge_to_next_range(&mut self, slot: u16, new_addrs: Arc<ShardAddrs>) -> bool {
+        if let Some((_next_end, next_slot_value)) = self.slots.range_mut((slot + 1)..).next() {
+            if next_slot_value.start == slot + 1
+                && Self::shard_addrs_equal(&next_slot_value.addrs, &new_addrs)
+            {
+                next_slot_value.start = slot;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Attempts to merge the current slot with the previous slot range in the `slots` map, if they are consecutive
+    /// and share the same shard addresses. If the previous slot ends at `slot - 1` and the shard addresses match,
+    /// the end of the previous slot is extended to `slot`, effectively merging the slot to the existing range.
+    ///
+    /// # Parameters:
+    /// - `slot`: The slot to attempt to merge with the previous slot.
+    /// - `new_addrs`: The shard addresses to compare with the previous slot's shard addresses.
+    ///
+    /// # Returns:
+    /// - `RedisResult<bool>`: Returns `Ok(true)` if the merge was successful, otherwise `Ok(false)`.
+    fn try_merge_to_prev_range(
+        &mut self,
+        slot: u16,
+        new_addrs: Arc<ShardAddrs>,
+    ) -> RedisResult<bool> {
+        if let Some((prev_end, prev_slot_value)) = self.slots.range_mut(..slot).next_back() {
+            if *prev_end == slot - 1 && Self::shard_addrs_equal(&prev_slot_value.addrs, &new_addrs)
+            {
+                let prev_end = *prev_end;
+                self.update_end_range(prev_end, slot)?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Updates the slot range in the `slots` to point to new shard addresses.
+    ///
+    /// This function handles the following scenarios when updating the slot mapping:
+    ///
+    /// **Scenario 1 - Same Shard Owner**:
+    ///    - If the slot is already associated with the same shard addresses, no changes are needed.
+    ///
+    /// **Scenario 2 - Single Slot Range**:
+    ///    - If the slot is the only slot in the current range (i.e., `start == end == slot`),
+    ///      the function simply replaces the shard addresses for this slot with the new shard addresses.
+    ///
+    /// **Scenario 3 - Slot Matches the End of a Range**:
+    ///    - If the slot is the last slot in the current range (`slot == end`), the function
+    ///      adjusts the range by decrementing the end of the current range by 1 (making the
+    ///      new end equal to `end - 1`). The current slot is then removed and a new entry is
+    ///      inserted for the slot with the new shard addresses.
+    ///
+    /// **Scenario 4 - Slot Matches the Start of a Range**:
+    ///    - If the slot is the first slot in the current range (`slot == start`), the function
+    ///      increments the start of the current range by 1 (making the new start equal to
+    ///      `start + 1`). A new entry is then inserted for the slot with the new shard addresses.
+    ///
+    /// **Scenario 5 - Slot is Within a Range**:
+    ///    - If the slot falls between the start and end of a current range (`start < slot < end`),
+    ///      the function splits the current range into two. The range before the slot (`start` to
+    ///      `slot - 1`) remains with the old shard addresses, a new entry for the slot is added
+    ///      with the new shard addresses, and the range after the slot (`slot + 1` to `end`) is
+    ///      reinserted with the old shard addresses.
+    ///
+    /// **Scenario 6 - Slot is Not Covered**:
+    ///    - If the slot is not part of any existing range, a new entry is simply inserted into
+    ///      the `slots` tree with the new shard addresses.
+    ///
+    /// # Parameters:
+    /// - `slot`: The specific slot that needs to be updated.
+    /// - `new_addrs`: The new shard addresses to associate with the slot.
+    ///
+    /// # Returns:
+    /// - `RedisResult<()>`: Indicates the success or failure of the operation.
+    pub(crate) fn update_slot_range(
+        &mut self,
+        slot: u16,
+        new_addrs: Arc<ShardAddrs>,
+    ) -> RedisResult<()> {
+        let curr_tree_node =
+            self.slots
+                .range_mut(slot..)
+                .next()
+                .and_then(|(&end, slot_map_value)| {
+                    if slot >= slot_map_value.start && slot <= end {
+                        Some((end, slot_map_value))
+                    } else {
+                        None
+                    }
+                });
+
+        if let Some((curr_end, curr_slot_val)) = curr_tree_node {
+            // Scenario 1: Same shard owner
+            if Self::shard_addrs_equal(&curr_slot_val.addrs, &new_addrs) {
+                return Ok(());
+            }
+            // Scenario 2: The slot is the only slot in the current range
+            else if curr_slot_val.start == curr_end && curr_slot_val.start == slot {
+                // Replace the shard addresses of the current slot value
+                curr_slot_val.addrs = new_addrs;
+            // Scenario 3: Slot matches the end of the current range
+            } else if slot == curr_end {
+                // Merge with the next range if shard addresses match
+                if self.try_merge_to_next_range(slot, new_addrs.clone()) {
+                    // Adjust current range end
+                    self.update_end_range(curr_end, curr_end - 1)?;
+                } else {
+                    // Insert as a standalone slot
+                    let curr_slot_val = self.insert_single_slot(curr_end, new_addrs);
+                    if let Some(curr_slot_val) = curr_slot_val {
+                        // Adjust current range end
+                        self.slots.insert(curr_end - 1, curr_slot_val);
+                    }
+                }
+
+            // Scenario 4: Slot matches the start of the current range
+            } else if slot == curr_slot_val.start {
+                // Adjust current range start
+                curr_slot_val.start += 1;
+                // Attempt to merge with the previous range
+                if !self.try_merge_to_prev_range(slot, new_addrs.clone())? {
+                    // Insert as a standalone slot
+                    self.insert_single_slot(slot, new_addrs);
+                }
+
+            // Scenario 5: Slot is within the current range
+            } else if slot > curr_slot_val.start && slot < curr_end {
+                // We will split the current range into three parts:
+                // A: [start, slot - 1], which will remain owned by the current shard,
+                // B: [slot, slot], which will be owned by the new shard addresses,
+                // C: [slot + 1, end], which will remain owned by the current shard.
+
+                let start: u16 = curr_slot_val.start;
+                let addrs = curr_slot_val.addrs.clone();
+                let last_used_replica = curr_slot_val.last_used_replica.clone();
+
+                // Modify the current slot range to become part C: [slot + 1, end], still owned by the current shard.
+                curr_slot_val.start = slot + 1;
+
+                // Create and insert a new SlotMapValue representing part A: [start, slot - 1],
+                // still owned by the current shard, into the slot map.
+                self.slots.insert(
+                    slot - 1,
+                    SlotMapValue {
+                        start,
+                        addrs,
+                        last_used_replica,
+                    },
+                );
+
+                // Insert the new shard addresses into the slot map as part B: [slot, slot],
+                // which will be owned by the new shard addresses.
+                self.insert_single_slot(slot, new_addrs);
+            }
+        // Scenario 6: Slot isn't covered by any existing range
+        } else {
+            // Try merging with the previous or next range; if no merge is possible, insert as a standalone slot
+            if !self.try_merge_to_prev_range(slot, new_addrs.clone())?
+                && !self.try_merge_to_next_range(slot, new_addrs.clone())
+            {
+                self.insert_single_slot(slot, new_addrs);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -166,13 +446,14 @@ impl Display for SlotMap {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Strategy: {:?}. Slot mapping:", self.read_from_replica)?;
         for (end, slot_map_value) in self.slots.iter() {
+            let addrs = &slot_map_value.addrs;
             writeln!(
                 f,
                 "({}-{}): primary: {}, replicas: {:?}",
                 slot_map_value.start,
                 end,
-                slot_map_value.addrs.primary,
-                slot_map_value.addrs.replicas
+                addrs.primary(),
+                addrs.replicas()
             )?;
         }
         Ok(())
@@ -180,8 +461,21 @@ impl Display for SlotMap {
 }
 
 #[cfg(test)]
-mod tests {
+mod tests_cluster_slotmap {
     use super::*;
+
+    fn process_expected(expected: Vec<&str>) -> HashSet<Arc<String>> {
+        <HashSet<&str> as IntoIterator>::into_iter(HashSet::from_iter(expected))
+            .map(|s| Arc::new(s.to_string()))
+            .collect()
+    }
+
+    fn process_expected_with_option(expected: Vec<Option<&str>>) -> Vec<Arc<String>> {
+        expected
+            .into_iter()
+            .filter_map(|opt| opt.map(|s| Arc::new(s.to_string())))
+            .collect()
+    }
 
     #[test]
     fn test_slot_map_retrieve_routes() {
@@ -208,19 +502,19 @@ mod tests {
             .is_none());
         assert_eq!(
             "node1:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node1:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(500, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node1:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1000, SlotAddr::Master))
                 .unwrap()
         );
@@ -230,19 +524,19 @@ mod tests {
 
         assert_eq!(
             "node2:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1002, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node2:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(1500, SlotAddr::Master))
                 .unwrap()
         );
         assert_eq!(
             "node2:6379",
-            slot_map
+            *slot_map
                 .slot_addr_for_route(&Route::new(2000, SlotAddr::Master))
                 .unwrap()
         );
@@ -293,17 +587,17 @@ mod tests {
         let addresses = slot_map.addresses_for_all_primaries();
         assert_eq!(
             addresses,
-            HashSet::from_iter(["node1:6379", "node2:6379", "node3:6379"])
+            process_expected(vec!["node1:6379", "node2:6379", "node3:6379"])
         );
     }
 
     #[test]
     fn test_slot_map_get_all_nodes() {
         let slot_map = get_slot_map(ReadFromReplicaStrategy::AlwaysFromPrimary);
-        let addresses = slot_map.addresses_for_all_nodes();
+        let addresses = slot_map.all_node_addresses();
         assert_eq!(
             addresses,
-            HashSet::from_iter([
+            process_expected(vec![
                 "node1:6379",
                 "node2:6379",
                 "node3:6379",
@@ -327,11 +621,11 @@ mod tests {
         let addresses = slot_map
             .addresses_for_multi_slot(&routes)
             .collect::<Vec<_>>();
-        assert!(addresses.contains(&Some("node1:6379")));
+        assert!(addresses.contains(&Some(Arc::new("node1:6379".to_string()))));
         assert!(
-            addresses.contains(&Some("replica4:6379"))
-                || addresses.contains(&Some("replica5:6379"))
-                || addresses.contains(&Some("replica6:6379"))
+            addresses.contains(&Some(Arc::new("replica4:6379".to_string())))
+                || addresses.contains(&Some(Arc::new("replica5:6379".to_string())))
+                || addresses.contains(&Some(Arc::new("replica6:6379".to_string())))
         );
     }
 
@@ -348,19 +642,21 @@ mod tests {
             (Route::new(3, SlotAddr::ReplicaOptional), vec![]),
             (Route::new(2003, SlotAddr::Master), vec![]),
         ];
-        let addresses = slot_map
+        let addresses: Vec<Arc<String>> = slot_map
             .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
+            .flatten()
+            .collect();
+
         assert_eq!(
             addresses,
-            vec![
+            process_expected_with_option(vec![
                 Some("replica1:6379"),
                 Some("node3:6379"),
                 Some("replica1:6379"),
                 Some("node3:6379"),
                 Some("replica1:6379"),
                 Some("node3:6379")
-            ]
+            ])
         );
     }
 
@@ -373,12 +669,19 @@ mod tests {
             (Route::new(6000, SlotAddr::ReplicaOptional), vec![]),
             (Route::new(2002, SlotAddr::Master), vec![]),
         ];
-        let addresses = slot_map
+        let addresses: Vec<Arc<String>> = slot_map
             .addresses_for_multi_slot(&routes)
-            .collect::<Vec<_>>();
+            .flatten()
+            .collect();
+
         assert_eq!(
             addresses,
-            vec![Some("replica1:6379"), None, None, Some("node3:6379")]
+            process_expected_with_option(vec![
+                Some("replica1:6379"),
+                None,
+                None,
+                Some("node3:6379")
+            ])
         );
     }
 
@@ -395,6 +698,9 @@ mod tests {
         assert_eq!(
             addresses,
             vec!["replica4:6379", "replica5:6379", "replica6:6379"]
+                .into_iter()
+                .map(|s| Arc::new(s.to_string()))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -402,34 +708,422 @@ mod tests {
     fn test_get_slots_of_node() {
         let slot_map = get_slot_map(ReadFromReplicaStrategy::AlwaysFromPrimary);
         assert_eq!(
-            slot_map.get_slots_of_node("node1:6379"),
+            slot_map.get_slots_of_node(Arc::new("node1:6379".to_string())),
             (1..1001).collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("node2:6379"),
+            slot_map.get_slots_of_node(Arc::new("node2:6379".to_string())),
             vec![1002..2001, 3001..4001]
                 .into_iter()
                 .flatten()
                 .collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica3:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica3:6379".to_string())),
             vec![1002..2001, 3001..4001]
                 .into_iter()
                 .flatten()
                 .collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica4:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica4:6379".to_string())),
             (2001..3001).collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica5:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica5:6379".to_string())),
             (2001..3001).collect::<Vec<u16>>()
         );
         assert_eq!(
-            slot_map.get_slots_of_node("replica6:6379"),
+            slot_map.get_slots_of_node(Arc::new("replica6:6379".to_string())),
             (2001..3001).collect::<Vec<u16>>()
         );
+    }
+
+    fn create_slot(start: u16, end: u16, master: &str, replicas: Vec<&str>) -> Slot {
+        Slot::new(
+            start,
+            end,
+            master.to_owned(),
+            replicas.into_iter().map(|r| r.to_owned()).collect(),
+        )
+    }
+
+    fn assert_equal_slot_maps(this: SlotMap, expected: Vec<Slot>) {
+        for ((end, slot_value), expected_slot) in this.slots.iter().zip(expected.iter()) {
+            assert_eq!(*end, expected_slot.end);
+            assert_eq!(slot_value.start, expected_slot.start);
+            let shard_addrs = &slot_value.addrs;
+            assert_eq!(*shard_addrs.primary(), expected_slot.master);
+            let _ = shard_addrs
+                .replicas()
+                .iter()
+                .zip(expected_slot.replicas.iter())
+                .map(|(curr, expected)| {
+                    assert_eq!(**curr, *expected);
+                });
+        }
+    }
+
+    fn assert_slot_map_and_shard_addrs(
+        slot_map: SlotMap,
+        slot: u16,
+        new_shard_addrs: Arc<ShardAddrs>,
+        expected_slots: Vec<Slot>,
+    ) {
+        assert!(SlotMap::shard_addrs_equal(
+            &slot_map.shard_addrs_for_slot(slot).unwrap(),
+            &new_shard_addrs
+        ));
+        assert_equal_slot_maps(slot_map, expected_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_single_slot_range() {
+        let test_slot = 8000;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 8000, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8001, 16383, "node3:6379", vec!["replica3:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(8001)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot - 1, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, test_slot, "node3:6379", vec!["replica3:6379"]),
+            create_slot(test_slot + 1, 16383, "node3:6379", vec!["replica3:6379"]),
+        ];
+
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_matches_end_range_merge_ranges() {
+        let test_slot = 7999;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(8000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot - 1, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_matches_end_range_cant_merge_ranges() {
+        let test_slot = 7999;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = Arc::new(ShardAddrs::new(
+            Arc::new("node3:6379".to_owned()),
+            vec![Arc::new("replica3:6379".to_owned())],
+        ));
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot - 1, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, test_slot, "node3:6379", vec!["replica3:6379"]),
+            create_slot(test_slot + 1, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_matches_start_range_merge_ranges() {
+        let test_slot = 8000;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(7999)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot + 1, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_matches_start_range_cant_merge_ranges() {
+        let test_slot = 8000;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = Arc::new(ShardAddrs::new(
+            Arc::new("node3:6379".to_owned()),
+            vec![Arc::new("replica3:6379".to_owned())],
+        ));
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot - 1, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, test_slot, "node3:6379", vec!["replica3:6379"]),
+            create_slot(test_slot + 1, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_is_within_a_range() {
+        let test_slot = 4000;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(8000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot - 1, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, test_slot, "node2:6379", vec!["replica2:6379"]),
+            create_slot(test_slot + 1, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_is_not_covered_cant_merge_ranges() {
+        let test_slot = 7998;
+        let before_slots = vec![
+            create_slot(0, 7000, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(8000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, 7000, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, test_slot, "node2:6379", vec!["replica2:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_is_not_covered_merge_with_next() {
+        let test_slot = 7999;
+        let before_slots = vec![
+            create_slot(0, 7000, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(8000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, 7000, "node1:6379", vec!["replica1:6379"]),
+            create_slot(test_slot, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_slot_is_not_covered_merge_with_prev() {
+        let test_slot = 7001;
+        let before_slots = vec![
+            create_slot(0, 7000, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(before_slots, ReadFromReplicaStrategy::AlwaysFromPrimary);
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(7000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, test_slot, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_same_shard_owner_no_change_needed() {
+        let test_slot = 7000;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(
+            before_slots.clone(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(7000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(test_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = before_slots;
+        assert_slot_map_and_shard_addrs(slot_map, test_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_max_slot_matches_end_range() {
+        let max_slot = 16383;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(
+            before_slots.clone(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(7000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(max_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, max_slot - 1, "node2:6379", vec!["replica2:6379"]),
+            create_slot(max_slot, max_slot, "node1:6379", vec!["replica1:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, max_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_max_slot_single_slot_range() {
+        let max_slot = 16383;
+        let before_slots = vec![
+            create_slot(0, 16382, "node1:6379", vec!["replica1:6379"]),
+            create_slot(16383, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(
+            before_slots.clone(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(0)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(max_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(0, max_slot - 1, "node1:6379", vec!["replica1:6379"]),
+            create_slot(max_slot, max_slot, "node1:6379", vec!["replica1:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, max_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_min_slot_matches_start_range() {
+        let min_slot = 0;
+        let before_slots = vec![
+            create_slot(0, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(
+            before_slots.clone(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(8000)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(min_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(min_slot, min_slot, "node2:6379", vec!["replica2:6379"]),
+            create_slot(min_slot + 1, 7999, "node1:6379", vec!["replica1:6379"]),
+            create_slot(8000, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, min_slot, new_shard_addrs, after_slots);
+    }
+
+    #[test]
+    fn test_update_slot_range_min_slot_single_slot_range() {
+        let min_slot = 0;
+        let before_slots = vec![
+            create_slot(0, 0, "node1:6379", vec!["replica1:6379"]),
+            create_slot(1, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+
+        let mut slot_map = SlotMap::new(
+            before_slots.clone(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        let new_shard_addrs = slot_map
+            .shard_addrs_for_slot(1)
+            .expect("Couldn't find shard address for slot");
+
+        let res = slot_map.update_slot_range(min_slot, new_shard_addrs.clone());
+        assert!(res.is_ok(), "{res:?}");
+
+        let after_slots = vec![
+            create_slot(min_slot, min_slot, "node2:6379", vec!["replica2:6379"]),
+            create_slot(min_slot + 1, 16383, "node2:6379", vec!["replica2:6379"]),
+        ];
+        assert_slot_map_and_shard_addrs(slot_map, min_slot, new_shard_addrs, after_slots);
     }
 }

--- a/glide-core/redis-rs/redis/src/commands/cluster_scan.rs
+++ b/glide-core/redis-rs/redis/src/commands/cluster_scan.rs
@@ -134,14 +134,14 @@ impl ScanStateRC {
 #[async_trait]
 pub(crate) trait ClusterInScan {
     /// Retrieves the address associated with a given slot in the cluster.
-    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<String>;
+    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<Arc<String>>;
 
     /// Retrieves the epoch of a given address in the cluster.
     /// The epoch represents the version of the address, which is updated when a failover occurs or slots migrate in.
     async fn get_address_epoch(&self, address: &str) -> Result<u64, RedisError>;
 
     /// Retrieves the slots assigned to a given address in the cluster.
-    async fn get_slots_of_address(&self, address: &str) -> Vec<u16>;
+    async fn get_slots_of_address(&self, address: Arc<String>) -> Vec<u16>;
 
     /// Routes a Redis command to a specific address in the cluster.
     async fn route_command(&self, cmd: Cmd, address: &str) -> RedisResult<Value>;
@@ -150,7 +150,7 @@ pub(crate) trait ClusterInScan {
     async fn are_all_slots_covered(&self) -> bool;
 
     /// Check if the topology of the cluster has changed and refresh the slots if needed
-    async fn refresh_if_topology_changed(&self);
+    async fn refresh_if_topology_changed(&self) -> RedisResult<bool>;
 }
 
 /// Represents the state of a scan operation in a Redis cluster.
@@ -165,7 +165,7 @@ pub(crate) struct ScanState {
     scanned_slots_map: SlotsBitsArray,
     // the address that is being scanned currently, based on the next slot set to 0 in the scanned_slots_map, and the address that "owns" the slot
     // in the SlotMap
-    pub(crate) address_in_scan: String,
+    pub(crate) address_in_scan: Arc<String>,
     // epoch represent the version of the address, when a failover happens or slots migrate in the epoch will be updated to +1
     address_epoch: u64,
     // the status of the scan operation
@@ -189,7 +189,7 @@ impl ScanState {
     pub fn new(
         cursor: u64,
         scanned_slots_map: SlotsBitsArray,
-        address_in_scan: String,
+        address_in_scan: Arc<String>,
         address_epoch: u64,
         scan_status: ScanStateStage,
     ) -> Self {
@@ -206,7 +206,7 @@ impl ScanState {
         Self {
             cursor: 0,
             scanned_slots_map: [0; BITS_ARRAY_SIZE],
-            address_in_scan: String::new(),
+            address_in_scan: Default::default(),
             address_epoch: 0,
             scan_status: ScanStateStage::Finished,
         }
@@ -288,7 +288,16 @@ impl ScanState {
         &mut self,
         connection: &C,
     ) -> RedisResult<ScanState> {
-        let _ = connection.refresh_if_topology_changed().await;
+        connection
+            .refresh_if_topology_changed()
+            .await
+            .map_err(|err| {
+                RedisError::from((
+                    ErrorKind::ResponseError,
+                    "Error during cluster scan: failed to refresh slots",
+                    format!("{:?}", err),
+                ))
+            })?;
         let mut scanned_slots_map = self.scanned_slots_map;
         // If the address epoch changed it mean that some slots in the address are new, so we cant know which slots been there from the beginning and which are new, or out and in later.
         // In this case we will skip updating the scanned_slots_map and will just update the address and the cursor
@@ -301,7 +310,9 @@ impl ScanState {
         }
         // If epoch wasn't changed, the slots owned by the address after the refresh are all valid as slots that been scanned
         // So we will update the scanned_slots_map with the slots owned by the address
-        let slots_scanned = connection.get_slots_of_address(&self.address_in_scan).await;
+        let slots_scanned = connection
+            .get_slots_of_address(self.address_in_scan.clone())
+            .await;
         for slot in slots_scanned {
             let slot_index = slot as usize / BITS_PER_U64;
             let slot_bit = slot as usize % BITS_PER_U64;
@@ -340,7 +351,7 @@ impl<C> ClusterInScan for Core<C>
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
 {
-    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<String> {
+    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<Arc<String>> {
         let address = self
             .get_address_from_slot(slot, SlotAddr::ReplicaRequired)
             .await;
@@ -365,7 +376,7 @@ where
     async fn get_address_epoch(&self, address: &str) -> Result<u64, RedisError> {
         self.as_ref().get_address_epoch(address).await
     }
-    async fn get_slots_of_address(&self, address: &str) -> Vec<u16> {
+    async fn get_slots_of_address(&self, address: Arc<String>) -> Vec<u16> {
         self.as_ref().get_slots_of_address(address).await
     }
     async fn route_command(&self, cmd: Cmd, address: &str) -> RedisResult<Value> {
@@ -389,14 +400,14 @@ where
             &self.conn_lock.read().expect(MUTEX_READ_ERR).slot_map,
         )
     }
-    async fn refresh_if_topology_changed(&self) {
+    async fn refresh_if_topology_changed(&self) -> RedisResult<bool> {
         ClusterConnInner::check_topology_and_refresh_if_diff(
             self.to_owned(),
             // The cluster SCAN implementation must refresh the slots when a topology change is found
             // to ensure the scan logic is correct.
             &RefreshPolicy::NotThrottable,
         )
-        .await;
+        .await
     }
 }
 
@@ -531,7 +542,13 @@ where
 {
     // TODO: This mechanism of refreshing on failure to route to address should be part of the routing mechanism
     // After the routing mechanism is updated to handle this case, this refresh in the case bellow should be removed
-    core.refresh_if_topology_changed().await;
+    core.refresh_if_topology_changed().await.map_err(|err| {
+        RedisError::from((
+            ErrorKind::ResponseError,
+            "Error during cluster scan: failed to refresh slots",
+            format!("{:?}", err),
+        ))
+    })?;
     if !core.are_all_slots_covered().await {
         return Err(RedisError::from((
             ErrorKind::NotAllSlotsCovered,
@@ -578,7 +595,7 @@ mod tests {
         let scan_state = ScanState {
             cursor: 0,
             scanned_slots_map: [0; BITS_ARRAY_SIZE],
-            address_in_scan: String::from("address1"),
+            address_in_scan: String::from("address1").into(),
             address_epoch: 1,
             scan_status: ScanStateStage::InProgress,
         };
@@ -594,7 +611,7 @@ mod tests {
         let scan_state = ScanState {
             cursor: 0,
             scanned_slots_map,
-            address_in_scan: String::from("address1"),
+            address_in_scan: String::from("address1").into(),
             address_epoch: 1,
             scan_status: ScanStateStage::InProgress,
         };
@@ -606,7 +623,7 @@ mod tests {
         let scan_state = ScanState {
             cursor: 0,
             scanned_slots_map,
-            address_in_scan: String::from("address1"),
+            address_in_scan: String::from("address1").into(),
             address_epoch: 1,
             scan_status: ScanStateStage::InProgress,
         };
@@ -617,15 +634,17 @@ mod tests {
     struct MockConnection;
     #[async_trait]
     impl ClusterInScan for MockConnection {
-        async fn refresh_if_topology_changed(&self) {}
-        async fn get_address_by_slot(&self, _slot: u16) -> RedisResult<String> {
-            Ok("mock_address".to_string())
+        async fn refresh_if_topology_changed(&self) -> RedisResult<bool> {
+            Ok(true)
+        }
+        async fn get_address_by_slot(&self, _slot: u16) -> RedisResult<Arc<String>> {
+            Ok("mock_address".to_string().into())
         }
         async fn get_address_epoch(&self, _address: &str) -> Result<u64, RedisError> {
             Ok(0)
         }
-        async fn get_slots_of_address(&self, address: &str) -> Vec<u16> {
-            if address == "mock_address" {
+        async fn get_slots_of_address(&self, address: Arc<String>) -> Vec<u16> {
+            if address.as_str() == "mock_address" {
                 vec![3, 4, 5]
             } else {
                 vec![0, 1, 2]
@@ -647,7 +666,10 @@ mod tests {
         // Assert that the scan state is initialized correctly
         assert_eq!(scan_state.cursor, 0);
         assert_eq!(scan_state.scanned_slots_map, [0; BITS_ARRAY_SIZE]);
-        assert_eq!(scan_state.address_in_scan, "mock_address");
+        assert_eq!(
+            scan_state.address_in_scan,
+            "mock_address".to_string().into()
+        );
         assert_eq!(scan_state.address_epoch, 0);
     }
 
@@ -657,7 +679,7 @@ mod tests {
         let scan_state = ScanState {
             cursor: 0,
             scanned_slots_map: [0; BITS_ARRAY_SIZE],
-            address_in_scan: "".to_string(),
+            address_in_scan: "".to_string().into(),
             address_epoch: 0,
             scan_status: ScanStateStage::InProgress,
         };
@@ -693,7 +715,10 @@ mod tests {
         assert_eq!(updated_scan_state.cursor, 0);
 
         // address_in_scan should be updated to the new address
-        assert_eq!(updated_scan_state.address_in_scan, "mock_address");
+        assert_eq!(
+            updated_scan_state.address_in_scan,
+            "mock_address".to_string().into()
+        );
 
         // address_epoch should be updated to the new address epoch
         assert_eq!(updated_scan_state.address_epoch, 0);
@@ -705,7 +730,7 @@ mod tests {
         let scan_state = ScanState::new(
             0,
             [0; BITS_ARRAY_SIZE],
-            "address".to_string(),
+            "address".to_string().into(),
             0,
             ScanStateStage::InProgress,
         );
@@ -716,7 +741,10 @@ mod tests {
             .unwrap();
         assert_eq!(updated_scan_state.scanned_slots_map, scanned_slots_map);
         assert_eq!(updated_scan_state.cursor, 0);
-        assert_eq!(updated_scan_state.address_in_scan, "mock_address");
+        assert_eq!(
+            updated_scan_state.address_in_scan,
+            "mock_address".to_string().into()
+        );
         assert_eq!(updated_scan_state.address_epoch, 0);
     }
 }

--- a/glide-core/redis-rs/redis/tests/auth.rs
+++ b/glide-core/redis-rs/redis/tests/auth.rs
@@ -134,7 +134,6 @@ mod auth {
             create_connection(None, ConnectionType::Cluster, Some(&cluster_context), None).await;
         assert!(connection_should_fail.is_err());
         let err = connection_should_fail.err().unwrap();
-        println!("{}", err.to_string());
         assert!(err.to_string().contains("Authentication required."));
 
         // Test that we can connect with password


### PR DESCRIPTION
### Description
This PR was previously reviewed in our redis-rs fork at https://github.com/amazon-contributing/redis-rs/pull/190 but was on hold due to lock issues. The recently merged PR #2643 addresses the encountered lock issues, making this PR now ready for merging.

This pull request introduces two significant updates:

1. **SlotMap Refactor**: The SlotMap structure has been updated with the addition of a `NodesMap`, which allows shard addresses to be shared between shard nodes and slot map values. This refactor optimizes how shard information is managed. For a detailed explanation, refer to PR [#185](https://github.com/amazon-contributing/redis-rs/pull/185).

   The diagram on the left illustrates the current SlotMap design, while the diagram on the right shows the newly implemented structure:
   ![image](https://github.com/user-attachments/assets/f62eeaf4-2b56-451e-8c0d-b5cf902c537f)

2. **MOVED Error Handling**: Logic has been added to update the slot map in response to `MOVED` errors. Previously, this was handled only during refresh_slots operations. With this change, the slot map is updated immediately upon encountering a `MOVED` error. More information can be found in PR [#186](https://github.com/amazon-contributing/redis-rs/pull/186).

### Issue link

This Pull Request is linked to issue (URL): closes #2123

### Checklist

Before submitting the PR make sure the following are checked:

-   [ X] This Pull Request is related to one issue.
-   [ X] Commit message has a detailed description of what changed and why.
-   [X ] Tests are added or updated.
-   [X ] CHANGELOG.md and documentation files are updated.
-   [ X] Destination branch is correct - main or release
-   [X ] Commits will be squashed upon merging.
