### PR TITLE
Go: Add base scan options for hscan

### DIFF
--- a/go/api/options/base_scan_options.go
+++ b/go/api/options/base_scan_options.go
@@ -1,0 +1,59 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package options
+
+import (
+	"strconv"
+)
+
+const (
+	CountKeyword string = "COUNT" // Valkey API keyword used to extract specific number of matching indices from a list.
+	MatchKeyword string = "MATCH" // Valkey API keyword used to indicate the match filter.
+)
+
+// This base option struct represents the common set of optional arguments for the SCAN family of commands.
+// Concrete implementations of this class are tied to specific SCAN commands (`SCAN`, `SSCAN`).
+type BaseScanOptions struct {
+	/**
+	 * The match filter is applied to the result of the command and will only include
+	 * strings that match the pattern specified. If the sorted set is large enough for scan commands to return
+	 * only a subset of the sorted set then there could be a case where the result is empty although there are
+	 * items that match the pattern specified. This is due to the default `COUNT` being `10` which indicates
+	 * that it will only fetch and match `10` items from the list.
+	 */
+	match string
+	/**
+	 * `COUNT` is a just a hint for the command for how many elements to fetch from the
+	 * sorted set. `COUNT` could be ignored until the sorted set is large enough for the `SCAN` commands to
+	 * represent the results as compact single-allocation packed encoding.
+	 */
+	count int64
+}
+
+func NewBaseScanOptionsBuilder() *BaseScanOptions {
+	return &BaseScanOptions{}
+}
+
+func (scanOptions *BaseScanOptions) SetMatch(m string) *BaseScanOptions {
+	scanOptions.match = m
+	return scanOptions
+}
+
+func (scanOptions *BaseScanOptions) SetCount(c int64) *BaseScanOptions {
+	scanOptions.count = c
+	return scanOptions
+}
+
+func (opts *BaseScanOptions) toArgs() ([]string, error) {
+	args := []string{}
+	var err error
+	if opts.match != "" {
+		args = append(args, MatchKeyword, opts.match)
+	}
+
+	if opts.count != 0 {
+		args = append(args, CountKeyword, strconv.FormatInt(opts.count, 10))
+	}
+
+	return args, err
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
### Description
Refactoring changes:
1. Move BaseScanOptions to a separate file: options/base_scan_options.go to use as an embedding in other commands.

### Issue link

This Pull Request is linked to issue (URL): #2832 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.
