### PR TITLE
Safer wrapping for FFI clients.

### DIFF
--- a/csharp/lib/src/lib.rs
+++ b/csharp/lib/src/lib.rs
@@ -7,6 +7,7 @@ use redis::{FromRedisValue, RedisResult};
 use std::{
     ffi::{c_void, CStr, CString},
     os::raw::c_char,
+    sync::Arc,
 };
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;
@@ -21,10 +22,14 @@ pub enum Level {
 }
 
 pub struct Client {
+    runtime: Runtime,
+    core: Arc<CommandExecutionCore>,
+}
+
+struct CommandExecutionCore {
     client: GlideClient,
     success_callback: unsafe extern "C" fn(usize, *const c_char) -> (),
     failure_callback: unsafe extern "C" fn(usize) -> (), // TODO - add specific error codes
-    runtime: Runtime,
 }
 
 fn create_connection_request(host: String, port: u32, use_tls: bool) -> client::ConnectionRequest {
@@ -60,15 +65,16 @@ fn create_client_internal(
         .build()?;
     let _runtime_handle = runtime.enter();
     let client = runtime.block_on(GlideClient::new(request, None)).unwrap(); // TODO - handle errors.
-    Ok(Client {
-        client,
+    let core = Arc::new(CommandExecutionCore {
         success_callback,
         failure_callback,
-        runtime,
-    })
+        client,
+    });
+    Ok(Client { runtime, core })
 }
 
-/// Creates a new client to the given address. The success callback needs to copy the given string synchronously, since it will be dropped by Rust once the callback returns. All callbacks should be offloaded to separate threads in order not to exhaust the client's thread pool.
+/// Creates a new client to the given address. The success callback needs to copy the given string synchronously, since it will be dropped by Rust once the callback returns.
+/// All callbacks should be offloaded to separate threads in order not to exhaust the client's thread pool.
 #[no_mangle]
 pub extern "C" fn create_client(
     host: *const c_char,
@@ -79,38 +85,48 @@ pub extern "C" fn create_client(
 ) -> *const c_void {
     match create_client_internal(host, port, use_tls, success_callback, failure_callback) {
         Err(_) => std::ptr::null(), // TODO - log errors
-        Ok(client) => Box::into_raw(Box::new(client)) as *const c_void,
+        Ok(client) => Arc::into_raw(Arc::new(client)) as *const c_void,
     }
 }
 
+/// # Safety
+///
+/// This function should only be called once per pointer created by [create_client]. After calling this function
+/// the `client_ptr` is not in a valid state.
 #[no_mangle]
-pub extern "C" fn close_client(client_ptr: *const c_void) {
-    let client_ptr = unsafe { Box::from_raw(client_ptr as *mut Client) };
-    let _runtime_handle = client_ptr.runtime.enter();
-    drop(client_ptr);
+pub extern "C" fn close_client(client_adapter_ptr: *const c_void) {
+    assert!(!client_adapter_ptr.is_null());
+    // This will bring the strong count down to 0 once all client requests are done.
+    unsafe { Arc::decrement_strong_count(client_adapter_ptr as *const Client) };
 }
 
 /// Expects that key and value will be kept valid until the callback is called.
+///
+/// # Safety
+///
+/// This function should only be called should with a pointer created by [create_client], before [close_client] was called with the pointer.
 #[no_mangle]
-pub extern "C" fn command(
+pub unsafe extern "C" fn command(
     client_ptr: *const c_void,
     callback_index: usize,
     request_type: RequestType,
     args: *const *mut c_char,
     arg_count: u32,
 ) {
-    let client = unsafe { Box::leak(Box::from_raw(client_ptr as *mut Client)) };
+    let client = unsafe {
+        // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
+        Arc::increment_strong_count(client_ptr);
+        Arc::from_raw(client_ptr as *mut Client)
+    };
 
     // The safety of these needs to be ensured by the calling code. Cannot dispose of the pointer before all operations have completed.
-    let ptr_address = client_ptr as usize;
     let args_address = args as usize;
 
-    let mut client_clone = client.client.clone();
+    let core = client.core.clone();
     client.runtime.spawn(async move {
         let Some(mut cmd) = request_type.get_command() else {
             unsafe {
-                let client = Box::leak(Box::from_raw(ptr_address as *mut Client));
-                (client.failure_callback)(callback_index); // TODO - report errors
+                (core.failure_callback)(callback_index); // TODO - report errors
                 return;
             }
         };
@@ -123,16 +139,17 @@ pub extern "C" fn command(
             cmd.arg(c_str.to_bytes());
         }
 
-        let result = client_clone
+        let result = core
+            .client
+            .clone()
             .send_command(&cmd, None)
             .await
             .and_then(Option::<CString>::from_owned_redis_value);
         unsafe {
-            let client = Box::leak(Box::from_raw(ptr_address as *mut Client));
             match result {
-                Ok(None) => (client.success_callback)(callback_index, std::ptr::null()),
-                Ok(Some(c_str)) => (client.success_callback)(callback_index, c_str.as_ptr()),
-                Err(_) => (client.failure_callback)(callback_index), // TODO - report errors
+                Ok(None) => (core.success_callback)(callback_index, std::ptr::null()),
+                Ok(Some(c_str)) => (core.success_callback)(callback_index, c_str.as_ptr()),
+                Err(_) => (core.failure_callback)(callback_index), // TODO - report errors
             };
         }
     });

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -189,8 +189,8 @@ fn create_client_internal(
 ///
 /// * `connection_request_bytes` must point to `connection_request_len` consecutive properly initialized bytes. It must be a well-formed Protobuf `ConnectionRequest` object. The array must be allocated by the caller and subsequently freed by the caller after this function returns.
 /// * `connection_request_len` must not be greater than the length of the connection request bytes array. It must also not be greater than the max value of a signed pointer-sized integer.
-/// * The `conn_ptr` pointer in the returned `ConnectionResponse` must live while the client is open/active and must be explicitly freed by calling [close_client].
-/// * The `connection_error_message` pointer in the returned `ConnectionResponse` must live until the returned `ConnectionResponse` pointer is passed to [free_connection_response].
+/// * The `conn_ptr` pointer in the returned `ConnectionResponse` must live while the client is open/active and must be explicitly freed by calling [`close_client``].
+/// * The `connection_error_message` pointer in the returned `ConnectionResponse` must live until the returned `ConnectionResponse` pointer is passed to [`free_connection_response``].
 /// * Both the `success_callback` and `failure_callback` function pointers need to live while the client is open/active. The caller is responsible for freeing both callbacks.
 // TODO: Consider making this async
 #[no_mangle]
@@ -229,9 +229,8 @@ pub unsafe extern "C" fn create_client(
 ///
 /// * `close_client` can only be called once per client. Calling it twice is undefined behavior, since the address will be freed twice.
 /// * `close_client` must be called after `free_connection_response` has been called to avoid creating a dangling pointer in the `ConnectionResponse`.
-/// * `client_adapter_ptr` must be obtained from the `ConnectionResponse` returned from [create_client].
+/// * `client_adapter_ptr` must be obtained from the `ConnectionResponse` returned from [`create_client`].
 /// * `client_adapter_ptr` must be valid until `close_client` is called.
-// TODO: Ensure safety when command has not completed yet
 #[no_mangle]
 pub unsafe extern "C" fn close_client(client_adapter_ptr: *const c_void) {
     assert!(!client_adapter_ptr.is_null());
@@ -512,7 +511,7 @@ fn valkey_value_to_command_response(value: Value) -> RedisResult<CommandResponse
 ///
 /// # Safety
 ///
-/// This function should only be called should with a pointer created by [create_client], before [close_client] was called with the pointer.
+/// This function should only be called should with a pointer created by [`create_client`], before [`close_client`] was called with the pointer.
 #[no_mangle]
 pub unsafe extern "C" fn command(
     client_adapter_ptr: *const c_void,

--- a/go/src/lib.rs
+++ b/go/src/lib.rs
@@ -22,6 +22,7 @@ use redis::{Cmd, RedisResult, Value};
 use std::ffi::CStr;
 use std::slice::from_raw_parts;
 use std::str;
+use std::sync::Arc;
 use std::{
     ffi::{c_void, CString},
     mem,
@@ -136,13 +137,15 @@ pub struct ConnectionResponse {
 }
 
 /// A `GlideClient` adapter.
-// TODO: Remove allow(dead_code) once connection logic is implemented
-#[allow(dead_code)]
 pub struct ClientAdapter {
-    client: GlideClient,
+    runtime: Runtime,
+    core: Arc<CommandExecutionCore>,
+}
+
+struct CommandExecutionCore {
     success_callback: SuccessCallback,
     failure_callback: FailureCallback,
-    runtime: Runtime,
+    client: GlideClient,
 }
 
 fn create_client_internal(
@@ -165,12 +168,12 @@ fn create_client_internal(
     let client = runtime
         .block_on(GlideClient::new(ConnectionRequest::from(request), None))
         .map_err(|err| err.to_string())?;
-    Ok(ClientAdapter {
-        client,
+    let core = Arc::new(CommandExecutionCore {
         success_callback,
         failure_callback,
-        runtime,
-    })
+        client,
+    });
+    Ok(ClientAdapter { runtime, core })
 }
 
 /// Creates a new `ClientAdapter` with a new `GlideClient` configured using a Protobuf `ConnectionRequest`.
@@ -186,8 +189,8 @@ fn create_client_internal(
 ///
 /// * `connection_request_bytes` must point to `connection_request_len` consecutive properly initialized bytes. It must be a well-formed Protobuf `ConnectionRequest` object. The array must be allocated by the caller and subsequently freed by the caller after this function returns.
 /// * `connection_request_len` must not be greater than the length of the connection request bytes array. It must also not be greater than the max value of a signed pointer-sized integer.
-/// * The `conn_ptr` pointer in the returned `ConnectionResponse` must live while the client is open/active and must be explicitly freed by calling [`close_client`].
-/// * The `connection_error_message` pointer in the returned `ConnectionResponse` must live until the returned `ConnectionResponse` pointer is passed to [`free_connection_response`].
+/// * The `conn_ptr` pointer in the returned `ConnectionResponse` must live while the client is open/active and must be explicitly freed by calling [close_client].
+/// * The `connection_error_message` pointer in the returned `ConnectionResponse` must live until the returned `ConnectionResponse` pointer is passed to [free_connection_response].
 /// * Both the `success_callback` and `failure_callback` function pointers need to live while the client is open/active. The caller is responsible for freeing both callbacks.
 // TODO: Consider making this async
 #[no_mangle]
@@ -207,7 +210,7 @@ pub unsafe extern "C" fn create_client(
             ),
         },
         Ok(client) => ConnectionResponse {
-            conn_ptr: Box::into_raw(Box::new(client)) as *const c_void,
+            conn_ptr: Arc::into_raw(Arc::new(client)) as *const c_void,
             connection_error_message: std::ptr::null(),
         },
     };
@@ -226,13 +229,14 @@ pub unsafe extern "C" fn create_client(
 ///
 /// * `close_client` can only be called once per client. Calling it twice is undefined behavior, since the address will be freed twice.
 /// * `close_client` must be called after `free_connection_response` has been called to avoid creating a dangling pointer in the `ConnectionResponse`.
-/// * `client_adapter_ptr` must be obtained from the `ConnectionResponse` returned from [`create_client`].
+/// * `client_adapter_ptr` must be obtained from the `ConnectionResponse` returned from [create_client].
 /// * `client_adapter_ptr` must be valid until `close_client` is called.
 // TODO: Ensure safety when command has not completed yet
 #[no_mangle]
 pub unsafe extern "C" fn close_client(client_adapter_ptr: *const c_void) {
     assert!(!client_adapter_ptr.is_null());
-    drop(unsafe { Box::from_raw(client_adapter_ptr as *mut ClientAdapter) });
+    // This will bring the strong count down to 0 once all client requests are done.
+    unsafe { Arc::decrement_strong_count(client_adapter_ptr as *const ClientAdapter) };
 }
 
 /// Deallocates a `ConnectionResponse`.
@@ -508,7 +512,7 @@ fn valkey_value_to_command_response(value: Value) -> RedisResult<CommandResponse
 ///
 /// # Safety
 ///
-/// * TODO: finish safety section.
+/// This function should only be called should with a pointer created by [create_client], before [close_client] was called with the pointer.
 #[no_mangle]
 pub unsafe extern "C" fn command(
     client_adapter_ptr: *const c_void,
@@ -520,16 +524,16 @@ pub unsafe extern "C" fn command(
     route_bytes: *const u8,
     route_bytes_len: usize,
 ) {
-    let client_adapter =
-        unsafe { Box::leak(Box::from_raw(client_adapter_ptr as *mut ClientAdapter)) };
-    // The safety of this needs to be ensured by the calling code. Cannot dispose of the pointer before
-    // all operations have completed.
-    let ptr_address = client_adapter_ptr as usize;
+    let client_adapter = unsafe {
+        // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
+        Arc::increment_strong_count(client_adapter_ptr);
+        Arc::from_raw(client_adapter_ptr as *mut ClientAdapter)
+    };
+
+    let core = client_adapter.core.clone();
 
     let arg_vec =
         unsafe { convert_double_pointer_to_vec(args as *const *const c_void, arg_count, args_len) };
-
-    let mut client_clone = client_adapter.client.clone();
 
     // Create the command outside of the task to ensure that the command arguments passed
     // from "go" are still valid
@@ -545,10 +549,11 @@ pub unsafe extern "C" fn command(
     let route = Routes::parse_from_bytes(r_bytes).unwrap();
 
     client_adapter.runtime.spawn(async move {
-        let result = client_clone
+        let result = core
+            .client
+            .clone()
             .send_command(&cmd, get_route(route, Some(&cmd)))
             .await;
-        let client_adapter = unsafe { Box::leak(Box::from_raw(ptr_address as *mut ClientAdapter)) };
         let value = match result {
             Ok(value) => value,
             Err(err) => {
@@ -558,7 +563,7 @@ pub unsafe extern "C" fn command(
                 let c_err_str = CString::into_raw(
                     CString::new(message).expect("Couldn't convert error message to CString"),
                 );
-                unsafe { (client_adapter.failure_callback)(channel, c_err_str, error_type) };
+                unsafe { (core.failure_callback)(channel, c_err_str, error_type) };
                 return;
             }
         };
@@ -567,9 +572,7 @@ pub unsafe extern "C" fn command(
 
         unsafe {
             match result {
-                Ok(message) => {
-                    (client_adapter.success_callback)(channel, Box::into_raw(Box::new(message)))
-                }
+                Ok(message) => (core.success_callback)(channel, Box::into_raw(Box::new(message))),
                 Err(err) => {
                     let message = errors::error_message(&err);
                     let error_type = errors::error_type(&err);
@@ -577,7 +580,7 @@ pub unsafe extern "C" fn command(
                     let c_err_str = CString::into_raw(
                         CString::new(message).expect("Couldn't convert error message to CString"),
                     );
-                    (client_adapter.failure_callback)(channel, c_err_str, error_type);
+                    (core.failure_callback)(channel, c_err_str, error_type);
                 }
             };
         }
@@ -712,11 +715,7 @@ pub unsafe extern "C" fn request_cluster_scan(
 ) {
     let client_adapter =
         unsafe { Box::leak(Box::from_raw(client_adapter_ptr as *mut ClientAdapter)) };
-    // The safety of this needs to be ensured by the calling code. Cannot dispose of the pointer before
-    // all operations have completed.
-    let ptr_address = client_adapter_ptr as usize;
-
-    let mut client_clone = client_adapter.client.clone();
+    let core = client_adapter.core.clone();
 
     let c_str = unsafe { CStr::from_ptr(cursor.get_cursor()) };
     let temp_str = c_str.to_str().expect("Must be UTF-8");
@@ -757,7 +756,7 @@ pub unsafe extern "C" fn request_cluster_scan(
                 let c_err_str = CString::into_raw(
                     CString::new(message).expect("Couldn't convert error message to CString"),
                 );
-                unsafe { (client_adapter.failure_callback)(channel, c_err_str, error_type) };
+                unsafe { (core.failure_callback)(channel, c_err_str, error_type) };
                 return;
             }
         };
@@ -772,7 +771,7 @@ pub unsafe extern "C" fn request_cluster_scan(
                 let c_err_str = CString::into_raw(
                     CString::new(message).expect("Couldn't convert error message to CString"),
                 );
-                unsafe { (client_adapter.failure_callback)(channel, c_err_str, error_type) };
+                unsafe { (core.failure_callback)(channel, c_err_str, error_type) };
                 return;
             }
         };
@@ -796,12 +795,14 @@ pub unsafe extern "C" fn request_cluster_scan(
         Ok(existing_cursor) => existing_cursor,
         Err(_error) => ScanStateRC::new(),
     };
+    let core = client_adapter.core.clone();
 
     client_adapter.runtime.spawn(async move {
-        let result = client_clone
+        let result = core
+            .client
+            .clone()
             .cluster_scan(&scan_state_cursor, cluster_scan_args)
             .await;
-        let client_adapter = unsafe { Box::leak(Box::from_raw(ptr_address as *mut ClientAdapter)) };
         let value = match result {
             Ok(value) => value,
             Err(err) => {
@@ -811,7 +812,7 @@ pub unsafe extern "C" fn request_cluster_scan(
                 let c_err_str = CString::into_raw(
                     CString::new(message).expect("Couldn't convert error message to CString"),
                 );
-                unsafe { (client_adapter.failure_callback)(channel, c_err_str, error_type) };
+                unsafe { (core.failure_callback)(channel, c_err_str, error_type) };
                 return;
             }
         };
@@ -820,9 +821,7 @@ pub unsafe extern "C" fn request_cluster_scan(
 
         unsafe {
             match result {
-                Ok(message) => {
-                    (client_adapter.success_callback)(channel, Box::into_raw(Box::new(message)))
-                }
+                Ok(message) => (core.success_callback)(channel, Box::into_raw(Box::new(message))),
                 Err(err) => {
                     let message = errors::error_message(&err);
                     let error_type = errors::error_type(&err);
@@ -830,7 +829,7 @@ pub unsafe extern "C" fn request_cluster_scan(
                     let c_err_str = CString::into_raw(
                         CString::new(message).expect("Couldn't convert error message to CString"),
                     );
-                    (client_adapter.failure_callback)(channel, c_err_str, error_type);
+                    (core.failure_callback)(channel, c_err_str, error_type);
                 }
             };
         }


### PR DESCRIPTION
Use `Arc` instead of `Box` to wrap the `ClientAdapter`, so that the lifetime of the adapter will be extended even in cases where the client is closed during commands. This also saves on using `as usize` conversions to the pointer, which cause provenance to be lost and might lead to undefined behavior.
The memory cost of this change is increasing the allocation of the client by one pointer size, and the runtime cost is 4 atomic increments/decrements per command. 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
