### PR TITLE
Rollback ort version to 26.0.0 since 44.0.0 fails for node

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -74,7 +74,7 @@ jobs:
               with:
                   repository: "oss-review-toolkit/ort"
                   path: "./ort"
-                  ref: "44.0.0"
+                  ref: "26.0.0"
                   submodules: recursive
 
             - name: Install Rust toolchain


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

Revert to 44.0.0 in order to restore CI

### Issue link
This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2952
### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[] Tests are added or updated.~
-   ~[ ] CHANGELOG.md and documentation files are updated.~
-   ~[ ] Destination branch is correct - main or release~
-   [X] Create merge commit if merging release branch into main, squash otherwise.
