### PR TITLE
Refactor to reference glide-rs as a separate external package - Yarn fix

### DIFF
--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -13,7 +13,7 @@ inputs:
         description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
         type: string
         required: false
-        defalt: "x86_64-unknown-linux-gnu"
+        default: "x86_64-unknown-linux-gnu"
         options:
             - x86_64-unknown-linux-gnu
             - aarch64-unknown-linux-gnu

--- a/.github/workflows/node-create-package-file/action.yml
+++ b/.github/workflows/node-create-package-file/action.yml
@@ -51,12 +51,12 @@ runs:
     steps:
         - name: Create package.json file
           shell: bash
-          working-directory: ./node
+          working-directory: ./node/rust-client
           run: |
               # echo -musl if inputs.target is musl
               export MUSL_FLAG=`if [[ "${{ inputs.target }}" =~ .*"musl".*  ]]; then echo "-musl"; fi`
               # set the package name
-              name="valkey-glide"
+              name="glide-rs"
               # derive the OS and architecture from the inputs
               export node_os="${{ inputs.named_os }}"
               export node_arch="${{ inputs.arch }}"

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -70,9 +70,37 @@ jobs:
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)
                   echo "PLATFORM_MATRIX=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
+      
+     publish-rust-client:
+        needs: [start-self-hosted-runner, load-platform-matrix]
+        if: github.repository_owner == 'valkey-io'
+        name: Publish Rust client to NPM
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  submodules: "true"
+
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "latest"
+                  registry-url: "https://registry.npmjs.org"
+                  scope: "${{ vars.NPM_SCOPE }}"
+                  always-auth: true
+
+            - name: Publish Rust client
+              working-directory: ./node/rust-client
+              run: |
+                  npm ci
+                  npm run build
+                  npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     publish-binaries:
-        needs: [start-self-hosted-runner, load-platform-matrix]
+        needs: [start-self-hosted-runner, load-platform-matrix, publish-rust-client]
         if: github.repository_owner == 'valkey-io'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
@@ -224,7 +252,7 @@ jobs:
     publish-base-to-npm:
         if: github.event_name != 'pull_request'
         name: Publish the base NPM package
-        needs: publish-binaries
+        needs: [publish-binaries, publish-rust-client]
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -386,7 +414,7 @@ jobs:
               working-directory: ./utils/release-candidate-testing/node
               run: |
                   npm install
-                  npm install --no-save @valkey/valkey-glide@${{ env.NPM_TAG }}
+                  npm install --no-save @valkey/valkey-glide@${{ env.NPM_TAG }} @valkey/glide-rs@${{ env.NPM_TAG }}
                   npm run test
 
             - name: Deprecating packages on failure
@@ -425,6 +453,8 @@ jobs:
 
                   # Deprecating base package
                   npm deprecate "@valkey/valkey-glide@${RELEASE_VERSION}" "This version has been deprecated" --force || true
+                  # Deprecating Rust client package
+                  npm deprecate "@valkey/glide-rs@${RELEASE_VERSION}" "This version has been deprecated" --force || true
 
                   # Process platform matrix
                   echo "${PLATFORM_MATRIX}" > platform_matrix.json

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -304,10 +304,10 @@ jobs:
                   if [[ ${{ env.RELEASE_VERSION }} == *"rc"* ]]
                   then
                     echo "This is a release candidate"
-                    echo "NPM_TAG=next" >> $GITHUB_ENV
+                    export npm_tag="next"
                   else
                     echo "This is a stable release"
-                    echo "NPM_TAG=latest" >> $GITHUB_ENV
+                    export npm_tag="latest"
                   fi
 
             - name: Publish the base package

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -130,27 +130,27 @@ jobs:
             - name: Set platform-specific package name
               shell: bash
               run: |
