### PR TITLE
Go: Fix return types, parn 5

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -376,7 +376,7 @@ func (client *baseClient) HGet(key string, field string) (Result[string], error)
 	return handleStringOrNilResponse(result)
 }
 
-func (client *baseClient) HGetAll(key string) (map[Result[string]]Result[string], error) {
+func (client *baseClient) HGetAll(key string) (map[string]string, error) {
 	result, err := client.executeCommand(C.HGetAll, []string{key})
 	if err != nil {
 		return nil, err
@@ -616,7 +616,7 @@ func (client *baseClient) SUnionStore(destination string, keys []string) (int64,
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) SMembers(key string) (map[Result[string]]struct{}, error) {
+func (client *baseClient) SMembers(key string) (map[string]struct{}, error) {
 	result, err := client.executeCommand(C.SMembers, []string{key})
 	if err != nil {
 		return nil, err
@@ -643,7 +643,7 @@ func (client *baseClient) SIsMember(key string, member string) (bool, error) {
 	return handleBoolResponse(result)
 }
 
-func (client *baseClient) SDiff(keys []string) (map[Result[string]]struct{}, error) {
+func (client *baseClient) SDiff(keys []string) (map[string]struct{}, error) {
 	result, err := client.executeCommand(C.SDiff, keys)
 	if err != nil {
 		return nil, err
@@ -661,7 +661,7 @@ func (client *baseClient) SDiffStore(destination string, keys []string) (int64, 
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) SInter(keys []string) (map[Result[string]]struct{}, error) {
+func (client *baseClient) SInter(keys []string) (map[string]struct{}, error) {
 	result, err := client.executeCommand(C.SInter, keys)
 	if err != nil {
 		return nil, err
@@ -726,7 +726,7 @@ func (client *baseClient) SMIsMember(key string, members []string) ([]bool, erro
 	return handleBoolArrayResponse(result)
 }
 
-func (client *baseClient) SUnion(keys []string) (map[Result[string]]struct{}, error) {
+func (client *baseClient) SUnion(keys []string) (map[string]struct{}, error) {
 	result, err := client.executeCommand(C.SUnion, keys)
 	if err != nil {
 		return nil, err
@@ -889,7 +889,7 @@ func (client *baseClient) LPushX(key string, elements []string) (int64, error) {
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) LMPop(keys []string, listDirection ListDirection) (map[Result[string]][]Result[string], error) {
+func (client *baseClient) LMPop(keys []string, listDirection ListDirection) (map[string][]string, error) {
 	listDirectionStr, err := listDirection.toString()
 	if err != nil {
 		return nil, err
@@ -910,14 +910,14 @@ func (client *baseClient) LMPop(keys []string, listDirection ListDirection) (map
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNullResponse(result)
+	return handleStringToStringArrayMapOrNilResponse(result)
 }
 
 func (client *baseClient) LMPopCount(
 	keys []string,
 	listDirection ListDirection,
 	count int64,
-) (map[Result[string]][]Result[string], error) {
+) (map[string][]string, error) {
 	listDirectionStr, err := listDirection.toString()
 	if err != nil {
 		return nil, err
@@ -938,14 +938,14 @@ func (client *baseClient) LMPopCount(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNullResponse(result)
+	return handleStringToStringArrayMapOrNilResponse(result)
 }
 
 func (client *baseClient) BLMPop(
 	keys []string,
 	listDirection ListDirection,
 	timeoutSecs float64,
-) (map[Result[string]][]Result[string], error) {
+) (map[string][]string, error) {
 	listDirectionStr, err := listDirection.toString()
 	if err != nil {
 		return nil, err
@@ -966,7 +966,7 @@ func (client *baseClient) BLMPop(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNullResponse(result)
+	return handleStringToStringArrayMapOrNilResponse(result)
 }
 
 func (client *baseClient) BLMPopCount(
@@ -974,7 +974,7 @@ func (client *baseClient) BLMPopCount(
 	listDirection ListDirection,
 	count int64,
 	timeoutSecs float64,
-) (map[Result[string]][]Result[string], error) {
+) (map[string][]string, error) {
 	listDirectionStr, err := listDirection.toString()
 	if err != nil {
 		return nil, err
@@ -995,7 +995,7 @@ func (client *baseClient) BLMPopCount(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNullResponse(result)
+	return handleStringToStringArrayMapOrNilResponse(result)
 }
 
 func (client *baseClient) LSet(key string, index int64, element string) (string, error) {
@@ -1495,7 +1495,7 @@ func (client *baseClient) ZIncrBy(key string, increment float64, member string) 
 	return handleFloatResponse(result)
 }
 
-func (client *baseClient) ZPopMin(key string) (map[Result[string]]Result[float64], error) {
+func (client *baseClient) ZPopMin(key string) (map[string]float64, error) {
 	result, err := client.executeCommand(C.ZPopMin, []string{key})
 	if err != nil {
 		return nil, err
@@ -1503,7 +1503,7 @@ func (client *baseClient) ZPopMin(key string) (map[Result[string]]Result[float64
 	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[float64], error) {
+func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[string]float64, error) {
 	result, err := client.executeCommand(C.ZPopMin, []string{key, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
@@ -1511,7 +1511,7 @@ func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[Result[
 	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZPopMax(key string) (map[Result[string]]Result[float64], error) {
+func (client *baseClient) ZPopMax(key string) (map[string]float64, error) {
 	result, err := client.executeCommand(C.ZPopMax, []string{key})
 	if err != nil {
 		return nil, err
@@ -1519,7 +1519,7 @@ func (client *baseClient) ZPopMax(key string) (map[Result[string]]Result[float64
 	return handleStringDoubleMapResponse(result)
 }
 
-func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[float64], error) {
+func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[string]float64, error) {
 	result, err := client.executeCommand(C.ZPopMax, []string{key, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
@@ -1635,7 +1635,7 @@ func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]
 func (client *baseClient) ZRangeWithScores(
 	key string,
 	rangeQuery options.ZRangeQueryWithScores,
-) (map[Result[string]]Result[float64], error) {
+) (map[string]float64, error) {
 	args := make([]string, 0, 10)
 	args = append(args, key)
 	args = append(args, rangeQuery.ToArgs()...)

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -51,7 +51,7 @@ func (client *glideClient) ConfigSet(parameters map[string]string) (string, erro
 	return handleStringResponse(result)
 }
 
-func (client *glideClient) ConfigGet(args []string) (map[Result[string]]Result[string], error) {
+func (client *glideClient) ConfigGet(args []string) (map[string]string, error) {
 	res, err := client.executeCommand(C.ConfigGet, args)
 	if err != nil {
 		return nil, err

--- a/go/api/hash_commands.go
+++ b/go/api/hash_commands.go
@@ -46,14 +46,10 @@ type HashCommands interface {
 	//
 	// For example:
 	//  fieldValueMap, err := client.HGetAll("my_hash")
-	//  // field1 equals api.CreateStringResult("field1")
-	//  // value1 equals api.CreateStringResult("value1")
-	//  // field2 equals api.CreateStringResult("field2")
-	//  // value2 equals api.CreateStringResult("value2")
-	//  // fieldValueMap equals map[api.Result[string]]api.Result[string]{field1: value1, field2: value2}
+	//  // fieldValueMap equals map[string]string{field1: value1, field2: value2}
 	//
 	// [valkey.io]: https://valkey.io/commands/hgetall/
-	HGetAll(key string) (map[Result[string]]Result[string], error)
+	HGetAll(key string) (map[string]string, error)
 
 	// HMGet returns the values associated with the specified fields in the hash stored at key.
 	//

--- a/go/api/list_commands.go
+++ b/go/api/list_commands.go
@@ -493,10 +493,10 @@ type ListCommands interface {
 	// For example:
 	//  result, err := client.LPush("my_list", []string{"one", "two", "three"})
 	//  result, err := client.LMPop([]string{"my_list"}, api.Left)
-	//  result[api.CreateStringResult("my_list")] = []api.Result[string]{api.CreateStringResult("three")}
+	//  result["my_list"] = []string{"three"}
 	//
 	// [valkey.io]: https://valkey.io/commands/lmpop/
-	LMPop(keys []string, listDirection ListDirection) (map[Result[string]][]Result[string], error)
+	LMPop(keys []string, listDirection ListDirection) (map[string][]string, error)
 
 	// Pops one or more elements from the first non-empty list from the provided keys.
 	//
@@ -516,10 +516,10 @@ type ListCommands interface {
 	// For example:
 	//  result, err := client.LPush("my_list", []string{"one", "two", "three"})
 	//  result, err := client.LMPopCount([]string{"my_list"}, api.Left, int64(1))
-	//  result[api.CreateStringResult("my_list")] = []api.Result[string]{api.CreateStringResult("three")}
+	//  result["my_list"] = []string{"three"}
 	//
 	// [valkey.io]: https://valkey.io/commands/lmpop/
-	LMPopCount(keys []string, listDirection ListDirection, count int64) (map[Result[string]][]Result[string], error)
+	LMPopCount(keys []string, listDirection ListDirection, count int64) (map[string][]string, error)
 
 	// Blocks the connection until it pops one element from the first non-empty list from the provided keys. BLMPop is the
 	// blocking variant of [api.LMPop].
@@ -546,11 +546,11 @@ type ListCommands interface {
 	// For example:
 	//  result, err := client.LPush("my_list", []string{"one", "two", "three"})
 	//  result, err := client.BLMPop([]string{"my_list"}, api.Left, float64(0.1))
-	//  result[api.CreateStringResult("my_list")] = []api.Result[string]{api.CreateStringResult("three")}
+	//  result["my_list"] = []string{"three"}
 	//
 	// [valkey.io]: https://valkey.io/commands/blmpop/
 	// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
-	BLMPop(keys []string, listDirection ListDirection, timeoutSecs float64) (map[Result[string]][]Result[string], error)
+	BLMPop(keys []string, listDirection ListDirection, timeoutSecs float64) (map[string][]string, error)
 
 	// Blocks the connection until it pops one or more elements from the first non-empty list from the provided keys.
 	// BLMPopCount is the blocking variant of [api.LMPopCount].
@@ -578,7 +578,7 @@ type ListCommands interface {
 	// For example:
 	//  result, err: client.LPush("my_list", []string{"one", "two", "three"})
 	//  result, err := client.BLMPopCount([]string{"my_list"}, api.Left, int64(1), float64(0.1))
-	//  result[api.CreateStringResult("my_list")] = []api.Result[string]{api.CreateStringResult("three")}
+	//  result["my_list"] = []string{"three"}
 	//
 	// [valkey.io]: https://valkey.io/commands/blmpop/
 	// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
@@ -587,7 +587,7 @@ type ListCommands interface {
 		listDirection ListDirection,
 		count int64,
 		timeoutSecs float64,
-	) (map[Result[string]][]Result[string], error)
+	) (map[string][]string, error)
 
 	// Sets the list element at index to element.
 	// The index is zero-based, so 0 means the first element,1 the second element and so on. Negative indices can be used to

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -338,7 +338,7 @@ func handleBoolArrayResponse(response *C.struct_CommandResponse) ([]bool, error)
 	return slice, nil
 }
 
-func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[Result[string]]Result[float64], error) {
+func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[string]float64, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Map, false)
@@ -346,23 +346,26 @@ func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[Resu
 		return nil, typeErr
 	}
 
-	m := make(map[Result[string]]Result[float64], response.array_value_len)
-	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
-		key, err := convertCharArrayToString(v.map_key, true)
-		if err != nil {
-			return nil, err
-		}
-		typeErr := checkResponseType(v.map_value, C.Float, false)
-		if typeErr != nil {
-			return nil, typeErr
-		}
-		value := CreateFloat64Result(float64(v.map_value.float_value))
-		m[key] = value
+	data, err := parseMap(response)
+	if err != nil {
+		return nil, err
 	}
-	return m, nil
+	aMap := data.(map[string]interface{})
+
+	converted, err := mapConverter[float64]{
+		nil,
+	}.convert(aMap)
+	if err != nil {
+		return nil, err
+	}
+	result, ok := converted.(map[string]float64)
+	if !ok {
+		return nil, &RequestError{fmt.Sprintf("unexpected type of map: %T", converted)}
+	}
+	return result, nil
 }
 
-func handleStringToStringMapResponse(response *C.struct_CommandResponse) (map[Result[string]]Result[string], error) {
+func handleStringToStringMapResponse(response *C.struct_CommandResponse) (map[string]string, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Map, false)
@@ -370,25 +373,28 @@ func handleStringToStringMapResponse(response *C.struct_CommandResponse) (map[Re
 		return nil, typeErr
 	}
 
-	m := make(map[Result[string]]Result[string], response.array_value_len)
-	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
-		key, err := convertCharArrayToString(v.map_key, true)
-		if err != nil {
-			return nil, err
-		}
-		value, err := convertCharArrayToString(v.map_value, true)
-		if err != nil {
-			return nil, err
-		}
-		m[key] = value
+	data, err := parseMap(response)
+	if err != nil {
+		return nil, err
 	}
+	aMap := data.(map[string]interface{})
 
-	return m, nil
+	converted, err := mapConverter[string]{
+		nil,
+	}.convert(aMap)
+	if err != nil {
+		return nil, err
+	}
+	result, ok := converted.(map[string]string)
+	if !ok {
+		return nil, &RequestError{fmt.Sprintf("unexpected type of map: %T", converted)}
+	}
+	return result, nil
 }
 
-func handleStringToStringArrayMapOrNullResponse(
+func handleStringToStringArrayMapOrNilResponse(
 	response *C.struct_CommandResponse,
-) (map[Result[string]][]Result[string], error) {
+) (map[string][]string, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Map, true)
@@ -400,23 +406,27 @@ func handleStringToStringArrayMapOrNullResponse(
 		return nil, nil
 	}
 
-	m := make(map[Result[string]][]Result[string], response.array_value_len)
-	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
-		key, err := convertCharArrayToString(v.map_key, true)
-		if err != nil {
-			return nil, err
-		}
-		value, err := convertStringArray(v.map_value)
-		if err != nil {
-			return nil, err
-		}
-		m[key] = value
+	data, err := parseMap(response)
+	if err != nil {
+		return nil, err
 	}
 
-	return m, nil
+	converters := mapConverter[[]string]{
+		arrayConverter[string]{},
+	}
+
+	res, err := converters.convert(data)
+	if err != nil {
+		return nil, err
+	}
+	if result, ok := res.(map[string][]string); ok {
+		return result, nil
+	}
+
+	return nil, &RequestError{fmt.Sprintf("unexpected type received: %T", res)}
 }
 
-func handleStringSetResponse(response *C.struct_CommandResponse) (map[Result[string]]struct{}, error) {
+func handleStringSetResponse(response *C.struct_CommandResponse) (map[string]struct{}, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Sets, false)
@@ -424,13 +434,13 @@ func handleStringSetResponse(response *C.struct_CommandResponse) (map[Result[str
 		return nil, typeErr
 	}
 
-	slice := make(map[Result[string]]struct{}, response.sets_value_len)
+	slice := make(map[string]struct{}, response.sets_value_len)
 	for _, v := range unsafe.Slice(response.sets_value, response.sets_value_len) {
 		res, err := convertCharArrayToString(&v, true)
 		if err != nil {
 			return nil, err
 		}
-		slice[res] = struct{}{}
+		slice[res.Value()] = struct{}{}
 	}
 
 	return slice, nil

--- a/go/api/server_management_commands.go
+++ b/go/api/server_management_commands.go
@@ -37,11 +37,11 @@ type ServerManagementCommands interface {
 	//
 	// For example:
 	//	result, err := client.ConfigGet([]string{"timeout" , "maxmemory"})
-	//	result[api.CreateStringResult("timeout")] = api.CreateStringResult("1000")
-	//	result[api.CreateStringResult"maxmemory")] = api.CreateStringResult("1GB")
+	//	// result["timeout"] = "1000"
+	//	// result["maxmemory"] = "1GB"
 	//
 	// [valkey.io]: https://valkey.io/commands/config-get/
-	ConfigGet(args []string) (map[Result[string]]Result[string], error)
+	ConfigGet(args []string) (map[string]string, error)
 
 	// Sets configuration parameters to the specified values.
 	//

--- a/go/api/set_commands.go
+++ b/go/api/set_commands.go
@@ -54,20 +54,16 @@ type SetCommands interface {
 	//   key - The key from which to retrieve the set members.
 	//
 	// Return value:
-	//   A map[Result[string]]struct{} containing all members of the set.
-	//   Returns an empty map if key does not exist.
+	//   A `map[string]struct{}` containing all members of the set.
+	//   Returns an empty collection if key does not exist.
 	//
 	// For example:
 	//   // Assume set "my_set" contains: "member1", "member2"
 	//   result, err := client.SMembers("my_set")
-	//   // result equals:
-	//   // map[Result[string]]struct{}{
-	//   //   api.CreateStringResult("member1"): {},
-	//   //   api.CreateStringResult("member2"): {}
-	//   // }
+	//   // result: map[string]struct{}{ "member1": {}, "member2": {} }
 	//
 	// [valkey.io]: https://valkey.io/commands/smembers/
-	SMembers(key string) (map[Result[string]]struct{}, error)
+	SMembers(key string) (map[string]struct{}, error)
 
 	// SCard retrieves the set cardinality (number of elements) of the set stored at key.
 	//
@@ -119,19 +115,16 @@ type SetCommands interface {
 	//   keys - The keys of the sets to diff.
 	//
 	// Return value:
-	//   A map[Result[string]]struct{} representing the difference between the sets.
+	//   A `map[string]struct{}` representing the difference between the sets.
 	//   If a key does not exist, it is treated as an empty set.
 	//
 	// Example:
 	//   result, err := client.SDiff([]string{"set1", "set2"})
-	//   // result might contain:
-	//   // map[Result[string]]struct{}{
-	//   //   api.CreateStringResult("element"): {},
-	//   // }
+	//   // result: map[string]struct{}{ "element": {} }
 	//   // Indicates that "element" is present in "set1", but missing in "set2"
 	//
 	// [valkey.io]: https://valkey.io/commands/sdiff/
-	SDiff(keys []string) (map[Result[string]]struct{}, error)
+	SDiff(keys []string) (map[string]struct{}, error)
 
 	// SDiffStore stores the difference between the first set and all the successive sets in keys
 	// into a new set at destination.
@@ -165,20 +158,16 @@ type SetCommands interface {
 	//   keys - The keys of the sets to intersect.
 	//
 	// Return value:
-	//   A map[Result[string]]struct{} containing members which are present in all given sets.
-	//   If one or more sets do not exist, an empty map will be returned.
-	//
+	//   A `map[string]struct{}` containing members which are present in all given sets.
+	//   If one or more sets do not exist, an empty collection will be returned.
 	//
 	// Example:
 	//   result, err := client.SInter([]string{"set1", "set2"})
-	//   // result might contain:
-	//   // map[Result[string]]struct{}{
-	//   //   api.CreateStringResult("element"): {},
-	//   // }
+	//   // result: map[string]struct{}{ "element": {} }
 	//   // Indicates that "element" is present in both "set1" and "set2"
 	//
 	// [valkey.io]: https://valkey.io/commands/sinter/
-	SInter(keys []string) (map[Result[string]]struct{}, error)
+	SInter(keys []string) (map[string]struct{}, error)
 
 	// Stores the members of the intersection of all given sets specified by `keys` into a new set at `destination`
 	//
@@ -353,9 +342,8 @@ type SetCommands interface {
 	//   keys - The keys of the sets.
 	//
 	// Return value:
-	//   A map[Result[string]]struct{} of members which are present in at least one of the given sets.
-	//   If none of the sets exist, an empty map will be returned.
-	//
+	//   A `map[string]struct{}` of members which are present in at least one of the given sets.
+	//   If none of the sets exist, an empty collection will be returned.
 	//
 	// Example:
 	//  result1, err := client.SAdd("my_set1", []string {"member1", "member2"})
@@ -367,15 +355,15 @@ type SetCommands interface {
 	//  // result.IsNil(): false
 	//
 	//  result3, err := client.SUnion([]string {"my_set1", "my_set2"})
-	//  // result3.Value(): "{'member1', 'member2', 'member3'}"
+	//  // result3: "{'member1', 'member2', 'member3'}"
 	//  // err: nil
 	//
 	//  result4, err := client.SUnion([]string {"my_set1", "non_existing_set"})
-	//  // result4.Value(): "{'member1', 'member2'}"
+	//  // result4: "{'member1', 'member2'}"
 	//  // err: nil
 	//
 	// [valkey.io]: https://valkey.io/commands/sunion/
-	SUnion(keys []string) (map[Result[string]]struct{}, error)
+	SUnion(keys []string) (map[string]struct{}, error)
 
 	// Iterates incrementally over a set.
 	//

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -127,10 +127,10 @@ type SortedSetCommands interface {
 	//
 	// Example:
 	//   res, err := client.zpopmin("mySortedSet")
-	//   fmt.Println(res.Value()) // Output: map["member1":5.0]
+	//   fmt.Println(res) // Output: map["member1": 5.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMin(key string) (map[Result[string]]Result[float64], error)
+	ZPopMin(key string) (map[string]float64, error)
 
 	// Removes and returns up to `count` members with the lowest scores from the sorted set
 	// stored at the specified `key`.
@@ -148,10 +148,10 @@ type SortedSetCommands interface {
 	//
 	// Example:
 	//   res, err := client.ZPopMinWithCount("mySortedSet", 2)
-	//   fmt.Println(res.Value()) // Output: map["member1":5.0, "member2":6.0]
+	//   fmt.Println(res) // Output: map["member1": 5.0, "member2": 6.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMinWithCount(key string, count int64) (map[Result[string]]Result[float64], error)
+	ZPopMinWithCount(key string, count int64) (map[string]float64, error)
 
 	// Removes and returns the member with the highest score from the sorted set stored at the
 	// specified `key`.
@@ -168,10 +168,10 @@ type SortedSetCommands interface {
 	//
 	// Example:
 	//   res, err := client.zpopmax("mySortedSet")
-	//   fmt.Println(res.Value()) // Output: map["member2":8.0]
+	//   fmt.Println(res) // Output: map["member2": 8.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMax(key string) (map[Result[string]]Result[float64], error)
+	ZPopMax(key string) (map[string]float64, error)
 
 	// Removes and returns up to `count` members with the highest scores from the sorted set
 	// stored at the specified `key`.
@@ -189,10 +189,10 @@ type SortedSetCommands interface {
 	//
 	// Example:
 	//   res, err := client.ZPopMaxWithCount("mySortedSet", 2)
-	//   fmt.Println(res.Value()) // Output: map["member1":5.0, "member2":6.0]
+	//   fmt.Println(res) // Output: map["member1": 5.0, "member2": 6.0]
 	//
 	// [valkey.io]: https://valkey.io/commands/zpopmin/
-	ZPopMaxWithCount(key string, count int64) (map[Result[string]]Result[float64], error)
+	ZPopMaxWithCount(key string, count int64) (map[string]float64, error)
 
 	// Removes the specified members from the sorted set stored at `key`.
 	// Specified members that are not a member of this set are ignored.
@@ -266,7 +266,7 @@ type SortedSetCommands interface {
 
 	ZRange(key string, rangeQuery options.ZRangeQuery) ([]Result[string], error)
 
-	ZRangeWithScores(key string, rangeQuery options.ZRangeQueryWithScores) (map[Result[string]]Result[float64], error)
+	ZRangeWithScores(key string, rangeQuery options.ZRangeQueryWithScores) (map[string]float64, error)
 
 	// Returns the rank of `member` in the sorted set stored at `key`, with
 	// scores ordered from low to high, starting from `0`.

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -635,9 +635,14 @@ func (suite *GlideTestSuite) TestHSet_WithExistingKey() {
 
 func (suite *GlideTestSuite) TestHSet_byteString() {
 	suite.runWithDefaultClients(func(client api.BaseClient) {
+		field1 := string([]byte{0xFF, 0x00, 0xAA})
+		value1 := string([]byte{0xDE, 0xAD, 0xBE, 0xEF})
+		field2 := string([]byte{0x01, 0x02, 0x03, 0xFE})
+		value2 := string([]byte{0xCA, 0xFE, 0xBA, 0xBE})
+
 		fields := map[string]string{
-			string([]byte{0xFF, 0x00, 0xAA}):       string([]byte{0xDE, 0xAD, 0xBE, 0xEF}),
-			string([]byte{0x01, 0x02, 0x03, 0xFE}): string([]byte{0xCA, 0xFE, 0xBA, 0xBE}),
+			field1: value1,
+			field2: value2,
 		}
 		key := string([]byte{0x01, 0x02, 0x03, 0xFE})
 
@@ -646,16 +651,8 @@ func (suite *GlideTestSuite) TestHSet_byteString() {
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGetAll(key)
-		key1 := api.CreateStringResult(string([]byte{0xFF, 0x00, 0xAA}))
-		value1 := api.CreateStringResult(string([]byte{0xDE, 0xAD, 0xBE, 0xEF}))
-		key2 := api.CreateStringResult(string([]byte{0x01, 0x02, 0x03, 0xFE}))
-		value2 := api.CreateStringResult(string([]byte{0xCA, 0xFE, 0xBA, 0xBE}))
-		fieldsResult := map[api.Result[string]]api.Result[string]{
-			key1: value1,
-			key2: value2,
-		}
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), fieldsResult, res2)
+		assert.Equal(suite.T(), fields, res2)
 	})
 }
 
@@ -728,14 +725,9 @@ func (suite *GlideTestSuite) TestHGetAll_WithExistingKey() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), int64(2), res1)
 
-		field1 := api.CreateStringResult("field1")
-		value1 := api.CreateStringResult("value1")
-		field2 := api.CreateStringResult("field2")
-		value2 := api.CreateStringResult("value2")
-		fieldsResult := map[api.Result[string]]api.Result[string]{field1: value1, field2: value2}
 		res2, err := client.HGetAll(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), fieldsResult, res2)
+		assert.Equal(suite.T(), fields, res2)
 	})
 }
 
@@ -818,10 +810,8 @@ func (suite *GlideTestSuite) TestHSetNX_WithNotExistingKey() {
 		assert.True(suite.T(), res1)
 
 		res2, err := client.HGetAll(key)
-		field1 := api.CreateStringResult("field1")
-		value1 := api.CreateStringResult("value1")
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), map[api.Result[string]]api.Result[string]{field1: value1}, res2)
+		assert.Equal(suite.T(), map[string]string{"field1": "value1"}, res2)
 	})
 }
 
@@ -1587,21 +1577,21 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		memberArray1 := []string{"a", "b", "c"}
 		memberArray2 := []string{"c", "d", "e"}
 		memberArray3 := []string{"e", "f", "g"}
-		expected1 := map[api.Result[string]]struct{}{
-			api.CreateStringResult("a"): {},
-			api.CreateStringResult("b"): {},
-			api.CreateStringResult("c"): {},
-			api.CreateStringResult("d"): {},
-			api.CreateStringResult("e"): {},
+		expected1 := map[string]struct{}{
+			"a": {},
+			"b": {},
+			"c": {},
+			"d": {},
+			"e": {},
 		}
-		expected2 := map[api.Result[string]]struct{}{
-			api.CreateStringResult("a"): {},
-			api.CreateStringResult("b"): {},
-			api.CreateStringResult("c"): {},
-			api.CreateStringResult("d"): {},
-			api.CreateStringResult("e"): {},
-			api.CreateStringResult("f"): {},
-			api.CreateStringResult("g"): {},
+		expected2 := map[string]struct{}{
+			"a": {},
+			"b": {},
+			"c": {},
+			"d": {},
+			"e": {},
+			"f": {},
+			"g": {},
 		}
 		t := suite.T()
 
@@ -1790,9 +1780,7 @@ func (suite *GlideTestSuite) TestSDiff() {
 
 		result, err := client.SDiff([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), result, 2)
-		assert.Contains(suite.T(), result, api.CreateStringResult("a"))
-		assert.Contains(suite.T(), result, api.CreateStringResult("b"))
+		assert.Equal(suite.T(), map[string]struct{}{"a": {}, "b": {}}, result)
 	})
 }
 
@@ -1818,10 +1806,7 @@ func (suite *GlideTestSuite) TestSDiff_WithSingleKeyExist() {
 
 		res2, err := client.SDiff([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), res2, 3)
-		assert.Contains(suite.T(), res2, api.CreateStringResult("a"))
-		assert.Contains(suite.T(), res2, api.CreateStringResult("b"))
-		assert.Contains(suite.T(), res2, api.CreateStringResult("c"))
+		assert.Equal(suite.T(), map[string]struct{}{"a": {}, "b": {}, "c": {}}, res2)
 	})
 }
 
@@ -1845,9 +1830,7 @@ func (suite *GlideTestSuite) TestSDiffStore() {
 
 		members, err := client.SMembers(key3)
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), members, 2)
-		assert.Contains(suite.T(), members, api.CreateStringResult("a"))
-		assert.Contains(suite.T(), members, api.CreateStringResult("b"))
+		assert.Equal(suite.T(), map[string]struct{}{"a": {}, "b": {}}, members)
 	})
 }
 
@@ -1882,9 +1865,7 @@ func (suite *GlideTestSuite) TestSinter() {
 
 		members, err := client.SInter([]string{key1, key2})
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), members, 2)
-		assert.Contains(suite.T(), members, api.CreateStringResult("c"))
-		assert.Contains(suite.T(), members, api.CreateStringResult("d"))
+		assert.Equal(suite.T(), map[string]struct{}{"c": {}, "d": {}}, members)
 	})
 }
 
@@ -1925,10 +1906,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 
 		res4, err := client.SMembers(key3)
 		assert.NoError(t, err)
-		assert.Len(t, res4, 1)
-		for key := range res4 {
-			assert.Equal(t, key.Value(), "c")
-		}
+		assert.Equal(t, map[string]struct{}{"c": {}}, res4)
 
 		// overwrite existing set, which is also a source set
 		res5, err := client.SInterStore(key2, []string{key1, key2})
@@ -1937,10 +1915,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 
 		res6, err := client.SMembers(key2)
 		assert.NoError(t, err)
-		assert.Len(t, res6, 1)
-		for key := range res6 {
-			assert.Equal(t, key.Value(), "c")
-		}
+		assert.Equal(t, map[string]struct{}{"c": {}}, res6)
 
 		// source set is the same as the existing set
 		res7, err := client.SInterStore(key1, []string{key2})
@@ -1949,10 +1924,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 
 		res8, err := client.SMembers(key2)
 		assert.NoError(t, err)
-		assert.Len(t, res8, 1)
-		for key := range res8 {
-			assert.Equal(t, key.Value(), "c")
-		}
+		assert.Equal(t, map[string]struct{}{"c": {}}, res8)
 
 		// intersection with non-existing key
 		res9, err := client.SInterStore(key1, []string{key2, nonExistingKey})
@@ -1987,10 +1959,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		// check that the key is now empty
 		res13, err := client.SMembers(stringKey)
 		assert.NoError(t, err)
-		assert.Len(t, res13, 1)
-		for key := range res13 {
-			assert.Equal(t, key.Value(), "c")
-		}
+		assert.Equal(t, map[string]struct{}{"c": {}}, res13)
 	})
 }
 
@@ -2138,17 +2107,17 @@ func (suite *GlideTestSuite) TestSUnion() {
 		nonSetKey := uuid.NewString()
 		memberList1 := []string{"a", "b", "c"}
 		memberList2 := []string{"b", "c", "d", "e"}
-		expected1 := map[api.Result[string]]struct{}{
-			api.CreateStringResult("a"): {},
-			api.CreateStringResult("b"): {},
-			api.CreateStringResult("c"): {},
-			api.CreateStringResult("d"): {},
-			api.CreateStringResult("e"): {},
+		expected1 := map[string]struct{}{
+			"a": {},
+			"b": {},
+			"c": {},
+			"d": {},
+			"e": {},
 		}
-		expected2 := map[api.Result[string]]struct{}{
-			api.CreateStringResult("a"): {},
-			api.CreateStringResult("b"): {},
-			api.CreateStringResult("c"): {},
+		expected2 := map[string]struct{}{
+			"a": {},
+			"b": {},
+			"c": {},
 		}
 
 		res1, err := client.SAdd(key1, memberList1)
@@ -2165,7 +2134,7 @@ func (suite *GlideTestSuite) TestSUnion() {
 
 		res4, err := client.SUnion([]string{key3})
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), map[api.Result[string]]struct{}{}, res4)
+		assert.Empty(suite.T(), res4)
 
 		res5, err := client.SUnion([]string{key1, key3})
 		assert.Nil(suite.T(), err)
@@ -2210,20 +2179,11 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res4, err := client.SMembers(key1)
 		assert.NoError(t, err)
-		expectedSet := map[api.Result[string]]struct{}{
-			api.CreateStringResult("2"): {},
-			api.CreateStringResult("3"): {},
-		}
-		assert.True(t, reflect.DeepEqual(expectedSet, res4))
+		assert.Equal(suite.T(), map[string]struct{}{"2": {}, "3": {}}, res4)
 
 		res5, err := client.SMembers(key2)
 		assert.NoError(t, err)
-		expectedSet = map[api.Result[string]]struct{}{
-			api.CreateStringResult("1"): {},
-			api.CreateStringResult("2"): {},
-			api.CreateStringResult("3"): {},
-		}
-		assert.True(t, reflect.DeepEqual(expectedSet, res5))
+		assert.Equal(suite.T(), map[string]struct{}{"1": {}, "2": {}, "3": {}}, res5)
 
 		// moved element already exists in the destination set
 		res6, err := client.SMove(key2, key1, "2")
@@ -2232,19 +2192,11 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res7, err := client.SMembers(key1)
 		assert.NoError(t, err)
-		expectedSet = map[api.Result[string]]struct{}{
-			api.CreateStringResult("2"): {},
-			api.CreateStringResult("3"): {},
-		}
-		assert.True(t, reflect.DeepEqual(expectedSet, res7))
+		assert.Equal(suite.T(), map[string]struct{}{"2": {}, "3": {}}, res7)
 
 		res8, err := client.SMembers(key2)
 		assert.NoError(t, err)
-		expectedSet = map[api.Result[string]]struct{}{
-			api.CreateStringResult("1"): {},
-			api.CreateStringResult("3"): {},
-		}
-		assert.True(t, reflect.DeepEqual(expectedSet, res8))
+		assert.Equal(suite.T(), map[string]struct{}{"1": {}, "3": {}}, res8)
 
 		// attempt to move from a non-existing key
 		res9, err := client.SMove(nonExistingKey, key1, "4")
@@ -2253,11 +2205,7 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res10, err := client.SMembers(key1)
 		assert.NoError(t, err)
-		expectedSet = map[api.Result[string]]struct{}{
-			api.CreateStringResult("2"): {},
-			api.CreateStringResult("3"): {},
-		}
-		assert.True(t, reflect.DeepEqual(expectedSet, res10))
+		assert.Equal(suite.T(), map[string]struct{}{"2": {}, "3": {}}, res10)
 
 		// move to a new set
 		res11, err := client.SMove(key1, key3, "2")
@@ -2266,13 +2214,11 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res12, err := client.SMembers(key1)
 		assert.NoError(t, err)
-		assert.Len(t, res12, 1)
-		assert.Contains(t, res12, api.CreateStringResult("3"))
+		assert.Equal(suite.T(), map[string]struct{}{"3": {}}, res12)
 
 		res13, err := client.SMembers(key3)
 		assert.NoError(t, err)
-		assert.Len(t, res13, 1)
-		assert.Contains(t, res13, api.CreateStringResult("2"))
+		assert.Equal(suite.T(), map[string]struct{}{"2": {}}, res13)
 
 		// attempt to move a missing element
 		res14, err := client.SMove(key1, key3, "42")
@@ -2281,13 +2227,11 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res12, err = client.SMembers(key1)
 		assert.NoError(t, err)
-		assert.Len(t, res12, 1)
-		assert.Contains(t, res12, api.CreateStringResult("3"))
+		assert.Equal(suite.T(), map[string]struct{}{"3": {}}, res12)
 
 		res13, err = client.SMembers(key3)
 		assert.NoError(t, err)
-		assert.Len(t, res13, 1)
-		assert.Contains(t, res13, api.CreateStringResult("2"))
+		assert.Equal(suite.T(), map[string]struct{}{"2": {}}, res13)
 
 		// moving missing element to missing key
 		res15, err := client.SMove(key1, nonExistingKey, "42")
@@ -2296,8 +2240,7 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		res12, err = client.SMembers(key1)
 		assert.NoError(t, err)
-		assert.Len(t, res12, 1)
-		assert.Contains(t, res12, api.CreateStringResult("3"))
+		assert.Equal(suite.T(), map[string]struct{}{"3": {}}, res12)
 
 		// key exists but is not contain a set
 		_, err = client.Set(stringKey, "value")
@@ -2843,11 +2786,11 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 
 		res1, err := client.LMPop([]string{key1}, api.Left)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res1)
+		assert.Nil(suite.T(), res1)
 
 		res2, err := client.LMPopCount([]string{key1}, api.Left, int64(1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res2)
+		assert.Nil(suite.T(), res2)
 
 		res3, err := client.LPush(key1, []string{"one", "two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
@@ -2860,7 +2803,7 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[api.Result[string]][]api.Result[string]{api.CreateStringResult(key1): {api.CreateStringResult("five")}},
+			map[string][]string{key1: {"five"}},
 			res5,
 		)
 
@@ -2868,8 +2811,8 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[api.Result[string]][]api.Result[string]{
-				api.CreateStringResult(key2): {api.CreateStringResult("one"), api.CreateStringResult("two")},
+			map[string][]string{
+				key2: {"one", "two"},
 			},
 			res6,
 		)
@@ -2877,12 +2820,12 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		suite.verifyOK(client.Set(key3, "value"))
 
 		res7, err := client.LMPop([]string{key3}, api.Left)
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res7)
+		assert.Nil(suite.T(), res7)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res8, err := client.LMPop([]string{key3}, "Invalid")
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res8)
+		assert.Nil(suite.T(), res8)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2899,11 +2842,11 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 
 		res1, err := client.BLMPop([]string{key1}, api.Left, float64(0.1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res1)
+		assert.Nil(suite.T(), res1)
 
 		res2, err := client.BLMPopCount([]string{key1}, api.Left, int64(1), float64(0.1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res2)
+		assert.Nil(suite.T(), res2)
 
 		res3, err := client.LPush(key1, []string{"one", "two", "three", "four", "five"})
 		assert.Nil(suite.T(), err)
@@ -2916,7 +2859,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[api.Result[string]][]api.Result[string]{api.CreateStringResult(key1): {api.CreateStringResult("five")}},
+			map[string][]string{key1: {"five"}},
 			res5,
 		)
 
@@ -2924,8 +2867,8 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[api.Result[string]][]api.Result[string]{
-				api.CreateStringResult(key2): {api.CreateStringResult("one"), api.CreateStringResult("two")},
+			map[string][]string{
+				key2: {"one", "two"},
 			},
 			res6,
 		)
@@ -2933,7 +2876,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		suite.verifyOK(client.Set(key3, "value"))
 
 		res7, err := client.BLMPop([]string{key3}, api.Left, float64(0.1))
-		assert.Equal(suite.T(), (map[api.Result[string]][]api.Result[string])(nil), res7)
+		assert.Nil(suite.T(), res7)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -4361,14 +4304,11 @@ func (suite *GlideTestSuite) TestZPopMin() {
 
 		res2, err := client.ZPopMin(key1)
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), res2, 1)
-		assert.Equal(suite.T(), float64(1.0), res2[api.CreateStringResult("one")].Value())
+		assert.Equal(suite.T(), map[string]float64{"one": float64(1)}, res2)
 
 		res3, err := client.ZPopMinWithCount(key1, 2)
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), res3, 2)
-		assert.Equal(suite.T(), float64(2.0), res3[api.CreateStringResult("two")].Value())
-		assert.Equal(suite.T(), float64(3.0), res3[api.CreateStringResult("three")].Value())
+		assert.Equal(suite.T(), map[string]float64{"two": float64(2), "three": float64(3)}, res3)
 
 		// non sorted set key
 		_, err = client.Set(key2, "test")
@@ -4395,14 +4335,11 @@ func (suite *GlideTestSuite) TestZPopMax() {
 
 		res2, err := client.ZPopMax(key1)
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), res2, 1)
-		assert.Equal(suite.T(), float64(3.0), res2[api.CreateStringResult("three")].Value())
+		assert.Equal(suite.T(), map[string]float64{"three": float64(3)}, res2)
 
 		res3, err := client.ZPopMaxWithCount(key1, 2)
 		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), res3, 2)
-		assert.Equal(suite.T(), float64(2.0), res3[api.CreateStringResult("two")].Value())
-		assert.Equal(suite.T(), float64(1.0), res3[api.CreateStringResult("one")].Value())
+		assert.Equal(suite.T(), map[string]float64{"two": float64(2), "one": float64(1)}, res3)
 
 		// non sorted set key
 		_, err = client.Set(key2, "test")
@@ -4603,18 +4540,18 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 		assert.NoError(t, err)
 		// index [0:1]
 		res, err := client.ZRangeWithScores(key, options.NewRangeByIndexQuery(0, 1))
-		expected := map[api.Result[string]]api.Result[float64]{
-			api.CreateStringResult("a"): api.CreateFloat64Result(1.0),
-			api.CreateStringResult("b"): api.CreateFloat64Result(2.0),
+		expected := map[string]float64{
+			"a": float64(1.0),
+			"b": float64(2.0),
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
 		// index [0:-1] (all)
 		res, err = client.ZRangeWithScores(key, options.NewRangeByIndexQuery(0, -1))
-		expected = map[api.Result[string]]api.Result[float64]{
-			api.CreateStringResult("a"): api.CreateFloat64Result(1.0),
-			api.CreateStringResult("b"): api.CreateFloat64Result(2.0),
-			api.CreateStringResult("c"): api.CreateFloat64Result(3.0),
+		expected = map[string]float64{
+			"a": float64(1.0),
+			"b": float64(2.0),
+			"c": float64(3.0),
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -4627,10 +4564,10 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewScoreBoundary(3, true))
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[api.Result[string]]api.Result[float64]{
-			api.CreateStringResult("a"): api.CreateFloat64Result(1.0),
-			api.CreateStringResult("b"): api.CreateFloat64Result(2.0),
-			api.CreateStringResult("c"): api.CreateFloat64Result(3.0),
+		expected = map[string]float64{
+			"a": float64(1.0),
+			"b": float64(2.0),
+			"c": float64(3.0),
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -4639,9 +4576,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewScoreBoundary(3, false))
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[api.Result[string]]api.Result[float64]{
-			api.CreateStringResult("a"): api.CreateFloat64Result(1.0),
-			api.CreateStringResult("b"): api.CreateFloat64Result(2.0),
+		expected = map[string]float64{
+			"a": float64(1.0),
+			"b": float64(2.0),
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -4651,9 +4588,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
 			SetReverse()
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[api.Result[string]]api.Result[float64]{
-			api.CreateStringResult("b"): api.CreateFloat64Result(2.0),
-			api.CreateStringResult("a"): api.CreateFloat64Result(1.0),
+		expected = map[string]float64{
+			"b": float64(2.0),
+			"a": float64(1.0),
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -4663,9 +4600,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.PositiveInfinity)).
 			SetLimit(1, 2)
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[api.Result[string]]api.Result[float64]{
-			api.CreateStringResult("b"): api.CreateFloat64Result(2.0),
-			api.CreateStringResult("c"): api.CreateFloat64Result(3.0),
+		expected = map[string]float64{
+			"b": float64(2.0),
+			"c": float64(3.0),
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -179,11 +179,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_multipleArgs() {
 		suite.T().Skip("This feature is added in version 7")
 	}
 	configMap := map[string]string{"timeout": "1000", "maxmemory": "1GB"}
-	key1 := api.CreateStringResult("timeout")
-	value1 := api.CreateStringResult("1000")
-	key2 := api.CreateStringResult("maxmemory")
-	value2 := api.CreateStringResult("1073741824")
-	resultConfigMap := map[api.Result[string]]api.Result[string]{key1: value1, key2: value2}
+	resultConfigMap := map[string]string{"timeout": "1000", "maxmemory": "1073741824"}
 	suite.verifyOK(client.ConfigSet(configMap))
 
 	result2, err := client.ConfigGet([]string{"timeout", "maxmemory"})
@@ -216,7 +212,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
 	assert.IsType(suite.T(), &api.RequestError{}, err)
 
 	result2, err := client.ConfigGet([]string{"time"})
-	assert.Equal(suite.T(), map[api.Result[string]]api.Result[string]{}, result2)
+	assert.Equal(suite.T(), map[string]string{}, result2)
 	assert.Nil(suite.T(), err)
 }
 


### PR DESCRIPTION
Fix return in go client commands.
Fix maps and sets.