### PR TITLE
[redis-rs][core] Move connection refresh to the background

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
@@ -267,7 +267,8 @@ impl Drop for RefreshTaskState {
     }
 }
 
-// This struct is used to track the status of each address refresh
+// This struct is used to track the status of each address refresh state
+// TODO move this struct logic into the connection_map itself
 #[derive(Default)]
 pub(crate) struct RefreshConnectionStates {
     // Follow the refresh ops on the connections

--- a/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
@@ -125,9 +125,8 @@ pub(crate) struct ConnectionsMap<Connection>(pub(crate) DashMap<String, ClusterN
 
 pub(crate) struct RefreshState<Connection> {
     pub handle: JoinHandle<()>, // The currect running refresh task
-    pub node_conn: Option<ClusterNode<Connection>> // The refreshed connection after the task is done
+    pub node_conn: Option<ClusterNode<Connection>>, // The refreshed connection after the task is done
 }
-
 
 impl<Connection> std::fmt::Display for ConnectionsMap<Connection> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -148,7 +147,6 @@ pub(crate) struct ConnectionsContainer<Connection> {
     read_from_replica_strategy: ReadFromReplicaStrategy,
     topology_hash: TopologyHash,
 
-    
     // Holds all the failed addresses that started a refresh task.
     pub(crate) refresh_addresses_started: DashSet<String>,
     // Follow the refresh ops on the connections

--- a/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_container.rs
@@ -5,7 +5,7 @@ use crate::cluster_topology::TopologyHash;
 use dashmap::DashMap;
 use futures::FutureExt;
 use rand::seq::IteratorRandom;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -288,37 +288,6 @@ impl RefreshConnectionStates {
 
         // Clear the entire map; Drop handles the cleanup
         self.refresh_address_in_progress.clear();
-
-        // Clear other state tracking
-    }
-
-    // Collects the notifiers for the given addresses and returns them as a vector.
-    //
-    // This function retrieves the notifiers for the provided addresses from the `refresh_address_in_progress`
-    // map and returns them, so they can be awaited outside of the lock.
-    //
-    // # Arguments
-    // * `addresses` - A list of addresses for which notifiers are required.
-    //
-    // # Returns
-    // A vector of `futures::future::Notified` that can be awaited.
-    pub(crate) fn collect_refresh_notifiers(
-        &self,
-        addresses: &HashSet<String>,
-    ) -> Vec<Arc<Notify>> {
-        addresses
-            .iter()
-            .filter_map(|address| {
-                self.refresh_address_in_progress
-                    .get(address)
-                    .and_then(|refresh_state| match &refresh_state.status {
-                        RefreshTaskStatus::Reconnecting(notifier) => {
-                            Some(notifier.get_notifier().clone())
-                        }
-                        _ => None,
-                    })
-            })
-            .collect()
     }
 }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -1284,6 +1284,13 @@ where
             }
         };
         Box::pin(async move {
+            // Remove all refresh_connection data, to have a new clear state
+            inner
+                .conn_lock
+                .write()
+                .expect(MUTEX_WRITE_ERR)
+                .clear_refresh_state();
+
             let connection_map = match Self::create_initial_connections(
                 &inner.initial_nodes,
                 &cluster_params,

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2548,9 +2548,8 @@ where
                             }
                         }
                     }
-                }
-                else {
-                    debug!("update_refreshed_connection: address {:?} current_existing_addresses_in_slot_map: {:?}", address, current_existing_addresses_in_slot_map);
+                } else {
+                    debug!("update_refreshed_connection: address {:?} doesn't appear in addresses in slot_map: {:?}", address, current_existing_addresses_in_slot_map);
                 }
 
                 // Remove this address from refresh_addresses_done

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2709,10 +2709,11 @@ where
                     .remove(&address);
 
                 // Remove this entry from refresh_address_in_progress
-                if let Some(_) = conn_lock_write
+                if conn_lock_write
                     .refresh_conn_state
                     .refresh_address_in_progress
                     .remove(&address)
