### PR TITLE
Go: Fix return types, part 1: `int64` instead of `Result[int64]`

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -267,7 +267,7 @@ func (client *baseClient) Incr(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) IncrBy(key string, amount int64) (int64, error) {
@@ -276,7 +276,7 @@ func (client *baseClient) IncrBy(key string, amount int64) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) IncrByFloat(key string, amount float64) (Result[float64], error) {
@@ -297,7 +297,7 @@ func (client *baseClient) Decr(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) DecrBy(key string, amount int64) (int64, error) {
@@ -306,7 +306,7 @@ func (client *baseClient) DecrBy(key string, amount int64) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) Strlen(key string) (int64, error) {
@@ -315,7 +315,7 @@ func (client *baseClient) Strlen(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SetRange(key string, offset int, value string) (int64, error) {
@@ -324,7 +324,7 @@ func (client *baseClient) SetRange(key string, offset int, value string) (int64,
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) GetRange(key string, start int, end int) (Result[string], error) {
@@ -342,7 +342,7 @@ func (client *baseClient) Append(key string, value string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) LCS(key1 string, key2 string) (Result[string], error) {
@@ -400,7 +400,7 @@ func (client *baseClient) HSet(key string, values map[string]string) (int64, err
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) HSetNX(key string, field string, value string) (Result[bool], error) {
@@ -418,7 +418,7 @@ func (client *baseClient) HDel(key string, fields []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) HLen(key string) (int64, error) {
@@ -427,7 +427,7 @@ func (client *baseClient) HLen(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) HVals(key string) ([]Result[string], error) {
@@ -463,7 +463,7 @@ func (client *baseClient) HStrLen(key string, field string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) HIncrBy(key string, field string, increment int64) (int64, error) {
@@ -472,7 +472,7 @@ func (client *baseClient) HIncrBy(key string, field string, increment int64) (in
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) HIncrByFloat(key string, field string, increment float64) (Result[float64], error) {
@@ -515,7 +515,7 @@ func (client *baseClient) LPush(key string, elements []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) LPop(key string) (Result[string], error) {
@@ -542,7 +542,7 @@ func (client *baseClient) LPos(key string, element string) (Result[int64], error
 		return CreateNilInt64Result(), err
 	}
 
-	return handleLongOrNullResponse(result)
+	return handleIntOrNilResponse(result)
 }
 
 func (client *baseClient) LPosWithOptions(key string, element string, options *LPosOptions) (Result[int64], error) {
@@ -551,7 +551,7 @@ func (client *baseClient) LPosWithOptions(key string, element string, options *L
 		return CreateNilInt64Result(), err
 	}
 
-	return handleLongOrNullResponse(result)
+	return handleIntOrNilResponse(result)
 }
 
 func (client *baseClient) LPosCount(key string, element string, count int64) ([]Result[int64], error) {
@@ -560,7 +560,7 @@ func (client *baseClient) LPosCount(key string, element string, count int64) ([]
 		return nil, err
 	}
 
-	return handleLongArrayResponse(result)
+	return handleIntArrayResponse(result)
 }
 
 func (client *baseClient) LPosCountWithOptions(
@@ -577,7 +577,7 @@ func (client *baseClient) LPosCountWithOptions(
 		return nil, err
 	}
 
-	return handleLongArrayResponse(result)
+	return handleIntArrayResponse(result)
 }
 
 func (client *baseClient) RPush(key string, elements []string) (int64, error) {
@@ -586,7 +586,7 @@ func (client *baseClient) RPush(key string, elements []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SAdd(key string, members []string) (int64, error) {
@@ -595,7 +595,7 @@ func (client *baseClient) SAdd(key string, members []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SRem(key string, members []string) (int64, error) {
@@ -604,7 +604,7 @@ func (client *baseClient) SRem(key string, members []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SUnionStore(destination string, keys []string) (int64, error) {
@@ -613,7 +613,7 @@ func (client *baseClient) SUnionStore(destination string, keys []string) (int64,
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SMembers(key string) (map[Result[string]]struct{}, error) {
@@ -631,7 +631,7 @@ func (client *baseClient) SCard(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SIsMember(key string, member string) (Result[bool], error) {
@@ -658,7 +658,7 @@ func (client *baseClient) SDiffStore(destination string, keys []string) (int64, 
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SInter(keys []string) (map[Result[string]]struct{}, error) {
@@ -676,7 +676,7 @@ func (client *baseClient) SInterStore(destination string, keys []string) (int64,
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SInterCard(keys []string) (int64, error) {
@@ -685,7 +685,7 @@ func (client *baseClient) SInterCard(keys []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SInterCardLimit(keys []string, limit int64) (int64, error) {
@@ -696,7 +696,7 @@ func (client *baseClient) SInterCardLimit(keys []string, limit int64) (int64, er
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SRandMember(key string) (Result[string], error) {
@@ -801,7 +801,7 @@ func (client *baseClient) LLen(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) LRem(key string, count int64, element string) (int64, error) {
@@ -810,7 +810,7 @@ func (client *baseClient) LRem(key string, count int64, element string) (int64, 
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) RPop(key string) (Result[string], error) {
@@ -850,7 +850,7 @@ func (client *baseClient) LInsert(
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) BLPop(keys []string, timeoutSecs float64) ([]Result[string], error) {
@@ -877,7 +877,7 @@ func (client *baseClient) RPushX(key string, elements []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) LPushX(key string, elements []string) (int64, error) {
@@ -886,7 +886,7 @@ func (client *baseClient) LPushX(key string, elements []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) LMPop(keys []string, listDirection ListDirection) (map[Result[string]][]Result[string], error) {
@@ -1091,7 +1091,7 @@ func (client *baseClient) Del(keys []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) Exists(keys []string) (int64, error) {
@@ -1100,7 +1100,7 @@ func (client *baseClient) Exists(keys []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) Expire(key string, seconds int64) (Result[bool], error) {
@@ -1209,7 +1209,7 @@ func (client *baseClient) ExpireTime(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) PExpireTime(key string) (int64, error) {
@@ -1218,7 +1218,7 @@ func (client *baseClient) PExpireTime(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) TTL(key string) (int64, error) {
@@ -1227,7 +1227,7 @@ func (client *baseClient) TTL(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) PTTL(key string) (int64, error) {
@@ -1236,7 +1236,7 @@ func (client *baseClient) PTTL(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) PfAdd(key string, elements []string) (int64, error) {
@@ -1245,7 +1245,7 @@ func (client *baseClient) PfAdd(key string, elements []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) PfCount(keys []string) (int64, error) {
@@ -1254,7 +1254,7 @@ func (client *baseClient) PfCount(keys []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) Unlink(keys []string) (int64, error) {
@@ -1263,7 +1263,7 @@ func (client *baseClient) Unlink(keys []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) Type(key string) (Result[string], error) {
@@ -1280,7 +1280,7 @@ func (client *baseClient) Touch(keys []string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) Rename(key string, newKey string) (Result[string], error) {
@@ -1344,7 +1344,7 @@ func (client *baseClient) ZAdd(
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) ZAddWithOptions(
@@ -1365,7 +1365,7 @@ func (client *baseClient) ZAddWithOptions(
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) zAddIncrBase(key string, opts *options.ZAddOptions) (Result[float64], error) {
@@ -1455,7 +1455,7 @@ func (client *baseClient) ZRem(key string, members []string) (int64, error) {
 	if err != nil {
 		return defaultIntResponse, err
 	}
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) ZCard(key string) (int64, error) {
@@ -1464,7 +1464,7 @@ func (client *baseClient) ZCard(key string) (int64, error) {
 		return defaultIntResponse, err
 	}
 
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) BZPopMin(keys []string, timeoutSecs float64) (Result[KeyWithMemberAndScore], error) {
@@ -1584,7 +1584,7 @@ func (client *baseClient) ZRank(key string, member string) (Result[int64], error
 	if err != nil {
 		return CreateNilInt64Result(), err
 	}
-	return handleLongOrNullResponse(result)
+	return handleIntOrNilResponse(result)
 }
 
 func (client *baseClient) ZRankWithScore(key string, member string) (Result[int64], Result[float64], error) {
@@ -1600,7 +1600,7 @@ func (client *baseClient) ZRevRank(key string, member string) (Result[int64], er
 	if err != nil {
 		return CreateNilInt64Result(), err
 	}
-	return handleLongOrNullResponse(result)
+	return handleIntOrNilResponse(result)
 }
 
 func (client *baseClient) ZRevRankWithScore(key string, member string) (Result[int64], Result[float64], error) {
@@ -1620,7 +1620,7 @@ func (client *baseClient) XTrim(key string, options *options.XTrimOptions) (int6
 	if err != nil {
 		return defaultIntResponse, err
 	}
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) XLen(key string) (int64, error) {
@@ -1628,5 +1628,5 @@ func (client *baseClient) XLen(key string) (int64, error) {
 	if err != nil {
 		return defaultIntResponse, err
 	}
-	return handleLongResponse(result)
+	return handleIntResponse(result)
 }

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -264,7 +264,7 @@ func (client *baseClient) MGet(keys []string) ([]Result[string], error) {
 func (client *baseClient) Incr(key string) (int64, error) {
 	result, err := client.executeCommand(C.Incr, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -273,7 +273,7 @@ func (client *baseClient) Incr(key string) (int64, error) {
 func (client *baseClient) IncrBy(key string, amount int64) (int64, error) {
 	result, err := client.executeCommand(C.IncrBy, []string{key, utils.IntToString(amount)})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -294,7 +294,7 @@ func (client *baseClient) IncrByFloat(key string, amount float64) (Result[float6
 func (client *baseClient) Decr(key string) (int64, error) {
 	result, err := client.executeCommand(C.Decr, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -303,7 +303,7 @@ func (client *baseClient) Decr(key string) (int64, error) {
 func (client *baseClient) DecrBy(key string, amount int64) (int64, error) {
 	result, err := client.executeCommand(C.DecrBy, []string{key, utils.IntToString(amount)})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -312,7 +312,7 @@ func (client *baseClient) DecrBy(key string, amount int64) (int64, error) {
 func (client *baseClient) Strlen(key string) (int64, error) {
 	result, err := client.executeCommand(C.Strlen, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -321,7 +321,7 @@ func (client *baseClient) Strlen(key string) (int64, error) {
 func (client *baseClient) SetRange(key string, offset int, value string) (int64, error) {
 	result, err := client.executeCommand(C.SetRange, []string{key, strconv.Itoa(offset), value})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -339,7 +339,7 @@ func (client *baseClient) GetRange(key string, start int, end int) (Result[strin
 func (client *baseClient) Append(key string, value string) (int64, error) {
 	result, err := client.executeCommand(C.Append, []string{key, value})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -397,7 +397,7 @@ func (client *baseClient) HMGet(key string, fields []string) ([]Result[string], 
 func (client *baseClient) HSet(key string, values map[string]string) (int64, error) {
 	result, err := client.executeCommand(C.HSet, utils.ConvertMapToKeyValueStringArray(key, values))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -415,7 +415,7 @@ func (client *baseClient) HSetNX(key string, field string, value string) (Result
 func (client *baseClient) HDel(key string, fields []string) (int64, error) {
 	result, err := client.executeCommand(C.HDel, append([]string{key}, fields...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -424,7 +424,7 @@ func (client *baseClient) HDel(key string, fields []string) (int64, error) {
 func (client *baseClient) HLen(key string) (int64, error) {
 	result, err := client.executeCommand(C.HLen, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -460,7 +460,7 @@ func (client *baseClient) HKeys(key string) ([]Result[string], error) {
 func (client *baseClient) HStrLen(key string, field string) (int64, error) {
 	result, err := client.executeCommand(C.HStrlen, []string{key, field})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -469,7 +469,7 @@ func (client *baseClient) HStrLen(key string, field string) (int64, error) {
 func (client *baseClient) HIncrBy(key string, field string, increment int64) (int64, error) {
 	result, err := client.executeCommand(C.HIncrBy, []string{key, field, utils.IntToString(increment)})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -512,7 +512,7 @@ func (client *baseClient) HScanWithOptions(
 func (client *baseClient) LPush(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.LPush, append([]string{key}, elements...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -583,7 +583,7 @@ func (client *baseClient) LPosCountWithOptions(
 func (client *baseClient) RPush(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.RPush, append([]string{key}, elements...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -592,7 +592,7 @@ func (client *baseClient) RPush(key string, elements []string) (int64, error) {
 func (client *baseClient) SAdd(key string, members []string) (int64, error) {
 	result, err := client.executeCommand(C.SAdd, append([]string{key}, members...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -601,7 +601,7 @@ func (client *baseClient) SAdd(key string, members []string) (int64, error) {
 func (client *baseClient) SRem(key string, members []string) (int64, error) {
 	result, err := client.executeCommand(C.SRem, append([]string{key}, members...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -610,7 +610,7 @@ func (client *baseClient) SRem(key string, members []string) (int64, error) {
 func (client *baseClient) SUnionStore(destination string, keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SUnionStore, append([]string{destination}, keys...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -628,7 +628,7 @@ func (client *baseClient) SMembers(key string) (map[Result[string]]struct{}, err
 func (client *baseClient) SCard(key string) (int64, error) {
 	result, err := client.executeCommand(C.SCard, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -655,7 +655,7 @@ func (client *baseClient) SDiff(keys []string) (map[Result[string]]struct{}, err
 func (client *baseClient) SDiffStore(destination string, keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SDiffStore, append([]string{destination}, keys...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -673,7 +673,7 @@ func (client *baseClient) SInter(keys []string) (map[Result[string]]struct{}, er
 func (client *baseClient) SInterStore(destination string, keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SInterStore, append([]string{destination}, keys...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -682,7 +682,7 @@ func (client *baseClient) SInterStore(destination string, keys []string) (int64,
 func (client *baseClient) SInterCard(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SInterCard, append([]string{strconv.Itoa(len(keys))}, keys...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -693,7 +693,7 @@ func (client *baseClient) SInterCardLimit(keys []string, limit int64) (int64, er
 
 	result, err := client.executeCommand(C.SInterCard, args)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -798,7 +798,7 @@ func (client *baseClient) LTrim(key string, start int64, end int64) (Result[stri
 func (client *baseClient) LLen(key string) (int64, error) {
 	result, err := client.executeCommand(C.LLen, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -807,7 +807,7 @@ func (client *baseClient) LLen(key string) (int64, error) {
 func (client *baseClient) LRem(key string, count int64, element string) (int64, error) {
 	result, err := client.executeCommand(C.LRem, []string{key, utils.IntToString(count), element})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -839,7 +839,7 @@ func (client *baseClient) LInsert(
 ) (int64, error) {
 	insertPositionStr, err := insertPosition.toString()
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	result, err := client.executeCommand(
@@ -847,7 +847,7 @@ func (client *baseClient) LInsert(
 		[]string{key, insertPositionStr, pivot, element},
 	)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -874,7 +874,7 @@ func (client *baseClient) BRPop(keys []string, timeoutSecs float64) ([]Result[st
 func (client *baseClient) RPushX(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.RPushX, append([]string{key}, elements...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -883,7 +883,7 @@ func (client *baseClient) RPushX(key string, elements []string) (int64, error) {
 func (client *baseClient) LPushX(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.LPushX, append([]string{key}, elements...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1088,7 +1088,7 @@ func (client *baseClient) PingWithMessage(message string) (string, error) {
 func (client *baseClient) Del(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Del, keys)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1097,7 +1097,7 @@ func (client *baseClient) Del(keys []string) (int64, error) {
 func (client *baseClient) Exists(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Exists, keys)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1206,7 +1206,7 @@ func (client *baseClient) PExpireAtWithOptions(
 func (client *baseClient) ExpireTime(key string) (int64, error) {
 	result, err := client.executeCommand(C.ExpireTime, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1215,7 +1215,7 @@ func (client *baseClient) ExpireTime(key string) (int64, error) {
 func (client *baseClient) PExpireTime(key string) (int64, error) {
 	result, err := client.executeCommand(C.PExpireTime, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1224,7 +1224,7 @@ func (client *baseClient) PExpireTime(key string) (int64, error) {
 func (client *baseClient) TTL(key string) (int64, error) {
 	result, err := client.executeCommand(C.TTL, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1233,7 +1233,7 @@ func (client *baseClient) TTL(key string) (int64, error) {
 func (client *baseClient) PTTL(key string) (int64, error) {
 	result, err := client.executeCommand(C.PTTL, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1242,7 +1242,7 @@ func (client *baseClient) PTTL(key string) (int64, error) {
 func (client *baseClient) PfAdd(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.PfAdd, append([]string{key}, elements...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1251,7 +1251,7 @@ func (client *baseClient) PfAdd(key string, elements []string) (int64, error) {
 func (client *baseClient) PfCount(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.PfCount, keys)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1260,7 +1260,7 @@ func (client *baseClient) PfCount(keys []string) (int64, error) {
 func (client *baseClient) Unlink(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Unlink, keys)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1277,7 +1277,7 @@ func (client *baseClient) Type(key string) (Result[string], error) {
 func (client *baseClient) Touch(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Touch, keys)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1341,7 +1341,7 @@ func (client *baseClient) ZAdd(
 		append([]string{key}, utils.ConvertMapToValueKeyStringArray(membersScoreMap)...),
 	)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1354,7 +1354,7 @@ func (client *baseClient) ZAddWithOptions(
 ) (int64, error) {
 	optionArgs, err := opts.ToArgs()
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 	commandArgs := append([]string{key}, optionArgs...)
 	result, err := client.executeCommand(
@@ -1362,7 +1362,7 @@ func (client *baseClient) ZAddWithOptions(
 		append(commandArgs, utils.ConvertMapToValueKeyStringArray(membersScoreMap)...),
 	)
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1453,7 +1453,7 @@ func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[Result[
 func (client *baseClient) ZRem(key string, members []string) (int64, error) {
 	result, err := client.executeCommand(C.ZRem, append([]string{key}, members...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 	return handleLongResponse(result)
 }
@@ -1461,7 +1461,7 @@ func (client *baseClient) ZRem(key string, members []string) (int64, error) {
 func (client *baseClient) ZCard(key string) (int64, error) {
 	result, err := client.executeCommand(C.ZCard, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 
 	return handleLongResponse(result)
@@ -1614,11 +1614,11 @@ func (client *baseClient) ZRevRankWithScore(key string, member string) (Result[i
 func (client *baseClient) XTrim(key string, options *options.XTrimOptions) (int64, error) {
 	xTrimArgs, err := options.ToArgs()
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 	result, err := client.executeCommand(C.XTrim, append([]string{key}, xTrimArgs...))
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 	return handleLongResponse(result)
 }
@@ -1626,7 +1626,7 @@ func (client *baseClient) XTrim(key string, options *options.XTrimOptions) (int6
 func (client *baseClient) XLen(key string) (int64, error) {
 	result, err := client.executeCommand(C.XLen, []string{key})
 	if err != nil {
-		return 0, err
+		return defaultIntResponse, err
 	}
 	return handleLongResponse(result)
 }

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -261,19 +261,19 @@ func (client *baseClient) MGet(keys []string) ([]Result[string], error) {
 	return handleStringArrayResponse(result)
 }
 
-func (client *baseClient) Incr(key string) (Result[int64], error) {
+func (client *baseClient) Incr(key string) (int64, error) {
 	result, err := client.executeCommand(C.Incr, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) IncrBy(key string, amount int64) (Result[int64], error) {
+func (client *baseClient) IncrBy(key string, amount int64) (int64, error) {
 	result, err := client.executeCommand(C.IncrBy, []string{key, utils.IntToString(amount)})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -291,37 +291,37 @@ func (client *baseClient) IncrByFloat(key string, amount float64) (Result[float6
 	return handleDoubleResponse(result)
 }
 
-func (client *baseClient) Decr(key string) (Result[int64], error) {
+func (client *baseClient) Decr(key string) (int64, error) {
 	result, err := client.executeCommand(C.Decr, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) DecrBy(key string, amount int64) (Result[int64], error) {
+func (client *baseClient) DecrBy(key string, amount int64) (int64, error) {
 	result, err := client.executeCommand(C.DecrBy, []string{key, utils.IntToString(amount)})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) Strlen(key string) (Result[int64], error) {
+func (client *baseClient) Strlen(key string) (int64, error) {
 	result, err := client.executeCommand(C.Strlen, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SetRange(key string, offset int, value string) (Result[int64], error) {
+func (client *baseClient) SetRange(key string, offset int, value string) (int64, error) {
 	result, err := client.executeCommand(C.SetRange, []string{key, strconv.Itoa(offset), value})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -336,10 +336,10 @@ func (client *baseClient) GetRange(key string, start int, end int) (Result[strin
 	return handleStringResponse(result)
 }
 
-func (client *baseClient) Append(key string, value string) (Result[int64], error) {
+func (client *baseClient) Append(key string, value string) (int64, error) {
 	result, err := client.executeCommand(C.Append, []string{key, value})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -394,10 +394,10 @@ func (client *baseClient) HMGet(key string, fields []string) ([]Result[string], 
 	return handleStringArrayResponse(result)
 }
 
-func (client *baseClient) HSet(key string, values map[string]string) (Result[int64], error) {
+func (client *baseClient) HSet(key string, values map[string]string) (int64, error) {
 	result, err := client.executeCommand(C.HSet, utils.ConvertMapToKeyValueStringArray(key, values))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -412,19 +412,19 @@ func (client *baseClient) HSetNX(key string, field string, value string) (Result
 	return handleBooleanResponse(result)
 }
 
-func (client *baseClient) HDel(key string, fields []string) (Result[int64], error) {
+func (client *baseClient) HDel(key string, fields []string) (int64, error) {
 	result, err := client.executeCommand(C.HDel, append([]string{key}, fields...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) HLen(key string) (Result[int64], error) {
+func (client *baseClient) HLen(key string) (int64, error) {
 	result, err := client.executeCommand(C.HLen, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -457,19 +457,19 @@ func (client *baseClient) HKeys(key string) ([]Result[string], error) {
 	return handleStringArrayResponse(result)
 }
 
-func (client *baseClient) HStrLen(key string, field string) (Result[int64], error) {
+func (client *baseClient) HStrLen(key string, field string) (int64, error) {
 	result, err := client.executeCommand(C.HStrlen, []string{key, field})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) HIncrBy(key string, field string, increment int64) (Result[int64], error) {
+func (client *baseClient) HIncrBy(key string, field string, increment int64) (int64, error) {
 	result, err := client.executeCommand(C.HIncrBy, []string{key, field, utils.IntToString(increment)})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -509,10 +509,10 @@ func (client *baseClient) HScanWithOptions(
 	return handleScanResponse(result)
 }
 
-func (client *baseClient) LPush(key string, elements []string) (Result[int64], error) {
+func (client *baseClient) LPush(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.LPush, append([]string{key}, elements...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -580,37 +580,37 @@ func (client *baseClient) LPosCountWithOptions(
 	return handleLongArrayResponse(result)
 }
 
-func (client *baseClient) RPush(key string, elements []string) (Result[int64], error) {
+func (client *baseClient) RPush(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.RPush, append([]string{key}, elements...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SAdd(key string, members []string) (Result[int64], error) {
+func (client *baseClient) SAdd(key string, members []string) (int64, error) {
 	result, err := client.executeCommand(C.SAdd, append([]string{key}, members...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SRem(key string, members []string) (Result[int64], error) {
+func (client *baseClient) SRem(key string, members []string) (int64, error) {
 	result, err := client.executeCommand(C.SRem, append([]string{key}, members...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SUnionStore(destination string, keys []string) (Result[int64], error) {
+func (client *baseClient) SUnionStore(destination string, keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SUnionStore, append([]string{destination}, keys...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -625,10 +625,10 @@ func (client *baseClient) SMembers(key string) (map[Result[string]]struct{}, err
 	return handleStringSetResponse(result)
 }
 
-func (client *baseClient) SCard(key string) (Result[int64], error) {
+func (client *baseClient) SCard(key string) (int64, error) {
 	result, err := client.executeCommand(C.SCard, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -652,10 +652,10 @@ func (client *baseClient) SDiff(keys []string) (map[Result[string]]struct{}, err
 	return handleStringSetResponse(result)
 }
 
-func (client *baseClient) SDiffStore(destination string, keys []string) (Result[int64], error) {
+func (client *baseClient) SDiffStore(destination string, keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SDiffStore, append([]string{destination}, keys...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -670,30 +670,30 @@ func (client *baseClient) SInter(keys []string) (map[Result[string]]struct{}, er
 	return handleStringSetResponse(result)
 }
 
-func (client *baseClient) SInterStore(destination string, keys []string) (Result[int64], error) {
+func (client *baseClient) SInterStore(destination string, keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SInterStore, append([]string{destination}, keys...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SInterCard(keys []string) (Result[int64], error) {
+func (client *baseClient) SInterCard(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.SInterCard, append([]string{strconv.Itoa(len(keys))}, keys...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SInterCardLimit(keys []string, limit int64) (Result[int64], error) {
+func (client *baseClient) SInterCardLimit(keys []string, limit int64) (int64, error) {
 	args := utils.Concat([]string{utils.IntToString(int64(len(keys)))}, keys, []string{"LIMIT", utils.IntToString(limit)})
 
 	result, err := client.executeCommand(C.SInterCard, args)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -795,19 +795,19 @@ func (client *baseClient) LTrim(key string, start int64, end int64) (Result[stri
 	return handleStringResponse(result)
 }
 
-func (client *baseClient) LLen(key string) (Result[int64], error) {
+func (client *baseClient) LLen(key string) (int64, error) {
 	result, err := client.executeCommand(C.LLen, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) LRem(key string, count int64, element string) (Result[int64], error) {
+func (client *baseClient) LRem(key string, count int64, element string) (int64, error) {
 	result, err := client.executeCommand(C.LRem, []string{key, utils.IntToString(count), element})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -836,10 +836,10 @@ func (client *baseClient) LInsert(
 	insertPosition InsertPosition,
 	pivot string,
 	element string,
-) (Result[int64], error) {
+) (int64, error) {
 	insertPositionStr, err := insertPosition.toString()
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	result, err := client.executeCommand(
@@ -847,7 +847,7 @@ func (client *baseClient) LInsert(
 		[]string{key, insertPositionStr, pivot, element},
 	)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -871,19 +871,19 @@ func (client *baseClient) BRPop(keys []string, timeoutSecs float64) ([]Result[st
 	return handleStringArrayOrNullResponse(result)
 }
 
-func (client *baseClient) RPushX(key string, elements []string) (Result[int64], error) {
+func (client *baseClient) RPushX(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.RPushX, append([]string{key}, elements...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) LPushX(key string, elements []string) (Result[int64], error) {
+func (client *baseClient) LPushX(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.LPushX, append([]string{key}, elements...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1085,19 +1085,19 @@ func (client *baseClient) PingWithMessage(message string) (string, error) {
 	return response.Value(), nil
 }
 
-func (client *baseClient) Del(keys []string) (Result[int64], error) {
+func (client *baseClient) Del(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Del, keys)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) Exists(keys []string) (Result[int64], error) {
+func (client *baseClient) Exists(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Exists, keys)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1203,64 +1203,64 @@ func (client *baseClient) PExpireAtWithOptions(
 	return handleBooleanResponse(result)
 }
 
-func (client *baseClient) ExpireTime(key string) (Result[int64], error) {
+func (client *baseClient) ExpireTime(key string) (int64, error) {
 	result, err := client.executeCommand(C.ExpireTime, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) PExpireTime(key string) (Result[int64], error) {
+func (client *baseClient) PExpireTime(key string) (int64, error) {
 	result, err := client.executeCommand(C.PExpireTime, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) TTL(key string) (Result[int64], error) {
+func (client *baseClient) TTL(key string) (int64, error) {
 	result, err := client.executeCommand(C.TTL, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) PTTL(key string) (Result[int64], error) {
+func (client *baseClient) PTTL(key string) (int64, error) {
 	result, err := client.executeCommand(C.PTTL, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) PfAdd(key string, elements []string) (Result[int64], error) {
+func (client *baseClient) PfAdd(key string, elements []string) (int64, error) {
 	result, err := client.executeCommand(C.PfAdd, append([]string{key}, elements...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) PfCount(keys []string) (Result[int64], error) {
+func (client *baseClient) PfCount(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.PfCount, keys)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) Unlink(keys []string) (Result[int64], error) {
+func (client *baseClient) Unlink(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Unlink, keys)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1274,10 +1274,10 @@ func (client *baseClient) Type(key string) (Result[string], error) {
 	return handleStringOrNullResponse(result)
 }
 
-func (client *baseClient) Touch(keys []string) (Result[int64], error) {
+func (client *baseClient) Touch(keys []string) (int64, error) {
 	result, err := client.executeCommand(C.Touch, keys)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1335,13 +1335,13 @@ func (client *baseClient) XAddWithOptions(
 func (client *baseClient) ZAdd(
 	key string,
 	membersScoreMap map[string]float64,
-) (Result[int64], error) {
+) (int64, error) {
 	result, err := client.executeCommand(
 		C.ZAdd,
 		append([]string{key}, utils.ConvertMapToValueKeyStringArray(membersScoreMap)...),
 	)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1351,10 +1351,10 @@ func (client *baseClient) ZAddWithOptions(
 	key string,
 	membersScoreMap map[string]float64,
 	opts *options.ZAddOptions,
-) (Result[int64], error) {
+) (int64, error) {
 	optionArgs, err := opts.ToArgs()
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 	commandArgs := append([]string{key}, optionArgs...)
 	result, err := client.executeCommand(
@@ -1362,7 +1362,7 @@ func (client *baseClient) ZAddWithOptions(
 		append(commandArgs, utils.ConvertMapToValueKeyStringArray(membersScoreMap)...),
 	)
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1450,18 +1450,18 @@ func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[Result[
 	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZRem(key string, members []string) (Result[int64], error) {
+func (client *baseClient) ZRem(key string, members []string) (int64, error) {
 	result, err := client.executeCommand(C.ZRem, append([]string{key}, members...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) ZCard(key string) (Result[int64], error) {
+func (client *baseClient) ZCard(key string) (int64, error) {
 	result, err := client.executeCommand(C.ZCard, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 
 	return handleLongResponse(result)
@@ -1611,22 +1611,22 @@ func (client *baseClient) ZRevRankWithScore(key string, member string) (Result[i
 	return handleLongAndDoubleOrNullResponse(result)
 }
 
-func (client *baseClient) XTrim(key string, options *options.XTrimOptions) (Result[int64], error) {
+func (client *baseClient) XTrim(key string, options *options.XTrimOptions) (int64, error) {
 	xTrimArgs, err := options.ToArgs()
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 	result, err := client.executeCommand(C.XTrim, append([]string{key}, xTrimArgs...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) XLen(key string) (Result[int64], error) {
+func (client *baseClient) XLen(key string) (int64, error) {
 	result, err := client.executeCommand(C.XLen, []string{key})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return 0, err
 	}
 	return handleLongResponse(result)
 }

--- a/go/api/generic_base_commands.go
+++ b/go/api/generic_base_commands.go
@@ -32,7 +32,7 @@ type GenericBaseCommands interface {
 	//	fmt.Println(result) // Output: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/del/
-	Del(keys []string) (Result[int64], error)
+	Del(keys []string) (int64, error)
 
 	// Exists returns the number of keys that exist in the database
 	//
@@ -52,11 +52,10 @@ type GenericBaseCommands interface {
 	//
 	// Example:
 	// result, err := client.Exists([]string{"key1", "key2", "key3"})
-	// result.Value(): 2
-	// result.IsNil(): false
+	// result: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/exists/
-	Exists(keys []string) (Result[int64], error)
+	Exists(keys []string) (int64, error)
 
 	// Expire sets a timeout on key. After the timeout has expired, the key will automatically be deleted
 	//
@@ -246,16 +245,15 @@ type GenericBaseCommands interface {
 	//
 	// Return value:
 	// The expiration Unix timestamp in seconds.
-	// -2 if key does not exist or -1 is key exists but has no associated expiration.
+	// `-2` if key does not exist or `-1` is key exists but has no associated expiration.
 	//
 	// Example:
 	//
 	// result, err := client.ExpireTime("key")
-	// result.Value(): 1732118030
-	// result.IsNil(): false
+	// result: 1732118030
 	//
 	// [valkey.io]: https://valkey.io/commands/expiretime/
-	ExpireTime(key string) (Result[int64], error)
+	ExpireTime(key string) (int64, error)
 
 	// PExpire Time returns the absolute Unix timestamp (since January 1, 1970) at which the given key
 	// will expire, in milliseconds.
@@ -265,16 +263,15 @@ type GenericBaseCommands interface {
 	//
 	// Return value:
 	// The expiration Unix timestamp in milliseconds.
-	// -2 if key does not exist or -1 is key exists but has no associated expiration.
+	// `-2` if key does not exist or `-1` is key exists but has no associated expiration.
 	//
 	// Example:
 	//
 	// result, err := client.PExpireTime("key")
-	// result.Value(): 33177117420000
-	// result.IsNil(): false
+	// result: 33177117420000
 	//
 	// [valkey.io]: https://valkey.io/commands/pexpiretime/
-	PExpireTime(key string) (Result[int64], error)
+	PExpireTime(key string) (int64, error)
 
 	// TTL returns the remaining time to live of key that has a timeout, in seconds.
 	//
@@ -283,16 +280,15 @@ type GenericBaseCommands interface {
 	//
 	// Return value:
 	// Returns TTL in seconds,
-	// -2 if key does not exist, or -1 if key exists but has no associated expiration.
+	// `-2` if key does not exist, or `-1` if key exists but has no associated expiration.
 	//
 	// Example:
 	//
 	// result, err := client.TTL("key")
-	// result.Value(): 3
-	// result.IsNil(): false
+	// result: 3
 	//
 	// [valkey.io]: https://valkey.io/commands/ttl/
-	TTL(key string) (Result[int64], error)
+	TTL(key string) (int64, error)
 
 	// PTTL returns the remaining time to live of key that has a timeout, in milliseconds.
 	//
@@ -301,16 +297,15 @@ type GenericBaseCommands interface {
 	//
 	// Return value:
 	// Returns TTL in milliseconds,
-	// -2 if key does not exist, or -1 if key exists but has no associated expiration.
+	// `-2` if key does not exist, or `-1` if key exists but has no associated expiration.
 	//
 	// Example:
 	//
 	// result, err := client.PTTL("key")
-	// result.Value(): 1000
-	// result.IsNil(): false
+	// result: 1000
 	//
 	// [valkey.io]: https://valkey.io/commands/pttl/
-	PTTL(key string) (Result[int64], error)
+	PTTL(key string) (int64, error)
 
 	// Unlink (delete) multiple keys from the database. A key is ignored if it does not exist.
 	// This command, similar to Del However, this command does not block the server
@@ -334,10 +329,10 @@ type GenericBaseCommands interface {
 	//	if err != nil {
 	//	    // handle error
 	//	}
-	//	fmt.Println(result.Value()) // Output: 3
+	//	fmt.Println(result) // Output: 3
 	//
 	// [valkey.io]: Https://valkey.io/commands/unlink/
-	Unlink(keys []string) (Result[int64], error)
+	Unlink(keys []string) (int64, error)
 
 	// Alters the last access time of a key(s). A key is ignored if it does not exist.
 	//
@@ -360,10 +355,10 @@ type GenericBaseCommands interface {
 	//	if err != nil {
 	//	    // handle error
 	//	}
-	//	fmt.Println(result.Value()) // Output: 3
+	//	fmt.Println(result) // Output: 3
 	//
 	// [valkey.io]: Https://valkey.io/commands/touch/
-	Touch(keys []string) (Result[int64], error)
+	Touch(keys []string) (int64, error)
 
 	// Type returns the string representation of the type of the value stored at key.
 	// The different types that can be returned are: string, list, set, zset, hash and stream.

--- a/go/api/hash_commands.go
+++ b/go/api/hash_commands.go
@@ -89,15 +89,14 @@ type HashCommands interface {
 	//  values - A map of field-value pairs to set in the hash.
 	//
 	// Return value:
-	//  The Result[int64] containing number of fields that were added or updated.
+	//  The number of fields that were added or updated.
 	//
 	// For example:
 	//  num, err := client.HSet("my_hash", map[string]string{"field": "value", "field2": "value2"})
-	//  // num.Value(): 2
-	//  // num.IsNil(): false
+	//  // num: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/hset/
-	HSet(key string, values map[string]string) (Result[int64], error)
+	HSet(key string, values map[string]string) (int64, error)
 
 	// HSetNX sets field in the hash stored at key to value, only if field does not yet exist.
 	// If key does not exist, a new key holding a hash is created.
@@ -136,16 +135,14 @@ type HashCommands interface {
 	//  fields - The fields to remove from the hash stored at key.
 	//
 	// Return value:
-	// The Result[int64] containing number of fields that were removed from the hash, not including specified but non-existing
-	// fields.
+	// The number of fields that were removed from the hash, not including specified but non-existing fields.
 	//
 	// For example:
 	//  num, err := client.HDel("my_hash", []string{"field_1", "field_2"})
-	//  // num.Value(): 2
-	//  // num.IsNil(): false
+	//  // num: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/hdel/
-	HDel(key string, fields []string) (Result[int64], error)
+	HDel(key string, fields []string) (int64, error)
 
 	// HLen returns the number of fields contained in the hash stored at key.
 	//
@@ -155,19 +152,17 @@ type HashCommands interface {
 	//  key - The key of the hash.
 	//
 	// Return value:
-	//  The Result[int64] containing number of fields in the hash, or 0 when key does not exist.
+	//  The number of fields in the hash, or `0` when key does not exist.
 	//  If key holds a value that is not a hash, an error is returned.
 	//
 	// For example:
 	//  num1, err := client.HLen("myHash")
-	//  // num.Value(): 3
-	//  // num.IsNil(): false
+	//  // num: 3
 	//  num2, err := client.HLen("nonExistingKey")
-	//  // num.Value(): 0
-	//  // num.IsNil(): false
+	//  // num: 0
 	//
 	// [valkey.io]: https://valkey.io/commands/hlen/
-	HLen(key string) (Result[int64], error)
+	HLen(key string) (int64, error)
 
 	// HVals returns all values in the hash stored at key.
 	//
@@ -241,7 +236,7 @@ type HashCommands interface {
 	//  field - The field to get the string length of its value.
 	//
 	// Return value:
-	//  The Result[int64] containing length of the string value associated with field, or 0 when field or key do not exist.
+	//  The length of the string value associated with field, or `0` when field or key do not exist.
 	//
 	// For example:
 	//  strlen, err := client.HStrLen("my_hash", "my_field")
@@ -249,7 +244,7 @@ type HashCommands interface {
 	//  // strlen.IsNil(): false
 	//
 	// [valkey.io]: https://valkey.io/commands/hstrlen/
-	HStrLen(key string, field string) (Result[int64], error)
+	HStrLen(key string, field string) (int64, error)
 
 	// Increments the number stored at `field` in the hash stored at `key` by increment.
 	// By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
@@ -263,15 +258,15 @@ type HashCommands interface {
 	// 	increment - The amount to increment.
 	//
 	// Return value:
-	// 	The Result[int64] value of `field` in the hash stored at `key` after the increment.
+	// 	The value of `field` in the hash stored at `key` after the increment.
 	//
 	// Example:
 	//  _, err := client.HSet("key", map[string]string{"field": "10"})
 	//  hincrByResult, err := client.HIncrBy("key", "field", 1)
-	//	// hincrByResult.Value(): 11
+	//	// hincrByResult: 11
 	//
 	// [valkey.io]: https://valkey.io/commands/hincrby/
-	HIncrBy(key string, field string, increment int64) (Result[int64], error)
+	HIncrBy(key string, field string, increment int64) (int64, error)
 
 	// Increments the string representing a floating point number stored at `field` in the hash stored at `key` by increment.
 	// By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.

--- a/go/api/hyperloglog_commands.go
+++ b/go/api/hyperloglog_commands.go
@@ -19,15 +19,14 @@ type HyperLogLogCommands interface {
 	//
 	// Return value:
 	//  If the HyperLogLog is newly created, or if the HyperLogLog approximated cardinality is
-	//  altered, then returns 1. Otherwise, returns 0.
+	//  altered, then returns `1`. Otherwise, returns `0`.
 	//
 	// Example:
 	//  result, err := client.PfAdd("key",[]string{"value1", "value2", "value3"})
-	//  result.Value(): 1
-	//  result.IsNil(): false
+	//  result: 1
 	//
 	// [valkey.io]: https://valkey.io/commands/pfadd/
-	PfAdd(key string, elements []string) (Result[int64], error)
+	PfAdd(key string, elements []string) (int64, error)
 
 	// Estimates the cardinality of the data stored in a HyperLogLog structure for a single key or
 	// calculates the combined cardinality of multiple keys by merging their HyperLogLogs temporarily.
@@ -45,13 +44,12 @@ type HyperLogLogCommands interface {
 	//
 	// Return value:
 	//  The approximated cardinality of given HyperLogLog data structures.
-	//  The cardinality of a key that does not exist is 0.
+	//  The cardinality of a key that does not exist is `0`.
 	//
 	// Example:
 	//  result, err := client.PfCount([]string{"key1","key2"})
-	//  result.Value(): 5
-	//  result.IsNil(): false
+	//  result: 5
 	//
 	// [valkey.io]: https://valkey.io/commands/pfcount/
-	PfCount(keys []string) (Result[int64], error)
+	PfCount(keys []string) (int64, error)
 }

--- a/go/api/list_commands.go
+++ b/go/api/list_commands.go
@@ -19,15 +19,14 @@ type ListCommands interface {
 	//  elements - The elements to insert at the head of the list stored at key.
 	//
 	// Return value:
-	//  A api.Result[int64] containing the length of the list after the push operation.
+	//  The length of the list after the push operation.
 	//
 	// For example:
 	//  result, err := client.LPush("my_list", []string{"value1", "value2"})
-	//  result.Value(): 2
-	//  result.IsNil(): false
+	//  result: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/lpush/
-	LPush(key string, elements []string) (Result[int64], error)
+	LPush(key string, elements []string) (int64, error)
 
 	// Removes and returns the first elements of the list stored at key. The command pops a single element from the beginning
 	// of the list.
@@ -183,15 +182,14 @@ type ListCommands interface {
 	//  elements - The elements to insert at the tail of the list stored at key.
 	//
 	// Return value:
-	//  The Result[int64] containing the length of the list after the push operation.
+	//  The length of the list after the push operation.
 	//
 	// For example:
 	//  result, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
-	//  result.Value(): 7
-	//  result.IsNil(): false
+	//  result: 7
 	//
 	// [valkey.io]: https://valkey.io/commands/rpush/
-	RPush(key string, elements []string) (Result[int64], error)
+	RPush(key string, elements []string) (int64, error)
 
 	// Returns the specified elements of the list stored at key.
 	// The offsets start and end are zero-based indexes, with 0 being the first element of the list, 1 being the next element
@@ -284,16 +282,15 @@ type ListCommands interface {
 	//  key - The key of the list.
 	//
 	// Return value:
-	//  The Result[int64] containing the length of the list at key.
-	//  If key does not exist, it is interpreted as an empty list and 0 is returned.
+	//  The length of the list at `key`.
+	//  If `key` does not exist, it is interpreted as an empty list and `0` is returned.
 	//
 	// For example:
 	//  result, err := client.LLen("my_list")
-	//  result.Value(): int64(3) // Indicates that there are 3 elements in the list.
-	//  result.IsNil(): false
+	//  result: 3 // Indicates that there are 3 elements in the list.
 	//
 	// [valkey.io]: https://valkey.io/commands/llen/
-	LLen(key string) (Result[int64], error)
+	LLen(key string) (int64, error)
 
 	// Removes the first count occurrences of elements equal to element from the list stored at key.
 	// If count is positive: Removes elements equal to element moving from head to tail.
@@ -309,16 +306,15 @@ type ListCommands interface {
 	//  element - The element to remove from the list.
 	//
 	// Return value:
-	//  The Result[int64] containing the number of the removed elements.
-	//  If key does not exist, 0 is returned.
+	//  The number of the removed elements.
+	//  If `key` does not exist, `0` is returned.
 	//
 	// For example:
 	//  result, err := client.LRem("my_list", 2, "value")
-	//  result.Value(): int64(2)
-	//  result.IsNil(): false
+	//  result: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/lrem/
-	LRem(key string, count int64, element string) (Result[int64], error)
+	LRem(key string, count int64, element string) (int64, error)
 
 	// Removes and returns the last elements of the list stored at key.
 	// The command pops a single element from the end of the list.
@@ -375,17 +371,17 @@ type ListCommands interface {
 	//  element        - The new element to insert.
 	//
 	// Return value:
-	//  The Result[int64] containing the list length after a successful insert operation.
-	//  If the key doesn't exist returns -1.
-	//  If the pivot wasn't found, returns 0.
+	//  The list length after a successful insert operation.
+	//  If the `key` doesn't exist returns `-1`.
+	//  If the `pivot` wasn't found, returns `0`.
 	//
 	// For example:
 	//  "my_list": {"Hello", "Wprld"}
 	//  result, err := client.LInsert("my_list", api.Before, "World", "There")
-	//  result.Value(): 3
+	//  result: 3
 	//
 	// [valkey.io]: https://valkey.io/commands/linsert/
-	LInsert(key string, insertPosition InsertPosition, pivot string, element string) (Result[int64], error)
+	LInsert(key string, insertPosition InsertPosition, pivot string, element string) (int64, error)
 
 	// Pops an element from the head of the first list that is non-empty, with the given keys being checked in the order that
 	// they are given.
@@ -451,15 +447,15 @@ type ListCommands interface {
 	//  elements - The elements to insert at the tail of the list stored at key.
 	//
 	// Return value:
-	//  The Result[int64] containing the length of the list after the push operation.
+	//  The length of the list after the push operation.
 	//
 	// For example:
 	//  my_list: {"value1", "value2"}
 	//  result, err := client.RPushX("my_list", []string{"value3", value4})
-	//  result.Value(): 4
+	//  result: 4
 	//
 	// [valkey.io]: https://valkey.io/commands/rpushx/
-	RPushX(key string, elements []string) (Result[int64], error)
+	RPushX(key string, elements []string) (int64, error)
 
 	// Inserts all the specified values at the head of the list stored at key, only if key exists and holds a list. If key is
 	// not a list, this performs no operation.
@@ -471,15 +467,15 @@ type ListCommands interface {
 	//  elements - The elements to insert at the head of the list stored at key.
 	//
 	// Return value:
-	//  The Result[int64] containing the length of the list after the push operation.
+	//  The length of the list after the push operation.
 	//
 	// For example:
 	//  my_list: {"value1", "value2"}
 	//  result, err := client.LPushX("my_list", []string{"value3", value4})
-	//  result.Value(): 4
+	//  result: 4
 	//
 	// [valkey.io]: https://valkey.io/commands/rpushx/
-	LPushX(key string, elements []string) (Result[int64], error)
+	LPushX(key string, elements []string) (int64, error)
 
 	// Pops one element from the first non-empty list from the provided keys.
 	//

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -211,7 +211,7 @@ func handleStringArrayOrNullResponse(response *C.struct_CommandResponse) ([]Resu
 	return slice, nil
 }
 
-func handleLongResponse(response *C.struct_CommandResponse) (int64, error) {
+func handleIntResponse(response *C.struct_CommandResponse) (int64, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Int, false)
@@ -222,7 +222,7 @@ func handleLongResponse(response *C.struct_CommandResponse) (int64, error) {
 	return int64(response.int_value), nil
 }
 
-func handleLongOrNullResponse(response *C.struct_CommandResponse) (Result[int64], error) {
+func handleIntOrNilResponse(response *C.struct_CommandResponse) (Result[int64], error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Int, true)
@@ -237,7 +237,7 @@ func handleLongOrNullResponse(response *C.struct_CommandResponse) (Result[int64]
 	return CreateInt64Result(int64(response.int_value)), nil
 }
 
-func handleLongArrayResponse(response *C.struct_CommandResponse) ([]Result[int64], error) {
+func handleIntArrayResponse(response *C.struct_CommandResponse) ([]Result[int64], error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Array, false)

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -211,15 +211,15 @@ func handleStringArrayOrNullResponse(response *C.struct_CommandResponse) ([]Resu
 	return slice, nil
 }
 
-func handleLongResponse(response *C.struct_CommandResponse) (Result[int64], error) {
+func handleLongResponse(response *C.struct_CommandResponse) (int64, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Int, false)
 	if typeErr != nil {
-		return CreateNilInt64Result(), typeErr
+		return 0, typeErr
 	}
 
-	return CreateInt64Result(int64(response.int_value)), nil
+	return int64(response.int_value), nil
 }
 
 func handleLongOrNullResponse(response *C.struct_CommandResponse) (Result[int64], error) {

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -2,6 +2,9 @@
 
 package api
 
+// A value to return alongside with error in case if command failed
+var defaultIntResponse int64
+
 type Result[T any] struct {
 	val   T
 	isNil bool

--- a/go/api/set_commands.go
+++ b/go/api/set_commands.go
@@ -248,7 +248,7 @@ type SetCommands interface {
 	//
 	// Example:
 	//   result, err := client.SInterCardLimit([]string{"set1", "set2"}, 3)
-	//   // resul: 2
+	//   // result: 2
 	//   // Indicates that the intersection of "set1" and "set2" contains 2 elements (or at least 3 if the actual
 	//   // intersection is larger)
 	//

--- a/go/api/set_commands.go
+++ b/go/api/set_commands.go
@@ -19,16 +19,14 @@ type SetCommands interface {
 	//  members - A list of members to add to the set stored at key.
 	//
 	// Return value:
-	//  The Result[int64] containing number of members that were added to the set,
-	//  or [api.NilResult[int64]](api.CreateNilInt64Result()) when the key does not exist.
+	//  The number of members that were added to the set, excluding members already present.
 	//
 	// For example:
 	//  result, err := client.SAdd("my_set", []string{"member1", "member2"})
-	//  // result.Value(): 2
-	//  // result.IsNil(): false
+	//  // result: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/sadd/
-	SAdd(key string, members []string) (Result[int64], error)
+	SAdd(key string, members []string) (int64, error)
 
 	// SRem removes specified members from the set stored at key.
 	//
@@ -39,16 +37,14 @@ type SetCommands interface {
 	//  members - A list of members to remove from the set stored at key.
 	//
 	// Return value:
-	//  The Result[int64] containing number of members that were removed from the set, excluding non-existing members.
-	//  Returns [api.NilResult[int64]](api.CreateNilInt64Result()) if key does not exist.
+	//  The number of members that were removed from the set, excluding non-existing members.
 	//
 	// For example:
 	//  result, err := client.SRem("my_set", []string{"member1", "member2"})
-	//  // result.Value(): 2
-	//  // result.IsNil(): false
+	//  // result: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/srem/
-	SRem(key string, members []string) (Result[int64], error)
+	SRem(key string, members []string) (int64, error)
 
 	// SMembers retrieves all the members of the set value stored at key.
 	//
@@ -81,16 +77,14 @@ type SetCommands interface {
 	//   key - The key from which to retrieve the number of set members.
 	//
 	// Return value:
-	//   The Result[int64] containing the cardinality (number of elements) of the set,
-	//   or 0 if the key does not exist.
+	//   The cardinality (number of elements) of the set, or `0` if the key does not exist.
 	//
 	// Example:
 	//   result, err := client.SCard("my_set")
-	//   // result.Value(): 3
-	//   // result.IsNil(): false
+	//   // result: 3
 	//
 	// [valkey.io]: https://valkey.io/commands/scard/
-	SCard(key string) (Result[int64], error)
+	SCard(key string) (int64, error)
 
 	// SIsMember returns if member is a member of the set stored at key.
 	//
@@ -151,15 +145,15 @@ type SetCommands interface {
 	//   keys        - The keys of the sets to diff.
 	//
 	// Return value:
-	//   A Result[int64] containing the number of elements in the resulting set.
+	//   The number of elements in the resulting set.
 	//
 	// Example:
 	//   result, err := client.SDiffStore("mySet", []string{"set1", "set2"})
-	//   // result.Value(): 5
+	//   // result: 5
 	//   // Indicates that the resulting set "mySet" contains 5 elements
 	//
 	// [valkey.io]: https://valkey.io/commands/sdiffstore/
-	SDiffStore(destination string, keys []string) (Result[int64], error)
+	SDiffStore(destination string, keys []string) (int64, error)
 
 	// SInter gets the intersection of all the given sets.
 	//
@@ -207,7 +201,7 @@ type SetCommands interface {
 	//   // Output: 2 - Two elements were stored at "my_set", and those elements are the intersection of "set1" and "set2".
 	//
 	// [valkey.io]: https://valkey.io/commands/sinterstore/
-	SInterStore(destination string, keys []string) (Result[int64], error)
+	SInterStore(destination string, keys []string) (int64, error)
 
 	// SInterCard gets the cardinality of the intersection of all the given sets.
 	//
@@ -222,18 +216,17 @@ type SetCommands interface {
 	//   keys - The keys of the sets to intersect.
 	//
 	// Return value:
-	//   A Result[int64] containing the cardinality of the intersection result.
-	//   If one or more sets do not exist, 0 is returned.
+	//   The cardinality of the intersection result. If one or more sets do not exist, `0` is returned.
 	//
 	// Example:
 	//   result, err := client.SInterCard([]string{"set1", "set2"})
-	//   // result.Value(): 2
+	//   // result: 2
 	//   // Indicates that the intersection of "set1" and "set2" contains 2 elements
 	//   result, err := client.SInterCard([]string{"set1", "nonExistingSet"})
-	//   // result.Value(): 0
+	//   // result: 0
 	//
 	// [valkey.io]: https://valkey.io/commands/sintercard/
-	SInterCard(keys []string) (Result[int64], error)
+	SInterCard(keys []string) (int64, error)
 
 	// SInterCardLimit gets the cardinality of the intersection of all the given sets, up to the specified limit.
 	//
@@ -249,18 +242,18 @@ type SetCommands interface {
 	//   limit - The limit for the intersection cardinality value.
 	//
 	// Return value:
-	//   A Result[int64] containing the cardinality of the intersection result, or the limit if reached.
-	//   If one or more sets do not exist, 0 is returned.
+	//   The cardinality of the intersection result, or the limit if reached.
+	//   If one or more sets do not exist, `0` is returned.
 	//   If the intersection cardinality reaches 'limit' partway through the computation, returns 'limit' as the cardinality.
 	//
 	// Example:
 	//   result, err := client.SInterCardLimit([]string{"set1", "set2"}, 3)
-	//   // result.Value(): 2
+	//   // resul: 2
 	//   // Indicates that the intersection of "set1" and "set2" contains 2 elements (or at least 3 if the actual
 	//   // intersection is larger)
 	//
 	// [valkey.io]: https://valkey.io/commands/sintercard/
-	SInterCardLimit(keys []string, limit int64) (Result[int64], error)
+	SInterCardLimit(keys []string, limit int64) (int64, error)
 
 	// SRandMember returns a random element from the set value stored at key.
 	//
@@ -343,12 +336,12 @@ type SetCommands interface {
 	// Example:
 	//   result, err := client.SUnionStore("my_set", []string{"set1", "set2"})
 	//   if err != nil {
-	//       fmt.Println(result.Value())
+	//       fmt.Println(result)
 	//   }
 	//   // Output: 2 - Two elements were stored at "my_set", and those elements are the union of "set1" and "set2".
 	//
 	// [valkey.io]: https://valkey.io/commands/sunionstore/
-	SUnionStore(destination string, keys []string) (Result[int64], error)
+	SUnionStore(destination string, keys []string) (int64, error)
 
 	// SUnion gets the union of all the given sets.
 	//

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -21,14 +21,14 @@ type SortedSetCommands interface {
 	//   membersScoreMap - A map of members to their scores.
 	//
 	// Return value:
-	//   Result[int64] - The number of members added to the set.
+	//   The number of members added to the set.
 	//
 	// Example:
 	//   res, err := client.ZAdd(key, map[string]float64{"one": 1.0, "two": 2.0, "three": 3.0})
-	//   fmt.Println(res.Value()) // Output: 3
+	//   fmt.Println(res) // Output: 3
 	//
 	// [valkey.io]: https://valkey.io/commands/zadd/
-	ZAdd(key string, membersScoreMap map[string]float64) (Result[int64], error)
+	ZAdd(key string, membersScoreMap map[string]float64) (int64, error)
 
 	// Adds one or more members to a sorted set, or updates their scores. Creates the key if it doesn't exist.
 	//
@@ -40,15 +40,15 @@ type SortedSetCommands interface {
 	//   opts - The options for the command. See [ZAddOptions] for details.
 	//
 	// Return value:
-	//   Result[int64] - The number of members added to the set. If CHANGED is set, the number of members that were updated.
+	//   The number of members added to the set. If `CHANGED` is set, the number of members that were updated.
 	//
 	// Example:
 	//   res, err := client.ZAddWithOptions(key, map[string]float64{"one": 1.0, "two": 2.0, "three": 3.0},
 	//   									options.NewZAddOptionsBuilder().SetChanged(true).Build())
-	//   fmt.Println(res.Value()) // Output: 3
+	//   fmt.Println(res) // Output: 3
 	//
 	// [valkey.io]: https://valkey.io/commands/zadd/
-	ZAddWithOptions(key string, membersScoreMap map[string]float64, opts *options.ZAddOptions) (Result[int64], error)
+	ZAddWithOptions(key string, membersScoreMap map[string]float64, opts *options.ZAddOptions) (int64, error)
 
 	// Adds one or more members to a sorted set, or updates their scores. Creates the key if it doesn't exist.
 	//
@@ -204,14 +204,14 @@ type SortedSetCommands interface {
 	//
 	// Return value:
 	//   The number of members that were removed from the sorted set, not including non-existing members.
-	//   If `key` does not exist, it is treated as an empty sorted set, and this command returns 0.
+	//   If `key` does not exist, it is treated as an empty sorted set, and this command returns `0`.
 	//
 	// Example:
 	//   res, err := client.ZRem("mySortedSet", []string{""member1", "member2", "missing"})
-	//   fmt.Println(res.Value()) // Output: 2
+	//   fmt.Println(res) // Output: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/zrem/
-	ZRem(key string, members []string) (Result[int64], error)
+	ZRem(key string, members []string) (int64, error)
 
 	// Returns the cardinality (number of elements) of the sorted set stored at `key`.
 	//
@@ -223,15 +223,15 @@ type SortedSetCommands interface {
 	// Return value:
 	//   The number of elements in the sorted set.
 	//
-	// If `key` does not exist, it is treated as an empty sorted set, and this command returns 0.
+	// If `key` does not exist, it is treated as an empty sorted set, and this command returns `0`.
 	// If `key` holds a value that is not a sorted set, an error is returned.
 	//
 	// Example:
-	//   result1, err := client.ZCard("mySet")
-	//   result1.Value() :1 // There is 1 item in the set
+	//   result, err := client.ZCard("mySet")
+	//   result: 1 // There is 1 item in the set
 	//
 	// [valkey.io]: https://valkey.io/commands/zcard/
-	ZCard(key string) (Result[int64], error)
+	ZCard(key string) (int64, error)
 
 	// Blocks the connection until it removes and returns a member with the lowest score from the
 	// first non-empty sorted set, with the given `keys` being checked in the order they

--- a/go/api/stream_commands.go
+++ b/go/api/stream_commands.go
@@ -59,7 +59,7 @@ type StreamCommands interface {
 	//  options - Stream trim options
 	//
 	// Return value:
-	//  Result[int64] - The number of entries deleted from the stream.
+	//  The number of entries deleted from the stream.
 	//
 	// For example:
 	//  xAddResult, err = client.XAddWithOptions(
@@ -73,10 +73,10 @@ type StreamCommands interface {
 	//		"key1",
 	//		options.NewXTrimOptionsWithMaxLen(1).SetExactTrimming(),
 	//  )
-	//  fmt.Println(xTrimResult.Value()) // Output: 1
+	//  fmt.Println(xTrimResult) // Output: 1
 	//
 	// [valkey.io]: https://valkey.io/commands/xtrim/
-	XTrim(key string, options *options.XTrimOptions) (Result[int64], error)
+	XTrim(key string, options *options.XTrimOptions) (int64, error)
 
 	// Returns the number of entries in the stream stored at `key`.
 	//
@@ -86,7 +86,7 @@ type StreamCommands interface {
 	//  key - The key of the stream.
 	//
 	// Return value:
-	//  Result[int64] - The number of entries in the stream. If `key` does not exist, return 0.
+	//  The number of entries in the stream. If `key` does not exist, return 0.
 	//
 	// For example:
 	//	xAddResult, err = client.XAddWithOptions(
@@ -97,8 +97,8 @@ type StreamCommands interface {
 	//		),
 	//	)
 	//	xLenResult, err = client.XLen("key1")
-	//  fmt.Println(xLenResult.Value()) // Output: 2
+	//  fmt.Println(xLenResult) // Output: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/xlen/
-	XLen(key string) (Result[int64], error)
+	XLen(key string) (int64, error)
 }

--- a/go/api/string_commands.go
+++ b/go/api/string_commands.go
@@ -219,16 +219,15 @@ type StringCommands interface {
 	//  key - The key to increment its value.
 	//
 	// Return value:
-	//  The Result[int64] of key after the increment.
+	//  The value of `key` after the increment.
 	//
 	// For example:
 	//  key: 1
 	//  result, err := client.Incr("key");
-	//  result.Value(): 2
-	//  result.IsNil(): false
+	//  result: 2
 	//
 	// [valkey.io]: https://valkey.io/commands/incr/
-	Incr(key string) (Result[int64], error)
+	Incr(key string) (int64, error)
 
 	// Increments the number stored at key by amount. If key does not exist, it is set to 0 before performing the operation.
 	//
@@ -239,16 +238,15 @@ type StringCommands interface {
 	//  amount - The amount to increment.
 	//
 	// Return value:
-	//  The Result[int64] of key after the increment.
+	//  The value of `key` after the increment.
 	//
 	// For example:
 	//  key: 1
 	//  result, err := client.IncrBy("key", 2)
-	//  result.Value(): 3
-	//  result.IsNil(): false
+	//  result: 3
 	//
 	// [valkey.io]: https://valkey.io/commands/incrby/
-	IncrBy(key string, amount int64) (Result[int64], error)
+	IncrBy(key string, amount int64) (int64, error)
 
 	// Increments the string representing a floating point number stored at key by amount. By using a negative increment value,
 	// the result is that the value stored at key is decremented. If key does not exist, it is set to 0 before performing the
@@ -280,16 +278,15 @@ type StringCommands interface {
 	//  key - The key to decrement its value.
 	//
 	// Return value:
-	//  The Result[int64] of key after the decrement.
+	//  The value of `key` after the decrement.
 	//
 	// For example:
 	//  key: 1
 	//  result, err := client.Decr("key")
-	//  result.Value(): 0
-	//  result.IsNil(): false
+	//  result: 0
 	//
 	// [valkey.io]: https://valkey.io/commands/decr/
-	Decr(key string) (Result[int64], error)
+	Decr(key string) (int64, error)
 
 	// Decrements the number stored at code by amount. If key does not exist, it is set to 0 before performing the operation.
 	//
@@ -300,16 +297,15 @@ type StringCommands interface {
 	//  amount - The amount to decrement.
 	//
 	// Return value:
-	//  The Result[int64] of key after the decrement.
+	//  The value of `key` after the decrement.
 	//
 	// For example:
 	//  key: 1
 	//  result, err := client.DecrBy("key", 2)
-	//  result.Value(): -1
-	//  result.IsNil(): false
+	//  result: -1
 	//
 	// [valkey.io]: https://valkey.io/commands/decrby/
-	DecrBy(key string, amount int64) (Result[int64], error)
+	DecrBy(key string, amount int64) (int64, error)
 
 	// Returns the length of the string value stored at key.
 	//
@@ -319,17 +315,16 @@ type StringCommands interface {
 	//  key - The key to check its length.
 	//
 	// Return value:
-	//  The length of the string value stored at key as Result[int64].
-	//  If key does not exist, it is treated as an empty string, and the command returns Result[int64] containing 0 .
+	//  The length of the string value stored at `key`.
+	//  If key does not exist, it is treated as an empty string, and the command returns `0`.
 	//
 	// For example:
 	//  key: value
 	//  result, err := client.Strlen("key")
-	//  result.Value(): 5
-	//  result.IsNil(): false
+	//  result: 5
 	//
 	// [valkey.io]: https://valkey.io/commands/strlen/
-	Strlen(key string) (Result[int64], error)
+	Strlen(key string) (int64, error)
 
 	// Overwrites part of the string stored at key, starting at the specified byte's offset, for the entire length of value.
 	// If the offset is larger than the current length of the string at key, the string is padded with zero bytes to make
@@ -344,12 +339,11 @@ type StringCommands interface {
 	//  value  - The string written with offset.
 	//
 	// Return value:
-	//  The length of the string stored at key after it was modified as Result[int64].
+	//  The length of the string stored at `key` after it was modified.
 	//
 	// For example:
 	//  1. result, err := client.SetRange("key", 6, "GLIDE");
-	//     result.Value(): 11 (New key created with length of 11 bytes)
-	//     result.IsNil(): false
+	//     result: 11 (New key created with length of 11 bytes)
 	//     value, err  := client.Get("key")
 	//     value.Value(): "\x00\x00\x00\x00\x00\x00GLIDE"
 	//  2. "key": "愛" (value char takes 3 bytes)
@@ -357,7 +351,7 @@ type StringCommands interface {
 	//     result.Value(): �a� // (becomes an invalid UTF-8 string)
 	//
 	// [valkey.io]: https://valkey.io/commands/setrange/
-	SetRange(key string, offset int, value string) (Result[int64], error)
+	SetRange(key string, offset int, value string) (int64, error)
 
 	// Returns the substring of the string value stored at key, determined by the byte's offsets start and end (both are
 	// inclusive).
@@ -401,15 +395,14 @@ type StringCommands interface {
 	//  value - The value to append.
 	//
 	// Return value:
-	//  The Result[int64] containing the length of the string after appending the value.
+	//  The length of the string after appending the value.
 	//
 	// For example:
 	//  result, err := client.Append("key", "value")
-	//  result.Value(): 5
-	//  result.IsNil(): false
+	//  result: 5
 	//
 	// [valkey.io]: https://valkey.io/commands/append/
-	Append(key string, value string) (Result[int64], error)
+	Append(key string, value string) (int64, error)
 
 	// Returns the longest common subsequence between strings stored at key1 and key2.
 	//

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -320,11 +320,11 @@ func (suite *GlideTestSuite) TestIncrCommands_existingKey() {
 
 		res1, err := client.Incr(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(11), res1.Value())
+		assert.Equal(suite.T(), int64(11), res1)
 
 		res2, err := client.IncrBy(key, 10)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(21), res2.Value())
+		assert.Equal(suite.T(), int64(21), res2)
 
 		res3, err := client.IncrByFloat(key, float64(10.1))
 		assert.Nil(suite.T(), err)
@@ -337,12 +337,12 @@ func (suite *GlideTestSuite) TestIncrCommands_nonExistingKey() {
 		key1 := uuid.New().String()
 		res1, err := client.Incr(key1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res1.Value())
+		assert.Equal(suite.T(), int64(1), res1)
 
 		key2 := uuid.New().String()
 		res2, err := client.IncrBy(key2, 10)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(10), res2.Value())
+		assert.Equal(suite.T(), int64(10), res2)
 
 		key3 := uuid.New().String()
 		res3, err := client.IncrByFloat(key3, float64(10.1))
@@ -357,12 +357,12 @@ func (suite *GlideTestSuite) TestIncrCommands_TypeError() {
 		suite.verifyOK(client.Set(key, "stringValue"))
 
 		res1, err := client.Incr(key)
-		assert.Equal(suite.T(), int64(0), res1.Value())
+		assert.Equal(suite.T(), int64(0), res1)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res2, err := client.IncrBy(key, 10)
-		assert.Equal(suite.T(), int64(0), res2.Value())
+		assert.Equal(suite.T(), int64(0), res2)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -380,11 +380,11 @@ func (suite *GlideTestSuite) TestDecrCommands_existingKey() {
 
 		res1, err := client.Decr(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(9), res1.Value())
+		assert.Equal(suite.T(), int64(9), res1)
 
 		res2, err := client.DecrBy(key, 10)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-1), res2.Value())
+		assert.Equal(suite.T(), int64(-1), res2)
 	})
 }
 
@@ -393,12 +393,12 @@ func (suite *GlideTestSuite) TestDecrCommands_nonExistingKey() {
 		key1 := uuid.New().String()
 		res1, err := client.Decr(key1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-1), res1.Value())
+		assert.Equal(suite.T(), int64(-1), res1)
 
 		key2 := uuid.New().String()
 		res2, err := client.DecrBy(key2, 10)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-10), res2.Value())
+		assert.Equal(suite.T(), int64(-10), res2)
 	})
 }
 
@@ -410,7 +410,7 @@ func (suite *GlideTestSuite) TestStrlen_existingKey() {
 
 		res, err := client.Strlen(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(len(value)), res.Value())
+		assert.Equal(suite.T(), int64(len(value)), res)
 	})
 }
 
@@ -419,7 +419,7 @@ func (suite *GlideTestSuite) TestStrlen_nonExistingKey() {
 		key := uuid.New().String()
 		res, err := client.Strlen(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 	})
 }
 
@@ -428,24 +428,24 @@ func (suite *GlideTestSuite) TestSetRange_existingAndNonExistingKeys() {
 		key := uuid.New().String()
 		res, err := client.SetRange(key, 0, "Dummy string")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(12), res.Value())
+		assert.Equal(suite.T(), int64(12), res)
 
 		res, err = client.SetRange(key, 6, "values")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(12), res.Value())
+		assert.Equal(suite.T(), int64(12), res)
 		res1, err := client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "Dummy values", res1.Value())
 
 		res, err = client.SetRange(key, 15, "test")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(19), res.Value())
+		assert.Equal(suite.T(), int64(19), res)
 		res1, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "Dummy values\x00\x00\x00test", res1.Value())
 
 		res, err = client.SetRange(key, math.MaxInt32, "test")
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -457,18 +457,18 @@ func (suite *GlideTestSuite) TestSetRange_existingAndNonExistingKeys_binaryStrin
 		key := uuid.New().String()
 		res, err := client.SetRange(key, 0, nonUtf8String)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(14), res.Value())
+		assert.Equal(suite.T(), int64(14), res)
 
 		res, err = client.SetRange(key, 6, "values ")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(14), res.Value())
+		assert.Equal(suite.T(), int64(14), res)
 		res1, err := client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "Dummy values g", res1.Value())
 
 		res, err = client.SetRange(key, 15, "test")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(19), res.Value())
+		assert.Equal(suite.T(), int64(19), res)
 		res1, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "Dummy values g\x00test", res1.Value())
@@ -523,14 +523,14 @@ func (suite *GlideTestSuite) TestAppend_existingAndNonExistingKeys() {
 
 		res, err := client.Append(key, value1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(len(value1)), res.Value())
+		assert.Equal(suite.T(), int64(len(value1)), res)
 		res1, err := client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), value1, res1.Value())
 
 		res, err = client.Append(key, value2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(len(value1)+len(value2)), res.Value())
+		assert.Equal(suite.T(), int64(len(value1)+len(value2)), res)
 		res1, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), value1+value2, res1.Value())
@@ -618,11 +618,11 @@ func (suite *GlideTestSuite) TestHSet_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
+		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
 
@@ -636,7 +636,7 @@ func (suite *GlideTestSuite) TestHSet_byteString() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGetAll(key)
 		key1 := api.CreateStringResult(string([]byte{0xFF, 0x00, 0xAA}))
@@ -659,16 +659,16 @@ func (suite *GlideTestSuite) TestHSet_WithAddNewField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
+		assert.Equal(suite.T(), int64(0), res2)
 
 		fields["field3"] = "value3"
 		res3, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res3.Value())
+		assert.Equal(suite.T(), int64(1), res3)
 	})
 }
 
@@ -679,7 +679,7 @@ func (suite *GlideTestSuite) TestHGet_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGet(key, "field1")
 		assert.Nil(suite.T(), err)
@@ -704,7 +704,7 @@ func (suite *GlideTestSuite) TestHGet_WithNotExistingField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGet(key, "foo")
 		assert.Nil(suite.T(), err)
@@ -719,7 +719,7 @@ func (suite *GlideTestSuite) TestHGetAll_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		field1 := api.CreateStringResult("field1")
 		value1 := api.CreateStringResult("value1")
@@ -749,7 +749,7 @@ func (suite *GlideTestSuite) TestHMGet() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HMGet(key, []string{"field1", "field2", "field3"})
 		value1 := api.CreateStringResult("value1")
@@ -778,7 +778,7 @@ func (suite *GlideTestSuite) TestHMGet_WithNotExistingField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HMGet(key, []string{"field3", "field4"})
 		nullValue := api.CreateNilStringResult()
@@ -794,11 +794,11 @@ func (suite *GlideTestSuite) TestHSetNX_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSetNX(key, "field1", "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2.Value())
 	})
 }
 
@@ -808,7 +808,7 @@ func (suite *GlideTestSuite) TestHSetNX_WithNotExistingKey() {
 
 		res1, err := client.HSetNX(key, "field1", "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), true, res1.Value())
+		assert.True(suite.T(), res1.Value())
 
 		res2, err := client.HGetAll(key)
 		field1 := api.CreateStringResult("field1")
@@ -825,11 +825,11 @@ func (suite *GlideTestSuite) TestHSetNX_WithExistingField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSetNX(key, "field1", "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2.Value())
 	})
 }
 
@@ -840,11 +840,11 @@ func (suite *GlideTestSuite) TestHDel() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HDel(key, []string{"field1", "field2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res2.Value())
+		assert.Equal(suite.T(), int64(2), res2)
 
 		res3, err := client.HGetAll(key)
 		assert.Nil(suite.T(), err)
@@ -852,7 +852,7 @@ func (suite *GlideTestSuite) TestHDel() {
 
 		res4, err := client.HDel(key, []string{"field1", "field2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res4.Value())
+		assert.Equal(suite.T(), int64(0), res4)
 	})
 }
 
@@ -861,7 +861,7 @@ func (suite *GlideTestSuite) TestHDel_WithNotExistingKey() {
 		key := uuid.NewString()
 		res, err := client.HDel(key, []string{"field1", "field2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 	})
 }
 
@@ -872,11 +872,11 @@ func (suite *GlideTestSuite) TestHDel_WithNotExistingField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HDel(key, []string{"field3", "field4"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
+		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
 
@@ -887,11 +887,11 @@ func (suite *GlideTestSuite) TestHLen() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HLen(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res2.Value())
+		assert.Equal(suite.T(), int64(2), res2)
 	})
 }
 
@@ -901,7 +901,7 @@ func (suite *GlideTestSuite) TestHLen_WithNotExistingKey() {
 		res, err := client.HLen(key)
 
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 	})
 }
 
@@ -912,7 +912,7 @@ func (suite *GlideTestSuite) TestHVals_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HVals(key)
 		value1 := api.CreateStringResult("value1")
@@ -940,11 +940,11 @@ func (suite *GlideTestSuite) TestHExists_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HExists(key, "field1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), true, res2.Value())
+		assert.True(suite.T(), res2.Value())
 	})
 }
 
@@ -954,7 +954,7 @@ func (suite *GlideTestSuite) TestHExists_WithNotExistingKey() {
 
 		res, err := client.HExists(key, "field1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res.Value())
+		assert.False(suite.T(), res.Value())
 	})
 }
 
@@ -965,11 +965,11 @@ func (suite *GlideTestSuite) TestHExists_WithNotExistingField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HExists(key, "field3")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2.Value())
 	})
 }
 
@@ -980,7 +980,7 @@ func (suite *GlideTestSuite) TestHKeys_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HKeys(key)
 		field1 := api.CreateStringResult("field1")
@@ -1008,11 +1008,11 @@ func (suite *GlideTestSuite) TestHStrLen_WithExistingKey() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HStrLen(key, "field1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(6), res2.Value())
+		assert.Equal(suite.T(), int64(6), res2)
 	})
 }
 
@@ -1022,7 +1022,7 @@ func (suite *GlideTestSuite) TestHStrLen_WithNotExistingKey() {
 
 		res, err := client.HStrLen(key, "field1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 	})
 }
 
@@ -1033,11 +1033,11 @@ func (suite *GlideTestSuite) TestHStrLen_WithNotExistingField() {
 
 		res1, err := client.HSet(key, fields)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HStrLen(key, "field3")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
+		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
 
@@ -1049,11 +1049,11 @@ func (suite *GlideTestSuite) TestHIncrBy_WithExistingField() {
 
 		hsetResult, err := client.HSet(key, fieldValueMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), hsetResult.Value())
+		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByResult, hincrByErr := client.HIncrBy(key, field, 1)
 		assert.Nil(suite.T(), hincrByErr)
-		assert.Equal(suite.T(), int64(11), hincrByResult.Value())
+		assert.Equal(suite.T(), int64(11), hincrByResult)
 	})
 }
 
@@ -1066,11 +1066,11 @@ func (suite *GlideTestSuite) TestHIncrBy_WithNonExistingField() {
 
 		hsetResult, err := client.HSet(key, fieldValueMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), hsetResult.Value())
+		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByResult, hincrByErr := client.HIncrBy(key, field, 2)
 		assert.Nil(suite.T(), hincrByErr)
-		assert.Equal(suite.T(), int64(2), hincrByResult.Value())
+		assert.Equal(suite.T(), int64(2), hincrByResult)
 	})
 }
 
@@ -1082,7 +1082,7 @@ func (suite *GlideTestSuite) TestHIncrByFloat_WithExistingField() {
 
 		hsetResult, err := client.HSet(key, fieldValueMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), hsetResult.Value())
+		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByFloatResult, hincrByFloatErr := client.HIncrByFloat(key, field, 1.5)
 		assert.Nil(suite.T(), hincrByFloatErr)
@@ -1099,7 +1099,7 @@ func (suite *GlideTestSuite) TestHIncrByFloat_WithNonExistingField() {
 
 		hsetResult, err := client.HSet(key, fieldValueMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), hsetResult.Value())
+		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByFloatResult, hincrByFloatErr := client.HIncrByFloat(key, field, 1.5)
 		assert.Nil(suite.T(), hincrByFloatErr)
@@ -1147,7 +1147,7 @@ func (suite *GlideTestSuite) TestHScan() {
 
 		// Result contains the whole set
 		hsetResult, _ := client.HSet(key1, charMap)
-		assert.Equal(t, int64(len(charMembers)), hsetResult.Value())
+		assert.Equal(t, int64(len(charMembers)), hsetResult)
 
 		resCursor, resCollection, _ = client.HScan(key1, initialCursor)
 		assert.Equal(t, initialCursor, resCursor.Value())
@@ -1182,7 +1182,7 @@ func (suite *GlideTestSuite) TestHScan() {
 		}
 
 		hsetResult, _ = client.HSet(key1, combinedMap)
-		assert.Equal(t, int64(len(numberMap)), hsetResult.Value())
+		assert.Equal(t, int64(len(numberMap)), hsetResult)
 		resultCursor := "0"
 		secondResultAllKeys := make([]api.Result[string], 0)
 		secondResultAllValues := make([]api.Result[string], 0)
@@ -1283,7 +1283,7 @@ func (suite *GlideTestSuite) TestLPushLPop_WithExistingKey() {
 
 		res1, err := client.LPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LPop(key)
 		assert.Nil(suite.T(), err)
@@ -1316,7 +1316,7 @@ func (suite *GlideTestSuite) TestLPushLPop_typeError() {
 		suite.verifyOK(client.Set(key, "value"))
 
 		res1, err := client.LPush(key, []string{"value1"})
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res1)
+		assert.Equal(suite.T(), int64(0), res1)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -1332,7 +1332,7 @@ func (suite *GlideTestSuite) TestLPos_withAndWithoutOptions() {
 		key := uuid.NewString()
 		res1, err := client.RPush(key, []string{"a", "a", "b", "c", "a", "b"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(6), res1.Value())
+		assert.Equal(suite.T(), int64(6), res1)
 
 		res2, err := client.LPos(key, "a")
 		assert.Nil(suite.T(), err)
@@ -1402,7 +1402,7 @@ func (suite *GlideTestSuite) TestLPosCount() {
 		key := uuid.NewString()
 
 		res1, err := client.RPush(key, []string{"a", "a", "b", "c", "a", "b"})
-		assert.Equal(suite.T(), int64(6), res1.Value())
+		assert.Equal(suite.T(), int64(6), res1)
 		assert.Nil(suite.T(), err)
 
 		res2, err := client.LPosCount(key, "a", int64(2))
@@ -1443,7 +1443,7 @@ func (suite *GlideTestSuite) TestLPosCount_withOptions() {
 		key := uuid.NewString()
 
 		res1, err := client.RPush(key, []string{"a", "a", "b", "c", "a", "b"})
-		assert.Equal(suite.T(), int64(6), res1.Value())
+		assert.Equal(suite.T(), int64(6), res1)
 		assert.Nil(suite.T(), err)
 
 		res2, err := client.LPosCountWithOptions(key, "a", int64(0), api.NewLPosOptionsBuilder().SetRank(1))
@@ -1476,13 +1476,13 @@ func (suite *GlideTestSuite) TestRPush() {
 
 		res1, err := client.RPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(key2, "value"))
 
 		res2, err := client.RPush(key2, []string{"value1"})
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res2)
+		assert.Equal(suite.T(), int64(0), res2)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -1495,8 +1495,7 @@ func (suite *GlideTestSuite) TestSAdd() {
 
 		res, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res.Value())
-		assert.False(suite.T(), res.IsNil())
+		assert.Equal(suite.T(), int64(2), res)
 	})
 }
 
@@ -1507,13 +1506,11 @@ func (suite *GlideTestSuite) TestSAdd_WithExistingKey() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
 
@@ -1524,13 +1521,11 @@ func (suite *GlideTestSuite) TestSRem() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SRem(key, []string{"member1", "member2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(2), res2)
 	})
 }
 
@@ -1541,13 +1536,11 @@ func (suite *GlideTestSuite) TestSRem_WithExistingKey() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.SRem(key, []string{"member3", "member4"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
 
@@ -1557,8 +1550,7 @@ func (suite *GlideTestSuite) TestSRem_WithNotExistingKey() {
 
 		res2, err := client.SRem(key, []string{"member1", "member2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
 
@@ -1569,13 +1561,11 @@ func (suite *GlideTestSuite) TestSRem_WithExistingKeyAndDifferentMembers() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SRem(key, []string{"member1", "member3", "member4"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(2), res2)
 	})
 }
 
@@ -1611,20 +1601,20 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 
 		res1, err := client.SAdd(key1, memberArray1)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res1.Value())
+		assert.Equal(t, int64(3), res1)
 
 		res2, err := client.SAdd(key2, memberArray2)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res2.Value())
+		assert.Equal(t, int64(3), res2)
 
 		res3, err := client.SAdd(key3, memberArray3)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res3.Value())
+		assert.Equal(t, int64(3), res3)
 
 		// store union in new key
 		res4, err := client.SUnionStore(key4, []string{key1, key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(5), res4.Value())
+		assert.Equal(t, int64(5), res4)
 
 		res5, err := client.SMembers(key4)
 		assert.NoError(t, err)
@@ -1634,7 +1624,7 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		// overwrite existing set
 		res6, err := client.SUnionStore(key1, []string{key4, key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(5), res6.Value())
+		assert.Equal(t, int64(5), res6)
 
 		res7, err := client.SMembers(key1)
 		assert.NoError(t, err)
@@ -1644,7 +1634,7 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		// overwrite one of the source keys
 		res8, err := client.SUnionStore(key2, []string{key4, key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(5), res8.Value())
+		assert.Equal(t, int64(5), res8)
 
 		res9, err := client.SMembers(key2)
 		assert.NoError(t, err)
@@ -1654,7 +1644,7 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		// union with non-existing key
 		res10, err := client.SUnionStore(key2, []string{nonExistingKey})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), res10.Value())
+		assert.Equal(t, int64(0), res10)
 
 		// check that the key is now empty
 		members1, err := client.SMembers(key2)
@@ -1663,7 +1653,7 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 
 		// invalid argument - key list must not be empty
 		res11, err := client.SUnionStore(key4, []string{})
-		assert.Equal(suite.T(), int64(0), res11.Value())
+		assert.Equal(suite.T(), int64(0), res11)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -1672,14 +1662,14 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		assert.NoError(t, err)
 
 		res12, err := client.SUnionStore(key4, []string{stringKey, key1})
-		assert.Equal(suite.T(), int64(0), res12.Value())
+		assert.Equal(suite.T(), int64(0), res12)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		// overwrite destination when destination is not a set
 		res13, err := client.SUnionStore(stringKey, []string{key1, key3})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(7), res13.Value())
+		assert.Equal(t, int64(7), res13)
 
 		// check that the key is now empty
 		res14, err := client.SMembers(stringKey)
@@ -1696,8 +1686,7 @@ func (suite *GlideTestSuite) TestSMembers() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SMembers(key)
 		assert.Nil(suite.T(), err)
@@ -1722,13 +1711,11 @@ func (suite *GlideTestSuite) TestSCard() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SCard(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(3), res2)
 	})
 }
 
@@ -1738,8 +1725,7 @@ func (suite *GlideTestSuite) TestSCard_WithNotExistingKey() {
 
 		res, err := client.SCard(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
-		assert.False(suite.T(), res.IsNil())
+		assert.Equal(suite.T(), int64(0), res)
 	})
 }
 
@@ -1750,7 +1736,7 @@ func (suite *GlideTestSuite) TestSIsMember() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SIsMember(key, "member2")
 		assert.Nil(suite.T(), err)
@@ -1777,8 +1763,7 @@ func (suite *GlideTestSuite) TestSIsMember_WithNotExistingMember() {
 
 		res1, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SIsMember(key, "nonExistingMember")
 		assert.Nil(suite.T(), err)
@@ -1794,13 +1779,11 @@ func (suite *GlideTestSuite) TestSDiff() {
 
 		res1, err := client.SAdd(key1, []string{"a", "b", "c", "d"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.SAdd(key2, []string{"c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(3), res2)
 
 		result, err := client.SDiff([]string{key1, key2})
 		assert.Nil(suite.T(), err)
@@ -1828,8 +1811,7 @@ func (suite *GlideTestSuite) TestSDiff_WithSingleKeyExist() {
 
 		res1, err := client.SAdd(key1, []string{"a", "b", "c"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SDiff([]string{key1, key2})
 		assert.Nil(suite.T(), err)
@@ -1848,18 +1830,15 @@ func (suite *GlideTestSuite) TestSDiffStore() {
 
 		res1, err := client.SAdd(key1, []string{"a", "b", "c"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SAdd(key2, []string{"c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(3), res2)
 
 		res3, err := client.SDiffStore(key3, []string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res3.Value())
-		assert.False(suite.T(), res3.IsNil())
+		assert.Equal(suite.T(), int64(2), res3)
 
 		members, err := client.SMembers(key3)
 		assert.Nil(suite.T(), err)
@@ -1877,8 +1856,7 @@ func (suite *GlideTestSuite) TestSDiffStore_WithNotExistingKeys() {
 
 		res, err := client.SDiffStore(key3, []string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
-		assert.False(suite.T(), res.IsNil())
+		assert.Equal(suite.T(), int64(0), res)
 
 		members, err := client.SMembers(key3)
 		assert.Nil(suite.T(), err)
@@ -1893,13 +1871,11 @@ func (suite *GlideTestSuite) TestSinter() {
 
 		res1, err := client.SAdd(key1, []string{"a", "b", "c", "d"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.SAdd(key2, []string{"c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(3), res2)
 
 		members, err := client.SInter([]string{key1, key2})
 		assert.Nil(suite.T(), err)
@@ -1933,16 +1909,16 @@ func (suite *GlideTestSuite) TestSinterStore() {
 
 		res1, err := client.SAdd(key1, memberArray1)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res1.Value())
+		assert.Equal(t, int64(3), res1)
 
 		res2, err := client.SAdd(key2, memberArray2)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res2.Value())
+		assert.Equal(t, int64(3), res2)
 
 		// store in new key
 		res3, err := client.SInterStore(key3, []string{key1, key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(1), res3.Value())
+		assert.Equal(t, int64(1), res3)
 
 		res4, err := client.SMembers(key3)
 		assert.NoError(t, err)
@@ -1954,7 +1930,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		// overwrite existing set, which is also a source set
 		res5, err := client.SInterStore(key2, []string{key1, key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(1), res5.Value())
+		assert.Equal(t, int64(1), res5)
 
 		res6, err := client.SMembers(key2)
 		assert.NoError(t, err)
@@ -1966,7 +1942,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		// source set is the same as the existing set
 		res7, err := client.SInterStore(key1, []string{key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(1), res7.Value())
+		assert.Equal(t, int64(1), res7)
 
 		res8, err := client.SMembers(key2)
 		assert.NoError(t, err)
@@ -1978,7 +1954,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		// intersection with non-existing key
 		res9, err := client.SInterStore(key1, []string{key2, nonExistingKey})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), res9.Value())
+		assert.Equal(t, int64(0), res9)
 
 		// check that the key is now empty
 		members1, err := client.SMembers(key1)
@@ -1987,7 +1963,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 
 		// invalid argument - key list must not be empty
 		res10, err := client.SInterStore(key3, []string{})
-		assert.Equal(suite.T(), int64(0), res10.Value())
+		assert.Equal(suite.T(), int64(0), res10)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -1996,14 +1972,14 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		assert.NoError(t, err)
 
 		res11, err := client.SInterStore(key3, []string{stringKey})
-		assert.Equal(suite.T(), int64(0), res11.Value())
+		assert.Equal(suite.T(), int64(0), res11)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		// overwrite the non-set key
 		res12, err := client.SInterStore(stringKey, []string{key2})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(1), res12.Value())
+		assert.Equal(t, int64(1), res12)
 
 		// check that the key is now empty
 		res13, err := client.SMembers(stringKey)
@@ -2024,23 +2000,19 @@ func (suite *GlideTestSuite) TestSInterCard() {
 
 		res1, err := client.SAdd(key1, []string{"one", "two", "three", "four"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		result1, err := client.SInterCard([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), result1.Value())
-		assert.False(suite.T(), result1.IsNil())
+		assert.Equal(suite.T(), int64(0), result1)
 
 		res2, err := client.SAdd(key2, []string{"two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		result2, err := client.SInterCard([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), result2.Value())
-		assert.False(suite.T(), result2.IsNil())
+		assert.Equal(suite.T(), int64(3), result2)
 	})
 }
 
@@ -2053,23 +2025,19 @@ func (suite *GlideTestSuite) TestSInterCardLimit() {
 
 		res1, err := client.SAdd(key1, []string{"one", "two", "three", "four"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.SAdd(key2, []string{"two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		result1, err := client.SInterCardLimit([]string{key1, key2}, 2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), result1.Value())
-		assert.False(suite.T(), result1.IsNil())
+		assert.Equal(suite.T(), int64(2), result1)
 
 		result2, err := client.SInterCardLimit([]string{key1, key2}, 4)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), result2.Value())
-		assert.False(suite.T(), result2.IsNil())
+		assert.Equal(suite.T(), int64(3), result2)
 	})
 }
 
@@ -2079,8 +2047,7 @@ func (suite *GlideTestSuite) TestSRandMember() {
 
 		res, err := client.SAdd(key, []string{"one"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
-		assert.False(suite.T(), res.IsNil())
+		assert.Equal(suite.T(), int64(1), res)
 
 		member, err := client.SRandMember(key)
 		assert.Nil(suite.T(), err)
@@ -2096,8 +2063,7 @@ func (suite *GlideTestSuite) TestSPop() {
 
 		res, err := client.SAdd(key, members)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res.Value())
-		assert.False(suite.T(), res.IsNil())
+		assert.Equal(suite.T(), int64(3), res)
 
 		popMember, err := client.SPop(key)
 		assert.Nil(suite.T(), err)
@@ -2117,8 +2083,7 @@ func (suite *GlideTestSuite) TestSPop_LastMember() {
 
 		res1, err := client.SAdd(key, []string{"lastValue"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(1), res1)
 
 		popMember, err := client.SPop(key)
 		assert.Nil(suite.T(), err)
@@ -2139,8 +2104,7 @@ func (suite *GlideTestSuite) TestSMIsMember() {
 
 		res1, err1 := client.SAdd(key1, []string{"one", "two"})
 		assert.Nil(suite.T(), err1)
-		assert.Equal(suite.T(), int64(2), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err2 := client.SMIsMember(key1, []string{"two", "three"})
 		assert.Nil(suite.T(), err2)
@@ -2194,13 +2158,11 @@ func (suite *GlideTestSuite) TestSUnion() {
 
 		res1, err := client.SAdd(key1, memberList1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1.Value())
-		assert.False(suite.T(), res1.IsNil())
+		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SAdd(key2, memberList2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.SUnion([]string{key1, key2})
 		assert.Nil(suite.T(), err)
@@ -2240,11 +2202,11 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res1, err := client.SAdd(key1, memberArray1)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res1.Value())
+		assert.Equal(t, int64(3), res1)
 
 		res2, err := client.SAdd(key2, memberArray2)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(2), res2.Value())
+		assert.Equal(t, int64(2), res2)
 
 		// move an element
 		res3, err := client.SMove(key1, key2, "1")
@@ -2398,7 +2360,7 @@ func (suite *GlideTestSuite) TestSScan() {
 		// result contains the whole set
 		res, err := client.SAdd(key1, charMembers)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(len(charMembers)), res.Value())
+		assert.Equal(t, int64(len(charMembers)), res)
 		resCursor, resCollection, err = client.SScan(key1, initialCursor)
 		assert.NoError(t, err)
 		assert.Equal(t, initialCursor, resCursor.Value())
@@ -2414,7 +2376,7 @@ func (suite *GlideTestSuite) TestSScan() {
 		// result contains a subset of the key
 		res, err = client.SAdd(key1, numMembers)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(50000), res.Value())
+		assert.Equal(t, int64(50000), res)
 		resCursor, resCollection, err = client.SScan(key1, "0")
 		assert.NoError(t, err)
 		resultCollection := resCollection
@@ -2471,7 +2433,7 @@ func (suite *GlideTestSuite) TestLRange() {
 
 		res1, err := client.LPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		resultList := []api.Result[string]{
 			api.CreateStringResult("value1"),
@@ -2504,17 +2466,17 @@ func (suite *GlideTestSuite) TestLIndex() {
 
 		res1, err := client.LPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LIndex(key, int64(0))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "value1", res2.Value())
-		assert.Equal(suite.T(), false, res2.IsNil())
+		assert.False(suite.T(), res2.IsNil())
 
 		res3, err := client.LIndex(key, int64(-1))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "value4", res3.Value())
-		assert.Equal(suite.T(), false, res3.IsNil())
+		assert.False(suite.T(), res3.IsNil())
 
 		res4, err := client.LIndex("non_existing_key", int64(0))
 		assert.Nil(suite.T(), err)
@@ -2537,7 +2499,7 @@ func (suite *GlideTestSuite) TestLTrim() {
 
 		res1, err := client.LPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		suite.verifyOK(client.LTrim(key, int64(0), int64(1)))
 
@@ -2568,23 +2530,21 @@ func (suite *GlideTestSuite) TestLLen() {
 
 		res1, err := client.LPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LLen(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
-		assert.Equal(suite.T(), false, res2.IsNil())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LLen("non_existing_key")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res3.Value())
-		assert.Equal(suite.T(), false, res3.IsNil())
+		assert.Equal(suite.T(), int64(0), res3)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(key2, "value"))
 
 		res4, err := client.LLen(key2)
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res4)
+		assert.Equal(suite.T(), int64(0), res4)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2597,12 +2557,11 @@ func (suite *GlideTestSuite) TestLRem() {
 
 		res1, err := client.LPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res1.Value())
+		assert.Equal(suite.T(), int64(5), res1)
 
 		res2, err := client.LRem(key, 2, "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res2.Value())
-		assert.Equal(suite.T(), false, res2.IsNil())
+		assert.Equal(suite.T(), int64(2), res2)
 		res3, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
 		assert.Equal(
@@ -2617,24 +2576,21 @@ func (suite *GlideTestSuite) TestLRem() {
 
 		res4, err := client.LRem(key, -1, "value2")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res4.Value())
-		assert.Equal(suite.T(), false, res4.IsNil())
+		assert.Equal(suite.T(), int64(1), res4)
 		res5, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult("value2"), api.CreateStringResult("value1")}, res5)
 
 		res6, err := client.LRem(key, 0, "value2")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res6.Value())
-		assert.Equal(suite.T(), false, res6.IsNil())
+		assert.Equal(suite.T(), int64(1), res6)
 		res7, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult("value1")}, res7)
 
 		res8, err := client.LRem("non_existing_key", 0, "value")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res8.Value())
-		assert.Equal(suite.T(), false, res8.IsNil())
+		assert.Equal(suite.T(), int64(0), res8)
 	})
 }
 
@@ -2645,12 +2601,12 @@ func (suite *GlideTestSuite) TestRPopAndRPopCount() {
 
 		res1, err := client.RPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.RPop(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "value4", res2.Value())
-		assert.Equal(suite.T(), false, res2.IsNil())
+		assert.False(suite.T(), res2.IsNil())
 
 		res3, err := client.RPopCount(key, int64(2))
 		assert.Nil(suite.T(), err)
@@ -2686,17 +2642,15 @@ func (suite *GlideTestSuite) TestLInsert() {
 
 		res1, err := client.RPush(key, list)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res1.Value())
+		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LInsert(key, api.Before, "value2", "value1.5")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res2.Value())
-		assert.Equal(suite.T(), false, res2.IsNil())
+		assert.Equal(suite.T(), int64(5), res2)
 
 		res3, err := client.LInsert(key, api.After, "value3", "value3.5")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(6), res3.Value())
-		assert.Equal(suite.T(), false, res3.IsNil())
+		assert.Equal(suite.T(), int64(6), res3)
 
 		res4, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -2715,19 +2669,17 @@ func (suite *GlideTestSuite) TestLInsert() {
 
 		res5, err := client.LInsert("non_existing_key", api.Before, "pivot", "elem")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res5.Value())
-		assert.Equal(suite.T(), false, res5.IsNil())
+		assert.Equal(suite.T(), int64(0), res5)
 
 		res6, err := client.LInsert(key, api.Before, "value5", "value6")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-1), res6.Value())
-		assert.Equal(suite.T(), false, res6.IsNil())
+		assert.Equal(suite.T(), int64(-1), res6)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(key2, "value"))
 
 		res7, err := client.LInsert(key2, api.Before, "value5", "value6")
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res7)
+		assert.Equal(suite.T(), int64(0), res7)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2740,7 +2692,7 @@ func (suite *GlideTestSuite) TestBLPop() {
 
 		res1, err := client.LPush(listKey1, []string{"value1", "value2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.BLPop([]string{listKey1, listKey2}, float64(0.5))
 		assert.Nil(suite.T(), err)
@@ -2767,7 +2719,7 @@ func (suite *GlideTestSuite) TestBRPop() {
 
 		res1, err := client.LPush(listKey1, []string{"value1", "value2"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res1.Value())
+		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.BRPop([]string{listKey1, listKey2}, float64(0.5))
 		assert.Nil(suite.T(), err)
@@ -2795,11 +2747,11 @@ func (suite *GlideTestSuite) TestRPushX() {
 
 		res1, err := client.RPush(key1, []string{"value1"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res1.Value())
+		assert.Equal(suite.T(), int64(1), res1)
 
 		res2, err := client.RPushX(key1, []string{"value2", "value3", "value4"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -2816,8 +2768,7 @@ func (suite *GlideTestSuite) TestRPushX() {
 
 		res4, err := client.RPushX(key2, []string{"value1"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res4.Value())
-		assert.Equal(suite.T(), false, res4.IsNil())
+		assert.Equal(suite.T(), int64(0), res4)
 
 		res5, err := client.LRange(key2, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -2826,12 +2777,12 @@ func (suite *GlideTestSuite) TestRPushX() {
 		suite.verifyOK(client.Set(key3, "value"))
 
 		res6, err := client.RPushX(key3, []string{"value1"})
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res6)
+		assert.Equal(suite.T(), int64(0), res6)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res7, err := client.RPushX(key2, []string{})
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res7)
+		assert.Equal(suite.T(), int64(0), res7)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2845,11 +2796,11 @@ func (suite *GlideTestSuite) TestLPushX() {
 
 		res1, err := client.LPush(key1, []string{"value1"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res1.Value())
+		assert.Equal(suite.T(), int64(1), res1)
 
 		res2, err := client.LPushX(key1, []string{"value2", "value3", "value4"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -2866,8 +2817,7 @@ func (suite *GlideTestSuite) TestLPushX() {
 
 		res4, err := client.LPushX(key2, []string{"value1"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res4.Value())
-		assert.Equal(suite.T(), false, res4.IsNil())
+		assert.Equal(suite.T(), int64(0), res4)
 
 		res5, err := client.LRange(key2, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -2876,12 +2826,12 @@ func (suite *GlideTestSuite) TestLPushX() {
 		suite.verifyOK(client.Set(key3, "value"))
 
 		res6, err := client.LPushX(key3, []string{"value1"})
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res6)
+		assert.Equal(suite.T(), int64(0), res6)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res7, err := client.LPushX(key2, []string{})
-		assert.Equal(suite.T(), api.CreateNilInt64Result(), res7)
+		assert.Equal(suite.T(), int64(0), res7)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2906,10 +2856,10 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 
 		res3, err := client.LPush(key1, []string{"one", "two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res3.Value())
+		assert.Equal(suite.T(), int64(5), res3)
 		res4, err := client.LPush(key2, []string{"one", "two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res4.Value())
+		assert.Equal(suite.T(), int64(5), res4)
 
 		res5, err := client.LMPop([]string{key1}, api.Left)
 		assert.Nil(suite.T(), err)
@@ -2962,10 +2912,10 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 
 		res3, err := client.LPush(key1, []string{"one", "two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res3.Value())
+		assert.Equal(suite.T(), int64(5), res3)
 		res4, err := client.LPush(key2, []string{"one", "two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res4.Value())
+		assert.Equal(suite.T(), int64(5), res4)
 
 		res5, err := client.BLMPop([]string{key1}, api.Left, float64(0.1))
 		assert.Nil(suite.T(), err)
@@ -3006,7 +2956,7 @@ func (suite *GlideTestSuite) TestLSet() {
 
 		res2, err := client.LPush(key, []string{"four", "three", "two", "one"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LSet(key, int64(10), "zero")
 		assert.Equal(suite.T(), api.CreateNilStringResult(), res3)
@@ -3065,7 +3015,7 @@ func (suite *GlideTestSuite) TestLMove() {
 
 		res2, err := client.LPush(key1, []string{"four", "three", "two", "one"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		// only source exists, only source elements gets popped, creates a list at nonExistingKey
 		res3, err := client.LMove(key1, nonExistentKey, api.Right, api.Left)
@@ -3103,7 +3053,7 @@ func (suite *GlideTestSuite) TestLMove() {
 		// normal use case, "three" gets popped and added to the left of destination
 		res7, err := client.LPush(key2, []string{"six", "five", "four"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res7.Value())
+		assert.Equal(suite.T(), int64(3), res7)
 
 		res8, err := client.LMove(key1, key2, api.Right, api.Left)
 		assert.Equal(suite.T(), "three", res8.Value())
@@ -3158,12 +3108,12 @@ func (suite *GlideTestSuite) TestExists() {
 		suite.verifyOK(client.Set(key, initialValue))
 		result, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), result.Value(), "The key should exist")
+		assert.Equal(suite.T(), int64(1), result, "The key should exist")
 
 		// Test 2: Check if a non-existent key returns 0
 		result, err = client.Exists([]string{"nonExistentKey"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), result.Value(), "The non-existent key should not exist")
+		assert.Equal(suite.T(), int64(0), result, "The non-existent key should not exist")
 
 		// Test 3: Multiple keys, some exist, some do not
 		existingKey := uuid.New().String()
@@ -3172,7 +3122,7 @@ func (suite *GlideTestSuite) TestExists() {
 		suite.verifyOK(client.Set(testKey, value))
 		result, err = client.Exists([]string{testKey, existingKey, "anotherNonExistentKey"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), result.Value(), "Two keys should exist")
+		assert.Equal(suite.T(), int64(2), result, "Two keys should exist")
 	})
 }
 
@@ -3250,7 +3200,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasExistingExpiry() {
 		resultExpireTest, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
 
-		assert.Equal(suite.T(), int64(0), resultExpireTest.Value())
+		assert.Equal(suite.T(), int64(0), resultExpireTest)
 	})
 }
 
@@ -3271,7 +3221,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryGreaterThanCurrent()
 		time.Sleep(6 * time.Second)
 		resultExpireTest, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExpireTest.Value())
+		assert.Equal(suite.T(), int64(0), resultExpireTest)
 	})
 }
 
@@ -3300,7 +3250,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryLessThanCurrent() {
 		time.Sleep(16 * time.Second)
 		resultExpireTest, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExpireTest.Value())
+		assert.Equal(suite.T(), int64(0), resultExpireTest)
 	})
 }
 
@@ -3393,7 +3343,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() 
 		resultExpireAtTest, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
 
-		assert.Equal(suite.T(), int64(0), resultExpireAtTest.Value())
+		assert.Equal(suite.T(), int64(0), resultExpireAtTest)
 	})
 }
 
@@ -3413,7 +3363,7 @@ func (suite *GlideTestSuite) TestPExpire() {
 		time.Sleep(600 * time.Millisecond)
 		resultExpireCheck, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExpireCheck.Value())
+		assert.Equal(suite.T(), int64(0), resultExpireCheck)
 	})
 }
 
@@ -3441,7 +3391,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3464,7 +3414,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
 		time.Sleep(600 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3492,7 +3442,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3520,7 +3470,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
 		time.Sleep(600 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3542,7 +3492,7 @@ func (suite *GlideTestSuite) TestPExpireAt() {
 
 		resultpExists, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultpExists.Value())
+		assert.Equal(suite.T(), int64(0), resultpExists)
 	})
 }
 
@@ -3563,7 +3513,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasNoExpiry() {
 		time.Sleep(2 * time.Second)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3587,7 +3537,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3613,7 +3563,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurren
 		time.Sleep(2100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3640,7 +3590,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent()
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultExist.Value())
+		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
 
@@ -3663,7 +3613,7 @@ func (suite *GlideTestSuite) TestExpireTime() {
 
 		resexptime, err := client.ExpireTime(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), expireTime, resexptime.Value())
+		assert.Equal(suite.T(), expireTime, resexptime)
 
 		time.Sleep(4 * time.Second)
 
@@ -3681,7 +3631,7 @@ func (suite *GlideTestSuite) TestExpireTime_KeyDoesNotExist() {
 		// Call ExpireTime on a key that doesn't exist
 		expiryResult, err := client.ExpireTime(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-2), expiryResult.Value())
+		assert.Equal(suite.T(), int64(-2), expiryResult)
 	})
 }
 
@@ -3704,7 +3654,7 @@ func (suite *GlideTestSuite) TestPExpireTime() {
 
 		respexptime, err := client.PExpireTime(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), pexpireTime, respexptime.Value())
+		assert.Equal(suite.T(), pexpireTime, respexptime)
 
 		time.Sleep(4 * time.Second)
 
@@ -3725,19 +3675,19 @@ func (suite *GlideTestSuite) Test_ZCard() {
 		t := suite.T()
 		res1, err := client.ZAdd(key, membersScores)
 		assert.Nil(t, err)
-		assert.Equal(t, int64(3), res1.Value())
+		assert.Equal(t, int64(3), res1)
 
 		res2, err := client.ZCard(key)
 		assert.Nil(t, err)
-		assert.Equal(t, int64(3), res2.Value())
+		assert.Equal(t, int64(3), res2)
 
 		res3, err := client.ZRem(key, []string{"one"})
 		assert.Nil(t, err)
-		assert.Equal(t, int64(1), res3.Value())
+		assert.Equal(t, int64(1), res3)
 
 		res4, err := client.ZCard(key)
 		assert.Nil(t, err)
-		assert.Equal(t, int64(2), res4.Value())
+		assert.Equal(t, int64(2), res4)
 	})
 }
 
@@ -3749,7 +3699,7 @@ func (suite *GlideTestSuite) TestPExpireTime_KeyDoesNotExist() {
 		// Call ExpireTime on a key that doesn't exist
 		expiryResult, err := client.PExpireTime(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-2), expiryResult.Value())
+		assert.Equal(suite.T(), int64(-2), expiryResult)
 	})
 }
 
@@ -3764,7 +3714,7 @@ func (suite *GlideTestSuite) TestTTL_WithValidKey() {
 		assert.True(suite.T(), resExpire.Value())
 		resTTL, err := client.TTL(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resTTL.Value(), int64(1))
+		assert.Equal(suite.T(), int64(1), resTTL)
 	})
 }
 
@@ -3782,7 +3732,7 @@ func (suite *GlideTestSuite) TestTTL_WithExpiredKey() {
 
 		resTTL, err := client.TTL(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-2), resTTL.Value())
+		assert.Equal(suite.T(), int64(-2), resTTL)
 	})
 }
 
@@ -3798,7 +3748,7 @@ func (suite *GlideTestSuite) TestPTTL_WithValidKey() {
 
 		resPTTL, err := client.PTTL(key)
 		assert.Nil(suite.T(), err)
-		assert.Greater(suite.T(), resPTTL.Value(), int64(900))
+		assert.Greater(suite.T(), resPTTL, int64(900))
 	})
 }
 
@@ -3816,7 +3766,7 @@ func (suite *GlideTestSuite) TestPTTL_WithExpiredKey() {
 
 		resPTTL, err := client.PTTL(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(-2), resPTTL.Value())
+		assert.Equal(suite.T(), resPTTL, int64(-2))
 	})
 }
 
@@ -3825,7 +3775,7 @@ func (suite *GlideTestSuite) TestPfAdd_SuccessfulAddition() {
 		key := uuid.New().String()
 		res, err := client.PfAdd(key, []string{"a", "b", "c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 	})
 }
 
@@ -3836,25 +3786,25 @@ func (suite *GlideTestSuite) TestPfAdd_DuplicateElements() {
 		// case : Add elements and add same elements again
 		res, err := client.PfAdd(key, []string{"a", "b", "c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 
 		res2, err := client.PfAdd(key, []string{"a", "b", "c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res2.Value())
+		assert.Equal(suite.T(), int64(0), res2)
 
 		// case : (mixed elements) add new elements with 1 duplicate elements
 		res1, err := client.PfAdd(key, []string{"f", "g", "h"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res1.Value())
+		assert.Equal(suite.T(), int64(1), res1)
 
 		res2, err = client.PfAdd(key, []string{"i", "j", "g"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res2.Value())
+		assert.Equal(suite.T(), int64(1), res2)
 
 		// case : add empty array(no elements to the HyperLogLog)
 		res, err = client.PfAdd(key, []string{})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 	})
 }
 
@@ -3863,11 +3813,11 @@ func (suite *GlideTestSuite) TestPfCount_SingleKey() {
 		key := uuid.New().String()
 		res, err := client.PfAdd(key, []string{"i", "j", "g"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 
 		resCount, err := client.PfCount([]string{key})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), resCount.Value())
+		assert.Equal(suite.T(), int64(3), resCount)
 	})
 }
 
@@ -3878,15 +3828,15 @@ func (suite *GlideTestSuite) TestPfCount_MultipleKeys() {
 
 		res, err := client.PfAdd(key1, []string{"a", "b", "c"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 
 		res, err = client.PfAdd(key2, []string{"c", "d", "e"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 
 		resCount, err := client.PfCount([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), resCount.Value())
+		assert.Equal(suite.T(), int64(5), resCount)
 	})
 }
 
@@ -3897,7 +3847,7 @@ func (suite *GlideTestSuite) TestPfCount_NoExistingKeys() {
 
 		resCount, err := client.PfCount([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resCount.Value())
+		assert.Equal(suite.T(), int64(0), resCount)
 	})
 }
 
@@ -3917,7 +3867,7 @@ func (suite *GlideTestSuite) TestBLMove() {
 
 		res2, err := client.LPush(key1, []string{"four", "three", "two", "one"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2.Value())
+		assert.Equal(suite.T(), int64(4), res2)
 
 		// only source exists, only source elements gets popped, creates a list at nonExistingKey
 		res3, err := client.BLMove(key1, nonExistentKey, api.Right, api.Left, float64(0.1))
@@ -3955,7 +3905,7 @@ func (suite *GlideTestSuite) TestBLMove() {
 		// normal use case, "three" gets popped and added to the left of destination
 		res7, err := client.LPush(key2, []string{"six", "five", "four"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res7.Value())
+		assert.Equal(suite.T(), int64(3), res7)
 
 		res8, err := client.BLMove(key1, key2, api.Right, api.Left, float64(0.1))
 		assert.Equal(suite.T(), "three", res8.Value())
@@ -4015,7 +3965,7 @@ func (suite *GlideTestSuite) TestDel_MultipleKeys() {
 		deletedCount, err := client.Del([]string{key1, key2, key3})
 
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), deletedCount.Value())
+		assert.Equal(suite.T(), int64(3), deletedCount)
 
 		result1, err1 := client.Get(key1)
 		result2, err2 := client.Get(key2)
@@ -4044,7 +3994,7 @@ func (suite *GlideTestSuite) TestType() {
 		// Test 2: Check if the value is list
 		key1 := "{keylist}-1" + uuid.NewString()
 		resultLPush, err := client.LPush(key1, []string{"one", "two", "three"})
-		assert.Equal(suite.T(), int64(3), resultLPush.Value())
+		assert.Equal(suite.T(), int64(3), resultLPush)
 		assert.Nil(suite.T(), err)
 		resultType, err := client.Type(key1)
 		assert.Nil(suite.T(), err)
@@ -4061,12 +4011,12 @@ func (suite *GlideTestSuite) TestTouch() {
 		suite.verifyOK(client.Set(keyName1, "anotherValue"))
 		result, err := client.Touch([]string{keyName, keyName1})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), result.Value(), "The touch should be 2")
+		assert.Equal(suite.T(), int64(2), result, "The touch should be 2")
 
 		// Test 2: Check if an touch invalid key
 		resultInvalidKey, err := client.Touch([]string{"invalidKey", "invalidKey1"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultInvalidKey.Value(), "The touch should be 0")
+		assert.Equal(suite.T(), int64(0), resultInvalidKey, "The touch should be 0")
 	})
 }
 
@@ -4079,12 +4029,12 @@ func (suite *GlideTestSuite) TestUnlink() {
 		suite.verifyOK(client.Set(keyName1, "anotherValue"))
 		resultValidKey, err := client.Unlink([]string{keyName, keyName1})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), resultValidKey.Value(), "The unlink should be 2")
+		assert.Equal(suite.T(), int64(2), resultValidKey, "The unlink should be 2")
 
 		// Test 2: Check if an unlink for invalid key
 		resultInvalidKey, err := client.Unlink([]string{"invalidKey2", "invalidKey3"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), resultInvalidKey.Value(), "The unlink should be 0")
+		assert.Equal(suite.T(), int64(0), resultInvalidKey, "The unlink should be 0")
 	})
 }
 
@@ -4114,7 +4064,7 @@ func (suite *GlideTestSuite) TestRenamenx() {
 		suite.verifyOK(client.Set(key, initialValue))
 		res1, err := client.Renamenx(key, key2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), true, res1.Value())
+		assert.True(suite.T(), res1.Value())
 
 		// Test 2 Check if the renamenx command return false if newKey already exists.
 		key3 := "{keyName}" + uuid.NewString()
@@ -4123,7 +4073,7 @@ func (suite *GlideTestSuite) TestRenamenx() {
 		suite.verifyOK(client.Set(key4, initialValue))
 		res2, err := client.Renamenx(key3, key4)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2.Value())
 	})
 }
 
@@ -4201,7 +4151,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 
 		res, err := client.ZAdd(key, membersScoreMap)
 		assert.Nil(t, err)
-		assert.Equal(t, int64(3), res.Value())
+		assert.Equal(t, int64(3), res)
 
 		resIncr, err := client.ZAddIncr(key, "one", float64(2))
 		assert.Nil(t, err)
@@ -4227,11 +4177,11 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 
 		res, err = client.ZAddWithOptions(key3, membersScoreMap, onlyIfExistsOpts)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 
 		res, err = client.ZAddWithOptions(key3, membersScoreMap, onlyIfDoesNotExistOpts)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res.Value())
+		assert.Equal(suite.T(), int64(3), res)
 
 		resIncr, err = client.ZAddIncrWithOptions(key3, "one", 5, onlyIfDoesNotExistOpts)
 		assert.NotNil(suite.T(), err)
@@ -4250,7 +4200,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 
 		res, err = client.ZAdd(key4, membersScoreMap2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res.Value())
+		assert.Equal(suite.T(), int64(3), res)
 
 		membersScoreMap2["one"] = 10.0
 
@@ -4261,11 +4211,11 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 
 		res, err = client.ZAddWithOptions(key4, membersScoreMap2, gtOptsChanged)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 
 		res, err = client.ZAddWithOptions(key4, membersScoreMap2, ltOptsChanged)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), res.Value())
+		assert.Equal(suite.T(), int64(0), res)
 
 		resIncr, err = client.ZAddIncrWithOptions(key4, "one", -3, ltOpts)
 		assert.Nil(suite.T(), err)
@@ -4300,7 +4250,7 @@ func (suite *GlideTestSuite) TestZincrBy() {
 		// Key exists, but it is not a sorted set
 		res4, err := client.SAdd(key2, []string{"one", "two"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res4.Value())
+		assert.Equal(suite.T(), int64(2), res4)
 
 		_, err = client.ZIncrBy(key2, 0.5, "_")
 		assert.NotNil(suite.T(), err)
@@ -4317,12 +4267,12 @@ func (suite *GlideTestSuite) TestBZPopMin() {
 		// Add elements to key1
 		zaddResult1, err := client.ZAdd(key1, map[string]float64{"a": 1.0, "b": 1.5})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), zaddResult1.Value())
+		assert.Equal(suite.T(), int64(2), zaddResult1)
 
 		// Add elements to key2
 		zaddResult2, err := client.ZAdd(key2, map[string]float64{"c": 2.0})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), zaddResult2.Value())
+		assert.Equal(suite.T(), int64(1), zaddResult2)
 
 		// Pop minimum element from key1 and key2
 		bzpopminResult1, err := client.BZPopMin([]string{key1, key2}, float64(.5))
@@ -4364,7 +4314,7 @@ func (suite *GlideTestSuite) TestZPopMin() {
 
 		res, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res.Value())
+		assert.Equal(suite.T(), int64(3), res)
 
 		res2, err := client.ZPopMin(key1)
 		assert.Nil(suite.T(), err)
@@ -4398,7 +4348,7 @@ func (suite *GlideTestSuite) TestZPopMax() {
 		}
 		res, err := client.ZAdd(key1, memberScoreMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res.Value())
+		assert.Equal(suite.T(), int64(3), res)
 
 		res2, err := client.ZPopMax(key1)
 		assert.Nil(suite.T(), err)
@@ -4431,7 +4381,7 @@ func (suite *GlideTestSuite) TestZRem() {
 		}
 		res, err := client.ZAdd(key, memberScoreMap)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res.Value())
+		assert.Equal(suite.T(), int64(3), res)
 
 		// no members to remove
 		_, err = client.ZRem(key, []string{})
@@ -4440,12 +4390,12 @@ func (suite *GlideTestSuite) TestZRem() {
 
 		res, err = client.ZRem(key, []string{"one"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), res.Value())
+		assert.Equal(suite.T(), int64(1), res)
 
 		// TODO: run ZCard there
 		res, err = client.ZRem(key, []string{"one", "two", "three"})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), res.Value())
+		assert.Equal(suite.T(), int64(2), res)
 
 		// non sorted set key
 		_, err = client.Set(key, "test")
@@ -4824,7 +4774,7 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 
 		xLenResult, err := client.XLen(key1)
 		assert.NoError(t, err)
-		assert.Equal(t, xLenResult.Value(), int64(2))
+		assert.Equal(t, int64(2), xLenResult)
 
 		// Trim the first entry.
 		xAddResult, err = client.XAddWithOptions(
@@ -4839,7 +4789,7 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 		id := xAddResult.Value()
 		xLenResult, err = client.XLen(key1)
 		assert.NoError(t, err)
-		assert.Equal(t, xLenResult.Value(), int64(2))
+		assert.Equal(t, int64(2), xLenResult)
 
 		// Trim the second entry.
 		xAddResult, err = client.XAddWithOptions(
@@ -4853,7 +4803,7 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 		assert.NotNil(t, xAddResult.Value())
 		xLenResult, err = client.XLen(key1)
 		assert.NoError(t, err)
-		assert.Equal(t, xLenResult.Value(), int64(2))
+		assert.Equal(t, int64(2), xLenResult)
 
 		// Test xtrim to remove 1 element
 		xTrimResult, err := client.XTrim(
@@ -4861,10 +4811,10 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 			options.NewXTrimOptionsWithMaxLen(1).SetExactTrimming(),
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, xTrimResult.Value(), int64(1))
+		assert.Equal(t, int64(1), xTrimResult)
 		xLenResult, err = client.XLen(key1)
 		assert.NoError(t, err)
-		assert.Equal(t, xLenResult.Value(), int64(1))
+		assert.Equal(t, int64(1), xLenResult)
 
 		// Key does not exist - returns 0
 		xTrimResult, err = client.XTrim(
@@ -4872,10 +4822,10 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 			options.NewXTrimOptionsWithMaxLen(1).SetExactTrimming(),
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, xTrimResult.Value(), int64(0))
+		assert.Equal(t, int64(0), xTrimResult)
 		xLenResult, err = client.XLen(key2)
 		assert.NoError(t, err)
-		assert.Equal(t, xLenResult.Value(), int64(0))
+		assert.Equal(t, int64(0), xLenResult)
 
 		// Throw Exception: Key exists - but it is not a stream
 		setResult, err := client.Set(key2, "xtrimtest")

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -71,7 +71,7 @@ func (suite *GlideTestSuite) TestCustomCommandHExists_BoolResponse() {
 
 	res1, err := client.HSet(key, fields)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), int64(1), res1.Value())
+	assert.Equal(suite.T(), int64(1), res1)
 
 	result, err := client.CustomCommand([]string{"HEXISTS", key, "field1"})
 
@@ -138,7 +138,7 @@ func (suite *GlideTestSuite) TestCustomCommandConfigSMembers_SetResponse() {
 
 	res1, err := client.SAdd(key, members)
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), int64(3), res1.Value())
+	assert.Equal(suite.T(), int64(3), res1)
 
 	result2, err := client.CustomCommand([]string{"SMEMBERS", key})
 	assert.Nil(suite.T(), err)


### PR DESCRIPTION
Return `int64` instead of `Result[int64]` where possible. 
Few commands still return nullable `int64`, e.g. `ZRANK`