### PR TITLE
Go: Add ZPopMin and ZPopMax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Go: Add `ZIncrBy` command ([#2830](https://github.com/valkey-io/valkey-glide/pull/2830))
 * Go: Add `SScan` and `SMove` ([#2789](https://github.com/valkey-io/valkey-glide/issues/2789))
 * Go: Add `ZADD` ([#2813](https://github.com/valkey-io/valkey-glide/issues/2813))
-* Go: Add `ZPopMin` and `ZPopMax` ([#TBD](https://github.com/valkey-io/valkey-glide/pull/TBD))
+* Go: Add `ZPopMin` and `ZPopMax` ([#2850](https://github.com/valkey-io/valkey-glide/pull/2850))
 
 #### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Go: Add `ZIncrBy` command ([#2830](https://github.com/valkey-io/valkey-glide/pull/2830))
 * Go: Add `SScan` and `SMove` ([#2789](https://github.com/valkey-io/valkey-glide/issues/2789))
 * Go: Add `ZADD` ([#2813](https://github.com/valkey-io/valkey-glide/issues/2813))
+* Go: Add `ZPopMin` and `ZPopMax` ([#TBD](https://github.com/valkey-io/valkey-glide/pull/TBD))
 
 #### Breaking Changes
 

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -1316,3 +1316,35 @@ func (client *baseClient) ZIncrBy(key string, increment float64, member string) 
 
 	return handleDoubleResponse(result)
 }
+
+func (client *baseClient) ZPopMin(key string) (map[Result[string]]Result[string], error) {
+	result, err := client.executeCommand(C.ZPopMin, []string{key})
+	if err != nil {
+		return nil, err
+	}
+	return handleStringToStringMapResponse(result)
+}
+
+func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[string], error) {
+	result, err := client.executeCommand(C.ZPopMin, []string{key, utils.IntToString(count)})
+	if err != nil {
+		return nil, err
+	}
+	return handleStringToStringMapResponse(result)
+}
+
+func (client *baseClient) ZPopMax(key string) (map[Result[string]]Result[string], error) {
+	result, err := client.executeCommand(C.ZPopMax, []string{key})
+	if err != nil {
+		return nil, err
+	}
+	return handleStringToStringMapResponse(result)
+}
+
+func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[string], error) {
+	result, err := client.executeCommand(C.ZPopMax, []string{key, utils.IntToString(count)})
+	if err != nil {
+		return nil, err
+	}
+	return handleStringToStringMapResponse(result)
+}

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -1317,34 +1317,34 @@ func (client *baseClient) ZIncrBy(key string, increment float64, member string) 
 	return handleDoubleResponse(result)
 }
 
-func (client *baseClient) ZPopMin(key string) (map[Result[string]]Result[string], error) {
+func (client *baseClient) ZPopMin(key string) (map[Result[string]]Result[float64], error) {
 	result, err := client.executeCommand(C.ZPopMin, []string{key})
 	if err != nil {
 		return nil, err
 	}
-	return handleStringToStringMapResponse(result)
+	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[string], error) {
+func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[float64], error) {
 	result, err := client.executeCommand(C.ZPopMin, []string{key, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
 	}
-	return handleStringToStringMapResponse(result)
+	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZPopMax(key string) (map[Result[string]]Result[string], error) {
+func (client *baseClient) ZPopMax(key string) (map[Result[string]]Result[float64], error) {
 	result, err := client.executeCommand(C.ZPopMax, []string{key})
 	if err != nil {
 		return nil, err
 	}
-	return handleStringToStringMapResponse(result)
+	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[string], error) {
+func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[float64], error) {
 	result, err := client.executeCommand(C.ZPopMax, []string{key, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
 	}
-	return handleStringToStringMapResponse(result)
+	return handleStringDoubleMapResponse(result)
 }

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -300,6 +300,8 @@ func handleBooleanArrayResponse(response *C.struct_CommandResponse) ([]Result[bo
 }
 
 func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[Result[string]]Result[float64], error) {
+	defer C.free_command_response(response)
+
 	typeErr := checkResponseType(response, C.Map, false)
 	if typeErr != nil {
 		return nil, typeErr
@@ -311,10 +313,11 @@ func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[Resu
 		if err != nil {
 			return nil, err
 		}
-		value, err := handleDoubleResponse(v.map_value)
-		if err != nil {
-			return nil, err
+		typeErr := checkResponseType(v.map_value, C.Float, false)
+		if typeErr != nil {
+			return nil, typeErr
 		}
+		value := CreateFloat64Result(float64(v.map_value.float_value))
 		m[key] = value
 	}
 	return m, nil

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -299,6 +299,27 @@ func handleBooleanArrayResponse(response *C.struct_CommandResponse) ([]Result[bo
 	return slice, nil
 }
 
+func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[Result[string]]Result[float64], error) {
+	typeErr := checkResponseType(response, C.Map, false)
+	if typeErr != nil {
+		return nil, typeErr
+	}
+
+	m := make(map[Result[string]]Result[float64], response.array_value_len)
+	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
+		key, err := convertCharArrayToString(v.map_key, true)
+		if err != nil {
+			return nil, err
+		}
+		value, err := handleDoubleResponse(v.map_value)
+		if err != nil {
+			return nil, err
+		}
+		m[key] = value
+	}
+	return m, nil
+}
+
 func handleStringToStringMapResponse(response *C.struct_CommandResponse) (map[Result[string]]Result[string], error) {
 	defer C.free_command_response(response)
 

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -110,4 +110,86 @@ type SortedSetCommands interface {
 	//
 	// [valkey.io]: https://valkey.io/commands/zincrby/
 	ZIncrBy(key string, increment float64, member string) (Result[float64], error)
+
+	// Removes and returns the member with the lowest score from the sorted set
+	// stored at the specified `key`.
+	//
+	// see [valkey.io] for details.
+	//
+	// Parameters:
+	//   key - The key of the sorted set.
+	//
+	// Return value:
+	//   A map containing the removed member and its corresponding score.
+	//   If `key` doesn't exist, it will be treated as an empty sorted set and the
+	//   command returns an empty map.
+	//
+	// Example:
+	//   res, err := client.zpopmin("mySortedSet")
+	//   fmt.Println(res.Value()) // Output: map["member1":5.0]
+	//
+	// [valkey.io]: https://valkey.io/commands/zpopmin/
+	ZPopMin(key string) (map[Result[string]]Result[string], error)
+
+	// Removes and returns up to `count` members with the lowest scores from the sorted set
+	// stored at the specified `key`.
+	//
+	// see [valkey.io] for details.
+	//
+	// Parameters:
+	//   key - The key of the sorted set.
+	//   count - The number of members to remove.
+	//
+	// Return value:
+	//   A map containing the removed members and their corresponding scores.
+	//   If `key` doesn't exist, it will be treated as an empty sorted set and the
+	//   command returns an empty map.
+	//
+	// Example:
+	//   res, err := client.ZPopMinWithCount("mySortedSet", 2)
+	//   fmt.Println(res.Value()) // Output: map["member1":5.0, "member2":6.0]
+	//
+	// [valkey.io]: https://valkey.io/commands/zpopmin/
+	ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[string], error)
+
+	// Removes and returns the member with the highest score from the sorted set stored at the
+	// specified `key`.
+	//
+	// see [valkey.io] for details.
+	//
+	// Parameters:
+	//   key - The key of the sorted set.
+	//
+	// Return value:
+	//   A map containing the removed member and its corresponding score.
+	//   If `key` doesn't exist, it will be treated as an empty sorted set and the
+	//   command returns an empty map.
+	//
+	// Example:
+	//   res, err := client.zpopmax("mySortedSet")
+	//   fmt.Println(res.Value()) // Output: map["member2":8.0]
+	//
+	// [valkey.io]: https://valkey.io/commands/zpopmin/
+	ZPopMax(key string) (map[Result[string]]Result[string], error)
+
+	// Removes and returns up to `count` members with the highest scores from the sorted set
+	// stored at the specified `key`.
+	//
+	// see [valkey.io] for details.
+	//
+	// Parameters:
+	//   key - The key of the sorted set.
+	//   count - The number of members to remove.
+	//
+	// Return value:
+	//   A map containing the removed members and their corresponding scores.
+	//   If `key` doesn't exist, it will be treated as an empty sorted set and the
+	//   command returns an empty map.
+	//
+	// Example:
+	//   res, err := client.ZPopMaxWithCount("mySortedSet", 2)
+	//   fmt.Println(res.Value()) // Output: map["member1":5.0, "member2":6.0]
+	//
+	// [valkey.io]: https://valkey.io/commands/zpopmin/
+	ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[string], error)
 }

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -129,7 +129,7 @@ type SortedSetCommands interface {
 	//   fmt.Println(res.Value()) // Output: map["member1":5.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMin(key string) (map[Result[string]]Result[string], error)
+	ZPopMin(key string) (map[Result[string]]Result[float64], error)
 
 	// Removes and returns up to `count` members with the lowest scores from the sorted set
 	// stored at the specified `key`.
@@ -150,7 +150,7 @@ type SortedSetCommands interface {
 	//   fmt.Println(res.Value()) // Output: map["member1":5.0, "member2":6.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[string], error)
+	ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[float64], error)
 
 	// Removes and returns the member with the highest score from the sorted set stored at the
 	// specified `key`.
@@ -170,7 +170,7 @@ type SortedSetCommands interface {
 	//   fmt.Println(res.Value()) // Output: map["member2":8.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMax(key string) (map[Result[string]]Result[string], error)
+	ZPopMax(key string) (map[Result[string]]Result[float64], error)
 
 	// Removes and returns up to `count` members with the highest scores from the sorted set
 	// stored at the specified `key`.
@@ -191,5 +191,5 @@ type SortedSetCommands interface {
 	//   fmt.Println(res.Value()) // Output: map["member1":5.0, "member2":6.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[string], error)
+	ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[float64], error)
 }

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3980,19 +3980,21 @@ func (suite *GlideTestSuite) TestZPopMin() {
 			"two":   2.0,
 			"three": 3.0,
 		}
+
 		res, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), int64(3), res.Value())
+
 		res2, err := client.ZPopMin(key1)
 		assert.Nil(suite.T(), err)
 		assert.Len(suite.T(), res2, 1)
-		assert.Equal(suite.T(), "1.0", res2[api.CreateStringResult("one")].Value())
+		assert.Equal(suite.T(), float64(1.0), res2[api.CreateStringResult("one")].Value())
 
 		res3, err := client.ZPopMinWithCount(key1, 2)
 		assert.Nil(suite.T(), err)
 		assert.Len(suite.T(), res3, 2)
-		assert.Equal(suite.T(), "2.0", res3[api.CreateStringResult("two")].Value())
-		assert.Equal(suite.T(), "3.0", res3[api.CreateStringResult("three")].Value())
+		assert.Equal(suite.T(), float64(2.0), res3[api.CreateStringResult("two")].Value())
+		assert.Equal(suite.T(), float64(3.0), res3[api.CreateStringResult("three")].Value())
 
 		// non sorted set key
 		_, err = client.Set(key2, "test")
@@ -4013,23 +4015,20 @@ func (suite *GlideTestSuite) TestZPopMax() {
 			"two":   2.0,
 			"three": 3.0,
 		}
-		resultMap1 := map[api.Result[string]]api.Result[string]{
-			api.CreateStringResult("three"): api.CreateStringResult("3.0"),
-		}
-		resultMap2 := map[api.Result[string]]api.Result[string]{
-			api.CreateStringResult("one"): api.CreateStringResult("1.0"),
-			api.CreateStringResult("two"): api.CreateStringResult("2.0"),
-		}
-		_, err := client.ZAdd(key1, memberScoreMap)
+		res, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), int64(3), res.Value())
 
 		res2, err := client.ZPopMax(key1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultMap1, res2)
+		assert.Len(suite.T(), res2, 1)
+		assert.Equal(suite.T(), float64(3.0), res2[api.CreateStringResult("three")].Value())
 
 		res3, err := client.ZPopMaxWithCount(key1, 2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultMap2, res3)
+		assert.Len(suite.T(), res3, 2)
+		assert.Equal(suite.T(), float64(2.0), res3[api.CreateStringResult("two")].Value())
+		assert.Equal(suite.T(), float64(1.0), res3[api.CreateStringResult("one")].Value())
 
 		// non sorted set key
 		_, err = client.Set(key2, "test")

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -4018,11 +4018,11 @@ func (suite *GlideTestSuite) TestZPopMax() {
 			"three": 3.0,
 		}
 		resultMap1 := map[api.Result[string]]api.Result[string]{
-			api.CreateStringResult("one"): api.CreateStringResult("3.0"),
+			api.CreateStringResult("three"): api.CreateStringResult("3.0"),
 		}
 		resultMap2 := map[api.Result[string]]api.Result[string]{
-			api.CreateStringResult("two"):   api.CreateStringResult("1.0"),
-			api.CreateStringResult("three"): api.CreateStringResult("2.0"),
+			api.CreateStringResult("one"): api.CreateStringResult("1.0"),
+			api.CreateStringResult("two"): api.CreateStringResult("2.0"),
 		}
 		_, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3980,9 +3980,9 @@ func (suite *GlideTestSuite) TestZPopMin() {
 			"two":   2.0,
 			"three": 3.0,
 		}
-		_, err := client.ZAdd(key1, memberScoreMap)
+		res, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)
-
+		assert.Equal(suite.T(), int64(3), res.Value())
 		res2, err := client.ZPopMin(key1)
 		assert.Nil(suite.T(), err)
 		assert.Len(suite.T(), res2, 1)

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3970,3 +3970,77 @@ func (suite *GlideTestSuite) TestZincrBy() {
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
 }
+
+func (suite *GlideTestSuite) TestZPopMin() {
+	suite.runWithDefaultClients(func(client api.BaseClient) {
+		key1 := uuid.New().String()
+		key2 := uuid.New().String()
+		memberScoreMap := map[string]float64{
+			"one":   1.0,
+			"two":   2.0,
+			"three": 3.0,
+		}
+		resultMap1 := map[api.Result[string]]api.Result[string]{
+			api.CreateStringResult("one"): api.CreateStringResult("1.0"),
+		}
+		resultMap2 := map[api.Result[string]]api.Result[string]{
+			api.CreateStringResult("two"):   api.CreateStringResult("2.0"),
+			api.CreateStringResult("three"): api.CreateStringResult("3.0"),
+		}
+		_, err := client.ZAdd(key1, memberScoreMap)
+		assert.Nil(suite.T(), err)
+
+		res2, err := client.ZPopMin(key1)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), resultMap1, res2)
+
+		res3, err := client.ZPopMinWithCount(key1, 2)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), resultMap2, res3)
+
+		// non sorted set key
+		_, err = client.Set(key2, "test")
+		assert.Nil(suite.T(), err)
+
+		_, err = client.ZPopMin(key2)
+		assert.NotNil(suite.T(), err)
+		assert.IsType(suite.T(), &api.RequestError{}, err)
+	})
+}
+
+func (suite *GlideTestSuite) TestZPopMax() {
+	suite.runWithDefaultClients(func(client api.BaseClient) {
+		key1 := uuid.New().String()
+		key2 := uuid.New().String()
+		memberScoreMap := map[string]float64{
+			"one":   1.0,
+			"two":   2.0,
+			"three": 3.0,
+		}
+		resultMap1 := map[api.Result[string]]api.Result[string]{
+			api.CreateStringResult("one"): api.CreateStringResult("3.0"),
+		}
+		resultMap2 := map[api.Result[string]]api.Result[string]{
+			api.CreateStringResult("two"):   api.CreateStringResult("1.0"),
+			api.CreateStringResult("three"): api.CreateStringResult("2.0"),
+		}
+		_, err := client.ZAdd(key1, memberScoreMap)
+		assert.Nil(suite.T(), err)
+
+		res2, err := client.ZPopMax(key1)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), resultMap1, res2)
+
+		res3, err := client.ZPopMaxWithCount(key1, 2)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), resultMap2, res3)
+
+		// non sorted set key
+		_, err = client.Set(key2, "test")
+		assert.Nil(suite.T(), err)
+
+		_, err = client.ZPopMax(key2)
+		assert.NotNil(suite.T(), err)
+		assert.IsType(suite.T(), &api.RequestError{}, err)
+	})
+}

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3980,23 +3980,19 @@ func (suite *GlideTestSuite) TestZPopMin() {
 			"two":   2.0,
 			"three": 3.0,
 		}
-		resultMap1 := map[api.Result[string]]api.Result[string]{
-			api.CreateStringResult("one"): api.CreateStringResult("1.0"),
-		}
-		resultMap2 := map[api.Result[string]]api.Result[string]{
-			api.CreateStringResult("two"):   api.CreateStringResult("2.0"),
-			api.CreateStringResult("three"): api.CreateStringResult("3.0"),
-		}
 		_, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)
 
 		res2, err := client.ZPopMin(key1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultMap1, res2)
+		assert.Len(suite.T(), res2, 1)
+		assert.Equal(suite.T(), "1.0", res2[api.CreateStringResult("one")].Value())
 
 		res3, err := client.ZPopMinWithCount(key1, 2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultMap2, res3)
+		assert.Len(suite.T(), res3, 2)
+		assert.Equal(suite.T(), "2.0", res3[api.CreateStringResult("two")].Value())
+		assert.Equal(suite.T(), "3.0", res3[api.CreateStringResult("three")].Value())
 
 		// non sorted set key
 		_, err = client.Set(key2, "test")


### PR DESCRIPTION
Adding command Zpopmin and zpopmax for the go wrapper

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2833

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Commits will be squashed upon merging.