-                PLATFORM_NAME="${{ matrix.build.NAMED_OS }}${{ contains(matrix.build.TARGET, 'musl') && '-musl' || '' }}-${{ matrix.build.ARCH }}"
-                echo "PLATFORM_NAME=${PLATFORM_NAME}" >> $GITHUB_ENV
-                echo "NODE_OS=${{ matrix.build.NAMED_OS }}" >> $GITHUB_ENV
-                echo "NODE_ARCH=${{ matrix.build.ARCH }}" >> $GITHUB_ENV
-                echo "PACKAGE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+                  PLATFORM_NAME="${{ matrix.build.NAMED_OS }}${{ contains(matrix.build.TARGET, 'musl') && '-musl' || '' }}-${{ matrix.build.ARCH }}"
+                  echo "PLATFORM_NAME=${PLATFORM_NAME}" >> $GITHUB_ENV
+                  echo "NODE_OS=${{ matrix.build.NAMED_OS }}" >> $GITHUB_ENV
+                  echo "NODE_ARCH=${{ matrix.build.ARCH }}" >> $GITHUB_ENV
+                  echo "PACKAGE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
             - name: Update Rust client package.json
               working-directory: ./node/rust-client
               run: |
-                sed -i 's|\${PLATFORM_NAME}|'"${PLATFORM_NAME}"'|g' package.json
-                sed -i 's|\${PACKAGE_VERSION}|'"${PACKAGE_VERSION}"'|g' package.json
-                sed -i 's|\${NODE_OS}|'"${NODE_OS}"'|g' package.json
-                sed -i 's|\${NODE_ARCH}|'"${NODE_ARCH}"'|g' package.json
+                  sed -i 's|\${PLATFORM_NAME}|'"${PLATFORM_NAME}"'|g' package.json
+                  sed -i 's|\${PACKAGE_VERSION}|'"${PACKAGE_VERSION}"'|g' package.json
+                  sed -i 's|\${NODE_OS}|'"${NODE_OS}"'|g' package.json
+                  sed -i 's|\${NODE_ARCH}|'"${NODE_ARCH}"'|g' package.json
 
             - name: Validate Rust client package.json
               working-directory: ./node/rust-client
               run: |
-                if ! grep -q "@valkey/glide-rs-${PLATFORM_NAME}" package.json; then
-                  echo "Error: package.json does not contain the correct package name"
-                  exit 1
-                fi
+                  if ! grep -q "@valkey/glide-rs-${PLATFORM_NAME}" package.json; then
+                    echo "Error: package.json does not contain the correct package name"
+                    exit 1
+                  fi
 
             - name: Setup node
               if: ${{ !contains(matrix.build.TARGET, 'musl') }}
@@ -265,42 +265,32 @@ jobs:
                   scope: "${{ vars.NPM_SCOPE }}"
                   always-auth: true
 
-            - name: Update package.json and index.ts
+            - name: Create package.json file
               shell: bash
               working-directory: ./node/npm/glide
               run: |
-                  # Set version
-                  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-                    R_VERSION="${{ github.event.inputs.version }}"
+                  export pkg_name=valkey-glide
+
+                  echo "The workflow is: ${{env.EVENT_NAME}}"
+                  if ${{ env.EVENT_NAME == 'workflow_dispatch' }}; then
+                    R_VERSION="${{ env.INPUT_VERSION }}"
                   else
-                    R_VERSION=${GITHUB_REF#refs/tags/v}
+                    R_VERSION=${GITHUB_REF:11}
                   fi
                   echo "RELEASE_VERSION=${R_VERSION}" >> $GITHUB_ENV
 
-                  # Update package.json
-                  jq '.version = env.RELEASE_VERSION | .name = "@valkey/valkey-glide" | .optionalDependencies = {
-                    "@valkey/glide-rs-linux-x64": env.RELEASE_VERSION,
-                    "@valkey/glide-rs-linux-arm64": env.RELEASE_VERSION,
-                    "@valkey/glide-rs-darwin-x64": env.RELEASE_VERSION,
-                    "@valkey/glide-rs-darwin-arm64": env.RELEASE_VERSION,
-                    "@valkey/glide-rs-linux-musl-x64": env.RELEASE_VERSION,
-                    "@valkey/glide-rs-linux-musl-arm64": env.RELEASE_VERSION
-                  }' package.json > temp.json && mv temp.json package.json
+                  export package_version=${R_VERSION}
+                  export scope=`if [ "$NPM_SCOPE" != ''  ]; then echo "$NPM_SCOPE/"; fi`
+                  mv package.json package.json.tmpl
+                  envsubst < package.json.tmpl > "package.json"
+                  cat package.json
+                  # Fix index.ts based on the scope variable
+                  sed -i "s|@scope/|${scope}|g" glide-rs.ts
+              env:
+                  NPM_SCOPE: ${{ vars.NPM_SCOPE }}
+                  EVENT_NAME: ${{ github.event_name }}
+                  INPUT_VERSION: ${{ github.event.inputs.version }}
 
