### PR TITLE
Fixes the RUNNER for the CD workflows 

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -39,7 +39,7 @@ jobs:
                       | .RUNNER = (
                           if (.RUNNER | type == "array") 
                           then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if . == "ephemeral" then "persistent" else . end) 
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
                           end
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -41,7 +41,7 @@ jobs:
                       | .RUNNER = (
                           if (.RUNNER | type == "array") 
                           then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if . == "ephemeral" then "persistent" else . end) 
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
                           end
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -65,7 +65,7 @@ jobs:
                       | .RUNNER = (
                           if (.RUNNER | type == "array") 
                           then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if . == "ephemeral" then "persistent" else . end) 
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
                           end
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -47,7 +47,7 @@ jobs:
                       | .RUNNER = (
                           if (.RUNNER | type == "array") 
                           then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if . == "ephemeral" then "persistent" else . end) 
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
                           end
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

Fixes the issue where running the CD workflows would result in this error - 
`Error when evaluating 'runs-on' for job 'publish-binaries'. .github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'OS',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'NAMED_OS',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'RUNNER',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'ARCH',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'TARGET',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'PACKAGE_MANAGERS',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'run',.github/workflows/pypi-cd.yml (Line: 77, Col: 18): Unexpected value 'languages'`
example - https://github.com/valkey-io/valkey-glide/actions/runs/13401312873

This line - 
`else (if . == "ephemeral" then "persistent" else . end)`, compared the entire matrix entry to `ephemeral`, hence would fail and replace the `.RUNNER` field to be the entire matrix entry. The fix makes sure only the `.RUNNER ` field is compared, and that it stays unchanged in case it isn't `ephemeral`. 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
