### PR TITLE
Java: Fix readme

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -57,7 +57,6 @@ Additionally, consider installing the Gradle plugin, [OS Detector](https://githu
 There are 4 types of classifiers for Valkey GLIDE which are
 ```
 osx-aarch_64
-osx-x86_64
 linux-aarch_64
 linux-x86_64
 ```
@@ -69,11 +68,6 @@ Gradle:
 // osx-aarch_64
 dependencies {
     implementation group: 'io.valkey', name: 'valkey-glide', version: '1.+', classifier: 'osx-aarch_64'
-}
-
-// osx-x86_64
-dependencies {
-    implementation group: 'io.valkey', name: 'valkey-glide', version: '1.+', classifier: 'osx-x86_64'
 }
 
 // linux-aarch_64
@@ -107,14 +101,6 @@ Maven:
    <version>[1.0.0,2.0.0)</version>
 </dependency>
 
-<!--osx-x86_64-->
-<dependency>
-   <groupId>io.valkey</groupId>
-   <artifactId>valkey-glide</artifactId>
-   <classifier>osx-x86_64</classifier>
-   <version>[1.0.0,2.0.0)</version>
-</dependency>
-
 <!--linux-aarch_64-->
 <dependency>
    <groupId>io.valkey</groupId>
@@ -137,9 +123,6 @@ SBT:
 ```scala
 // osx-aarch_64
 libraryDependencies += "io.valkey" % "valkey-glide" % "1.+" classifier "osx-aarch_64"
-
-// osx-x86_64
-libraryDependencies += "io.valkey" % "valkey-glide" % "1.+" classifier "osx-x86_64"
 
 // linux-aarch_64
 libraryDependencies += "io.valkey" % "valkey-glide" % "1.+" classifier "linux-aarch_64"

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     // At the moment, Windows is not supported
     implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.100.Final', classifier: 'linux-x86_64'
     implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.100.Final', classifier: 'linux-aarch_64'
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.100.Final', classifier: 'osx-x86_64'
     implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.100.Final', classifier: 'osx-aarch_64'
 
     // junit

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     // https://github.com/netty/netty/wiki/Native-transports
     // At the moment, Windows is not supported
     implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.100.Final', classifier: 'linux-x86_64'
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.100.Final', classifier: 'osx-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.100.Final', classifier: 'linux-aarch_64'
     implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.100.Final', classifier: 'osx-aarch_64'
 
     // junit


### PR DESCRIPTION
Remove macos x64 references left from readme - not supported anymore