### PR TITLE
Go: Fix flaky test.

### DIFF
--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -249,8 +249,7 @@ func (suite *GlideTestSuite) TestDBSizeRandomRoute() {
 	result, err := client.DBSizeWithOptions(options)
 	assert.NoError(suite.T(), err)
 	assert.NotNil(suite.T(), result)
-	assert.NotEmpty(suite.T(), result)
-	assert.Greater(suite.T(), result, int64(0))
+	assert.GreaterOrEqual(suite.T(), result, int64(0))
 }
 
 func (suite *GlideTestSuite) TestEchoCluster() {


### PR DESCRIPTION
https://github.com/valkey-io/valkey-glide/actions/runs/13419211709/job/37487583002#step:5:663
`DBSize` test fails if command was randomly routed to a node which has no keys (or it was flushed in a previous test).
Note: `RandomRoute` is used in that test.