### PR TITLE
Go: fix ld warnings on macos

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -48,8 +48,6 @@ jobs:
     validate-release-version:
         if: ${{ github.event.inputs.pkg_go_dev_publish }}
         runs-on: ubuntu-latest
-        outputs:
-            RELEASE_VERSION: ${{ steps.release-tag.outputs.RELEASE_VERSION }}
         env:
             INPUT_VERSION: ${{ github.event.inputs.version }}
         steps:
@@ -74,7 +72,7 @@ jobs:
             - name: Output release tag
               id: release-tag
               run: |
-                  echo "RELEASE_VERSION=${{ env.INPUT_VERSION }}" >> $GITHUB_OUTPUT
+                  echo "RELEASE_VERSION=${{ env.INPUT_VERSION }}" >> $GITHUB_ENV
 
     create-binaries:
         needs: [load-platform-matrix]
@@ -146,15 +144,21 @@ jobs:
                   cp lib.h $GITHUB_WORKSPACE/go/
                   mkdir -p $GITHUB_WORKSPACE/go/protobuf
                   cp protobuf/* $GITHUB_WORKSPACE/go/protobuf/
+            # Need to patch it to avoid error which GLIDE mac users may see while building their code
+            # > ... github.com/valkey-io/valkey-glide/go@***/target/release not found
+            # https://github.com/valkey-io/valkey-glide/issues/3177
+            - name: Patch cgo definitions
+              run: |
+                  sed -i '\|// #cgo LDFLAGS: -L../target/release|d' go/api/base_client.go
             - name: Commit and push tag
               run: |
                   git config user.name github-actions
                   git config user.email github-actions@github.com
                   git add -f .
                   git commit -m "Automated commit from GitHub Actions"
