### PR TITLE
C#: Fixes in CI

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -109,7 +109,7 @@ jobs:
                   engine-version: ${{ matrix.engine.version }}
 
             - name: Create temporary global.json
-              run: echo "{\"sdk\":{\"version\": \"${{ steps.dotnet.outputs.dotnet-version }}\"}}" > csharp/global.json
+              run: echo ${{ steps.dotnet.outputs.dotnet-version }}
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -92,7 +92,7 @@ jobs:
               if: ${{ contains(matrix.host.RUNNER, 'self-hosted') }}
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y npm
+                  sudo apt-get install -y npm nodejs
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -109,7 +109,7 @@ jobs:
                   engine-version: ${{ matrix.engine.version }}
 
             - name: Create temporary global.json
-              run: echo '{"sdk":{"version": "${{ steps.dotnet.outputs.dotnet-version }}"}}' > csharp/global.json
+              run: echo "{\"sdk\":{\"version\": \"${{ steps.dotnet.outputs.dotnet-version }}\"}}" > csharp/global.json
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp
@@ -185,7 +185,7 @@ jobs:
                   engine-version: ${{ matrix.engine.version }}
 
             - name: Create temporary global.json
-              run: echo '{"sdk":{"version": "${{ steps.dotnet.outputs.dotnet-version }}"}}' > csharp/global.json
+              run: echo "{\"sdk\":{\"version\": \"${{ steps.dotnet.outputs.dotnet-version }}\"}}" > csharp/global.json
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -109,7 +109,7 @@ jobs:
                   engine-version: ${{ matrix.engine.version }}
 
             - name: Create temporary global.json
-              run: echo ${{ steps.dotnet.outputs.dotnet-version }}
+              run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.dotnet-version }}
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp
@@ -185,7 +185,7 @@ jobs:
                   engine-version: ${{ matrix.engine.version }}
 
             - name: Create temporary global.json
-              run: echo "{\"sdk\":{\"version\": \"${{ steps.dotnet.outputs.dotnet-version }}\"}}" > csharp/global.json
+              run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.dotnet-version }}
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -101,6 +101,13 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: ${{ matrix.engine.version }}
 
+            # Older dotnet fails if sees a references to a newer one
+            - name: Patch project files
+              run: |
+                  SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
+                  find {benchmarks,csharp} -name '*.csproj' | xargs \
+                      sed -i $SED_FOR_MACOS "s|<TargetFrameworks>.*</TargetFrameworks>|<TargetFrameworks>net${{ matrix.dotnet }}</TargetFrameworks>|g"
+
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp
               run: dotnet test --framework net${{ matrix.dotnet }} "-l:html;LogFileName=TestReport.html" --results-directory . -warnaserror
@@ -160,8 +167,6 @@ jobs:
                   echo IMAGE=amazonlinux:latest | sed -r 's/:/-/g' >> $GITHUB_ENV
             # Replace `:` in the variable otherwise it can't be used in `upload-artifact`
             - uses: actions/checkout@v4
