### PR TITLE
fix: handle non-string types in Buffer conversion for keys, args, and matchPattern

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3861,8 +3861,12 @@ export class BaseClient {
     ): Promise<GlideReturnType> {
         const scriptInvocation = command_request.ScriptInvocation.create({
             hash: script.getHash(),
-            keys: options?.keys?.map(Buffer.from),
-            args: options?.args?.map(Buffer.from),
+            keys: options?.keys?.map((key) =>
+                typeof key === "string" ? Buffer.from(key) : key,
+            ),
+            args: options?.args?.map((arg) =>
+                typeof arg === "string" ? Buffer.from(arg) : arg,
+            ),
         });
         return this.createScriptInvocationPromise(scriptInvocation, options);
     }

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -613,7 +613,10 @@ export class GlideClusterClient extends BaseClient {
         command.cursor = cursor;
 
         if (options?.match) {
-            command.matchPattern = Buffer.from(options.match);
+            command.matchPattern =
+                typeof options.match === "string"
+                    ? Buffer.from(options.match)
+                    : options.match;
         }
 
         if (options?.count) {
@@ -1793,7 +1796,9 @@ export class GlideClusterClient extends BaseClient {
         const scriptInvocation = command_request.ScriptInvocation.create({
             hash: script.getHash(),
             keys: [],
-            args: options?.args?.map(Buffer.from),
+            args: options?.args?.map((arg) =>
+                typeof arg === "string" ? Buffer.from(arg) : arg,
+            ),
         });
         return this.createScriptInvocationWithRoutePromise<
             ClusterGlideRecord<GlideReturnType>


### PR DESCRIPTION
Signed-off-by: avifenesh <aviarchi1995@gmail.com>

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): #

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
