### PR TITLE
Go: CD pipeline

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -15,18 +15,8 @@
         "RUNNER": ["self-hosted", "Linux", "ARM64", "ephemeral"],
         "ARCH": "arm64",
         "TARGET": "aarch64-unknown-linux-gnu",
-        "PACKAGE_MANAGERS": ["pypi", "npm", "maven"],
-        "languages": ["python", "node", "java", "dotnet"]
-    },
-    {
-        "OS": "ubuntu",
-        "NAMED_OS": "linux",
-        "RUNNER": "ubuntu-22.04-arm",
-        "ARCH": "arm64",
-        "TARGET": "aarch64-unknown-linux-gnu",
-        "PACKAGE_MANAGERS": ["pkg_go_dev"],
-        "run": "always",
-        "languages": ["go"]
+        "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
+        "languages": ["python", "node", "java", "go", "dotnet"]
     },
     {
         "OS": "macos",

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -5,7 +5,7 @@
         "RUNNER": "ubuntu-latest",
         "ARCH": "x64",
         "TARGET": "x86_64-unknown-linux-gnu",
-        "PACKAGE_MANAGERS": ["pypi", "npm", "maven"],
+        "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
         "run": "always",
         "languages": ["python", "node", "java", "go", "dotnet"]
     },
@@ -16,7 +16,17 @@
         "ARCH": "arm64",
         "TARGET": "aarch64-unknown-linux-gnu",
         "PACKAGE_MANAGERS": ["pypi", "npm", "maven"],
-        "languages": ["python", "node", "java", "go", "dotnet"]
+        "languages": ["python", "node", "java", "dotnet"]
+    },
+    {
+        "OS": "ubuntu",
+        "NAMED_OS": "linux",
+        "RUNNER": "ubuntu-22.04-arm",
+        "ARCH": "arm64",
+        "TARGET": "aarch64-unknown-linux-gnu",
+        "PACKAGE_MANAGERS": ["pkg_go_dev"],
+        "run": "always",
+        "languages": ["go"]
     },
     {
         "OS": "macos",
@@ -24,7 +34,7 @@
         "RUNNER": "macos-14",
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",
-        "PACKAGE_MANAGERS": ["pypi", "npm", "maven"],
+        "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
         "languages": ["python", "node", "java", "go", "dotnet"]
     },
     {

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -1,186 +1,188 @@
 name: Go - Continuous Deployment
 
-env:
-  TESTING_VERSION: "v0.0.9"
-
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*"
-        required: true
-      pkg_go_dev_publish:
-        description: "Publish to pkg.go.dev"
-        required: true
-        type: boolean
-        default: false
+    workflow_dispatch:
+        inputs:
+            version:
+                description: "The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*"
+                required: true
+            pkg_go_dev_publish:
+                description: "Publish to pkg.go.dev"
+                required: true
+                type: boolean
+                default: false
 
 concurrency:
-  group: go-cd-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+    group: go-cd-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 permissions:
-  id-token: write
+    id-token: write
 
 jobs:
-  load-platform-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.PLATFORM_MATRIX }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    load-platform-matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.PLATFORM_MATRIX }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: load-platform-matrix
-        id: load-platform-matrix
-        shell: bash
-        run: |
-          # Get the matrix from the matrix.json file, without the object that has the IMAGE key
-          export "PLATFORM_MATRIX=$(jq 'map(select(.PACKAGE_MANAGERS | contains(["pkg_go_dev"])))' < .github/json_matrices/build-matrix.json | jq -c .)"
-          echo "PLATFORM_MATRIX=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
+            - name: load-platform-matrix
+              id: load-platform-matrix
+              shell: bash
+              run: |
+                  # Get the matrix from the matrix.json file, without the object that has the IMAGE key
+                  export "PLATFORM_MATRIX=$(jq 'map(select(.PACKAGE_MANAGERS | contains(["pkg_go_dev"])))' < .github/json_matrices/build-matrix.json | jq -c .)"
+                  echo "PLATFORM_MATRIX=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
 
-  validate-release-version:
-    runs-on: ubuntu-latest
-    outputs:
-      RELEASE_VERSION: ${{ steps.release-tag.outputs.RELEASE_VERSION }}
-    steps:
-      - name: Validate Version Agaisnt RegEx
-        run: |
-          echo "input version is: ${{ github.event.inputs.version || env.TESTING_VERSION }}"
-          if ! echo "${{ github.event.inputs.version || env.TESTING_VERSION }}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
-              echo "Version is not valid, must be v*.*.* or v*.*.*-rc*"
-              exit 1
-          fi
+    validate-release-version:
+        if: ${{ github.event.inputs.pkg_go_dev_publish }}
+        runs-on: ubuntu-latest
+        outputs:
+            RELEASE_VERSION: ${{ steps.release-tag.outputs.RELEASE_VERSION }}
+        steps:
+            - name: Validate Version Agaisnt RegEx
+              run: |
+                  echo "input version is: ${{ github.event.inputs.version }}"
+                  if ! echo "${{ github.event.inputs.version }}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
+                      echo "Version is not valid, must be v*.*.* or v*.*.*-rc*"
+                      exit 1
+                  fi
 
-      - name: Checkout for tag check
-        uses: actions/checkout@v4
+            - name: Checkout for tag check
+              uses: actions/checkout@v4
 
-      - name: Validate version agaisnt tags
-        run: |
-          git fetch --tags
-          # testing with default TESTING_VERSION to procceed to follow up jobs
-          if git tag | grep -q "^go/${{ github.event.inputs.version || env.TESTING_VERSION }}$"; then
-              echo "Version ${{ github.event.inputs.version || env.TESTING_VERSION }} already exists."
-              exit 1
-          fi
-      - name: Output release tag
-        id: release-tag
-        run: |
-          echo "RELEASE_VERSION=${{ github.event.inputs.version || env.TESTING_VERSION }}" >> $GITHUB_OUTPUT
+            - name: Validate version agaisnt tags
+              run: |
+                  git fetch --tags
+                  if git tag | grep -q "^go/${{ github.event.inputs.version }}$"; then
+                      echo "Version ${{ github.event.inputs.version }} already exists."
+                      exit 1
+                  fi
+            - name: Output release tag
+              id: release-tag
+              run: |
+                  echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
 
