### PR TITLE
Authentication: Fix immediate update_connection_password to use username

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -418,6 +418,7 @@ pub struct MultiplexedConnection {
     protocol: ProtocolVersion,
     push_manager: PushManager,
     availability_zone: Option<String>,
+    username: Option<String>,
     password: Option<String>,
 }
 
@@ -479,6 +480,7 @@ impl MultiplexedConnection {
             .with_response_timeout(response_timeout)
             .with_push_manager(pm)
             .with_protocol(connection_info.redis.protocol)
+            .with_username(connection_info.redis.username.clone())
             .with_password(connection_info.redis.password.clone())
             .with_availability_zone(None)
             .build()
@@ -596,6 +598,13 @@ impl MultiplexedConnection {
         Ok(Value::Okay)
     }
 
+    /// Get the username used to authenticate with the server.
+    /// If `None` is provided, the password will be removed.
+    /// Get the username used to authenticate with the server.
+    pub fn get_username(&self) -> Option<String> {
+        self.username.clone()
+    }
+
     /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
     pub(crate) fn builder(pipeline: Pipeline<Vec<u8>>) -> MultiplexedConnectionBuilder {
         MultiplexedConnectionBuilder::new(pipeline)
@@ -609,6 +618,7 @@ pub struct MultiplexedConnectionBuilder {
     response_timeout: Option<Duration>,
     push_manager: Option<PushManager>,
     protocol: Option<ProtocolVersion>,
+    username: Option<String>,
     password: Option<String>,
     /// Represents the node's availability zone
     availability_zone: Option<String>,
@@ -623,6 +633,7 @@ impl MultiplexedConnectionBuilder {
             response_timeout: None,
             push_manager: None,
             protocol: None,
+            username: None,
             password: None,
             availability_zone: None,
         }
@@ -652,6 +663,12 @@ impl MultiplexedConnectionBuilder {
         self
     }
 
+    /// Sets the username for the `MultiplexedConnectionBuilder`.
+    pub fn with_username(mut self, username: Option<String>) -> Self {
+        self.username = username;
+        self
+    }
+
     /// Sets the password for the `MultiplexedConnectionBuilder`.
     pub fn with_password(mut self, password: Option<String>) -> Self {
         self.password = password;
@@ -672,6 +689,7 @@ impl MultiplexedConnectionBuilder {
             .unwrap_or(DEFAULT_CONNECTION_ATTEMPT_TIMEOUT);
         let push_manager = self.push_manager.unwrap_or_default();
         let protocol = self.protocol.unwrap_or_default();
+        let username = self.username;
         let password = self.password;
 
         let con = MultiplexedConnection {
@@ -680,6 +698,7 @@ impl MultiplexedConnectionBuilder {
             response_timeout,
             push_manager,
             protocol,
+            username,
             password,
             availability_zone: self.availability_zone,
         };

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -418,7 +418,6 @@ pub struct MultiplexedConnection {
     protocol: ProtocolVersion,
     push_manager: PushManager,
     availability_zone: Option<String>,
-    username: Option<String>,
     password: Option<String>,
 }
 
@@ -480,7 +479,6 @@ impl MultiplexedConnection {
             .with_response_timeout(response_timeout)
             .with_push_manager(pm)
             .with_protocol(connection_info.redis.protocol)
-            .with_username(connection_info.redis.username.clone())
             .with_password(connection_info.redis.password.clone())
             .with_availability_zone(None)
             .build()
@@ -598,13 +596,6 @@ impl MultiplexedConnection {
         Ok(Value::Okay)
     }
 
-    /// Get the username used to authenticate with the server.
-    /// If `None` is provided, the password will be removed.
-    /// Get the username used to authenticate with the server.
-    pub fn get_username(&self) -> Option<String> {
-        self.username.clone()
-    }
-
     /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
     pub(crate) fn builder(pipeline: Pipeline<Vec<u8>>) -> MultiplexedConnectionBuilder {
         MultiplexedConnectionBuilder::new(pipeline)
@@ -618,7 +609,6 @@ pub struct MultiplexedConnectionBuilder {
     response_timeout: Option<Duration>,
     push_manager: Option<PushManager>,
     protocol: Option<ProtocolVersion>,
-    username: Option<String>,
     password: Option<String>,
     /// Represents the node's availability zone
     availability_zone: Option<String>,
@@ -633,7 +623,6 @@ impl MultiplexedConnectionBuilder {
             response_timeout: None,
             push_manager: None,
             protocol: None,
-            username: None,
             password: None,
             availability_zone: None,
         }
@@ -663,12 +652,6 @@ impl MultiplexedConnectionBuilder {
         self
     }
 
-    /// Sets the username for the `MultiplexedConnectionBuilder`.
-    pub fn with_username(mut self, username: Option<String>) -> Self {
-        self.username = username;
-        self
-    }
-
     /// Sets the password for the `MultiplexedConnectionBuilder`.
     pub fn with_password(mut self, password: Option<String>) -> Self {
         self.password = password;
@@ -689,7 +672,6 @@ impl MultiplexedConnectionBuilder {
             .unwrap_or(DEFAULT_CONNECTION_ATTEMPT_TIMEOUT);
         let push_manager = self.push_manager.unwrap_or_default();
         let protocol = self.protocol.unwrap_or_default();
-        let username = self.username;
         let password = self.password;
 
         let con = MultiplexedConnection {
@@ -698,7 +680,6 @@ impl MultiplexedConnectionBuilder {
             response_timeout,
             push_manager,
             protocol,
-            username,
             password,
             availability_zone: self.availability_zone,
         };

--- a/glide-core/redis-rs/redis/src/client.rs
+++ b/glide-core/redis-rs/redis/src/client.rs
@@ -563,6 +563,11 @@ impl Client {
             .await
             .map(|connection| connection.into_monitor())
     }
+
+    /// Updates the password in connection_info.
+    pub fn update_password(&mut self, password: Option<String>) {
+        self.connection_info.redis.password = password;
+    }
 }
 
 #[cfg(feature = "aio")]

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -320,7 +320,7 @@ where
     pub async fn get_username(&mut self) -> RedisResult<Value> {
         self.route_operation_request(Operation::GetUsername).await
     }
-    
+
     /// Routes an operation request to the appropriate handler.
     async fn route_operation_request(
         &mut self,
@@ -625,7 +625,7 @@ enum CmdArg<C> {
 #[derive(Clone)]
 enum Operation {
     UpdateConnectionPassword(Option<String>),
-    GetUsername
+    GetUsername,
 }
 
 fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
@@ -2283,11 +2283,12 @@ where
                     Ok(Response::Single(Value::Okay))
                 }
                 Operation::GetUsername => {
-                    let username = core.get_cluster_param(|params| params.username.clone())
+                    let username = core
+                        .get_cluster_param(|params| params.username.clone())
                         .expect(MUTEX_WRITE_ERR);
                     Ok(Response::Single(match username {
                         Some(u) => Value::SimpleString(u),
-                        None => Value::Nil
+                        None => Value::Nil,
                     }))
                 }
             },

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -316,6 +316,11 @@ where
             .await
     }
 
+    /// Get the username used to authenticate with all cluster servers
+    pub async fn get_username(&mut self) -> RedisResult<Value> {
+        self.route_operation_request(Operation::GetUsername).await
+    }
+    
     /// Routes an operation request to the appropriate handler.
     async fn route_operation_request(
         &mut self,
@@ -620,6 +625,7 @@ enum CmdArg<C> {
 #[derive(Clone)]
 enum Operation {
     UpdateConnectionPassword(Option<String>),
+    GetUsername
 }
 
 fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
@@ -2275,6 +2281,14 @@ where
                     core.set_cluster_param(|params| params.password = password)
                         .expect(MUTEX_WRITE_ERR);
                     Ok(Response::Single(Value::Okay))
+                }
+                Operation::GetUsername => {
+                    let username = core.get_cluster_param(|params| params.username.clone())
+                        .expect(MUTEX_WRITE_ERR);
+                    Ok(Response::Single(match username {
+                        Some(u) => Value::SimpleString(u),
+                        None => Value::Nil
+                    }))
                 }
             },
         }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2283,13 +2283,14 @@ where
                     Ok(Response::Single(Value::Okay))
                 }
                 Operation::GetUsername => {
-                    let username = core
+                    let username = match core
                         .get_cluster_param(|params| params.username.clone())
-                        .expect(MUTEX_WRITE_ERR);
-                    Ok(Response::Single(match username {
-                        Some(u) => Value::SimpleString(u),
+                        .expect(MUTEX_READ_ERR)
+                    {
+                        Some(username) => Value::SimpleString(username),
                         None => Value::Nil,
-                    }))
+                    };
+                    Ok(Response::Single(username))
                 }
             },
         }

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -531,8 +531,10 @@ impl Client {
                             cmd.arg(username);
                         }
                     }
-                    ClientWrapper::Standalone(_) => {
-                        //TODO: get username and add it as arg in standalone
+                    ClientWrapper::Standalone(ref client) => {
+                        if let Some(username) = client.get_username().await {
+                            cmd.arg(username);
+                        }
                     }
                 }
                 cmd.arg(password);

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -534,18 +534,17 @@ impl Client {
         }
     }
 
+    /// Returns the username if one was configured during client creation. Otherwise, returns None.
     async fn get_username(&mut self) -> Option<String> {
         match &mut self.internal_client {
-            ClientWrapper::Cluster { client } => {
-                if let Ok(Value::SimpleString(username)) = client.get_username().await {
-                    return Some(username);
-                }
-            }
-            ClientWrapper::Standalone(client) => {
-                return client.get_username().await;
-            }
+            ClientWrapper::Cluster { client } => match client.get_username().await {
+                Ok(Value::SimpleString(username)) => Some(username),
+                Ok(Value::Nil) => None,
+                Ok(other) => panic!("Expected SimpleString, got: {:?}", other),
+                Err(e) => panic!("Got error trying to get username: {:?}", e),
+            },
+            ClientWrapper::Standalone(client) => client.get_username(),
         }
-        None
     }
 }
 

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -525,7 +525,7 @@ impl Client {
                     Some(ResponsePolicy::AllSucceeded),
                 ));
                 let mut cmd = redis::cmd("AUTH");
-                if let Ok(Some(username)) = self.get_username().await {
+                if let Some(username) = self.get_username().await? {
                     cmd.arg(username);
                 }
                 cmd.arg(password);
@@ -540,7 +540,11 @@ impl Client {
             ClientWrapper::Cluster { client } => match client.get_username().await {
                 Ok(Value::SimpleString(username)) => Ok(Some(username)),
                 Ok(Value::Nil) => Ok(None),
-                Ok(other) => unreachable!("Expected SimpleString or Nil, got: {:?}", other),
+                Ok(other) => Err(RedisError::from((
+                    ErrorKind::ClientError,
+                    "Unexpected type",
+                    format!("Expected SimpleString or Nil, got: {other:?}"),
+                ))),
                 Err(e) => Err(RedisError::from((
                     ErrorKind::ResponseError,
                     "Error getting username",

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -527,27 +527,22 @@ impl Client {
                 let mut cmd = redis::cmd("AUTH");
                 match self.internal_client {
                     ClientWrapper::Cluster { ref mut client } => {
-                        match client.get_username().await? {
-                            Value::SimpleString(username) => {
-                                cmd.arg(username);
-                            }
-                            _ => {}
+                        if let Ok(Value::SimpleString(username)) = client.get_username().await {
+                            cmd.arg(username);
                         }
                     }
                     ClientWrapper::Standalone(ref mut client) => {
                         if let Ok(Some(username)) = client.get_username().await {
                             cmd.arg(username);
                         }
-                    }                    
+                    }
                 }
                 cmd.arg(password);
                 self.send_command(&cmd, Some(routing)).await
-                }
             }
         }
     }
-    
-
+}
 
 fn load_cmd(code: &[u8]) -> Cmd {
     let mut cmd = redis::cmd("SCRIPT");

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -534,9 +534,11 @@ impl Client {
                             _ => {}
                         }
                     }
-                    ClientWrapper::Standalone(_) => {
-                        // Standalone mode doesn't support username
-                    }
+                    ClientWrapper::Standalone(ref mut client) => {
+                        if let Ok(Some(username)) = client.get_username().await {
+                            cmd.arg(username);
+                        }
+                    }                    
                 }
                 cmd.arg(password);
                 self.send_command(&cmd, Some(routing)).await

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -531,10 +531,8 @@ impl Client {
                             cmd.arg(username);
                         }
                     }
-                    ClientWrapper::Standalone(ref mut client) => {
-                        if let Ok(Some(username)) = client.get_username().await {
-                            cmd.arg(username);
-                        }
+                    ClientWrapper::Standalone(_) => {
+                        //TODO: get username and add it as arg in standalone
                     }
                 }
                 cmd.arg(password);

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -540,7 +540,7 @@ impl Client {
             ClientWrapper::Cluster { client } => match client.get_username().await {
                 Ok(Value::SimpleString(username)) => Some(username),
                 Ok(Value::Nil) => None,
-                Ok(other) => panic!("Expected SimpleString, got: {:?}", other),
+                Ok(other) => unreachable!("Expected SimpleString or Nil, got: {:?}", other),
                 Err(e) => panic!("Got error trying to get username: {:?}", e),
             },
             ClientWrapper::Standalone(client) => client.get_username(),

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -120,7 +120,11 @@ async fn create_connection(
     discover_az: bool,
     connection_timeout: Duration,
 ) -> Result<ReconnectingConnection, (ReconnectingConnection, RedisError)> {
-    let client = connection_backend.connection_info.read().unwrap();
+    let client = {
+        let guard = connection_backend.connection_info.read().unwrap();
+        guard.clone()
+    };
+
     let connection_options = GlideConnectionOptions {
         push_sender,
         disconnect_notifier: Some::<Box<dyn DisconnectNotifier>>(Box::new(
@@ -129,6 +133,7 @@ async fn create_connection(
         discover_az,
         connection_timeout: Some(connection_timeout),
     };
+
     let action = || async {
         get_multiplexed_connection(&client, &connection_options)
             .await

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -617,18 +617,6 @@ impl StandaloneClient {
             .update_connection_password(password.clone())
             .await
     }
-
-    pub async fn get_username(
-        &mut self
-    ) -> RedisResult<Option<String>> {
-        let connection = self.get_connection(false)
-            .await
-            .get_connection()
-            .await?;
-            
-        Ok(connection.get_username())
-    }
-
 }
 
 async fn get_connection_and_replication_info(

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -617,6 +617,18 @@ impl StandaloneClient {
             .update_connection_password(password.clone())
             .await
     }
+
+    pub async fn get_username(
+        &mut self
+    ) -> RedisResult<Option<String>> {
+        let connection = self.get_connection(false)
+            .await
+            .get_connection()
+            .await?;
+            
+        Ok(connection.get_username())
+    }
+
 }
 
 async fn get_connection_and_replication_info(

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -607,15 +607,18 @@ impl StandaloneClient {
     /// Update the password used to authenticate with the servers.
     /// If the password is `None`, the password will be removed.
     pub async fn update_connection_password(
-        &mut self,
-        password: Option<String>,
+        &self,
+        new_password: Option<String>,
     ) -> RedisResult<Value> {
-        self.get_connection(false)
-            .await
-            .get_connection()
-            .await?
-            .update_connection_password(password.clone())
-            .await
+        for node in self.inner.nodes.iter() {
+            node.update_connection_password(new_password.clone());
+        }
+
+        Ok(Value::Okay)
+    }
+
+    pub async fn get_username(&self) -> Option<String> {
+        self.get_primary_connection().get_username()
     }
 }
 

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -604,7 +604,7 @@ impl StandaloneClient {
         });
     }
 
-    /// Update the password used to authenticate with the server.
+    /// Update the password used to authenticate with the servers.
     /// If the password is `None`, the password will be removed.
     pub async fn update_connection_password(
         &self,

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -604,7 +604,7 @@ impl StandaloneClient {
         });
     }
 
-    /// Update the password used to authenticate with the servers.
+    /// Update the password used to authenticate with the server.
     /// If the password is `None`, the password will be removed.
     pub async fn update_connection_password(
         &self,
@@ -617,7 +617,9 @@ impl StandaloneClient {
         Ok(Value::Okay)
     }
 
-    pub async fn get_username(&self) -> Option<String> {
+    /// Retrieve the username used to authenticate with the server.
+    pub fn get_username(&self) -> Option<String> {
+        // All nodes in the client should have the same username configured, thus any connection would work here.
         self.get_primary_connection().get_username()
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -5,6 +5,7 @@ import static glide.TestConfiguration.AZ_CLUSTER_HOSTS;
 import static glide.TestConfiguration.CLUSTER_HOSTS;
 import static glide.TestConfiguration.STANDALONE_HOSTS;
 import static glide.TestConfiguration.TLS;
+import static glide.api.BaseClient.OK;
 import static glide.api.models.GlideString.gs;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleSingleNodeRoute.RANDOM;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -451,5 +452,105 @@ public class TestUtilities {
             return infoResponseMap.get(REDIS_VERSION_KEY);
         }
         return null;
+    }
+
+    /**
+     * Delete an ACL user and assert it was deleted.
+     *
+     * @param client Glide client to be used for running the ACL DELUSER command.
+     * @param username The username of the ACL user to be deleted.
+     */
+    @SneakyThrows
+    public static void deleteAclUser(GlideClient client, String username) {
+        try {
+            assertEquals(1L, client.customCommand(new String[] {"ACL", "DELUSER", username}).get());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Set an ACL user and a password for it.
+     *
+     * @param client Glide client to be used for running the ACL SETUSER command.
+     * @param username The username of the ACL user to be registered.
+     * @param password The password of the ACL user to be registered.
+     */
+    @SneakyThrows
+    public static void setNewAclUserPassword(GlideClient client, String username, String password) {
+        try {
+            assertEquals(
+                    OK,
+                    client
+                            .customCommand(
+                                    new String[] {
+                                        "ACL",
+                                        "SETUSER",
+                                        username,
+                                        "on",
+                                        "allkeys",
+                                        "+get",
+                                        "+cluster",
+                                        "+ping",
+                                        "+info",
+                                        "+client",
+                                        ">" + password,
+                                    })
+                            .get());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Delete an ACL user and assert it was deleted.
+     *
+     * @param client Glide client to be used for running the ACL DELUSER command.
+     * @param username The username of the ACL user to be deleted.
+     */
+    @SneakyThrows
+    public static void deleteAclUser(GlideClusterClient client, String username) {
+        try {
+            assertEquals(
+                    1L,
+                    client.customCommand(new String[] {"ACL", "DELUSER", username}).get().getSingleValue());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Set an ACL user and a password for it.
+     *
+     * @param client Glide client to be used for running the ACL SETUSER command.
+     * @param username The username of the ACL user to be registered.
+     * @param password The password of the ACL user to be registered.
+     */
+    @SneakyThrows
+    public static void setNewAclUserPassword(
+            GlideClusterClient client, String username, String password) {
+        try {
+            assertEquals(
+                    OK,
+                    client
+                            .customCommand(
+                                    new String[] {
+                                        "ACL",
+                                        "SETUSER",
+                                        username,
+                                        "on",
+                                        "allkeys",
+                                        "+get",
+                                        "+cluster",
+                                        "+ping",
+                                        "+info",
+                                        "+client",
+                                        ">" + password,
+                                    })
+                            .get()
+                            .getSingleValue());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -484,17 +484,7 @@ public class TestUtilities {
                     client
                             .customCommand(
                                     new String[] {
-                                        "ACL",
-                                        "SETUSER",
-                                        username,
-                                        "on",
-                                        "allkeys",
-                                        "+get",
-                                        "+cluster",
-                                        "+ping",
-                                        "+info",
-                                        "+client",
-                                        ">" + password,
+                                        "ACL", "SETUSER", username, "on", ">" + password, "~*", "&*", "+@all",
                                     })
                             .get());
         } catch (InterruptedException e) {
@@ -535,17 +525,7 @@ public class TestUtilities {
                     client
                             .customCommand(
                                     new String[] {
-                                        "ACL",
-                                        "SETUSER",
-                                        username,
-                                        "on",
-                                        "allkeys",
-                                        "+get",
-                                        "+cluster",
-                                        "+ping",
-                                        "+info",
-                                        "+client",
-                                        ">" + password,
+                                        "ACL", "SETUSER", username, "on", ">" + password, "~*", "&*", "+@all",
                                     })
                             .get()
                             .getSingleValue());

--- a/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
+++ b/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
@@ -3,7 +3,9 @@ package glide.standalone;
 
 import static glide.TestConfiguration.SERVER_VERSION;
 import static glide.TestUtilities.commonClientConfig;
+import static glide.TestUtilities.deleteAclUser;
 import static glide.TestUtilities.getRandomString;
+import static glide.TestUtilities.setNewAclUserPassword;
 import static glide.api.BaseClient.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -16,6 +18,7 @@ import glide.api.GlideClient;
 import glide.api.models.configuration.ServerCredentials;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -238,6 +241,179 @@ public class StandaloneClientTests {
             assertEquals(OK, testClient.updateConnectionPassword(notThePwd, true).get());
         } finally {
             adminClient.configSet(Map.of("requirepass", "")).get();
+            adminClient.close();
+        }
+    }
+
+    @Timeout(50)
+    @SneakyThrows
+    @Test
+    public void test_update_connection_password_acl_user() {
+        var username = "username";
+        var pwd = UUID.randomUUID().toString();
+        var newPwd = UUID.randomUUID().toString();
+
+        GlideClient adminClient = GlideClient.createClient(commonClientConfig().build()).get();
+
+        try {
+            setNewAclUserPassword(adminClient, username, pwd);
+
+            // Create client with ACL user credentials
+            GlideClient testClient =
+                    GlideClient.createClient(
+                                    commonClientConfig()
+                                            .credentials(
+                                                    ServerCredentials.builder().username(username).password(pwd).build())
+                                            .build())
+                            .get();
+
+            // Validate client works
+            assertNotNull(testClient.info().get());
+
+            // Update the password of the client with non immediate auth
+            assertEquals(OK, testClient.updateConnectionPassword(newPwd, false).get());
+
+            // Delete the user (which will cause reconnection) and reset it with the new password
+            deleteAclUser(adminClient, username);
+            setNewAclUserPassword(adminClient, username, newPwd);
+
+            // Sleep to ensure password change in server and client reconnection
+            Thread.sleep(2000);
+
+            // Validate client reconnected succsessfuly
+            assertNotNull(testClient.info().get());
+
+            // Verify immediate auth with the same password works
+            assertEquals(OK, testClient.updateConnectionPassword(newPwd, true).get());
+
+            // Validate client still working
+            assertNotNull(testClient.info().get());
+
+        } finally {
+            deleteAclUser(adminClient, username);
+            adminClient.close();
+        }
+    }
+
+    @Timeout(50)
+    @SneakyThrows
+    @Test
+    public void test_update_connection_password_connection_lost_before_password_update_acl_user() {
+        var username = "username";
+        var pwd = UUID.randomUUID().toString();
+        var newPwd = UUID.randomUUID().toString();
+
+        GlideClient adminClient = GlideClient.createClient(commonClientConfig().build()).get();
+
+        try {
+            setNewAclUserPassword(adminClient, username, pwd);
+
+            // Create client with ACL user credentials
+            GlideClient testClient =
+                    GlideClient.createClient(
+                                    commonClientConfig()
+                                            .credentials(
+                                                    ServerCredentials.builder().username(username).password(pwd).build())
+                                            .build())
+                            .get();
+
+            // Validate client works
+            assertNotNull(testClient.info().get());
+
+            // Delete user name and reset with new  password (this will cause disconnection)
+            deleteAclUser(adminClient, username);
+            setNewAclUserPassword(adminClient, username, newPwd);
+
+            // Sleep to ensure password change in server and client reconnection
+            Thread.sleep(2000);
+
+            // Ensure client can still update the password with non-immediate auth (this doesn't require
+            // server connection)
+            assertEquals(OK, testClient.updateConnectionPassword(newPwd, false).get());
+
+            // Check that the client is unable to perform operations that require server connection,
+            // as it is still trying to reconnect with the old password
+            var timeoutException =
+                    assertThrows(
+                            ExecutionException.class,
+                            () -> testClient.updateConnectionPassword(newPwd, true).get());
+
+        } finally {
+            deleteAclUser(adminClient, username);
+            adminClient.close();
+        }
+    }
+
+    @Timeout(50)
+    @SneakyThrows
+    @Test
+    public void test_update_connection_password_replace_password_immediateAuth_acl_user() {
+        var username = "username";
+        var pwd = UUID.randomUUID().toString();
+        var newPwd = UUID.randomUUID().toString();
+
+        GlideClient adminClient = GlideClient.createClient(commonClientConfig().build()).get();
+
+        try {
+            setNewAclUserPassword(adminClient, username, pwd);
+
+            // Create client with ACL user credentials
+            GlideClient testClient =
+                    GlideClient.createClient(
+                                    commonClientConfig()
+                                            .credentials(
+                                                    ServerCredentials.builder().username(username).password(pwd).build())
+                                            .build())
+                            .get();
+
+            // Validate client works
+            assertNotNull(testClient.info().get());
+
+            // Add a new password to the client
+            setNewAclUserPassword(adminClient, username, newPwd);
+
+            // Ensure client can authenticate immediately with the new password
+            assertEquals(OK, testClient.updateConnectionPassword(newPwd, true).get());
+
+        } finally {
+            deleteAclUser(adminClient, username);
+            adminClient.close();
+        }
+    }
+
+    @Timeout(50)
+    @SneakyThrows
+    @Test
+    public void test_update_connection_password_non_valid_auth_acl_user() {
+        var username = "username";
+        var pwd = UUID.randomUUID().toString();
+        var newPwd = UUID.randomUUID().toString();
+
+        GlideClient adminClient = GlideClient.createClient(commonClientConfig().build()).get();
+
+        try {
+            setNewAclUserPassword(adminClient, username, pwd);
+
+            // Create client with ACL user credentials
+            GlideClient testClient =
+                    GlideClient.createClient(
+                                    commonClientConfig()
+                                            .credentials(
+                                                    ServerCredentials.builder().username(username).password(pwd).build())
+                                            .build())
+                            .get();
+
+            var emptyPasswordException =
+                    assertThrows(
+                            ExecutionException.class, () -> testClient.updateConnectionPassword("", true).get());
+            assertInstanceOf(RequestException.class, emptyPasswordException.getCause());
+
+            var noPasswordException =
+                    assertThrows(
+                            ExecutionException.class, () -> testClient.updateConnectionPassword(true).get());
+            assertInstanceOf(RequestException.class, noPasswordException.getCause());
+        } finally {
+            deleteAclUser(adminClient, username);
             adminClient.close();
         }
     }

--- a/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
+++ b/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
@@ -18,7 +18,6 @@ import glide.api.GlideClient;
 import glide.api.models.configuration.ServerCredentials;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.RequestException;
-import glide.api.models.exceptions.TimeoutException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;

--- a/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
+++ b/java/integTest/src/test/java/glide/standalone/StandaloneClientTests.java
@@ -263,6 +263,7 @@ public class StandaloneClientTests {
                                     commonClientConfig()
                                             .credentials(
                                                     ServerCredentials.builder().username(username).password(pwd).build())
+                                            .requestTimeout(5000)
                                             .build())
                             .get();
 
@@ -313,6 +314,7 @@ public class StandaloneClientTests {
                                     commonClientConfig()
                                             .credentials(
                                                     ServerCredentials.builder().username(username).password(pwd).build())
+                                            .requestTimeout(5000)
                                             .build())
                             .get();
 

--- a/node/tests/AuthTest.test.ts
+++ b/node/tests/AuthTest.test.ts
@@ -15,7 +15,7 @@ import {
     GlideClient,
     GlideClusterClient,
     ProtocolVersion,
-    RequestError,
+    RequestError
 } from "..";
 import { ValkeyCluster } from "../../utils/TestUtils";
 import {
@@ -26,6 +26,10 @@ import {
 
 type BaseClient = GlideClient | GlideClusterClient;
 
+const USERNAME = "username"
+const INITIAL_PASSWORD = "initial_password"
+const NEW_PASSWORD = "new_password";
+const WRONG_PASSWORD = "wrong_password";
 const TIMEOUT = 50000;
 
 type AddressEntry = [string, number];
@@ -42,18 +46,18 @@ describe("Auth tests", () => {
         // Connect to cluster or create a new one based on the parsed addresses
         cmdCluster = standaloneAddresses
             ? await ValkeyCluster.initFromExistingCluster(
-                  false,
-                  parseEndpoints(standaloneAddresses),
-                  getServerVersion,
-              )
+                false,
+                parseEndpoints(standaloneAddresses),
+                getServerVersion,
+            )
             : await ValkeyCluster.createCluster(false, 1, 1, getServerVersion);
 
         cmeCluster = clusterAddresses
             ? await ValkeyCluster.initFromExistingCluster(
-                  true,
-                  parseEndpoints(clusterAddresses),
-                  getServerVersion,
-              )
+                true,
+                parseEndpoints(clusterAddresses),
+                getServerVersion,
+            )
             : await ValkeyCluster.createCluster(true, 3, 1, getServerVersion);
 
         // Create appropriate client based on mode
@@ -70,6 +74,14 @@ describe("Auth tests", () => {
         addresses: AddressEntry[],
     ): { host: string; port: number }[] =>
         addresses.map(([host, port]) => ({ host, port }));
+
+    async function setNewAclUsernameWithPassword(client: BaseClient, username: string, password: string) {
+        await client.customCommand(['ACL', 'SETUSER', username, 'on', `>${password}`, '~*', '+@all']);
+    }
+
+    async function deleteAclUsernameAndPassword(client: BaseClient, username: string) {
+        return await client.customCommand(['ACL', 'DELUSER', username]);
+    }
 
     afterEach(async () => {
         if (managementClient) {
@@ -88,6 +100,8 @@ describe("Auth tests", () => {
                 // Ignore errors
             }
         }
+
+        await deleteAclUsernameAndPassword(managementClient, USERNAME);
 
         if (cmdCluster) {
             await flushAndCloseClient(false, cmdCluster.getAddresses());
@@ -118,6 +132,8 @@ describe("Auth tests", () => {
             );
         }
 
+        await setNewAclUsernameWithPassword(managementClient, USERNAME, INITIAL_PASSWORD);
+
         const ClientClass = isStandaloneMode ? GlideClient : GlideClusterClient;
         const addresses = formatAddresses(activeCluster.getAddresses());
 
@@ -137,9 +153,6 @@ describe("Auth tests", () => {
     describe.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "update_connection_password_%p",
         (protocol) => {
-            const NEW_PASSWORD = "new_password";
-            const WRONG_PASSWORD = "wrong_password";
-
             /**
              * Test replacing connection password with immediate re-authentication using a non-valid password.
              * Verifies that immediate re-authentication fails when the password is not valid.
@@ -324,6 +337,157 @@ describe("Auth tests", () => {
                         client.updateConnectionPassword(NEW_PASSWORD, true),
                     ).rejects.toThrow(RequestError);
                 }, protocol);
+            });
+            /*
+            * Test replacing the connection password without immediate re-authentication, when the client is pre-authenticated as an acl user.
+            * Verifies that:
+            * 1. The client can update its internal password
+            * 2. The client remains connected with current auth after non-immediate password update.
+            * 3. The client can reconnect using the new password after the user was deleted and reset with the new password on the server side (which causes the server to kill connections).
+            * Currently, this test is only supported for cluster mode,
+            * since standalone mode dont have multiple connections to manage,
+            * and the client will try to reconnect and will not listen to new tasks.
+            */
+            it(
+                "test_update_connection_password_with_acl_user",
+                async () => {
+                    await runTest(async (client: BaseClient,) => {
+                        if (client instanceof GlideClient) {
+                            return;
+                        }
+                        // Update password without re-authentication
+                        const result = await client.updateConnectionPassword(
+                            NEW_PASSWORD,
+                            false,
+                        );
+                        expect(result).toEqual("OK");
+
+                        // Verify client still works with old auth
+                        await client.set("test_key", "test_value");
+                        const value = await client.get("test_key");
+                        expect(value).toEqual("test_value");
+
+                        // Update server password - this also kills the connection 
+                        await deleteAclUsernameAndPassword(managementClient, USERNAME);
+                        await setNewAclUsernameWithPassword(managementClient, USERNAME, NEW_PASSWORD);
+
+                        // Verify client auto-reconnects with new password
+                        await client.set("test_key2", "test_value2");
+                        const value2 = await client.get("test_key2");
+                        expect(value2).toEqual("test_value2");
+                    }, protocol, {
+                        credentials: {
+                            username: USERNAME,
+                            password: INITIAL_PASSWORD
+                        }
+                    });
+                },
+                TIMEOUT,
+            );
+            /**
+             * Test replacing connection password with immediate re-authentication using a non-valid password, with an acl user.
+             * Verifies that immediate re-authentication fails when the password is not valid.
+             */
+            it("test_update_connection_password_auth_non_valid_pass_acl_user", async () => {
+                await runTest(async (client: BaseClient) => {
+                    await expect(
+                        client.updateConnectionPassword(null, true),
+                    ).rejects.toThrow(RequestError);
+                    await expect(
+                        client.updateConnectionPassword("", true),
+                    ).rejects.toThrow(RequestError);
+                }, protocol, {
+                    credentials: {
+                        username: USERNAME,
+                        password: INITIAL_PASSWORD
+                    }
+                });
+            });
+            /**
+             * Test that re-authentication fails when using wrong password with an acl user.
+             */
+            it("test_replace_password_immediateAuth_wrong_password_acl_user", async () => {
+                await runTest(async (client: BaseClient) => {
+                    await deleteAclUsernameAndPassword(managementClient, USERNAME);
+                    await setNewAclUsernameWithPassword(managementClient, USERNAME, NEW_PASSWORD);
+
+                    await expect(
+                        client.updateConnectionPassword(WRONG_PASSWORD, true),
+                    ).rejects.toThrow(RequestError);
+                    await expect(
+                        client.updateConnectionPassword(NEW_PASSWORD, true),
+                    ).resolves.toBe("OK");
+                }, protocol, {
+                    credentials: {
+                        username: USERNAME,
+                        password: INITIAL_PASSWORD
+                    }
+                });
+            });
+            /**
+            * Test deleting the user and reseting it with new password, which kills the connections, then re-authenticating with immediate re-authentication.
+            */
+            it(
+                "test_update_connection_password_with_immediateAuth_acl_user",
+                async () => {
+                    await runTest(async (client: BaseClient) => {
+                        // Delete user and reset it with new password
+                        await deleteAclUsernameAndPassword(managementClient, USERNAME);
+                        await setNewAclUsernameWithPassword(managementClient, USERNAME, NEW_PASSWORD);
+
+                        // Update client password with re-auth - make sure it reconnects successfuly with new password
+                        expect(
+                            await client.updateConnectionPassword(
+                                NEW_PASSWORD,
+                                true,
+                            ),
+                        ).toEqual("OK");
+
+                        // Verify client works with new auth
+                        await client.set("test_key", "test_value");
+                        const value = await client.get("test_key");
+                        expect(value).toEqual("test_value");
+                    }, protocol, {
+                        credentials: {
+                            username: USERNAME,
+                            password: INITIAL_PASSWORD
+                        }
+                    });
+                },
+                TIMEOUT,
+            );
+            /**
+            * Test changing server password when connection is lost before password update.
+            * Verifies that the client will not be able to reach the connection under the abstraction and return an error.
+            *
+            * **Note: This test is only supported for standalone mode, bellow explanation why*
+            */
+            it("test_update_connection_password_connection_lost_before_password_update_acl_user", async () => {
+                await runTest(async (client: BaseClient) => {
+                    if (client instanceof GlideClusterClient) {
+                        return;
+                    }
+
+                    // Set a key to ensure connection is established
+                    await client.set("test_key", "test_value");
+
+                    // Delete user and reset it with new password. This also kills the server conneciton. 
+                    await deleteAclUsernameAndPassword(managementClient, USERNAME);
+                    await setNewAclUsernameWithPassword(managementClient, USERNAME, NEW_PASSWORD);
+
+                    // Try updating client password without immediate re-auth and with, both should fail
+                    await expect(
+                        client.updateConnectionPassword(NEW_PASSWORD, false),
+                    ).rejects.toThrow(RequestError);
+                    await expect(
+                        client.updateConnectionPassword(NEW_PASSWORD, true),
+                    ).rejects.toThrow(RequestError);
+                }, protocol, {
+                    credentials: {
+                        username: USERNAME,
+                        password: INITIAL_PASSWORD
+                    }
+                });
             });
         },
     );

--- a/node/tests/AuthTest.test.ts
+++ b/node/tests/AuthTest.test.ts
@@ -39,6 +39,8 @@ describe("Auth tests", () => {
     let cmdCluster: ValkeyCluster;
     let managementClient: BaseClient;
     let client: BaseClient;
+    let managementClientCMD: GlideClient;
+    let managementClientCME: GlideClusterClient;
     beforeAll(async () => {
         const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
         const clusterAddresses = global.CLUSTER_ENDPOINTS;
@@ -60,13 +62,11 @@ describe("Auth tests", () => {
               )
             : await ValkeyCluster.createCluster(true, 3, 1, getServerVersion);
 
-        // Create appropriate client based on mode
-        const isStandaloneMode = !!standaloneAddresses;
-        const activeCluster = isStandaloneMode ? cmdCluster : cmeCluster;
-        const ClientClass = isStandaloneMode ? GlideClient : GlideClusterClient;
-
-        managementClient = await ClientClass.createClient({
-            addresses: formatAddresses(activeCluster.getAddresses()),
+        managementClientCMD = await GlideClient.createClient({
+            addresses: formatAddresses(cmdCluster.getAddresses()),
+        });
+        managementClientCME = await GlideClusterClient.createClient({
+            addresses: formatAddresses(cmeCluster.getAddresses()),
         });
     }, 40000);
 
@@ -87,6 +87,7 @@ describe("Auth tests", () => {
             "on",
             `>${password}`,
             "~*",
+            "&*",
             "+@all",
         ]);
     }
@@ -131,15 +132,30 @@ describe("Auth tests", () => {
         await cmdCluster?.close();
         await cmeCluster?.close();
         managementClient?.close();
+        managementClientCME?.close();
+        managementClientCMD?.close();
     });
 
     const runTest = async (
         test: (client: BaseClient) => Promise<void>,
         protocol: ProtocolVersion,
+        cluster_mode: boolean,
         configOverrides?: Partial<BaseClientConfiguration>,
     ) => {
-        const isStandaloneMode = configOverrides?.addresses?.length === 1;
+        let isStandaloneMode;
+
+        if (configOverrides?.addresses) {
+            isStandaloneMode =
+                configOverrides.addresses.length === 1 ? false : true;
+        } else {
+            isStandaloneMode = !cluster_mode;
+        }
+
         const activeCluster = isStandaloneMode ? cmdCluster : cmeCluster;
+
+        managementClient = isStandaloneMode
+            ? managementClientCMD
+            : managementClientCME;
 
         if (!activeCluster) {
             throw new Error(
@@ -169,22 +185,31 @@ describe("Auth tests", () => {
         }
     };
 
-    describe.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
-        "update_connection_password_%p",
-        (protocol) => {
+    describe.each([
+        { clusterMode: false, protocol: ProtocolVersion.RESP2 },
+        { clusterMode: false, protocol: ProtocolVersion.RESP3 },
+        { clusterMode: true, protocol: ProtocolVersion.RESP2 },
+        { clusterMode: true, protocol: ProtocolVersion.RESP3 },
+    ])(
+        "update_connection_password_cluster$clusterMode_$protocol",
+        ({ clusterMode, protocol }) => {
             /**
              * Test replacing connection password with immediate re-authentication using a non-valid password.
              * Verifies that immediate re-authentication fails when the password is not valid.
              */
             it("test_update_connection_password_auth_non_valid_pass", async () => {
-                await runTest(async (client: BaseClient) => {
-                    await expect(
-                        client.updateConnectionPassword(null, true),
-                    ).rejects.toThrow(RequestError);
-                    await expect(
-                        client.updateConnectionPassword("", true),
-                    ).rejects.toThrow(RequestError);
-                }, protocol);
+                await runTest(
+                    async (client: BaseClient) => {
+                        await expect(
+                            client.updateConnectionPassword(null, true),
+                        ).rejects.toThrow(RequestError);
+                        await expect(
+                            client.updateConnectionPassword("", true),
+                        ).rejects.toThrow(RequestError);
+                    },
+                    protocol,
+                    clusterMode,
+                );
             });
 
             /**
@@ -200,39 +225,46 @@ describe("Auth tests", () => {
             it(
                 "test_update_connection_password",
                 async () => {
-                    await runTest(async (client: BaseClient) => {
-                        if (client instanceof GlideClient) {
-                            return;
-                        }
+                    await runTest(
+                        async (client: BaseClient) => {
+                            // if (client instanceof GlideClient) {
+                            //     return;
+                            // }
 
-                        // Update password without re-authentication
-                        const result = await client.updateConnectionPassword(
-                            NEW_PASSWORD,
-                            false,
-                        );
-                        expect(result).toEqual("OK");
+                            // Update password without re-authentication
+                            const result =
+                                await client.updateConnectionPassword(
+                                    NEW_PASSWORD,
+                                    false,
+                                );
+                            expect(result).toEqual("OK");
 
-                        // Verify client still works with old auth
-                        await client.set("test_key", "test_value");
-                        const value = await client.get("test_key");
-                        expect(value).toEqual("test_value");
+                            // Verify client still works with old auth
+                            await client.set("test_key", "test_value");
+                            const value = await client.get("test_key");
+                            expect(value).toEqual("test_value");
 
-                        // Update server password
-                        await client.configSet({ requirepass: NEW_PASSWORD });
+                            // Update server password
+                            await client.configSet({
+                                requirepass: NEW_PASSWORD,
+                            });
 
-                        // Kill all other clients to force reconnection
-                        await managementClient.customCommand([
-                            "CLIENT",
-                            "KILL",
-                            "TYPE",
-                            "normal",
-                        ]);
+                            // Kill all other clients to force reconnection
+                            await managementClient.customCommand([
+                                "CLIENT",
+                                "KILL",
+                                "TYPE",
+                                "normal",
+                            ]);
 
-                        // Verify client auto-reconnects with new password
-                        await client.set("test_key2", "test_value2");
-                        const value2 = await client.get("test_key2");
-                        expect(value2).toEqual("test_value2");
-                    }, protocol);
+                            // Verify client auto-reconnects with new password
+                            await client.set("test_key2", "test_value2");
+                            const value2 = await client.get("test_key2");
+                            expect(value2).toEqual("test_value2");
+                        },
+                        protocol,
+                        clusterMode,
+                    );
                 },
                 TIMEOUT,
             );
@@ -241,50 +273,68 @@ describe("Auth tests", () => {
              * Test that immediate re-authentication fails when no server password is set.
              */
             it("test_update_connection_password_no_server_auth", async () => {
-                await runTest(async (client: BaseClient) => {
-                    try {
-                        await expect(
-                            client.updateConnectionPassword(NEW_PASSWORD, true),
-                        ).rejects.toThrow(RequestError);
-                    } finally {
-                        client?.close();
-                    }
-                }, protocol);
+                await runTest(
+                    async (client: BaseClient) => {
+                        try {
+                            await expect(
+                                client.updateConnectionPassword(
+                                    NEW_PASSWORD,
+                                    true,
+                                ),
+                            ).rejects.toThrow(RequestError);
+                        } finally {
+                            client?.close();
+                        }
+                    },
+                    protocol,
+                    clusterMode,
+                );
             });
 
             /**
              * Test replacing connection password with a long password string.
              */
             it("test_update_connection_password_long", async () => {
-                await runTest(async (client: BaseClient) => {
-                    const longPassword = "p".repeat(1000);
-                    expect(
-                        await client.updateConnectionPassword(
-                            longPassword,
-                            false,
-                        ),
-                    ).toEqual("OK");
-                    await client.configSet({
-                        requirepass: "",
-                    });
-                }, protocol);
+                await runTest(
+                    async (client: BaseClient) => {
+                        const longPassword = "p".repeat(1000);
+                        expect(
+                            await client.updateConnectionPassword(
+                                longPassword,
+                                false,
+                            ),
+                        ).toEqual("OK");
+                        await client.configSet({
+                            requirepass: "",
+                        });
+                    },
+                    protocol,
+                    clusterMode,
+                );
             });
 
             /**
              * Test that re-authentication fails when using wrong password.
              */
             it("test_replace_password_immediateAuth_wrong_password", async () => {
-                await runTest(async (client: BaseClient) => {
-                    await client.configSet({
-                        requirepass: NEW_PASSWORD,
-                    });
-                    await expect(
-                        client.updateConnectionPassword(WRONG_PASSWORD, true),
-                    ).rejects.toThrow(RequestError);
-                    await expect(
-                        client.updateConnectionPassword(NEW_PASSWORD, true),
-                    ).resolves.toBe("OK");
-                }, protocol);
+                await runTest(
+                    async (client: BaseClient) => {
+                        await client.configSet({
+                            requirepass: NEW_PASSWORD,
+                        });
+                        await expect(
+                            client.updateConnectionPassword(
+                                WRONG_PASSWORD,
+                                true,
+                            ),
+                        ).rejects.toThrow(RequestError);
+                        await expect(
+                            client.updateConnectionPassword(NEW_PASSWORD, true),
+                        ).resolves.toBe("OK");
+                    },
+                    protocol,
+                    clusterMode,
+                );
             });
 
             /**
@@ -293,23 +343,29 @@ describe("Auth tests", () => {
             it(
                 "test_update_connection_password_with_immediateAuth",
                 async () => {
-                    await runTest(async (client: BaseClient) => {
-                        // Set server password
-                        await client.configSet({ requirepass: NEW_PASSWORD });
+                    await runTest(
+                        async (client: BaseClient) => {
+                            // Set server password
+                            await client.configSet({
+                                requirepass: NEW_PASSWORD,
+                            });
 
-                        // Update client password with re-auth
-                        expect(
-                            await client.updateConnectionPassword(
-                                NEW_PASSWORD,
-                                true,
-                            ),
-                        ).toEqual("OK");
+                            // Update client password with re-auth
+                            expect(
+                                await client.updateConnectionPassword(
+                                    NEW_PASSWORD,
+                                    true,
+                                ),
+                            ).toEqual("OK");
 
-                        // Verify client works with new auth
-                        await client.set("test_key", "test_value");
-                        const value = await client.get("test_key");
-                        expect(value).toEqual("test_value");
-                    }, protocol);
+                            // Verify client works with new auth
+                            await client.set("test_key", "test_value");
+                            const value = await client.get("test_key");
+                            expect(value).toEqual("test_value");
+                        },
+                        protocol,
+                        clusterMode,
+                    );
                 },
                 TIMEOUT,
             );
@@ -323,39 +379,46 @@ describe("Auth tests", () => {
              * Some explanation for the curious mind:
              * Our library is abstracting a connection or connections, with a lot of mechanism around it, making it behave like what we call a "client".
              * When using standalone mode, the client is a single connection, so on disconnection the first thing it planned to do is to reconnect.
-             * Theres no reason to get other commands and to take care of them since to serve commands we need to be connected.
-             * Hence, the client will try to reconnect and will not listen try to take care of new tasks, but will let them wait in line,
-             * so the update connection password will not be able to reach the connection and will return an error.
+             * However, it will try to reconnect with the wrong password, and thus will fail to reconnect and won't have valid connection
+             * to server. Hence, authenticating with non-immediate auth will succeed, since it doesn't require an active connection
+             * to the server (it's an internal update), while immediate auth will fail (as would any command that requires an active server connection).
              * For future versions, standalone will be considered as a different animal then it is now, since standalone is not necessarily one node.
              * It can be replicated and have a lot of nodes, and to be what we like to call "one shard cluster".
              * So, in the future, we will have many existing connection and request can be managed also when one connection is locked.
              *
              */
             it("test_update_connection_password_connection_lost_before_password_update", async () => {
-                await runTest(async (client: BaseClient) => {
-                    if (client instanceof GlideClusterClient) {
-                        return;
-                    }
+                await runTest(
+                    async (client: BaseClient) => {
+                        if (client instanceof GlideClusterClient) {
+                            return;
+                        }
 
-                    // Set a key to ensure connection is established
-                    await client.set("test_key", "test_value");
-                    // Update server password
-                    await client.configSet({ requirepass: NEW_PASSWORD });
-                    // Kill client connections
-                    await managementClient.customCommand([
-                        "CLIENT",
-                        "KILL",
-                        "TYPE",
-                        "normal",
-                    ]);
-                    // Try updating client password without immediate re-auth and with, both should fail
-                    await expect(
-                        client.updateConnectionPassword(NEW_PASSWORD, false),
-                    ).rejects.toThrow(RequestError);
-                    await expect(
-                        client.updateConnectionPassword(NEW_PASSWORD, true),
-                    ).rejects.toThrow(RequestError);
-                }, protocol);
+                        // Set a key to ensure connection is established
+                        await client.set("test_key", "test_value");
+                        // Update server password
+                        await client.configSet({ requirepass: NEW_PASSWORD });
+                        // Kill client connections
+                        await managementClient.customCommand([
+                            "CLIENT",
+                            "KILL",
+                            "TYPE",
+                            "normal",
+                        ]);
+                        // Try updating client password without immediate re-auth and with - non immediate should succeed,
+                        // immediate auth should fail (failing to reconnect)
+                        const result = await client.updateConnectionPassword(
+                            NEW_PASSWORD,
+                            false,
+                        );
+                        expect(result).toEqual("OK");
+                        await expect(
+                            client.updateConnectionPassword(NEW_PASSWORD, true),
+                        ).rejects.toThrow(RequestError);
+                    },
+                    protocol,
+                    clusterMode,
+                );
             });
             /*
              * Test replacing the connection password without immediate re-authentication, when the client is pre-authenticated as an acl user.
@@ -406,6 +469,7 @@ describe("Auth tests", () => {
                             expect(value2).toEqual("test_value2");
                         },
                         protocol,
+                        clusterMode,
                         {
                             credentials: {
                                 username: USERNAME,
@@ -431,6 +495,7 @@ describe("Auth tests", () => {
                         ).rejects.toThrow(RequestError);
                     },
                     protocol,
+                    clusterMode,
                     {
                         credentials: {
                             username: USERNAME,
@@ -440,15 +505,11 @@ describe("Auth tests", () => {
                 );
             });
             /**
-             * Test that re-authentication fails when using wrong password with an acl user.
+             * Test that re-authentication with a new password succeeds.
              */
-            it("test_replace_password_immediateAuth_wrong_password_acl_user", async () => {
+            it("test_replace_password_immediateAuth_acl_user", async () => {
                 await runTest(
                     async (client: BaseClient) => {
-                        await deleteAclUsernameAndPassword(
-                            managementClient,
-                            USERNAME,
-                        );
                         await setNewAclUsernameWithPassword(
                             managementClient,
                             USERNAME,
@@ -456,16 +517,11 @@ describe("Auth tests", () => {
                         );
 
                         await expect(
-                            client.updateConnectionPassword(
-                                WRONG_PASSWORD,
-                                true,
-                            ),
-                        ).rejects.toThrow(RequestError);
-                        await expect(
                             client.updateConnectionPassword(NEW_PASSWORD, true),
                         ).resolves.toBe("OK");
                     },
                     protocol,
+                    clusterMode,
                     {
                         credentials: {
                             username: USERNAME,
@@ -475,53 +531,10 @@ describe("Auth tests", () => {
                 );
             });
             /**
-             * Test deleting the user and reseting it with new password, which kills the connections, then re-authenticating with immediate re-authentication.
-             */
-            it(
-                "test_update_connection_password_with_immediateAuth_acl_user",
-                async () => {
-                    await runTest(
-                        async (client: BaseClient) => {
-                            // Delete user and reset it with new password
-                            await deleteAclUsernameAndPassword(
-                                managementClient,
-                                USERNAME,
-                            );
-                            await setNewAclUsernameWithPassword(
-                                managementClient,
-                                USERNAME,
-                                NEW_PASSWORD,
-                            );
-
-                            // Update client password with re-auth - make sure it reconnects successfuly with new password
-                            expect(
-                                await client.updateConnectionPassword(
-                                    NEW_PASSWORD,
-                                    true,
-                                ),
-                            ).toEqual("OK");
-
-                            // Verify client works with new auth
-                            await client.set("test_key", "test_value");
-                            const value = await client.get("test_key");
-                            expect(value).toEqual("test_value");
-                        },
-                        protocol,
-                        {
-                            credentials: {
-                                username: USERNAME,
-                                password: INITIAL_PASSWORD,
-                            },
-                        },
-                    );
-                },
-                TIMEOUT,
-            );
-            /**
              * Test changing server password when connection is lost before password update.
              * Verifies that the client will not be able to reach the connection under the abstraction and return an error.
              *
-             * **Note: This test is only supported for standalone mode, bellow explanation why*
+             * **Note: This test is only supported for standalone mode, see explanation at the parallel test above*
              */
             it("test_update_connection_password_connection_lost_before_password_update_acl_user", async () => {
                 await runTest(
@@ -544,18 +557,20 @@ describe("Auth tests", () => {
                             NEW_PASSWORD,
                         );
 
-                        // Try updating client password without immediate re-auth and with, both should fail
-                        await expect(
-                            client.updateConnectionPassword(
+                        // Try updating client password without immediate re-auth and with - non immediate should succeed,
+                        // immediate auth should fail (failing to reconnect)
+                        expect(
+                            await client.updateConnectionPassword(
                                 NEW_PASSWORD,
                                 false,
                             ),
-                        ).rejects.toThrow(RequestError);
+                        ).toEqual("OK");
                         await expect(
                             client.updateConnectionPassword(NEW_PASSWORD, true),
                         ).rejects.toThrow(RequestError);
                     },
                     protocol,
+                    clusterMode,
                     {
                         credentials: {
                             username: USERNAME,

--- a/node/tests/AuthTest.test.ts
+++ b/node/tests/AuthTest.test.ts
@@ -80,7 +80,7 @@ describe("Auth tests", () => {
         username: string,
         password: string,
     ) {
-        await client.customCommand([
+        const result = await client.customCommand([
             "ACL",
             "SETUSER",
             username,
@@ -90,13 +90,15 @@ describe("Auth tests", () => {
             "&*",
             "+@all",
         ]);
+        expect(result).toEqual("OK");
     }
 
     async function deleteAclUsernameAndPassword(
         client: BaseClient,
         username: string,
     ) {
-        return await client.customCommand(["ACL", "DELUSER", username]);
+        const result = await client.customCommand(["ACL", "DELUSER", username]);
+        expect(result).toEqual(1);
     }
 
     afterEach(async () => {
@@ -227,10 +229,6 @@ describe("Auth tests", () => {
                 async () => {
                     await runTest(
                         async (client: BaseClient) => {
-                            // if (client instanceof GlideClient) {
-                            //     return;
-                            // }
-
                             // Update password without re-authentication
                             const result =
                                 await client.updateConnectionPassword(
@@ -256,6 +254,11 @@ describe("Auth tests", () => {
                                 "TYPE",
                                 "normal",
                             ]);
+
+                            // Sleep to ensure disconnection
+                            await new Promise((resolve) =>
+                                setTimeout(resolve, 1000),
+                            );
 
                             // Verify client auto-reconnects with new password
                             await client.set("test_key2", "test_value2");
@@ -405,8 +408,14 @@ describe("Auth tests", () => {
                             "TYPE",
                             "normal",
                         ]);
+                        // Sleep to ensure disconnection
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, 1000),
+                        );
+
                         // Try updating client password without immediate re-auth and with - non immediate should succeed,
                         // immediate auth should fail (failing to reconnect)
+
                         const result = await client.updateConnectionPassword(
                             NEW_PASSWORD,
                             false,
@@ -461,6 +470,11 @@ describe("Auth tests", () => {
                                 managementClient,
                                 USERNAME,
                                 NEW_PASSWORD,
+                            );
+
+                            // Sleep to ensure disconnection
+                            await new Promise((resolve) =>
+                                setTimeout(resolve, 1000),
                             );
 
                             // Verify client auto-reconnects with new password
@@ -555,6 +569,11 @@ describe("Auth tests", () => {
                             managementClient,
                             USERNAME,
                             NEW_PASSWORD,
+                        );
+
+                        // Sleep to ensure disconnection
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, 1000),
                         );
 
                         // Try updating client password without immediate re-auth and with - non immediate should succeed,

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -261,6 +261,7 @@ async def acl_glide_client(
         request,
         cluster_mode,
         protocol=protocol,
+        request_timeout=5000,
         credentials=ServerCredentials(username=USERNAME, password=INITIAL_PASSWORD),
     )
     yield client

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -237,31 +237,36 @@ async def management_client(
     yield client
     await test_teardown(request, cluster_mode, protocol)
     await client.close()
-    
-@pytest.fixture(scope="function")    
+
+
+@pytest.fixture(scope="function")
 async def acl_glide_client(
     request,
     cluster_mode: bool,
     protocol: ProtocolVersion,
-    management_client: TGlideClient
+    management_client: TGlideClient,
 ) -> AsyncGenerator[TGlideClient, None]:
     """
-    Client fot tests that use a server pre-configured with an ACL user. 
-    This function first uses the management client to register the USERNAME with INITIAL_PASSWORD, so that the client would be ablt to connect.
+    Client fot tests that use a server pre-configured with an ACL user.
+    This function first uses the management client to register the USERNAME with INITIAL_PASSWORD,so that
+    the client would be ablt to connect.
     It then returns a client with this USERNAME and INITIAL_PASSWORD already set as its ServerCredentials.
     """
-    
-    await set_new_acl_username_with_password(management_client, USERNAME, INITIAL_PASSWORD)
-                                 
+
+    await set_new_acl_username_with_password(
+        management_client, USERNAME, INITIAL_PASSWORD
+    )
+
     client = await create_client(
         request,
         cluster_mode,
         protocol=protocol,
-        credentials=ServerCredentials(username=USERNAME, password=INITIAL_PASSWORD)
+        credentials=ServerCredentials(username=USERNAME, password=INITIAL_PASSWORD),
     )
-    yield client    
+    yield client
     await test_teardown(request, cluster_mode, protocol)
     await client.close()
+
 
 async def create_client(
     request,
@@ -328,20 +333,23 @@ async def create_client(
         )
         return await GlideClient.create(config)
 
+
 USERNAME = "username"
 INITIAL_PASSWORD = "initial_password"
 NEW_PASSWORD = "new_secure_password"
 WRONG_PASSWORD = "wrong_password"
 
 
-async def auth_client(client: TGlideClient, password, username = 'default'):
+async def auth_client(client: TGlideClient, password, username="default"):
     """
     Authenticates the given TGlideClient server connected. If no username is provided, uses the 'default' user.
     """
     if isinstance(client, GlideClient):
-        return await client.custom_command(["AUTH", username ,password])
+        return await client.custom_command(["AUTH", username, password])
     elif isinstance(client, GlideClusterClient):
-        return await client.custom_command(["AUTH", username, password], route=AllNodes())
+        return await client.custom_command(
+            ["AUTH", username, password], route=AllNodes()
+        )
 
 
 async def config_set_new_password(client: TGlideClient, password):
@@ -353,16 +361,23 @@ async def config_set_new_password(client: TGlideClient, password):
         await client.config_set({"requirepass": password})
     elif isinstance(client, GlideClusterClient):
         await client.config_set({"requirepass": password}, route=AllNodes())
-        
+
+
 async def set_new_acl_username_with_password(client: TGlideClient, username, password):
     """
     Sets a new password for the given TGlideClient server connected.
     This function updates the server to require a new password.
     """
     if isinstance(client, GlideClient):
-        await client.custom_command(["ACL", "SETUSER", username, "ON",  f">{password}", "~*", "&*", "+@all" ])
+        await client.custom_command(
+            ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"]
+        )
     elif isinstance(client, GlideClusterClient):
-        await client.custom_command(["ACL", "SETUSER", username, "ON",  f">{password}", "~*", "&*", "+@all" ], route=AllNodes())
+        await client.custom_command(
+            ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"],
+            route=AllNodes(),
+        )
+
 
 async def delete_acl_username_and_password(client: TGlideClient, username):
     """
@@ -371,8 +386,10 @@ async def delete_acl_username_and_password(client: TGlideClient, username):
     if isinstance(client, GlideClient):
         return await client.custom_command(["ACL", "DELUSER", username])
     elif isinstance(client, GlideClusterClient):
-        return await client.custom_command(["ACL", "DELUSER", username], route=AllNodes())
-    
+        return await client.custom_command(
+            ["ACL", "DELUSER", username], route=AllNodes()
+        )
+
 
 async def kill_connections(client: TGlideClient):
     """

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -366,18 +366,20 @@ async def config_set_new_password(client: TGlideClient, password):
 
 async def set_new_acl_username_with_password(client: TGlideClient, username, password):
     """
-    Sets a new password for the given TGlideClient server connected.
-    This function updates the server to require a new password.
+    Sets a new ACL user with the provided password
     """
-    if isinstance(client, GlideClient):
-        await client.custom_command(
-            ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"]
-        )
-    elif isinstance(client, GlideClusterClient):
-        await client.custom_command(
-            ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"],
-            route=AllNodes(),
-        )
+    try:
+        if isinstance(client, GlideClient):
+            await client.custom_command(
+                ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"]
+            )
+        elif isinstance(client, GlideClusterClient):
+            await client.custom_command(
+                ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"],
+                route=AllNodes(),
+            )
+    except Exception as e:
+        raise RuntimeError(f"Failed to set ACL user: {e}")
 
 
 async def delete_acl_username_and_password(client: TGlideClient, username):
@@ -386,6 +388,7 @@ async def delete_acl_username_and_password(client: TGlideClient, username):
     """
     if isinstance(client, GlideClient):
         return await client.custom_command(["ACL", "DELUSER", username])
+
     elif isinstance(client, GlideClusterClient):
         return await client.custom_command(
             ["ACL", "DELUSER", username], route=AllNodes()

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -13,8 +13,10 @@ from tests.conftest import (
     WRONG_PASSWORD,
     auth_client,
     config_set_new_password,
-    delete_acl_username_and_password,
     kill_connections,
+)
+from tests.utils.utils import (
+    delete_acl_username_and_password,
     set_new_acl_username_with_password,
 )
 
@@ -274,7 +276,7 @@ class TestAuthCommands:
         Verifies that:
         1. Upon disconnection (which is caused by the user deletion), the client succeeds in updating the password
         with non-immediate auth (this is an internal operation not requiring a server connection).
-        2.
+        2. Trying to connect with immediate authentication fails due to reconnection attempts with the previous password.
         This test is relevant only for standalone - in standalone, reconnection will fail and new requests for
         the server won't be served.
         """
@@ -291,7 +293,7 @@ class TestAuthCommands:
 
         with pytest.raises(RequestError):
             await acl_glide_client.update_connection_password(
-                WRONG_PASSWORD, immediate_auth=True
+                NEW_PASSWORD, immediate_auth=True
             )
 
     @pytest.mark.parametrize("cluster_mode", [True, False])

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -185,26 +185,6 @@ class TestAuthCommands:
         value = await acl_glide_client.get("new_key")
         assert value == b"new_value"
 
-    @pytest.mark.parametrize("cluster_mode", [False])
-    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_update_connection_password_connection_lost_before_password_update_with_acl_user(
-        self, acl_glide_client: TGlideClient, management_client: TGlideClient
-    ):
-        """
-        Test changing server password when connection is lost before password update.
-        Verifies that the client will not be able to reach the inner core and return an error.
-        """
-        await acl_glide_client.set("test_key", "test_value")
-        assert await delete_acl_username_and_password(management_client, USERNAME) == 1
-        await set_new_acl_username_with_password(
-            management_client, USERNAME, NEW_PASSWORD
-        )
-        await asyncio.sleep(1)
-        with pytest.raises(RequestError):
-            await acl_glide_client.update_connection_password(
-                NEW_PASSWORD, immediate_auth=False
-            )
-
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_update_connection_password_with_immediate_auth_with_acl_user(

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -285,13 +285,7 @@ class TestAuthCommands:
             management_client, USERNAME, NEW_PASSWORD
         )
 
-        result = await acl_glide_client.update_connection_password(
-            NEW_PASSWORD, immediate_auth=False
-        )
-
-        assert result == OK
-
-        # ensure client disconnection and password update
+        # ensure client disconnection
         await asyncio.sleep(2)
 
         with pytest.raises(RequestError):
@@ -316,6 +310,10 @@ class TestAuthCommands:
         )
 
         assert result == OK
+
+        assert await acl_glide_client.set("test_key", "test_value") == OK
+        value = await acl_glide_client.get("test_key")
+        assert value == b"test_value"
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -291,6 +291,9 @@ class TestAuthCommands:
 
         assert result == OK
 
+        # ensure client disconnection and password update
+        await asyncio.sleep(2)
+
         with pytest.raises(RequestError):
             await acl_glide_client.update_connection_password(
                 NEW_PASSWORD, immediate_auth=True

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -41,6 +41,46 @@ class TestAuthCommands:
         except RequestError:
             pass
 
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_update_connection_password(
+        self, glide_client: TGlideClient, management_client: TGlideClient
+    ):
+        """
+        Test replacing the connection password without immediate re-authentication.
+        Verifies that:
+        1. The client can update its internal password
+        2. The client remains connected with current auth
+        3. The client can reconnect using the new password after server password change
+        This test is only for cluster mode, as standalone mode does not have a connection available handler
+        """
+        result = await glide_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=False
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert await glide_client.set("test_key", "test_value") == OK
+        value = await glide_client.get("test_key")
+        assert value == b"test_value"
+        await config_set_new_password(glide_client, NEW_PASSWORD)
+        await kill_connections(management_client)
+        # Add a short delay to allow the server to apply the new password
+        # without this delay, command may or may not time out while the client reconnect
+        # ending up with a flaky test
+        await asyncio.sleep(2)
+        # Verify that the client is able to reconnect with the new password,
+        value = await glide_client.get("test_key")
+        assert value == b"test_value"
+        await kill_connections(management_client)
+        await asyncio.sleep(2)
+        # Verify that the client is able to immediateAuth with the new password after client is killed
+        result = await glide_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert await glide_client.set("test_key", "test_value") == OK
+
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_update_connection_password_connection_lost_before_password_update(
@@ -54,7 +94,7 @@ class TestAuthCommands:
         await glide_client.set("test_key", "test_value")
         await config_set_new_password(glide_client, NEW_PASSWORD)
         await kill_connections(management_client)
-        await asyncio.sleep(1)
+        await asyncio.sleep(2)
         result = await glide_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=False
         )
@@ -176,6 +216,9 @@ class TestAuthCommands:
             management_client, USERNAME, NEW_PASSWORD
         )
 
+        # Sleep to allow enough time for reconnecting
+        await asyncio.sleep(2)
+
         # The client should now reconnect with the new password automatically
         # Verify that the client is still able to perform operations
         value = await acl_glide_client.get("test_key")
@@ -207,6 +250,9 @@ class TestAuthCommands:
         await set_new_acl_username_with_password(
             management_client, USERNAME, NEW_PASSWORD
         )
+
+        # Sleep to allow enough time for reconnecting
+        await asyncio.sleep(2)
 
         result = await acl_glide_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=True

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -220,13 +220,6 @@ class TestAuthCommands:
         assert await delete_acl_username_and_password(management_client, USERNAME) == 1
         await set_new_acl_username_with_password(management_client, USERNAME, NEW_PASSWORD)
         
-        # Add delay to ensure ACL changes are propagated
-        await asyncio.sleep(1)
-        
-        # Verify ACL user exists before proceeding
-        result = await management_client.custom_command(["ACL", "LIST"])
-        assert USERNAME in str(result)
-        
         result = await acl_glide_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=True
         )

--- a/python/python/tests/test_auth.py
+++ b/python/python/tests/test_auth.py
@@ -8,11 +8,14 @@ from glide.constants import OK
 from glide.exceptions import RequestError
 from glide.glide_client import TGlideClient
 from tests.conftest import (
+    USERNAME,
     NEW_PASSWORD,
     WRONG_PASSWORD,
     auth_client,
     config_set_new_password,
     kill_connections,
+    set_new_acl_username_with_password,
+    delete_acl_username_and_password
 )
 
 
@@ -23,16 +26,21 @@ class TestAuthCommands:
     @pytest.fixture(autouse=True, scope="function")
     async def cleanup(self, request, management_client: TGlideClient):
         """
-        Ensure password is reset after each test, regardless of test outcome.
+        Ensure password is reset for default user and USERNAME user is deleted after each test, regardless of test outcome.
         This fixture runs after each test.
         """
         yield
         try:
+            # reset password for default user
             await auth_client(management_client, NEW_PASSWORD)
             await config_set_new_password(management_client, "")
             await management_client.update_connection_password(None)
+            
+            # delete USERNAME user
+            await delete_acl_username_and_password(management_client, USERNAME)
         except RequestError:
             pass
+        
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
@@ -132,3 +140,116 @@ class TestAuthCommands:
             await glide_client.update_connection_password(None, immediate_auth=True)
         with pytest.raises(RequestError):
             await glide_client.update_connection_password("", immediate_auth=True)
+            
+            
+    @pytest.mark.parametrize("cluster_mode", [True])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_update_connection_password_with_acl_user(
+        self, acl_glide_client: TGlideClient, management_client: TGlideClient
+    ):
+        """
+        Test replacing the connection password for an ACL user without immediate re-authentication. Similiar to the previous test, but with an ACL user
+        and not the default one.
+        Verifies that:
+        1. The client can update its internal password for the ACL user
+        2. The client remains connected with current auth
+        3. The client can reconnect using the new password after server password change
+        This test is only for cluster mode, as standalone mode does not have a connection available handler.
+        """
+        
+        # Create a new ACL user and authenticate the client as the new user
+        await acl_glide_client.update_connection_password(NEW_PASSWORD, immediate_auth= False)
+
+        # Verify that the client is authenticated
+        assert await acl_glide_client.set("test_key", "test_value") == OK
+        value = await acl_glide_client.get("test_key")
+        assert value == b"test_value"
+
+        # Delete the username and reset it with new password (The same effect as doing config_set_new_password in the non-acl tests)
+        assert await delete_acl_username_and_password(management_client, USERNAME) == 1
+        await set_new_acl_username_with_password(management_client, USERNAME, NEW_PASSWORD)
+
+        # Kill all connections to force a reconnect
+        await kill_connections(management_client)
+        await asyncio.sleep(1)  
+
+        # The client should now reconnect with the new password automatically
+        # Verify that the client is still able to perform operations
+        value = await acl_glide_client.get("test_key")
+        assert value == b"test_value"
+
+        await acl_glide_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+
+        assert await acl_glide_client.set("new_key", "new_value") == OK
+        value = await acl_glide_client.get("new_key")
+        assert value == b"new_value"
+
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_update_connection_password_connection_lost_before_password_update_with_acl_user(
+        self, acl_glide_client: TGlideClient, management_client: TGlideClient
+    ):
+        """
+        Test changing server password when connection is lost before password update.
+        Verifies that the client will not be able to reach the inner core and return an error.
+        """
+        await acl_glide_client.set("test_key", "test_value")
+        assert await delete_acl_username_and_password(management_client, USERNAME) == 1
+        await set_new_acl_username_with_password(management_client, USERNAME, NEW_PASSWORD)
+        await kill_connections(management_client)
+        await asyncio.sleep(1)
+        with pytest.raises(RequestError):
+            await acl_glide_client.update_connection_password(
+                NEW_PASSWORD, immediate_auth=False
+            )
+            
+    @pytest.mark.parametrize("cluster_mode", [True])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_update_connection_password_with_immediate_auth_with_acl_user(
+        self, acl_glide_client: TGlideClient, management_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication.
+        Verifies that:
+        1. The client can update its password and re-authenticate immediately
+        2. The client remains operational after re-authentication
+        """
+        assert await delete_acl_username_and_password(management_client, USERNAME) == 1
+        await set_new_acl_username_with_password(management_client, USERNAME, NEW_PASSWORD)
+        
+        # Add delay to ensure ACL changes are propagated
+        await asyncio.sleep(1)
+        
+        # Verify ACL user exists before proceeding
+        result = await management_client.custom_command(["ACL", "LIST"])
+        assert USERNAME in str(result)
+        
+        result = await acl_glide_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+        assert result == OK
+        
+        # Verify client is authenticated
+        assert await acl_glide_client.set("test_key", "test_value") == OK
+        value = await acl_glide_client.get("test_key")
+        assert value == b"test_value"
+        
+    @pytest.mark.parametrize("cluster_mode", [True])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_update_connection_password_auth_non_valid_pass(
+        self, acl_glide_client: TGlideClient, management_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication using a non-valid password.
+        Verifies that immediate re-authentication fails when the password is not valid.
+        """
+        with pytest.raises(RequestError):
+            await acl_glide_client.update_connection_password(None, immediate_auth=True)
+        with pytest.raises(RequestError):
+            await acl_glide_client.update_connection_password("", immediate_auth=True)
+            
+            
+    

--- a/python/python/tests/utils/utils.py
+++ b/python/python/tests/utils/utils.py
@@ -11,7 +11,8 @@ from glide.constants import (
     TFunctionStatsSingleNodeResponse,
     TResult,
 )
-from glide.glide_client import TGlideClient
+from glide.glide_client import GlideClient, GlideClusterClient, TGlideClient
+from glide.routes import AllNodes
 from packaging import version
 
 T = TypeVar("T")
@@ -373,3 +374,36 @@ def check_function_stats_response(
         b"LUA": {b"libraries_count": lib_count, b"functions_count": function_count}
     }
     assert expected == response.get(b"engines")
+
+
+async def set_new_acl_username_with_password(
+    client: TGlideClient, username: str, password: str
+):
+    """
+    Sets a new ACL user with the provided password
+    """
+    try:
+        if isinstance(client, GlideClient):
+            await client.custom_command(
+                ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"]
+            )
+        elif isinstance(client, GlideClusterClient):
+            await client.custom_command(
+                ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"],
+                route=AllNodes(),
+            )
+    except Exception as e:
+        raise RuntimeError(f"Failed to set ACL user: {e}")
+
+
+async def delete_acl_username_and_password(client: TGlideClient, username: str):
+    """
+    Deletes the username and its password from the ACL list
+    """
+    if isinstance(client, GlideClient):
+        return await client.custom_command(["ACL", "DELUSER", username])
+
+    elif isinstance(client, GlideClusterClient):
+        return await client.custom_command(
+            ["ACL", "DELUSER", username], route=AllNodes()
+        )


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/3289

This PR fixes the update connection password to add the username as arg in `update_connection_password(immediateAuth = True)`  (i.e. send "AUTH [username] [password]")  in case username was configured in ServerCredentials during client creation.
Currently, only "AUTH [password]" is sent.

Additionally, it fixes the implementation of `update_connection_password` in CMD - previously, the updated password would be saved only in the multiplexed_connection struct, and then upon disconnection the authentication would still be with the old password. Now, the password is updated in the `ReconnectingConnection` struct which is used in reconnecitons.

NOTES- 
- Deleting the user with `delete_acl_username_and_password` is triggering a disconnect from clients authenticated with that username. 
- Unlike the previous tests, calling update_connection_password with non-immediate authentication **when disconnected from server** (for example after deleting the user or actively killing the connection) is supposed to succeed both for CME and CMD. That's because this is an internal operation and doesn't require an active connection. The difference is, when calling with immediate auth, CME can reconnect with that supplied password while CMD tries to reconnect with the initial password and thus won't succeed. 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
