### PR TITLE
Adding option to print logs in redis-rs tests

### DIFF
--- a/glide-core/redis-rs/README.md
+++ b/glide-core/redis-rs/README.md
@@ -210,6 +210,16 @@ To test:
 
     $ make test
 
+To test with logs output:
+-   Add `init_logger();` call in the beginning of the desired test, note that all logs from all tests will be collected from that point.
+-   `RUST_LOG` indicate the desired log level to collect. Options are `error, warn, info, debug, trace`.
+
+    $ RUST_LOG=<log level> cargo test --locked -p redis -- --nocapture --test-threads=1
+
+To run a specific test with logs output:
+
+    $ RUST_LOG=<log level> cargo test --locked -p redis --test <test suite name> <test name> -- --nocapture --test-threads=1
+
 To run benchmarks:
 
     $ make bench

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -182,6 +182,7 @@ sscanf = "0.4.1"
 serial_test = "^2"
 versions = "6.3"
 which = "7.0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [[test]]
 name = "test_async"

--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -868,3 +868,16 @@ pub fn build_simple_pipeline_for_invalidation() -> Pipeline {
         .ignore();
     pipe
 }
+
+use std::sync::Once;
+
+static INIT_LOGGER: Once = Once::new();
+
+pub fn init_logger() {
+    INIT_LOGGER.call_once(|| {
+        tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env()) // Read `RUST_LOG` from the environment
+        .with_test_writer() // Ensure logs are captured and outputted for tests
+        .init();
+    });
+}


### PR DESCRIPTION
Adding option to print logs in redis-rs tests.

When running tests, you might want to see the logs from with-in redis-rs or glide.
In order to print logs, add `init_logger();` in the beginning of the needed test, and from then all logs will appear.

Note to run the test with **nocapture** and **RUST_LOG** with the needed log level:
e.g.: `RUST_LOG=debug cargo test --locked -p redis -- --nocapture --test-threads=1`