### PR TITLE
Fix rust CI: bump `idna`.

### DIFF
--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -33,7 +33,7 @@ strum_macros = "0.26"
 percent-encoding = "2.1"
 
 # We need this for redis url parsing
-url = "= 2.5.0"
+url = "2.5.4"
 
 # We need this for script support
 sha1_smol = { version = "1.0", optional = true }


### PR DESCRIPTION
Fix [CI failures on main](https://github.com/valkey-io/valkey-glide/actions/runs/12242609472/job/34150311714#step:3:762):
```
warning[license-not-encountered]: license was not encountered
   ┌─ /home/runner/work/valkey-glide/valkey-glide/deny.toml:57:6
   │
57 │     "Unicode-DFS-2016",
   │      ━━━━━━━━━━━━━━━━ unmatched license allowance

error[vulnerability]: `idna` accepts Punycode labels that do not produce any non-ASCII when decoded
   ┌─ /home/runner/work/valkey-glide/valkey-glide/glide-core/Cargo.lock:83:1
   │
83 │ idna 0.5.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
   │
   ├ ID: RUSTSEC-2024-0421
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0421
   ├ `idna` 0.5.0 and earlier accepts Punycode labels that do not produce any non-ASCII output, which means that either ASCII labels or the empty root label can be masked such that they appear unequal without IDNA processing or when processed with a different implementation and equal when processed with `idna` 0.5.0 or earlier.
     
     Concretely, `example.org` and `xn--example-.org` become equal after processing by `idna` 0.5.0 or earlier. Also, `example.org.xn--` and `example.org.` become equal after processing by `idna` 0.5.0 or earlier.
     
     In applications using `idna` (but not in `idna` itself) this may be able to lead to privilege escalation when host name comparison is part of a privilege check and the behavior is combined with a client that resolves domains with such labels instead of treating them as errors that preclude DNS resolution / URL fetching and with the attacker managing to introduce a DNS entry (and TLS certificate) for an `xn--`-masked name that turns into the name of the target when processed by `idna` 0.5.0 or earlier.
     
     ## Remedy
     
     Upgrade to `idna` 1.0.3 or later, if depending on `idna` directly, or to `url` 2.5.4 or later, if depending on `idna` via `url`. (This issue was fixed in `idna` 1.0.0, but versions earlier than 1.0.3 are not recommended for other reasons.)
     
     When upgrading, please take a moment to read about [alternative Unicode back ends for `idna`](https://docs.rs/crate/idna_adapter/latest).
     
     If you are using Rust earlier than 1.81 in combination with SQLx 0.8.2 or earlier, please also read an [issue](https://github.com/servo/rust-url/issues/992) about combining them with `url` 2.5.4 and `idna` 1.0.3.
     
     ## Additional information
     
     This issue resulted from `idna` 0.5.0 and earlier implementing the UTS 46 specification literally on this point and the specification having this bug. The specification bug has been fixed in [revision 33 of UTS 46](https://www.unicode.org/reports/tr46/tr46-33.html#Modifications).
     
     ## Acknowledgements
     
     Thanks to kageshiron for recognizing the security implications of this behavior.
   ├ Announcement: https://bugzilla.mozilla.org/show_bug.cgi?id=1887898
   ├ Solution: Upgrade to >=1.0.0 (try `cargo update -p idna`)
   ├ idna v0.5.0
     └── url v2.5.0
         └── redis v0.25.2
             └── glide-core v0.1.0
                 └── (dev) glide-core v0.1.0 (*)

warning[advisory-not-detected]: advisory was not encountered
   ┌─ /home/runner/work/valkey-glide/valkey-glide/deny.toml:26:6
   │
26 │     "RUSTSEC-2024-0370",
   │      ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

advisories FAILED, bans ok, licenses ok, sources ok
```

```
$ cargo tree -p idna -i
idna v0.5.0
└── url v2.5.0
    └── redis v0.25.2 (/mnt/c/GitHub/babushka/glide-core/redis-rs/redis)
        └── glide-core v0.1.0 (/mnt/c/GitHub/babushka/glide-core)
            [dev-dependencies]
            └── glide-core v0.1.0 (/mnt/c/GitHub/babushka/glide-core) (*)
        [dev-dependencies]
        └── glide-core v0.1.0 (/mnt/c/GitHub/babushka/glide-core) (*)
```

So I upgraded `url` in `redis-rs` which caused `idna` upgrade:
```
$ cargo tree -p idna -i
idna v1.0.3
└── url v2.5.4
    └── redis v0.25.2 (/mnt/c/GitHub/babushka/glide-core/redis-rs/redis)
        ├── glide-core v0.1.0 (/mnt/c/GitHub/babushka/glide-core)
        │   └── glide-rs v0.1.0 (/mnt/c/GitHub/babushka/java)
        └── glide-rs v0.1.0 (/mnt/c/GitHub/babushka/java)
```