### PR TITLE
Python: Temporarily suppress rust linter warnings

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+#![allow(clippy::useless_conversion)]
 
 use bytes::Bytes;
 use glide_core::client::FINISHED_SCAN_CURSOR;


### PR DESCRIPTION
For now, we temporarily suppress the useless conversion warnings until we get more information on what we need to change for upgrading to rust 1.85.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