-                  # Update index.ts
-                  sed -i 's/@scope\/valkey-glide/@valkey\/glide-rs/g' index.ts
-                  
-            - name: Validate base package.json and index.ts
-              working-directory: ./node/npm/glide
-              run: |
-                if ! grep -q '"@valkey/valkey-glide"' package.json; then
-                  echo "Error: package.json does not contain the correct package name"
-                  exit 1
-                fi
-                if ! grep -q '@valkey/glide-rs' index.ts; then
-                  echo "Error: index.ts does not contain the correct import statements"
-                  exit 1
-                fi
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -70,37 +70,9 @@ jobs:
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)
                   echo "PLATFORM_MATRIX=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
-      
-     publish-rust-client:
-        needs: [start-self-hosted-runner, load-platform-matrix]
-        if: github.repository_owner == 'valkey-io'
-        name: Publish Rust client to NPM
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-              with:
-                  submodules: "true"
-
-            - name: Setup node
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "latest"
-                  registry-url: "https://registry.npmjs.org"
-                  scope: "${{ vars.NPM_SCOPE }}"
-                  always-auth: true
-
-            - name: Publish Rust client
-              working-directory: ./node/rust-client
-              run: |
-                  npm ci
-                  npm run build
-                  npm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     publish-binaries:
-        needs: [start-self-hosted-runner, load-platform-matrix, publish-rust-client]
+        needs: [start-self-hosted-runner, load-platform-matrix]
         if: github.repository_owner == 'valkey-io'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
@@ -154,6 +126,31 @@ jobs:
               env:
                   EVENT_NAME: ${{ github.event_name }}
                   INPUT_VERSION: ${{ github.event.inputs.version }}
+
+            - name: Set platform-specific package name
+              shell: bash
+              run: |
+                PLATFORM_NAME="${{ matrix.build.NAMED_OS }}${{ contains(matrix.build.TARGET, 'musl') && '-musl' || '' }}-${{ matrix.build.ARCH }}"
+                echo "PLATFORM_NAME=${PLATFORM_NAME}" >> $GITHUB_ENV
+                echo "NODE_OS=${{ matrix.build.NAMED_OS }}" >> $GITHUB_ENV
+                echo "NODE_ARCH=${{ matrix.build.ARCH }}" >> $GITHUB_ENV
+                echo "PACKAGE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+
+            - name: Update Rust client package.json
+              working-directory: ./node/rust-client
+              run: |
+                sed -i 's|\${PLATFORM_NAME}|'"${PLATFORM_NAME}"'|g' package.json
+                sed -i 's|\${PACKAGE_VERSION}|'"${PACKAGE_VERSION}"'|g' package.json
+                sed -i 's|\${NODE_OS}|'"${NODE_OS}"'|g' package.json
+                sed -i 's|\${NODE_ARCH}|'"${NODE_ARCH}"'|g' package.json
+
+            - name: Validate Rust client package.json
+              working-directory: ./node/rust-client
+              run: |
+                if ! grep -q "@valkey/glide-rs-${PLATFORM_NAME}" package.json; then
+                  echo "Error: package.json does not contain the correct package name"
+                  exit 1
+                fi
 
             - name: Setup node
               if: ${{ !contains(matrix.build.TARGET, 'musl') }}
@@ -214,7 +211,7 @@ jobs:
             - name: Publish to NPM
               if: github.event_name != 'pull_request'
               shell: bash
-              working-directory: ./node
+              working-directory: ./node/rust-client
               run: |
                   npm pkg fix
                   set +e  # Disable immediate exit on non-zero exit codes
