### PR TITLE
Go: Fix return types, part 6

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -1575,16 +1575,16 @@ func (client *baseClient) BZPopMin(keys []string, timeoutSecs float64) (Result[K
 //
 // Example:
 //
-//		// Retrieve all members of a sorted set in ascending order
-//		result, err := client.ZRange("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
+//	// Retrieve all members of a sorted set in ascending order
+//	result, err := client.ZRange("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
 //
-//		// Retrieve members within a score range in descending order
-//	 query := options.NewRangeByScoreQuery(
-//	     options.NewScoreBoundary(3, false),
-//	     options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
-//	   SetReverse()
-//		result, err := client.ZRange("my_sorted_set", query)
-//		// `result` contains members which have scores within the range of negative infinity to 3, in descending order
+//	// Retrieve members within a score range in descending order
+//	query := options.NewRangeByScoreQuery(
+//	    options.NewScoreBoundary(3, false),
+//	    options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
+//	  SetReverse()
+//	result, err := client.ZRange("my_sorted_set", query)
+//	// `result` contains members which have scores within the range of negative infinity to 3, in descending order
 //
 // [valkey.io]: https://valkey.io/commands/zrange/
 func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]string, error) {
@@ -1618,16 +1618,16 @@ func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]
 //
 // Example:
 //
-//		// Retrieve all members of a sorted set in ascending order
-//		result, err := client.ZRangeWithScores("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
+//	// Retrieve all members of a sorted set in ascending order
+//	result, err := client.ZRangeWithScores("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
 //