+                    .is_some()
                 {
                     debug!(
                         "update_refreshed_connection: Successfully removed refresh state for address: {}",

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -1445,21 +1445,21 @@ where
                 .refresh_addresses_started
                 .insert(address_clone_for_task.clone());
 
+            let node_option = if check_existing_conn {
+                let connections_container = inner_clone.conn_lock.read().expect(MUTEX_READ_ERR);
+                connections_container
+                    .connection_map()
+                    .get(&address_clone_for_task)
+                    .map(|node| node.value().clone())
+            } else {
+                None
+            };
+
             let handle = tokio::spawn(async move {
                 info!(
-                    "Refreshing connection task to {:?} started",
+                    "refreshing connection task to {:?} started",
                     address_clone_for_task
                 );
-
-                let node_option = if check_existing_conn {
-                    let connections_container = inner_clone.conn_lock.read().expect(MUTEX_READ_ERR);
-                    connections_container
-                        .connection_map()
-                        .get(&address_clone_for_task)
-                        .map(|node| node.value().clone())
-                } else {
-                    None
-                };
 
                 let mut cluster_params = inner_clone
                     .cluster_params
@@ -1556,7 +1556,7 @@ where
                 .refresh_address_in_progress
                 .insert(address.clone(), RefreshTaskState::new(handle));
         }
-        debug!("refresh connection tasks initiated");
+        debug!("trigger_refresh_connection_tasks: Done");
     }
 
     async fn aggregate_results(

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2703,19 +2703,13 @@ where
                 }
 
                 // Remove this address from refresh_addresses_done
-                inner
-                    .conn_lock
-                    .write()
-                    .expect(MUTEX_READ_ERR)
+                conn_lock_write
                     .refresh_conn_state
                     .refresh_addresses_done
                     .remove(&address);
 
                 // Remove this entry from refresh_address_in_progress
-                if let Some(_) = inner
-                    .conn_lock
-                    .write()
-                    .expect(MUTEX_READ_ERR)
+                if let Some(_) = conn_lock_write
                     .refresh_conn_state
                     .refresh_address_in_progress
                     .remove(&address)

--- a/glide-core/redis-rs/redis/src/cluster_client.rs
+++ b/glide-core/redis-rs/redis/src/cluster_client.rs
@@ -433,8 +433,11 @@ impl ClusterClientBuilder {
     /// In addition, for tokio runtime, passive disconnections could be detected instantly,
     /// triggering reestablishment, w/o waiting for the next periodic check.
     #[cfg(feature = "cluster-async")]
-    pub fn periodic_connections_checks(mut self, interval: Duration) -> ClusterClientBuilder {
-        self.builder_params.connections_validation_interval = Some(interval);
+    pub fn periodic_connections_checks(
+        mut self,
+        interval: Option<Duration>,
+    ) -> ClusterClientBuilder {
+        self.builder_params.connections_validation_interval = interval;
         self
     }
 

--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -238,6 +238,7 @@ impl RedisServer {
         if let Some(config_path) = config_file {
             server_cmd.arg(config_path);
         }
+        server_cmd.arg("--enable-debug-command").arg("yes");
 
         // Load Redis Modules
         for module in modules {

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -3951,7 +3951,7 @@ mod cluster_async {
             // STEP 4: Give a short delay to help ensure the pipeline has started.
             tokio::time::sleep(Duration::from_millis(10)).await;
 
-            // STEP 5: Use con_tx to send a PING to the blocked shard (shard 0)
+            // STEP 5: Use con_tx to send a SET to the blocked shard (shard 0)
             // to trigger reconnection logic.
             // Wrap with a timeout so it fails quickly.
             {

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -604,7 +604,7 @@ async fn create_cluster_client(
     }
 
     // Always use with Glide
-    builder = builder.periodic_connections_checks(CONNECTION_CHECKS_INTERVAL);
+    builder = builder.periodic_connections_checks(Some(CONNECTION_CHECKS_INTERVAL));
 
     let client = builder.build()?;
     let mut con = client.get_async_connection(push_sender).await?;

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -218,7 +218,7 @@ async def glide_client(
     protocol: ProtocolVersion,
 ) -> AsyncGenerator[TGlideClient, None]:
     "Get async socket client for tests"
-    client = await create_client(request, cluster_mode, protocol=protocol)
+    client = await create_client(request, cluster_mode, protocol=protocol, request_timeout=10000)
     yield client
     await test_teardown(request, cluster_mode, protocol)
     await client.close()

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -225,6 +225,22 @@ async def glide_client(
 
 
 @pytest.fixture(scope="function")
+async def glide_client(
+    request,
+    cluster_mode: bool,
+    protocol: ProtocolVersion,
+    request_timeout: int,
+) -> AsyncGenerator[TGlideClient, None]:
+    "Get async socket client for tests"
+    client = await create_client(
+        request, cluster_mode, protocol=protocol, request_timeout=request_timeout
+    )
+    yield client
+    await test_teardown(request, cluster_mode, protocol)
+    await client.close()
+
+
+@pytest.fixture(scope="function")
 async def management_client(
     request,
     cluster_mode: bool,
@@ -232,6 +248,22 @@ async def management_client(
 ) -> AsyncGenerator[TGlideClient, None]:
     "Get async socket client for tests, used to manage the state when tests are on the client ability to connect"
     client = await create_client(request, cluster_mode, protocol=protocol)
+    yield client
+    await test_teardown(request, cluster_mode, protocol)
+    await client.close()
+
+
+@pytest.fixture(scope="function")
+async def management_client(
+    request,
+    cluster_mode: bool,
+    protocol: ProtocolVersion,
+    request_timeout: int,
+) -> AsyncGenerator[TGlideClient, None]:
+    "Get async socket client for tests, used to manage the state when tests are on the client ability to connect"
+    client = await create_client(
+        request, cluster_mode, protocol=protocol, request_timeout=request_timeout
+    )
     yield client
     await test_teardown(request, cluster_mode, protocol)
     await client.close()

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -225,22 +225,6 @@ async def glide_client(
 
 
 @pytest.fixture(scope="function")
-async def glide_client(
-    request,
-    cluster_mode: bool,
-    protocol: ProtocolVersion,
-    request_timeout: int,
-) -> AsyncGenerator[TGlideClient, None]:
-    "Get async socket client for tests"
-    client = await create_client(
-        request, cluster_mode, protocol=protocol, request_timeout=request_timeout
-    )
-    yield client
-    await test_teardown(request, cluster_mode, protocol)
-    await client.close()
-
-
-@pytest.fixture(scope="function")
 async def management_client(
     request,
     cluster_mode: bool,
@@ -248,22 +232,6 @@ async def management_client(
 ) -> AsyncGenerator[TGlideClient, None]:
     "Get async socket client for tests, used to manage the state when tests are on the client ability to connect"
     client = await create_client(request, cluster_mode, protocol=protocol)
-    yield client
-    await test_teardown(request, cluster_mode, protocol)
-    await client.close()
-
-
-@pytest.fixture(scope="function")
-async def management_client(
-    request,
-    cluster_mode: bool,
-    protocol: ProtocolVersion,
-    request_timeout: int,
-) -> AsyncGenerator[TGlideClient, None]:
-    "Get async socket client for tests, used to manage the state when tests are on the client ability to connect"
-    client = await create_client(
-        request, cluster_mode, protocol=protocol, request_timeout=request_timeout
-    )
     yield client
     await test_teardown(request, cluster_mode, protocol)
     await client.close()

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -218,7 +218,9 @@ async def glide_client(
     protocol: ProtocolVersion,
 ) -> AsyncGenerator[TGlideClient, None]:
     "Get async socket client for tests"
-    client = await create_client(request, cluster_mode, protocol=protocol, request_timeout=10000)
+    client = await create_client(
+        request, cluster_mode, protocol=protocol, request_timeout=5000
+    )
     yield client
     await test_teardown(request, cluster_mode, protocol)
     await client.close()

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -36,7 +36,6 @@ class TestAuthCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    @pytest.mark.parametrize("request_timeout", [3000])
     async def test_update_connection_password(
         self, glide_client: TGlideClient, management_client: TGlideClient
     ):

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -66,6 +66,7 @@ class TestAuthCommands:
         assert value == b"test_value"
         await glide_client.update_connection_password(None)
         await kill_connections(management_client)
+        await asyncio.sleep(1)
         # Verify that the client is able to immediateAuth with the new password after client is killed
         result = await glide_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=True

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -36,6 +36,7 @@ class TestAuthCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    @pytest.mark.parametrize("request_timeout", [3000])
     async def test_update_connection_password(
         self, glide_client: TGlideClient, management_client: TGlideClient
     ):


### PR DESCRIPTION
**Core Changes:**

* Move refresh_connection to run as a tokio task in the background, eliminating blocking in poll_recover for Reconnect.
* Modify get_connection to intelligently wait on refresh operations so it won't send the command right away when the connection is removed when triggering a new refresh task.

**Triggering Refresh Task:**
 - Removes the existing failed connection from the connection_map
 - Triggering a new Tokio task to run in the background.

**Refresh Task Behavior:**
 - Starting a new connection to the node
 - Adding the connection into the connection_map

**New State Management:**
- Add refresh state tracking per address
- Introduce notifier mechanism that's triggered by the refreshing task after the first connection attempt
- New state enum for refresh operations:
  * Refreshing
  * RefreshingTooLong (when refresh operation takes more than expected)

**New Connection Retrieval Flow:**
1. When connection not found for a route:
   - Check if address has active refresh operation
2. If refresh is active:
   - Await on address's notifier
   - When notified:
     * If connection exists in map - use it
     * Otherwise, send to random node as it means there's no active connection to this node.
3. If no refresh active:
   - Proceed with current random node logic

**Key Benefits:**
- Unblocks poll_recover, improving system responsiveness
- Enables concurrent refresh operations
- Preserves existing batch processing model
- Maintains current behavior of falling back to random node after a single try, like it used to work in poll_recovery.
- Replaces blocking recovery with controlled waiting period
- Provides natural transition from current blocking behavior to more efficient approach

**Comparison to Current Behavior:**
- Current: Blocks entirely during recover task
- Proposed: Waits briefly for refresh completion before random routing
- Both ensure consistent handling of request batches
- Both eventually route to random node when connection unavailable