@@ -232,7 +229,7 @@ jobs:
                     echo "Skipping publishing, package already published."
                   elif [[ ! -z "$npm_publish_err" ]]; then
                     echo "Failed to publish with error: $npm_publish_err"
-                  exit 1
+                    exit 1
                   fi
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -252,7 +249,7 @@ jobs:
     publish-base-to-npm:
         if: github.event_name != 'pull_request'
         name: Publish the base NPM package
-        needs: [publish-binaries, publish-rust-client]
+        needs: [publish-binaries]
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -268,32 +265,42 @@ jobs:
                   scope: "${{ vars.NPM_SCOPE }}"
                   always-auth: true
 
-            - name: Create package.json file
+            - name: Update package.json and index.ts
               shell: bash
               working-directory: ./node/npm/glide
               run: |
-                  export pkg_name=valkey-glide
-
-                  echo "The workflow is: ${{env.EVENT_NAME}}"
-                  if ${{ env.EVENT_NAME == 'workflow_dispatch' }}; then
-                    R_VERSION="${{ env.INPUT_VERSION }}"
+                  # Set version
+                  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+                    R_VERSION="${{ github.event.inputs.version }}"
                   else
-                    R_VERSION=${GITHUB_REF:11}
+                    R_VERSION=${GITHUB_REF#refs/tags/v}
                   fi
                   echo "RELEASE_VERSION=${R_VERSION}" >> $GITHUB_ENV
 
-                  export package_version=${R_VERSION}
-                  export scope=`if [ "$NPM_SCOPE" != ''  ]; then echo "$NPM_SCOPE/"; fi`
-                  mv package.json package.json.tmpl
-                  envsubst < package.json.tmpl > "package.json"
-                  cat package.json
-                  # Fix index.ts based on the scope variable
-                  sed -i "s|@scope/|${scope}|g" index.ts
-              env:
-                  NPM_SCOPE: ${{ vars.NPM_SCOPE }}
-                  EVENT_NAME: ${{ github.event_name }}
-                  INPUT_VERSION: ${{ github.event.inputs.version }}
+                  # Update package.json
+                  jq '.version = env.RELEASE_VERSION | .name = "@valkey/valkey-glide" | .optionalDependencies = {
+                    "@valkey/glide-rs-linux-x64": env.RELEASE_VERSION,
+                    "@valkey/glide-rs-linux-arm64": env.RELEASE_VERSION,
+                    "@valkey/glide-rs-darwin-x64": env.RELEASE_VERSION,
+                    "@valkey/glide-rs-darwin-arm64": env.RELEASE_VERSION,
+                    "@valkey/glide-rs-linux-musl-x64": env.RELEASE_VERSION,
+                    "@valkey/glide-rs-linux-musl-arm64": env.RELEASE_VERSION
+                  }' package.json > temp.json && mv temp.json package.json
 
+                  # Update index.ts
+                  sed -i 's/@scope\/valkey-glide/@valkey\/glide-rs/g' index.ts
+                  
+            - name: Validate base package.json and index.ts
+              working-directory: ./node/npm/glide
+              run: |
+                if ! grep -q '"@valkey/valkey-glide"' package.json; then
+                  echo "Error: package.json does not contain the correct package name"
+                  exit 1
+                fi
+                if ! grep -q '@valkey/glide-rs' index.ts; then
+                  echo "Error: index.ts does not contain the correct import statements"
+                  exit 1
+                fi
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
@@ -307,12 +314,11 @@ jobs:
                   if [[ ${{ env.RELEASE_VERSION }} == *"rc"* ]]
                   then
                     echo "This is a release candidate"
-                    export npm_tag="next"
+                    echo "NPM_TAG=next" >> $GITHUB_ENV
                   else
                     echo "This is a stable release"
-                    export npm_tag="latest"
+                    echo "NPM_TAG=latest" >> $GITHUB_ENV
                   fi
-                  echo "NPM_TAG=${npm_tag}" >> $GITHUB_ENV
 
             - name: Publish the base package
               if: github.event_name != 'pull_request'
@@ -414,7 +420,7 @@ jobs:
               working-directory: ./utils/release-candidate-testing/node
               run: |
                   npm install