-//		// Retrieve members within a score range in descending order
-//	 query := options.NewRangeByScoreQuery(
-//	     options.NewScoreBoundary(3, false),
-//	     options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
-//	   SetReverse()
-//		result, err := client.ZRangeWithScores("my_sorted_set", query)
-//		// `result` contains members with scores within the range of negative infinity to 3, in descending order
+//	// Retrieve members within a score range in descending order
+//	query := options.NewRangeByScoreQuery(
+//	    options.NewScoreBoundary(3, false),
+//	    options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
+//	  SetReverse()
+//	result, err := client.ZRangeWithScores("my_sorted_set", query)
+//	// `result` contains members with scores within the range of negative infinity to 3, in descending order
 //
 // [valkey.io]: https://valkey.io/commands/zrange/
 func (client *baseClient) ZRangeWithScores(

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -2819,7 +2819,7 @@ func (client *baseClient) Sort(key string) ([]Result[string], error) {
 	if err != nil {
 		return nil, err
 	}
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
 func (client *baseClient) SortWithOptions(key string, options *options.SortOptions) ([]Result[string], error) {
@@ -2828,7 +2828,7 @@ func (client *baseClient) SortWithOptions(key string, options *options.SortOptio
 	if err != nil {
 		return nil, err
 	}
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
 func (client *baseClient) SortReadOnly(key string) ([]Result[string], error) {
@@ -2836,7 +2836,7 @@ func (client *baseClient) SortReadOnly(key string) ([]Result[string], error) {
 	if err != nil {
 		return nil, err
 	}
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
 func (client *baseClient) SortReadOnlyWithOptions(key string, options *options.SortOptions) ([]Result[string], error) {
@@ -2845,26 +2845,26 @@ func (client *baseClient) SortReadOnlyWithOptions(key string, options *options.S
 	if err != nil {
 		return nil, err
 	}
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
-func (client *baseClient) SortStore(key string, destination string) (Result[int64], error) {
+func (client *baseClient) SortStore(key string, destination string) (int64, error) {
 	result, err := client.executeCommand(C.Sort, []string{key, "STORE", destination})
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return defaultIntResponse, err
 	}
-	return handleIntOrNilResponse(result)
+	return handleIntResponse(result)
 }
 
 func (client *baseClient) SortStoreWithOptions(
 	key string,
 	destination string,
 	options *options.SortOptions,
-) (Result[int64], error) {
+) (int64, error) {
 	optionArgs := options.ToArgs()
 	result, err := client.executeCommand(C.Sort, append([]string{key, "STORE", destination}, optionArgs...))
 	if err != nil {
-		return CreateNilInt64Result(), err
+		return defaultIntResponse, err
 	}
-	return handleIntOrNilResponse(result)
+	return handleIntResponse(result)
 }

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -258,7 +258,7 @@ func (client *baseClient) MGet(keys []string) ([]Result[string], error) {
 		return nil, err
 	}
 
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
 func (client *baseClient) Incr(key string) (int64, error) {
@@ -391,7 +391,7 @@ func (client *baseClient) HMGet(key string, fields []string) ([]Result[string], 
 		return nil, err
 	}
 
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
 func (client *baseClient) HSet(key string, values map[string]string) (int64, error) {
@@ -430,7 +430,7 @@ func (client *baseClient) HLen(key string) (int64, error) {
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) HVals(key string) ([]Result[string], error) {
+func (client *baseClient) HVals(key string) ([]string, error) {
 	result, err := client.executeCommand(C.HVals, []string{key})
 	if err != nil {
 		return nil, err
@@ -448,7 +448,7 @@ func (client *baseClient) HExists(key string, field string) (bool, error) {
 	return handleBoolResponse(result)
 }
 
-func (client *baseClient) HKeys(key string) ([]Result[string], error) {
+func (client *baseClient) HKeys(key string) ([]string, error) {
 	result, err := client.executeCommand(C.HKeys, []string{key})
 	if err != nil {
 		return nil, err
@@ -527,13 +527,13 @@ func (client *baseClient) LPop(key string) (Result[string], error) {
 	return handleStringOrNilResponse(result)
 }
 
-func (client *baseClient) LPopCount(key string, count int64) ([]Result[string], error) {
+func (client *baseClient) LPopCount(key string, count int64) ([]string, error) {
 	result, err := client.executeCommand(C.LPop, []string{key, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
 	}
 
-	return handleStringArrayOrNullResponse(result)
+	return handleStringArrayOrNilResponse(result)
 }
 
 func (client *baseClient) LPos(key string, element string) (Result[int64], error) {
@@ -554,7 +554,7 @@ func (client *baseClient) LPosWithOptions(key string, element string, options *L
 	return handleIntOrNilResponse(result)
 }
 
-func (client *baseClient) LPosCount(key string, element string, count int64) ([]Result[int64], error) {
+func (client *baseClient) LPosCount(key string, element string, count int64) ([]int64, error) {
 	result, err := client.executeCommand(C.LPos, []string{key, element, CountKeyword, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
@@ -568,7 +568,7 @@ func (client *baseClient) LPosCountWithOptions(
 	element string,
 	count int64,
 	options *LPosOptions,
-) ([]Result[int64], error) {
+) ([]int64, error) {
 	result, err := client.executeCommand(
 		C.LPos,
 		append([]string{key, element, CountKeyword, utils.IntToString(count)}, options.toArgs()...),
@@ -768,7 +768,7 @@ func (client *baseClient) SMove(source string, destination string, member string
 	return handleBoolResponse(result)
 }
 
-func (client *baseClient) LRange(key string, start int64, end int64) ([]Result[string], error) {
+func (client *baseClient) LRange(key string, start int64, end int64) ([]string, error) {
 	result, err := client.executeCommand(C.LRange, []string{key, utils.IntToString(start), utils.IntToString(end)})
 	if err != nil {
 		return nil, err
@@ -822,13 +822,13 @@ func (client *baseClient) RPop(key string) (Result[string], error) {
 	return handleStringOrNilResponse(result)
 }
 
-func (client *baseClient) RPopCount(key string, count int64) ([]Result[string], error) {
+func (client *baseClient) RPopCount(key string, count int64) ([]string, error) {
 	result, err := client.executeCommand(C.RPop, []string{key, utils.IntToString(count)})
 	if err != nil {
 		return nil, err
 	}
 
-	return handleStringArrayOrNullResponse(result)
+	return handleStringArrayOrNilResponse(result)
 }
 
 func (client *baseClient) LInsert(
@@ -853,22 +853,22 @@ func (client *baseClient) LInsert(
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) BLPop(keys []string, timeoutSecs float64) ([]Result[string], error) {
+func (client *baseClient) BLPop(keys []string, timeoutSecs float64) ([]string, error) {
 	result, err := client.executeCommand(C.BLPop, append(keys, utils.FloatToString(timeoutSecs)))
 	if err != nil {
 		return nil, err
 	}
 
-	return handleStringArrayOrNullResponse(result)
+	return handleStringArrayOrNilResponse(result)
 }
 
-func (client *baseClient) BRPop(keys []string, timeoutSecs float64) ([]Result[string], error) {
+func (client *baseClient) BRPop(keys []string, timeoutSecs float64) ([]string, error) {
 	result, err := client.executeCommand(C.BRPop, append(keys, utils.FloatToString(timeoutSecs)))
 	if err != nil {
 		return nil, err
 	}
 
-	return handleStringArrayOrNullResponse(result)
+	return handleStringArrayOrNilResponse(result)
 }
 
 func (client *baseClient) RPushX(key string, elements []string) (int64, error) {
@@ -1258,12 +1258,12 @@ func (client *baseClient) Unlink(keys []string) (int64, error) {
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) Type(key string) (Result[string], error) {
+func (client *baseClient) Type(key string) (string, error) {
 	result, err := client.executeCommand(C.Type, []string{key})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return defaultStringResponse, err
 	}
-	return handleStringOrNilResponse(result)
+	return handleStringResponse(result)
 }
 
 func (client *baseClient) Touch(keys []string) (int64, error) {
@@ -1275,12 +1275,12 @@ func (client *baseClient) Touch(keys []string) (int64, error) {
 	return handleIntResponse(result)
 }
 
-func (client *baseClient) Rename(key string, newKey string) (Result[string], error) {
+func (client *baseClient) Rename(key string, newKey string) (string, error) {
 	result, err := client.executeCommand(C.Rename, []string{key, newKey})
 	if err != nil {
-		return CreateNilStringResult(), err
+		return defaultStringResponse, err
 	}
-	return handleStringOrNilResponse(result)
+	return handleStringResponse(result)
 }
 
 func (client *baseClient) Renamenx(key string, newKey string) (bool, error) {
@@ -1575,20 +1575,19 @@ func (client *baseClient) BZPopMin(keys []string, timeoutSecs float64) (Result[K
 //
 // Example:
 //
-//	// Retrieve all members of a sorted set in ascending order
-//	result, err := client.ZRange("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
+//		// Retrieve all members of a sorted set in ascending order
+//		result, err := client.ZRange("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
 //
-//	// Retrieve members within a score range in descending order
-//
-// query := options.NewRangeByScoreQuery(options.NewScoreBoundary(3, false),
-// options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
-//
-//	  .SetReverse()
-//	result, err := client.ZRange("my_sorted_set", query)
-//	// `result` contains members which have scores within the range of negative infinity to 3, in descending order
+//		// Retrieve members within a score range in descending order
+//	 query := options.NewRangeByScoreQuery(
+//	     options.NewScoreBoundary(3, false),
+//	     options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
+//	   SetReverse()
+//		result, err := client.ZRange("my_sorted_set", query)
+//		// `result` contains members which have scores within the range of negative infinity to 3, in descending order
 //
 // [valkey.io]: https://valkey.io/commands/zrange/
-func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]Result[string], error) {
+func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]string, error) {
 	args := make([]string, 0, 10)
 	args = append(args, key)
 	args = append(args, rangeQuery.ToArgs()...)
@@ -1619,17 +1618,16 @@ func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]
 //
 // Example:
 //
-//	// Retrieve all members of a sorted set in ascending order
-//	result, err := client.ZRangeWithScores("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
+//		// Retrieve all members of a sorted set in ascending order
+//		result, err := client.ZRangeWithScores("my_sorted_set", options.NewRangeByIndexQuery(0, -1))
 //
-//	// Retrieve members within a score range in descending order
-//
-// query := options.NewRangeByScoreQuery(options.NewScoreBoundary(3, false),
-// options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
-//
-//	  SetReverse()
-//	result, err := client.ZRangeWithScores("my_sorted_set", query)
-//	// `result` contains members with scores within the range of negative infinity to 3, in descending order
+//		// Retrieve members within a score range in descending order
+//	 query := options.NewRangeByScoreQuery(
+//	     options.NewScoreBoundary(3, false),
+//	     options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
+//	   SetReverse()
+//		result, err := client.ZRangeWithScores("my_sorted_set", query)
+//		// `result` contains members with scores within the range of negative infinity to 3, in descending order
 //
 // [valkey.io]: https://valkey.io/commands/zrange/
 func (client *baseClient) ZRangeWithScores(

--- a/go/api/generic_base_commands.go
+++ b/go/api/generic_base_commands.go
@@ -367,17 +367,17 @@ type GenericBaseCommands interface {
 	//  key - string
 	//
 	// Return value:
-	//  If the key exists, the type of the stored value is returned. Otherwise, a none" string is returned.
+	//  If the key exists, the type of the stored value is returned. Otherwise, a "none" string is returned.
 	//
 	// Example:
 	//	result, err := client.Type([]string{"key"})
 	//	if err != nil {
 	//	    // handle error
 	//	}
-	//	fmt.Println(result.Value()) // Output: string
+	//	fmt.Println(result) // Output: string
 	//
 	// [valkey.io]: Https://valkey.io/commands/type/
-	Type(key string) (Result[string], error)
+	Type(key string) (string, error)
 
 	// Renames key to new key.
 	//  If new Key already exists it is overwritten.
@@ -397,10 +397,10 @@ type GenericBaseCommands interface {
 	//	if err != nil {
 	//	    // handle error
 	//	}
-	//	fmt.Println(result.Value()) // Output: OK
+	//	fmt.Println(result) // Output: OK
 	//
 	// [valkey.io]: https://valkey.io/commands/rename/
-	Rename(key string, newKey string) (Result[string], error)
+	Rename(key string, newKey string) (string, error)
 
 	// Renames key to newkey if newKey does not yet exist.
 	//

--- a/go/api/generic_base_commands.go
+++ b/go/api/generic_base_commands.go
@@ -613,11 +613,10 @@ type GenericBaseCommands interface {
 	// Example:
 	//
 	// result, err := client.SortStore("key","destkey")
-	// result.Value(): 1
-	// result.IsNil(): false
+	// result: 1
 	//
 	// [valkey.io]: https://valkey.io/commands/sort/
-	SortStore(key string, destination string) (Result[int64], error)
+	SortStore(key string, destination string) (int64, error)
 
 	// Sorts the elements in the list, set, or sorted set at key and stores the result in
 	// destination. The sort command can be used to sort elements based on
@@ -648,11 +647,10 @@ type GenericBaseCommands interface {
 	//
 	// options := api.NewSortOptions().SetByPattern("weight_*").SetIsAlpha(false).AddGetPattern("object_*").AddGetPattern("#")
 	// result, err := client.SortStore("key","destkey",options)
-	// result.Value(): 1
-	// result.IsNil(): false
+	// result: 1
 	//
 	// [valkey.io]: https://valkey.io/commands/sort/
-	SortStoreWithOptions(key string, destination string, sortOptions *options.SortOptions) (Result[int64], error)
+	SortStoreWithOptions(key string, destination string, sortOptions *options.SortOptions) (int64, error)
 
 	// Sorts the elements in the list, set, or sorted set at key and returns the result.
 	// The sortReadOnly command can be used to sort elements based on different criteria and apply

--- a/go/api/hash_commands.go
+++ b/go/api/hash_commands.go
@@ -172,17 +172,14 @@ type HashCommands interface {
 	//  key - The key of the hash.
 	//
 	// Return value:
-	//  A slice of Result[string]s containing all the values in the hash, or an empty slice when key does not exist.
+	//  A slice containing all the values in the hash, or an empty slice when key does not exist.
 	//
 	// For example:
 	//  values, err := client.HVals("myHash")
-	//  // value1 equals api.CreateStringResult("value1")
-	//  // value2 equals api.CreateStringResult("value2")
-	//  // value3 equals api.CreateStringResult("value3")
-	//  // values equals []api.Result[string]{value1, value2, value3}
+	//  values: []string{"value1", "value2", "value3"}
 	//
 	// [valkey.io]: https://valkey.io/commands/hvals/
-	HVals(key string) ([]Result[string], error)
+	HVals(key string) ([]string, error)
 
 	// HExists returns if field is an existing field in the hash stored at key.
 	//
@@ -215,16 +212,14 @@ type HashCommands interface {
 	//  key - The key of the hash.
 	//
 	// Return value:
-	//  A slice of Result[string]s containing all the field names in the hash, or an empty slice when key does not exist.
+	//  A slice containing all the field names in the hash, or an empty slice when key does not exist.
 	//
 	// For example:
 	//  names, err := client.HKeys("my_hash")
-	//  // field1 equals api.CreateStringResult("field_1")
-	//  // field2 equals api.CreateStringResult("field_2")
-	//  // names equals []api.Result[string]{field1, field2}
+	//  names: []string{"field1", "field2"}
 	//
 	// [valkey.io]: https://valkey.io/commands/hkeys/
-	HKeys(key string) ([]Result[string], error)
+	HKeys(key string) ([]string, error)
 
 	// HStrLen returns the string length of the value associated with field in the hash stored at key.
 	// If the key or the field do not exist, 0 is returned.

--- a/go/api/list_commands.go
+++ b/go/api/list_commands.go
@@ -71,7 +71,7 @@ type ListCommands interface {
 	//     result: nil
 	//
 	// [valkey.io]: https://valkey.io/commands/lpop/
-	LPopCount(key string, count int64) ([]Result[string], error)
+	LPopCount(key string, count int64) ([]string, error)
 
 	// Returns the index of the first occurrence of element inside the list specified by key. If no match is found,
 	// [api.CreateNilInt64Result()] is returned.
@@ -132,13 +132,12 @@ type ListCommands interface {
 	//  An array that holds the indices of the matching elements within the list.
 	//
 	// For example:
-	//  result, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
+	//  _, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
 	//  result, err := client.LPosCount("my_list", "e", int64(3))
-	//  result: []api.Result[int64]{api.CreateInt64Result(4), api.CreateInt64Result(5), api.CreateInt64Result(6)}
-	//
+	//  result: []int64{ 4, 5, 6 }
 	//
 	// [valkey.io]: https://valkey.io/commands/lpos/
-	LPosCount(key string, element string, count int64) ([]Result[int64], error)
+	LPosCount(key string, element string, count int64) ([]int64, error)
 
 	// Returns an array of indices of matching elements within a list based on the given options. If no match is found, an
 	// empty array is returned.
@@ -155,21 +154,21 @@ type ListCommands interface {
 	//  An array that holds the indices of the matching elements within the list.
 	//
 	// For example:
-	//  1. result, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
+	//  1. _, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
 	//     result, err := client.LPosWithOptions("my_list", "e", int64(1), api.NewLPosOptionsBuilder().SetRank(2))
-	//     result: []api.Result[int64]{api.CreateInt64Result(5)}
-	//  2. result, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
+	//     result: []int64{ 5 }
+	//  2. _, err := client.RPush("my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
 	//     result, err := client.LPosWithOptions(
 	//             "my_list",
 	//             "e",
 	//             int64(3),
 	//             api.NewLPosOptionsBuilder().SetRank(2).SetMaxLen(1000),
 	//            )
-	//     result: []api.Result[int64]{api.CreateInt64Result(5), api.CreateInt64Result(6)}
+	//     result: []int64{ 5, 6 }
 	//
 	//
 	// [valkey.io]: https://valkey.io/commands/lpos/
-	LPosCountWithOptions(key string, element string, count int64, options *LPosOptions) ([]Result[int64], error)
+	LPosCountWithOptions(key string, element string, count int64, options *LPosOptions) ([]int64, error)
 
 	// Inserts all the specified values at the tail of the list stored at key.
 	// elements are inserted one after the other to the tail of the list, from the leftmost element to the rightmost element.
@@ -211,15 +210,14 @@ type ListCommands interface {
 	//
 	// For example:
 	//  1. result, err := client.LRange("my_list", 0, 2)
-	// result: []api.Result[string]{api.CreateStringResult("value1"), api.CreateStringResult("value2"),
-	// api.CreateStringResult("value3")}
+	//     result: []string{ "value1", "value2", "value3" }
 	//  2. result, err := client.LRange("my_list", -2, -1)
-	//     result: []api.Result[string]{api.CreateStringResult("value2"), api.CreateStringResult("value3")}
+	//     result: []string{ "value2", "value3" }
 	//  3. result, err := client.LRange("non_existent_key", 0, 2)
-	//     result: []api.Result[string]{}
+	//     result: []string{}
 	//
 	// [valkey.io]: https://valkey.io/commands/lrange/
-	LRange(key string, start int64, end int64) ([]Result[string], error)
+	LRange(key string, start int64, end int64) ([]string, error)
 
 	// Returns the element at index from the list stored at key.
 	// The index is zero-based, so 0 means the first element, 1 the second element and so on. Negative indices can be used to
@@ -357,7 +355,7 @@ type ListCommands interface {
 	//     result: nil
 	//
 	// [valkey.io]: https://valkey.io/commands/rpop/
-	RPopCount(key string, count int64) ([]Result[string], error)
+	RPopCount(key string, count int64) ([]string, error)
 
 	// Inserts element in the list at key either before or after the pivot.
 	//
@@ -397,17 +395,17 @@ type ListCommands interface {
 	//  timeoutSecs - The number of seconds to wait for a blocking operation to complete. A value of 0 will block indefinitely.
 	//
 	// Return value:
-	//  A two-element array of Result[string] containing the key from which the element was popped and the value of the popped
+	//  A two-element array containing the key from which the element was popped and the value of the popped
 	//  element, formatted as [key, value].
-	//  If no element could be popped and the timeout expired, returns nil.
+	//  If no element could be popped and the timeout expired, returns `nil`.
 	//
 	// For example:
 	//  result, err := client.BLPop("list1", "list2", 0.5)
-	//  result: []api.Result[string]{api.CreateStringResult("list1"), api.CreateStringResult("element")}
+	//  result: []string{ "list1", "element" }
 	//
 	// [valkey.io]: https://valkey.io/commands/blpop/
 	// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
-	BLPop(keys []string, timeoutSecs float64) ([]Result[string], error)
+	BLPop(keys []string, timeoutSecs float64) ([]string, error)
 
 	// Pops an element from the tail of the first list that is non-empty, with the given keys being checked in the order that
 	// they are given.
@@ -424,17 +422,17 @@ type ListCommands interface {
 	//  timeoutSecs - The number of seconds to wait for a blocking operation to complete. A value of 0 will block indefinitely.
 	//
 	// Return value:
-	//  A two-element array of Result[string] containing the key from which the element was popped and the value of the popped
+	//  A two-element array containing the key from which the element was popped and the value of the popped
 	//  element, formatted as [key, value].
-	//  If no element could be popped and the timeoutSecs expired, returns nil.
+	//  If no element could be popped and the timeoutSecs expired, returns `nil`.
 	//
 	// For example:
 	//  result, err := client.BRPop("list1", "list2", 0.5)
-	//  result: []api.Result[string]{api.CreateStringResult("list1"), api.CreateStringResult("element")}
+	//  result: []string{ "list1", "element" }
 	//
 	// [valkey.io]: https://valkey.io/commands/brpop/
 	// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
-	BRPop(keys []string, timeoutSecs float64) ([]Result[string], error)
+	BRPop(keys []string, timeoutSecs float64) ([]string, error)
 
 	// Inserts all the specified values at the tail of the list stored at key, only if key exists and holds a list. If key is
 	// not a list, this performs no operation.
@@ -632,9 +630,8 @@ type ListCommands interface {
 	//  result.Value(): "one"
 	//  updatedList1, err: client.LRange("my_list1", int64(0), int64(-1))
 	//  updatedList2, err: client.LRange("my_list2", int64(0), int64(-1))
-	//  updatedList1: []api.Result[string]{api.CreateStringResult("two")}
-	//  updatedList2: []api.Result[string]{api.CreateStringResult("one"), api.CreateStringResult("three"),
-	//  api.CreateStringResult("four")}
+	//  updatedList1: []string{ "two" }
+	//  updatedList2: []string{ "one", "three", "four" }
 	//
 	// [valkey.io]: https://valkey.io/commands/lmove/
 	LMove(source string, destination string, whereFrom ListDirection, whereTo ListDirection) (Result[string], error)
@@ -671,9 +668,8 @@ type ListCommands interface {
 	//  result.Value(): "one"
 	//  updatedList1, err: client.LRange("my_list1", int64(0), int64(-1))
 	//  updatedList2, err: client.LRange("my_list2", int64(0), int64(-1))
-	//  updatedList1: []api.Result[string]{api.CreateStringResult("two")}
-	//  updatedList2: []api.Result[string]{api.CreateStringResult("one"), api.CreateStringResult("three"),
-	//  api.CreateStringResult("four")}
+	//  updatedList1: []string{ "two" }
+	//  updatedList2: []string{ "one", "three", "four" }
 	//
 	// [valkey.io]: https://valkey.io/commands/blmove/
 	// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -167,7 +167,8 @@ func handleStringOrNilResponse(response *C.struct_CommandResponse) (Result[strin
 	return convertCharArrayToString(response, true)
 }
 
-func convertStringArray(response *C.struct_CommandResponse) ([]Result[string], error) {
+// Fix after merging with https://github.com/valkey-io/valkey-glide/pull/2964
+func convertStringOrNilArray(response *C.struct_CommandResponse) ([]Result[string], error) {
 	typeErr := checkResponseType(response, C.Array, false)
 	if typeErr != nil {
 		return nil, typeErr
@@ -184,33 +185,44 @@ func convertStringArray(response *C.struct_CommandResponse) ([]Result[string], e
 	return slice, nil
 }
 
-func handleStringArrayResponse(response *C.struct_CommandResponse) ([]Result[string], error) {
-	defer C.free_command_response(response)
-
-	return convertStringArray(response)
-}
-
-func handleStringArrayOrNullResponse(response *C.struct_CommandResponse) ([]Result[string], error) {
-	defer C.free_command_response(response)
-
-	typeErr := checkResponseType(response, C.Array, true)
+// array could be nillable, but strings - aren't
+func convertStringArray(response *C.struct_CommandResponse, isNilable bool) ([]string, error) {
+	typeErr := checkResponseType(response, C.Array, isNilable)
 	if typeErr != nil {
 		return nil, typeErr
 	}
 
-	if response.response_type == C.Null {
+	if isNilable && response.array_value == nil {
 		return nil, nil
 	}
 
-	slice := make([]Result[string], 0, response.array_value_len)
+	slice := make([]string, 0, response.array_value_len)
 	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
-		res, err := convertCharArrayToString(&v, true)
+		res, err := convertCharArrayToString(&v, false)
 		if err != nil {
 			return nil, err
 		}
-		slice = append(slice, res)
+		slice = append(slice, res.Value())
 	}
 	return slice, nil
+}
+
+func handleStringOrNilArrayResponse(response *C.struct_CommandResponse) ([]Result[string], error) {
+	defer C.free_command_response(response)
+
+	return convertStringOrNilArray(response)
+}
+
+func handleStringArrayResponse(response *C.struct_CommandResponse) ([]string, error) {
+	defer C.free_command_response(response)
+
+	return convertStringArray(response, false)
+}
+
+func handleStringArrayOrNilResponse(response *C.struct_CommandResponse) ([]string, error) {
+	defer C.free_command_response(response)
+
+	return convertStringArray(response, true)
 }
 
 func handleIntResponse(response *C.struct_CommandResponse) (int64, error) {
@@ -239,7 +251,7 @@ func handleIntOrNilResponse(response *C.struct_CommandResponse) (Result[int64], 
 	return CreateInt64Result(int64(response.int_value)), nil
 }
 
-func handleIntArrayResponse(response *C.struct_CommandResponse) ([]Result[int64], error) {
+func handleIntArrayResponse(response *C.struct_CommandResponse) ([]int64, error) {
 	defer C.free_command_response(response)
 
 	typeErr := checkResponseType(response, C.Array, false)
@@ -247,13 +259,13 @@ func handleIntArrayResponse(response *C.struct_CommandResponse) ([]Result[int64]
 		return nil, typeErr
 	}
 
-	slice := make([]Result[int64], 0, response.array_value_len)
+	slice := make([]int64, 0, response.array_value_len)
 	for _, v := range unsafe.Slice(response.array_value, response.array_value_len) {
 		err := checkResponseType(&v, C.Int, false)
 		if err != nil {
 			return nil, err
 		}
-		slice = append(slice, CreateInt64Result(int64(v.int_value)))
+		slice = append(slice, int64(v.int_value))
 	}
 	return slice, nil
 }
@@ -406,7 +418,7 @@ func handleStringToStringArrayMapOrNullResponse(
 		if err != nil {
 			return nil, err
 		}
-		value, err := convertStringArray(v.map_value)
+		value, err := convertStringOrNilArray(v.map_value)
 		if err != nil {
 			return nil, err
 		}

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -264,7 +264,7 @@ type SortedSetCommands interface {
 	// [blocking commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
 	BZPopMin(keys []string, timeoutSecs float64) (Result[KeyWithMemberAndScore], error)
 
-	ZRange(key string, rangeQuery options.ZRangeQuery) ([]Result[string], error)
+	ZRange(key string, rangeQuery options.ZRangeQuery) ([]string, error)
 
 	ZRangeWithScores(key string, rangeQuery options.ZRangeQueryWithScores) (map[Result[string]]Result[float64], error)
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -922,11 +922,8 @@ func (suite *GlideTestSuite) TestHVals_WithExistingKey() {
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HVals(key)
-		value1 := api.CreateStringResult("value1")
-		value2 := api.CreateStringResult("value2")
 		assert.Nil(suite.T(), err)
-		assert.Contains(suite.T(), res2, value1)
-		assert.Contains(suite.T(), res2, value2)
+		assert.ElementsMatch(suite.T(), []string{"value1", "value2"}, res2)
 	})
 }
 
@@ -936,7 +933,7 @@ func (suite *GlideTestSuite) TestHVals_WithNotExistingKey() {
 
 		res, err := client.HVals(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{}, res)
+		assert.Empty(suite.T(), res)
 	})
 }
 
@@ -990,11 +987,8 @@ func (suite *GlideTestSuite) TestHKeys_WithExistingKey() {
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HKeys(key)
-		field1 := api.CreateStringResult("field1")
-		field2 := api.CreateStringResult("field2")
 		assert.Nil(suite.T(), err)
-		assert.Contains(suite.T(), res2, field1)
-		assert.Contains(suite.T(), res2, field2)
+		assert.ElementsMatch(suite.T(), []string{"field1", "field2"}, res2)
 	})
 }
 
@@ -1004,7 +998,7 @@ func (suite *GlideTestSuite) TestHKeys_WithNotExistingKey() {
 
 		res, err := client.HKeys(key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{}, res)
+		assert.Empty(suite.T(), res)
 	})
 }
 
@@ -1295,10 +1289,9 @@ func (suite *GlideTestSuite) TestLPushLPop_WithExistingKey() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "value1", res2.Value())
 
-		resultList := []api.Result[string]{api.CreateStringResult("value2"), api.CreateStringResult("value3")}
 		res3, err := client.LPopCount(key, 2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultList, res3)
+		assert.Equal(suite.T(), []string{"value2", "value3"}, res3)
 	})
 }
 
@@ -1312,7 +1305,7 @@ func (suite *GlideTestSuite) TestLPop_nonExistingKey() {
 
 		res2, err := client.LPopCount(key, 2)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res2)
+		assert.Nil(suite.T(), res2)
 	})
 }
 
@@ -1327,7 +1320,7 @@ func (suite *GlideTestSuite) TestLPushLPop_typeError() {
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res2, err := client.LPopCount(key, 2)
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res2)
+		assert.Nil(suite.T(), res2)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -1412,33 +1405,29 @@ func (suite *GlideTestSuite) TestLPosCount() {
 		assert.Nil(suite.T(), err)
 
 		res2, err := client.LPosCount(key, "a", int64(2))
-		assert.Equal(suite.T(), []api.Result[int64]{api.CreateInt64Result(0), api.CreateInt64Result(1)}, res2)
+		assert.Equal(suite.T(), []int64{0, 1}, res2)
 		assert.Nil(suite.T(), err)
 
 		res3, err := client.LPosCount(key, "a", int64(0))
-		assert.Equal(
-			suite.T(),
-			[]api.Result[int64]{api.CreateInt64Result(0), api.CreateInt64Result(1), api.CreateInt64Result(4)},
-			res3,
-		)
+		assert.Equal(suite.T(), []int64{0, 1, 4}, res3)
 		assert.Nil(suite.T(), err)
 
 		// invalid count value
 		res4, err := client.LPosCount(key, "a", int64(-1))
-		assert.Equal(suite.T(), ([]api.Result[int64])(nil), res4)
+		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		// non-existent key
 		res5, err := client.LPosCount("non_existent_key", "a", int64(1))
-		assert.Equal(suite.T(), []api.Result[int64]{}, res5)
+		assert.Empty(suite.T(), res5)
 		assert.Nil(suite.T(), err)
 
 		// wrong key data type
 		keyString := uuid.NewString()
 		suite.verifyOK(client.Set(keyString, "value"))
 		res6, err := client.LPosCount(keyString, "a", int64(1))
-		assert.Equal(suite.T(), ([]api.Result[int64])(nil), res6)
+		assert.Nil(suite.T(), res6)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -1453,24 +1442,16 @@ func (suite *GlideTestSuite) TestLPosCount_withOptions() {
 		assert.Nil(suite.T(), err)
 
 		res2, err := client.LPosCountWithOptions(key, "a", int64(0), api.NewLPosOptionsBuilder().SetRank(1))
-		assert.Equal(
-			suite.T(),
-			[]api.Result[int64]{api.CreateInt64Result(0), api.CreateInt64Result(1), api.CreateInt64Result(4)},
-			res2,
-		)
+		assert.Equal(suite.T(), []int64{0, 1, 4}, res2)
 		assert.Nil(suite.T(), err)
 
 		res3, err := client.LPosCountWithOptions(key, "a", int64(0), api.NewLPosOptionsBuilder().SetRank(2))
-		assert.Equal(suite.T(), []api.Result[int64]{api.CreateInt64Result(1), api.CreateInt64Result(4)}, res3)
+		assert.Equal(suite.T(), []int64{1, 4}, res3)
 		assert.Nil(suite.T(), err)
 
 		// reverse traversal
 		res4, err := client.LPosCountWithOptions(key, "a", int64(0), api.NewLPosOptionsBuilder().SetRank(-1))
-		assert.Equal(
-			suite.T(),
-			[]api.Result[int64]{api.CreateInt64Result(4), api.CreateInt64Result(1), api.CreateInt64Result(0)},
-			res4,
-		)
+		assert.Equal(suite.T(), []int64{4, 1, 0}, res4)
 		assert.Nil(suite.T(), err)
 	})
 }
@@ -2430,25 +2411,19 @@ func (suite *GlideTestSuite) TestLRange() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), int64(4), res1)
 
-		resultList := []api.Result[string]{
-			api.CreateStringResult("value1"),
-			api.CreateStringResult("value2"),
-			api.CreateStringResult("value3"),
-			api.CreateStringResult("value4"),
-		}
 		res2, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultList, res2)
+		assert.Equal(suite.T(), []string{"value1", "value2", "value3", "value4"}, res2)
 
 		res3, err := client.LRange("non_existing_key", int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{}, res3)
+		assert.Empty(suite.T(), res3)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(key2, "value"))
 
 		res4, err := client.LRange(key2, int64(0), int64(1))
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res4)
+		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2500,13 +2475,13 @@ func (suite *GlideTestSuite) TestLTrim() {
 
 		res2, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult("value1"), api.CreateStringResult("value2")}, res2)
+		assert.Equal(suite.T(), []string{"value1", "value2"}, res2)
 
 		suite.verifyOK(client.LTrim(key, int64(4), int64(2)))
 
 		res3, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{}, res3)
+		assert.Empty(suite.T(), res3)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(key2, "value"))
@@ -2559,29 +2534,21 @@ func (suite *GlideTestSuite) TestLRem() {
 		assert.Equal(suite.T(), int64(2), res2)
 		res3, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("value2"),
-				api.CreateStringResult("value2"),
-				api.CreateStringResult("value1"),
-			},
-			res3,
-		)
+		assert.Equal(suite.T(), []string{"value2", "value2", "value1"}, res3)
 
 		res4, err := client.LRem(key, -1, "value2")
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), int64(1), res4)
 		res5, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult("value2"), api.CreateStringResult("value1")}, res5)
+		assert.Equal(suite.T(), []string{"value2", "value1"}, res5)
 
 		res6, err := client.LRem(key, 0, "value2")
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), int64(1), res6)
 		res7, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult("value1")}, res7)
+		assert.Equal(suite.T(), []string{"value1"}, res7)
 
 		res8, err := client.LRem("non_existing_key", 0, "value")
 		assert.Nil(suite.T(), err)
@@ -2605,14 +2572,14 @@ func (suite *GlideTestSuite) TestRPopAndRPopCount() {
 
 		res3, err := client.RPopCount(key, int64(2))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult("value3"), api.CreateStringResult("value2")}, res3)
+		assert.Equal(suite.T(), []string{"value3", "value2"}, res3)
 
 		res4, err := client.RPop("non_existing_key")
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), api.CreateNilStringResult(), res4)
 
 		res5, err := client.RPopCount("non_existing_key", int64(2))
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res5)
+		assert.Nil(suite.T(), res5)
 		assert.Nil(suite.T(), err)
 
 		key2 := uuid.NewString()
@@ -2624,7 +2591,7 @@ func (suite *GlideTestSuite) TestRPopAndRPopCount() {
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 
 		res7, err := client.RPopCount(key2, int64(2))
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res7)
+		assert.Nil(suite.T(), res7)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2649,18 +2616,7 @@ func (suite *GlideTestSuite) TestLInsert() {
 
 		res4, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("value1"),
-				api.CreateStringResult("value1.5"),
-				api.CreateStringResult("value2"),
-				api.CreateStringResult("value3"),
-				api.CreateStringResult("value3.5"),
-				api.CreateStringResult("value4"),
-			},
-			res4,
-		)
+		assert.Equal(suite.T(), []string{"value1", "value1.5", "value2", "value3", "value3.5", "value4"}, res4)
 
 		res5, err := client.LInsert("non_existing_key", api.Before, "pivot", "elem")
 		assert.Nil(suite.T(), err)
@@ -2691,17 +2647,17 @@ func (suite *GlideTestSuite) TestBLPop() {
 
 		res2, err := client.BLPop([]string{listKey1, listKey2}, float64(0.5))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult(listKey1), api.CreateStringResult("value2")}, res2)
+		assert.Equal(suite.T(), []string{listKey1, "value2"}, res2)
 
 		res3, err := client.BLPop([]string{listKey2}, float64(1.0))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res3)
+		assert.Nil(suite.T(), res3)
 
 		key := uuid.NewString()
 		suite.verifyOK(client.Set(key, "value"))
 
 		res4, err := client.BLPop([]string{key}, float64(1.0))
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res4)
+		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2718,17 +2674,17 @@ func (suite *GlideTestSuite) TestBRPop() {
 
 		res2, err := client.BRPop([]string{listKey1, listKey2}, float64(0.5))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{api.CreateStringResult(listKey1), api.CreateStringResult("value1")}, res2)
+		assert.Equal(suite.T(), []string{listKey1, "value1"}, res2)
 
 		res3, err := client.BRPop([]string{listKey2}, float64(1.0))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res3)
+		assert.Nil(suite.T(), res3)
 
 		key := uuid.NewString()
 		suite.verifyOK(client.Set(key, "value"))
 
 		res4, err := client.BRPop([]string{key}, float64(1.0))
-		assert.Equal(suite.T(), ([]api.Result[string])(nil), res4)
+		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -2750,16 +2706,7 @@ func (suite *GlideTestSuite) TestRPushX() {
 
 		res3, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("value1"),
-				api.CreateStringResult("value2"),
-				api.CreateStringResult("value3"),
-				api.CreateStringResult("value4"),
-			},
-			res3,
-		)
+		assert.Equal(suite.T(), []string{"value1", "value2", "value3", "value4"}, res3)
 
 		res4, err := client.RPushX(key2, []string{"value1"})
 		assert.Nil(suite.T(), err)
@@ -2767,7 +2714,7 @@ func (suite *GlideTestSuite) TestRPushX() {
 
 		res5, err := client.LRange(key2, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{}, res5)
+		assert.Empty(suite.T(), res5)
 
 		suite.verifyOK(client.Set(key3, "value"))
 
@@ -2799,16 +2746,7 @@ func (suite *GlideTestSuite) TestLPushX() {
 
 		res3, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("value4"),
-				api.CreateStringResult("value3"),
-				api.CreateStringResult("value2"),
-				api.CreateStringResult("value1"),
-			},
-			res3,
-		)
+		assert.Equal(suite.T(), []string{"value4", "value3", "value2", "value1"}, res3)
 
 		res4, err := client.LPushX(key2, []string{"value1"})
 		assert.Nil(suite.T(), err)
@@ -2816,7 +2754,7 @@ func (suite *GlideTestSuite) TestLPushX() {
 
 		res5, err := client.LRange(key2, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), []api.Result[string]{}, res5)
+		assert.Empty(suite.T(), res5)
 
 		suite.verifyOK(client.Set(key3, "value"))
 
@@ -2960,31 +2898,13 @@ func (suite *GlideTestSuite) TestLSet() {
 
 		res5, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("zero"),
-				api.CreateStringResult("two"),
-				api.CreateStringResult("three"),
-				api.CreateStringResult("four"),
-			},
-			res5,
-		)
+		assert.Equal(suite.T(), []string{"zero", "two", "three", "four"}, res5)
 
 		suite.verifyOK(client.LSet(key, int64(-1), "zero"))
 
 		res7, err := client.LRange(key, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("zero"),
-				api.CreateStringResult("two"),
-				api.CreateStringResult("three"),
-				api.CreateStringResult("zero"),
-			},
-			res7,
-		)
+		assert.Equal(suite.T(), []string{"zero", "two", "three", "zero"}, res7)
 	})
 }
 
@@ -3013,15 +2933,7 @@ func (suite *GlideTestSuite) TestLMove() {
 
 		res4, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("one"),
-				api.CreateStringResult("two"),
-				api.CreateStringResult("three"),
-			},
-			res4,
-		)
+		assert.Equal(suite.T(), []string{"one", "two", "three"}, res4)
 
 		// source and destination are the same, performing list rotation, "one" gets popped and added back
 		res5, err := client.LMove(key1, key1, api.Left, api.Left)
@@ -3030,15 +2942,7 @@ func (suite *GlideTestSuite) TestLMove() {
 
 		res6, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("one"),
-				api.CreateStringResult("two"),
-				api.CreateStringResult("three"),
-			},
-			res6,
-		)
+		assert.Equal(suite.T(), []string{"one", "two", "three"}, res6)
 		// normal use case, "three" gets popped and added to the left of destination
 		res7, err := client.LPush(key2, []string{"six", "five", "four"})
 		assert.Nil(suite.T(), err)
@@ -3050,26 +2954,10 @@ func (suite *GlideTestSuite) TestLMove() {
 
 		res9, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("one"),
-				api.CreateStringResult("two"),
-			},
-			res9,
-		)
+		assert.Equal(suite.T(), []string{"one", "two"}, res9)
 		res10, err := client.LRange(key2, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("three"),
-				api.CreateStringResult("four"),
-				api.CreateStringResult("five"),
-				api.CreateStringResult("six"),
-			},
-			res10,
-		)
+		assert.Equal(suite.T(), []string{"three", "four", "five", "six"}, res10)
 
 		// source exists but is not a list type key
 		suite.verifyOK(client.Set(nonListKey, "value"))
@@ -3845,15 +3733,7 @@ func (suite *GlideTestSuite) TestBLMove() {
 
 		res4, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("one"),
-				api.CreateStringResult("two"),
-				api.CreateStringResult("three"),
-			},
-			res4,
-		)
+		assert.Equal(suite.T(), []string{"one", "two", "three"}, res4)
 
 		// source and destination are the same, performing list rotation, "one" gets popped and added back
 		res5, err := client.BLMove(key1, key1, api.Left, api.Left, float64(0.1))
@@ -3862,15 +3742,7 @@ func (suite *GlideTestSuite) TestBLMove() {
 
 		res6, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("one"),
-				api.CreateStringResult("two"),
-				api.CreateStringResult("three"),
-			},
-			res6,
-		)
+		assert.Equal(suite.T(), []string{"one", "two", "three"}, res6)
 		// normal use case, "three" gets popped and added to the left of destination
 		res7, err := client.LPush(key2, []string{"six", "five", "four"})
 		assert.Nil(suite.T(), err)
@@ -3882,26 +3754,11 @@ func (suite *GlideTestSuite) TestBLMove() {
 
 		res9, err := client.LRange(key1, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("one"),
-				api.CreateStringResult("two"),
-			},
-			res9,
-		)
+		assert.Equal(suite.T(), []string{"one", "two"}, res9)
+
 		res10, err := client.LRange(key2, int64(0), int64(-1))
 		assert.Nil(suite.T(), err)
-		assert.Equal(
-			suite.T(),
-			[]api.Result[string]{
-				api.CreateStringResult("three"),
-				api.CreateStringResult("four"),
-				api.CreateStringResult("five"),
-				api.CreateStringResult("six"),
-			},
-			res10,
-		)
+		assert.Equal(suite.T(), []string{"three", "four", "five", "six"}, res10)
 
 		// source exists but is not a list type key
 		suite.verifyOK(client.Set(nonListKey, "value"))
@@ -3958,7 +3815,7 @@ func (suite *GlideTestSuite) TestType() {
 		suite.verifyOK(client.Set(keyName, initialValue))
 		result, err := client.Type(keyName)
 		assert.Nil(suite.T(), err)
-		assert.IsType(suite.T(), result, api.CreateStringResult("string"), "Value is string")
+		assert.IsType(suite.T(), result, "string", "Value is string")
 
 		// Test 2: Check if the value is list
 		key1 := "{keylist}-1" + uuid.NewString()
@@ -3967,7 +3824,7 @@ func (suite *GlideTestSuite) TestType() {
 		assert.Nil(suite.T(), err)
 		resultType, err := client.Type(key1)
 		assert.Nil(suite.T(), err)
-		assert.IsType(suite.T(), resultType, api.CreateStringResult("list"), "Value is list")
+		assert.IsType(suite.T(), resultType, "list", "Value is list")
 	})
 }
 
@@ -4019,7 +3876,7 @@ func (suite *GlideTestSuite) TestRename() {
 		// Test 2 Check if the rename command return false if the key/newkey is invalid.
 		key1 := "{keyName}" + uuid.NewString()
 		res1, err := client.Rename(key1, "invalidKey")
-		assert.Equal(suite.T(), "", res1.Value())
+		assert.Equal(suite.T(), "", res1)
 		assert.NotNil(suite.T(), err)
 		assert.IsType(suite.T(), &api.RequestError{}, err)
 	})
@@ -4463,21 +4320,12 @@ func (suite *GlideTestSuite) TestZRange() {
 		assert.NoError(t, err)
 		// index [0:1]
 		res, err := client.ZRange(key, options.NewRangeByIndexQuery(0, 1))
-		expected := []api.Result[string]{
-			api.CreateStringResult("a"),
-			api.CreateStringResult("b"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"a", "b"}, res)
 		// index [0:-1] (all)
 		res, err = client.ZRange(key, options.NewRangeByIndexQuery(0, -1))
-		expected = []api.Result[string]{
-			api.CreateStringResult("a"),
-			api.CreateStringResult("b"),
-			api.CreateStringResult("c"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"a", "b", "c"}, res)
 		// index [3:1] (none)
 		res, err = client.ZRange(key, options.NewRangeByIndexQuery(3, 1))
 		assert.NoError(t, err)
@@ -4488,48 +4336,31 @@ func (suite *GlideTestSuite) TestZRange() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewScoreBoundary(3, true))
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("a"),
-			api.CreateStringResult("b"),
-			api.CreateStringResult("c"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"a", "b", "c"}, res)
 		// score [-inf:3)
 		query = options.NewRangeByScoreQuery(
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewScoreBoundary(3, false))
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("a"),
-			api.CreateStringResult("b"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"a", "b"}, res)
 		// score (3:-inf] reverse
 		query = options.NewRangeByScoreQuery(
 			options.NewScoreBoundary(3, false),
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
 			SetReverse()
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("b"),
-			api.CreateStringResult("a"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"b", "a"}, res)
 		// score [-inf:+inf] limit 1 2
 		query = options.NewRangeByScoreQuery(
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewInfiniteScoreBoundary(options.PositiveInfinity)).
 			SetLimit(1, 2)
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("b"),
-			api.CreateStringResult("c"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"b", "c"}, res)
 		// score [-inf:3) reverse (none)
 		query = options.NewRangeByScoreQuery(
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
@@ -4550,36 +4381,24 @@ func (suite *GlideTestSuite) TestZRange() {
 			options.NewInfiniteLexBoundary(options.NegativeInfinity),
 			options.NewLexBoundary("c", false))
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("a"),
-			api.CreateStringResult("b"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"a", "b"}, res)
 		// lex [+:-] reverse limit 1 2
 		query = options.NewRangeByLexQuery(
 			options.NewInfiniteLexBoundary(options.PositiveInfinity),
 			options.NewInfiniteLexBoundary(options.NegativeInfinity)).
 			SetReverse().SetLimit(1, 2)
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("b"),
-			api.CreateStringResult("a"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"b", "a"}, res)
 		// lex (c:-] reverse
 		query = options.NewRangeByLexQuery(
 			options.NewLexBoundary("c", false),
 			options.NewInfiniteLexBoundary(options.NegativeInfinity)).
 			SetReverse()
 		res, err = client.ZRange(key, query)
