### PR TITLE
Go: Fix return types, part 3: `string` instead of `Result[string]`

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -182,7 +182,7 @@ func toCStrings(args []string) ([]C.uintptr_t, []C.ulong) {
 func (client *baseClient) Set(key string, value string) (string, error) {
 	result, err := client.executeCommand(C.Set, []string{key, value})
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -199,7 +199,7 @@ func (client *baseClient) SetWithOptions(key string, value string, options *SetO
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) Get(key string) (Result[string], error) {
@@ -208,7 +208,7 @@ func (client *baseClient) Get(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) GetEx(key string) (Result[string], error) {
@@ -217,7 +217,7 @@ func (client *baseClient) GetEx(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) GetExWithOptions(key string, options *GetExOptions) (Result[string], error) {
@@ -231,13 +231,13 @@ func (client *baseClient) GetExWithOptions(key string, options *GetExOptions) (R
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) MSet(keyValueMap map[string]string) (string, error) {
 	result, err := client.executeCommand(C.MSet, utils.MapToString(keyValueMap))
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -330,7 +330,7 @@ func (client *baseClient) SetRange(key string, offset int, value string) (Result
 func (client *baseClient) GetRange(key string, start int, end int) (string, error) {
 	result, err := client.executeCommand(C.GetRange, []string{key, strconv.Itoa(start), strconv.Itoa(end)})
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -348,7 +348,7 @@ func (client *baseClient) Append(key string, value string) (Result[int64], error
 func (client *baseClient) LCS(key1 string, key2 string) (string, error) {
 	result, err := client.executeCommand(C.LCS, []string{key1, key2})
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -364,7 +364,7 @@ func (client *baseClient) GetDel(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) HGet(key string, field string) (Result[string], error) {
@@ -373,7 +373,7 @@ func (client *baseClient) HGet(key string, field string) (Result[string], error)
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) HGetAll(key string) (map[Result[string]]Result[string], error) {
@@ -524,7 +524,7 @@ func (client *baseClient) LPop(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) LPopCount(key string, count int64) ([]Result[string], error) {
@@ -705,7 +705,7 @@ func (client *baseClient) SRandMember(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) SPop(key string) (Result[string], error) {
@@ -714,7 +714,7 @@ func (client *baseClient) SPop(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) SMIsMember(key string, members []string) ([]Result[bool], error) {
@@ -783,13 +783,13 @@ func (client *baseClient) LIndex(key string, index int64) (Result[string], error
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) LTrim(key string, start int64, end int64) (string, error) {
 	result, err := client.executeCommand(C.LTrim, []string{key, utils.IntToString(start), utils.IntToString(end)})
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -819,7 +819,7 @@ func (client *baseClient) RPop(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) RPopCount(key string, count int64) ([]Result[string], error) {
@@ -1001,7 +1001,7 @@ func (client *baseClient) BLMPopCount(
 func (client *baseClient) LSet(key string, index int64, element string) (string, error) {
 	result, err := client.executeCommand(C.LSet, []string{key, utils.IntToString(index), element})
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -1027,7 +1027,7 @@ func (client *baseClient) LMove(
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) BLMove(
@@ -1054,13 +1054,13 @@ func (client *baseClient) BLMove(
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) Ping() (string, error) {
 	result, err := client.executeCommand(C.Ping, []string{})
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -1071,7 +1071,7 @@ func (client *baseClient) PingWithMessage(message string) (string, error) {
 
 	result, err := client.executeCommand(C.Ping, args)
 	if err != nil {
-		return "", err
+		return defaultStringResponse, err
 	}
 
 	return handleStringResponse(result)
@@ -1263,7 +1263,7 @@ func (client *baseClient) Type(key string) (Result[string], error) {
 	if err != nil {
 		return CreateNilStringResult(), err
 	}
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) Touch(keys []string) (Result[int64], error) {
@@ -1280,7 +1280,7 @@ func (client *baseClient) Rename(key string, newKey string) (Result[string], err
 	if err != nil {
 		return CreateNilStringResult(), err
 	}
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) Renamenx(key string, newKey string) (Result[bool], error) {
@@ -1321,7 +1321,7 @@ func (client *baseClient) XAddWithOptions(
 	if err != nil {
 		return CreateNilStringResult(), err
 	}
-	return handleStringOrNullResponse(result)
+	return handleStringOrNilResponse(result)
 }
 
 func (client *baseClient) ZAdd(

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -179,10 +179,10 @@ func toCStrings(args []string) ([]C.uintptr_t, []C.ulong) {
 	return cStrings, stringLengths
 }
 
-func (client *baseClient) Set(key string, value string) (Result[string], error) {
+func (client *baseClient) Set(key string, value string) (string, error) {
 	result, err := client.executeCommand(C.Set, []string{key, value})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)
@@ -234,10 +234,10 @@ func (client *baseClient) GetExWithOptions(key string, options *GetExOptions) (R
 	return handleStringOrNullResponse(result)
 }
 
-func (client *baseClient) MSet(keyValueMap map[string]string) (Result[string], error) {
+func (client *baseClient) MSet(keyValueMap map[string]string) (string, error) {
 	result, err := client.executeCommand(C.MSet, utils.MapToString(keyValueMap))
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)
@@ -327,10 +327,10 @@ func (client *baseClient) SetRange(key string, offset int, value string) (Result
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) GetRange(key string, start int, end int) (Result[string], error) {
+func (client *baseClient) GetRange(key string, start int, end int) (string, error) {
 	result, err := client.executeCommand(C.GetRange, []string{key, strconv.Itoa(start), strconv.Itoa(end)})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)
@@ -345,10 +345,10 @@ func (client *baseClient) Append(key string, value string) (Result[int64], error
 	return handleLongResponse(result)
 }
 
-func (client *baseClient) LCS(key1 string, key2 string) (Result[string], error) {
+func (client *baseClient) LCS(key1 string, key2 string) (string, error) {
 	result, err := client.executeCommand(C.LCS, []string{key1, key2})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)
@@ -705,7 +705,7 @@ func (client *baseClient) SRandMember(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringResponse(result)
+	return handleStringOrNullResponse(result)
 }
 
 func (client *baseClient) SPop(key string) (Result[string], error) {
@@ -714,7 +714,7 @@ func (client *baseClient) SPop(key string) (Result[string], error) {
 		return CreateNilStringResult(), err
 	}
 
-	return handleStringResponse(result)
+	return handleStringOrNullResponse(result)
 }
 
 func (client *baseClient) SMIsMember(key string, members []string) ([]Result[bool], error) {
@@ -786,10 +786,10 @@ func (client *baseClient) LIndex(key string, index int64) (Result[string], error
 	return handleStringOrNullResponse(result)
 }
 
-func (client *baseClient) LTrim(key string, start int64, end int64) (Result[string], error) {
+func (client *baseClient) LTrim(key string, start int64, end int64) (string, error) {
 	result, err := client.executeCommand(C.LTrim, []string{key, utils.IntToString(start), utils.IntToString(end)})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)
@@ -998,10 +998,10 @@ func (client *baseClient) BLMPopCount(
 	return handleStringToStringArrayMapOrNullResponse(result)
 }
 
-func (client *baseClient) LSet(key string, index int64, element string) (Result[string], error) {
+func (client *baseClient) LSet(key string, index int64, element string) (string, error) {
 	result, err := client.executeCommand(C.LSet, []string{key, utils.IntToString(index), element})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)
@@ -1063,11 +1063,7 @@ func (client *baseClient) Ping() (string, error) {
 		return "", err
 	}
 
-	response, err := handleStringResponse(result)
-	if err != nil {
-		return "", err
-	}
-	return response.Value(), nil
+	return handleStringResponse(result)
 }
 
 func (client *baseClient) PingWithMessage(message string) (string, error) {
@@ -1078,11 +1074,7 @@ func (client *baseClient) PingWithMessage(message string) (string, error) {
 		return "", err
 	}
 
-	response, err := handleStringResponse(result)
-	if err != nil {
-		return "", err
-	}
-	return response.Value(), nil
+	return handleStringResponse(result)
 }
 
 func (client *baseClient) Del(keys []string) (Result[int64], error) {

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -43,10 +43,10 @@ func (client *glideClient) CustomCommand(args []string) (interface{}, error) {
 	return handleInterfaceResponse(res)
 }
 
-func (client *glideClient) ConfigSet(parameters map[string]string) (Result[string], error) {
+func (client *glideClient) ConfigSet(parameters map[string]string) (string, error) {
 	result, err := client.executeCommand(C.ConfigSet, utils.MapToString(parameters))
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 	return handleStringResponse(result)
 }
@@ -59,10 +59,10 @@ func (client *glideClient) ConfigGet(args []string) (map[Result[string]]Result[s
 	return handleStringToStringMapResponse(res)
 }
 
-func (client *glideClient) Select(index int64) (Result[string], error) {
+func (client *glideClient) Select(index int64) (string, error) {
 	result, err := client.executeCommand(C.Select, []string{utils.IntToString(index)})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return "", err
 	}
 
 	return handleStringResponse(result)

--- a/go/api/list_commands.go
+++ b/go/api/list_commands.go
@@ -262,19 +262,18 @@ type ListCommands interface {
 	//  end   - The end of the range.
 	//
 	// Return value:
-	//  The Result[string] containing always "OK".
-	// If start exceeds the end of the list, or if start is greater than end, the result will be an empty list (which causes
-	// key to be removed).
+	//  Always `"OK"`.
+	//  If start exceeds the end of the list, or if start is greater than end, the result will be an empty list (which causes
+	//  key to be removed).
 	//  If end exceeds the actual end of the list, it will be treated like the last element of the list.
-	//  If key does not exist, OK will be returned without changes to the database.
+	//  If key does not exist, `"OK"` will be returned without changes to the database.
 	//
 	// For example:
 	//  result, err := client.LTrim("my_list", 0, 1)
-	//  result.Value(): "OK"
-	//  result.IsNil(): false
+	//  result: "OK"
 	//
 	// [valkey.io]: https://valkey.io/commands/ltrim/
-	LTrim(key string, start int64, end int64) (Result[string], error)
+	LTrim(key string, start int64, end int64) (string, error)
 
 	// Returns the length of the list stored at key.
 	//
@@ -607,14 +606,14 @@ type ListCommands interface {
 	//  element - The element to be set.
 	//
 	// Return value:
-	//  A Result[string] containing "OK".
+	//  `"OK"`.
 	//
 	// For example:
 	//  result, err: client.LSet("my_list", int64(1), "two")
-	//  result.Value(): "OK"
+	//  result: "OK"
 	//
 	// [valkey.io]: https://valkey.io/commands/lset/
-	LSet(key string, index int64, element string) (Result[string], error)
+	LSet(key string, index int64, element string) (string, error)
 
 	// Atomically pops and removes the left/right-most element to the list stored at source depending on whereFrom, and pushes
 	// the element at the first/last element of the list stored at destination depending on whereTo.

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -153,10 +153,11 @@ func parseSet(response *C.struct_CommandResponse) (interface{}, error) {
 	return slice, nil
 }
 
-func handleStringResponse(response *C.struct_CommandResponse) (Result[string], error) {
+func handleStringResponse(response *C.struct_CommandResponse) (string, error) {
 	defer C.free_command_response(response)
 
-	return convertCharArrayToString(response, false)
+	res, err := convertCharArrayToString(response, false)
+	return res.Value(), err
 }
 
 func handleStringOrNullResponse(response *C.struct_CommandResponse) (Result[string], error) {

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -160,7 +160,7 @@ func handleStringResponse(response *C.struct_CommandResponse) (string, error) {
 	return res.Value(), err
 }
 
-func handleStringOrNullResponse(response *C.struct_CommandResponse) (Result[string], error) {
+func handleStringOrNilResponse(response *C.struct_CommandResponse) (Result[string], error) {
 	defer C.free_command_response(response)
 
 	return convertCharArrayToString(response, true)

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -2,6 +2,9 @@
 
 package api
 
+// A value to return alongside with error in case if command failed
+var defaultStringResponse string
+
 type Result[T any] struct {
 	val   T
 	isNil bool

--- a/go/api/server_management_commands.go
+++ b/go/api/server_management_commands.go
@@ -14,15 +14,14 @@ type ServerManagementCommands interface {
 	//	index - The index of the database to select.
 	//
 	// Return value:
-	//	A simple OK response.
+	//	A simple `"OK"` response.
 	//
 	// Example:
 	//	result, err := client.Select(2)
-	//	result.Value() : "OK"
-	//	result.IsNil() : false
+	//	result: "OK"
 	//
 	// [valkey.io]: https://valkey.io/commands/select/
-	Select(index int64) (Result[string], error)
+	Select(index int64) (string, error)
 
 	// Gets the values of configuration parameters.
 	//
@@ -54,12 +53,12 @@ type ServerManagementCommands interface {
 	//	parameters - A map consisting of configuration parameters and their respective values to set.
 	//
 	// Return value:
-	//	A api.Result[string] containing "OK" if all configurations have been successfully set. Otherwise, raises an error.
+	//	`"OK"` if all configurations have been successfully set. Otherwise, raises an error.
 	//
 	// For example:
 	//	result, err := client.ConfigSet(map[string]string{"timeout": "1000", "maxmemory": "1GB"})
-	//	result.Value(): "OK"
+	//	result: "OK"
 	//
 	// [valkey.io]: https://valkey.io/commands/config-set/
-	ConfigSet(parameters map[string]string) (Result[string], error)
+	ConfigSet(parameters map[string]string) (string, error)
 }

--- a/go/api/string_commands.go
+++ b/go/api/string_commands.go
@@ -17,21 +17,19 @@ type StringCommands interface {
 	//  value - The value to store with the given key.
 	//
 	// Return value:
-	//  A api.Result[string] containing "OK" response on success.
+	//  `"OK"` response on success.
 	//
 	// For example:
 	//	result, err := client.Set("key", "value")
-	//  result.Value() : "OK"
-	//  result.IsNil() : false
+	//  result: "OK"
 	//
 	// [valkey.io]: https://valkey.io/commands/set/
-	Set(key string, value string) (Result[string], error)
+	Set(key string, value string) (string, error)
 
 	// SetWithOptions sets the given key with the given value using the given options. The return value is dependent on the
 	// passed options. If the value is successfully set, "OK" is returned. If value isn't set because of [OnlyIfExists] or
 	// [OnlyIfDoesNotExist] conditions, api.CreateNilStringResult() is returned. If [SetOptions#ReturnOldValue] is
-	// set, the old
-	// value is returned.
+	// set, the old value is returned.
 	//
 	// See [valkey.io] for details.
 	//
@@ -143,15 +141,14 @@ type StringCommands interface {
 	//  keyValueMap - A key-value map consisting of keys and their respective values to set.
 	//
 	// Return value:
-	//  A Result[string] containing "OK" on success.
+	//  `"OK"` on success.
 	//
 	// For example:
 	//	result, err := client.MSet(map[string]string{"key1": "value1", "key2": "value2"})
-	//  result.Value(): "OK"
-	//  result.IsNil(): false
+	//  result: "OK"
 	//
 	// [valkey.io]: https://valkey.io/commands/mset/
-	MSet(keyValueMap map[string]string) (Result[string], error)
+	MSet(keyValueMap map[string]string) (string, error)
 
 	// Retrieves the values of multiple keys.
 	//
@@ -361,8 +358,8 @@ type StringCommands interface {
 
 	// Returns the substring of the string value stored at key, determined by the byte's offsets start and end (both are
 	// inclusive).
-	// Negative offsets can be used in order to provide an offset starting from the end of the string. So -1 means the last
-	// character, -2 the penultimate and so forth.
+	// Negative offsets can be used in order to provide an offset starting from the end of the string. So `-1` means the last
+	// character, `-2` the penultimate and so forth.
 	//
 	// See [valkey.io] for details.
 	//
@@ -372,24 +369,20 @@ type StringCommands interface {
 	//  end   - The ending offset.
 	//
 	// Return value:
-	//  A Result[string] containing substring extracted from the value stored at key.
-	//  A [api.NilResult[string]] (api.CreateNilStringResult()) is returned if the offset is out of bounds.
+	//  A substring extracted from the value stored at key. Returns empty string if the offset is out of bounds.
 	//
 	// For example:
 	//  1. mykey: "This is a string"
 	//     result, err := client.GetRange("mykey", 0, 3)
-	//     result.Value(): "This"
-	//     result.IsNil(): false
+	//     result: "This"
 	//     result, err := client.GetRange("mykey", -3, -1)
-	//     result.Value(): "ing" (extracted last 3 characters of a string)
-	//     result.IsNil(): false
+	//     result: "ing" (extracted last 3 characters of a string)
 	//  2. "key": "愛" (value char takes 3 bytes)
 	//     result, err = client.GetRange("key", 0, 1)
-	//     result.Value(): "�" (returns an invalid UTF-8 string)
-	//     result.IsNil(): false
+	//     result: "�" (returns an invalid UTF-8 string)
 	//
 	// [valkey.io]: https://valkey.io/commands/getrange/
-	GetRange(key string, start int, end int) (Result[string], error)
+	GetRange(key string, start int, end int) (string, error)
 
 	// Appends a value to a key. If key does not exist it is created and set as an empty string, so APPEND will be similar to
 	// SET in this special case.
@@ -429,17 +422,16 @@ type StringCommands interface {
 	//  key2 - The key that stores the second string.
 	//
 	// Return value:
-	//  A Result[string] containing the longest common subsequence between the 2 strings.
-	//  A Result[string] containing empty String is returned if the keys do not exist or have no common subsequences.
+	//  The longest common subsequence between the 2 strings.
+	//  An empty string is returned if the keys do not exist or have no common subsequences.
 	//
 	// For example:
 	//  testKey1: foo, testKey2: fao
 	//  result, err := client.LCS("testKey1", "testKey2")
-	//  result.Value(): "fo"
-	//  result.IsNil(): false
+	//  result: "fo"
 	//
 	// [valkey.io]: https://valkey.io/commands/lcs/
-	LCS(key1 string, key2 string) (Result[string], error)
+	LCS(key1 string, key2 string) (string, error)
 
 	// GetDel gets the value associated with the given key and deletes the key.
 	//

--- a/go/benchmarks/glide_benchmark_client.go
+++ b/go/benchmarks/glide_benchmark_client.go
@@ -46,12 +46,7 @@ func (glideBenchmarkClient *glideBenchmarkClient) get(key string) (string, error
 }
 
 func (glideBenchmarkClient *glideBenchmarkClient) set(key string, value string) (string, error) {
-	result, err := glideBenchmarkClient.client.Set(key, value)
-	if err != nil {
-		return "", err
-	}
-
-	return result.Value(), nil
+	return glideBenchmarkClient.client.Set(key, value)
 }
 
 func (glideBenchmarkClient *glideBenchmarkClient) close() error {

--- a/go/examples/main.go
+++ b/go/examples/main.go
@@ -28,13 +28,13 @@ func main() {
 	}
 	fmt.Println("PING:", res)
 
-	result, err := client.Set("apples", "oran\x00ges")
+	result1, err := client.Set("apples", "oran\x00ges")
 	if err != nil {
 		log.Fatal("Glide example failed with an error: ", err)
 	}
-	fmt.Println("SET(apples, oranges):", result.Value())
+	fmt.Println("SET(apples, oranges):", result1)
 
-	result, err = client.Get("invalidKey")
+	result, err := client.Get("invalidKey")
 	if err != nil {
 		log.Fatal("Glide example failed with an error: ", err)
 	}

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -271,9 +271,9 @@ func (suite *GlideTestSuite) runWithClients(clients []api.BaseClient, test func(
 	}
 }
 
-func (suite *GlideTestSuite) verifyOK(result api.Result[string], err error) {
+func (suite *GlideTestSuite) verifyOK(result string, err error) {
 	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), api.OK, result.Value())
+	assert.Equal(suite.T(), api.OK, result)
 }
 
 func (suite *GlideTestSuite) SkipIfServerVersionLowerThanBy(version string) {

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -60,10 +60,11 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfExists_overwrite() {
 		suite.verifyOK(client.Set(key, initialValue))
 
 		opts := api.NewSetOptionsBuilder().SetConditionalSet(api.OnlyIfExists)
-		suite.verifyOK(client.SetWithOptions(key, anotherValue, opts))
+		result, err := client.SetWithOptions(key, anotherValue, opts)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), "OK", result.Value())
 
-		result, err := client.Get(key)
-
+		result, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 	})
@@ -84,10 +85,11 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfDoesNotExist_missingKey() 
 	suite.runWithDefaultClients(func(client api.BaseClient) {
 		key := uuid.New().String()
 		opts := api.NewSetOptionsBuilder().SetConditionalSet(api.OnlyIfDoesNotExist)
-		suite.verifyOK(client.SetWithOptions(key, anotherValue, opts))
+		result, err := client.SetWithOptions(key, anotherValue, opts)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), "OK", result.Value())
 
-		result, err := client.Get(key)
-
+		result, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 	})
@@ -115,15 +117,18 @@ func (suite *GlideTestSuite) TestSetWithOptions_KeepExistingExpiry() {
 	suite.runWithDefaultClients(func(client api.BaseClient) {
 		key := uuid.New().String()
 		opts := api.NewSetOptionsBuilder().SetExpiry(api.NewExpiryBuilder().SetType(api.Milliseconds).SetCount(uint64(2000)))
-		suite.verifyOK(client.SetWithOptions(key, initialValue, opts))
+		result, err := client.SetWithOptions(key, initialValue, opts)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), "OK", result.Value())
 
-		result, err := client.Get(key)
-
+		result, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		opts = api.NewSetOptionsBuilder().SetExpiry(api.NewExpiryBuilder().SetType(api.KeepExisting))
-		suite.verifyOK(client.SetWithOptions(key, anotherValue, opts))
+		result, err = client.SetWithOptions(key, anotherValue, opts)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(key)
 
@@ -142,18 +147,20 @@ func (suite *GlideTestSuite) TestSetWithOptions_UpdateExistingExpiry() {
 	suite.runWithDefaultClients(func(client api.BaseClient) {
 		key := uuid.New().String()
 		opts := api.NewSetOptionsBuilder().SetExpiry(api.NewExpiryBuilder().SetType(api.Milliseconds).SetCount(uint64(100500)))
-		suite.verifyOK(client.SetWithOptions(key, initialValue, opts))
+		result, err := client.SetWithOptions(key, initialValue, opts)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), "OK", result.Value())
 
-		result, err := client.Get(key)
-
+		result, err = client.Get(key)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		opts = api.NewSetOptionsBuilder().SetExpiry(api.NewExpiryBuilder().SetType(api.Milliseconds).SetCount(uint64(2000)))
-		suite.verifyOK(client.SetWithOptions(key, anotherValue, opts))
+		result, err = client.SetWithOptions(key, anotherValue, opts)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(key)
-
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 
@@ -482,24 +489,24 @@ func (suite *GlideTestSuite) TestGetRange_existingAndNonExistingKeys() {
 
 		res, err := client.GetRange(key, 0, 4)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "Dummy", res.Value())
+		assert.Equal(suite.T(), "Dummy", res)
 
 		res, err = client.GetRange(key, -6, -1)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "string", res.Value())
+		assert.Equal(suite.T(), "string", res)
 
 		res, err = client.GetRange(key, -1, -6)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "", res.Value())
+		assert.Equal(suite.T(), "", res)
 
 		res, err = client.GetRange(key, 15, 16)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "", res.Value())
+		assert.Equal(suite.T(), "", res)
 
 		nonExistingKey := uuid.New().String()
 		res, err = client.GetRange(nonExistingKey, 0, 5)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "", res.Value())
+		assert.Equal(suite.T(), "", res)
 	})
 }
 
@@ -511,7 +518,7 @@ func (suite *GlideTestSuite) TestGetRange_binaryString() {
 
 		res, err := client.GetRange(key, 4, 6)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "y \xFF", res.Value())
+		assert.Equal(suite.T(), "y \xFF", res)
 	})
 }
 
@@ -546,14 +553,14 @@ func (suite *GlideTestSuite) TestLCS_existingAndNonExistingKeys() {
 
 		res, err := client.LCS(key1, key2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "", res.Value())
+		assert.Equal(suite.T(), "", res)
 
 		suite.verifyOK(client.Set(key1, "Dummy string"))
 		suite.verifyOK(client.Set(key2, "Dummy value"))
 
 		res, err = client.LCS(key1, key2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "Dummy ", res.Value())
+		assert.Equal(suite.T(), "Dummy ", res)
 	})
 }
 
@@ -1259,8 +1266,7 @@ func (suite *GlideTestSuite) TestHScan() {
 		}
 
 		// Check if Non-hash key throws an error.
-		setResult, _ := client.Set(key2, "test")
-		assert.Equal(t, setResult.Value(), "OK")
+		suite.verifyOK(client.Set(key2, "test"))
 		_, _, err = client.HScan(key2, initialCursor)
 		assert.NotEmpty(t, err)
 
@@ -2162,9 +2168,7 @@ func (suite *GlideTestSuite) TestSMIsMember() {
 		assert.IsType(suite.T(), &api.RequestError{}, err4)
 
 		// source key exists, but it is not a set
-		setRes, setErr := client.Set(stringKey, "value")
-		assert.Nil(suite.T(), setErr)
-		assert.Equal(suite.T(), "OK", setRes.Value())
+		suite.verifyOK(client.Set(stringKey, "value"))
 		_, err5 := client.SMIsMember(stringKey, []string{"two"})
 		assert.NotNil(suite.T(), err5)
 		assert.IsType(suite.T(), &api.RequestError{}, err5)
@@ -2999,8 +3003,7 @@ func (suite *GlideTestSuite) TestLSet() {
 		key := uuid.NewString()
 		nonExistentKey := uuid.NewString()
 
-		res1, err := client.LSet(nonExistentKey, int64(0), "zero")
-		assert.Equal(suite.T(), api.CreateNilStringResult(), res1)
+		_, err := client.LSet(nonExistentKey, int64(0), "zero")
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -3008,14 +3011,11 @@ func (suite *GlideTestSuite) TestLSet() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), int64(4), res2.Value())
 
-		res3, err := client.LSet(key, int64(10), "zero")
-		assert.Equal(suite.T(), api.CreateNilStringResult(), res3)
+		_, err = client.LSet(key, int64(10), "zero")
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
-		res4, err := client.LSet(key, int64(0), "zero")
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "OK", res4.Value())
+		suite.verifyOK(client.LSet(key, int64(0), "zero"))
 
 		res5, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -3030,9 +3030,7 @@ func (suite *GlideTestSuite) TestLSet() {
 			res5,
 		)
 
-		res6, err := client.LSet(key, int64(-1), "zero")
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "OK", res6.Value())
+		suite.verifyOK(client.LSet(key, int64(-1), "zero"))
 
 		res7, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
@@ -3309,9 +3307,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 	suite.runWithDefaultClients(func(client api.BaseClient) {
 		key := uuid.New().String()
 		value := uuid.New().String()
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 
@@ -3332,9 +3328,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 	suite.runWithDefaultClients(func(client api.BaseClient) {
 		key := uuid.New().String()
 		value := uuid.New().String()
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
@@ -3353,9 +3347,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
@@ -3375,9 +3367,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() 
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(key, futureTimestamp)
@@ -3402,9 +3392,7 @@ func (suite *GlideTestSuite) TestPExpire() {
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		resultExpire, err := client.PExpire(key, 500)
 		assert.Nil(suite.T(), err)
@@ -3423,9 +3411,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
@@ -3451,9 +3437,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		newExpire := 500
 
@@ -3474,9 +3458,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
@@ -3502,9 +3484,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
 		key := uuid.New().String()
 		value := uuid.New().String()
 
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(key, int64(initialExpire))
@@ -3528,9 +3508,7 @@ func (suite *GlideTestSuite) TestPExpireAt() {
 	suite.runWithDefaultClients(func(client api.BaseClient) {
 		key := uuid.New().String()
 		value := uuid.New().String()
-		resultSet, err := client.Set(key, value)
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), resultSet.Value() != "")
+		suite.verifyOK(client.Set(key, value))
 
 		expireAfterMilliseconds := time.Now().Unix() * 1000
 		resultPExpireAt, err := client.PExpireAt(key, expireAfterMilliseconds)
@@ -4340,9 +4318,7 @@ func (suite *GlideTestSuite) TestBZPopMin() {
 		assert.Equal(suite.T(), api.KeyWithMemberAndScore{Key: key2, Member: "c", Score: 2.0}, bzpopminResult3.Value())
 
 		// Set key3 to a non-sorted set value
-		setResult, err := client.Set(key3, "value")
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "OK", setResult.Value())
+		suite.verifyOK(client.Set(key3, "value"))
 
 		// Attempt to pop from key3 which is not a sorted set
 		_, err = client.BZPopMin([]string{key3}, float64(.5))
@@ -4747,9 +4723,7 @@ func (suite *GlideTestSuite) TestZRank() {
 		assert.True(suite.T(), res3.IsNil())
 
 		// key exists, but it is not a set
-		setRes, err := client.Set(stringKey, "value")
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "OK", setRes.Value())
+		suite.verifyOK(client.Set(stringKey, "value"))
 
 		_, err = client.ZRank(stringKey, "value")
 		assert.NotNil(suite.T(), err)
@@ -4782,9 +4756,7 @@ func (suite *GlideTestSuite) TestZRevRank() {
 		assert.True(suite.T(), res3.IsNil())
 
 		// key exists, but it is not a set
-		setRes, err := client.Set(stringKey, "value")
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), "OK", setRes.Value())
+		suite.verifyOK(client.Set(stringKey, "value"))
 
 		_, err = client.ZRevRank(stringKey, "value")
 		assert.NotNil(suite.T(), err)
@@ -4878,9 +4850,7 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 		assert.Equal(t, xLenResult.Value(), int64(0))
 
 		// Throw Exception: Key exists - but it is not a stream
-		setResult, err := client.Set(key2, "xtrimtest")
-		assert.NoError(t, err)
-		assert.Equal(t, setResult.Value(), "OK")
+		suite.verifyOK(client.Set(key2, "xtrimtest"))
 		_, err = client.XTrim(key2, options.NewXTrimOptionsWithMinId("0-1"))
 		assert.NotNil(t, err)
 		assert.IsType(t, &api.RequestError{}, err)

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -122,9 +122,7 @@ func (suite *GlideTestSuite) TestCustomCommandConfigGet_MapResponse() {
 		suite.T().Skip("This feature is added in version 7")
 	}
 	configMap := map[string]string{"timeout": "1000", "maxmemory": "1GB"}
-	result, err := client.ConfigSet(configMap)
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), "OK", result.Value())
+	suite.verifyOK(client.ConfigSet(configMap))
 
 	result2, err := client.CustomCommand([]string{"CONFIG", "GET", "timeout", "maxmemory"})
 	assert.Nil(suite.T(), err)
@@ -186,9 +184,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_multipleArgs() {
 	key2 := api.CreateStringResult("maxmemory")
 	value2 := api.CreateStringResult("1073741824")
 	resultConfigMap := map[api.Result[string]]api.Result[string]{key1: value1, key2: value2}
-	result, err := client.ConfigSet(configMap)
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), "OK", result.Value())
+	suite.verifyOK(client.ConfigSet(configMap))
 
 	result2, err := client.ConfigGet([]string{"timeout", "maxmemory"})
 	assert.Nil(suite.T(), err)
@@ -200,8 +196,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_noArgs() {
 
 	configMap := map[string]string{}
 
-	result, err := client.ConfigSet(configMap)
-	assert.Equal(suite.T(), api.CreateNilStringResult(), result)
+	_, err := client.ConfigSet(configMap)
 	assert.NotNil(suite.T(), err)
 	assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -216,8 +211,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
 
 	configMap := map[string]string{"time": "1000"}
 
-	result, err := client.ConfigSet(configMap)
-	assert.Equal(suite.T(), api.CreateNilStringResult(), result)
+	_, err := client.ConfigSet(configMap)
 	assert.NotNil(suite.T(), err)
 	assert.IsType(suite.T(), &api.RequestError{}, err)
 
@@ -229,10 +223,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
 func (suite *GlideTestSuite) TestSelect_WithValidIndex() {
 	client := suite.defaultClient()
 	index := int64(1)
-	result, err := client.Select(index)
-
-	assert.Nil(suite.T(), err)
-	assert.Equal(suite.T(), "OK", result.Value())
+	suite.verifyOK(client.Select(index))
 
 	key := uuid.New().String()
 	value := uuid.New().String()
@@ -248,11 +239,11 @@ func (suite *GlideTestSuite) TestSelect_InvalidIndex_OutOfBounds() {
 
 	result, err := client.Select(-1)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), "", result.Value())
+	assert.Equal(suite.T(), "", result)
 
 	result, err = client.Select(1000)
 	assert.NotNil(suite.T(), err)
-	assert.Equal(suite.T(), "", result.Value())
+	assert.Equal(suite.T(), "", result)
 }
 
 func (suite *GlideTestSuite) TestSelect_SwitchBetweenDatabases() {


### PR DESCRIPTION
Return `string` instead of `Result[string]` where possible. 
Few commands still return nullable `string`.
Also fixed null handling for few commands.