### PR TITLE
Refactor command handling to use Arc<Cmd> for pipelines

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -469,7 +469,7 @@ where
         }
     }
 
-    fn map_cmds_to_nodes(&self, cmds: &[Cmd]) -> RedisResult<Vec<NodeCmd>> {
+    fn map_cmds_to_nodes(&self, cmds: &[Arc<Cmd>]) -> RedisResult<Vec<NodeCmd>> {
         let mut cmd_map: HashMap<String, NodeCmd> = HashMap::new();
 
         for (idx, cmd) in cmds.iter().enumerate() {
@@ -790,7 +790,7 @@ where
         }
     }
 
-    fn send_recv_and_retry_cmds(&self, cmds: &[Cmd]) -> RedisResult<Vec<Value>> {
+    fn send_recv_and_retry_cmds(&self, cmds: &[Arc<Cmd>]) -> RedisResult<Vec<Value>> {
         // Vector to hold the results, pre-populated with `Nil` values. This allows the original
         // cmd ordering to be re-established by inserting the response directly into the result
         // vector (e.g., results[10] = response).
@@ -818,7 +818,7 @@ where
     }
 
     // Build up a pipeline per node, then send it
-    fn send_all_commands(&self, cmds: &[Cmd]) -> RedisResult<Vec<NodeCmd>> {
+    fn send_all_commands(&self, cmds: &[Arc<Cmd>]) -> RedisResult<Vec<NodeCmd>> {
         let mut connections = self.connections.borrow_mut();
 
         let node_cmds = self.map_cmds_to_nodes(cmds)?;

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -51,8 +51,8 @@ impl<C> NodePipelineContext<C> {
     }
 
     // Adds a command to the pipeline and records its index
-    fn add_command(&mut self, cmd: Cmd, index: usize, inner_index: Option<usize>) {
-        self.pipeline.add_command(cmd);
+    fn add_command(&mut self, cmd: Arc<Cmd>, index: usize, inner_index: Option<usize>) {
+        self.pipeline.add_command_with_arc(cmd);
         self.command_indices.push((index, inner_index));
     }
 }
@@ -74,7 +74,7 @@ pub fn add_command_to_node_pipeline_map<C>(
     pipeline_map: &mut NodePipelineMap<C>,
     address: String,
     connection: C,
-    cmd: Cmd,
+    cmd: Arc<Cmd>,
     index: usize,
     inner_index: Option<usize>,
 ) {
@@ -121,7 +121,9 @@ where
     let mut response_policies = Vec::new();
 
     for (index, cmd) in pipeline.cmd_iter().enumerate() {
-        match RoutingInfo::for_routable(cmd).unwrap_or(SingleNode(SingleNodeRoutingInfo::Random)) {
+        match RoutingInfo::for_routable(cmd.as_ref())
+            .unwrap_or(SingleNode(SingleNodeRoutingInfo::Random))
+        {
             SingleNode(route) => {
                 handle_pipeline_single_node_routing(
                     &mut pipelines_per_node,
@@ -178,7 +180,7 @@ where
                         handle_pipeline_multi_slot_routing(
                             &mut pipelines_per_node,
                             core.clone(),
-                            cmd,
+                            cmd.clone(),
                             index,
                             slots,
                         )
@@ -204,7 +206,7 @@ where
 /// - `index`: The position of the command in the overall pipeline.
 pub async fn handle_pipeline_single_node_routing<C>(
     pipeline_map: &mut NodePipelineMap<C>,
-    cmd: Cmd,
+    cmd: Arc<Cmd>,
     routing: InternalSingleNodeRouting<C>,
     core: Core<C>,
     index: usize,
@@ -221,10 +223,9 @@ where
         }
     }
 
-    let (address, conn) =
-        ClusterConnInner::get_connection(routing, core, Some(Arc::new(cmd.clone())))
-            .await
-            .map_err(|err| (OperationTarget::NotFound, err))?;
+    let (address, conn) = ClusterConnInner::get_connection(routing, core, Some(cmd.clone()))
+        .await
+        .map_err(|err| (OperationTarget::NotFound, err))?;
     add_command_to_node_pipeline_map(pipeline_map, address, conn, cmd, index, None);
     Ok(())
 }
@@ -246,7 +247,7 @@ where
 pub async fn handle_pipeline_multi_slot_routing<C>(
     pipelines_by_connection: &mut NodePipelineMap<C>,
     core: Core<C>,
-    cmd: &Cmd,
+    cmd: Arc<Cmd>,
     index: usize,
     slots: Vec<(Route, Vec<usize>)>,
 ) -> Result<(), (OperationTarget, RedisError)>
@@ -261,7 +262,7 @@ where
         };
         if let Some((address, conn)) = conn {
             // create the sub-command for the slot
-            let new_cmd = command_for_multi_slot_indices(cmd, indices.iter());
+            let new_cmd = Arc::new(command_for_multi_slot_indices(cmd.as_ref(), indices.iter()));
             add_command_to_node_pipeline_map(
                 pipelines_by_connection,
                 address,
@@ -531,7 +532,7 @@ pub fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Rout
         // should be routed to a different slot, since the server will return an error indicating this.
         pipeline
             .cmd_iter()
-            .map(route_for_command)
+            .map(|cmd| route_for_command(cmd.as_ref()))
             .try_fold(None, |chosen_route, next_cmd_route| {
                 match (chosen_route, next_cmd_route) {
                     (None, _) => Ok(next_cmd_route),

--- a/glide-core/redis-rs/redis/src/cluster_pipeline.rs
+++ b/glide-core/redis-rs/redis/src/cluster_pipeline.rs
@@ -3,6 +3,7 @@ use crate::cmd::{cmd, Cmd};
 use crate::types::{
     from_owned_redis_value, ErrorKind, FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value,
 };
+use std::sync::Arc;
 
 pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
     ErrorKind::ClientError,
@@ -44,7 +45,7 @@ fn is_illegal_cmd(cmd: &str) -> bool {
 /// Represents a Redis Cluster command pipeline.
 #[derive(Clone)]
 pub struct ClusterPipeline {
-    commands: Vec<Cmd>,
+    commands: Vec<Arc<Cmd>>,
     ignored_commands: HashSet<usize>,
 }
 
@@ -84,7 +85,7 @@ impl ClusterPipeline {
         }
     }
 
-    pub(crate) fn commands(&self) -> &Vec<Cmd> {
+    pub(crate) fn commands(&self) -> &Vec<Arc<Cmd>> {
         &self.commands
     }
 

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -6,7 +6,7 @@ use futures_util::{
 };
 #[cfg(feature = "aio")]
 use std::pin::Pin;
-use std::{fmt, io};
+use std::{borrow::Borrow, fmt, io};
 
 use crate::connection::ConnectionLike;
 use crate::pipeline::Pipeline;
@@ -217,8 +217,9 @@ where
     total_len
 }
 
-pub(crate) fn cmd_len(cmd: &Cmd) -> usize {
-    args_len(cmd.args_iter(), cmd.cursor.unwrap_or(0))
+pub(crate) fn cmd_len(cmd: &impl Borrow<Cmd>) -> usize {
+    let cmd_ref: &Cmd = cmd.borrow();
+    args_len(cmd_ref.args_iter(), cmd_ref.cursor.unwrap_or(0))
 }
 
 fn encode_command<'a, I>(args: I, cursor: u64) -> Vec<u8>

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -377,7 +377,11 @@ impl Client {
     ) -> RedisResult<Value> {
         let values = values
             .into_iter()
-            .zip(pipeline.cmd_iter().map(expected_type_for_cmd))
+            .zip(
+                pipeline
+                    .cmd_iter()
+                    .map(|cmd| expected_type_for_cmd(cmd.as_ref())),
+            )
             .map(|(value, expected_type)| convert_to_expected_type(value, expected_type))
             .try_fold(
                 Vec::with_capacity(command_count),


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This PR refactors the pipeline command handling by replacing direct Cmd instances with Arc<Cmd>. Previously, commands were frequently cloned due to being used in multiple places, leading to unnecessary allocations. Using Arc allows for efficient shared ownership, reducing memory overhead and improving performance.

This change is part of the ongoing work on pipelines and is targeted at the pipelines-target-branch, as the pipeline implementation is still in progress.

### Issue link

This Pull Request is linked to issue (URL): #3237 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
