### PR TITLE
C#: Fix tests logging.

### DIFF
--- a/csharp/tests/Integration/GetAndSet.cs
+++ b/csharp/tests/Integration/GetAndSet.cs
@@ -4,11 +4,21 @@ using System.Runtime.InteropServices;
 
 using Glide;
 
+using Microsoft.VisualStudio.TestPlatform.Utilities;
+
 using static Tests.Integration.IntegrationTestBase;
 
 namespace Tests.Integration;
 public class GetAndSet : IClassFixture<IntegrationTestBase>
 {
+
+    private readonly ITestOutputHelper output;
+
+    public GetAndSet(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
     private async Task GetAndSetValues(AsyncClient client, string key, string value)
     {
         Assert.Equal("OK", await client.SetAsync(key, value));

--- a/csharp/tests/Integration/GetAndSet.cs
+++ b/csharp/tests/Integration/GetAndSet.cs
@@ -4,21 +4,11 @@ using System.Runtime.InteropServices;
 
 using Glide;
 
-using Microsoft.VisualStudio.TestPlatform.Utilities;
-
 using static Tests.Integration.IntegrationTestBase;
 
 namespace Tests.Integration;
 public class GetAndSet : IClassFixture<IntegrationTestBase>
 {
-
-    private readonly ITestOutputHelper output;
-
-    public GetAndSet(ITestOutputHelper output)
-    {
-        this.output = output;
-    }
-
     private async Task GetAndSetValues(AsyncClient client, string key, string value)
     {
         Assert.Equal("OK", await client.SetAsync(key, value));

--- a/csharp/tests/tests.csproj
+++ b/csharp/tests/tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
@@ -33,6 +33,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\lib\glide.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/csharp/tests/xunit.runner.json
+++ b/csharp/tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "showLiveOutput": true,
+    "diagnosticMessages": true
+}


### PR DESCRIPTION
Without these changes, logs from tests were never printed.
To have logging in IT, use `ITestOutputHelper` which has `WriteLine` API similar to `Console.WriteLine`.
```diff
--- a/csharp/tests/Integration/GetAndSet.cs
+++ b/csharp/tests/Integration/GetAndSet.cs
@@ -7,8 +7,10 @@ using Glide;
 using static Tests.Integration.IntegrationTestBase;

 namespace Tests.Integration;
-public class GetAndSet : IClassFixture<IntegrationTestBase>
+public class GetAndSet(ITestOutputHelper output) : IClassFixture<IntegrationTestBase>
 {
+    private readonly ITestOutputHelper _output = output;
+
     private async Task GetAndSetValues(AsyncClient client, string key, string value)
     {
         Assert.Equal("OK", await client.SetAsync(key, value));
```

See xunit docs on https://xunit.net/docs/capturing-output and https://xunit.net/docs/configuration-files.