-		expected = []api.Result[string]{
-			api.CreateStringResult("b"),
-			api.CreateStringResult("a"),
-		}
 		assert.NoError(t, err)
-		assert.Equal(t, expected, res)
+		assert.Equal(t, []string{"b", "a"}, res)
 		// lex [+:c] (none)
 		query = options.NewRangeByLexQuery(
 			options.NewInfiniteLexBoundary(options.PositiveInfinity),

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3776,18 +3776,11 @@ func (suite *GlideTestSuite) TestSortStore_BasicSorting() {
 
 		assert.Nil(suite.T(), err)
 		assert.NotNil(suite.T(), result)
-		assert.Equal(suite.T(), int64(5), result.Value())
+		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(sortedKey, 0, -1)
-		resultList := []api.Result[string]{
-			api.CreateStringResult("1"),
-			api.CreateStringResult("2"),
-			api.CreateStringResult("4"),
-			api.CreateStringResult("5"),
-			api.CreateStringResult("10"),
-		}
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultList, sortedValues)
+		assert.Equal(suite.T(), []string{"1", "2", "4", "5", "10"}, sortedValues)
 	})
 }
 
@@ -3796,7 +3789,7 @@ func (suite *GlideTestSuite) TestSortStore_ErrorHandling() {
 		result, err := client.SortStore("{listKey}nonExistingKey", "{listKey}mydestinationKey")
 
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), result.Value())
+		assert.Equal(suite.T(), int64(0), result)
 	})
 }
 