-  create-binaries:
-    needs: [load-platform-matrix, validate-release-version]
-    if: success() && github.repository_owner == 'valkey-io'
-    strategy:
-      fail-fast: false
-      matrix:
-        host: ${{ fromJson(needs.load-platform-matrix.outputs.PLATFORM_MATRIX)}}
-    runs-on: ${{ matrix.host.RUNNER}}
-    steps:
-      - name: Setup self-hosted runner access
-        run: |
-          GHA_HOME=/home/ubuntu/actions-runner/_work/valkey-glide
-          if [ -d $GHA_HOME ]; then
-            sudo chown -R $USER:$USER $GHA_HOME
-            sudo rm -rf $GHA_HOME
-            mkdir -p $GHA_HOME/valkey-glide
-          else
-            echo "No cleaning needed"
-          fi
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "^1.22.0"
-      - name: Install shared software dependencies
-        uses: ./.github/workflows/install-shared-dependencies
-        with:
-          os: ${{ matrix.host.OS }}
-          target: ${{ matrix.host.TARGET }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Go client
-        working-directory: go
-        run: |
-          make install-build-tools
-          make build-glide-client
-          # TODO: move generation of protobuf and header file to a non-matrix step
-          make generate-protobuf
-      - name: Upload artifacts
-        continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.host.TARGET }}
-          path: |
-            go/target/release/libglide_rs.a
-            go/lib.h
-            go/protobuf/
+    create-binaries:
+        needs: [load-platform-matrix]
+        if: success() && github.repository_owner == 'valkey-io'
+        strategy:
+            fail-fast: false
+            matrix:
+                host: ${{ fromJson(needs.load-platform-matrix.outputs.PLATFORM_MATRIX) }}
+        runs-on: ${{ matrix.host.RUNNER }}
+        steps:
+            - name: Setup self-hosted runner access
+              run: |
+                  GHA_HOME=/home/ubuntu/actions-runner/_work/valkey-glide
+                  if [ -d $GHA_HOME ]; then
+                    sudo chown -R $USER:$USER $GHA_HOME
+                    sudo rm -rf $GHA_HOME
+                    mkdir -p $GHA_HOME/valkey-glide
+                  else
+                    echo "No cleaning needed"
+                  fi
+            - uses: actions/checkout@v4
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: "^1.22.0"
+            - name: Install shared software dependencies
+              uses: ./.github/workflows/install-shared-dependencies
+              with:
+                  os: ${{ matrix.host.OS }}
+                  target: ${{ matrix.host.TARGET }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Build Go client
+              working-directory: go
+              run: |
+                  make install-build-tools
+                  make build-glide-client
+                  # TODO: move generation of protobuf and header file to a non-matrix step
+                  make generate-protobuf
+            - name: Upload artifacts
+              continue-on-error: true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ${{ matrix.host.TARGET }}
+                  path: |
+                      go/target/release/libglide_rs.a
+                      go/lib.h
+                      go/protobuf/
 
-  commit-auto-gen-files-with-tag:
-    if: ${{ github.event.inputs.pkg_go_dev_publish }}
-    needs: [validate-release-version, create-binaries]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-      - name: Copy generated files to repo
-        run: |
-          cd artifacts
-          for dir in */; do
-            target_name=${dir%/}
-            mkdir -p $GITHUB_WORKSPACE/go/rustbin/${target_name}
-            cp ${target_name}/target/release/libglide_rs.a $GITHUB_WORKSPACE/go/rustbin/${target_name}/
-          done
-          # TODO: move generation of protobuf and header file to a non-matrix step
-          cd x86_64-unknown-linux-gnu
-          cp lib.h $GITHUB_WORKSPACE/go/
-          mkdir -p $GITHUB_WORKSPACE/go/protobuf
-          cp protobuf/* $GITHUB_WORKSPACE/go/protobuf/
-      - name: Commit and push tag
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add -f .
-          git commit -m "Automated commit from GitHub Actions"
-          git tag go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
-          git push origin go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
-          GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go@${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
+    commit-auto-gen-files-with-tag:
+        if: ${{ github.event.inputs.pkg_go_dev_publish }}
+        needs: [validate-release-version, create-binaries]
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/download-artifact@v4
+              with:
+                  path: artifacts
+            - name: Copy generated files to repo
+              run: |
+                  cd artifacts
+                  for dir in */; do
+                    target_name=${dir%/}
+                    mkdir -p $GITHUB_WORKSPACE/go/rustbin/${target_name}
+                    cp ${target_name}/target/release/libglide_rs.a $GITHUB_WORKSPACE/go/rustbin/${target_name}/
+                  done
+                  # TODO: move generation of protobuf and header file to a non-matrix step
+                  cd x86_64-unknown-linux-gnu
+                  cp lib.h $GITHUB_WORKSPACE/go/
+                  mkdir -p $GITHUB_WORKSPACE/go/protobuf
+                  cp protobuf/* $GITHUB_WORKSPACE/go/protobuf/
+            - name: Commit and push tag
+              run: |
+                  git config user.name github-actions
+                  git config user.email github-actions@github.com
+                  git add -f .
+                  git commit -m "Automated commit from GitHub Actions"
+                  git tag go/${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
+                  git push origin go/${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
+                  GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go@${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
 
-  extra-post-commit-test:
-    needs: [load-platform-matrix, validate-release-version, commit-auto-gen-files-with-tag]
-    strategy:
-      fail-fast: false
-      matrix:
-        host: ${{ fromJson(needs.load-platform-matrix.outputs.PLATFORM_MATRIX)}}
-    runs-on: ${{ matrix.host.RUNNER}}
-    steps:
-      - name: Setup self-hosted runner access
-        run: |
-          GHA_HOME=/home/ubuntu/actions-runner/_work/valkey-glide
-          if [ -d $GHA_HOME ]; then
-            sudo chown -R $USER:$USER $GHA_HOME
-            sudo rm -rf $GHA_HOME
-            mkdir -p $GHA_HOME/valkey-glide
-          else
-            echo "No cleaning needed"
-          fi
-      - uses: actions/checkout@v4
-        with:
-          ref: 'go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}'
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "^1.22.0"
-      - name: Install shared software dependencies
-        uses: ./.github/workflows/install-shared-dependencies
-        with:
-          os: ${{ matrix.host.OS }}
-          target: ${{ matrix.host.TARGET }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          engine-version: "8.0"
-      - name: test go at tag
-        working-directory: go
-        run: |
-          make install-tools-go1.22.0
-          make -k unit-test integ-test
+    extra-post-commit-test:
+        needs:
+            [
+                load-platform-matrix,
+                validate-release-version,
+                commit-auto-gen-files-with-tag,
+            ]
+        strategy:
+            fail-fast: false
+            matrix:
+                host: ${{ fromJson(needs.load-platform-matrix.outputs.PLATFORM_MATRIX) }}
+        runs-on: ${{ matrix.host.RUNNER }}
+        steps:
+            - name: Setup self-hosted runner access
+              run: |
+                  GHA_HOME=/home/ubuntu/actions-runner/_work/valkey-glide
+                  if [ -d $GHA_HOME ]; then
+                    sudo chown -R $USER:$USER $GHA_HOME
+                    sudo rm -rf $GHA_HOME
+                    mkdir -p $GHA_HOME/valkey-glide
+                  else
+                    echo "No cleaning needed"
+                  fi
+            - uses: actions/checkout@v4
+              with:
+                  ref: "go/${{ needs.validate-release-version.outputs.RELEASE_VERSION }}"
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: "^1.22.0"
+            - name: Install shared software dependencies
+              uses: ./.github/workflows/install-shared-dependencies
+              with:
+                  os: ${{ matrix.host.OS }}
+                  target: ${{ matrix.host.TARGET }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  engine-version: "8.0"
+            - name: test go at tag
+              working-directory: go
+              run: |
+                  make install-tools-go1.22.0
+                  make -k unit-test integ-test

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -1,7 +1,7 @@
 name: Go - Continuous Deployment
 
 env:
-  TESTING_VERSION: "v0.0.8"
+  TESTING_VERSION: "v0.0.9"
 
 on:
   push:

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -4,9 +4,6 @@ env:
   TESTING_VERSION: "v0.0.9"
 
 on:
-  # push:
-  #   branches:
-  #     - "go/jamesx-cd"
   workflow_dispatch:
     inputs:
       version:
@@ -73,8 +70,7 @@ jobs:
 
   create-binaries:
     needs: [load-platform-matrix, validate-release-version]
-    # TODO: change repository_owner to 'valkey-io' before merge to upstream
-    if: success() && github.repository_owner == 'jamesx-improving'
+    if: success() && github.repository_owner == 'valkey-io'
     strategy:
       fail-fast: false
       matrix:
@@ -119,6 +115,7 @@ jobs:
             go/protobuf/
 
   commit-auto-gen-files-with-tag:
+    if: ${{ github.event.inputs.pkg_go_dev_publish }}
     needs: [validate-release-version, create-binaries]
     runs-on: ubuntu-latest
     permissions:
@@ -149,8 +146,7 @@ jobs:
           git commit -m "Automated commit from GitHub Actions"
           git tag go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
           git push origin go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
-          # TODO: change to valkey-io
-          GOPROXY=proxy.golang.org go list -m github.com/jamesx-improving/valkey-glide/go@${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
+          GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go@${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
 
   extra-post-commit-test:
     needs: [load-platform-matrix, validate-release-version, commit-auto-gen-files-with-tag]

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -44,7 +44,7 @@ jobs:
         env:
             INPUT_VERSION: ${{ github.event.inputs.version }}
         steps:
-            - name: Validate Version Agaisnt RegEx
+            - name: Validate Version Against RegEx
               run: |
                   echo "input version is: ${{ env.INPUT_VERSION }}"
                   if ! echo "${{ env.INPUT_VERSION }}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -4,9 +4,9 @@ env:
   TESTING_VERSION: "v0.0.9"
 
 on:
-  push:
-    branches:
-      - "go/jamesx-cd"
+  # push:
+  #   branches:
+  #     - "go/jamesx-cd"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -41,11 +41,13 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             RELEASE_VERSION: ${{ steps.release-tag.outputs.RELEASE_VERSION }}
+        env:
+            INPUT_VERSION: ${{ github.event.inputs.version }}
         steps:
             - name: Validate Version Agaisnt RegEx
               run: |
-                  echo "input version is: ${{ github.event.inputs.version }}"
-                  if ! echo "${{ github.event.inputs.version }}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
+                  echo "input version is: ${{ env.INPUT_VERSION }}"
+                  if ! echo "${{ env.INPUT_VERSION }}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
                       echo "Version is not valid, must be v*.*.* or v*.*.*-rc*"
                       exit 1
                   fi
@@ -56,14 +58,14 @@ jobs:
             - name: Validate version agaisnt tags
               run: |
                   git fetch --tags
-                  if git tag | grep -q "^go/${{ github.event.inputs.version }}$"; then
-                      echo "Version ${{ github.event.inputs.version }} already exists."
+                  if git tag | grep -q "^go/${{ env.INPUT_VERSION }}$"; then
+                      echo "Version ${{ env.INPUT_VERSION }} already exists."
                       exit 1
                   fi
             - name: Output release tag
               id: release-tag
               run: |
-                  echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+                  echo "RELEASE_VERSION=${{ env.INPUT_VERSION }}" >> $GITHUB_OUTPUT
 
     create-binaries:
         needs: [load-platform-matrix]

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -183,8 +183,25 @@ jobs:
                   target: ${{ matrix.host.TARGET }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: "8.0"
-            - name: test go at tag
-              working-directory: go
+            - name: Start standalone Valkey server
+              working-directory: utils
+              id: start-server
               run: |
-                  make install-tools-go1.22.0
-                  make -k unit-test integ-test
+                  PORT=$(python3 ./cluster_manager.py start -r 0 2>&1 | grep CLUSTER_NODES | cut -d = -f 2 | cut -d , -f 1 | cut -d : -f 2)
+                  echo "PORT=$PORT" >> $GITHUB_OUTPUT
+            - name: test newly released go client
+              env:
+                  PORT: ${{ steps.start-server.outputs.PORT }}
+              working-directory: go/benchmarks
+              run: |
+                  # change go/benchmarks/go.mod on the fly
+                  export ESCAPED_VERSION=$(echo "${{ needs.validate-release-version.outputs.RELEASE_VERSION }}" | sed 's/\./\\./g')
+                  if [[ "${{ matrix.host.OS }}" == "macos" ]]; then
+                      sed -i '' '/replace github\.com\/valkey-io\/valkey-glide\/go/d' go.mod
+                      sed -i '' "s/github\.com\/valkey-io\/valkey-glide\/go v0\.0\.0/github.com\/valkey-io\/valkey-glide\/go $ESCAPED_VERSION/g" go.mod
+                  else
+                      sed -i '/replace github\.com\/valkey-io\/valkey-glide\/go/d' go.mod
+                      sed -i "s/github\.com\/valkey-io\/valkey-glide\/go v0\.0\.0/github.com\/valkey-io\/valkey-glide\/go $ESCAPED_VERSION/g" go.mod
+                  fi
+                  go mod tidy
+                  go run . -minimal -clients glide -concurrentTasks 10 -port ${{ env.PORT }}

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -1,0 +1,190 @@
+name: Go - Continuous Deployment
+
+env:
+  TESTING_VERSION: "v0.0.8"
+
+on:
+  push:
+    branches:
+      - "go/jamesx-cd"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The release version of GLIDE, formatted as v*.*.* or v*.*.*-rc*"
+        required: true
+      pkg_go_dev_publish:
+        description: "Publish to pkg.go.dev"
+        required: true
+        type: boolean
+        default: false
+
+concurrency:
+  group: go-cd-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+
+jobs:
+  load-platform-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.PLATFORM_MATRIX }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: load-platform-matrix
+        id: load-platform-matrix
+        shell: bash
+        run: |
+          # Get the matrix from the matrix.json file, without the object that has the IMAGE key
+          export "PLATFORM_MATRIX=$(jq 'map(select(.PACKAGE_MANAGERS | contains(["pkg_go_dev"])))' < .github/json_matrices/build-matrix.json | jq -c .)"
+          echo "PLATFORM_MATRIX=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
+
+  validate-release-version:
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.release-tag.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Validate Version Agaisnt RegEx
+        run: |
+          echo "input version is: ${{ github.event.inputs.version || env.TESTING_VERSION }}"
+          if ! echo "${{ github.event.inputs.version || env.TESTING_VERSION }}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
+              echo "Version is not valid, must be v*.*.* or v*.*.*-rc*"
+              exit 1
+          fi
+
+      - name: Checkout for tag check
+        uses: actions/checkout@v4
+
+      - name: Validate version agaisnt tags
+        run: |
+          git fetch --tags
+          # testing with default TESTING_VERSION to procceed to follow up jobs
+          if git tag | grep -q "^go/${{ github.event.inputs.version || env.TESTING_VERSION }}$"; then
+              echo "Version ${{ github.event.inputs.version || env.TESTING_VERSION }} already exists."
+              exit 1
+          fi
+      - name: Output release tag
+        id: release-tag
+        run: |
+          echo "RELEASE_VERSION=${{ github.event.inputs.version || env.TESTING_VERSION }}" >> $GITHUB_OUTPUT
+
+  create-binaries:
+    needs: [load-platform-matrix, validate-release-version]
+    # TODO: change repository_owner to 'valkey-io' before merge to upstream
+    if: success() && github.repository_owner == 'jamesx-improving'
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.load-platform-matrix.outputs.PLATFORM_MATRIX)}}
+    runs-on: ${{ matrix.host.RUNNER}}
+    steps:
+      - name: Setup self-hosted runner access
+        run: |
+          GHA_HOME=/home/ubuntu/actions-runner/_work/valkey-glide
+          if [ -d $GHA_HOME ]; then
+            sudo chown -R $USER:$USER $GHA_HOME
+            sudo rm -rf $GHA_HOME
+            mkdir -p $GHA_HOME/valkey-glide
+          else
+            echo "No cleaning needed"
+          fi
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "^1.22.0"
+      - name: Install shared software dependencies
+        uses: ./.github/workflows/install-shared-dependencies
+        with:
+          os: ${{ matrix.host.OS }}
+          target: ${{ matrix.host.TARGET }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Go client
+        working-directory: go
+        run: |
+          make install-build-tools
+          make build-glide-client
+          # TODO: move generation of protobuf and header file to a non-matrix step
+          make generate-protobuf
+      - name: Upload artifacts
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.host.TARGET }}
+          path: |
+            go/target/release/libglide_rs.a
+            go/lib.h
+            go/protobuf/
+
+  commit-auto-gen-files-with-tag:
+    needs: [validate-release-version, create-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Copy generated files to repo
+        run: |
+          cd artifacts
+          for dir in */; do
+            target_name=${dir%/}
+            mkdir -p $GITHUB_WORKSPACE/go/rustbin/${target_name}
+            cp ${target_name}/target/release/libglide_rs.a $GITHUB_WORKSPACE/go/rustbin/${target_name}/
+          done
+          # TODO: move generation of protobuf and header file to a non-matrix step
+          cd x86_64-unknown-linux-gnu
+          cp lib.h $GITHUB_WORKSPACE/go/
+          mkdir -p $GITHUB_WORKSPACE/go/protobuf
+          cp protobuf/* $GITHUB_WORKSPACE/go/protobuf/
+      - name: Commit and push tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add -f .
+          git commit -m "Automated commit from GitHub Actions"
+          git tag go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
+          git push origin go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
+          # TODO: change to valkey-io
+          GOPROXY=proxy.golang.org go list -m github.com/jamesx-improving/valkey-glide/go@${{ needs.validate-release-version.outputs.RELEASE_VERSION}}
+
+  extra-post-commit-test:
+    needs: [load-platform-matrix, validate-release-version, commit-auto-gen-files-with-tag]
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.load-platform-matrix.outputs.PLATFORM_MATRIX)}}
+    runs-on: ${{ matrix.host.RUNNER}}
+    steps:
+      - name: Setup self-hosted runner access
+        run: |
+          GHA_HOME=/home/ubuntu/actions-runner/_work/valkey-glide
+          if [ -d $GHA_HOME ]; then
+            sudo chown -R $USER:$USER $GHA_HOME
+            sudo rm -rf $GHA_HOME
+            mkdir -p $GHA_HOME/valkey-glide
+          else
+            echo "No cleaning needed"
+          fi
+      - uses: actions/checkout@v4
+        with:
+          ref: 'go/${{ needs.validate-release-version.outputs.RELEASE_VERSION}}'
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "^1.22.0"
+      - name: Install shared software dependencies
+        uses: ./.github/workflows/install-shared-dependencies
+        with:
+          os: ${{ matrix.host.OS }}
+          target: ${{ matrix.host.TARGET }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          engine-version: "8.0"
+      - name: test go at tag
+        working-directory: go
+        run: |
+          make install-tools-go1.22.0
+          make -k unit-test integ-test

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -10,3 +10,6 @@ lib.h
 benchmarks/results/**
 benchmarks/gobenchmarks.json
 benchmarks/benchmarks
+
+# compiled static library file
+*.a

--- a/go/Cargo.toml
+++ b/go/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 authors = ["Valkey GLIDE Maintainers"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["staticlib"]
 
 [dependencies]
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "connection-manager", "tokio-rustls-comp"] }

--- a/go/Makefile
+++ b/go/Makefile
@@ -46,19 +46,25 @@ clean:
 
 build-glide-client:
 	cargo build --release
-	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h
+	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h --lang c
+	if [ "$$(uname)" = "Darwin" ]; then \
+		strip -x target/release/libglide_rs.a; \
+	else \
+		strip --strip-unneeded target/release/libglide_rs.a; \
+	fi
+		
 
 build-glide-client-debug:
 	cargo build
-	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h
+	cbindgen --config cbindgen.toml --crate glide-rs --output lib.h --lang c
 
 generate-protobuf:
 	rm -rf protobuf
 	mkdir -p protobuf
 	protoc --proto_path=../glide-core/src/protobuf \
-		--go_opt=Mconnection_request.proto=github.com/valkey-io/valkey-glide/go/protobuf \
-		--go_opt=Mcommand_request.proto=github.com/valkey-io/valkey-glide/go/protobuf \
-		--go_opt=Mresponse.proto=github.com/valkey-io/valkey-glide/go/protobuf \
+		--go_opt=Mconnection_request.proto=github.com/jamesx-improving/valkey-glide/go/protobuf \
+		--go_opt=Mcommand_request.proto=github.com/jamesx-improving/valkey-glide/go/protobuf \
+		--go_opt=Mresponse.proto=github.com/jamesx-improving/valkey-glide/go/protobuf \
 		--go_out=./protobuf \
 		--go_opt=paths=source_relative \
 		../glide-core/src/protobuf/*.proto
@@ -81,9 +87,9 @@ format:
 unit-test:
 	mkdir -p reports
 	set -o pipefail; \
-	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.so|grep -w release|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
+	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.a|grep -w release|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
 	go test -v -race ./... -skip TestGlideTestSuite $(if $(test-filter), -testify.m $(test-filter)) \
-	| tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/glide/utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
+	| tee >(go tool test2json -t -p github.com/jamesx-improving/valkey-glide/go/utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
 
 # integration tests - run subtask with skipping modules tests
 integ-test: export TEST_FILTER = -skip TestGlideTestSuite/TestModule $(if $(test-filter), -testify.m $(test-filter))
@@ -96,12 +102,12 @@ modules-test: __it
 __it:
 	mkdir -p reports
 	set -o pipefail; \
-	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.so|grep -w release|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
+	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.a|grep -w release|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
 	go test -v -race ./integTest/... \
 	$(TEST_FILTER) \
 	$(if $(filter true, $(tls)), --tls,) \
 	$(if $(standalone-endpoints), --standalone-endpoints=$(standalone-endpoints)) \
 	$(if $(cluster-endpoints), --cluster-endpoints=$(cluster-endpoints)) \
-	| tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/glide/integTest | go-test-report -o reports/integ-tests.html -t integ-test > /dev/null)
+	| tee >(go tool test2json -t -p github.com/jamesx-improving/valkey-glide/go/integTest | go-test-report -o reports/integ-tests.html -t integ-test > /dev/null)
 # code above ^ is similar to `go test .... -json | go-test-report ....`, but it also prints plain text output to stdout
 # `go test` prints plain text, tee duplicates it to stdout and to `test2json` which is coupled with `go-test-report` to generate the report

--- a/go/Makefile
+++ b/go/Makefile
@@ -62,9 +62,9 @@ generate-protobuf:
 	rm -rf protobuf
 	mkdir -p protobuf
 	protoc --proto_path=../glide-core/src/protobuf \
-		--go_opt=Mconnection_request.proto=github.com/jamesx-improving/valkey-glide/go/protobuf \
-		--go_opt=Mcommand_request.proto=github.com/jamesx-improving/valkey-glide/go/protobuf \
-		--go_opt=Mresponse.proto=github.com/jamesx-improving/valkey-glide/go/protobuf \
+		--go_opt=Mconnection_request.proto=github.com/valkey-io/valkey-glide/go/protobuf \
+		--go_opt=Mcommand_request.proto=github.com/valkey-io/valkey-glide/go/protobuf \
+		--go_opt=Mresponse.proto=github.com/valkey-io/valkey-glide/go/protobuf \
 		--go_out=./protobuf \
 		--go_opt=paths=source_relative \
 		../glide-core/src/protobuf/*.proto
@@ -89,7 +89,7 @@ unit-test:
 	set -o pipefail; \
 	LD_LIBRARY_PATH=$(shell find . -name libglide_rs.a|grep -w release|tail -1|xargs dirname|xargs readlink -f):${LD_LIBRARY_PATH} \
 	go test -v -race ./... -skip TestGlideTestSuite $(if $(test-filter), -testify.m $(test-filter)) \
-	| tee >(go tool test2json -t -p github.com/jamesx-improving/valkey-glide/go/utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
+	| tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
 
 # integration tests - run subtask with skipping modules tests
 integ-test: export TEST_FILTER = -skip TestGlideTestSuite/TestModule $(if $(test-filter), -testify.m $(test-filter))
@@ -108,6 +108,6 @@ __it:
 	$(if $(filter true, $(tls)), --tls,) \
 	$(if $(standalone-endpoints), --standalone-endpoints=$(standalone-endpoints)) \
 	$(if $(cluster-endpoints), --cluster-endpoints=$(cluster-endpoints)) \
-	| tee >(go tool test2json -t -p github.com/jamesx-improving/valkey-glide/go/integTest | go-test-report -o reports/integ-tests.html -t integ-test > /dev/null)
+	| tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/integTest | go-test-report -o reports/integ-tests.html -t integ-test > /dev/null)
 # code above ^ is similar to `go test .... -json | go-test-report ....`, but it also prints plain text output to stdout
 # `go test` prints plain text, tee duplicates it to stdout and to `test2json` which is coupled with `go-test-report` to generate the report

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"unsafe"
 
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/jamesx-improving/valkey-glide/go/utils"
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
-	"github.com/jamesx-improving/valkey-glide/go/protobuf"
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/api/config"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
+	"github.com/valkey-io/valkey-glide/go/api/options"
+	"github.com/valkey-io/valkey-glide/go/protobuf"
+	"github.com/valkey-io/valkey-glide/go/utils"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -2,7 +2,13 @@
 
 package api
 
-// #cgo LDFLAGS: -L../target/release -lglide_rs
+// #cgo LDFLAGS: -lglide_rs
+// #cgo !windows LDFLAGS: -lm
+// #cgo darwin LDFLAGS: -framework Security
+// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
+// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
+// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
+// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 //
 // void successCallback(void *channelPtr, struct CommandResponse *message);
@@ -15,11 +21,11 @@ import (
 	"strconv"
 	"unsafe"
 
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
+	"github.com/jamesx-improving/valkey-glide/go/protobuf"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 	"github.com/valkey-io/valkey-glide/go/glide/api/config"
 	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
-	"github.com/valkey-io/valkey-glide/go/glide/protobuf"
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/go/api/bitmap_commands.go
+++ b/go/api/bitmap_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Bitmap" group of commands for standalone and cluster clients.
 //

--- a/go/api/bitmap_commands.go
+++ b/go/api/bitmap_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Bitmap" group of commands for standalone and cluster clients.
 //

--- a/go/api/command_options.go
+++ b/go/api/command_options.go
@@ -5,9 +5,9 @@ package api
 import (
 	"strconv"
 
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/api/config"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 // SetOptions represents optional arguments for the [api.StringCommands.SetWithOptions] command.

--- a/go/api/command_options.go
+++ b/go/api/command_options.go
@@ -5,9 +5,9 @@ package api
 import (
 	"strconv"
 
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 	"github.com/jamesx-improving/valkey-glide/go/utils"
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 )
 
 // SetOptions represents optional arguments for the [api.StringCommands.SetWithOptions] command.

--- a/go/api/command_options.go
+++ b/go/api/command_options.go
@@ -5,9 +5,9 @@ package api
 import (
 	"strconv"
 
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 	"github.com/valkey-io/valkey-glide/go/glide/api/config"
 	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
 )
 
 // SetOptions represents optional arguments for the [api.StringCommands.SetWithOptions] command.

--- a/go/api/config.go
+++ b/go/api/config.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/protobuf"
+import "github.com/jamesx-improving/valkey-glide/go/protobuf"
 
 const (
 	defaultHost = "localhost"

--- a/go/api/config.go
+++ b/go/api/config.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/protobuf"
+import "github.com/valkey-io/valkey-glide/go/protobuf"
 
 const (
 	defaultHost = "localhost"

--- a/go/api/config/request_routing_config.go
+++ b/go/api/config/request_routing_config.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
-	"github.com/valkey-io/valkey-glide/go/glide/protobuf"
 )
 
 // Request routing basic interface. Please use one of the following:

--- a/go/api/config/request_routing_config.go
+++ b/go/api/config/request_routing_config.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 	"github.com/jamesx-improving/valkey-glide/go/protobuf"
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 )
 
 // Request routing basic interface. Please use one of the following:

--- a/go/api/config/request_routing_config.go
+++ b/go/api/config/request_routing_config.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
-	"github.com/jamesx-improving/valkey-glide/go/protobuf"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
+	"github.com/valkey-io/valkey-glide/go/protobuf"
 )
 
 // Request routing basic interface. Please use one of the following:

--- a/go/api/config_test.go
+++ b/go/api/config_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/protobuf"
 )
 
 func TestDefaultStandaloneConfig(t *testing.T) {

--- a/go/api/config_test.go
+++ b/go/api/config_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/protobuf"
 )
 
 func TestDefaultStandaloneConfig(t *testing.T) {

--- a/go/api/connection_management_cluster_commands.go
+++ b/go/api/connection_management_cluster_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Connection Management" group of commands for cluster client.
 //

--- a/go/api/connection_management_cluster_commands.go
+++ b/go/api/connection_management_cluster_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Connection Management" group of commands for cluster client.
 //

--- a/go/api/connection_management_commands.go
+++ b/go/api/connection_management_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Connection Management" group of commands for standalone client.
 //

--- a/go/api/connection_management_commands.go
+++ b/go/api/connection_management_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Connection Management" group of commands for standalone client.
 //

--- a/go/api/errors/errors.go
+++ b/go/api/errors/errors.go
@@ -2,7 +2,13 @@
 
 package errors
 
-// #cgo LDFLAGS: -L../target/release -lglide_rs
+// #cgo LDFLAGS: -lglide_rs
+// #cgo !windows LDFLAGS: -lm
+// #cgo darwin LDFLAGS: -framework Security
+// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
+// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
+// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
+// #cgo LDFLAGS: -L../target/release
 // #include "../../lib.h"
 import "C"
 

--- a/go/api/generic_base_commands.go
+++ b/go/api/generic_base_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Generic Commands" group for standalone and cluster clients.
 //

--- a/go/api/generic_base_commands.go
+++ b/go/api/generic_base_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Generic Commands" group for standalone and cluster clients.
 //

--- a/go/api/generic_cluster_commands.go
+++ b/go/api/generic_cluster_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/config"
+import "github.com/jamesx-improving/valkey-glide/go/api/config"
 
 // GenericClusterCommands supports commands for the "Generic Commands" group for cluster client.
 //

--- a/go/api/generic_cluster_commands.go
+++ b/go/api/generic_cluster_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/config"
+import "github.com/valkey-io/valkey-glide/go/api/config"
 
 // GenericClusterCommands supports commands for the "Generic Commands" group for cluster client.
 //

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -2,13 +2,19 @@
 
 package api
 
-// #cgo LDFLAGS: -L../target/release -lglide_rs
+// #cgo LDFLAGS: -lglide_rs
+// #cgo !windows LDFLAGS: -lm
+// #cgo darwin LDFLAGS: -framework Security
+// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
+// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
+// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
+// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 import "C"
 
 import (
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 	"github.com/valkey-io/valkey-glide/go/glide/api/options"
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
 )
 
 // GlideClient interface compliance check.

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -13,8 +13,8 @@ package api
 import "C"
 
 import (
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/jamesx-improving/valkey-glide/go/utils"
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
 )
 
 // GlideClient interface compliance check.

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -13,8 +13,8 @@ package api
 import "C"
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/api/options"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 // GlideClient interface compliance check.

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -2,7 +2,13 @@
 
 package api
 
-// #cgo LDFLAGS: -L../target/release -lglide_rs
+// #cgo LDFLAGS: -lglide_rs
+// #cgo !windows LDFLAGS: -lm
+// #cgo darwin LDFLAGS: -framework Security
+// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
+// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
+// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
+// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 import "C"
 

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -13,8 +13,8 @@ package api
 import "C"
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
 )
 
 // GlideClusterClient interface compliance check.

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -13,8 +13,8 @@ package api
 import "C"
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
+	"github.com/valkey-io/valkey-glide/go/api/config"
+	"github.com/valkey-io/valkey-glide/go/api/options"
 )
 
 // GlideClusterClient interface compliance check.

--- a/go/api/hash_commands.go
+++ b/go/api/hash_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Hash" group of commands for standalone and cluster clients.
 //

--- a/go/api/hash_commands.go
+++ b/go/api/hash_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Hash" group of commands for standalone and cluster clients.
 //

--- a/go/api/options/bitcount_options.go
+++ b/go/api/options/bitcount_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 type BitmapIndexType string

--- a/go/api/options/bitcount_options.go
+++ b/go/api/options/bitcount_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 type BitmapIndexType string

--- a/go/api/options/bitfield_options.go
+++ b/go/api/options/bitfield_options.go
@@ -1,7 +1,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 // Subcommands for bitfield operations.

--- a/go/api/options/bitfield_options.go
+++ b/go/api/options/bitfield_options.go
@@ -1,7 +1,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 // Subcommands for bitfield operations.

--- a/go/api/options/db_size_options.go
+++ b/go/api/options/db_size_options.go
@@ -1,6 +1,6 @@
 package options
 
-import "github.com/jamesx-improving/valkey-glide/go/api/config"
+import "github.com/valkey-io/valkey-glide/go/api/config"
 
 type DBSizeOptions struct {
 	Route config.Route

--- a/go/api/options/db_size_options.go
+++ b/go/api/options/db_size_options.go
@@ -1,6 +1,6 @@
 package options
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/config"
+import "github.com/jamesx-improving/valkey-glide/go/api/config"
 
 type DBSizeOptions struct {
 	Route config.Route

--- a/go/api/options/ping_options.go
+++ b/go/api/options/ping_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
 )
 
 // Optional arguments for `Ping` for standalone client

--- a/go/api/options/ping_options.go
+++ b/go/api/options/ping_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
+	"github.com/valkey-io/valkey-glide/go/api/config"
 )
 
 // Optional arguments for `Ping` for standalone client

--- a/go/api/options/route_options.go
+++ b/go/api/options/route_options.go
@@ -2,7 +2,7 @@
 
 package options
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/config"
+import "github.com/jamesx-improving/valkey-glide/go/api/config"
 
 // An extension to command option types with Routes
 type RouteOption struct {

--- a/go/api/options/route_options.go
+++ b/go/api/options/route_options.go
@@ -2,7 +2,7 @@
 
 package options
 
-import "github.com/jamesx-improving/valkey-glide/go/api/config"
+import "github.com/valkey-io/valkey-glide/go/api/config"
 
 // An extension to command option types with Routes
 type RouteOption struct {

--- a/go/api/options/sort_options.go
+++ b/go/api/options/sort_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 const (

--- a/go/api/options/sort_options.go
+++ b/go/api/options/sort_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 const (

--- a/go/api/options/stream_options.go
+++ b/go/api/options/stream_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 type triStateBool int

--- a/go/api/options/stream_options.go
+++ b/go/api/options/stream_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 type triStateBool int

--- a/go/api/options/weight_aggregate_options.go
+++ b/go/api/options/weight_aggregate_options.go
@@ -2,7 +2,7 @@
 
 package options
 
-import "github.com/jamesx-improving/valkey-glide/go/utils"
+import "github.com/valkey-io/valkey-glide/go/utils"
 
 // Aggregate represents the method of aggregating scores from multiple sets
 type Aggregate string

--- a/go/api/options/weight_aggregate_options.go
+++ b/go/api/options/weight_aggregate_options.go
@@ -2,7 +2,7 @@
 
 package options
 
-import "github.com/valkey-io/valkey-glide/go/glide/utils"
+import "github.com/jamesx-improving/valkey-glide/go/utils"
 
 // Aggregate represents the method of aggregating scores from multiple sets
 type Aggregate string

--- a/go/api/options/zadd_options.go
+++ b/go/api/options/zadd_options.go
@@ -5,7 +5,7 @@ package options
 import (
 	"errors"
 
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 // Optional arguments to `ZAdd` in [SortedSetCommands]

--- a/go/api/options/zadd_options.go
+++ b/go/api/options/zadd_options.go
@@ -5,7 +5,7 @@ package options
 import (
 	"errors"
 
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 // Optional arguments to `ZAdd` in [SortedSetCommands]

--- a/go/api/options/zmpop_options.go
+++ b/go/api/options/zmpop_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 // Optional arguments for `ZMPop` and `BZMPop` in [SortedSetCommands]

--- a/go/api/options/zmpop_options.go
+++ b/go/api/options/zmpop_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 // Optional arguments for `ZMPop` and `BZMPop` in [SortedSetCommands]

--- a/go/api/options/zrange_options.go
+++ b/go/api/options/zrange_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/utils"
+	"github.com/jamesx-improving/valkey-glide/go/utils"
 )
 
 // Query for `ZRange` in [SortedSetCommands]

--- a/go/api/options/zrange_options.go
+++ b/go/api/options/zrange_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/utils"
+	"github.com/valkey-io/valkey-glide/go/utils"
 )
 
 // Query for `ZRange` in [SortedSetCommands]

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -2,7 +2,13 @@
 
 package api
 
-// #cgo LDFLAGS: -L../target/release -lglide_rs
+// #cgo LDFLAGS: -lglide_rs
+// #cgo !windows LDFLAGS: -lm
+// #cgo darwin LDFLAGS: -framework Security
+// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
+// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
+// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
+// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 import "C"
 

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
 )
 
 func checkResponseType(response *C.struct_CommandResponse, expectedType C.ResponseType, isNilable bool) error {

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 )
 
 func checkResponseType(response *C.struct_CommandResponse, expectedType C.ResponseType, isNilable bool) error {

--- a/go/api/server_management_cluster_commands.go
+++ b/go/api/server_management_cluster_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // ServerManagementCommands supports commands for the "Server Management" group for a cluster client.
 //

--- a/go/api/server_management_cluster_commands.go
+++ b/go/api/server_management_cluster_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // ServerManagementCommands supports commands for the "Server Management" group for a cluster client.
 //

--- a/go/api/set_commands.go
+++ b/go/api/set_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Set" group of commands for standalone and cluster clients.
 //

--- a/go/api/set_commands.go
+++ b/go/api/set_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Set" group of commands for standalone and cluster clients.
 //

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -3,7 +3,7 @@
 package api
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
+	"github.com/valkey-io/valkey-glide/go/api/options"
 )
 
 // SortedSetCommands supports commands and transactions for the "Sorted Set Commands" group for standalone and cluster clients.

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -3,7 +3,7 @@
 package api
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
 )
 
 // SortedSetCommands supports commands and transactions for the "Sorted Set Commands" group for standalone and cluster clients.

--- a/go/api/stream_commands.go
+++ b/go/api/stream_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/jamesx-improving/valkey-glide/go/api/options"
+import "github.com/valkey-io/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Stream" group of commands for standalone and cluster clients.
 //

--- a/go/api/stream_commands.go
+++ b/go/api/stream_commands.go
@@ -2,7 +2,7 @@
 
 package api
 
-import "github.com/valkey-io/valkey-glide/go/glide/api/options"
+import "github.com/jamesx-improving/valkey-glide/go/api/options"
 
 // Supports commands and transactions for the "Stream" group of commands for standalone and cluster clients.
 //

--- a/go/benchmarks/glide_benchmark_client.go
+++ b/go/benchmarks/glide_benchmark_client.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api"
 )
 
 type glideBenchmarkClient struct {

--- a/go/benchmarks/glide_benchmark_client.go
+++ b/go/benchmarks/glide_benchmark_client.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/valkey-io/valkey-glide/go/glide/api"
+	"github.com/jamesx-improving/valkey-glide/go/api"
 )
 
 type glideBenchmarkClient struct {

--- a/go/benchmarks/go.mod
+++ b/go/benchmarks/go.mod
@@ -1,11 +1,11 @@
-module github.com/valkey-io/valkey-glide/go/glide/benchmarks
+module github.com/jamesx-improving/valkey-glide/go/benchmarks
 
 go 1.20
 
-replace github.com/valkey-io/valkey-glide/go/glide => ../
+replace github.com/jamesx-improving/valkey-glide/go => ../
 
 require (
-	github.com/valkey-io/valkey-glide/go/glide v0.0.0
+	github.com/jamesx-improving/valkey-glide/go v0.0.0
 	github.com/redis/go-redis/v9 v9.5.1
 )
 

--- a/go/benchmarks/go.mod
+++ b/go/benchmarks/go.mod
@@ -1,11 +1,11 @@
-module github.com/jamesx-improving/valkey-glide/go/benchmarks
+module github.com/valkey-io/valkey-glide/go/benchmarks
 
 go 1.20
 
-replace github.com/jamesx-improving/valkey-glide/go => ../
+replace github.com/valkey-io/valkey-glide/go => ../
 
 require (
-	github.com/jamesx-improving/valkey-glide/go v0.0.0
+	github.com/valkey-io/valkey-glide/go v0.0.0
 	github.com/redis/go-redis/v9 v9.5.1
 )
 

--- a/go/examples/main.go
+++ b/go/examples/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/valkey-io/valkey-glide/go/glide/api"
+	"github.com/jamesx-improving/valkey-glide/go/api"
 )
 
 // TODO: Update the file based on the template used in other clients.

--- a/go/examples/main.go
+++ b/go/examples/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api"
 )
 
 // TODO: Update the file based on the template used in other clients.

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/jamesx-improving/valkey-glide/go
+module github.com/valkey-io/valkey-glide/go
 
 go 1.20
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/valkey-io/valkey-glide/go/glide
+module github.com/jamesx-improving/valkey-glide/go
 
 go 1.20
 

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -5,10 +5,10 @@ package integTest
 import (
 	"strings"
 
-	"github.com/jamesx-improving/valkey-glide/go/api"
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api/config"
+	"github.com/valkey-io/valkey-glide/go/api/options"
 )
 
 func (suite *GlideTestSuite) TestClusterCustomCommandInfo() {

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -5,10 +5,10 @@ package integTest
 import (
 	"strings"
 
+	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
 )
 
 func (suite *GlideTestSuite) TestClusterCustomCommandInfo() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -4,8 +4,8 @@ package integTest
 
 import (
 	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 )
 
 func (suite *GlideTestSuite) TestStandaloneConnect() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -3,9 +3,9 @@
 package integTest
 
 import (
-	"github.com/jamesx-improving/valkey-glide/go/api"
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
 )
 
 func (suite *GlideTestSuite) TestStandaloneConnect() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -3,8 +3,8 @@
 package integTest
 
 import (
+	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
 	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 )
 

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jamesx-improving/valkey-glide/go/api"
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"github.com/valkey-io/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api/config"
 )
 
 type GlideTestSuite struct {

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 
 	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
 )
 
 type GlideTestSuite struct {

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
 	"github.com/valkey-io/valkey-glide/go/glide/api/config"
 )
 

--- a/go/integTest/json_module_test.go
+++ b/go/integTest/json_module_test.go
@@ -5,8 +5,8 @@ package integTest
 import (
 	"strings"
 
-	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/api"
 )
 
 func (suite *GlideTestSuite) TestModuleVerifyJsonLoaded() {

--- a/go/integTest/json_module_test.go
+++ b/go/integTest/json_module_test.go
@@ -5,8 +5,8 @@ package integTest
 import (
 	"strings"
 
+	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
 )
 
 func (suite *GlideTestSuite) TestModuleVerifyJsonLoaded() {

--- a/go/integTest/request_routing_config_test.go
+++ b/go/integTest/request_routing_config_test.go
@@ -5,9 +5,9 @@ package integTest
 import (
 	"testing"
 
+	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/valkey-io/valkey-glide/go/glide/api/config"
-	"github.com/valkey-io/valkey-glide/go/glide/protobuf"
 )
 
 func TestSimpleNodeRoute(t *testing.T) {

--- a/go/integTest/request_routing_config_test.go
+++ b/go/integTest/request_routing_config_test.go
@@ -5,9 +5,9 @@ package integTest
 import (
 	"testing"
 
+	"github.com/jamesx-improving/valkey-glide/go/api/config"
 	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api/config"
 )
 
 func TestSimpleNodeRoute(t *testing.T) {

--- a/go/integTest/request_routing_config_test.go
+++ b/go/integTest/request_routing_config_test.go
@@ -5,9 +5,9 @@ package integTest
 import (
 	"testing"
 
-	"github.com/jamesx-improving/valkey-glide/go/api/config"
-	"github.com/jamesx-improving/valkey-glide/go/protobuf"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/api/config"
+	"github.com/valkey-io/valkey-glide/go/protobuf"
 )
 
 func TestSimpleNodeRoute(t *testing.T) {

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jamesx-improving/valkey-glide/go/api"
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
+	"github.com/valkey-io/valkey-glide/go/api/options"
 )
 
 const (

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
 	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
 )
 
 const (

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jamesx-improving/valkey-glide/go/api"
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
 	"github.com/jamesx-improving/valkey-glide/go/api/options"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 )
 
 const (

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jamesx-improving/valkey-glide/go/api"
-	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
-	"github.com/valkey-io/valkey-glide/go/glide/api/options"
+	"github.com/jamesx-improving/valkey-glide/go/api/errors"
+	"github.com/jamesx-improving/valkey-glide/go/api/options"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jamesx-improving/valkey-glide/go/api"
-	"github.com/jamesx-improving/valkey-glide/go/api/errors"
-	"github.com/jamesx-improving/valkey-glide/go/api/options"
+	"github.com/valkey-io/valkey-glide/go/api"
+	"github.com/valkey-io/valkey-glide/go/api/errors"
+	"github.com/valkey-io/valkey-glide/go/api/options"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
+	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/valkey-io/valkey-glide/go/glide/api/errors"
 	"github.com/valkey-io/valkey-glide/go/glide/api/options"
 

--- a/go/integTest/vss_module_test.go
+++ b/go/integTest/vss_module_test.go
@@ -5,8 +5,8 @@ package integTest
 import (
 	"strings"
 
+	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/glide/api"
 )
 
 func (suite *GlideTestSuite) TestModuleVerifyVssLoaded() {

--- a/go/integTest/vss_module_test.go
+++ b/go/integTest/vss_module_test.go
@@ -5,8 +5,8 @@ package integTest
 import (
 	"strings"
 
-	"github.com/jamesx-improving/valkey-glide/go/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/api"
 )
 
 func (suite *GlideTestSuite) TestModuleVerifyVssLoaded() {


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3051

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.

This workflow publish Valkey-GLIDE's Go client with the given version number.

![image](https://github.com/user-attachments/assets/2159acb6-52a0-45b1-8636-f39c2d36fda9)

It loads the supported platforms of Go from `build-matrix.json`, then build the `.a` binary files and other nesessary auto-generated files, including protobuf generated `.pb.go` files as well as `lib.h` header file, on all platforms, and evetually commit and push these files on a git tag. Note that this specific for-release-only commit/tag is not part of any branch, but an isolated commit. They only way to refer to this commit (apart from its commit hash of course) is this tag. This design is to minimize the existance of binary and auto-generated files in our repo.

As the official Go package management system essentially uses a distribute-by-source-code mechanism, meaning there's no "artifact" you can precompile, pack and release. Instead, your github repo, specifically the tag with the version info, is your release, which means the options left for corss languages project like us is to either include binary files in the repo, or require ALL end users to install the rust toolchain and compile our rust code on their own machine. We chose the former, as it seems to be the easier option for the end user.