### PR TITLE
Go: Fix flaky test.

### DIFF
--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -6579,7 +6579,7 @@ func (suite *GlideTestSuite) TestObjectIdleTime() {
 		time.Sleep(time.Duration(sleepSec) * time.Second)
 		resultIdleTime, err := defaultClient.ObjectIdleTime(key)
 		assert.Nil(t, err)
-		assert.GreaterOrEqual(t, resultIdleTime.Value(), sleepSec)
+		assert.GreaterOrEqual(t, resultIdleTime.Value(), sleepSec - 1)
 	})
 }
 


### PR DESCRIPTION
Sometimes `TestObjectIdleTime` fails:

```
=== NAME  TestGlideTestSuite/TestObjectIdleTime
    shared_commands_test.go:6339: 
        	Error Trace:	/home/runner/work/valkey-glide/valkey-glide/go/integTest/shared_commands_test.go:6582
        	            				/home/runner/work/valkey-glide/valkey-glide/go/integTest/glide_test_suite_test.go:269
        	Error:      	"4" is not greater than or equal to "5"
        	Test:       	TestGlideTestSuite/TestObjectIdleTime
```