### PR TITLE
remove native package references for MacOS x64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 #### Changes
+
 * Java: Bump protobuf (protoc) version ([#2561](https://github.com/valkey-io/valkey-glide/pull/2561), [#2802](https://github.com/valkey-io/valkey-glide/pull/2802)
 * Java: bump `netty` version ([#2777](https://github.com/valkey-io/valkey-glide/pull/2777))
+* Node: Remove native package references for MacOs x64 architecture ([#2799](https://github.com/valkey-io/valkey-glide/issues/2799))
 
 #### Breaking Changes
 
@@ -13,6 +15,7 @@
 ## 1.2.0 (2024-11-27)
 
 #### Changes
+
 * Node: Client API for retrieving internal statistics ([#2727](https://github.com/valkey-io/valkey-glide/pull/2727))
 * Python: Client API for retrieving internal statistics ([#2707](https://github.com/valkey-io/valkey-glide/pull/2707))
 * Node, Python, Java: Adding support for replacing connection configured password ([#2651](https://github.com/valkey-io/valkey-glide/pull/2651), [#2659](https://github.com/valkey-io/valkey-glide/pull/2659), [#2677](https://github.com/valkey-io/valkey-glide/pull/2677))
@@ -107,7 +110,9 @@
 
 #### Breaking Changes
 
+
 #### Fixes
+
 * Core: UDS Socket Handling Rework ([#2482](https://github.com/valkey-io/valkey-glide/pull/2482))
 
 #### Operational Enhancements

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -53,9 +53,6 @@ function loadNativeBinding() {
             break;
         case "darwin":
             switch (arch) {
-                case "x64":
-                    nativeBinding = require("@scope/valkey-glide-darwin-x64");
-                    break;
                 case "arm64":
                     nativeBinding = require("@scope/valkey-glide-darwin-arm64");
                     break;

--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -41,7 +41,6 @@
     },
     "optionalDependencies": {
         "${scope}valkey-glide-darwin-arm64": "${package_version}",
-        "${scope}valkey-glide-darwin-x64": "${package_version}",
         "${scope}valkey-glide-linux-arm64": "${package_version}",
         "${scope}valkey-glide-linux-x64": "${package_version}",
         "${scope}valkey-glide-linux-musl-arm64": "${package_version}",


### PR DESCRIPTION
This change removes the native package reference in package.json and updates the npm/glide index file to remove the native binding for the Darwin-x64 package which was removed in the Valkey-Glide 1.2.0 release.

### Issue link

This Pull Request resolves issue (https://github.com/valkey-io/valkey-glide/issues/2799).

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Commits will be squashed upon merging.