@@ -3811,18 +3804,11 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_DescendingOrder() {
 
 		assert.Nil(suite.T(), err)
 		assert.NotNil(suite.T(), result)
-		assert.Equal(suite.T(), int64(5), result.Value())
+		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(sortedKey, 0, -1)
-		resultList := []api.Result[string]{
-			api.CreateStringResult("50"),
-			api.CreateStringResult("40"),
-			api.CreateStringResult("30"),
-			api.CreateStringResult("20"),
-			api.CreateStringResult("10"),
-		}
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultList, sortedValues)
+		assert.Equal(suite.T(), []string{"50", "40", "30", "20", "10"}, sortedValues)
 	})
 }
 
@@ -3837,16 +3823,10 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_AlphaSorting() {
 
 		assert.Nil(suite.T(), err)
 		assert.NotNil(suite.T(), result)
-		assert.Equal(suite.T(), int64(5), result.Value())
+		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(sortedKey, 0, -1)
-		resultList := []api.Result[string]{
-			api.CreateStringResult("apple"),
-			api.CreateStringResult("banana"),
-			api.CreateStringResult("cherry"),
-			api.CreateStringResult("date"),
-			api.CreateStringResult("elderberry"),
-		}
+		resultList := []string{"apple", "banana", "cherry", "date", "elderberry"}
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), resultList, sortedValues)
 	})