-              with:
-                  submodules: recursive
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4
@@ -175,6 +180,13 @@ jobs:
                   target: ${{ matrix.host.TARGET }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: ${{ matrix.engine.version }}
+
+            # Older dotnet fails if sees a references to a newer one
+            - name: Patch project files
+              run: |
+                  SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
+                  find {benchmarks,csharp} -name '*.csproj' | xargs \
+                      sed -i $SED_FOR_MACOS "s|<TargetFrameworks>.*</TargetFrameworks>|<TargetFrameworks>net${{ matrix.dotnet }}</TargetFrameworks>|g"
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -90,7 +90,9 @@ jobs:
 
             - name: Install extra software on self-hosted runner
               if: ${{ contains(matrix.host.RUNNER, 'self-hosted') }}
-              uses: actions/setup-node@v4
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y npm
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -88,10 +88,17 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - name: Setup self-hosted runner access
+              if: ${{ contains(matrix.host.RUNNER, 'self-hosted') }}
+              run: sudo mkdir -p /usr/share/dotnet
+
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4
+              id: dotnet
               with:
                   dotnet-version: ${{ matrix.dotnet }}
+              env:
+                  DOTNET_INSTALL_DIR: ~/.dotnet
 
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
@@ -101,12 +108,8 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: ${{ matrix.engine.version }}
 
-            # Older dotnet fails if sees a references to a newer one
-            - name: Patch project files
-              run: |
-                  SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
-                  find {benchmarks,csharp} -name '*.csproj' | xargs \
-                      sed -i $SED_FOR_MACOS "s|<TargetFrameworks>.*</TargetFrameworks>|<TargetFrameworks>net${{ matrix.dotnet }}</TargetFrameworks>|g"
+            - name: Create temporary global.json
+              run: echo '{"sdk":{"version": "${{ steps.dotnet.outputs.dotnet-version }}"}}' > csharp/global.json
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp
@@ -181,12 +184,8 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: ${{ matrix.engine.version }}
 
-            # Older dotnet fails if sees a references to a newer one
-            - name: Patch project files
-              run: |
-                  SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
-                  find {benchmarks,csharp} -name '*.csproj' | xargs \
-                      sed -i $SED_FOR_MACOS "s|<TargetFrameworks>.*</TargetFrameworks>|<TargetFrameworks>net${{ matrix.dotnet }}</TargetFrameworks>|g"
+            - name: Create temporary global.json
+              run: echo '{"sdk":{"version": "${{ steps.dotnet.outputs.dotnet-version }}"}}' > csharp/global.json
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -90,9 +90,7 @@ jobs:
 
             - name: Install extra software on self-hosted runner
               if: ${{ contains(matrix.host.RUNNER, 'self-hosted') }}
-              run: | 
-                  sudo apt-get update
-                  sudo apt-get install npm --no-install-recommends
+              uses: actions/setup-node@v4
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -94,7 +94,6 @@ jobs:
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4
-              id: dotnet
               with:
                   dotnet-version: ${{ matrix.dotnet }}
               env:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -108,8 +108,12 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: ${{ matrix.engine.version }}
 
-            - name: Create temporary global.json
-              run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.dotnet-version }}
+            # Older dotnet fails if sees a references to a newer one
+            - name: Patch project files
+              run: |
+                  SED_FOR_MACOS=`if [[ "${{ matrix.host.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
+                  find {benchmarks,csharp} -name '*.csproj' | xargs \
+                      sed -i $SED_FOR_MACOS "s|<TargetFrameworks>.*</TargetFrameworks>|<TargetFrameworks>net${{ matrix.dotnet }}</TargetFrameworks>|g"
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp
@@ -184,8 +188,11 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   engine-version: ${{ matrix.engine.version }}
 
-            - name: Create temporary global.json
-              run: dotnet new globaljson --sdk-version ${{ steps.dotnet.outputs.dotnet-version }}
+            # Older dotnet fails if sees a references to a newer one
+            - name: Patch project files
+              run: |
+                  find {benchmarks,csharp} -name '*.csproj' | xargs \
+                      sed -i "s|<TargetFrameworks>.*</TargetFrameworks>|<TargetFrameworks>net${{ matrix.dotnet }}</TargetFrameworks>|g"
 
             - name: Test dotnet ${{ matrix.dotnet }}
               working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -88,9 +88,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Setup self-hosted runner access
+            - name: Install extra software on self-hosted runner
               if: ${{ contains(matrix.host.RUNNER, 'self-hosted') }}
-              run: sudo mkdir -p /usr/share/dotnet
+              run: | 
+                  sudo apt-get update
+                  sudo apt-get install npm --no-install-recommends
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4


### PR DESCRIPTION
1. Fix for [dotnet installation on SH runner](https://github.com/valkey-io/valkey-glide/actions/runs/13644062631/job/38139605743#step:3:14):
```
/home/ubuntu/actions-runner/_work/_actions/actions/setup-dotnet/v4/externals/install-dotnet.sh --skip-non-versioned-files --runtime dotnet --channel LTS
mkdir: cannot create directory ‘/usr/share/dotnet’: Permission denied
Warning: Failed to install dotnet runtime + cli, exit code: 1. mkdir: cannot create directory ‘/usr/share/dotnet’: Permission denied

/home/ubuntu/actions-runner/_work/_actions/actions/setup-dotnet/v4/externals/install-dotnet.sh --skip-non-versioned-files --channel 8.0
mkdir: cannot create directory ‘/usr/share/dotnet’: Permission denied
Error: Failed to install dotnet, exit code: 1. mkdir: cannot create directory ‘/usr/share/dotnet’: Permission denied
```
2. Fix for [running build on older versions of dotnet](https://github.com/Bit-Quill/valkey-glide/actions/runs/13643146822/job/38137060854#step:5:11):
```
Error: /usr/share/dotnet/sdk/6.0.428/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 8.0. [/home/runner/work/valkey-glide/valkey-glide/csharp/lib/glide.csproj]
Error: /usr/share/dotnet/sdk/6.0.428/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 8.0. [/home/runner/work/valkey-glide/valkey-glide/csharp/tests/tests.csproj]
Error: /usr/share/dotnet/sdk/6.0.428/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 8.0. [/home/runner/work/valkey-glide/valkey-glide/benchmarks/csharp/csharp_benchmark.csproj]
Error: Process completed with exit code 1.
```
3. Fix for [missing `npm` on SH runner](https://github.com/valkey-io/valkey-glide/actions/runs/13644420044/job/38140565908#step:8:31):
```
Minimal run, not filling database
./install_and_test.sh: line 98: npm: command not found
Error: Process completed with exit code 127.
```
TODO:
- [ ] Fix up node version on SH runner
- [ ] Fix up .net version on mac

Full matrix CI now works. All .net6 runs fails due to code incompatibility - will be fixed in another version.

### Issue link

This Pull Request is linked to issue (URL): #216

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>