### PR TITLE
Core + Py: add allow_non_covered_slots to ClusterScan and related commands

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_slotmap.rs
+++ b/glide-core/redis-rs/redis/src/cluster_slotmap.rs
@@ -202,7 +202,7 @@ impl SlotMap {
             .collect()
     }
 
-    pub(crate) fn get_node_address_for_slot(
+    pub(crate) fn node_address_for_slot(
         &self,
         slot: u16,
         slot_addr: SlotAddr,

--- a/glide-core/redis-rs/redis/src/commands/cluster_scan.rs
+++ b/glide-core/redis-rs/redis/src/commands/cluster_scan.rs
@@ -1,73 +1,265 @@
-//! This module contains the implementation of scanning operations in a Redis cluster.
+//! This module implements cluster-wide scanning operations for clusters.
 //!
-//! The [`ClusterScanArgs`] struct represents the arguments for a cluster scan operation,
-//! including the scan state reference, match pattern, count, and object type.
+//! # Overview
 //!
-//! The [[`ScanStateRC`]] struct is a wrapper for managing the state of a scan operation in a cluster.
-//! It holds a reference to the scan state and provides methods for accessing the state.
+//! The module provides functionality to scan keys across all nodes in a cluster,
+//! handling topology changes, failovers, and partial cluster coverage scenarios.
+//! It maintains state between scan iterations and ensures consistent scanning even
+//! when cluster topology changes.
 //!
-//! The [[`ClusterInScan`]] trait defines the methods for interacting with a Redis cluster during scanning,
-//! including retrieving address information, refreshing slot mapping, and routing commands to specific address.
+//! # Key Components
 //!
-//! The [[`ScanState`]] struct represents the state of a scan operation in a Redis cluster.
-//! It holds information about the current scan state, including the cursor position, scanned slots map,
-//! address being scanned, and address's epoch.
+//! - [`ClusterScanArgs`]: Configuration for scan operations including filtering and behavior options
+//! - [`ScanStateRC`]: Thread-safe reference-counted wrapper for scan state management
+//! - [`ScanState`]: Internal state tracking for cluster-wide scanning progress
+//! - [`ObjectType`]: Supported data types for filtering scan results
+//!
+//! # Key Features
+//!
+//! - Resumable scanning across cluster nodes
+//! - Automatic handling of cluster topology changes
+//! - Support for all regular SCAN options
+//! - Resilient to node failures and resharding
+//!
+//! # Implementation Details
+//!
+//! The scanning process is implemented using a bitmap to track scanned slots and
+//! maintains epoch information to handle topology changes. The implementation:
+//!
+//! - Uses a 64-bit aligned bitmap for efficient slot tracking
+//! - Maintains cursor position per node
+//! - Handles partial cluster coverage scenarios
+//! - Provides automatic recovery from node failures
+//! - Ensures consistent scanning across topology changes
+//!
+//! # Error Handling
+//!
+//! The module handles various error scenarios including:
+//! - Node failures during scanning
+//! - Cluster topology changes
+//! - Network connectivity issues
+//! - Invalid routing scenarios
 
 use crate::aio::ConnectionLike;
-use crate::cluster_async::{
-    ClusterConnInner, Connect, Core, InternalRoutingInfo, InternalSingleNodeRouting, RefreshPolicy,
-    Response, MUTEX_READ_ERR,
-};
+use crate::cluster_async::{ClusterConnInner, Connect, InnerCore, RefreshPolicy, MUTEX_READ_ERR};
 use crate::cluster_routing::SlotAddr;
 use crate::cluster_topology::SLOT_SIZE;
-use crate::{cmd, from_redis_value, Cmd, ErrorKind, RedisError, RedisResult, Value};
-use async_trait::async_trait;
+use crate::{cmd, from_redis_value, ErrorKind, RedisError, RedisResult, Value};
 use std::sync::Arc;
-use strum_macros::Display;
+use strum_macros::{Display, EnumString};
 
-const BITS_PER_U64: usize = u64::BITS as usize;
-const NUM_OF_SLOTS: usize = SLOT_SIZE as usize;
-const BITS_ARRAY_SIZE: usize = NUM_OF_SLOTS / BITS_PER_U64;
-const END_OF_SCAN: u16 = NUM_OF_SLOTS as u16 + 1;
-type SlotsBitsArray = [u64; BITS_ARRAY_SIZE];
+const BITS_PER_U64: u16 = u64::BITS as u16;
+const NUM_OF_SLOTS: u16 = SLOT_SIZE;
+const BITS_ARRAY_SIZE: u16 = NUM_OF_SLOTS / BITS_PER_U64;
+const END_OF_SCAN: u16 = NUM_OF_SLOTS;
+type SlotsBitsArray = [u64; BITS_ARRAY_SIZE as usize];
 
-#[derive(Clone)]
-pub(crate) struct ClusterScanArgs {
-    pub(crate) scan_state_cursor: ScanStateRC,
-    match_pattern: Option<Vec<u8>>,
-    count: Option<usize>,
-    object_type: Option<ObjectType>,
-}
+/// Holds configuration for a cluster scan operation.
+///
+/// # Fields
+/// - `scan_state_cursor`: Internal state tracking scan progress
+/// - `match_pattern`: Optional pattern to filter keys
+/// - `count`: Optional limit on number of keys returned per iteration
+/// - `object_type`: Optional filter for specific data types
+/// - `allow_non_covered_slots`: Whether to continue if some slots are uncovered
+///
+/// See examples below for usage with the builder pattern.
+/// # Examples
+///
+/// Create a new `ClusterScanArgs` instance using the builder pattern:
+///
+/// ```rust,no_run
+/// use redis::ClusterScanArgs;
+/// use redis::ObjectType;
+///
+/// // Create basic scan args with defaults
+/// let basic_scan = ClusterScanArgs::builder().build();
+///
+/// // Create scan args with custom options
+/// let custom_scan = ClusterScanArgs::builder()
+///     .with_match_pattern("user:*")      // Match keys starting with "user:"
+///     .with_count(100)                   // Return 100 keys per iteration
+///     .with_object_type(ObjectType::Hash) // Only scan hash objects
+///     .allow_non_covered_slots(true)     // Continue scanning even if some slots aren't covered
+///     .build();
+///
+/// // The builder can be used to create multiple configurations
+/// let another_scan = ClusterScanArgs::builder()
+///     .with_match_pattern("session:*")
+///     .with_object_type(ObjectType::String)
+///     .build();
+/// ```
 
-#[derive(Debug, Clone, Display)]
-/// Represents the type of an object in Redis.
-pub enum ObjectType {
-    /// Represents a string object in Redis.
-    String,
-    /// Represents a list object in Redis.
-    List,
-    /// Represents a set object in Redis.
-    Set,
-    /// Represents a sorted set object in Redis.
-    ZSet,
-    /// Represents a hash object in Redis.
-    Hash,
-    /// Represents a stream object in Redis.
-    Stream,
+#[derive(Clone, Default)]
+pub struct ClusterScanArgs {
+    /// Reference-counted scan state cursor, managed internally.
+    pub scan_state_cursor: ScanStateRC,
+
+    /// Optional pattern to match keys during the scan.
+    pub match_pattern: Option<Vec<u8>>,
+
+    /// Optional number of keys to return per scan.
+    pub count: Option<u32>,
+
+    /// Optional filter to include only keys of a specific data type.
+    pub object_type: Option<ObjectType>,
+
+    /// Flag indicating whether to allow scanning when there are slots not covered by the cluster.
+    pub allow_non_covered_slots: bool,
 }
 
 impl ClusterScanArgs {
-    pub(crate) fn new(
-        scan_state_cursor: ScanStateRC,
-        match_pattern: Option<Vec<u8>>,
-        count: Option<usize>,
-        object_type: Option<ObjectType>,
-    ) -> Self {
-        Self {
-            scan_state_cursor,
-            match_pattern,
-            count,
-            object_type,
+    /// Creates a new [`ClusterScanArgsBuilder`] instance.
+    ///
+    /// # Returns
+    ///
+    /// A [`ClusterScanArgsBuilder`] instance for configuring cluster scan arguments.
+    pub fn builder() -> ClusterScanArgsBuilder {
+        ClusterScanArgsBuilder::default()
+    }
+    pub(crate) fn set_scan_state_cursor(&mut self, scan_state_cursor: ScanStateRC) {
+        self.scan_state_cursor = scan_state_cursor;
+    }
+}
+
+#[derive(Default)]
+/// Builder pattern for creating cluster scan arguments.
+///
+/// This struct allows configuring various parameters for scanning keys in a cluster:
+/// * Pattern matching for key filtering
+/// * Count limit for returned keys
+/// * Filtering by object type
+/// * Control over scanning non-covered slots
+///
+/// # Example
+/// ```
+/// use redis::{ClusterScanArgs, ObjectType};
+///
+/// let args = ClusterScanArgs::builder()
+///     .with_match_pattern(b"user:*")
+///     .with_count(100)
+///     .with_object_type(ObjectType::Hash)
+///     .build();
+/// ```
+pub struct ClusterScanArgsBuilder {
+    match_pattern: Option<Vec<u8>>,
+    count: Option<u32>,
+    object_type: Option<ObjectType>,
+    allow_non_covered_slots: Option<bool>,
+}
+
+impl ClusterScanArgsBuilder {
+    /// Sets the match pattern for the scan operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `pattern` - The pattern to match keys against.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`ClusterScanArgsBuilder`] instance.
+    pub fn with_match_pattern<T: Into<Vec<u8>>>(mut self, pattern: T) -> Self {
+        self.match_pattern = Some(pattern.into());
+        self
+    }
+
+    /// Sets the count for the scan operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `count` - A "hint" to the cluster of how much keys to return per scan iteration.
+    ///
+    /// The actual number of keys returned may be less or more than the count specified.
+    ///
+    /// 4,294,967,295 is the maximum keys possible in a cluster, so higher values will be capped.
+    /// Hence the count is represented as a `u32` instead of `usize`.
+    ///
+    /// The default value is 10, if nothing is sent to the server, meaning nothing set in the builder.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`ClusterScanArgsBuilder`] instance.
+    pub fn with_count(mut self, count: u32) -> Self {
+        self.count = Some(count);
+        self
+    }
+
+    /// Sets the object type for the scan operation.
+    ///
+    /// # Arguments
+    ///
+    /// * `object_type` - The type of object to filter keys by.
+    ///
+    /// See [`ObjectType`] for supported data types.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`ClusterScanArgsBuilder`] instance.
+    pub fn with_object_type(mut self, object_type: ObjectType) -> Self {
+        self.object_type = Some(object_type);
+        self
+    }
+
+    /// Sets the flag to allow scanning non-covered slots.
+    ///
+    /// # Arguments
+    ///
+    /// * `allow` - A boolean flag indicating whether to allow scanning non-covered slots.
+    ///
+    /// # Returns
+    ///
+    /// The updated [`ClusterScanArgsBuilder`] instance.
+    pub fn allow_non_covered_slots(mut self, allow: bool) -> Self {
+        self.allow_non_covered_slots = Some(allow);
+        self
+    }
+
+    /// Builds the [`ClusterScanArgs`] instance with the provided configuration.
+    ///
+    /// # Returns
+    ///
+    /// A [`ClusterScanArgs`] instance with the configured options.
+    pub fn build(self) -> ClusterScanArgs {
+        ClusterScanArgs {
+            scan_state_cursor: ScanStateRC::new(),
+            match_pattern: self.match_pattern,
+            count: self.count,
+            object_type: self.object_type,
+            allow_non_covered_slots: self.allow_non_covered_slots.unwrap_or(false),
+        }
+    }
+}
+
+/// Represents the type of an object used to filter keys by data type.
+///
+/// This enum is used with the `TYPE` option in the `SCAN` command to
+/// filter keys by their data type.
+#[derive(Debug, Clone, Display, PartialEq, EnumString)]
+pub enum ObjectType {
+    /// String data type.
+    String,
+    /// List data type.
+    List,
+    /// Set data type.
+    Set,
+    /// Sorted set data type.
+    ZSet,
+    /// Hash data type.
+    Hash,
+    /// Stream data type.
+    Stream,
+}
+
+impl From<String> for ObjectType {
+    fn from(s: String) -> Self {
+        match s.to_lowercase().as_str() {
+            "string" => ObjectType::String,
+            "list" => ObjectType::List,
+            "set" => ObjectType::Set,
+            "zset" => ObjectType::ZSet,
+            "hash" => ObjectType::Hash,
+            "stream" => ObjectType::Stream,
+            _ => ObjectType::String,
         }
     }
 }
@@ -80,10 +272,11 @@ pub enum ScanStateStage {
     Finished,
 }
 
+/// Wrapper struct for managing the state of a cluster scan operation.
+///
+/// This struct holds an `Arc` to the actual scan state and a status indicating
+/// whether the scan is initiating, in progress, or finished.
 #[derive(Debug, Clone, Default)]
-/// A wrapper struct for managing the state of a scan operation in a cluster.
-/// It holds a reference to the scan state and provides methods for accessing the state.
-/// The `status` field indicates the status of the scan operation.
 pub struct ScanStateRC {
     scan_state_rc: Arc<Option<ScanState>>,
     status: ScanStateStage,
@@ -121,7 +314,7 @@ impl ScanStateRC {
     }
 
     /// Returns a clone of the scan state, if it exist.
-    pub(crate) fn get_state_from_wrapper(&self) -> Option<ScanState> {
+    pub(crate) fn state_from_wrapper(&self) -> Option<ScanState> {
         if self.status == ScanStateStage::Initiating || self.status == ScanStateStage::Finished {
             None
         } else {
@@ -130,33 +323,10 @@ impl ScanStateRC {
     }
 }
 
-/// This trait defines the methods for interacting with a Redis cluster during scanning.
-#[async_trait]
-pub(crate) trait ClusterInScan {
-    /// Retrieves the address associated with a given slot in the cluster.
-    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<Arc<String>>;
-
-    /// Retrieves the epoch of a given address in the cluster.
-    /// The epoch represents the version of the address, which is updated when a failover occurs or slots migrate in.
-    async fn get_address_epoch(&self, address: &str) -> Result<u64, RedisError>;
-
-    /// Retrieves the slots assigned to a given address in the cluster.
-    async fn get_slots_of_address(&self, address: Arc<String>) -> Vec<u16>;
-
-    /// Routes a Redis command to a specific address in the cluster.
-    async fn route_command(&self, cmd: Cmd, address: &str) -> RedisResult<Value>;
-
-    /// Check if all slots are covered by the cluster
-    async fn are_all_slots_covered(&self) -> bool;
-
-    /// Check if the topology of the cluster has changed and refresh the slots if needed
-    async fn refresh_if_topology_changed(&self) -> RedisResult<bool>;
-}
-
-/// Represents the state of a scan operation in a Redis cluster.
+/// Represents the state of a cluster scan operation.
 ///
-/// This struct holds information about the current scan state, including the cursor position,
-/// the scanned slots map, the address being scanned, and the address's epoch.
+/// This struct keeps track of the current cursor, which slots have been scanned,
+/// the address currently being scanned, and the epoch of that address.
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) struct ScanState {
     // the real cursor in the scan operation
@@ -205,7 +375,7 @@ impl ScanState {
     fn create_finished_state() -> Self {
         Self {
             cursor: 0,
-            scanned_slots_map: [0; BITS_ARRAY_SIZE],
+            scanned_slots_map: [0; BITS_ARRAY_SIZE as usize],
             address_in_scan: Default::default(),
             address_epoch: 0,
             scan_status: ScanStateStage::Finished,
@@ -217,23 +387,36 @@ impl ScanState {
     /// and the address set to the address associated with slot 0.
     /// The address epoch is set to the epoch of the address.
     /// If the address epoch cannot be retrieved, the method returns an error.
-    async fn initiate_scan<C: ClusterInScan + ?Sized>(connection: &C) -> RedisResult<ScanState> {
-        let new_scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
+    async fn initiate_scan<C>(
+        core: &InnerCore<C>,
+        allow_non_covered_slots: bool,
+    ) -> RedisResult<ScanState>
+    where
+        C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
+    {
+        let mut new_scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE as usize];
         let new_cursor = 0;
-        let address = connection.get_address_by_slot(0).await?;
-        let address_epoch = connection.get_address_epoch(&address).await.unwrap_or(0);
-        Ok(ScanState::new(
-            new_cursor,
-            new_scanned_slots_map,
-            address,
-            address_epoch,
-            ScanStateStage::InProgress,
-        ))
+        let address =
+            next_address_to_scan(core, 0, &mut new_scanned_slots_map, allow_non_covered_slots)?;
+
+        match address {
+            NextNodeResult::AllSlotsCompleted => Ok(ScanState::create_finished_state()),
+            NextNodeResult::Address(address) => {
+                let address_epoch = core.address_epoch(&address).await.unwrap_or(0);
+                Ok(ScanState::new(
+                    new_cursor,
+                    new_scanned_slots_map,
+                    address,
+                    address_epoch,
+                    ScanStateStage::InProgress,
+                ))
+            }
+        }
     }
 
     /// Get the next slot to be scanned based on the scanned slots map.
     /// If all slots have been scanned, the method returns [`END_OF_SCAN`].
-    fn get_next_slot(&self, scanned_slots_map: &SlotsBitsArray) -> Option<u16> {
+    fn next_slot(&self, scanned_slots_map: &SlotsBitsArray) -> Option<u16> {
         let all_slots_scanned = scanned_slots_map.iter().all(|&word| word == u64::MAX);
         if all_slots_scanned {
             return Some(END_OF_SCAN);
@@ -242,7 +425,7 @@ impl ScanState {
             let mut mask = 1;
             for j in 0..BITS_PER_U64 {
                 if (slot & mask) == 0 {
-                    return Some((i * BITS_PER_U64 + j) as u16);
+                    return Some(i as u16 * BITS_PER_U64 + j);
                 }
                 mask <<= 1;
             }
@@ -253,27 +436,38 @@ impl ScanState {
     /// Update the scan state without updating the scanned slots map.
     /// This method is used when the address epoch has changed, and we can't determine which slots are new.
     /// In this case, we skip updating the scanned slots map and only update the address and cursor.
-    async fn creating_state_without_slot_changes<C: ClusterInScan + ?Sized>(
+    async fn new_scan_state<C>(
         &self,
-        connection: &C,
-    ) -> RedisResult<ScanState> {
-        let next_slot = self.get_next_slot(&self.scanned_slots_map).unwrap_or(0);
-        let new_address = if next_slot == END_OF_SCAN {
-            return Ok(ScanState::create_finished_state());
-        } else {
-            connection.get_address_by_slot(next_slot).await
-        };
-        match new_address {
-            Ok(address) => {
-                let new_epoch = connection.get_address_epoch(&address).await.unwrap_or(0);
+        core: Arc<InnerCore<C>>,
+        allow_non_covered_slots: bool,
+        new_scanned_slots_map: Option<SlotsBitsArray>,
+    ) -> RedisResult<ScanState>
+    where
+        C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
+    {
+        // If the new scanned slots map is not provided, use the current scanned slots map.
+        // The new scanned slots map is provided in the general case when the address epoch has not changed,
+        // meaning that we could safely update the scanned slots map with the slots owned by the node.
+        // Epoch change means that some slots are new, and we can't determine which slots been there from the beginning and which are new.
+        let mut scanned_slots_map = new_scanned_slots_map.unwrap_or(self.scanned_slots_map);
+        let next_slot = self.next_slot(&scanned_slots_map).unwrap_or(0);
+        match next_address_to_scan(
+            &core,
+            next_slot,
+            &mut scanned_slots_map,
+            allow_non_covered_slots,
+        ) {
+            Ok(NextNodeResult::Address(new_address)) => {
+                let new_epoch = core.address_epoch(&new_address).await.unwrap_or(0);
                 Ok(ScanState::new(
                     0,
-                    self.scanned_slots_map,
-                    address,
+                    scanned_slots_map,
+                    new_address,
                     new_epoch,
                     ScanStateStage::InProgress,
                 ))
             }
+            Ok(NextNodeResult::AllSlotsCompleted) => Ok(ScanState::create_finished_state()),
             Err(err) => Err(err),
         }
     }
@@ -284,210 +478,190 @@ impl ScanState {
     /// If the address epoch has changed, the method skips updating the scanned slots map and only updates the address and cursor.
     /// If the address epoch has not changed, the method updates the scanned slots map with the slots owned by the address.
     /// The method returns the new scan state with the updated cursor, scanned slots map, address, and epoch.
-    async fn create_updated_scan_state_for_completed_address<C: ClusterInScan + ?Sized>(
+    async fn create_updated_scan_state_for_completed_address<C>(
         &mut self,
-        connection: &C,
-    ) -> RedisResult<ScanState> {
-        connection
-            .refresh_if_topology_changed()
-            .await
-            .map_err(|err| {
-                RedisError::from((
-                    ErrorKind::ResponseError,
-                    "Error during cluster scan: failed to refresh slots",
-                    format!("{:?}", err),
-                ))
-            })?;
+        core: Arc<InnerCore<C>>,
+        allow_non_covered_slots: bool,
+    ) -> RedisResult<ScanState>
+    where
+        C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
+    {
+        ClusterConnInner::check_topology_and_refresh_if_diff(
+            core.clone(),
+            &RefreshPolicy::NotThrottable,
+        )
+        .await?;
+
         let mut scanned_slots_map = self.scanned_slots_map;
         // If the address epoch changed it mean that some slots in the address are new, so we cant know which slots been there from the beginning and which are new, or out and in later.
         // In this case we will skip updating the scanned_slots_map and will just update the address and the cursor
-        let new_address_epoch = connection
-            .get_address_epoch(&self.address_in_scan)
-            .await
-            .unwrap_or(0);
+        let new_address_epoch = core.address_epoch(&self.address_in_scan).await.unwrap_or(0);
         if new_address_epoch != self.address_epoch {
-            return self.creating_state_without_slot_changes(connection).await;
+            return self
+                .new_scan_state(core, allow_non_covered_slots, None)
+                .await;
         }
         // If epoch wasn't changed, the slots owned by the address after the refresh are all valid as slots that been scanned
         // So we will update the scanned_slots_map with the slots owned by the address
-        let slots_scanned = connection
-            .get_slots_of_address(self.address_in_scan.clone())
-            .await;
+        let slots_scanned = core.slots_of_address(self.address_in_scan.clone()).await;
         for slot in slots_scanned {
-            let slot_index = slot as usize / BITS_PER_U64;
-            let slot_bit = slot as usize % BITS_PER_U64;
-            scanned_slots_map[slot_index] |= 1 << slot_bit;
+            mark_slot_as_scanned(&mut scanned_slots_map, slot);
         }
         // Get the next address to scan and its param base on the next slot set to 0 in the scanned_slots_map
-        let next_slot = self.get_next_slot(&scanned_slots_map).unwrap_or(0);
-        let new_address = if next_slot == END_OF_SCAN {
-            return Ok(ScanState::create_finished_state());
-        } else {
-            connection.get_address_by_slot(next_slot).await
-        };
-        match new_address {
-            Ok(new_address) => {
-                let new_epoch = connection
-                    .get_address_epoch(&new_address)
-                    .await
-                    .unwrap_or(0);
-                let new_cursor = 0;
-                Ok(ScanState::new(
-                    new_cursor,
-                    scanned_slots_map,
-                    new_address,
-                    new_epoch,
-                    ScanStateStage::InProgress,
-                ))
-            }
-            Err(err) => Err(err),
-        }
+        self.new_scan_state(core, allow_non_covered_slots, Some(scanned_slots_map))
+            .await
     }
 }
 
-// Implement the [`ClusterInScan`] trait for [`InnerCore`] of async cluster connection.
-#[async_trait]
-impl<C> ClusterInScan for Core<C>
+fn mark_slot_as_scanned(scanned_slots_map: &mut SlotsBitsArray, slot: u16) {
+    let slot_index = (slot as u64 / BITS_PER_U64 as u64) as usize;
+    let slot_bit = slot as u64 % (BITS_PER_U64 as u64);
+    scanned_slots_map[slot_index] |= 1 << slot_bit;
+}
+
+#[derive(PartialEq, Debug, Clone)]
+/// The address type representing a connection address
+///
+/// # Fields
+///
+/// * `Address` - A thread-safe shared string containing the server address
+/// * `AllSlotsCompleted` - Indicates that all slots have been scanned
+enum NextNodeResult {
+    Address(Arc<String>),
+    AllSlotsCompleted,
+}
+
+/// Determines the next node address to scan within the cluster.
+///
+/// This asynchronous function iterates through cluster slots to find the next available
+/// node responsible for scanning. If a slot is not covered and `allow_non_covered_slots`
+/// is enabled, it marks the slot as scanned and proceeds to the next one. The process
+/// continues until a valid address is found or all slots have been scanned.
+///
+/// # Arguments
+///
+/// * `core` - Reference to the cluster's inner core connection.
+/// * `slot` - The current slot number to scan.
+/// * `scanned_slots_map` - Mutable reference to the bitmap tracking scanned slots.
+/// * `allow_non_covered_slots` - Flag indicating whether to allow scanning of uncovered slots.
+///
+/// # Returns
+///
+/// * `RedisResult<NextNodeResult>` - Returns the next node address to scan or indicates completion.
+///
+/// # Type Parameters
+///
+/// * `C`: The connection type that must implement `ConnectionLike`, `Connect`, `Clone`, `Send`, `Sync`, and `'static`.
+///
+fn next_address_to_scan<C>(
+    core: &InnerCore<C>,
+    mut slot: u16,
+    scanned_slots_map: &mut SlotsBitsArray,
+    allow_non_covered_slots: bool,
+) -> RedisResult<NextNodeResult>
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
 {
-    async fn get_address_by_slot(&self, slot: u16) -> RedisResult<Arc<String>> {
-        let address = self
-            .get_address_from_slot(slot, SlotAddr::ReplicaRequired)
-            .await;
-        match address {
-            Some(addr) => Ok(addr),
+    loop {
+        if slot == END_OF_SCAN {
+            return Ok(NextNodeResult::AllSlotsCompleted);
+        }
+        // Attempt to retrieve the node address responsible for the current slot
+        match core
+            .conn_lock
+            .read()
+            .expect(MUTEX_READ_ERR)
+            .slot_map
+            .node_address_for_slot(slot, SlotAddr::ReplicaRequired)
+        {
+            Some(addr) => {
+                // Found a valid address for the slot
+                return Ok(NextNodeResult::Address(addr));
+            }
+            None if allow_non_covered_slots => {
+                // Mark the current slot as scanned
+                mark_slot_as_scanned(scanned_slots_map, slot);
+                // Move to the next slot
+                slot = slot.saturating_add(1);
+            }
             None => {
-                if self.are_all_slots_covered().await {
-                    Err(RedisError::from((
-                        ErrorKind::IoError,
-                        "Failed to get connection to the node cover the slot, please check the cluster configuration ",
-                    )))
-                } else {
-                    Err(RedisError::from((
+                // Error if slots are not covered and scanning is not allowed
+                return Err(RedisError::from((
                         ErrorKind::NotAllSlotsCovered,
-                        "All slots are not covered by the cluster, please check the cluster configuration ",
-                    )))
-                }
+                        "Could not find an address covering a slot, SCAN operation cannot continue \n 
+                        If you want to continue scanning even if some slots are not covered, set allow_non_covered_slots to true \n 
+                        Note that this may lead to incomplete scanning, and the SCAN operation lose its all guarantees ",
+                    )));
             }
         }
     }
-
-    async fn get_address_epoch(&self, address: &str) -> Result<u64, RedisError> {
-        self.as_ref().get_address_epoch(address).await
-    }
-    async fn get_slots_of_address(&self, address: Arc<String>) -> Vec<u16> {
-        self.as_ref().get_slots_of_address(address).await
-    }
-    async fn route_command(&self, cmd: Cmd, address: &str) -> RedisResult<Value> {
-        let routing = InternalRoutingInfo::SingleNode(InternalSingleNodeRouting::ByAddress(
-            address.to_string(),
-        ));
-        let core = self.to_owned();
-        let response = ClusterConnInner::<C>::try_cmd_request(Arc::new(cmd), routing, core)
-            .await
-            .map_err(|err| err.1)?;
-        match response {
-            Response::Single(value) => Ok(value),
-            _ => Err(RedisError::from((
-                ErrorKind::ClientError,
-                "Expected single response, got unexpected response",
-            ))),
-        }
-    }
-    async fn are_all_slots_covered(&self) -> bool {
-        ClusterConnInner::<C>::check_if_all_slots_covered(
-            &self.conn_lock.read().expect(MUTEX_READ_ERR).slot_map,
-        )
-    }
-    async fn refresh_if_topology_changed(&self) -> RedisResult<bool> {
-        ClusterConnInner::check_topology_and_refresh_if_diff(
-            self.to_owned(),
-            // The cluster SCAN implementation must refresh the slots when a topology change is found
-            // to ensure the scan logic is correct.
-            &RefreshPolicy::NotThrottable,
-        )
-        .await
-    }
 }
 
-/// Perform a cluster scan operation.
-/// This function performs a scan operation in a Redis cluster using the given [`ClusterInScan`] connection.
-/// It scans the cluster for keys based on the given `ClusterScanArgs` arguments.
-/// The function returns a tuple containing the new scan state cursor and the keys found in the scan operation.
-/// If the scan operation fails, an error is returned.
+/// Performs a cluster-wide `SCAN` operation.
+///
+/// This function scans the cluster for keys based on the provided arguments.
+/// It handles the initiation of a new scan or continues an existing scan, manages
+/// scan state, handles routing failures, and ensures consistent scanning across
+/// cluster topology changes.
 ///
 /// # Arguments
-/// * `core` - The connection to the Redis cluster.
-/// * `cluster_scan_args` - The arguments for the cluster scan operation.
+///
+/// * `core` - An `Arc`-wrapped reference to the cluster connection (`InnerCore<C>`).
+/// * `cluster_scan_args` - Configuration and arguments for the scan operation.
 ///
 /// # Returns
-/// A tuple containing the new scan state cursor and the keys found in the scan operation.
-/// If the scan operation fails, an error is returned.
+///
+/// * `RedisResult<(ScanStateRC, Vec<Value>)>` -
+///   - On success: A tuple containing the updated scan state (`ScanStateRC`) and a vector of `Value`s representing the found keys.
+///   - On failure: A `RedisError` detailing the reason for the failure.
+///
+/// # Type Parameters
+///
+/// * `C`: The connection type that must implement `ConnectionLike`, `Connect`, `Clone`, `Send`, `Sync`, and `'static`.
+///
 pub(crate) async fn cluster_scan<C>(
-    core: C,
+    core: Arc<InnerCore<C>>,
     cluster_scan_args: ClusterScanArgs,
 ) -> RedisResult<(ScanStateRC, Vec<Value>)>
 where
-    C: ClusterInScan,
+    C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
 {
-    let ClusterScanArgs {
-        scan_state_cursor,
-        match_pattern,
-        count,
-        object_type,
-    } = cluster_scan_args;
-    // If scan_state is None, meaning we start a new scan
-    let scan_state = match scan_state_cursor.get_state_from_wrapper() {
+    // Extract the current scan state cursor and the flag for non-covered slots
+    let scan_state_cursor = &cluster_scan_args.scan_state_cursor;
+    let allow_non_covered_slots = cluster_scan_args.allow_non_covered_slots;
+
+    // Determine the current scan state:
+    // - If an existing scan state is present, use it.
+    // - Otherwise, initiate a new scan.
+    let scan_state = match scan_state_cursor.state_from_wrapper() {
         Some(state) => state,
-        None => match ScanState::initiate_scan(&core).await {
+        None => match ScanState::initiate_scan(&core, allow_non_covered_slots).await {
             Ok(state) => state,
             Err(err) => {
+                // Early return if initiating the scan fails
                 return Err(err);
             }
         },
     };
-    // Send the actual scan command to the address in the scan_state
-    let scan_result = send_scan(
-        &scan_state,
-        &core,
-        match_pattern.clone(),
-        count,
-        object_type.clone(),
-    )
-    .await;
-    let ((new_cursor, new_keys), mut scan_state): ((u64, Vec<Value>), ScanState) = match scan_result
-    {
-        Ok(scan_result) => (from_redis_value(&scan_result)?, scan_state.clone()),
-        Err(err) => match err.kind() {
-            // If the scan command failed to route to the address because the address is not found in the cluster or
-            // the connection to the address cant be reached from different reasons, we will check we want to check if
-            // the problem is problem that we can recover from like failover or scale down or some network issue
-            // that we can retry the scan command to an address that own the next slot we are at.
-            ErrorKind::IoError
-            | ErrorKind::AllConnectionsUnavailable
-            | ErrorKind::ConnectionNotFoundForRoute => {
-                let retry =
-                    retry_scan(&scan_state, &core, match_pattern, count, object_type).await?;
-                (from_redis_value(&retry.0?)?, retry.1)
-            }
-            _ => return Err(err),
-        },
-    };
+    // Send the SCAN command using the current scan state and scan arguments
+    let ((new_cursor, new_keys), mut scan_state): ((u64, Vec<Value>), ScanState) =
+        try_scan(&scan_state, &cluster_scan_args, core.clone()).await?;
 
-    // If the cursor is 0, meaning we finished scanning the address
-    // we will update the scan state to get the next address to scan
+    // Check if the cursor indicates the end of the current scan segment
     if new_cursor == 0 {
+        // Update the scan state to move to the next address/node in the cluster
         scan_state = scan_state
-            .create_updated_scan_state_for_completed_address(&core)
+            .create_updated_scan_state_for_completed_address(core, allow_non_covered_slots)
             .await?;
     }
 
-    // If the address is empty, meaning we finished scanning all the address
+    // Verify if the entire cluster has been scanned
     if scan_state.scan_status == ScanStateStage::Finished {
+        // Return the final scan state and the collected keys
         return Ok((ScanStateRC::create_finished(), new_keys));
     }
 
+    // Update the scan state with the new cursor and maintain the progress
     scan_state = ScanState::new(
         new_cursor,
         scan_state.scanned_slots_map,
@@ -495,256 +669,215 @@ where
         scan_state.address_epoch,
         ScanStateStage::InProgress,
     );
+
+    // Return the updated scan state and the newly found keys
     Ok((ScanStateRC::from_scan_state(scan_state), new_keys))
 }
 
-// Send the scan command to the address in the scan_state
+/// Sends the `SCAN` command to the specified address.
+///
+/// # Arguments
+///
+/// * `scan_state` - The current scan state.
+/// * `cluster_scan_args` - Arguments for the scan operation, including match pattern, count, object type, and allow_non_covered_slots.
+/// * `core` - The cluster connection.
+///
+/// # Returns
+///
+/// A `RedisResult` containing the response from the `SCAN` command.
 async fn send_scan<C>(
     scan_state: &ScanState,
-    core: &C,
-    match_pattern: Option<Vec<u8>>,
-    count: Option<usize>,
-    object_type: Option<ObjectType>,
+    cluster_scan_args: &ClusterScanArgs,
+    core: Arc<InnerCore<C>>,
 ) -> RedisResult<Value>
 where
-    C: ClusterInScan,
+    C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
 {
-    let mut scan_command = cmd("SCAN");
-    scan_command.arg(scan_state.cursor);
-    if let Some(match_pattern) = match_pattern {
-        scan_command.arg("MATCH").arg(match_pattern);
-    }
-    if let Some(count) = count {
-        scan_command.arg("COUNT").arg(count);
-    }
-    if let Some(object_type) = object_type {
-        scan_command.arg("TYPE").arg(object_type.to_string());
-    }
-
-    core.route_command(scan_command, &scan_state.address_in_scan)
+    if let Some(conn_future) = core
+        .connection_for_address(&scan_state.address_in_scan)
         .await
+    {
+        let mut conn = conn_future.await;
+        let mut scan_command = cmd("SCAN");
+        scan_command.arg(scan_state.cursor);
+        if let Some(match_pattern) = cluster_scan_args.match_pattern.as_ref() {
+            scan_command.arg("MATCH").arg(match_pattern);
+        }
+        if let Some(count) = cluster_scan_args.count {
+            scan_command.arg("COUNT").arg(count);
+        }
+        if let Some(object_type) = &cluster_scan_args.object_type {
+            scan_command.arg("TYPE").arg(object_type.to_string());
+        }
+        conn.req_packed_command(&scan_command).await
+    } else {
+        Err(RedisError::from((
+            ErrorKind::ConnectionNotFoundForRoute,
+            "No connection available for address",
+        )))
+    }
 }
 
-// If the scan command failed to route to the address we will check we will first refresh the slots, we will check if all slots are covered by cluster,
-// and if so we will try to get a new address to scan for handling case of failover.
-// if all slots are not covered by the cluster we will return an error indicating that the cluster is not well configured.
-// if all slots are covered by cluster but we failed to get a new address to scan we will return an error indicating that we failed to get a new address to scan.
-// if we got a new address to scan but the scan command failed to route to the address we will return an error indicating that we failed to route the command.
-async fn retry_scan<C>(
-    scan_state: &ScanState,
-    core: &C,
-    match_pattern: Option<Vec<u8>>,
-    count: Option<usize>,
-    object_type: Option<ObjectType>,
-) -> RedisResult<(RedisResult<Value>, ScanState)>
-where
-    C: ClusterInScan,
-{
-    // TODO: This mechanism of refreshing on failure to route to address should be part of the routing mechanism
-    // After the routing mechanism is updated to handle this case, this refresh in the case bellow should be removed
-    core.refresh_if_topology_changed().await.map_err(|err| {
-        RedisError::from((
-            ErrorKind::ResponseError,
-            "Error during cluster scan: failed to refresh slots",
-            format!("{:?}", err),
-        ))
-    })?;
-    if !core.are_all_slots_covered().await {
-        return Err(RedisError::from((
-            ErrorKind::NotAllSlotsCovered,
-            "Not all slots are covered by the cluster, please check the cluster configuration",
-        )));
-    }
-    // If for some reason we failed to reach the address we don't know if its a scale down or a failover.
-    // Since it might be scale down we cant just keep going with the current state we the same cursor as we are at
-    // the same point in the new address, so we need to get the new address own the next slot that haven't been scanned
-    // and start from the beginning of this address.
-    let next_slot = scan_state
-        .get_next_slot(&scan_state.scanned_slots_map)
-        .unwrap_or(0);
-    let address = core.get_address_by_slot(next_slot).await?;
+/// Checks if the error is retryable during scanning.
+/// Retryable errors include network issues, cluster topology changes, and unavailable connections.
+/// Scan operations are not keyspace operations, so they are not affected by keyspace errors like `MOVED`.
+fn is_scanwise_retryable_error(err: &RedisError) -> bool {
+    matches!(
+        err.kind(),
+        ErrorKind::IoError
+            | ErrorKind::AllConnectionsUnavailable
+            | ErrorKind::ConnectionNotFoundForRoute
+            | ErrorKind::ClusterDown
+            | ErrorKind::FatalSendError
+    )
+}
 
-    let new_epoch = core.get_address_epoch(&address).await.unwrap_or(0);
-    let scan_state = &ScanState::new(
-        0,
-        scan_state.scanned_slots_map,
-        address,
-        new_epoch,
-        ScanStateStage::InProgress,
-    );
-    let res = (
-        send_scan(scan_state, core, match_pattern, count, object_type).await,
-        scan_state.clone(),
-    );
-    Ok(res)
+/// Gets the next scan state by finding the next address to scan.
+/// The method updates the scanned slots map and retrieves the next address to scan.
+/// If the address epoch has changed, the method creates a new scan state without updating the scanned slots map.
+/// If the address epoch has not changed, the method updates the scanned slots map with the slots owned by the address.
+/// The method returns the new scan state with the updated cursor, scanned slots map, address, and epoch.
+/// The method is used to continue scanning the cluster after completing a scan segment.
+async fn next_scan_state<C>(
+    core: &Arc<InnerCore<C>>,
+    scan_state: &ScanState,
+    cluster_scan_args: &ClusterScanArgs,
+) -> RedisResult<Option<ScanState>>
+where
+    C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
+{
+    let next_slot = scan_state
+        .next_slot(&scan_state.scanned_slots_map)
+        .unwrap_or(0);
+    let mut scanned_slots_map = scan_state.scanned_slots_map;
+    match next_address_to_scan(
+        core,
+        next_slot,
+        &mut scanned_slots_map,
+        cluster_scan_args.allow_non_covered_slots,
+    ) {
+        Ok(NextNodeResult::Address(new_address)) => {
+            let new_epoch = core.address_epoch(&new_address).await.unwrap_or(0);
+            Ok(Some(ScanState::new(
+                0,
+                scanned_slots_map,
+                new_address,
+                new_epoch,
+                ScanStateStage::InProgress,
+            )))
+        }
+        Ok(NextNodeResult::AllSlotsCompleted) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// Attempts to scan the cluster for keys based on the current scan state.
+/// Sends the `SCAN` command to the current address and processes the response.
+/// On retryable errors, refreshes the cluster topology and retries the scan.
+/// Returns the new cursor and keys found upon success.
+async fn try_scan<C>(
+    scan_state: &ScanState,
+    cluster_scan_args: &ClusterScanArgs,
+    core: Arc<InnerCore<C>>,
+) -> RedisResult<((u64, Vec<Value>), ScanState)>
+where
+    C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
+{
+    let mut new_scan_state = scan_state.clone();
+
+    loop {
+        match send_scan(&new_scan_state, cluster_scan_args, core.clone()).await {
+            Ok(scan_response) => {
+                let (new_cursor, new_keys) = from_redis_value::<(u64, Vec<Value>)>(&scan_response)?;
+                return Ok(((new_cursor, new_keys), new_scan_state));
+            }
+            Err(err) if is_scanwise_retryable_error(&err) => {
+                ClusterConnInner::check_topology_and_refresh_if_diff(
+                    core.clone(),
+                    &RefreshPolicy::NotThrottable,
+                )
+                .await?;
+
+                if let Some(next_scan_state) =
+                    next_scan_state(&core, &new_scan_state, cluster_scan_args).await?
+                {
+                    new_scan_state = next_scan_state;
+                } else {
+                    return Ok(((0, Vec::new()), ScanState::create_finished_state()));
+                }
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
-    #[test]
-    fn test_creation_of_empty_scan_wrapper() {
-        let scan_state_wrapper = ScanStateRC::new();
-        assert!(scan_state_wrapper.status == ScanStateStage::Initiating);
-    }
-
-    #[test]
-    fn test_creation_of_scan_state_wrapper_from() {
-        let scan_state = ScanState {
-            cursor: 0,
-            scanned_slots_map: [0; BITS_ARRAY_SIZE],
-            address_in_scan: String::from("address1").into(),
-            address_epoch: 1,
-            scan_status: ScanStateStage::InProgress,
-        };
-
-        let scan_state_wrapper = ScanStateRC::from_scan_state(scan_state);
-        assert!(!scan_state_wrapper.is_finished());
-    }
-
-    #[test]
-    // Test the get_next_slot method
-    fn test_scan_state_get_next_slot() {
-        let scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
-        let scan_state = ScanState {
-            cursor: 0,
-            scanned_slots_map,
-            address_in_scan: String::from("address1").into(),
-            address_epoch: 1,
-            scan_status: ScanStateStage::InProgress,
-        };
-        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
-        assert_eq!(next_slot, Some(0));
-        // Set the first slot to 1
-        let mut scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
-        scanned_slots_map[0] = 1;
-        let scan_state = ScanState {
-            cursor: 0,
-            scanned_slots_map,
-            address_in_scan: String::from("address1").into(),
-            address_epoch: 1,
-            scan_status: ScanStateStage::InProgress,
-        };
-        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
-        assert_eq!(next_slot, Some(1));
-    }
-    // Create a mock connection
-    struct MockConnection;
-    #[async_trait]
-    impl ClusterInScan for MockConnection {
-        async fn refresh_if_topology_changed(&self) -> RedisResult<bool> {
-            Ok(true)
-        }
-        async fn get_address_by_slot(&self, _slot: u16) -> RedisResult<Arc<String>> {
-            Ok("mock_address".to_string().into())
-        }
-        async fn get_address_epoch(&self, _address: &str) -> Result<u64, RedisError> {
-            Ok(0)
-        }
-        async fn get_slots_of_address(&self, address: Arc<String>) -> Vec<u16> {
-            if address.as_str() == "mock_address" {
-                vec![3, 4, 5]
-            } else {
-                vec![0, 1, 2]
-            }
-        }
-        async fn route_command(&self, _: Cmd, _: &str) -> RedisResult<Value> {
-            unimplemented!()
-        }
-        async fn are_all_slots_covered(&self) -> bool {
-            true
-        }
-    }
-    // Test the initiate_scan function
     #[tokio::test]
-    async fn test_initiate_scan() {
-        let connection = MockConnection;
-        let scan_state = ScanState::initiate_scan(&connection).await.unwrap();
+    async fn test_cluster_scan_args_builder() {
+        let args = ClusterScanArgs::builder()
+            .with_match_pattern("user:*")
+            .with_count(100)
+            .with_object_type(ObjectType::Hash)
+            .allow_non_covered_slots(true)
+            .build();
 
-        // Assert that the scan state is initialized correctly
-        assert_eq!(scan_state.cursor, 0);
-        assert_eq!(scan_state.scanned_slots_map, [0; BITS_ARRAY_SIZE]);
-        assert_eq!(
-            scan_state.address_in_scan,
-            "mock_address".to_string().into()
-        );
-        assert_eq!(scan_state.address_epoch, 0);
-    }
-
-    // Test the get_next_slot function
-    #[test]
-    fn test_get_next_slot() {
-        let scan_state = ScanState {
-            cursor: 0,
-            scanned_slots_map: [0; BITS_ARRAY_SIZE],
-            address_in_scan: "".to_string().into(),
-            address_epoch: 0,
-            scan_status: ScanStateStage::InProgress,
-        };
-        // Test when all first bits of each u6 are set to 1, the next slots should be 1
-        let scanned_slots_map: SlotsBitsArray = [1; BITS_ARRAY_SIZE];
-        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
-        assert_eq!(next_slot, Some(1));
-
-        // Test when all slots are scanned, the next slot should be 0
-        let scanned_slots_map: SlotsBitsArray = [u64::MAX; BITS_ARRAY_SIZE];
-        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
-        assert_eq!(next_slot, Some(16385));
-
-        // Test when first, second, fourth, sixth and eighth slots scanned, the next slot should be 2
-        let mut scanned_slots_map: SlotsBitsArray = [0; BITS_ARRAY_SIZE];
-        scanned_slots_map[0] = 171; // 10101011
-        let next_slot = scan_state.get_next_slot(&scanned_slots_map);
-        assert_eq!(next_slot, Some(2));
-    }
-
-    // Test the update_scan_state_and_get_next_address function
-    #[tokio::test]
-    async fn test_update_scan_state_and_get_next_address() {
-        let connection = MockConnection;
-        let scan_state = ScanState::initiate_scan(&connection).await;
-        let updated_scan_state = scan_state
-            .unwrap()
-            .create_updated_scan_state_for_completed_address(&connection)
-            .await
-            .unwrap();
-
-        // cursor should be reset to 0
-        assert_eq!(updated_scan_state.cursor, 0);
-
-        // address_in_scan should be updated to the new address
-        assert_eq!(
-            updated_scan_state.address_in_scan,
-            "mock_address".to_string().into()
-        );
-
-        // address_epoch should be updated to the new address epoch
-        assert_eq!(updated_scan_state.address_epoch, 0);
+        assert_eq!(args.match_pattern, Some(b"user:*".to_vec()));
+        assert_eq!(args.count, Some(100));
+        assert_eq!(args.object_type, Some(ObjectType::Hash));
+        assert!(args.allow_non_covered_slots);
     }
 
     #[tokio::test]
-    async fn test_update_scan_state_without_updating_scanned_map() {
-        let connection = MockConnection;
+    async fn test_scan_state_new() {
+        let address = Arc::new("127.0.0.1:6379".to_string());
         let scan_state = ScanState::new(
             0,
-            [0; BITS_ARRAY_SIZE],
-            "address".to_string().into(),
-            0,
+            [0; BITS_ARRAY_SIZE as usize],
+            address.clone(),
+            1,
             ScanStateStage::InProgress,
         );
-        let scanned_slots_map = scan_state.scanned_slots_map;
-        let updated_scan_state = scan_state
-            .creating_state_without_slot_changes(&connection)
-            .await
-            .unwrap();
-        assert_eq!(updated_scan_state.scanned_slots_map, scanned_slots_map);
-        assert_eq!(updated_scan_state.cursor, 0);
-        assert_eq!(
-            updated_scan_state.address_in_scan,
-            "mock_address".to_string().into()
+
+        assert_eq!(scan_state.cursor, 0);
+        assert_eq!(scan_state.scanned_slots_map, [0; BITS_ARRAY_SIZE as usize]);
+        assert_eq!(scan_state.address_in_scan, address);
+        assert_eq!(scan_state.address_epoch, 1);
+        assert_eq!(scan_state.scan_status, ScanStateStage::InProgress);
+    }
+
+    #[tokio::test]
+    async fn test_scan_state_create_finished() {
+        let scan_state = ScanState::create_finished_state();
+
+        assert_eq!(scan_state.cursor, 0);
+        assert_eq!(scan_state.scanned_slots_map, [0; BITS_ARRAY_SIZE as usize]);
+        assert_eq!(scan_state.address_in_scan, Arc::new(String::new()));
+        assert_eq!(scan_state.address_epoch, 0);
+        assert_eq!(scan_state.scan_status, ScanStateStage::Finished);
+    }
+
+    #[tokio::test]
+    async fn test_mark_slot_as_scanned() {
+        let mut scanned_slots_map = [0; BITS_ARRAY_SIZE as usize];
+        mark_slot_as_scanned(&mut scanned_slots_map, 5);
+
+        assert_eq!(scanned_slots_map[0], 1 << 5);
+    }
+
+    #[tokio::test]
+    async fn test_next_slot() {
+        let scan_state = ScanState::new(
+            0,
+            [0; BITS_ARRAY_SIZE as usize],
+            Arc::new("127.0.0.1:6379".to_string()),
+            1,
+            ScanStateStage::InProgress,
         );
-        assert_eq!(updated_scan_state.address_epoch, 0);
+        let next_slot = scan_state.next_slot(&[0; BITS_ARRAY_SIZE as usize]);
+
+        assert_eq!(next_slot, Some(0));
     }
 }

--- a/glide-core/redis-rs/redis/src/commands/mod.rs
+++ b/glide-core/redis-rs/redis/src/commands/mod.rs
@@ -17,6 +17,9 @@ mod json;
 pub use cluster_scan::ScanStateRC;
 
 #[cfg(feature = "cluster-async")]
+pub use cluster_scan::ClusterScanArgs;
+
+#[cfg(feature = "cluster-async")]
 pub(crate) mod cluster_scan;
 
 #[cfg(feature = "cluster-async")]

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -457,6 +457,9 @@ pub use crate::commands::ScanStateRC;
 #[cfg(feature = "cluster-async")]
 pub use crate::commands::ObjectType;
 
+#[cfg(feature = "cluster-async")]
+pub use crate::commands::ClusterScanArgs;
+
 #[cfg(feature = "cluster")]
 mod cluster_client;
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_scan.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_scan.rs
@@ -5,8 +5,12 @@ mod support;
 mod test_cluster_scan_async {
     use crate::support::*;
     use rand::Rng;
-    use redis::cluster_routing::{RoutingInfo, SingleNodeRoutingInfo};
-    use redis::{cmd, from_redis_value, ObjectType, RedisResult, ScanStateRC, Value};
+    use redis::cluster_routing::{
+        MultipleNodeRoutingInfo, ResponsePolicy, RoutingInfo, SingleNodeRoutingInfo,
+    };
+    use redis::{
+        cmd, from_redis_value, ClusterScanArgs, ObjectType, RedisResult, ScanStateRC, Value,
+    };
     use std::time::Duration;
 
     async fn kill_one_node(
@@ -49,7 +53,12 @@ mod test_cluster_scan_async {
     #[tokio::test]
     #[serial_test::serial]
     async fn test_async_cluster_scan() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| builder.retries(1),
+            false,
+        );
         let mut connection = cluster.async_connection(None).await;
 
         // Set some keys
@@ -67,14 +76,14 @@ mod test_cluster_scan_async {
         let mut keys: Vec<String> = vec![];
         loop {
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc, None, None)
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
                 .await
                 .unwrap();
             scan_state_rc = next_cursor;
             let mut scan_keys = scan_keys
                 .into_iter()
                 .map(|v| from_redis_value(&v).unwrap())
-                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+                .collect::<Vec<String>>();
             keys.append(&mut scan_keys);
             if scan_state_rc.is_finished() {
                 break;
@@ -91,7 +100,12 @@ mod test_cluster_scan_async {
     #[tokio::test]
     #[serial_test::serial] // test cluster scan with slot migration in the middle
     async fn test_async_cluster_scan_with_migration() {
-        let cluster = TestClusterContext::new(3, 0);
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| builder.retries(1),
+            false,
+        );
 
         let mut connection = cluster.async_connection(None).await;
         // Set some keys
@@ -114,7 +128,7 @@ mod test_cluster_scan_async {
         loop {
             count += 1;
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc, None, None)
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
                 .await
                 .unwrap();
             scan_state_rc = next_cursor;
@@ -189,18 +203,21 @@ mod test_cluster_scan_async {
         let mut keys: Vec<String> = Vec::new();
         let mut count = 0;
         let mut result: RedisResult<Value> = Ok(Value::Nil);
+        let mut next_cursor = ScanStateRC::new();
+        let mut scan_keys;
         loop {
             count += 1;
-            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> =
-                connection.cluster_scan(scan_state_rc, None, None).await;
-            let (next_cursor, scan_keys) = match scan_response {
-                Ok((cursor, keys)) => (cursor, keys),
+            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> = connection
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
+                .await;
+            (next_cursor, scan_keys) = match scan_response {
+                Ok((cursor, keys)) => (cursor.clone(), keys),
                 Err(e) => {
                     result = Err(e);
                     break;
                 }
             };
-            scan_state_rc = next_cursor;
+            scan_state_rc = next_cursor.clone();
             keys.extend(scan_keys.into_iter().map(|v| from_redis_value(&v).unwrap()));
             if scan_state_rc.is_finished() {
                 break;
@@ -225,6 +242,47 @@ mod test_cluster_scan_async {
         }
         // We expect an error of finding address
         assert!(result.is_err());
+
+        // Test we can continue scanning after the fail using allow_non_covered_slots=true
+        scan_state_rc = next_cursor;
+        // config cluster to allow missing slots
+        let mut config_cmd = cmd("CONFIG");
+        config_cmd
+            .arg("SET")
+            .arg("cluster-require-full-coverage")
+            .arg("no");
+        let res: RedisResult<Value> = connection
+            .route_command(
+                &config_cmd,
+                RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllNodes, None)),
+            )
+            .await;
+        print!("config result: {:?}", res);
+        let args = ClusterScanArgs::builder()
+            .allow_non_covered_slots(true)
+            .build();
+        loop {
+            let res = connection
+                .cluster_scan(scan_state_rc.clone(), args.clone())
+                .await;
+            let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = match res {
+                Ok((cursor, keys)) => (cursor.clone(), keys),
+                Err(e) => {
+                    println!("error: {:?}", e);
+                    break;
+                }
+            };
+            scan_state_rc = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>();
+            keys.append(&mut scan_keys);
+            if scan_state_rc.is_finished() {
+                break;
+            }
+        }
+        assert!(scan_state_rc.is_finished());
     }
 
     #[tokio::test]
@@ -268,8 +326,9 @@ mod test_cluster_scan_async {
         let mut count = 0;
         loop {
             count += 1;
-            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> =
-                connection.cluster_scan(scan_state_rc, None, None).await;
+            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> = connection
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
+                .await;
             if scan_response.is_err() {
                 println!("error: {:?}", scan_response);
             }
@@ -439,12 +498,13 @@ mod test_cluster_scan_async {
         }
         // Scan the keys
         let mut scan_state_rc = ScanStateRC::new();
-        let mut keys: Vec<String> = Vec::new();
+        let mut keys: Vec<String> = vec![];
         let mut count = 0;
         loop {
             count += 1;
-            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> =
-                connection.cluster_scan(scan_state_rc, None, None).await;
+            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> = connection
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
+                .await;
             if scan_response.is_err() {
                 println!("error: {:?}", scan_response);
             }
@@ -513,7 +573,7 @@ mod test_cluster_scan_async {
         let mut keys: Vec<String> = vec![];
         loop {
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc, None, None)
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
                 .await
                 .unwrap();
             scan_state_rc = next_cursor;
@@ -574,7 +634,7 @@ mod test_cluster_scan_async {
         let mut keys: Vec<String> = vec![];
         loop {
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc, None, None)
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
                 .await
                 .unwrap();
             scan_state_rc = next_cursor;
@@ -642,15 +702,20 @@ mod test_cluster_scan_async {
         let mut scan_state_rc = ScanStateRC::new();
         let mut keys: Vec<String> = vec![];
         loop {
+            let cluster_scan_args = ClusterScanArgs::builder()
+                .with_match_pattern("key:pattern:*")
+                .allow_non_covered_slots(false)
+                .build();
+
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan_with_pattern(scan_state_rc, "key:pattern:*", None, None)
+                .cluster_scan(scan_state_rc, cluster_scan_args)
                 .await
                 .unwrap();
             scan_state_rc = next_cursor;
             let mut scan_keys = scan_keys
                 .into_iter()
                 .map(|v| from_redis_value(&v).unwrap())
-                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+                .collect::<Vec<String>>();
             keys.append(&mut scan_keys);
             if scan_state_rc.is_finished() {
                 break;
@@ -665,7 +730,7 @@ mod test_cluster_scan_async {
         for key in expected_keys.iter() {
             assert!(keys.contains(key));
         }
-        assert!(keys.len() == expected_keys.len());
+        assert_eq!(keys.len(), expected_keys.len());
     }
 
     #[tokio::test]
@@ -701,15 +766,20 @@ mod test_cluster_scan_async {
         let mut scan_state_rc = ScanStateRC::new();
         let mut keys: Vec<String> = vec![];
         loop {
+            let cluster_scan_args = ClusterScanArgs::builder()
+                .with_object_type(ObjectType::Set)
+                .allow_non_covered_slots(false)
+                .build();
+
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc, None, Some(ObjectType::Set))
+                .cluster_scan(scan_state_rc, cluster_scan_args)
                 .await
                 .unwrap();
             scan_state_rc = next_cursor;
             let mut scan_keys = scan_keys
                 .into_iter()
                 .map(|v| from_redis_value(&v).unwrap())
-                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+                .collect::<Vec<String>>();
             keys.append(&mut scan_keys);
             if scan_state_rc.is_finished() {
                 break;
@@ -724,7 +794,7 @@ mod test_cluster_scan_async {
         for key in expected_keys.iter() {
             assert!(keys.contains(key));
         }
-        assert!(keys.len() == expected_keys.len());
+        assert_eq!(keys.len(), expected_keys.len());
     }
 
     #[tokio::test]
@@ -755,24 +825,35 @@ mod test_cluster_scan_async {
         let mut keys: Vec<String> = vec![];
         let mut comparing_times = 0;
         loop {
+            let cluster_scan_args = ClusterScanArgs::builder()
+                .with_count(100)
+                .allow_non_covered_slots(false)
+                .build();
+
+            let cluster_scan_args_no_count = ClusterScanArgs::builder()
+                .allow_non_covered_slots(false)
+                .build();
+
             let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc.clone(), Some(100), None)
+                .cluster_scan(scan_state_rc.clone(), cluster_scan_args)
                 .await
                 .unwrap();
+
             let (_, scan_without_count_keys): (ScanStateRC, Vec<Value>) = connection
-                .cluster_scan(scan_state_rc, Some(100), None)
+                .cluster_scan(scan_state_rc, cluster_scan_args_no_count)
                 .await
                 .unwrap();
+
             if !scan_keys.is_empty() && !scan_without_count_keys.is_empty() {
                 assert!(scan_keys.len() >= scan_without_count_keys.len());
-
                 comparing_times += 1;
             }
+
             scan_state_rc = next_cursor;
             let mut scan_keys = scan_keys
                 .into_iter()
                 .map(|v| from_redis_value(&v).unwrap())
-                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+                .collect::<Vec<String>>();
             keys.append(&mut scan_keys);
             if scan_state_rc.is_finished() {
                 break;
@@ -788,7 +869,7 @@ mod test_cluster_scan_async {
         for key in expected_keys.iter() {
             assert!(keys.contains(key));
         }
-        assert!(keys.len() == expected_keys.len());
+        assert_eq!(keys.len(), expected_keys.len());
     }
 
     #[tokio::test]
@@ -821,8 +902,9 @@ mod test_cluster_scan_async {
         let mut count = 0;
         loop {
             count += 1;
-            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> =
-                connection.cluster_scan(scan_state_rc, None, None).await;
+            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> = connection
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
+                .await;
             if scan_response.is_err() {
                 println!("error: {:?}", scan_response);
             }
@@ -835,7 +917,7 @@ mod test_cluster_scan_async {
             if count == 5 {
                 drop(cluster);
                 let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> = connection
-                    .cluster_scan(scan_state_rc.clone(), None, None)
+                    .cluster_scan(scan_state_rc.clone(), ClusterScanArgs::default())
                     .await;
                 assert!(scan_response.is_err());
                 break;
@@ -844,8 +926,9 @@ mod test_cluster_scan_async {
         cluster = TestClusterContext::new(3, 0);
         connection = cluster.async_connection(None).await;
         loop {
-            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> =
-                connection.cluster_scan(scan_state_rc, None, None).await;
+            let scan_response: RedisResult<(ScanStateRC, Vec<Value>)> = connection
+                .cluster_scan(scan_state_rc, ClusterScanArgs::default())
+                .await;
             if scan_response.is_err() {
                 println!("error: {:?}", scan_response);
             }
@@ -856,5 +939,247 @@ mod test_cluster_scan_async {
                 break;
             }
         }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    /// Test a case where a node is killed, key set into the cluster, and the client is still able to scan all keys
+    async fn test_async_cluster_scan_uncovered_slots_of_missing_node() {
+        // Create a cluster with 3 nodes
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| builder.retries(0),
+            false,
+        );
+        let mut connection = cluster.async_connection(None).await;
+
+        let mut config_cmd = cmd("CONFIG");
+        config_cmd
+            .arg("SET")
+            .arg("cluster-require-full-coverage")
+            .arg("no");
+        let _: RedisResult<Value> = connection
+            .route_command(
+                &config_cmd,
+                RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllNodes, None)),
+            )
+            .await;
+        // Kill one node
+        let mut cluster_nodes = cluster.get_cluster_nodes().await;
+        let slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+        let killed_node_routing = kill_one_node(&cluster, slot_distribution.clone()).await;
+        let ready = cluster.wait_for_fail_to_finish(&killed_node_routing).await;
+        match ready {
+            Ok(_) => {}
+            Err(e) => {
+                println!("error: {:?}", e);
+            }
+        }
+
+        // Compare slot distribution before and after killing a node
+        cluster_nodes = cluster.get_cluster_nodes().await;
+        let new_slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+        assert_ne!(slot_distribution, new_slot_distribution);
+        let mut excepted_keys: Vec<String> = vec![];
+        // Set some keys
+        for i in 0..100 {
+            let key = format!("key{}", i);
+            let res: Result<(), redis::RedisError> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+            if res.is_ok() {
+                excepted_keys.push(key);
+            }
+        }
+
+        // Scan the keys
+        let mut scan_state_rc = ScanStateRC::new();
+        let mut keys: Vec<String> = vec![];
+        let args = ClusterScanArgs::builder()
+            .allow_non_covered_slots(true)
+            .build();
+        loop {
+            let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
+                .cluster_scan(scan_state_rc, args.clone())
+                .await
+                .unwrap();
+            scan_state_rc = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_rc.is_finished() {
+                break;
+            }
+        }
+        // Check if all keys available scanned
+        keys.sort();
+        keys.dedup();
+        excepted_keys.sort();
+        excepted_keys.dedup();
+        for key in excepted_keys.iter() {
+            assert!(keys.contains(key));
+        }
+        assert!(keys.len() > 0);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    /// Test scanning after killing a node and compare with "KEYS *" from remaining nodes
+    async fn test_async_cluster_scan_after_node_killed() {
+        // Create a cluster with 3 nodes
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| builder.retries(0),
+            false,
+        );
+        let mut connection = cluster.async_connection(None).await;
+
+        // Set cluster-require-full-coverage to no
+        let mut config_cmd = cmd("CONFIG");
+        config_cmd
+            .arg("SET")
+            .arg("cluster-require-full-coverage")
+            .arg("no");
+        let _: RedisResult<Value> = connection
+            .route_command(
+                &config_cmd,
+                RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllNodes, None)),
+            )
+            .await;
+
+        for i in 0..100 {
+            let key = format!("key{}", i);
+            let _res: RedisResult<()> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+        }
+
+        // Kill one node
+        let cluster_nodes = cluster.get_cluster_nodes().await;
+        let slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+        let killed_node_routing = kill_one_node(&cluster, slot_distribution.clone()).await;
+        let ready = cluster.wait_for_fail_to_finish(&killed_node_routing).await;
+        match ready {
+            Ok(_) => {}
+            Err(e) => {
+                println!("error: {:?}", e);
+            }
+        }
+
+        // Scan the keys
+        let mut scan_state_rc = ScanStateRC::new();
+        let mut keys: Vec<String> = vec![];
+        let args = ClusterScanArgs::builder()
+            .allow_non_covered_slots(true)
+            .build();
+        loop {
+            let (next_cursor, scan_keys): (ScanStateRC, Vec<Value>) = connection
+                .cluster_scan(scan_state_rc, args.clone())
+                .await
+                .unwrap();
+            scan_state_rc = next_cursor;
+            let mut scan_keys = scan_keys
+                .into_iter()
+                .map(|v| from_redis_value(&v).unwrap())
+                .collect::<Vec<String>>(); // Change the type of `keys` to `Vec<String>`
+            keys.append(&mut scan_keys);
+            if scan_state_rc.is_finished() {
+                break;
+            }
+        }
+
+        // Get keys from remaining nodes using "KEYS *"
+        let mut keys_from_keys_command: Vec<String> = Vec::new();
+        let key_res: RedisResult<Value> = connection
+            .route_command(
+                cmd("KEYS").arg("*"),
+                RoutingInfo::MultiNode((
+                    MultipleNodeRoutingInfo::AllNodes,
+                    Some(ResponsePolicy::CombineArrays),
+                )),
+            )
+            .await;
+        if let Ok(value) = key_res {
+            let values: Vec<Value> = from_redis_value(&value).unwrap();
+            keys_from_keys_command
+                .extend(values.into_iter().map(|v| from_redis_value(&v).unwrap()));
+        }
+
+        // Sort and dedup keys
+        keys.sort();
+        keys.dedup();
+        keys_from_keys_command.sort();
+        keys_from_keys_command.dedup();
+
+        // Check if scanned keys match keys from "KEYS *"
+        assert_eq!(keys, keys_from_keys_command);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    /// Test scanning with allow_non_covered_slots as false after killing a node
+    async fn test_async_cluster_scan_uncovered_slots_fail() {
+        // Create a cluster with 3 nodes
+        let cluster = TestClusterContext::new_with_cluster_client_builder(
+            3,
+            0,
+            |builder| builder.retries(0),
+            false,
+        );
+        let mut connection = cluster.async_connection(None).await;
+
+        // Kill one node
+        let cluster_nodes = cluster.get_cluster_nodes().await;
+        let slot_distribution = cluster.get_slots_ranges_distribution(&cluster_nodes);
+        let killed_node_routing = kill_one_node(&cluster, slot_distribution.clone()).await;
+        let ready = cluster.wait_for_fail_to_finish(&killed_node_routing).await;
+        match ready {
+            Ok(_) => {}
+            Err(e) => {
+                println!("error: {:?}", e);
+            }
+        }
+
+        for i in 0..100 {
+            let key = format!("key{}", i);
+            let _res: RedisResult<()> = redis::cmd("SET")
+                .arg(&key)
+                .arg("value")
+                .query_async(&mut connection)
+                .await;
+        }
+
+        // Try scanning with allow_non_covered_slots as false
+        let mut scan_state_rc = ScanStateRC::new();
+        let mut had_error = false;
+        loop {
+            let result = connection
+                .cluster_scan(scan_state_rc.clone(), ClusterScanArgs::default())
+                .await;
+
+            match result {
+                Ok((next_cursor, _)) => {
+                    scan_state_rc = next_cursor;
+                    if scan_state_rc.is_finished() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    had_error = true;
+                    assert_eq!(e.kind(), redis::ErrorKind::NotAllSlotsCovered);
+                    break;
+                }
+            }
+        }
+
+        assert!(had_error);
     }
 }

--- a/glide-core/src/protobuf/command_request.proto
+++ b/glide-core/src/protobuf/command_request.proto
@@ -506,6 +506,7 @@ message ClusterScan {
     optional bytes match_pattern = 2;
     optional int64 count = 3;
     optional string object_type = 4;
+    bool allow_non_covered_slots = 5;
 }
 
 message UpdateConnectionPassword {

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -390,6 +390,7 @@ class CoreCommands(Protocol):
         match: Optional[TEncodable] = ...,
         count: Optional[int] = ...,
         type: Optional[ObjectType] = ...,
+        allow_non_covered_slots: bool = ...,
     ) -> TResult: ...
 
     async def _update_connection_password(

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -566,6 +566,7 @@ class GlideClusterClient(BaseClient, ClusterCommands):
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
         type: Optional[ObjectType] = None,
+        allow_non_covered_slots: bool = False,
     ) -> List[Union[ClusterScanCursor, List[bytes]]]:
         if self._is_closed:
             raise ClosingError(
@@ -576,6 +577,7 @@ class GlideClusterClient(BaseClient, ClusterCommands):
         # Take out the id string from the wrapping object
         cursor_string = cursor.get_cursor()
         request.cluster_scan.cursor = cursor_string
+        request.cluster_scan.allow_non_covered_slots = allow_non_covered_slots
         if match is not None:
             request.cluster_scan.match_pattern = (
                 self._encode_arg(match) if isinstance(match, str) else match

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -252,14 +252,16 @@ async def create_client(
     inflight_requests_limit: Optional[int] = None,
     read_from: ReadFrom = ReadFrom.PRIMARY,
     client_az: Optional[str] = None,
+    valkey_cluster: Optional[ValkeyCluster] = None,
 ) -> Union[GlideClient, GlideClusterClient]:
     # Create async socket client
     use_tls = request.config.getoption("--tls")
     if cluster_mode:
-        assert type(pytest.valkey_cluster) is ValkeyCluster
+        valkey_cluster = valkey_cluster or pytest.valkey_cluster
+        assert type(valkey_cluster) is ValkeyCluster
         assert database_id == 0
-        k = min(3, len(pytest.valkey_cluster.nodes_addr))
-        seed_nodes = random.sample(pytest.valkey_cluster.nodes_addr, k=k)
+        k = min(3, len(valkey_cluster.nodes_addr))
+        seed_nodes = random.sample(valkey_cluster.nodes_addr, k=k)
         cluster_config = GlideClusterClientConfiguration(
             addresses=seed_nodes if addresses is None else addresses,
             use_tls=use_tls,

--- a/python/python/tests/test_scan.py
+++ b/python/python/tests/test_scan.py
@@ -375,6 +375,7 @@ class TestScan:
                     in str(e_info)
                 )
                 break
+        cursor = ClusterScanCursor()
         # Scan with allow_non_covered_slots=True
         while not cursor.is_finished():
             result = await glide_client_scoped.scan(

--- a/python/python/tests/test_scan.py
+++ b/python/python/tests/test_scan.py
@@ -1,8 +1,9 @@
+
 import asyncio
 from typing import AsyncGenerator, List, cast
 
 import pytest
-from glide import ByAddressRoute
+from glide import AllNodes, AllPrimaries, ByAddressRoute
 from glide.async_commands.command_args import ObjectType
 from glide.config import ProtocolVersion
 from glide.exceptions import RequestError
@@ -17,40 +18,18 @@ from tests.utils.utils import get_random_string
 async def is_cluster_ready(client: GlideClusterClient, count: int) -> bool:
     # we allow max 20 seconds to get the nodes
     timeout = 20
-    start_time = asyncio.get_event_loop().time()
-
+    start = asyncio.get_event_loop().time()
     while True:
-        if asyncio.get_event_loop().time() - start_time > timeout:
+        if asyncio.get_event_loop().time() - start > timeout:
             return False
-
-        cluster_info = await client.custom_command(["CLUSTER", "INFO"])
-        cluster_info_map = {}
-
-        if cluster_info:
-            info_str = (
-                cluster_info
-                if isinstance(cluster_info, str)
-                else (
-                    cluster_info.decode()
-                    if isinstance(cluster_info, bytes)
-                    else str(cluster_info)
-                )
-            )
-            cluster_info_lines = info_str.split("\n")
-            cluster_info_lines = [line for line in cluster_info_lines if line]
-
-            for line in cluster_info_lines:
-                key, value = line.split(":")
-                cluster_info_map[key.strip()] = value.strip()
-
-            if (
-                cluster_info_map.get("cluster_state") == "ok"
-                and int(cluster_info_map.get("cluster_known_nodes", "0")) == count
-            ):
-                break
-
-        await asyncio.sleep(2)
-
+        nodes_raw = await client.custom_command(["CLUSTER", "NODES"])
+        node_bytes_raw = cast(bytes, nodes_raw)
+        parsed_nodes = [
+            line for line in node_bytes_raw.decode().split("\n") if line.strip()
+        ]
+        if len(parsed_nodes) == count:
+            break
+        await asyncio.sleep(1)
     return True
 
 
@@ -85,6 +64,7 @@ async def glide_client_scoped(
         True,
         valkey_cluster=function_scoped_cluster,
         protocol=protocol,
+        timeout=100,
     )
     assert isinstance(client, GlideClusterClient)
     yield client
@@ -339,8 +319,11 @@ class TestScan:
         glide_client_scoped: GlideClusterClient,
     ):
         key = get_random_string(10)
-        for i in range(1000):
-            await glide_client_scoped.set(f"{key}:{i}", "value")
+        for i in range(10000):
+            try:
+                await glide_client_scoped.set(f"{key}:{i}", "value")
+            except RequestError as e:
+                continue
         cursor = ClusterScanCursor()
         result = await glide_client_scoped.scan(cursor)
         cursor = cast(ClusterScanCursor, result[0])
@@ -360,22 +343,16 @@ class TestScan:
             )
         # now we let it few seconds gossip to get the new cluster configuration
         await is_cluster_ready(glide_client_scoped, len(all_other_addresses))
-        # Iterate scan until error is returned, as it might take time for the inner core to forget the missing node
+        # Iterate scan to get missing slots error
         cursor = ClusterScanCursor()
-        while True:
-            try:
-                while not cursor.is_finished():
-                    result = await glide_client_scoped.scan(cursor)
-                    cursor = cast(ClusterScanCursor, result[0])
-                # Reset cursor for next iteration
-                cursor = ClusterScanCursor()
-            except RequestError as e_info:
-                assert (
-                    "Could not find an address covering a slot, SCAN operation cannot continue"
-                    in str(e_info)
-                )
-                break
-        cursor = ClusterScanCursor()
+        with pytest.raises(RequestError) as e_info:
+            while not cursor.is_finished():
+                result = await glide_client_scoped.scan(cursor)
+                cursor = cast(ClusterScanCursor, result[0])
+        assert (
+            "Could not find an address covering a slot, SCAN operation cannot continue"
+            in str(e_info.value)
+        )
         # Scan with allow_non_covered_slots=True
         while not cursor.is_finished():
             result = await glide_client_scoped.scan(

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -1033,10 +1033,7 @@ class TestTransaction:
         assert result[5:13] == [2, 2, 2, [b"Bob", b"Alice"], 2, OK, None, 0]
         assert result[13:] == expected
 
-    @pytest.mark.filterwarnings(
-        action="ignore", message="The test <Function test_transaction_clear>"
-    )
-    def test_transaction_clear(self):
+    async def test_transaction_clear(self):
         transaction = Transaction()
         transaction.info()
         transaction.select(1)


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This pull request focuses on refactoring and simplifying the `cluster_scan` functionality in the `glide-core/redis-rs` library and adding allow non cover slots functionality to the core and py. Other important changes include removing redundant methods, consolidating the `cluster_scan` functions, and updating the related tests.

Refactoring and simplification:

* [`glide-core/redis-rs/redis/src/cluster_async/mod.rs`](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL145-R154): Removed the `cluster_scan_with_pattern` method and consolidated its functionality into the `cluster_scan` method. Updated the `cluster_scan` method to use the `ClusterScanArgs` struct for arguments. [[1]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL145-R154) [[2]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL254-R197)
* [`glide-core/redis-rs/redis/src/cluster_async/mod.rs`](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL492-R426): Removed redundant methods such as `get_address_from_slot` and `check_if_all_slots_covered`. Renamed methods for clarity, e.g., `get_address_epoch` to `address_epoch` and `get_slots_of_address` to `slots_of_address`. [[1]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL492-R426) [[2]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL1887-L1894) [[3]](diffhunk://#diff-9c3e4d9638d5611e8d51d6b4be0bdc67218c0216d0eb349874dddca560ad17e1L205-R205) [[4]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL544-R483)

Error handling improvements:

* [`glide-core/redis-rs/redis/src/cluster_async/mod.rs`](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL282-R224): Enhanced error messages for better clarity when sending and receiving commands in the `map_err` and `unwrap_or_else` methods. [[1]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL282-R224) [[2]](diffhunk://#diff-75c8b034d9c8c02514ee9481ea89ba896f0d6ba79831ad28f91630b454aff53bL319-R263)

Test updates:

* [`glide-core/redis-rs/redis/tests/test_cluster_scan.rs`](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L8-R13): Updated tests to use the new `ClusterScanArgs` struct and added tests for scanning with slot migration and handling missing slots. [[1]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L8-R13) [[2]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L52-R61) [[3]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L70-R86) [[4]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L94-R108) [[5]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L117-R131) [[6]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769R206-R220) [[7]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769R245-R285) [[8]](diffhunk://#diff-688e10e8c97177d1b024cffcd4cc7452afe2c06858b76941b0d45a4200b49769L271-R331)

These changes aim to streamline the codebase, improve error handling, and ensure the tests are up-to-date with the new functionality.
### Issue link

This Pull Request is linked to issue https://github.com/valkey-io/valkey-glide/issues/2436

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
