### PR TITLE
Fix flaky test set for more margine for ttl

### DIFF
--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -8108,7 +8108,7 @@ export function runBaseTests(config: {
         const setWithUnixSec = await client.set(key, value, {
             expiry: {
                 type: TimeUnit.UnixSeconds,
-                count: Math.floor(Date.now() / 1000) + 1,
+                count: Math.floor(Date.now() / 1000) + 2,
             },
         });
         expect(setWithUnixSec).toEqual("OK");
@@ -8122,7 +8122,7 @@ export function runBaseTests(config: {
         const getResWithExpiryKeep = await client.get(key);
         expect(getResWithExpiryKeep).toEqual(value);
         // wait for the key to expire base on the previous set
-        let sleep = new Promise((resolve) => setTimeout(resolve, 1000));
+        let sleep = new Promise((resolve) => setTimeout(resolve, 2000));
         await sleep;
         const getResExpire = await client.get(key);
         // key should have expired


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link
#3061 
Flakiness is happening on ephemeral only, which has less compute power, so potentially having CPU throttling while running long tests suite.
Using the exact second for TTL, in case of throttling, might not be enough margin, and while the next command arrive to the server the second already changed. Note that we use exact, and not how long it will live, meaning in some cases the next second is just a few ms away.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
