### PR TITLE
Enable refresh slots after reconnecting to initial nodes.

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -1301,7 +1301,7 @@ where
                 .extend_connection_map(connection_map);
             if let Err(err) = Self::refresh_slots_and_subscriptions_with_retries(
                 inner.clone(),
-                &RefreshPolicy::Throttable,
+                &RefreshPolicy::NotThrottable,
             )
             .await
             {


### PR DESCRIPTION
Moving to not throttle refresh slots after reconnecting to initial nodes, as this operation is kind of 'resetting' the client, so it should let it discover the whole topology before moving on to handle requests.

