### PR TITLE
[Backport `1.3`] Rust: Fix opentelemetry_sdk dependency (#3123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Node: Fix `zrangeWithScores` (disallow `RangeByLex` as it is not supported) ([#2926](https://github.com/valkey-io/valkey-glide/pull/2926))
 * Core: improve fix in #2381 ([#2929](https://github.com/valkey-io/valkey-glide/pull/2929))
 * Java: Fix `lpopCount` null handling ([#3025](https://github.com/valkey-io/valkey-glide/pull/3025))
-* Core: Fix `opentelemetry` related dependency issue ([#3123](https://github.com/valkey-io/valkey-glide/pull/3123))
+* Core: Fix `opentelemetry` related dependency issue (backport to 1.3) ([#3130](https://github.com/valkey-io/valkey-glide/pull/3130))
 
 #### Operational Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Node: Fix `zrangeWithScores` (disallow `RangeByLex` as it is not supported) ([#2926](https://github.com/valkey-io/valkey-glide/pull/2926))
 * Core: improve fix in #2381 ([#2929](https://github.com/valkey-io/valkey-glide/pull/2929))
 * Java: Fix `lpopCount` null handling ([#3025](https://github.com/valkey-io/valkey-glide/pull/3025))
+* Core: Fix `opentelemetry` related dependency issue ([#3123](https://github.com/valkey-io/valkey-glide/pull/3123))
 
 #### Operational Enhancements
 

--- a/glide-core/telemetry/Cargo.toml
+++ b/glide-core/telemetry/Cargo.toml
@@ -9,9 +9,9 @@ authors = ["Valkey GLIDE Maintainers"]
 lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-chrono = "0"
-futures-util = "0"
+chrono = "0.4"
+futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "time"] }
 
-opentelemetry = "0"
-opentelemetry_sdk = { version = "0", features = ["rt-tokio"] }
+opentelemetry = "0.27"
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }


### PR DESCRIPTION
Backport #3123 to `release-1.3` branch.