### PR TITLE
Fix py-cd for ARM CD

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -171,7 +171,7 @@ jobs:
                         PROTOC_ARCH="x86_64"
                       elif [[ $ARCH == 'aarch64' ]]; then 
                         PROTOC_ARCH="aarch_64"
-                        export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+                        export CC_aarch64_unknown_linux_gnu=gcc
                         export CFLAGS_aarch64_unknown_linux_gnu="-march=armv8-a"
                       else 
                         echo "Running on unsupported architecture: $ARCH. Expected one of: ['x86_64', 'aarch64']"


### PR DESCRIPTION
PyO3/maturin-action@v1 fails for ARM build due to aarch64-linux-gnu-gcc cannot be found in the docker.
Since the script uses quay.io/pypa/manylinux2014_aarch64:latest docker, the compiler name is probably changed to a more convenient gcc in the latest version

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/2037

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[] Tests are added or updated.~
-   ~[ ] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
