### PR TITLE
C#: Fix build on windows.

### DIFF
--- a/csharp/lib/glide.csproj
+++ b/csharp/lib/glide.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)target/$(Configuration.ToLower())/glide_rs.dll" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>%(FileName)%(Extension)</Link>
+      <Link>lib%(FileName)%(Extension)</Link>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)target/$(Configuration.ToLower())/libglide_rs.so" Condition="$([MSBuild]::IsOSPlatform('Linux'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Fix IT failure on windows ([logs](https://github.com/Yury-Fridlyand/valkey-glide/actions/runs/13464806277/job/37628183568#step:5:208)):
```
System.DllNotFoundException : Unable to load DLL 'libglide_rs' or one of its dependencies: The specified module could not be found. (0x8007007E)
```
`cargo` on windows creates `glide_rs.dll`, while on other platforms `libglide_rs.*`. To align file name (not extension) I add file name fix. It [worked](https://github.com/Yury-Fridlyand/valkey-glide/actions/runs/13465016151/job/37628860553#step:5:201).

### Issue link

This Pull Request is linked to issue (URL): Fixes #3269

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.