### PR TITLE
[Backport to Release 1.3.1] Go: Fix channel passing from Go to Rust by using `runtime.Pinner` or …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 #### Changes
 
+#### Breaking Changes
+
+#### Fixes
+
+* Go: Fix channel passing from Go to Rust by using `runtime.Pinner` or `cgo.Handle` ([#3208](https://github.com/valkey-io/valkey-glide/pull/3208))
+
+#### Operational Enhancements
+
+## 1.3.0 (2025-02-14)
+
+#### Changes
 
 * Java: Add support to AzAffinityReplicasAndPrimary read strategy ([#3083](https://github.com/valkey-io/valkey-glide/pull/3083))
 * Python: Add support to AzAffinityReplicasAndPrimary read strategy ([#3071](https://github.com/valkey-io/valkey-glide/pull/3071))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Fixes
 
-* Go: Fix channel passing from Go to Rust by using `runtime.Pinner` or `cgo.Handle` ([#3208](https://github.com/valkey-io/valkey-glide/pull/3208))
+* Go: Fix channel passing from Go to Rust by using `runtime.Pinner` or `cgo.Handle` ([#3208](https://github.com/valkey-io/valkey-glide/pull/3270))
 
 #### Operational Enhancements
 

--- a/go/api/pinner.go
+++ b/go/api/pinner.go
@@ -1,0 +1,30 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//go:build go1.21
+
+package api
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+// pinner is a wrapper of a runtime.Pinner making the interface
+// compatible to the cgo.Handle in the Go < 1.21.
+// Note that this make a pinner can only hold one unsafe.Pointer.
+type pinner struct {
+	r runtime.Pinner
+}
+
+func (p *pinner) Pin(v unsafe.Pointer) unsafe.Pointer {
+	p.r.Pin(v)
+	return v
+}
+
+func (p *pinner) Unpin() {
+	p.r.Unpin()
+}
+
+func getPinnedPtr(v unsafe.Pointer) unsafe.Pointer {
+	return v
+}

--- a/go/api/pinner_old.go
+++ b/go/api/pinner_old.go
@@ -1,0 +1,30 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//go:build !go1.21
+
+package api
+
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+// pinner is a wrapper of a cgo.Handle making the interface
+// compatible to the runtime.Pinner in the Go >= 1.21.
+// Note that a pinner can only hold one unsafe.Pointer.
+type pinner struct {
+	h cgo.Handle
+}
+
+func (p *pinner) Pin(v unsafe.Pointer) unsafe.Pointer {
+	p.h = cgo.NewHandle(v)
+	return unsafe.Pointer(p.h) // Note that unsafe.Pointer(&p.h) is incorrect.
+}
+
+func (p *pinner) Unpin() {
+	p.h.Delete()
+}
+
+func getPinnedPtr(v unsafe.Pointer) unsafe.Pointer {
+	return (cgo.Handle)(v).Value().(unsafe.Pointer)
+}

--- a/go/api/pinner_test.go
+++ b/go/api/pinner_test.go
@@ -1,0 +1,20 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package api
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestPinner(t *testing.T) {
+	v := make(chan payload)
+
+	p := pinner{}
+	n := p.Pin(unsafe.Pointer(&v))
+	defer p.Unpin()
+
+	if *(*chan payload)(getPinnedPtr(n)) != v {
+		t.Fail()
+	}
+}

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -11,7 +11,9 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -227,6 +229,16 @@ func (suite *GlideTestSuite) runWithDefaultClients(test func(client api.BaseClie
 	suite.runWithClients(clients, test)
 }
 
+func (suite *GlideTestSuite) runParallelizedWithDefaultClients(
+	parallelism int,
+	count int64,
+	timeout time.Duration,
+	test func(client api.BaseClient),
+) {
+	clients := suite.getDefaultClients()
+	suite.runParallelizedWithClients(clients, parallelism, count, timeout, test)
+}
+
 func (suite *GlideTestSuite) getDefaultClients() []api.BaseClient {
 	return []api.BaseClient{suite.defaultClient(), suite.defaultClusterClient()}
 }
@@ -271,6 +283,37 @@ func (suite *GlideTestSuite) runWithClients(clients []api.BaseClient, test func(
 	for _, client := range clients {
 		suite.T().Run(fmt.Sprintf("%T", client)[5:], func(t *testing.T) {
 			test(client)
+		})
+	}
+}
+
+func (suite *GlideTestSuite) runParallelizedWithClients(
+	clients []api.BaseClient,
+	parallelism int,
+	count int64,
+	timeout time.Duration,
+	test func(client api.BaseClient),
+) {
+	for _, client := range clients {
+		suite.T().Run(fmt.Sprintf("%T", client)[5:], func(t *testing.T) {
+			done := make(chan struct{}, parallelism)
+			for i := 0; i < parallelism; i++ {
+				go func() {
+					defer func() { done <- struct{}{} }()
+					for !suite.T().Failed() && atomic.AddInt64(&count, -1) > 0 {
+						test(client)
+					}
+				}()
+			}
+			tm := time.NewTimer(timeout)
+			defer tm.Stop()
+			for i := 0; i < parallelism; i++ {
+				select {
+				case <-done:
+				case <-tm.C:
+					suite.T().Fatalf("parallelized test timeout in %s", timeout)
+				}
+			}
 		})
 	}
 }

--- a/go/integTest/parallelized_test.go
+++ b/go/integTest/parallelized_test.go
@@ -1,0 +1,21 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valkey-io/valkey-glide/go/api"
+)
+
+func (suite *GlideTestSuite) TestParallelizedSetWithGC() {
+	// The insane 640 parallelism is required to reproduce https://github.com/valkey-io/valkey-glide/issues/3207.
+	suite.runParallelizedWithDefaultClients(640, 640000, 2*time.Minute, func(client api.BaseClient) {
+		runtime.GC()
+		key := uuid.New().String()
+		value := uuid.New().String()
+		suite.verifyOK(client.Set(key, value))
+	})
+}


### PR DESCRIPTION
…`cgo.Handle` (#3208)

* Go: fix channel passing from Go->Rust->Go by runtime.Pinner

The current way of passing uintptr(unsafe.Pointer) to rust and back to Go is not safe for dereferencing. The address can still be moved by Go.

Starting from Go 1.21, we can use runtime.Pinner to make an address fixed. Before Go 1.21, we can use cgo.Handle but it is subject to overflow. https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/runtime/cgo/handle.go;l=111

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3174

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
