### PR TITLE
Node: Add server-modules to npm release

### DIFF
--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -10,8 +10,8 @@
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "clean": "rm -rf build-ts/",
-        "copy-declaration-files": "cp ../../build-ts/*.d.ts build-ts/ && cp ../../build-ts/src/*.d.ts build-ts/src/",
-        "build": "tsc && mkdir -p build-ts/src && npm run copy-declaration-files"
+        "copy-declaration-files": "cp ../../build-ts/*.d.ts build-ts/ && cp ../../build-ts/src/*.d.ts build-ts/src/ && cp ../../build-ts/src/server-modules/*.d.ts build-ts/src/server-modules/",
+        "build": "tsc && mkdir -p build-ts/src && mkdir -p build-ts/src/server-modules && npm run copy-declaration-files"
     },
     "files": [
         "/build-ts"


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

npm RC release is missing the server-modules definition files: 
see: https://www.npmjs.com/package/@valkey/valkey-glide/v/1.2.0-rc16?activeTab=code

With this change, we have the following files in node/npm/glide/build-ts with a `build`: 
```
index.d.ts	index.js	src

./src:
BaseClient.d.ts		Errors.d.ts		GlideClusterClient.d.ts	ProtobufMessage.d.ts	server-modules
Commands.d.ts		GlideClient.d.ts	Logger.d.ts		Transaction.d.ts

./src/server-modules:
GlideFt.d.ts		GlideFtOptions.d.ts	GlideJson.d.ts
```

### Issue link

This Pull Request is linked to issue (URL): #2755

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   N/A Tests are added or updated.
-   N/A CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
