### PR TITLE
Go: Fix return types, part 2: `float64` instead of `Result[float64]` and bool

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -246,10 +246,10 @@ func (client *baseClient) MSet(keyValueMap map[string]string) (Result[string], e
 func (client *baseClient) MSetNX(keyValueMap map[string]string) (bool, error) {
 	result, err := client.executeCommand(C.MSetNX, utils.MapToString(keyValueMap))
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) MGet(keys []string) ([]Result[string], error) {
@@ -285,10 +285,10 @@ func (client *baseClient) IncrByFloat(key string, amount float64) (float64, erro
 		[]string{key, utils.FloatToString(amount)},
 	)
 	if err != nil {
-		return float64(0), err
+		return defaultFloatResponse, err
 	}
 
-	return handleDoubleResponse(result)
+	return handleFloatResponse(result)
 }
 
 func (client *baseClient) Decr(key string) (Result[int64], error) {
@@ -406,10 +406,10 @@ func (client *baseClient) HSet(key string, values map[string]string) (Result[int
 func (client *baseClient) HSetNX(key string, field string, value string) (bool, error) {
 	result, err := client.executeCommand(C.HSetNX, []string{key, field, value})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) HDel(key string, fields []string) (Result[int64], error) {
@@ -442,10 +442,10 @@ func (client *baseClient) HVals(key string) ([]Result[string], error) {
 func (client *baseClient) HExists(key string, field string) (bool, error) {
 	result, err := client.executeCommand(C.HExists, []string{key, field})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) HKeys(key string) ([]Result[string], error) {
@@ -478,10 +478,10 @@ func (client *baseClient) HIncrBy(key string, field string, increment int64) (Re
 func (client *baseClient) HIncrByFloat(key string, field string, increment float64) (float64, error) {
 	result, err := client.executeCommand(C.HIncrByFloat, []string{key, field, utils.FloatToString(increment)})
 	if err != nil {
-		return float64(0), err
+		return defaultFloatResponse, err
 	}
 
-	return handleDoubleResponse(result)
+	return handleFloatResponse(result)
 }
 
 func (client *baseClient) HScan(key string, cursor string) (Result[string], []Result[string], error) {
@@ -637,10 +637,10 @@ func (client *baseClient) SCard(key string) (Result[int64], error) {
 func (client *baseClient) SIsMember(key string, member string) (bool, error) {
 	result, err := client.executeCommand(C.SIsMember, []string{key, member})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) SDiff(keys []string) (map[Result[string]]struct{}, error) {
@@ -723,7 +723,7 @@ func (client *baseClient) SMIsMember(key string, members []string) ([]bool, erro
 		return nil, err
 	}
 
-	return handleBooleanArrayResponse(result)
+	return handleBoolArrayResponse(result)
 }
 
 func (client *baseClient) SUnion(keys []string) (map[Result[string]]struct{}, error) {
@@ -763,9 +763,9 @@ func (client *baseClient) SScanWithOptions(
 func (client *baseClient) SMove(source string, destination string, member string) (bool, error) {
 	result, err := client.executeCommand(C.SMove, []string{source, destination, member})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) LRange(key string, start int64, end int64) ([]Result[string], error) {
@@ -1106,31 +1106,31 @@ func (client *baseClient) Exists(keys []string) (Result[int64], error) {
 func (client *baseClient) Expire(key string, seconds int64) (bool, error) {
 	result, err := client.executeCommand(C.Expire, []string{key, utils.IntToString(seconds)})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) ExpireWithOptions(key string, seconds int64, expireCondition ExpireCondition) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 	result, err := client.executeCommand(C.Expire, []string{key, utils.IntToString(seconds), expireConditionStr})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) ExpireAt(key string, unixTimestampInSeconds int64) (bool, error) {
 	result, err := client.executeCommand(C.ExpireAt, []string{key, utils.IntToString(unixTimestampInSeconds)})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) ExpireAtWithOptions(
@@ -1140,24 +1140,24 @@ func (client *baseClient) ExpireAtWithOptions(
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 	result, err := client.executeCommand(
 		C.ExpireAt,
 		[]string{key, utils.IntToString(unixTimestampInSeconds), expireConditionStr},
 	)
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) PExpire(key string, milliseconds int64) (bool, error) {
 	result, err := client.executeCommand(C.PExpire, []string{key, utils.IntToString(milliseconds)})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) PExpireWithOptions(
@@ -1167,21 +1167,21 @@ func (client *baseClient) PExpireWithOptions(
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 	result, err := client.executeCommand(C.PExpire, []string{key, utils.IntToString(milliseconds), expireConditionStr})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) PExpireAt(key string, unixTimestampInMilliSeconds int64) (bool, error) {
 	result, err := client.executeCommand(C.PExpireAt, []string{key, utils.IntToString(unixTimestampInMilliSeconds)})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) PExpireAtWithOptions(
@@ -1191,16 +1191,16 @@ func (client *baseClient) PExpireAtWithOptions(
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
 	result, err := client.executeCommand(
 		C.PExpireAt,
 		[]string{key, utils.IntToString(unixTimestampInMilliSeconds), expireConditionStr},
 	)
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) ExpireTime(key string) (Result[int64], error) {
@@ -1294,9 +1294,9 @@ func (client *baseClient) Rename(key string, newKey string) (Result[string], err
 func (client *baseClient) Renamenx(key string, newKey string) (bool, error) {
 	result, err := client.executeCommand(C.RenameNX, []string{key, newKey})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) XAdd(key string, values [][]string) (Result[string], error) {
@@ -1379,7 +1379,7 @@ func (client *baseClient) zAddIncrBase(key string, opts *options.ZAddOptions) (R
 		return CreateNilFloat64Result(), err
 	}
 
-	return handleDoubleOrNullResponse(result)
+	return handleFloatOrNilResponse(result)
 }
 
 func (client *baseClient) ZAddIncr(
@@ -1412,10 +1412,10 @@ func (client *baseClient) ZAddIncrWithOptions(
 func (client *baseClient) ZIncrBy(key string, increment float64, member string) (float64, error) {
 	result, err := client.executeCommand(C.ZIncrBy, []string{key, utils.FloatToString(increment), member})
 	if err != nil {
-		return float64(0), err
+		return defaultFloatResponse, err
 	}
 
-	return handleDoubleResponse(result)
+	return handleFloatResponse(result)
 }
 
 func (client *baseClient) ZPopMin(key string) (map[Result[string]]Result[float64], error) {
@@ -1574,9 +1574,9 @@ func (client *baseClient) ZRangeWithScores(
 func (client *baseClient) Persist(key string) (bool, error) {
 	result, err := client.executeCommand(C.Persist, []string{key})
 	if err != nil {
-		return false, err
+		return defaultBoolResponse, err
 	}
-	return handleBooleanResponse(result)
+	return handleBoolResponse(result)
 }
 
 func (client *baseClient) ZRank(key string, member string) (Result[int64], error) {

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -243,10 +243,10 @@ func (client *baseClient) MSet(keyValueMap map[string]string) (Result[string], e
 	return handleStringResponse(result)
 }
 
-func (client *baseClient) MSetNX(keyValueMap map[string]string) (Result[bool], error) {
+func (client *baseClient) MSetNX(keyValueMap map[string]string) (bool, error) {
 	result, err := client.executeCommand(C.MSetNX, utils.MapToString(keyValueMap))
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 
 	return handleBooleanResponse(result)
@@ -279,13 +279,13 @@ func (client *baseClient) IncrBy(key string, amount int64) (Result[int64], error
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) IncrByFloat(key string, amount float64) (Result[float64], error) {
+func (client *baseClient) IncrByFloat(key string, amount float64) (float64, error) {
 	result, err := client.executeCommand(
 		C.IncrByFloat,
 		[]string{key, utils.FloatToString(amount)},
 	)
 	if err != nil {
-		return CreateNilFloat64Result(), err
+		return float64(0), err
 	}
 
 	return handleDoubleResponse(result)
@@ -403,10 +403,10 @@ func (client *baseClient) HSet(key string, values map[string]string) (Result[int
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) HSetNX(key string, field string, value string) (Result[bool], error) {
+func (client *baseClient) HSetNX(key string, field string, value string) (bool, error) {
 	result, err := client.executeCommand(C.HSetNX, []string{key, field, value})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 
 	return handleBooleanResponse(result)
@@ -439,10 +439,10 @@ func (client *baseClient) HVals(key string) ([]Result[string], error) {
 	return handleStringArrayResponse(result)
 }
 
-func (client *baseClient) HExists(key string, field string) (Result[bool], error) {
+func (client *baseClient) HExists(key string, field string) (bool, error) {
 	result, err := client.executeCommand(C.HExists, []string{key, field})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 
 	return handleBooleanResponse(result)
@@ -475,10 +475,10 @@ func (client *baseClient) HIncrBy(key string, field string, increment int64) (Re
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) HIncrByFloat(key string, field string, increment float64) (Result[float64], error) {
+func (client *baseClient) HIncrByFloat(key string, field string, increment float64) (float64, error) {
 	result, err := client.executeCommand(C.HIncrByFloat, []string{key, field, utils.FloatToString(increment)})
 	if err != nil {
-		return CreateNilFloat64Result(), err
+		return float64(0), err
 	}
 
 	return handleDoubleResponse(result)
@@ -634,10 +634,10 @@ func (client *baseClient) SCard(key string) (Result[int64], error) {
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) SIsMember(key string, member string) (Result[bool], error) {
+func (client *baseClient) SIsMember(key string, member string) (bool, error) {
 	result, err := client.executeCommand(C.SIsMember, []string{key, member})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 
 	return handleBooleanResponse(result)
@@ -717,7 +717,7 @@ func (client *baseClient) SPop(key string) (Result[string], error) {
 	return handleStringResponse(result)
 }
 
-func (client *baseClient) SMIsMember(key string, members []string) ([]Result[bool], error) {
+func (client *baseClient) SMIsMember(key string, members []string) ([]bool, error) {
 	result, err := client.executeCommand(C.SMIsMember, append([]string{key}, members...))
 	if err != nil {
 		return nil, err
@@ -760,10 +760,10 @@ func (client *baseClient) SScanWithOptions(
 	return handleScanResponse(result)
 }
 
-func (client *baseClient) SMove(source string, destination string, member string) (Result[bool], error) {
+func (client *baseClient) SMove(source string, destination string, member string) (bool, error) {
 	result, err := client.executeCommand(C.SMove, []string{source, destination, member})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
@@ -1103,31 +1103,31 @@ func (client *baseClient) Exists(keys []string) (Result[int64], error) {
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) Expire(key string, seconds int64) (Result[bool], error) {
+func (client *baseClient) Expire(key string, seconds int64) (bool, error) {
 	result, err := client.executeCommand(C.Expire, []string{key, utils.IntToString(seconds)})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 
 	return handleBooleanResponse(result)
 }
 
-func (client *baseClient) ExpireWithOptions(key string, seconds int64, expireCondition ExpireCondition) (Result[bool], error) {
+func (client *baseClient) ExpireWithOptions(key string, seconds int64, expireCondition ExpireCondition) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	result, err := client.executeCommand(C.Expire, []string{key, utils.IntToString(seconds), expireConditionStr})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
 
-func (client *baseClient) ExpireAt(key string, unixTimestampInSeconds int64) (Result[bool], error) {
+func (client *baseClient) ExpireAt(key string, unixTimestampInSeconds int64) (bool, error) {
 	result, err := client.executeCommand(C.ExpireAt, []string{key, utils.IntToString(unixTimestampInSeconds)})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 
 	return handleBooleanResponse(result)
@@ -1137,25 +1137,25 @@ func (client *baseClient) ExpireAtWithOptions(
 	key string,
 	unixTimestampInSeconds int64,
 	expireCondition ExpireCondition,
-) (Result[bool], error) {
+) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	result, err := client.executeCommand(
 		C.ExpireAt,
 		[]string{key, utils.IntToString(unixTimestampInSeconds), expireConditionStr},
 	)
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
 
-func (client *baseClient) PExpire(key string, milliseconds int64) (Result[bool], error) {
+func (client *baseClient) PExpire(key string, milliseconds int64) (bool, error) {
 	result, err := client.executeCommand(C.PExpire, []string{key, utils.IntToString(milliseconds)})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
@@ -1164,22 +1164,22 @@ func (client *baseClient) PExpireWithOptions(
 	key string,
 	milliseconds int64,
 	expireCondition ExpireCondition,
-) (Result[bool], error) {
+) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	result, err := client.executeCommand(C.PExpire, []string{key, utils.IntToString(milliseconds), expireConditionStr})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
 
-func (client *baseClient) PExpireAt(key string, unixTimestampInMilliSeconds int64) (Result[bool], error) {
+func (client *baseClient) PExpireAt(key string, unixTimestampInMilliSeconds int64) (bool, error) {
 	result, err := client.executeCommand(C.PExpireAt, []string{key, utils.IntToString(unixTimestampInMilliSeconds)})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
@@ -1188,17 +1188,17 @@ func (client *baseClient) PExpireAtWithOptions(
 	key string,
 	unixTimestampInMilliSeconds int64,
 	expireCondition ExpireCondition,
-) (Result[bool], error) {
+) (bool, error) {
 	expireConditionStr, err := expireCondition.toString()
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	result, err := client.executeCommand(
 		C.PExpireAt,
 		[]string{key, utils.IntToString(unixTimestampInMilliSeconds), expireConditionStr},
 	)
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
@@ -1291,10 +1291,10 @@ func (client *baseClient) Rename(key string, newKey string) (Result[string], err
 	return handleStringOrNullResponse(result)
 }
 
-func (client *baseClient) Renamenx(key string, newKey string) (Result[bool], error) {
+func (client *baseClient) Renamenx(key string, newKey string) (bool, error) {
 	result, err := client.executeCommand(C.RenameNX, []string{key, newKey})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }
@@ -1379,7 +1379,7 @@ func (client *baseClient) zAddIncrBase(key string, opts *options.ZAddOptions) (R
 		return CreateNilFloat64Result(), err
 	}
 
-	return handleDoubleResponse(result)
+	return handleDoubleOrNullResponse(result)
 }
 
 func (client *baseClient) ZAddIncr(
@@ -1409,10 +1409,10 @@ func (client *baseClient) ZAddIncrWithOptions(
 	return client.zAddIncrBase(key, incrOpts)
 }
 
-func (client *baseClient) ZIncrBy(key string, increment float64, member string) (Result[float64], error) {
+func (client *baseClient) ZIncrBy(key string, increment float64, member string) (float64, error) {
 	result, err := client.executeCommand(C.ZIncrBy, []string{key, utils.FloatToString(increment), member})
 	if err != nil {
-		return CreateNilFloat64Result(), err
+		return float64(0), err
 	}
 
 	return handleDoubleResponse(result)
@@ -1571,10 +1571,10 @@ func (client *baseClient) ZRangeWithScores(
 	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) Persist(key string) (Result[bool], error) {
+func (client *baseClient) Persist(key string) (bool, error) {
 	result, err := client.executeCommand(C.Persist, []string{key})
 	if err != nil {
-		return CreateNilBoolResult(), err
+		return false, err
 	}
 	return handleBooleanResponse(result)
 }

--- a/go/api/generic_base_commands.go
+++ b/go/api/generic_base_commands.go
@@ -69,15 +69,15 @@ type GenericBaseCommands interface {
 	// seconds - Time in seconds for the key to expire
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.Expire("key", 1)
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	// [valkey.io]: https://valkey.io/commands/expire/
-	Expire(key string, seconds int64) (Result[bool], error)
+	Expire(key string, seconds int64) (bool, error)
 
 	// Expire sets a timeout on key. After the timeout has expired, the key will automatically be deleted
 	//
@@ -91,15 +91,15 @@ type GenericBaseCommands interface {
 	// option - The option  to set expiry - NX, XX, GT, LT
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.Expire("key", 1, api.OnlyIfDoesNotExist)
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	// [valkey.io]: https://valkey.io/commands/expire/
-	ExpireWithOptions(key string, seconds int64, expireCondition ExpireCondition) (Result[bool], error)
+	ExpireWithOptions(key string, seconds int64, expireCondition ExpireCondition) (bool, error)
 
 	// ExpireAt sets a timeout on key. It takes an absolute Unix timestamp (seconds since January 1, 1970) instead of
 	// specifying the number of seconds. A timestamp in the past will delete the key immediately. After the timeout has
@@ -115,15 +115,15 @@ type GenericBaseCommands interface {
 	// unixTimestampInSeconds - Absolute Unix timestamp
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.ExpireAt("key", time.Now().Unix())
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	// [valkey.io]: https://valkey.io/commands/expireat/
-	ExpireAt(key string, unixTimestampInSeconds int64) (Result[bool], error)
+	ExpireAt(key string, unixTimestampInSeconds int64) (bool, error)
 
 	// ExpireAt sets a timeout on key. It takes an absolute Unix timestamp (seconds since January 1, 1970) instead of
 	// specifying the number of seconds. A timestamp in the past will delete the key immediately. After the timeout has
@@ -140,15 +140,15 @@ type GenericBaseCommands interface {
 	// option - The option  to set expiry - NX, XX, GT, LT
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.ExpireAt("key", time.Now().Unix(), api.OnlyIfDoesNotExist)
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	// [valkey.io]: https://valkey.io/commands/expireat/
-	ExpireAtWithOptions(key string, unixTimestampInSeconds int64, expireCondition ExpireCondition) (Result[bool], error)
+	ExpireAtWithOptions(key string, unixTimestampInSeconds int64, expireCondition ExpireCondition) (bool, error)
 
 	// Sets a timeout on key in milliseconds. After the timeout has expired, the key will automatically be deleted.
 	// If key already has an existing expire set, the time to live is updated to the new value.
@@ -160,15 +160,15 @@ type GenericBaseCommands interface {
 	// milliseconds - The timeout in milliseconds.
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.PExpire("key", int64(5 * 1000))
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	//  [valkey.io]: https://valkey.io/commands/pexpire/
-	PExpire(key string, milliseconds int64) (Result[bool], error)
+	PExpire(key string, milliseconds int64) (bool, error)
 
 	// Sets a timeout on key in milliseconds. After the timeout has expired, the key will automatically be deleted.
 	// If key already has an existing expire set, the time to live is updated to the new value.
@@ -181,15 +181,15 @@ type GenericBaseCommands interface {
 	// option - The option  to set expiry - NX, XX, GT, LT
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.PExpire("key", int64(5 * 1000), api.OnlyIfDoesNotExist)
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	//	[valkey.io]: https://valkey.io/commands/pexpire/
-	PExpireWithOptions(key string, milliseconds int64, expireCondition ExpireCondition) (Result[bool], error)
+	PExpireWithOptions(key string, milliseconds int64, expireCondition ExpireCondition) (bool, error)
 
 	// Sets a timeout on key. It takes an absolute Unix timestamp (milliseconds since
 	// January 1, 1970) instead of specifying the number of milliseconds.
@@ -204,15 +204,15 @@ type GenericBaseCommands interface {
 	// unixMilliseconds - The timeout in an absolute Unix timestamp.
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.PExpire("key", time.Now().Unix()*1000)
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	//	[valkey.io]: https://valkey.io/commands/pexpireat/
-	PExpireAt(key string, unixTimestampInMilliSeconds int64) (Result[bool], error)
+	PExpireAt(key string, unixTimestampInMilliSeconds int64) (bool, error)
 
 	// Sets a timeout on key. It takes an absolute Unix timestamp (milliseconds since
 	// January 1, 1970) instead of specifying the number of milliseconds.
@@ -228,15 +228,15 @@ type GenericBaseCommands interface {
 	// option - The option  to set expiry - NX, XX, GT, LT
 	//
 	// Return value:
-	// A Result[bool] containing true is expiry is set.
+	//  `true` if the timeout was set. `false` if the timeout was not set. e.g. key doesn't exist,
+	//  or operation skipped due to the provided arguments.
 	//
 	// Example:
 	// result, err := client.PExpire("key", time.Now().Unix()*1000, api.OnlyIfDoesNotExist)
-	// result.Value(): true
-	// result.IsNil(): false
+	// result: true
 	//
 	//	[valkey.io]: https://valkey.io/commands/pexpireat/
-	PExpireAtWithOptions(key string, unixTimestampInMilliSeconds int64, expireCondition ExpireCondition) (Result[bool], error)
+	PExpireAtWithOptions(key string, unixTimestampInMilliSeconds int64, expireCondition ExpireCondition) (bool, error)
 
 	// Expire Time returns the absolute Unix timestamp (since January 1, 1970) at which the given key
 	// will expire, in seconds.
@@ -398,7 +398,7 @@ type GenericBaseCommands interface {
 	// If the key was successfully renamed, return "OK". If key does not exist, an error is thrown.
 	//
 	// Example:
-	//  result, err := client.Rename([]string{"key","newkey"})
+	//  result, err := client.Rename([]string{"key", "newkey"})
 	//	if err != nil {
 	//	    // handle error
 	//	}
@@ -417,17 +417,17 @@ type GenericBaseCommands interface {
 	//  newKey The new name of the key.
 	//
 	// Return value:
-	// true if key was renamed to newKey, false if newKey already exists.
+	//  `true` if k`ey was renamed to `newKey`, `false` if `newKey` already exists.
 	//
 	// Example:
-	//  result, err := client.Renamenx([]string{"key","newkey"})
+	//  result, err := client.Renamenx([]string{"key", "newkey"})
 	//	if err != nil {
 	//	    // handle error
 	//	}
-	//	fmt.Println(result.Value()) // Output: OK
+	//	fmt.Println(result) // Output: true
 	//
 	// [valkey.io]: https://valkey.io/commands/renamenx/
-	Renamenx(key string, newKey string) (Result[bool], error)
+	Renamenx(key string, newKey string) (bool, error)
 
 	// Removes the existing timeout on key, turning the key from volatile
 	// (a key with an expire set) to persistent (a key that will never expire as no timeout is associated).
@@ -436,15 +436,15 @@ type GenericBaseCommands interface {
 	//  key - The key to remove the existing timeout on.
 	//
 	// Return value:
-	//  false if key does not exist or does not have an associated timeout, true if the timeout has been removed.
+	//  `false` if key does not exist or does not have an associated timeout, `true` if the timeout has been removed.
 	//
 	// Example:
 	//  result, err := client.Persist([]string{"key"})
 	//	if err != nil {
 	//	    // handle error
 	//	}
-	//	fmt.Println(result.Value()) // Output: true
+	//	fmt.Println(result) // Output: true
 	//
 	// [valkey.io]: https://valkey.io/commands/persist/
-	Persist(key string) (Result[bool], error)
+	Persist(key string) (bool, error)
 }

--- a/go/api/hash_commands.go
+++ b/go/api/hash_commands.go
@@ -111,7 +111,7 @@ type HashCommands interface {
 	//  value - The value to set.
 	//
 	// Return value:
-	//  A Result[bool] containing true if field is a new field in the hash and value was set.
+	//  A bool containing true if field is a new field in the hash and value was set.
 	//  false if field already exists in the hash and no operation was performed.
 	//
 	// For example:
@@ -123,7 +123,7 @@ type HashCommands interface {
 	//  // payload2.IsNil(): false
 	//
 	// [valkey.io]: https://valkey.io/commands/hsetnx/
-	HSetNX(key string, field string, value string) (Result[bool], error)
+	HSetNX(key string, field string, value string) (bool, error)
 
 	// HDel removes the specified fields from the hash stored at key.
 	// Specified fields that do not exist within this hash are ignored.
@@ -198,7 +198,7 @@ type HashCommands interface {
 	//  field - The field to check in the hash stored at key.
 	//
 	// Return value:
-	//  A Result[bool] containing true if the hash contains the specified field.
+	//  A bool containing true if the hash contains the specified field.
 	//  false if the hash does not contain the field, or if the key does not exist.
 	//
 	// For example:
@@ -210,7 +210,7 @@ type HashCommands interface {
 	//  // exists.IsNil(): false
 	//
 	// [valkey.io]: https://valkey.io/commands/hexists/
-	HExists(key string, field string) (Result[bool], error)
+	HExists(key string, field string) (bool, error)
 
 	// HKeys returns all field names in the hash stored at key.
 	//
@@ -275,7 +275,7 @@ type HashCommands interface {
 
 	// Increments the string representing a floating point number stored at `field` in the hash stored at `key` by increment.
 	// By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
-	// If `field` or `key` does not exist, it is set to 0 before performing the operation.
+	// If `field` or `key` does not exist, it is set to `0` before performing the operation.
 	//
 	// See [valkey.io] for details.
 	//
@@ -285,15 +285,15 @@ type HashCommands interface {
 	// 	increment - The amount to increment.
 	//
 	// Return value:
-	// 	The Result[float64] value of `field` in the hash stored at `key` after the increment.
+	// 	The value of `field` in the hash stored at `key` after the increment.
 	//
 	// Example:
 	//  _, err := client.HSet("key", map[string]string{"field": "10"})
 	//  hincrByFloatResult, err := client.HIncrByFloat("key", "field", 1.5)
-	//	// hincrByFloatResult.Value(): 11.5
+	//	// hincrByFloatResult: 11.5
 	//
 	// [valkey.io]: https://valkey.io/commands/hincrbyfloat/
-	HIncrByFloat(key string, field string, increment float64) (Result[float64], error)
+	HIncrByFloat(key string, field string, increment float64) (float64, error)
 
 	// Iterates fields of Hash types and their associated values. This definition of HSCAN command does not include the
 	// optional arguments of the command.

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -274,7 +274,9 @@ func handleDoubleOrNullResponse(response *C.struct_CommandResponse) (Result[floa
 	if typeErr != nil {
 		return CreateNilFloat64Result(), typeErr
 	}
-
+	if response.response_type == C.Null {
+		return CreateNilFloat64Result(), nil
+	}
 	return CreateFloat64Result(float64(response.float_value)), nil
 }
 

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -256,7 +256,7 @@ func handleLongArrayResponse(response *C.struct_CommandResponse) ([]Result[int64
 	return slice, nil
 }
 
-func handleDoubleResponse(response *C.struct_CommandResponse) (float64, error) {
+func handleFloatResponse(response *C.struct_CommandResponse) (float64, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Float, false)
@@ -267,7 +267,7 @@ func handleDoubleResponse(response *C.struct_CommandResponse) (float64, error) {
 	return float64(response.float_value), nil
 }
 
-func handleDoubleOrNullResponse(response *C.struct_CommandResponse) (Result[float64], error) {
+func handleFloatOrNilResponse(response *C.struct_CommandResponse) (Result[float64], error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Float, true)
@@ -306,7 +306,7 @@ func handleLongAndDoubleOrNullResponse(response *C.struct_CommandResponse) (Resu
 	return rank, score, nil
 }
 
-func handleBooleanResponse(response *C.struct_CommandResponse) (bool, error) {
+func handleBoolResponse(response *C.struct_CommandResponse) (bool, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Bool, false)
@@ -317,7 +317,7 @@ func handleBooleanResponse(response *C.struct_CommandResponse) (bool, error) {
 	return bool(response.bool_value), nil
 }
 
-func handleBooleanArrayResponse(response *C.struct_CommandResponse) ([]bool, error) {
+func handleBoolArrayResponse(response *C.struct_CommandResponse) ([]bool, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Array, false)

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -270,7 +270,7 @@ func handleDoubleResponse(response *C.struct_CommandResponse) (float64, error) {
 func handleDoubleOrNullResponse(response *C.struct_CommandResponse) (Result[float64], error) {
 	defer C.free_command_response(response)
 
-	typeErr := checkResponseType(response, C.Float, false)
+	typeErr := checkResponseType(response, C.Float, true)
 	if typeErr != nil {
 		return CreateNilFloat64Result(), typeErr
 	}

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -47,14 +47,6 @@ func CreateNilFloat64Result() Result[float64] {
 	return Result[float64]{val: 0, isNil: true}
 }
 
-func CreateBoolResult(boolVal bool) Result[bool] {
-	return Result[bool]{val: boolVal, isNil: false}
-}
-
-func CreateNilBoolResult() Result[bool] {
-	return Result[bool]{val: false, isNil: true}
-}
-
 func CreateKeyWithMemberAndScoreResult(kmsVal KeyWithMemberAndScore) Result[KeyWithMemberAndScore] {
 	return Result[KeyWithMemberAndScore]{val: kmsVal, isNil: false}
 }

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -2,6 +2,12 @@
 
 package api
 
+// A value to return alongside with error in case if command failed
+var (
+	defaultFloatResponse float64
+	defaultBoolResponse  bool
+)
+
 type Result[T any] struct {
 	val   T
 	isNil bool

--- a/go/api/set_commands.go
+++ b/go/api/set_commands.go
@@ -101,7 +101,7 @@ type SetCommands interface {
 	//   member - The member to check for existence in the set.
 	//
 	// Return value:
-	//   A Result[bool] containing true if the member exists in the set, false otherwise.
+	//   A bool containing true if the member exists in the set, false otherwise.
 	//   If key doesn't exist, it is treated as an empty set and the method returns false.
 	//
 	// Example:
@@ -113,7 +113,7 @@ type SetCommands interface {
 	//   // Indicates that "nonExistingMember" does not exist in the set "mySet".
 	//
 	// [valkey.io]: https://valkey.io/commands/sismember/
-	SIsMember(key string, member string) (Result[bool], error)
+	SIsMember(key string, member string) (bool, error)
 
 	// SDiff computes the difference between the first set and all the successive sets in keys.
 	//
@@ -312,7 +312,7 @@ type SetCommands interface {
 	//   key - The key of the set.
 	//
 	// Return value:
-	//   A []Result[bool] containing whether each member is a member of the set stored at key.
+	//   A []bool containing whether each member is a member of the set stored at key.
 	//
 	// Example:
 	//	 client.SAdd("myKey", []string{"one", "two"})
@@ -325,7 +325,7 @@ type SetCommands interface {
 	//   // err: nil
 	//
 	// [valkey.io]: https://valkey.io/commands/smismember/
-	SMIsMember(key string, members []string) ([]Result[bool], error)
+	SMIsMember(key string, members []string) ([]bool, error)
 
 	// SUnionStore stores the members of the union of all given sets specified by `keys` into a new set at `destination`.
 	//
@@ -478,5 +478,5 @@ type SetCommands interface {
 	//   fmt.Println(moved.Value()) // Output: true
 	//
 	// [valkey.io]: https://valkey.io/commands/smove/
-	SMove(source string, destination string, member string) (Result[bool], error)
+	SMove(source string, destination string, member string) (bool, error)
 }

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -80,7 +80,8 @@ type SortedSetCommands interface {
 	//   opts - The options for the command. See [ZAddOptions] for details.
 	//
 	// Return value:
-	//   Result[float64] - The new score of the member.
+	//   The new score of the member.
+	//   If there was a conflict with the options, the operation aborts and `nil` is returned.
 	//
 	// Example:
 	//   res, err := client.ZAddIncrWithOptions(key, "one", 1.0, options.NewZAddOptionsBuilder().SetChanged(true))

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -106,10 +106,10 @@ type SortedSetCommands interface {
 	//
 	// Example:
 	//   res, err := client.ZIncrBy("myzset", 2.0, "one")
-	//   fmt.Println(res.Value()) // Output: 2.0
+	//   fmt.Println(res) // Output: 2.0
 	//
 	// [valkey.io]: https://valkey.io/commands/zincrby/
-	ZIncrBy(key string, increment float64, member string) (Result[float64], error)
+	ZIncrBy(key string, increment float64, member string) (float64, error)
 
 	// Removes and returns the member with the lowest score from the sorted set
 	// stored at the specified `key`.

--- a/go/api/string_commands.go
+++ b/go/api/string_commands.go
@@ -197,7 +197,7 @@ type StringCommands interface {
 	//  keyValueMap - A key-value map consisting of keys and their respective values to set.
 	//
 	// Return value:
-	//  A Result[bool] containing true, if all keys were set. false, if no key was set.
+	//  A bool containing true, if all keys were set. false, if no key was set.
 	//
 	// For example:
 	//  1. result, err := client.MSetNX(map[string]string{"key1": "value1", "key2": "value2"})
@@ -209,7 +209,7 @@ type StringCommands interface {
 	//     result.IsNil(): false
 	//
 	// [valkey.io]: https://valkey.io/commands/msetnx/
-	MSetNX(keyValueMap map[string]string) (Result[bool], error)
+	MSetNX(keyValueMap map[string]string) (bool, error)
 
 	// Increments the number stored at key by one. If key does not exist, it is set to 0 before performing the operation.
 	//
@@ -251,7 +251,7 @@ type StringCommands interface {
 	IncrBy(key string, amount int64) (Result[int64], error)
 
 	// Increments the string representing a floating point number stored at key by amount. By using a negative increment value,
-	// the result is that the value stored at key is decremented. If key does not exist, it is set to 0 before performing the
+	// the result is that the value stored at key is decremented. If key does not exist, it is set to `0` before performing the
 	// operation.
 	//
 	// See [valkey.io] for details.
@@ -261,16 +261,15 @@ type StringCommands interface {
 	//  amount - The amount to increment.
 	//
 	// Return value:
-	//  The Result[float64] of key after the increment.
+	//  The value of key after the increment.
 	//
 	// For example:
 	//  key: 1
 	//  result, err := client.IncrBy("key", 0.5)
-	//  result.Value(): 1.5
-	//  result.IsNil(): false
+	//  result: 1.5
 	//
 	// [valkey.io]: https://valkey.io/commands/incrbyfloat/
-	IncrByFloat(key string, amount float64) (Result[float64], error)
+	IncrByFloat(key string, amount float64) (float64, error)
 
 	// Decrements the number stored at key by one. If key does not exist, it is set to 0 before performing the operation.
 	//

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -275,7 +275,7 @@ func (suite *GlideTestSuite) TestMSetNXAndMGet_nonExistingKey_valuesSet() {
 		}
 		res, err := client.MSetNX(keyValueMap)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), res.Value())
+		assert.True(suite.T(), res)
 		keys := []string{key1, key2, key3}
 		stringValue := api.CreateStringResult(value)
 		values := []api.Result[string]{stringValue, stringValue, stringValue}
@@ -301,7 +301,7 @@ func (suite *GlideTestSuite) TestMSetNXAndMGet_existingKey_valuesNotUpdated() {
 		}
 		res, err := client.MSetNX(keyValueMap)
 		assert.Nil(suite.T(), err)
-		assert.False(suite.T(), res.Value())
+		assert.False(suite.T(), res)
 		keys := []string{key1, key2, key3}
 		oldResult := api.CreateStringResult(oldValue)
 		nullResult := api.CreateNilStringResult()
@@ -328,7 +328,7 @@ func (suite *GlideTestSuite) TestIncrCommands_existingKey() {
 
 		res3, err := client.IncrByFloat(key, float64(10.1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), float64(31.1), res3.Value())
+		assert.Equal(suite.T(), float64(31.1), res3)
 	})
 }
 
@@ -347,7 +347,7 @@ func (suite *GlideTestSuite) TestIncrCommands_nonExistingKey() {
 		key3 := uuid.New().String()
 		res3, err := client.IncrByFloat(key3, float64(10.1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), float64(10.1), res3.Value())
+		assert.Equal(suite.T(), float64(10.1), res3)
 	})
 }
 
@@ -367,7 +367,7 @@ func (suite *GlideTestSuite) TestIncrCommands_TypeError() {
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res3, err := client.IncrByFloat(key, float64(10.1))
-		assert.Equal(suite.T(), float64(0), res3.Value())
+		assert.Equal(suite.T(), float64(0), res3)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -798,7 +798,7 @@ func (suite *GlideTestSuite) TestHSetNX_WithExistingKey() {
 
 		res2, err := client.HSetNX(key, "field1", "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2)
 	})
 }
 
@@ -808,7 +808,7 @@ func (suite *GlideTestSuite) TestHSetNX_WithNotExistingKey() {
 
 		res1, err := client.HSetNX(key, "field1", "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), true, res1.Value())
+		assert.True(suite.T(), res1)
 
 		res2, err := client.HGetAll(key)
 		field1 := api.CreateStringResult("field1")
@@ -829,7 +829,7 @@ func (suite *GlideTestSuite) TestHSetNX_WithExistingField() {
 
 		res2, err := client.HSetNX(key, "field1", "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2)
 	})
 }
 
@@ -944,7 +944,7 @@ func (suite *GlideTestSuite) TestHExists_WithExistingKey() {
 
 		res2, err := client.HExists(key, "field1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), true, res2.Value())
+		assert.True(suite.T(), res2)
 	})
 }
 
@@ -954,7 +954,7 @@ func (suite *GlideTestSuite) TestHExists_WithNotExistingKey() {
 
 		res, err := client.HExists(key, "field1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res.Value())
+		assert.False(suite.T(), res)
 	})
 }
 
@@ -969,7 +969,7 @@ func (suite *GlideTestSuite) TestHExists_WithNotExistingField() {
 
 		res2, err := client.HExists(key, "field3")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2)
 	})
 }
 
@@ -1086,7 +1086,7 @@ func (suite *GlideTestSuite) TestHIncrByFloat_WithExistingField() {
 
 		hincrByFloatResult, hincrByFloatErr := client.HIncrByFloat(key, field, 1.5)
 		assert.Nil(suite.T(), hincrByFloatErr)
-		assert.Equal(suite.T(), float64(11.5), hincrByFloatResult.Value())
+		assert.Equal(suite.T(), float64(11.5), hincrByFloatResult)
 	})
 }
 
@@ -1103,7 +1103,7 @@ func (suite *GlideTestSuite) TestHIncrByFloat_WithNonExistingField() {
 
 		hincrByFloatResult, hincrByFloatErr := client.HIncrByFloat(key, field, 1.5)
 		assert.Nil(suite.T(), hincrByFloatErr)
-		assert.Equal(suite.T(), float64(1.5), hincrByFloatResult.Value())
+		assert.Equal(suite.T(), float64(1.5), hincrByFloatResult)
 	})
 }
 
@@ -1754,8 +1754,7 @@ func (suite *GlideTestSuite) TestSIsMember() {
 
 		res2, err := client.SIsMember(key, "member2")
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.True(suite.T(), res2)
 	})
 }
 
@@ -1765,8 +1764,7 @@ func (suite *GlideTestSuite) TestSIsMember_WithNotExistingKey() {
 
 		res, err := client.SIsMember(key, "member2")
 		assert.Nil(suite.T(), err)
-		assert.False(suite.T(), res.Value())
-		assert.False(suite.T(), res.IsNil())
+		assert.False(suite.T(), res)
 	})
 }
 
@@ -1782,8 +1780,7 @@ func (suite *GlideTestSuite) TestSIsMember_WithNotExistingMember() {
 
 		res2, err := client.SIsMember(key, "nonExistingMember")
 		assert.Nil(suite.T(), err)
-		assert.False(suite.T(), res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		assert.False(suite.T(), res2)
 	})
 }
 
@@ -2144,17 +2141,11 @@ func (suite *GlideTestSuite) TestSMIsMember() {
 
 		res2, err2 := client.SMIsMember(key1, []string{"two", "three"})
 		assert.Nil(suite.T(), err2)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[bool]{
-				api.CreateBoolResult(true),
-				api.CreateBoolResult(false),
-			},
-			res2)
+		assert.Equal(suite.T(), []bool{true, false}, res2)
 
 		res3, err3 := client.SMIsMember(nonExistingKey, []string{"two"})
 		assert.Nil(suite.T(), err3)
-		assert.Equal(suite.T(), []api.Result[bool]{api.CreateBoolResult(false)}, res3)
+		assert.Equal(suite.T(), []bool{false}, res3)
 
 		// invalid argument - member list must not be empty
 		_, err4 := client.SMIsMember(key1, []string{})
@@ -2249,7 +2240,7 @@ func (suite *GlideTestSuite) TestSMove() {
 		// move an element
 		res3, err := client.SMove(key1, key2, "1")
 		assert.NoError(t, err)
-		assert.True(t, res3.Value())
+		assert.True(t, res3)
 
 		res4, err := client.SMembers(key1)
 		assert.NoError(t, err)
@@ -2271,7 +2262,7 @@ func (suite *GlideTestSuite) TestSMove() {
 		// moved element already exists in the destination set
 		res6, err := client.SMove(key2, key1, "2")
 		assert.NoError(t, err)
-		assert.True(t, res6.Value())
+		assert.True(t, res6)
 
 		res7, err := client.SMembers(key1)
 		assert.NoError(t, err)
@@ -2292,7 +2283,7 @@ func (suite *GlideTestSuite) TestSMove() {
 		// attempt to move from a non-existing key
 		res9, err := client.SMove(nonExistingKey, key1, "4")
 		assert.NoError(t, err)
-		assert.False(t, res9.Value())
+		assert.False(t, res9)
 
 		res10, err := client.SMembers(key1)
 		assert.NoError(t, err)
@@ -2305,7 +2296,7 @@ func (suite *GlideTestSuite) TestSMove() {
 		// move to a new set
 		res11, err := client.SMove(key1, key3, "2")
 		assert.NoError(t, err)
-		assert.True(t, res11.Value())
+		assert.True(t, res11)
 
 		res12, err := client.SMembers(key1)
 		assert.NoError(t, err)
@@ -2320,7 +2311,7 @@ func (suite *GlideTestSuite) TestSMove() {
 		// attempt to move a missing element
 		res14, err := client.SMove(key1, key3, "42")
 		assert.NoError(t, err)
-		assert.False(t, res14.Value())
+		assert.False(t, res14)
 
 		res12, err = client.SMembers(key1)
 		assert.NoError(t, err)
@@ -2335,7 +2326,7 @@ func (suite *GlideTestSuite) TestSMove() {
 		// moving missing element to missing key
 		res15, err := client.SMove(key1, nonExistingKey, "42")
 		assert.NoError(t, err)
-		assert.False(t, res15.Value())
+		assert.False(t, res15)
 
 		res12, err = client.SMembers(key1)
 		assert.NoError(t, err)
@@ -2509,12 +2500,12 @@ func (suite *GlideTestSuite) TestLIndex() {
 		res2, err := client.LIndex(key, int64(0))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "value1", res2.Value())
-		assert.Equal(suite.T(), false, res2.IsNil())
+		assert.False(suite.T(), res2.IsNil())
 
 		res3, err := client.LIndex(key, int64(-1))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "value4", res3.Value())
-		assert.Equal(suite.T(), false, res3.IsNil())
+		assert.False(suite.T(), res3.IsNil())
 
 		res4, err := client.LIndex("non_existing_key", int64(0))
 		assert.Nil(suite.T(), err)
@@ -3185,7 +3176,7 @@ func (suite *GlideTestSuite) TestExpire() {
 
 		result, err := client.Expire(key, 1)
 		assert.Nil(suite.T(), err, "Expected no error from Expire command")
-		assert.True(suite.T(), result.Value(), "Expire command should return true when expiry is set")
+		assert.True(suite.T(), result, "Expire command should return true when expiry is set")
 
 		time.Sleep(1500 * time.Millisecond)
 
@@ -3201,7 +3192,7 @@ func (suite *GlideTestSuite) TestExpire_KeyDoesNotExist() {
 		// Trying to set an expiry on a non-existent key
 		result, err := client.Expire(key, 1)
 		assert.Nil(suite.T(), err)
-		assert.False(suite.T(), result.Value())
+		assert.False(suite.T(), result)
 	})
 }
 
@@ -3215,7 +3206,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
 
 		result, err := client.ExpireWithOptions(key, 2, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), result.Value())
+		assert.True(suite.T(), result)
 
 		time.Sleep(2500 * time.Millisecond)
 
@@ -3225,7 +3216,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
 
 		result, err = client.ExpireWithOptions(key, 1, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.False(suite.T(), result.Value())
+		assert.False(suite.T(), result)
 	})
 }
 
@@ -3239,11 +3230,11 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasExistingExpiry() {
 
 		resexp, err := client.ExpireWithOptions(key, 20, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resexp.Value())
+		assert.True(suite.T(), resexp)
 
 		resultExpire, err := client.ExpireWithOptions(key, 1, api.HasExistingExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		time.Sleep(2 * time.Second)
 
@@ -3263,11 +3254,11 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryGreaterThanCurrent()
 
 		resultExpire, err := client.ExpireWithOptions(key, 2, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		resultExpire, err = client.ExpireWithOptions(key, 5, api.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 		time.Sleep(6 * time.Second)
 		resultExpireTest, err := client.Exists([]string{key})
 		assert.Nil(suite.T(), err)
@@ -3285,17 +3276,17 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryLessThanCurrent() {
 
 		resultExpire, err := client.ExpireWithOptions(key, 10, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		resultExpire, err = client.ExpireWithOptions(key, 5, api.NewExpiryLessThanCurrent)
 		assert.Nil(suite.T(), err)
 
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		resultExpire, err = client.ExpireWithOptions(key, 15, api.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
 
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		time.Sleep(16 * time.Second)
 		resultExpireTest, err := client.Exists([]string{key})
@@ -3311,19 +3302,19 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 		value := uuid.New().String()
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 
 		resultExpire, err := client.ExpireAtWithOptions(key, futureTimestamp, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireAt.Value())
+		assert.True(suite.T(), resultExpireAt)
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(key, futureTimestamp+10, api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.False(suite.T(), resultExpireWithOptions.Value())
+		assert.False(suite.T(), resultExpireWithOptions)
 	})
 }
 
@@ -3334,16 +3325,16 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 		value := uuid.New().String()
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireAt.Value())
+		assert.True(suite.T(), resultExpireAt)
 
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(key, futureTimestamp+10, api.HasExistingExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 	})
 }
 
@@ -3355,17 +3346,17 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireAt.Value())
+		assert.True(suite.T(), resultExpireAt)
 
 		newFutureTimestamp := time.Now().Add(20 * time.Second).Unix()
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(key, newFutureTimestamp, api.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 	})
 }
 
@@ -3377,17 +3368,17 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() 
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireAt.Value())
+		assert.True(suite.T(), resultExpireAt)
 
 		newFutureTimestamp := time.Now().Add(5 * time.Second).Unix()
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(key, newFutureTimestamp, api.NewExpiryLessThanCurrent)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(5 * time.Second)
 		resultExpireAtTest, err := client.Exists([]string{key})
@@ -3404,11 +3395,11 @@ func (suite *GlideTestSuite) TestPExpire() {
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		resultExpire, err := client.PExpire(key, 500)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		time.Sleep(600 * time.Millisecond)
 		resultExpireCheck, err := client.Exists([]string{key})
@@ -3425,18 +3416,18 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		newExpire := 1000
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(key, int64(newExpire), api.HasExistingExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3453,13 +3444,13 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		newExpire := 500
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(key, int64(newExpire), api.HasNoExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(600 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3476,18 +3467,18 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		newExpire := 1000
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(key, int64(newExpire), api.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3504,18 +3495,18 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
 
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		newExpire := 200
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(key, int64(newExpire), api.NewExpiryLessThanCurrent)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(600 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3530,13 +3521,13 @@ func (suite *GlideTestSuite) TestPExpireAt() {
 		value := uuid.New().String()
 		resultSet, err := client.Set(key, value)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(resultSet, err)
 
 		expireAfterMilliseconds := time.Now().Unix() * 1000
 		resultPExpireAt, err := client.PExpireAt(key, expireAfterMilliseconds)
 		assert.Nil(suite.T(), err)
 
-		assert.True(suite.T(), resultPExpireAt.Value())
+		assert.True(suite.T(), resultPExpireAt)
 
 		time.Sleep(6 * time.Second)
 
@@ -3558,7 +3549,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasNoExpiry() {
 		result, err := client.PExpireAtWithOptions(key, timestamp, api.HasNoExpiry)
 
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), result.Value())
+		assert.True(suite.T(), result)
 
 		time.Sleep(2 * time.Second)
 		resultExist, err := client.Exists([]string{key})
@@ -3577,12 +3568,12 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 		newExpire := time.Now().Unix()*1000 + 1000
 
 		resultExpireWithOptions, err := client.PExpireAtWithOptions(key, newExpire, api.HasExistingExpiry)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3602,13 +3593,13 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurren
 		initialExpire := time.Now().UnixMilli() + 1000
 		resultExpire, err := client.PExpireAt(key, initialExpire)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		newExpire := time.Now().UnixMilli() + 2000
 
 		resultExpireWithOptions, err := client.PExpireAtWithOptions(key, newExpire, api.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(2100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3628,14 +3619,14 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent()
 		initialExpire := 1000
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpire.Value())
+		assert.True(suite.T(), resultExpire)
 
 		newExpire := time.Now().Unix()*1000 + 500
 
 		resultExpireWithOptions, err := client.PExpireAtWithOptions(key, newExpire, api.NewExpiryLessThanCurrent)
 		assert.Nil(suite.T(), err)
 
-		assert.True(suite.T(), resultExpireWithOptions.Value())
+		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists([]string{key})
@@ -3659,7 +3650,7 @@ func (suite *GlideTestSuite) TestExpireTime() {
 		expireTime := time.Now().Unix() + 3
 		resultExpAt, err := client.ExpireAt(key, expireTime)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpAt.Value())
+		assert.True(suite.T(), resultExpAt)
 
 		resexptime, err := client.ExpireTime(key)
 		assert.Nil(suite.T(), err)
@@ -3700,7 +3691,7 @@ func (suite *GlideTestSuite) TestPExpireTime() {
 		pexpireTime := time.Now().UnixMilli() + 3000
 		resultExpAt, err := client.PExpireAt(key, pexpireTime)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultExpAt.Value())
+		assert.True(suite.T(), resultExpAt)
 
 		respexptime, err := client.PExpireTime(key)
 		assert.Nil(suite.T(), err)
@@ -3761,7 +3752,7 @@ func (suite *GlideTestSuite) TestTTL_WithValidKey() {
 
 		resExpire, err := client.Expire(key, 1)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resExpire.Value())
+		assert.True(suite.T(), resExpire)
 		resTTL, err := client.TTL(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), resTTL.Value(), int64(1))
@@ -3776,7 +3767,7 @@ func (suite *GlideTestSuite) TestTTL_WithExpiredKey() {
 
 		resExpire, err := client.Expire(key, 1)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resExpire.Value())
+		assert.True(suite.T(), resExpire)
 
 		time.Sleep(2 * time.Second)
 
@@ -3794,7 +3785,7 @@ func (suite *GlideTestSuite) TestPTTL_WithValidKey() {
 
 		resExpire, err := client.Expire(key, 1)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resExpire.Value())
+		assert.True(suite.T(), resExpire)
 
 		resPTTL, err := client.PTTL(key)
 		assert.Nil(suite.T(), err)
@@ -3810,7 +3801,7 @@ func (suite *GlideTestSuite) TestPTTL_WithExpiredKey() {
 
 		resExpire, err := client.Expire(key, 1)
 		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resExpire.Value())
+		assert.True(suite.T(), resExpire)
 
 		time.Sleep(2 * time.Second)
 
@@ -4114,7 +4105,7 @@ func (suite *GlideTestSuite) TestRenamenx() {
 		suite.verifyOK(client.Set(key, initialValue))
 		res1, err := client.Renamenx(key, key2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), true, res1.Value())
+		assert.True(suite.T(), res1)
 
 		// Test 2 Check if the renamenx command return false if newKey already exists.
 		key3 := "{keyName}" + uuid.NewString()
@@ -4123,7 +4114,7 @@ func (suite *GlideTestSuite) TestRenamenx() {
 		suite.verifyOK(client.Set(key4, initialValue))
 		res2, err := client.Renamenx(key3, key4)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), false, res2.Value())
+		assert.False(suite.T(), res2)
 	})
 }
 
@@ -4285,17 +4276,17 @@ func (suite *GlideTestSuite) TestZincrBy() {
 		// key does not exist
 		res1, err := client.ZIncrBy(key1, 2.5, "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), 2.5, res1.Value())
+		assert.Equal(suite.T(), 2.5, res1)
 
 		// key exists, but value doesn't
 		res2, err := client.ZIncrBy(key1, -3.3, "value2")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), -3.3, res2.Value())
+		assert.Equal(suite.T(), -3.3, res2)
 
 		// updating existing value in existing key
 		res3, err := client.ZIncrBy(key1, 1.0, "value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), 3.5, res3.Value())
+		assert.Equal(suite.T(), 3.5, res3)
 
 		// Key exists, but it is not a sorted set
 		res4, err := client.SAdd(key2, []string{"one", "two"})
@@ -4702,23 +4693,23 @@ func (suite *GlideTestSuite) TestPersist() {
 		suite.verifyOK(client.Set(keyName, initialValue))
 		resultExpire, err := client.Expire(keyName, 300)
 		assert.Nil(t, err)
-		assert.True(t, resultExpire.Value())
+		assert.True(t, resultExpire)
 		resultPersist, err := client.Persist(keyName)
 		assert.Nil(t, err)
-		assert.True(t, resultPersist.Value())
+		assert.True(t, resultPersist)
 
 		// Test 2: Check if persist command return false if key that doesnt have associated timeout.
 		keyNoExp := "{keyName}" + uuid.NewString()
 		suite.verifyOK(client.Set(keyNoExp, initialValue))
 		resultPersistNoExp, err := client.Persist(keyNoExp)
 		assert.Nil(t, err)
-		assert.False(t, resultPersistNoExp.Value())
+		assert.False(t, resultPersistNoExp)
 
 		// Test 3: Check if persist command return false if key not exist.
 		keyInvalid := "{invalidkey_forPersistTest}" + uuid.NewString()
 		resultInvalidKey, err := client.Persist(keyInvalid)
 		assert.Nil(t, err)
-		assert.False(t, resultInvalidKey.Value())
+		assert.False(t, resultInvalidKey)
 	})
 }
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -4225,7 +4225,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		assert.Equal(suite.T(), int64(3), res.Value())
 
 		resIncr, err = client.ZAddIncrWithOptions(key3, "one", 5, onlyIfDoesNotExistOpts)
-		assert.NotNil(suite.T(), err)
+		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resIncr.IsNil())
 
 		resIncr, err = client.ZAddIncrWithOptions(key3, "one", 5, onlyIfExistsOpts)
@@ -4263,7 +4263,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		assert.Equal(suite.T(), float64(7), resIncr.Value())
 
 		resIncr, err = client.ZAddIncrWithOptions(key4, "one", -3, gtOpts)
-		assert.NotNil(suite.T(), err)
+		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resIncr.IsNil())
 	})
 }


### PR DESCRIPTION
Return `float64` instead of `Result[float64]` where possible. 
Few commands still return nullable `float64`, but no commands return nullable bool