### PR TITLE
Java: Fix version check in IT/MT startup.

### DIFF
--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -137,8 +137,10 @@ compileTestJava.dependsOn ':client:publishToMavenLocal'
 
 tasks.withType(Test) {
     useJUnitPlatform()
-    dependsOn 'beforeTests'
-    finalizedBy 'afterTests'
+    if (!project.gradle.startParameter.taskNames.contains(':integTest:modulesTest')) {
+        dependsOn 'beforeTests'
+        finalizedBy 'afterTests'
+    }
 
     doFirst {
         systemProperty 'test.server.standalone', standaloneHosts

--- a/java/integTest/src/test/java/glide/TestConfiguration.java
+++ b/java/integTest/src/test/java/glide/TestConfiguration.java
@@ -9,9 +9,9 @@ import glide.api.BaseClient;
 import glide.api.GlideClient;
 import glide.api.GlideClusterClient;
 import glide.api.logging.Logger;
+import org.apache.commons.lang3.tuple.Pair;
 
 public final class TestConfiguration {
-    // All servers are hosted on localhost
     public static final String[] STANDALONE_HOSTS =
             System.getProperty("test.server.standalone", "").split(",");
     public static final String[] CLUSTER_HOSTS =
@@ -24,21 +24,64 @@ public final class TestConfiguration {
     static {
         Logger.init(Logger.Level.OFF);
         Logger.setLoggerConfig(Logger.Level.OFF);
+
+        System.out.printf("STANDALONE_HOSTS = %s\n", System.getProperty("test.server.standalone", ""));
+        System.out.printf("CLUSTER_HOSTS = %s\n", System.getProperty("test.server.cluster", ""));
+        System.out.printf("AZ_CLUSTER_HOSTS = %s\n", System.getProperty("test.server.azcluster", ""));
+
+        var result = getVersionFromStandalone();
+        if (result.getKey() != null) {
+            SERVER_VERSION = result.getKey();
+        } else {
+            var errorStandalone = result.getValue();
+            result = getVersionFromCluster();
+            if (result.getKey() != null) {
+                SERVER_VERSION = result.getKey();
+            } else {
+                var errorCluster = result.getValue();
+                errorStandalone.printStackTrace(System.err);
+                System.err.println();
+                errorCluster.printStackTrace(System.err);
+                throw new RuntimeException("Failed to get server version");
+            }
+        }
+        System.out.printf("SERVER_VERSION = %s\n", SERVER_VERSION);
+    }
+
+    private static Pair<Semver, Exception> getVersionFromStandalone() {
+        if (STANDALONE_HOSTS[0].isEmpty()) {
+            return Pair.of(null, new Exception("No standalone nodes given"));
+        }
         try {
-            BaseClient client =
-                    !STANDALONE_HOSTS[0].isEmpty()
-                            ? GlideClient.createClient(commonClientConfig().build()).get()
-                            : GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
+            BaseClient client = GlideClient.createClient(commonClientConfig().build()).get();
 
             String serverVersion = TestUtilities.getServerVersion(client);
             if (serverVersion != null) {
-                SERVER_VERSION = new Semver(serverVersion);
+                return Pair.of(new Semver(serverVersion), null);
             } else {
-                throw new Exception("Failed to get server version");
+                return Pair.of(null, new Exception("Failed to parse version"));
             }
-
         } catch (Exception e) {
-            throw new RuntimeException("Failed to get server version", e);
+            return Pair.of(null, e);
+        }
+    }
+
+    private static Pair<Semver, Exception> getVersionFromCluster() {
+        if (CLUSTER_HOSTS[0].isEmpty()) {
+            return Pair.of(null, new Exception("No cluster nodes given"));
+        }
+        try {
+            BaseClient client =
+                    GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
+
+            String serverVersion = TestUtilities.getServerVersion(client);
+            if (serverVersion != null) {
+                return Pair.of(new Semver(serverVersion), null);
+            } else {
+                return Pair.of(null, new Exception("Failed to parse version"));
+            }
+        } catch (Exception e) {
+            return Pair.of(null, e);
         }
     }
 }


### PR DESCRIPTION
Issue introduced by #2352 - modules test was starting clusters and tried to use them to get the version version. Connection was failing because TLS flag was set.
The actual fix is in `build.gradle`, but I also added verbose diagnostics and more accurate version checking in `TestConfiguration` init.

### Issue link

This Pull Request is linked to issue (URL): Fixes #3341

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.