-                  npm install --no-save @valkey/valkey-glide@${{ env.NPM_TAG }} @valkey/glide-rs@${{ env.NPM_TAG }}
+                  npm install --no-save @valkey/valkey-glide@${{ env.NPM_TAG }}
                   npm run test
 
             - name: Deprecating packages on failure
@@ -453,14 +459,12 @@ jobs:
 
                   # Deprecating base package
                   npm deprecate "@valkey/valkey-glide@${RELEASE_VERSION}" "This version has been deprecated" --force || true
-                  # Deprecating Rust client package
-                  npm deprecate "@valkey/glide-rs@${RELEASE_VERSION}" "This version has been deprecated" --force || true
 
                   # Process platform matrix
                   echo "${PLATFORM_MATRIX}" > platform_matrix.json
 
                   while read -r pkg; do
-                      package_name="@valkey/valkey-glide-${pkg}"
+                      package_name="@valkey/glide-rs-${pkg}"
                       echo "Deprecating ${package_name}@${RELEASE_VERSION}"
                       npm deprecate "${package_name}@${RELEASE_VERSION}" "This version has been deprecated" --force || true
                   done < <(jq -r '.[] | "\(.NAMED_OS)\(.TARGET | test("musl") | if . then "-musl" else "" end)-\(.ARCH)"' platform_matrix.json)

--- a/node/index.ts
+++ b/node/index.ts
@@ -2,14 +2,14 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-export { ClusterScanCursor, Script } from "glide-rs";
+export { ClusterScanCursor, Script } from "@valkey/glide-rs";
 export * from "./src/BaseClient";
 export * from "./src/Commands";
 export * from "./src/Errors";
 export * from "./src/GlideClient";
 export * from "./src/GlideClusterClient";
 export * from "./src/Logger";
-export * from "./src/server-modules/GlideJson";
 export * from "./src/server-modules/GlideFt";
 export * from "./src/server-modules/GlideFtOptions";
+export * from "./src/server-modules/GlideJson";
 export * from "./src/Transaction";

--- a/node/index.ts
+++ b/node/index.ts
@@ -2,7 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-export { ClusterScanCursor, Script } from "@valkey/glide-rs";
+export { ClusterScanCursor, Script } from "../npm/glide/glide-rs";
 export * from "./src/BaseClient";
 export * from "./src/Commands";
 export * from "./src/Errors";

--- a/node/npm/glide/glide-rs.ts
+++ b/node/npm/glide/glide-rs.ts
@@ -26,7 +26,7 @@ function loadNativeBinding() {
                             nativeBinding = require("@scope/glide-rs-linux-x64");
                             break;
                     }
