### PR TITLE
[Backport `1.3`] Go: Add Go CD approval (#3146)

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
     load-platform-matrix:
         runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
         outputs:
             PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.PLATFORM_MATRIX }}
         steps:


### PR DESCRIPTION
Backport #3146 to `release-1.3` branch.