### PR TITLE
Fix for ORT sweeper: Ensure multiple release-* branches are parsed correctly

### DIFF
--- a/.github/workflows/ort-sweeper.yml
+++ b/.github/workflows/ort-sweeper.yml
@@ -16,7 +16,7 @@ jobs:
               id: get-branches
               run: |
                   # Get all branches matching 'release-*' and include 'main'
-                  branches=$(git ls-remote --heads origin | awk -F'/' '/refs\/heads\/release-/ {print $NF}')
+                  branches=$(git ls-remote --heads origin | awk -F'/' '/refs\/heads\/release-/ {printf $NF" "}')
                   branches="main $branches"
                   echo "::set-output name=branches::$branches"
               env:


### PR DESCRIPTION
Currently multiple release-* branches include new lines which results in only the first 'release-' branch is processed.
This commit ensures all the target branches a given in a single string w/o new lines between

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2531

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[ ] Tests are added or updated.~
-   ~[ ] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Commits will be squashed upon merging.
