### PR TITLE
Fix relocation for shadowed packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * Go: Add `ZCARD` ([#2838](https://github.com/valkey-io/valkey-glide/pull/2838))
 * Java, Node, Python: Update documentation for CONFIG SET and CONFIG GET ([#2919](https://github.com/valkey-io/valkey-glide/pull/2919))
 * Go: Add `BZPopMin` ([#2849](https://github.com/valkey-io/valkey-glide/pull/2849))
-* Java: Shadow `protobuf` dependency ([#2931](https://github.com/valkey-io/valkey-glide/pull/2931))
+* Java: Shadow `protobuf` dependency ([#2931](https://github.com/valkey-io/valkey-glide/pull/2931) and [#3164](https://github.com/valkey-io/valkey-glide/pull/3164))
 * Java: Add `RESP2` support ([#2383](https://github.com/valkey-io/valkey-glide/pull/2383))
 * Node, Python: Add `IFEQ` option ([#2909](https://github.com/valkey-io/valkey-glide/pull/2909), [#2962](https://github.com/valkey-io/valkey-glide/pull/2962))
 * Java: Add `IFEQ` option ([#2978](https://github.com/valkey-io/valkey-glide/pull/2978))

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -246,6 +246,7 @@ jar {
 shadowJar {
     dependsOn('copyNativeLib')
     archiveClassifier = osdetector.classifier
+    relocate 'com.google.protobuf', 'glide.com.google.protobuf'
 }
 
 sourcesJar {


### PR DESCRIPTION
Fix relocation for shadowed packages (`protobuf`). This is needed to avoid conflicts on user's side if their app is also using that package.