### PR TITLE
remove native package references for MacOS x64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 #### Changes
+
 * Java: bump `netty` version ([#2795](https://github.com/valkey-io/valkey-glide/pull/2795))
 * Java: Bump protobuf (protoc) version ([#2796](https://github.com/valkey-io/valkey-glide/pull/2796), [#2800](https://github.com/valkey-io/valkey-glide/pull/2800))
 * Go: Add `SInterStore` ([#2779](https://github.com/valkey-io/valkey-glide/issues/2779))
+* Node: Remove native package references for MacOs x64 architecture ([#2799](https://github.com/valkey-io/valkey-glide/issues/2799))
 
 #### Breaking Changes
 
@@ -12,6 +14,7 @@
 ## 1.2.0 (2024-11-27)
 
 #### Changes
+
 * Node: Client API for retrieving internal statistics ([#2727](https://github.com/valkey-io/valkey-glide/pull/2727))
 * Python: Client API for retrieving internal statistics ([#2707](https://github.com/valkey-io/valkey-glide/pull/2707))
 * Node, Python, Java: Adding support for replacing connection configured password ([#2651](https://github.com/valkey-io/valkey-glide/pull/2651), [#2659](https://github.com/valkey-io/valkey-glide/pull/2659), [#2677](https://github.com/valkey-io/valkey-glide/pull/2677))
@@ -105,9 +108,11 @@
 * Core: SlotMap refactor - Added NodesMap, Update the slot map upon MOVED errors ([#2682](https://github.com/valkey-io/valkey-glide/issues/2682))
 
 #### Breaking Changes
+
 **None**
 
 #### Fixes
+
 * Core: UDS Socket Handling Rework ([#2482](https://github.com/valkey-io/valkey-glide/pull/2482))
 
 #### Operational Enhancements

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -53,9 +53,6 @@ function loadNativeBinding() {
             break;
         case "darwin":
             switch (arch) {
-                case "x64":
-                    nativeBinding = require("@scope/valkey-glide-darwin-x64");
-                    break;
                 case "arm64":
                     nativeBinding = require("@scope/valkey-glide-darwin-arm64");
                     break;

--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -41,7 +41,6 @@
     },
     "optionalDependencies": {
         "${scope}valkey-glide-darwin-arm64": "${package_version}",
-        "${scope}valkey-glide-darwin-x64": "${package_version}",
         "${scope}valkey-glide-linux-arm64": "${package_version}",
         "${scope}valkey-glide-linux-x64": "${package_version}",
         "${scope}valkey-glide-linux-musl-arm64": "${package_version}",


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request resolves issue (https://github.com/valkey-io/valkey-glide/issues/2799).

This change removes the native package reference in package.json and updates the `npm/glide` index file to remove the native binding for the Darwin-x64 package which was removed in the Valkey-Glide 1.2.0 release.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
