### PR TITLE
Go: refactoring API

### DIFF
--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -4306,12 +4306,17 @@ func (client *baseClient) ZPopMin(key string) (map[string]float64, error) {
 //
 // Example:
 //
-//	res, err := client.ZPopMinWithCount("mySortedSet", 2)
+//	opts := NewZPopOptions().SetCount(2)
+//	res, err := client.ZPopMinWithOptions("mySortedSet", opts)
 //	fmt.Println(res) // Output: map["member1": 5.0, "member2": 6.0]
 //
 // [valkey.io]: https://valkey.io/commands/zpopmin/
-func (client *baseClient) ZPopMinWithCount(key string, count int64) (map[string]float64, error) {
-	result, err := client.executeCommand(C.ZPopMin, []string{key, utils.IntToString(count)})
+func (client *baseClient) ZPopMinWithOptions(key string, options ZPopOptions) (map[string]float64, error) {
+	optArgs, err := options.ToArgs()
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.executeCommand(C.ZPopMin, append([]string{key}, optArgs...))
 	if err != nil {
 		return nil, err
 	}
@@ -4365,12 +4370,17 @@ func (client *baseClient) ZPopMax(key string) (map[string]float64, error) {
 //
 // Example:
 //
-//	res, err := client.ZPopMaxWithCount("mySortedSet", 2)
+//	opts := NewZPopOptions().SetCount(2)
+//	res, err := client.ZPopMaxWithOptions("mySortedSet", opts)
 //	fmt.Println(res) // Output: map["member1": 5.0, "member2": 6.0]
 //
 // [valkey.io]: https://valkey.io/commands/zpopmin/
-func (client *baseClient) ZPopMaxWithCount(key string, count int64) (map[string]float64, error) {
-	result, err := client.executeCommand(C.ZPopMax, []string{key, utils.IntToString(count)})
+func (client *baseClient) ZPopMaxWithOptions(key string, options ZPopOptions) (map[string]float64, error) {
+	optArgs, err := options.ToArgs()
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.executeCommand(C.ZPopMax, append([]string{key}, optArgs...))
 	if err != nil {
 		return nil, err
 	}

--- a/go/api/command_options.go
+++ b/go/api/command_options.go
@@ -484,3 +484,22 @@ func (opts *CopyOptions) toArgs() ([]string, error) {
 	}
 	return args, err
 }
+
+// Optional arguments for `ZPopMin` and `ZPopMax` commands.
+type ZPopOptions struct {
+	count int64
+}
+
+func NewZPopOptions() ZPopOptions {
+	return ZPopOptions{}
+}
+
+// The maximum number of popped elements. If not specified, pops one member.
+func (opts ZPopOptions) SetCount(count int64) ZPopOptions {
+	opts.count = count
+	return opts
+}
+
+func (opts ZPopOptions) ToArgs() ([]string, error) {
+	return []string{utils.IntToString(opts.count)}, nil
+}

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -24,11 +24,11 @@ type SortedSetCommands interface {
 
 	ZPopMin(key string) (map[string]float64, error)
 
-	ZPopMinWithCount(key string, count int64) (map[string]float64, error)
+	ZPopMinWithOptions(key string, options ZPopOptions) (map[string]float64, error)
 
 	ZPopMax(key string) (map[string]float64, error)
 
-	ZPopMaxWithCount(key string, count int64) (map[string]float64, error)
+	ZPopMaxWithOptions(key string, options ZPopOptions) (map[string]float64, error)
 
 	ZRem(key string, members []string) (int64, error)
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -4832,7 +4832,7 @@ func (suite *GlideTestSuite) TestZPopMin() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), map[string]float64{"one": float64(1)}, res2)
 
-		res3, err := client.ZPopMinWithCount(key1, 2)
+		res3, err := client.ZPopMinWithOptions(key1, api.NewZPopOptions().SetCount(2))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), map[string]float64{"two": float64(2), "three": float64(3)}, res3)
 
@@ -4863,7 +4863,7 @@ func (suite *GlideTestSuite) TestZPopMax() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), map[string]float64{"three": float64(3)}, res2)
 
-		res3, err := client.ZPopMaxWithCount(key1, 2)
+		res3, err := client.ZPopMaxWithOptions(key1, api.NewZPopOptions().SetCount(2))
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), map[string]float64{"two": float64(2), "one": float64(1)}, res3)
 


### PR DESCRIPTION
Refactor APIs to follow `...WithOptions` naming style. Commands having different return types with optional arguments (e.g. `zrandmember`) remain unchanged.
This follows naming approach we started in node client.
Could be merged in 1.3 before initial release or never.