### PR TITLE
Python: Temporarily suppress rust linter warnings for release-1.3 (backporting #3255)

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+#![allow(clippy::useless_conversion)]
 
 use bytes::Bytes;
 use glide_core::client::FINISHED_SCAN_CURSOR;


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