-                    
+
                     break;
                 case "arm64":
                     switch (familySync()) {

--- a/node/npm/glide/glide-rs.ts
+++ b/node/npm/glide/glide-rs.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
+import { GLIBC, MUSL, familySync } from "detect-libc";
+import { arch, platform } from "process";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+function loadNativeBinding() {
+    let nativeBinding = null;
+
+    switch (platform) {
+        case "linux":
+            switch (arch) {
+                case "x64":
+                    switch (familySync()) {
+                        case GLIBC:
+                            nativeBinding = require("@scope/glide-rs-linux-x64");
+                            break;
+                        case MUSL:
+                            nativeBinding = require("@scope/glide-rs-linux-musl-x64");
+                            break;
+                        default:
+                            nativeBinding = require("@scope/glide-rs-linux-x64");
+                            break;
+                    }
+                    
+                    break;
+                case "arm64":
+                    switch (familySync()) {
+                        case GLIBC:
+                            nativeBinding = require("@scope/glide-rs-linux-arm64");
+                            break;
+                        case MUSL:
+                            nativeBinding = require("@scope/glide-rs-linux-musl-arm64");
+                            break;
+                        default:
+                            nativeBinding = require("@scope/glide-rs-linux-arm64");
+                            break;
+                    }
+
+                    break;
+                default:
+                    throw new Error(
+                        `Unsupported OS: ${platform}, architecture: ${arch}`,
+                    );
+            }
+
+            break;
+        case "darwin":
+            switch (arch) {
+                case "arm64":
+                    nativeBinding = require("@scope/glide-rs-darwin-arm64");
+                    break;
+                default:
+                    throw new Error(
+                        `Unsupported OS: ${platform}, architecture: ${arch}`,
+                    );
+            }
+
+            break;
+        default:
+            throw new Error(
+                `Unsupported OS: ${platform}, architecture: ${arch}`,
+            );
+    }
+
+    if (!nativeBinding) {
+        throw new Error(`Failed to load native binding`);
+    }
+
+    return nativeBinding;
+}
+
+const nativeBinding = loadNativeBinding();
+
+export = nativeBinding;

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -2,7 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import glideRs from './glide-rs';
+import glideRs from "./glide-rs";
 
 let globalObject = global as unknown;
 

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -1,49 +1,18 @@
-#!/usr/bin/env node
-
 /**
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { GLIBC, familySync } from "detect-libc";
-import { arch, platform } from "process";
+import glideRs from './glide-rs';
 
 let globalObject = global as unknown;
 
-/* eslint-disable @typescript-eslint/no-require-imports */
-function loadNativeBinding() {
-    let nativeStr = process.env.native_binding;
+=======
+import glideRs from './glide-rs';
 
-    if (nativeStr == undefined) {
-        const prefix = familySync() == GLIBC ? "" : "-musl";
-        nativeStr = `${platform}${prefix}-${arch}`;
+let globalObject = global as unknown;
 
-        if (
-            !["x64", "arm64"].includes(arch) ||
-            !["linux", "darwin"].includes(platform)
-        ) {
-            throw new Error(
-                `Unsupported OS: ${platform}, architecture: ${arch}`,
-            );
-        }
-    }
-
-    let scope = process.env.scope || "@scope";
-
-    if (scope == "@scope") {
-        scope = "@valkey/";
-    }
-
-    const nativeBinding = require(`${scope}valkey-glide-${nativeStr}`);
-
-    if (!nativeBinding) {
-        throw new Error(`Failed to load native binding`);
-    }
-
-    return nativeBinding;
-}
-
+>>>>>>> 3ed65fe3 (additional refactoring)
 function initialize() {
-    const nativeBinding = loadNativeBinding();
     const {
         AggregationType,
         BaseScanOptions,
@@ -191,7 +160,7 @@ function initialize() {
         ReturnTypeAttribute,
         ReturnTypeJson,
         UniversalReturnTypeJson,
-    } = nativeBinding;
+    } = glideRs;
 
     module.exports = {
         AggregationType,
@@ -342,7 +311,7 @@ function initialize() {
         UniversalReturnTypeJson,
     };
 
-    globalObject = Object.assign(global, nativeBinding);
+    globalObject = Object.assign(global, glideRs);
 }
 
 initialize();

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -6,12 +6,6 @@ import glideRs from "./glide-rs";
 
 let globalObject = global as unknown;
 
-=======
-import glideRs from './glide-rs';
-
-let globalObject = global as unknown;
-
->>>>>>> 3ed65fe3 (additional refactoring)
 function initialize() {
     const {
         AggregationType,

--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -40,11 +40,11 @@
         "typescript": "^5.7.3"
     },
     "optionalDependencies": {
-        "${scope}valkey-glide-darwin-arm64": "${package_version}",
-        "${scope}valkey-glide-linux-arm64": "${package_version}",
-        "${scope}valkey-glide-linux-x64": "${package_version}",
-        "${scope}valkey-glide-linux-musl-arm64": "${package_version}",
-        "${scope}valkey-glide-linux-musl-x64": "${package_version}"
+        "${scope}glide-rs-darwin-arm64": "${package_version}",
+        "${scope}glide-rs-linux-arm64": "${package_version}",
+        "${scope}glide-rs-linux-x64": "${package_version}",
+        "${scope}glide-rs-linux-musl-arm64": "${package_version}",
+        "${scope}glide-rs-linux-musl-x64": "${package_version}"
     },
     "eslintConfig": {
         "extends": [

--- a/node/package.json
+++ b/node/package.json
@@ -11,15 +11,25 @@
     },
     "homepage": "https://github.com/valkey-io/valkey-glide#readme",
     "dependencies": {
-        "@valkey/glide-rs": "^0.1.0",
         "long": "^5.2.3",
         "npmignore": "^0.3.1",
         "protobufjs": "^7.4.0"
     },
+    "optionalDependencies": {
+        "@valkey/glide-rs-linux-x64": "${package_version}",
+        "@valkey/glide-rs-linux-arm64": "${package_version}",
+        "@valkey/glide-rs-darwin-x64": "${package_version}",
+        "@valkey/glide-rs-darwin-arm64": "${package_version}",
+        "@valkey/glide-rs-linux-musl-x64": "${package_version}",
+        "@valkey/glide-rs-linux-musl-arm64": "${package_version}"
+    },
     "scripts": {
-        "build": "npm run prereq &&  npm run build-protobuf && npm run build-external",
-        "build:release": " npm run build-protobuf && npm run build-external:release",
-        "build:benchmark": " npm run build-protobuf && npm run build-external",
+        "build": "npm run prereq && npm run build-internal && npm run build-protobuf && npm run build-external",
+        "build:release": "npm run build-internal:release && npm run build-protobuf && npm run build-external:release",
+        "build:benchmark": "npm run build-internal:benchmark && npm run build-protobuf && npm run build-external",
+        "build-internal": "cd rust-client && npm run build",
+        "build-internal:release": "cd rust-client && npm run build:release",
+        "build-internal:benchmark": "cd rust-client && npm run build:benchmark",
         "build-external": "rm -rf build-ts && tsc",
         "build-external:release": "rm -rf build-ts && tsc --stripInternal",
         "build-protobuf": "npm run compile-protobuf-files && npm run fix-protobuf-file",

--- a/node/package.json
+++ b/node/package.json
@@ -11,21 +11,15 @@
     },
     "homepage": "https://github.com/valkey-io/valkey-glide#readme",
     "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "^5.3.0",
+        "@valkey/glide-rs": "^0.1.0",
+        "long": "^5.2.3",
         "npmignore": "^0.3.1",
         "protobufjs": "^7.4.0"
     },
-    "bundleDependencies": [
-        "glide-rs"
-    ],
     "scripts": {
-        "build": "npm run prereq && npm run build-internal && npm run build-protobuf && npm run build-external",
-        "build:release": "npm run build-internal:release && npm run build-protobuf && npm run build-external:release",
-        "build:benchmark": "npm run build-internal:benchmark && npm run build-protobuf && npm run build-external",
-        "build-internal": "cd rust-client && npm run build",
-        "build-internal:release": "cd rust-client && npm run build:release",
-        "build-internal:benchmark": "cd rust-client && npm run build:benchmark",
+        "build": "npm run prereq &&  npm run build-protobuf && npm run build-external",
+        "build:release": " npm run build-protobuf && npm run build-external:release",
+        "build:benchmark": " npm run build-protobuf && npm run build-external",
         "build-external": "rm -rf build-ts && tsc",
         "build-external:release": "rm -rf build-ts && tsc --stripInternal",
         "build-protobuf": "npm run compile-protobuf-files && npm run fix-protobuf-file",

--- a/node/rust-client/package.json
+++ b/node/rust-client/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "glide-rs",
+    "name": "@valkey/glide-rs",
     "version": "0.1.0",
     "description": "Valkey client",
     "main": "index.js",

--- a/node/rust-client/package.json
+++ b/node/rust-client/package.json
@@ -3,8 +3,12 @@
     "version": "${PACKAGE_VERSION}",
     "description": "Valkey client for ${PLATFORM_NAME}",
     "main": "index.js",
-    "os": ["${NODE_OS}"],
-    "cpu": ["${NODE_ARCH}"],
+    "os": [
+        "${NODE_OS}"
+    ],
+    "cpu": [
+        "${NODE_ARCH}"
+    ],
     "license": "Apache-2.0",
     "files": [
         "index.d.ts",

--- a/node/rust-client/package.json
+++ b/node/rust-client/package.json
@@ -1,8 +1,10 @@
 {
-    "name": "@valkey/glide-rs",
-    "version": "0.1.0",
-    "description": "Valkey client",
+    "name": "@valkey/glide-rs-${PLATFORM_NAME}",
+    "version": "${PACKAGE_VERSION}",
+    "description": "Valkey client for ${PLATFORM_NAME}",
     "main": "index.js",
+    "os": ["${NODE_OS}"],
+    "cpu": ["${NODE_ARCH}"],
     "license": "Apache-2.0",
     "files": [
         "index.d.ts",

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1,6 +1,8 @@
 /**
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
+import * as net from "net";
+import { Buffer, BufferWriter, Long, Reader, Writer } from "protobufjs";
 import {
     DEFAULT_CONNECTION_TIMEOUT_IN_MILLISECONDS,
     DEFAULT_INFLIGHT_REQUESTS_LIMIT,
@@ -9,9 +11,7 @@ import {
     StartSocketConnection,
     getStatistics,
     valueFromSplitPointer,
-} from "@valkey/glide-rs";
-import * as net from "net";
-import { Buffer, BufferWriter, Long, Reader, Writer } from "protobufjs";
+} from "../npm/glide/glide-rs";
 import {
     AggregationType,
     BaseScanOptions,

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -9,7 +9,7 @@ import {
     StartSocketConnection,
     getStatistics,
     valueFromSplitPointer,
-} from "glide-rs";
+} from "@valkey/glide-rs";
 import * as net from "net";
 import { Buffer, BufferWriter, Long, Reader, Writer } from "protobufjs";
 import {

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2,7 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "glide-rs";
+import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "@valkey/glide-rs";
 import Long from "long";
 
 import {

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2,8 +2,8 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "@valkey/glide-rs";
 import Long from "long";
+import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "../npm/glide/glide-rs";
 
 import {
     BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -3,7 +3,10 @@
  */
 
 import Long from "long";
-import { createLeakedStringVec, MAX_REQUEST_ARGS_LEN } from "../npm/glide/glide-rs";
+import {
+    createLeakedStringVec,
+    MAX_REQUEST_ARGS_LEN,
+} from "../npm/glide/glide-rs";
 
 import {
     BaseClient, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -2,9 +2,9 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { ClusterScanCursor, Script } from "@valkey/glide-rs";
 import * as net from "net";
 import { Writer } from "protobufjs";
+import { ClusterScanCursor, Script } from "../npm/glide/glide-rs";
 import {
     AdvancedBaseClientConfiguration,
     BaseClient,

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -2,7 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { ClusterScanCursor, Script } from "glide-rs";
+import { ClusterScanCursor, Script } from "@valkey/glide-rs";
 import * as net from "net";
 import { Writer } from "protobufjs";
 import {

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -2,7 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { InitInternalLogger, Level, log } from "glide-rs";
+import { InitInternalLogger, Level, log } from "@valkey/glide-rs";
 
 const LEVEL = new Map<LevelOptions | undefined, Level | undefined>([
     ["error", Level.Error],

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -2,7 +2,7 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { InitInternalLogger, Level, log } from "@valkey/glide-rs";
+import { InitInternalLogger, Level, log } from "../npm/glide/glide-rs";
 
 const LEVEL = new Map<LevelOptions | undefined, Level | undefined>([
     ["error", Level.Error],


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!
Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
### Description
Yarn interprets the 'file:rust-client' path relative to the user's working directory instead of the package's actual location, which causes the dependency resolution to fail.

### Desired Architecture
**Base Package (Node.js Code)**

- Should be published as a standalone package

- Contains platform-independent Node.js code

- Only needs to be published once since it's not architecture-specific

- Serves as the main entry point for users

**Rust Client Package**

- Should be published separately for each platform/architecture

- Contains the architecture-specific binaries

- Needs multiple versions:

- One for each supported operating system (Linux, MacOS, etc.)

- One for each supported CPU architecture (x64, arm64, etc.)

- Includes its own package.json for version management

- Gets published multiple times to support different platforms

### Issue link

This Pull Request is linked to issue (URL): #2680 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
