### PR TITLE
Remove flaky and redundant update_connection_password_connection_lost_before_password_update Java test

### DIFF
--- a/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
+++ b/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
@@ -243,43 +243,4 @@ public class StandaloneClientTests {
             adminClient.close();
         }
     }
-
-    @SneakyThrows
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    public void update_connection_password_connection_lost_before_password_update(
-            boolean immediateAuth) {
-        GlideClient adminClient = GlideClient.createClient(commonClientConfig().build()).get();
-        var pwd = UUID.randomUUID().toString();
-
-        try (var testClient = GlideClient.createClient(commonClientConfig().build()).get()) {
-            // validate that we can use the client
-            assertNotNull(testClient.info().get());
-
-            // set the password and forcefully drop connection for the testClient
-            assertEquals("OK", adminClient.configSet(Map.of("requirepass", pwd)).get());
-            adminClient.customCommand(new String[] {"CLIENT", "KILL", "TYPE", "NORMAL"}).get();
-
-            /*
-             * Some explanation for the curious mind:
-             * Our library is abstracting a connection or connections, with a lot of mechanism around it, making it behave like what we call a "client".
-             * When using standalone mode, the client is a single connection, so on disconnection the first thing it planned to do is to reconnect.
-             *
-             * There's no reason to get other commands and to take care of them since to serve commands we need to be connected.
-             *
-             * Hence, the client will try to reconnect and will not listen try to take care of new tasks, but will let them wait in line,
-             * so the update connection password will not be able to reach the connection and will return an error.
-             * For future versions, standalone will be considered as a different animal then it is now, since standalone is not necessarily one node.
-             * It can be replicated and have a lot of nodes, and to be what we like to call "one shard cluster".
-             * So, in the future, we will have many existing connection and request can be managed also when one connection is locked,
-             */
-            var exception =
-                    assertThrows(
-                            ExecutionException.class,
-                            () -> testClient.updateConnectionPassword(pwd, immediateAuth).get());
-        } finally {
-            adminClient.configSet(Map.of("requirepass", "")).get();
-            adminClient.close();
-        }
-    }
 }


### PR DESCRIPTION
This test is redundant due to the active reconnect mechanism introduced in commit 68c6b3b8fa.

The reconnect mechanism efficiently handles passive reconnects and reestablishes connections in both CMD and CME modes, rendering this test unnecessary.

Additionally, the test is flaky due to timing interdependencies between the updateConnectionPassword() implementation and the reconnect mechanism.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2037

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [X] Tests are added or updated.
-   ~[] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
