### PR TITLE
Fix engine builds on non ephemeral self hosted runner 

### DIFF
--- a/.github/workflows/install-engine/action.yml
+++ b/.github/workflows/install-engine/action.yml
@@ -26,7 +26,7 @@ runs:
     # TODO: self-hosted runners are actually cloning the repo, using the cache from the previous run
     # will not work as expected. We need to find a way to cache the valkey repo on the runner itself.
     steps:
-        - name: Cache Valkey
+        - name: Cache Valkey for non self hosted runners
           if: ${{!contains(inputs.target, 'aarch64-unknown') }}
           uses: actions/cache@v4
           id: cache-valkey
@@ -35,18 +35,20 @@ runs:
                   ~/valkey
               key: valkey-${{ inputs.engine-version }}-${{ inputs.target }}
 
-        # if no cache hit, build the engine
-        - name: Build Valkey
+        - name: Prepare Valkey sources
           if: ${{ steps.cache-valkey.outputs.cache-hit != 'true' }}
           shell: bash
+          working-directory: ~
           run: |
-              echo "Building valkey ${{ inputs.engine-version }}"
-              cd ~
+              echo "Cloning and checking out Valkey ${{ inputs.engine-version }}"
+              if [[ ! -d valkey ]]; then
+                rm -fR valkey
+              fi
               git clone https://github.com/valkey-io/valkey.git
               cd valkey
               git checkout ${{ inputs.engine-version }}
 
-        - name: Install engine
+        - name: Build and install engine
           shell: bash
           run: |
               cd ~/valkey


### PR DESCRIPTION
This commit https://github.com/valkey-io/valkey-glide/commit/890cffc882eb4281e80accadfa37f2446150fa74
removed the preparation of the sources for the non ephemeral self-hosted runner, where valkey directory is already exist. The assumption was that the non ephemeral runner will be deprecated. Since we decided to keep the CD workflows on the non ephemeral runner, the preparation on existing sources should be reintroduced


### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2037

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[ ] Tests are added or updated.~
-   ~[ ] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
