### PR TITLE
Go: Fix channel passing from Go to Rust by using `runtime.Pinner` or `cgo.Handle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Go: Add `XINFO CONSUMERS` ([#3120](https://github.com/valkey-io/valkey-glide/pull/3120))
 * Go: Add `XINFO GROUPS` ([#3106](https://github.com/valkey-io/valkey-glide/pull/3106))
 * Go: Add `ZInterCard` ([#3078](https://github.com/valkey-io/valkey-glide/issues/3078))
+* Go: Fix channel passing from Go to Rust by using `runtime.Pinner` or `cgo.Handle` ([#3208](https://github.com/valkey-io/valkey-glide/pull/3208))
 
 #### Breaking Changes
 

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -229,12 +229,12 @@ func (client *baseClient) executeCommandWithRoute(
 	resultChannelPtr := unsafe.Pointer(&resultChannel)
 
 	pinner := pinner{}
-	pinnedChannelPtr := pinner.Pin(resultChannelPtr)
+	pinnedChannelPtr := uintptr(pinner.Pin(resultChannelPtr))
 	defer pinner.Unpin()
 
 	C.command(
 		client.coreClient,
-		C.uintptr_t(uintptr(pinnedChannelPtr)),
+		C.uintptr_t(pinnedChannelPtr),
 		uint32(requestType),
 		C.size_t(len(args)),
 		cArgsPtr,

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -53,7 +53,7 @@ type payload struct {
 //export successCallback
 func successCallback(channelPtr unsafe.Pointer, cResponse *C.struct_CommandResponse) {
 	response := cResponse
-	resultChannel := *(*chan payload)(channelPtr)
+	resultChannel := *(*chan payload)(getPinnedPtr(channelPtr))
 	resultChannel <- payload{value: response, error: nil}
 }
 
@@ -61,7 +61,7 @@ func successCallback(channelPtr unsafe.Pointer, cResponse *C.struct_CommandRespo
 func failureCallback(channelPtr unsafe.Pointer, cErrorMessage *C.char, cErrorType C.RequestErrorType) {
 	defer C.free_error_message(cErrorMessage)
 	msg := C.GoString(cErrorMessage)
-	resultChannel := *(*chan payload)(channelPtr)
+	resultChannel := *(*chan payload)(getPinnedPtr(channelPtr))
 	resultChannel <- payload{value: nil, error: errors.GoError(uint32(cErrorType), msg)}
 }
 
@@ -209,9 +209,6 @@ func (client *baseClient) executeCommandWithRoute(
 		argLengthsPtr = &argLengths[0]
 	}
 
-	resultChannel := make(chan payload)
-	resultChannelPtr := uintptr(unsafe.Pointer(&resultChannel))
-
 	var routeBytesPtr *C.uchar = nil
 	var routeBytesCount C.uintptr_t = 0
 	if route != nil {
@@ -228,9 +225,16 @@ func (client *baseClient) executeCommandWithRoute(
 		routeBytesPtr = (*C.uchar)(C.CBytes(msg))
 	}
 
+	resultChannel := make(chan payload)
+	resultChannelPtr := unsafe.Pointer(&resultChannel)
+
+	pinner := pinner{}
+	pinnedChannelPtr := pinner.Pin(resultChannelPtr)
+	defer pinner.Unpin()
+
 	C.command(
 		client.coreClient,
-		C.uintptr_t(resultChannelPtr),
+		C.uintptr_t(uintptr(pinnedChannelPtr)),
 		uint32(requestType),
 		C.size_t(len(args)),
 		cArgsPtr,

--- a/go/api/pinner.go
+++ b/go/api/pinner.go
@@ -1,0 +1,25 @@
+//go:build go1.21
+
+package api
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+type pinner struct {
+	r runtime.Pinner
+}
+
+func (p *pinner) Pin(v unsafe.Pointer) unsafe.Pointer {
+	p.r.Pin(v)
+	return v
+}
+
+func (p *pinner) Unpin() {
+	p.r.Unpin()
+}
+
+func getPinnedPtr(v unsafe.Pointer) unsafe.Pointer {
+	return v
+}

--- a/go/api/pinner.go
+++ b/go/api/pinner.go
@@ -1,3 +1,5 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 //go:build go1.21
 
 package api

--- a/go/api/pinner.go
+++ b/go/api/pinner.go
@@ -7,6 +7,9 @@ import (
 	"unsafe"
 )
 
+// pinner is a wrapper of a runtime.Pinner making the interface
+// compatible to the cgo.Handle in the Go < 1.21.
+// Note that this make a pinner can only hold one unsafe.Pointer.
 type pinner struct {
 	r runtime.Pinner
 }

--- a/go/api/pinner_old.go
+++ b/go/api/pinner_old.go
@@ -1,0 +1,25 @@
+//go:build !go1.21
+
+package api
+
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+type pinner struct {
+	h cgo.Handle
+}
+
+func (p *pinner) Pin(v unsafe.Pointer) unsafe.Pointer {
+	p.h = cgo.NewHandle(v)
+	return unsafe.Pointer(&p.h)
+}
+
+func (p *pinner) Unpin() {
+	p.h.Delete()
+}
+
+func getPinnedPtr(v unsafe.Pointer) unsafe.Pointer {
+	return (*(*cgo.Handle)(v)).Value().(unsafe.Pointer)
+}

--- a/go/api/pinner_old.go
+++ b/go/api/pinner_old.go
@@ -1,3 +1,5 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 //go:build !go1.21
 
 package api

--- a/go/api/pinner_old.go
+++ b/go/api/pinner_old.go
@@ -18,7 +18,7 @@ type pinner struct {
 
 func (p *pinner) Pin(v unsafe.Pointer) unsafe.Pointer {
 	p.h = cgo.NewHandle(v)
-	return unsafe.Pointer(&p.h)
+	return unsafe.Pointer(p.h) // Note that unsafe.Pointer(&p.h) is incorrect.
 }
 
 func (p *pinner) Unpin() {
@@ -26,5 +26,5 @@ func (p *pinner) Unpin() {
 }
 
 func getPinnedPtr(v unsafe.Pointer) unsafe.Pointer {
-	return (*(*cgo.Handle)(v)).Value().(unsafe.Pointer)
+	return (cgo.Handle)(v).Value().(unsafe.Pointer)
 }

--- a/go/api/pinner_old.go
+++ b/go/api/pinner_old.go
@@ -7,6 +7,9 @@ import (
 	"unsafe"
 )
 
+// pinner is a wrapper of a cgo.Handle making the interface
+// compatible to the runtime.Pinner in the Go >= 1.21.
+// Note that a pinner can only hold one unsafe.Pointer.
 type pinner struct {
 	h cgo.Handle
 }

--- a/go/api/pinner_test.go
+++ b/go/api/pinner_test.go
@@ -1,3 +1,5 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 package api
 
 import (

--- a/go/api/pinner_test.go
+++ b/go/api/pinner_test.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestPinner(t *testing.T) {
+	v := make(chan payload)
+
+	p := pinner{}
+	n := p.Pin(unsafe.Pointer(&v))
+	defer p.Unpin()
+
+	if *(*chan payload)(getPinnedPtr(n)) != v {
+		t.Fail()
+	}
+}

--- a/go/integTest/parallelized_test.go
+++ b/go/integTest/parallelized_test.go
@@ -1,0 +1,18 @@
+package integTest
+
+import (
+	"runtime"
+
+	"github.com/google/uuid"
+	"github.com/valkey-io/valkey-glide/go/api"
+)
+
+func (suite *GlideTestSuite) TestParallelizedSetWithGC() {
+	// The insane 640 parallelism is required to reproduce https://github.com/valkey-io/valkey-glide/issues/3207.
+	suite.runParallelizedWithDefaultClients(640, 640000, func(client api.BaseClient) {
+		runtime.GC()
+		key := uuid.New().String()
+		value := uuid.New().String()
+		suite.verifyOK(client.Set(key, value))
+	})
+}

--- a/go/integTest/parallelized_test.go
+++ b/go/integTest/parallelized_test.go
@@ -1,7 +1,10 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 package integTest
 
 import (
 	"runtime"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/valkey-io/valkey-glide/go/api"
@@ -9,7 +12,7 @@ import (
 
 func (suite *GlideTestSuite) TestParallelizedSetWithGC() {
 	// The insane 640 parallelism is required to reproduce https://github.com/valkey-io/valkey-glide/issues/3207.
-	suite.runParallelizedWithDefaultClients(640, 640000, func(client api.BaseClient) {
+	suite.runParallelizedWithDefaultClients(640, 640000, time.Minute, func(client api.BaseClient) {
 		runtime.GC()
 		key := uuid.New().String()
 		value := uuid.New().String()

--- a/go/integTest/parallelized_test.go
+++ b/go/integTest/parallelized_test.go
@@ -12,7 +12,7 @@ import (
 
 func (suite *GlideTestSuite) TestParallelizedSetWithGC() {
 	// The insane 640 parallelism is required to reproduce https://github.com/valkey-io/valkey-glide/issues/3207.
-	suite.runParallelizedWithDefaultClients(640, 640000, time.Minute, func(client api.BaseClient) {
+	suite.runParallelizedWithDefaultClients(640, 640000, 2*time.Minute, func(client api.BaseClient) {
 		runtime.GC()
 		key := uuid.New().String()
 		value := uuid.New().String()


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This fixes https://github.com/valkey-io/valkey-glide/issues/3207 and makes the Go client deliver responses to the correct channels.

The current way of passing `uintptr(unsafe.Pointer)` to rust and back to Go is not safe for dereferencing. Go can still move the address.

Use [`runtime.Pinner`](https://pkg.go.dev/runtime#Pinner) or  `cgo.Handle` to pin the channel address before passing it to the rust.

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3207

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
