### PR TITLE
Go: Add custom command to cluster client

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -50,6 +50,7 @@ build-glide-client-debug:
 	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h
 
 generate-protobuf:
+	rm -rf protobuf
 	mkdir -p protobuf
 	protoc --proto_path=../glide-core/src/protobuf \
 		--go_opt=Mconnection_request.proto=github.com/valkey-io/valkey-glide/go/protobuf \

--- a/go/Makefile
+++ b/go/Makefile
@@ -38,7 +38,8 @@ clean:
 	go clean
 	rm -f lib.h
 	rm -f benchmarks/benchmarks
-
+	rm -rf protobuf
+	rm -rf target
 
 build-glide-client:
 	cargo build --release

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -32,9 +32,18 @@ func NewGlideClient(config *GlideClientConfiguration) (*GlideClient, error) {
 // (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
 // behavior (such as entering pub/sub mode on RESP2 connections) shouldn't be called using this function.
 //
-// For example, to return a list of all pub/sub clients:
+// Parameters:
 //
-//	result, err := client.CustomCommand([]string{"CLIENT", "LIST", "TYPE", "PUBSUB"})
+//	args - Arguments for the custom command including the command name.
+//
+// Return value:
+//
+//	The returned value for the custom command.
+//
+// For example:
+//
+//	result, err := client.CustomCommand([]string{"ping"})
+//	result.(string): "PONG"
 //
 // [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
 func (client *GlideClient) CustomCommand(args []string) (interface{}, error) {

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -26,13 +26,17 @@ func NewGlideClient(config *GlideClientConfiguration) (*GlideClient, error) {
 // the command name and subcommands, should be added as a separate value in args. The returning value depends on the executed
 // command.
 //
+// See [Valkey GLIDE Wiki] for details on the restrictions and limitations of the custom command API.
+//
 // This function should only be used for single-response commands. Commands that don't return complete response and awaits
 // (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
 // behavior (such as entering pub/sub mode on RESP2 connections) shouldn't be called using this function.
 //
 // For example, to return a list of all pub/sub clients:
 //
-//	client.CustomCommand([]string{"CLIENT", "LIST","TYPE", "PUBSUB"})
+//	result, err := client.CustomCommand([]string{"CLIENT", "LIST", "TYPE", "PUBSUB"})
+//
+// [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
 func (client *GlideClient) CustomCommand(args []string) (interface{}, error) {
 	res, err := client.executeCommand(C.CustomCommand, args)
 	if err != nil {

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -2,6 +2,10 @@
 
 package api
 
+// #cgo LDFLAGS: -L../target/release -lglide_rs
+// #include "../lib.h"
+import "C"
+
 // GlideClusterClient is a client used for connection in cluster mode.
 type GlideClusterClient struct {
 	*baseClient
@@ -15,4 +19,29 @@ func NewGlideClusterClient(config *GlideClusterClientConfiguration) (*GlideClust
 	}
 
 	return &GlideClusterClient{client}, nil
+}
+
+// CustomCommand executes a single command, specified by args, without checking inputs. Every part of the command, including
+// the command name and subcommands, should be added as a separate value in args. The returning value depends on the executed
+// command.
+//
+// The command will be routed automatically based on the passed command's default request policy.
+//
+// See [Valkey GLIDE Wiki] for details on the restrictions and limitations of the custom command API.
+//
+// This function should only be used for single-response commands. Commands that don't return complete response and awaits
+// (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
+// behavior (such as entering pub/sub mode on RESP2 connections) shouldn't be called using this function.
+//
+// For example, to return a list of all pub/sub clients:
+//
+//	result, err := client.CustomCommand([]string{"CLIENT", "LIST", "TYPE", "PUBSUB"})
+//
+// [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
+func (client *GlideClusterClient) CustomCommand(args []string) (interface{}, error) {
+	res, err := client.executeCommand(C.CustomCommand, args)
+	if err != nil {
+		return nil, err
+	}
+	return handleInterfaceResponse(res)
 }

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -44,13 +44,17 @@ func NewGlideClusterClient(config *GlideClusterClientConfiguration) (*GlideClust
 // For example:
 //
 //	result, err := client.CustomCommand([]string{"ping"})
-//	result.(string): "PONG"
+//	result.Value().(string): "PONG"
 //
 // [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
-func (client *GlideClusterClient) CustomCommand(args []string) (interface{}, error) {
+func (client *GlideClusterClient) CustomCommand(args []string) (ClusterValue, error) {
 	res, err := client.executeCommand(C.CustomCommand, args)
 	if err != nil {
-		return nil, err
+		return CreateEmptyClusterValue(), err
 	}
-	return handleInterfaceResponse(res)
+	data, err := handleInterfaceResponse(res)
+	if err != nil {
+		return CreateEmptyClusterValue(), err
+	}
+	return CreateClusterValue(data), nil
 }

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -33,9 +33,18 @@ func NewGlideClusterClient(config *GlideClusterClientConfiguration) (*GlideClust
 // (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
 // behavior (such as entering pub/sub mode on RESP2 connections) shouldn't be called using this function.
 //
-// For example, to return a list of all pub/sub clients:
+// Parameters:
 //
-//	result, err := client.CustomCommand([]string{"CLIENT", "LIST", "TYPE", "PUBSUB"})
+//	args - Arguments for the custom command including the command name.
+//
+// Return value:
+//
+//	The returned value for the custom command.
+//
+// For example:
+//
+//	result, err := client.CustomCommand([]string{"ping"})
+//	result.(string): "PONG"
 //
 // [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
 func (client *GlideClusterClient) CustomCommand(args []string) (interface{}, error) {

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -47,7 +47,7 @@ func NewGlideClusterClient(config *GlideClusterClientConfiguration) (*GlideClust
 //	result.Value().(string): "PONG"
 //
 // [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
-func (client *GlideClusterClient) CustomCommand(args []string) (ClusterValue, error) {
+func (client *GlideClusterClient) CustomCommand(args []string) (ClusterValue[interface{}], error) {
 	res, err := client.executeCommand(C.CustomCommand, args)
 	if err != nil {
 		return CreateEmptyClusterValue(), err

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -123,9 +123,9 @@ func parseMap(response *C.struct_CommandResponse) (interface{}, error) {
 		return nil, nil
 	}
 
-	value_map := make(map[interface{}]interface{}, response.array_value_len)
+	value_map := make(map[string]interface{}, response.array_value_len)
 	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
-		res_key, err := parseInterface(v.map_key)
+		res_key, err := parseString(v.map_key)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +133,7 @@ func parseMap(response *C.struct_CommandResponse) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		value_map[res_key] = res_val
+		value_map[res_key.(string)] = res_val
 	}
 	return value_map, nil
 }
@@ -143,13 +143,13 @@ func parseSet(response *C.struct_CommandResponse) (interface{}, error) {
 		return nil, nil
 	}
 
-	slice := make(map[interface{}]struct{}, response.sets_value_len)
+	slice := make(map[string]struct{}, response.sets_value_len)
 	for _, v := range unsafe.Slice(response.sets_value, response.sets_value_len) {
-		res, err := parseInterface(&v)
+		res, err := parseString(&v)
 		if err != nil {
 			return nil, err
 		}
-		slice[res] = struct{}{}
+		slice[res.(string)] = struct{}{}
 	}
 
 	return slice, nil

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -46,3 +46,51 @@ func CreateBoolResult(boolVal bool) Result[bool] {
 func CreateNilBoolResult() Result[bool] {
 	return Result[bool]{val: false, isNil: true}
 }
+
+// Enum-like structure which stores either a single-node response or multi-node response.
+// Multi-node response stored in a map, where keys are hostnames or "<ip>:<port>" strings.
+type ClusterValue struct {
+	singleValue Result[interface{}]
+	multiValue  Result[map[string]interface{}]
+}
+
+func (value ClusterValue) Value() interface{} {
+	if !value.singleValue.isNil {
+		return value.singleValue.Value()
+	}
+	return value.multiValue.Value()
+}
+
+// Create a `ClusterValue` with auto-detecting the value type.
+// Could confuse a user if data is a map received as a response from a single node.
+func CreateClusterValue(data interface{}) ClusterValue {
+	switch data.(type) {
+	case map[interface{}]interface{}:
+		return CreateClusterMultiValue(data)
+	default:
+		return CreateClusterSingleValue(data)
+	}
+}
+
+func CreateClusterSingleValue(data interface{}) ClusterValue {
+	return ClusterValue{
+		singleValue: Result[interface{}]{data, false},
+		multiValue:  Result[map[string]interface{}]{make(map[string]interface{}, 0), true},
+	}
+}
+
+func CreateClusterMultiValue(data interface{}) ClusterValue {
+	var empty interface{}
+	return ClusterValue{
+		multiValue:  Result[map[string]interface{}]{data.(map[string]interface{}), false},
+		singleValue: Result[interface{}]{empty, true},
+	}
+}
+
+func CreateEmptyClusterValue() ClusterValue {
+	var empty interface{}
+	return ClusterValue{
+		multiValue:  Result[map[string]interface{}]{make(map[string]interface{}, 0), true},
+		singleValue: Result[interface{}]{empty, true},
+	}
+}

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -14,7 +14,7 @@ func (suite *GlideTestSuite) TestClusterCustomCommandInfo() {
 
 	assert.Nil(suite.T(), err)
 	// INFO is routed to all primary nodes by default
-	for _, value := range result.(map[interface{}]interface{}) {
+	for _, value := range result.Value().(map[string]interface{}) {
 		assert.True(suite.T(), strings.Contains(value.(string), "# Stats"))
 	}
 }
@@ -25,5 +25,5 @@ func (suite *GlideTestSuite) TestClusterCustomCommandEcho() {
 
 	assert.Nil(suite.T(), err)
 	// ECHO is routed to a single random node
-	assert.Equal(suite.T(), "GO GLIDE GO", result.(string))
+	assert.Equal(suite.T(), "GO GLIDE GO", result.Value().(string))
 }

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -1,0 +1,29 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *GlideTestSuite) TestClusterCustomCommandInfo() {
+	client := suite.defaultClusterClient()
+	result, err := client.CustomCommand([]string{"INFO"})
+
+	assert.Nil(suite.T(), err)
+	// INFO is routed to all primary nodes by default
+	for _, value := range result.(map[interface{}]interface{}) {
+		assert.True(suite.T(), strings.Contains(value.(string), "# Stats"))
+	}
+}
+
+func (suite *GlideTestSuite) TestClusterCustomCommandEcho() {
+	client := suite.defaultClusterClient()
+	result, err := client.CustomCommand([]string{"ECHO", "GO GLIDE GO"})
+
+	assert.Nil(suite.T(), err)
+	// ECHO is routed to a single random node
+	assert.Equal(suite.T(), "GO GLIDE GO", result.(string))
+}

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -128,7 +128,7 @@ func (suite *GlideTestSuite) TestCustomCommandConfigGet_MapResponse() {
 
 	result2, err := client.CustomCommand([]string{"CONFIG", "GET", "timeout", "maxmemory"})
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), map[interface{}]interface{}{"timeout": "1000", "maxmemory": "1073741824"}, result2)
+	assert.Equal(suite.T(), map[string]interface{}{"timeout": "1000", "maxmemory": "1073741824"}, result2)
 }
 
 func (suite *GlideTestSuite) TestCustomCommandConfigSMembers_SetResponse() {
@@ -142,7 +142,7 @@ func (suite *GlideTestSuite) TestCustomCommandConfigSMembers_SetResponse() {
 
 	result2, err := client.CustomCommand([]string{"SMEMBERS", key})
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), map[interface{}]struct{}{"member1": {}, "member2": {}, "member3": {}}, result2)
+	assert.Equal(suite.T(), map[string]struct{}{"member1": {}, "member2": {}, "member3": {}}, result2)
 }
 
 func (suite *GlideTestSuite) TestCustomCommand_invalidCommand() {


### PR DESCRIPTION
* cluster client compilation fixes
* `CustomCommand` for cluster client
* `CustomCommand` doc update for standalone
* `ClusterValue` and related things
* Tests (no routing yet)
* Update map and set handling to store strings only as keys (and test update)
* makefile fixes