@@ -3863,16 +3843,11 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_Limit() {
 
 		assert.Nil(suite.T(), err)
 		assert.NotNil(suite.T(), result)
-		assert.Equal(suite.T(), int64(3), result.Value())
+		assert.Equal(suite.T(), int64(3), result)
 
 		sortedValues, err := client.LRange(sortedKey, 0, -1)
-		resultList := []api.Result[string]{
-			api.CreateStringResult("20"),
-			api.CreateStringResult("30"),
-			api.CreateStringResult("40"),
-		}
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultList, sortedValues)
+		assert.Equal(suite.T(), []string{"20", "30", "40"}, sortedValues)
 	})
 }
 
@@ -6513,17 +6488,10 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_ByPattern() {
 
 		assert.Nil(suite.T(), err)
 		assert.NotNil(suite.T(), result)
-		assert.Equal(suite.T(), int64(5), result.Value())
+		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(sortedKey, 0, -1)
-		resultList := []api.Result[string]{
-			api.CreateStringResult("d"),
-			api.CreateStringResult("b"),
-			api.CreateStringResult("c"),
-			api.CreateStringResult("e"),
-			api.CreateStringResult("a"),
-		}
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), resultList, sortedValues)
+		assert.Equal(suite.T(), []string{"d", "b", "c", "e", "a"}, sortedValues)
 	})
 }


### PR DESCRIPTION
Fix return types for commands which return arrays.
\+ fix couple of comments left which return strings.