### PR TITLE
Node: Fix `zrangeWithScores` (disallow `RangeByLex` as it is not supported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 #### Fixes
 
+* Node: Fix `zrangeWithScores` (disallow `RangeByLex` as it is not supported) ([#2926](https://github.com/valkey-io/valkey-glide/pull/2926))
+
 #### Operational Enhancements
 
 ## 1.2.1 (2024-12-29)

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -4443,7 +4443,6 @@ export class BaseClient {
      * @param key - The key of the sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
      * - For range queries by index (rank), use {@link RangeByIndex}.
-     * - For range queries by lexicographical order, use {@link RangeByLex}.
      * - For range queries by score, use {@link RangeByScore}.
      * @param options - (Optional) Additional parameters:
      * - (Optional) `reverse`: if `true`, reverses the sorted set, with index `0` as the element with the highest score.
@@ -4476,7 +4475,7 @@ export class BaseClient {
      */
     public async zrangeWithScores(
         key: GlideString,
-        rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
+        rangeQuery: RangeByScore | RangeByIndex,
         options?: { reverse?: boolean } & DecoderOption,
     ): Promise<SortedSetDataType> {
         return this.createWritePromise<GlideRecord<number>>(

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1989,7 +1989,6 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key - The key of the sorted set.
      * @param rangeQuery - The range query object representing the type of range query to perform.
      * - For range queries by index (rank), use {@link RangeByIndex}.
-     * - For range queries by lexicographical order, use {@link RangeByLex}.
      * - For range queries by score, use {@link RangeByScore}.
      * @param reverse - If `true`, reverses the sorted set, with index `0` as the element with the highest score.
      *
@@ -1999,7 +1998,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public zrangeWithScores(
         key: GlideString,
-        rangeQuery: RangeByScore | RangeByLex | RangeByIndex,
+        rangeQuery: RangeByScore | RangeByIndex,
         reverse = false,
     ): T {
         return this.addAndReturn(


### PR DESCRIPTION
Node: Fix `zrangeWithScores` (disallow `RangeByLex` as it is not supported)
```ts
> await client.zrangeWithScores("zz", { start: '-', end: '+', type: "byLex"})
2025-01-08T02:49:25.077335Z  WARN logger_core: received error - An error was signalled by the server - ResponseError: syntax error, WITHSCORES not supported in combination with BYLEX
Uncaught:
RequestError: An error was signalled by the server - ResponseError: syntax error, WITHSCORES not supported in combination with BYLEX
    at GlideClient.processResponse (node/build-ts/src/BaseClient.js:337:20)
    at GlideClient.handleReadData (node/build-ts/src/BaseClient.js:322:22)
```