### PR TITLE
Fix `cluster_manager` script

### DIFF
--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -364,7 +364,7 @@ def start_server(
         )
         version_output = result.stdout
         version_match = re.search(
-            r"(?:Redis|Valkey) server v=(\d+\.\d+\.\d+)", version_output, re.IGNORECASE
+            r"server v=(\d+\.\d+\.\d+)", version_output, re.IGNORECASE
         )
         if version_match:
             return tuple(map(int, version_match.group(1).split(".")))


### PR DESCRIPTION
Valkey changed template for `--version`
```
$ ./valkey-7.2.8 --version
Server v=7.2.8 sha=f6852069:0 malloc=jemalloc-5.3.0 bits=64 build=67cf89c66d1115f6
$ ./redis-7.2.3 --version
Redis server v=7.2.3 sha=00000000:0 malloc=jemalloc-5.3.0 bits=64 build=9b0796a828280810
$ ./valkey-8 --version
Valkey server v=8.0.0 sha=2b5c7a0d:0 malloc=jemalloc-5.3.0 bits=64 build=3c5eadb1cbf9fac2
```
Need to adopt script, otherwise it crashes all CI on version 7.2
```
Traceback (most recent call last):
  File "/mnt/c/GitHub/babushka/utils/./cluster_manager.py", line 1257, in <module>
    main()
  File "/mnt/c/GitHub/babushka/utils/./cluster_manager.py", line 1193, in main
    servers = create_servers(
              ^^^^^^^^^^^^^^^
  File "/mnt/c/GitHub/babushka/utils/./cluster_manager.py", line 472, in create_servers
    start_server(
  File "/mnt/c/GitHub/babushka/utils/./cluster_manager.py", line 374, in start_server
    server_version = get_server_version(server_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/c/GitHub/babushka/utils/./cluster_manager.py", line 371, in get_server_version
    raise Exception("Unable to determine server version.")
```