### PR TITLE
Python: Revert clippy suppression

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,5 +1,4 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-#![allow(clippy::useless_conversion)]
 
 use bytes::Bytes;
 use glide_core::client::FINISHED_SCAN_CURSOR;


### PR DESCRIPTION
According to the issue raised in the clippy community, an update to pyo3 could have fixed the problem. This PR reverts the added warning suppression.

### Issue link

This Pull Request is linked to issue (URL): 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