-                  git tag go/${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
-                  git push origin go/${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
-                  GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go@${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
+                  git tag go/$RELEASE_VERSION
+                  git push origin go/$RELEASE_VERSION
+                  GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go@$RELEASE_VERSION
 
     extra-post-commit-test:
         needs:
@@ -181,7 +185,7 @@ jobs:
                   fi
             - uses: actions/checkout@v4
               with:
-                  ref: "go/${{ needs.validate-release-version.outputs.RELEASE_VERSION }}"
+                  ref: "go/${{ RELEASE_VERSION }}"
             - uses: actions/setup-go@v5
               with:
                   go-version: "^1.22.0"
@@ -204,13 +208,12 @@ jobs:
               working-directory: go/benchmarks
               run: |
                   # change go/benchmarks/go.mod on the fly
-                  export ESCAPED_VERSION=$(echo "${{ needs.validate-release-version.outputs.RELEASE_VERSION }}" | sed 's/\./\\./g')
                   if [[ "${{ matrix.host.OS }}" == "macos" ]]; then
-                      sed -i '' '/replace github\.com\/valkey-io\/valkey-glide\/go/d' go.mod
-                      sed -i '' "s/github\.com\/valkey-io\/valkey-glide\/go v0\.0\.0/github.com\/valkey-io\/valkey-glide\/go $ESCAPED_VERSION/g" go.mod
+                      sed -i '' '\|replace github\.com/valkey-io/valkey-glide/go|d' go.mod
+                      sed -i '' "s|github\.com/valkey-io/valkey-glide/go v.*|github.com/valkey-io/valkey-glide/go $RELEASE_VERSION|g" go.mod
                   else
-                      sed -i '/replace github\.com\/valkey-io\/valkey-glide\/go/d' go.mod
-                      sed -i "s/github\.com\/valkey-io\/valkey-glide\/go v0\.0\.0/github.com\/valkey-io\/valkey-glide\/go $ESCAPED_VERSION/g" go.mod
+                      sed -i '\|replace github\.com/valkey-io/valkey-glide/go|d' go.mod
+                      sed -i "s|github\.com/valkey-io/valkey-glide/go v.*|github.com/valkey-io/valkey-glide/go $RELEASE_VERSION|g" go.mod
                   fi
                   go mod tidy
                   go run . -minimal -clients glide -concurrentTasks 10 -port ${{ env.PORT }}

--- a/go/.cargo/config.toml
+++ b/go/.cargo/config.toml
@@ -1,9 +1,7 @@
 [env]
 GLIDE_NAME = { value = "GlideGo", force = true }
 GLIDE_VERSION = "0.1.0"
+MACOSX_DEPLOYMENT_TARGET = "10.0"
 
 # [target.aarch64-apple-darwin]
 # rustflags = ["-mmacosx-version-min=10.0"]
-
-[env]
-MACOSX_DEPLOYMENT_TARGET = "10.0"

--- a/go/.cargo/config.toml
+++ b/go/.cargo/config.toml
@@ -2,5 +2,8 @@
 GLIDE_NAME = { value = "GlideGo", force = true }
 GLIDE_VERSION = "0.1.0"
 
-[target.aarch64-apple-darwin]
-rustflags = ["-mmacosx-version-min=10.0"]
+# [target.aarch64-apple-darwin]
+# rustflags = ["-mmacosx-version-min=10.0"]
+
+[env]
+MACOSX_DEPLOYMENT_TARGET = "10.0"

--- a/go/.cargo/config.toml
+++ b/go/.cargo/config.toml
@@ -1,7 +1,8 @@
 [env]
 GLIDE_NAME = { value = "GlideGo", force = true }
 GLIDE_VERSION = "0.1.0"
-MACOSX_DEPLOYMENT_TARGET = "10.0"
-
-# [target.aarch64-apple-darwin]
-# rustflags = ["-mmacosx-version-min=10.0"]
+# Suppress error
+# > ... was built for newer 'macOS' version (14.5) than being linked (14.0)
+# See https://github.com/valkey-io/valkey-glide/issues/3177 and https://github.com/valkey-io/valkey-glide/pull/3178
+# TODO: set env var for specific target only https://github.com/rust-lang/cargo/issues/8801
+MACOSX_DEPLOYMENT_TARGET = "10.12"

--- a/go/.cargo/config.toml
+++ b/go/.cargo/config.toml
@@ -1,3 +1,6 @@
 [env]
 GLIDE_NAME = { value = "GlideGo", force = true }
 GLIDE_VERSION = "0.1.0"
+
+[target.aarch64-apple-darwin]
+rustflags = ["-mmacosx-version-min=10.0"]

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -4,7 +4,7 @@ package api
 
 // #cgo LDFLAGS: -lglide_rs
 // #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security -mmacosx-version-min=10.0
+// #cgo darwin LDFLAGS: -framework Security
 // #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
 // #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -4,7 +4,7 @@ package api
 
 // #cgo LDFLAGS: -lglide_rs
 // #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security -Wl,-ld_classic -mmacosx-version-min=10.0
+// #cgo darwin LDFLAGS: -framework Security -mmacosx-version-min=10.0
 // #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
 // #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -4,7 +4,7 @@ package api
 
 // #cgo LDFLAGS: -lglide_rs
 // #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security
+// #cgo darwin LDFLAGS: -framework Security -Wl,-ld_classic -mmacosx-version-min=10.0
 // #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
 // #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin

--- a/go/api/errors/errors.go
+++ b/go/api/errors/errors.go
@@ -2,13 +2,6 @@
 
 package errors
 
-// #cgo LDFLAGS: -lglide_rs
-// #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security
-// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
-// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
-// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
-// #cgo LDFLAGS: -L../target/release
 // #include "../../lib.h"
 import "C"
 

--- a/go/api/glide_client.go
+++ b/go/api/glide_client.go
@@ -2,13 +2,6 @@
 
 package api
 
-// #cgo LDFLAGS: -lglide_rs
-// #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security
-// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
-// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
-// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
-// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 import "C"
 

--- a/go/api/glide_cluster_client.go
+++ b/go/api/glide_cluster_client.go
@@ -2,13 +2,6 @@
 
 package api
 
-// #cgo LDFLAGS: -lglide_rs
-// #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security
-// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
-// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
-// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
-// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 import "C"
 

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -2,13 +2,6 @@
 
 package api
 
-// #cgo LDFLAGS: -lglide_rs
-// #cgo !windows LDFLAGS: -lm
-// #cgo darwin LDFLAGS: -framework Security
-// #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
-// #cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
-// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
-// #cgo LDFLAGS: -L../target/release
 // #include "../lib.h"
 import "C"
 


### PR DESCRIPTION
Partially fixes #3177 (1, 2, 3, 4 and 6 from https://github.com/valkey-io/valkey-glide/issues/3177#issuecomment-2660623226, 5 remains unfixed)

Fix following errors:
```
ld: warning: ignoring duplicate libraries: '-lglide_rs', '-lm'
```
```
ld: warning: search path '/Users/runner/work/valkey-glide/valkey-glide/go/api/errors/../rustbin/aarch64-apple-darwin' not found
ld: warning: search path '/Users/runner/work/valkey-glide/valkey-glide/go/api/target/release' not found
```

```
ld: warning: search path '/Users/runner/work/valkey-glide/valkey-glide/go/target/release' not found
```
(visible if GLIDE go glide is taken from the repo)

```
ld: warning: object file (/Users/runner/work/valkey-glide/valkey-glide/go/target/release/libglide_rs.a....) was built for newer 'macOS' version (14.5) than being linked (14.0)
```

Error
```
ld: warning: search path '/Users/runner/work/valkey-glide/valkey-glide/go/api/../rustbin/aarch64-apple-darwin' not found
```
is visible to developers only

The error (actually a warning) like
```
ld: warning: '/private/var/folders/2s/h6hvv9ps03xgz_krkkstvq_r0000gn/T/go-link-197988188/000019.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
```
remains unfixed. See [there more details about it](https://github.com/golang/go/issues/61229#issuecomment-1988965927).