### PR TITLE
Go: Fix `XRange` and `XRevRange` return data type

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -6812,7 +6812,7 @@ func (client *baseClient) CopyWithOptions(
 //
 // Return value:
 //
-//	A `map` of key to stream entry data, where entry data is an array of
+//	An `array` of stream entry data, where entry data is an array of
 //	pairings with format `[[field, entry], [field, entry], ...]`. Returns `nil` if `count` is non-positive.
 //
 // Example:
@@ -6823,7 +6823,7 @@ func (client *baseClient) CopyWithOptions(
 //		options.NewInfiniteStreamBoundary(options.NegativeInfinity),
 //		options.NewInfiniteStreamBoundary(options.PositiveInfinity),
 //	)
-//	fmt.Println(res) // map[key:[["field1", "entry1"], ["field2", "entry2"]]]
+//	fmt.Println(res) // [{streamId [["field1", "entry1"], ["field2", "entry2"]]}]
 //
 //	// Retrieve exactly one stream entry by id
 //	res, err := client.XRange(
@@ -6831,14 +6831,14 @@ func (client *baseClient) CopyWithOptions(
 //		options.NewStreamBoundary(streamId, true),
 //		options.NewStreamBoundary(streamId, true),
 //	)
-//	fmt.Println(res) // map[key:[["field1", "entry1"]]
+//	fmt.Println(res) // [{streamId [["field1", "entry1"]]}]
 //
 // [valkey.io]: https://valkey.io/commands/xrange/
 func (client *baseClient) XRange(
 	key string,
 	start options.StreamBoundary,
 	end options.StreamBoundary,
-) (map[string][][]string, error) {
+) ([]XRangeResponse, error) {
 	return client.XRangeWithOptions(key, start, end, nil)
 }
 
@@ -6859,7 +6859,7 @@ func (client *baseClient) XRange(
 //
 // Return value:
 //
-//	A `map` of key to stream entry data, where entry data is an array of
+//	An `array` of stream entry data, where entry data is an array of
 //	pairings with format `[[field, entry], [field, entry], ...]`. Returns `nil` if `count` is non-positive.
 //
 // Example:
@@ -6871,7 +6871,7 @@ func (client *baseClient) XRange(
 //		options.NewInfiniteStreamBoundary(options.PositiveInfinity),
 //		options.NewStreamRangeOptions().SetCount(10),
 //	)
-//	fmt.Println(res) // map[key:[["field1", "entry1"], ["field2", "entry2"]]]
+//	fmt.Println(res) // [{streamId [["field1", "entry1"], ["field2", "entry2"]]}]
 //
 //	// Retrieve exactly one stream entry by id
 //	res, err := client.XRangeWithOptions(
@@ -6880,7 +6880,7 @@ func (client *baseClient) XRange(
 //		options.NewStreamBoundary(streamId, true),
 //		options.NewStreamRangeOptions().SetCount(1),
 //	)
-//	fmt.Println(res) // map[key:[["field1", "entry1"]]
+//	fmt.Println(res) // [{streamId [["field1", "entry1"]]}]
 //
 // [valkey.io]: https://valkey.io/commands/xrange/
 func (client *baseClient) XRangeWithOptions(
@@ -6888,7 +6888,7 @@ func (client *baseClient) XRangeWithOptions(
 	start options.StreamBoundary,
 	end options.StreamBoundary,
 	opts *options.StreamRangeOptions,
-) (map[string][][]string, error) {
+) ([]XRangeResponse, error) {
 	args := []string{key, string(start), string(end)}
 	if opts != nil {
 		optionArgs, err := opts.ToArgs()
@@ -6901,7 +6901,7 @@ func (client *baseClient) XRangeWithOptions(
 	if err != nil {
 		return nil, err
 	}
-	return handleMapOfArrayOfStringArrayOrNilResponse(result)
+	return handleXRangeResponse(result)
 }
 
 // Returns stream entries matching a given range of IDs in reverse order.
@@ -6921,7 +6921,7 @@ func (client *baseClient) XRangeWithOptions(
 //
 // Return value:
 //
-//	A `map` of key to stream entry data, where entry data is an array of
+//	An `array` of stream entry data, where entry data is an array of
 //	pairings with format `[[field, entry], [field, entry], ...]`.
 //
 // Example:
@@ -6932,14 +6932,14 @@ func (client *baseClient) XRangeWithOptions(
 //		options.NewInfiniteStreamBoundary(options.PositiveInfinity),
 //		options.NewInfiniteStreamBoundary(options.NegativeInfinity),
 //	)
-//	fmt.Println(res) // map[key:[["field2", "entry2"], ["field1", "entry1"]]]
+//	fmt.Println(res) // [{streamID ["field2", "entry2"], ["field1", "entry1"]]}]
 //
 // [valkey.io]: https://valkey.io/commands/xrevrange/
 func (client *baseClient) XRevRange(
 	key string,
 	start options.StreamBoundary,
 	end options.StreamBoundary,
-) (map[string][][]string, error) {
+) ([]XRangeResponse, error) {
 	return client.XRevRangeWithOptions(key, start, end, nil)
 }
 
@@ -6961,7 +6961,7 @@ func (client *baseClient) XRevRange(
 //
 // Return value:
 //
-//	A `map` of key to stream entry data, where entry data is an array of
+//	An `array` of stream entry data, where entry data is an array of
 //	pairings with format `[[field, entry], [field, entry], ...]`.
 //	Returns `nil` if `count` is non-positive.
 //
@@ -6974,7 +6974,7 @@ func (client *baseClient) XRevRange(
 //		options.NewInfiniteStreamBoundary(options.NegativeInfinity),
 //		options.NewStreamRangeOptions().SetCount(10),
 //	)
-//	fmt.Println(res) // map[key:[["field2", "entry2"], ["field1", "entry1"]]]
+//	fmt.Println(res) // [{streamID [["field2", "entry2"], ["field1", "entry1"]]}]
 //
 // [valkey.io]: https://valkey.io/commands/xrevrange/
 func (client *baseClient) XRevRangeWithOptions(
@@ -6982,7 +6982,7 @@ func (client *baseClient) XRevRangeWithOptions(
 	start options.StreamBoundary,
 	end options.StreamBoundary,
 	opts *options.StreamRangeOptions,
-) (map[string][][]string, error) {
+) ([]XRangeResponse, error) {
 	args := []string{key, string(start), string(end)}
 	if opts != nil {
 		optionArgs, err := opts.ToArgs()
@@ -6995,7 +6995,7 @@ func (client *baseClient) XRevRangeWithOptions(
 	if err != nil {
 		return nil, err
 	}
-	return handleMapOfArrayOfStringArrayOrNilResponse(result)
+	return handleXRevRangeResponse(result)
 }
 
 // Reads or modifies the array of bits representing the string that is held at key

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -9,6 +9,7 @@ import "C"
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"unsafe"
 
@@ -839,6 +840,96 @@ func handleMapOfArrayOfStringArrayOrNilResponse(response *C.struct_CommandRespon
 	}
 
 	return handleMapOfArrayOfStringArrayResponse(response)
+}
+
+func handleXRangeResponse(response *C.struct_CommandResponse) ([]XRangeResponse, error) {
+	defer C.free_command_response(response)
+
+	if response.response_type == uint32(C.Null) {
+		return nil, nil
+	}
+
+	typeErr := checkResponseType(response, C.Map, false)
+	if typeErr != nil {
+		return nil, typeErr
+	}
+	mapData, err := parseMap(response)
+	if err != nil {
+		return nil, err
+	}
+	converted, err := mapConverter[[][]string]{
+		arrayConverter[[]string]{
+			arrayConverter[string]{
+				nil,
+				false,
+			},
+			false,
+		},
+		false,
+	}.convert(mapData)
+	if err != nil {
+		return nil, err
+	}
+	claimedEntries, ok := converted.(map[string][][]string)
+	if !ok {
+		return nil, &errors.RequestError{Msg: fmt.Sprintf("unexpected type of second element: %T", converted)}
+	}
+
+	xRangeResponseArray := make([]XRangeResponse, 0, len(claimedEntries))
+
+	for k, v := range claimedEntries {
+		xRangeResponseArray = append(xRangeResponseArray, XRangeResponse{k, v})
+	}
+
+	sort.Slice(xRangeResponseArray, func(i, j int) bool {
+		return xRangeResponseArray[i].StreamId < xRangeResponseArray[j].StreamId
+	})
+	return xRangeResponseArray, nil
+}
+
+func handleXRevRangeResponse(response *C.struct_CommandResponse) ([]XRangeResponse, error) {
+	defer C.free_command_response(response)
+
+	if response.response_type == uint32(C.Null) {
+		return nil, nil
+	}
+
+	typeErr := checkResponseType(response, C.Map, false)
+	if typeErr != nil {
+		return nil, typeErr
+	}
+	mapData, err := parseMap(response)
+	if err != nil {
+		return nil, err
+	}
+	converted, err := mapConverter[[][]string]{
+		arrayConverter[[]string]{
+			arrayConverter[string]{
+				nil,
+				false,
+			},
+			false,
+		},
+		false,
+	}.convert(mapData)
+	if err != nil {
+		return nil, err
+	}
+	claimedEntries, ok := converted.(map[string][][]string)
+	if !ok {
+		return nil, &errors.RequestError{Msg: fmt.Sprintf("unexpected type of second element: %T", converted)}
+	}
+
+	xRangeResponseArray := make([]XRangeResponse, 0, len(claimedEntries))
+
+	for k, v := range claimedEntries {
+		xRangeResponseArray = append(xRangeResponseArray, XRangeResponse{k, v})
+	}
+
+	sort.Slice(xRangeResponseArray, func(i, j int) bool {
+		return xRangeResponseArray[i].StreamId > xRangeResponseArray[j].StreamId
+	})
+	return xRangeResponseArray, nil
 }
 
 func handleXAutoClaimResponse(response *C.struct_CommandResponse) (XAutoClaimResponse, error) {

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -35,7 +35,7 @@ type MemberAndScore struct {
 	Score  float64
 }
 
-// Response type of [XRangeResponse] command.
+// Response type of [XRange] and [XRevRange] commands.
 type XRangeResponse struct {
 	StreamId string
 	Entries  [][]string

--- a/go/api/response_types.go
+++ b/go/api/response_types.go
@@ -35,6 +35,12 @@ type MemberAndScore struct {
 	Score  float64
 }
 
+// Response type of [XRangeResponse] command.
+type XRangeResponse struct {
+	StreamId string
+	Entries  [][]string
+}
+
 // Response type of [XAutoClaim] command.
 type XAutoClaimResponse struct {
 	NextEntry       string

--- a/go/api/stream_commands.go
+++ b/go/api/stream_commands.go
@@ -109,21 +109,21 @@ type StreamCommands interface {
 		options *options.StreamClaimOptions,
 	) ([]string, error)
 
-	XRange(key string, start options.StreamBoundary, end options.StreamBoundary) (map[string][][]string, error)
+	XRange(key string, start options.StreamBoundary, end options.StreamBoundary) ([]XRangeResponse, error)
 
 	XRangeWithOptions(
 		key string,
 		start options.StreamBoundary,
 		end options.StreamBoundary,
 		options *options.StreamRangeOptions,
-	) (map[string][][]string, error)
+	) ([]XRangeResponse, error)
 
-	XRevRange(key string, start options.StreamBoundary, end options.StreamBoundary) (map[string][][]string, error)
+	XRevRange(key string, start options.StreamBoundary, end options.StreamBoundary) ([]XRangeResponse, error)
 
 	XRevRangeWithOptions(
 		key string,
 		start options.StreamBoundary,
 		end options.StreamBoundary,
 		options *options.StreamRangeOptions,
-	) (map[string][][]string, error)
+	) ([]XRangeResponse, error)
 }

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -7455,7 +7455,10 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[string][][]string{streamId1.Value(): {{"field1", "value1"}}, streamId2.Value(): {{"field2", "value2"}}},
+			[]api.XRangeResponse{
+				{StreamId: streamId1.Value(), Entries: [][]string{{"field1", "value1"}}},
+				{StreamId: streamId2.Value(), Entries: [][]string{{"field2", "value2"}}},
+			},
 			xrangeResult,
 		)
 
@@ -7468,7 +7471,10 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[string][][]string{streamId2.Value(): {{"field2", "value2"}}, streamId1.Value(): {{"field1", "value1"}}},
+			[]api.XRangeResponse{
+				{StreamId: streamId2.Value(), Entries: [][]string{{"field2", "value2"}}},
+				{StreamId: streamId1.Value(), Entries: [][]string{{"field1", "value1"}}},
+			},
 			xrevrangeResult,
 		)
 
@@ -7507,7 +7513,9 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[string][][]string{streamId3.Value(): {{"field3", "value3"}}},
+			[]api.XRangeResponse{
+				{StreamId: streamId3.Value(), Entries: [][]string{{"field3", "value3"}}},
+			},
 			xrangeResult,
 		)
 
@@ -7521,7 +7529,9 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[string][][]string{streamId3.Value(): {{"field3", "value3"}}},
+			[]api.XRangeResponse{
+				{StreamId: streamId3.Value(), Entries: [][]string{{"field3", "value3"}}},
+			},
 			xrevrangeResult,
 		)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
