### PR TITLE
Move ServerError into Value

### DIFF
--- a/glide-core/redis-rs/redis-test/src/lib.rs
+++ b/glide-core/redis-rs/redis-test/src/lib.rs
@@ -201,6 +201,7 @@ impl ConnectionLike for MockRedisConnection {
 
         next_cmd
             .responses
+            .and_then(Value::extract_error_vec)
             .and_then(|values| match values.as_slice() {
                 [value] => Ok(value.clone()),
                 [] => Err(RedisError::from((

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -15,7 +15,6 @@ use ::tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 #[cfg(feature = "tokio-comp")]
 use ::tokio::net::lookup_host;
 use combine::{parser::combinator::AnySendSyncPartialState, stream::PointerOffset};
-use futures::TryFutureExt;
 use futures_util::future::select_ok;
 use futures_util::{
     future::FutureExt,

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -184,9 +184,9 @@ where
                 return Ok(Value::Nil);
             }
             loop {
-                match self.read_response().await.and_then(|v| v.extract_error())? {
+                match self.read_response().await? {
                     Value::Push { .. } => continue,
-                    val => return Ok(val),
+                    val => return val.extract_error(),
                 }
             }
         })

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -214,7 +214,8 @@ where
                 let response = self.read_response().await;
                 match response {
                     Ok(Value::ServerError(err)) if first_err.is_none() && cmd.is_atomic() => {
-                        // If we got an error here, it means that the error is before `EXEC` was sent, so all this transaction will be discarded
+                        // If we receive a `ServerError` here, it means the error occurred between `MULTI` and `EXEC`.
+                        // As a result, the entire transaction will be discarded.
                         first_err = Some(err.into());
                     }
                     Err(err) if first_err.is_none() => {

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -580,7 +580,7 @@ impl MultiplexedConnection {
                 }
             }
         }
-        let value = result?;
+        let value = result.and_then(|v| v.extract_error())?;
         match value {
             Value::Array(mut values) => {
                 values.drain(..offset);

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -44,17 +44,19 @@ enum ResponseAggregate {
         current_response_count: usize,
         buffer: Vec<Value>,
         first_err: Option<RedisError>,
+        is_transaction: bool,
     },
 }
 
 impl ResponseAggregate {
-    fn new(pipeline_response_count: Option<usize>) -> Self {
+    fn new(pipeline_response_count: Option<usize>, is_transaction: bool) -> Self {
         match pipeline_response_count {
             Some(response_count) => ResponseAggregate::Pipeline {
                 expected_response_count: response_count,
                 current_response_count: 0,
                 buffer: Vec::new(),
                 first_err: None,
+                is_transaction,
             },
             None => ResponseAggregate::SingleCommand,
         }
@@ -72,6 +74,7 @@ struct PipelineMessage<S> {
     output: PipelineOutput,
     // If `None`, this is a single request, not a pipeline of multiple requests.
     pipeline_response_count: Option<usize>,
+    is_transaction: bool,
 }
 
 /// Wrapper around a `Stream + Sink` where each item sent through the `Sink` results in one or more
@@ -182,8 +185,17 @@ where
                 current_response_count,
                 buffer,
                 first_err,
+                is_transaction,
             } => {
                 match result {
+                    Ok(Value::ServerError(err))
+                        if *current_response_count < (*expected_response_count - 1)
+                            && *is_transaction =>
+                    {
+                        if first_err.is_none() {
+                            *first_err = Some(err.into());
+                        }
+                    }
                     Ok(item) => {
                         buffer.push(item);
                     }
@@ -241,6 +253,7 @@ where
             input,
             output,
             pipeline_response_count,
+            is_transaction,
         }: PipelineMessage<SinkItem>,
     ) -> Result<(), Self::Error> {
         // If there is nothing to receive our output we do not need to send the message as it is
@@ -259,7 +272,8 @@ where
 
         match self_.sink_stream.start_send(input) {
             Ok(()) => {
-                let response_aggregate = ResponseAggregate::new(pipeline_response_count);
+                let response_aggregate =
+                    ResponseAggregate::new(pipeline_response_count, is_transaction);
                 let entry = InFlight {
                     output,
                     response_aggregate,
@@ -347,12 +361,10 @@ where
     }
 
     // `None` means that the stream was out of items causing that poll loop to shut down.
-    async fn send_single(
-        &mut self,
-        item: SinkItem,
-        timeout: Duration,
-    ) -> Result<Value, RedisError> {
-        self.send_recv(item, None, timeout).await
+    async fn send_single(&mut self, item: SinkItem, timeout: Duration) -> RedisResult<Value> {
+        self.send_recv(item, None, timeout, true)
+            .await
+            .and_then(|v| v.extract_error())
     }
 
     async fn send_recv(
@@ -361,6 +373,7 @@ where
         // If `None`, this is a single request, not a pipeline of multiple requests.
         pipeline_response_count: Option<usize>,
         timeout: Duration,
+        is_atomic: bool,
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
@@ -369,6 +382,7 @@ where
                 input,
                 pipeline_response_count,
                 output: sender,
+                is_transaction: is_atomic,
             })
             .await
             .map_err(|err| {
@@ -551,6 +565,7 @@ impl MultiplexedConnection {
                 cmd.get_packed_pipeline(),
                 Some(offset + count),
                 self.response_timeout,
+                cmd.is_atomic(),
             )
             .await;
 

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -874,7 +874,7 @@ impl<C: Connect + ConnectionLike> ConnectionLike for ClusterConnection<C> {
         } else {
             cmd
         };
-        let value = parse_redis_value(actual_cmd)?;
+        let value = parse_redis_value(actual_cmd).and_then(|v| v.extract_error())?;
         self.request(Input::Slice {
             cmd,
             routable: value,

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2204,8 +2204,6 @@ where
         let (address, mut conn) = conn.await.map_err(|err| (OperationTarget::NotFound, err))?;
         conn.req_packed_commands(&pipeline, offset, count)
             .await
-            // TODO: remove this when raise_on_error flag will be added
-            .and_then(Value::extract_error_vec)
             .map(Response::Multiple)
             .map_err(|err| (OperationTarget::Node { address }, err))
     }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2204,6 +2204,8 @@ where
         let (address, mut conn) = conn.await.map_err(|err| (OperationTarget::NotFound, err))?;
         conn.req_packed_commands(&pipeline, offset, count)
             .await
+            // TODO: remove this when raise_on_error flag will be added
+            .and_then(|v| Value::extract_error_vec(v))
             .map(Response::Multiple)
             .map_err(|err| (OperationTarget::Node { address }, err))
     }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2205,7 +2205,7 @@ where
         conn.req_packed_commands(&pipeline, offset, count)
             .await
             // TODO: remove this when raise_on_error flag will be added
-            .and_then(|v| Value::extract_error_vec(v))
+            .and_then(Value::extract_error_vec)
             .map(Response::Multiple)
             .map_err(|err| (OperationTarget::Node { address }, err))
     }

--- a/glide-core/redis-rs/redis/src/cluster_pipeline.rs
+++ b/glide-core/redis-rs/redis/src/cluster_pipeline.rs
@@ -121,7 +121,7 @@ impl ClusterPipeline {
         from_owned_redis_value(if self.commands.is_empty() {
             Value::Array(vec![])
         } else {
-            self.make_pipeline_results(con.execute_pipeline(self)?)
+            self.make_pipeline_results(con.execute_pipeline(self)?)?
         })
     }
 

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -1382,7 +1382,7 @@ impl ConnectionLike for Connection {
                     kind: _kind,
                     data: _data,
                 } => continue,
-                val => return Ok(val),
+                val => return Ok(val.extract_error()?),
             }
         }
     }
@@ -1408,6 +1408,11 @@ impl ConnectionLike for Connection {
             // See: https://github.com/redis-rs/redis-rs/issues/436
             let response = self.read_response();
             match response {
+                Ok(Value::ServerError(err)) if idx < offset && offset > 0 => {
+                    if first_err.is_none() {
+                        first_err = Some(err.into());
+                    }
+                }
                 Ok(item) => {
                     // RESP3 can insert push data between command replies
                     if let Value::Push {

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -1366,7 +1366,7 @@ impl ConnectionLike for Connection {
                     kind: _kind,
                     data: _data,
                 } => continue,
-                val => return Ok(val),
+                val => return val.extract_error(),
             }
         }
     }

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -1382,7 +1382,7 @@ impl ConnectionLike for Connection {
                     kind: _kind,
                     data: _data,
                 } => continue,
-                val => return Ok(val.extract_error()?),
+                val => return val.extract_error(),
             }
         }
     }

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::types::{
-    ErrorKind, InternalValue, PushKind, RedisError, RedisResult, ServerError, ServerErrorKind,
-    Value, VerbatimFormat,
+    ErrorKind, PushKind, RedisError, RedisResult, ServerError, ServerErrorKind, Value,
+    VerbatimFormat,
 };
 
 use combine::{
@@ -68,7 +68,7 @@ pub fn get_push_kind(kind: String) -> PushKind {
 
 fn value<'a, I>(
     count: Option<usize>,
-) -> impl combine::Parser<I, Output = InternalValue, PartialState = AnySendSyncPartialState>
+) -> impl combine::Parser<I, Output = Value, PartialState = AnySendSyncPartialState>
 where
     I: RangeStream<Token = u8, Range = &'a [u8]>,
     I::Error: combine::ParseError<u8, &'a [u8], I::Position>,
@@ -97,9 +97,9 @@ where
                 let simple_string = || {
                     line().map(|line| {
                         if line == "OK" {
-                            InternalValue::Okay
+                            Value::Okay
                         } else {
-                            InternalValue::SimpleString(line.into())
+                            Value::SimpleString(line.into())
                         }
                     })
                 };
@@ -117,10 +117,10 @@ where
                 let bulk_string = || {
                     int().then_partial(move |size| {
                         if *size < 0 {
-                            combine::produce(|| InternalValue::Nil).left()
+                            combine::produce(|| Value::Nil).left()
                         } else {
                             take(*size as usize)
-                                .map(|bs: &[u8]| InternalValue::BulkString(bs.to_vec()))
+                                .map(|bs: &[u8]| Value::BulkString(bs.to_vec()))
                                 .skip(crlf())
                                 .right()
                         }
@@ -137,11 +137,11 @@ where
                 let array = || {
                     int().then_partial(move |&mut length| {
                         if length < 0 {
-                            combine::produce(|| InternalValue::Nil).left()
+                            combine::produce(|| Value::Nil).left()
                         } else {
                             let length = length as usize;
                             combine::count_min_max(length, length, value(Some(count + 1)))
-                                .map(InternalValue::Array)
+                                .map(Value::Array)
                                 .right()
                         }
                     })
@@ -152,7 +152,7 @@ where
                     int().then_partial(move |&mut kv_length| {
                         let length = kv_length as usize * 2;
                         combine::count_min_max(length, length, value(Some(count + 1))).map(
-                            move |result: Vec<InternalValue>| {
+                            move |result: Vec<Value>| {
                                 let mut it = result.into_iter();
                                 let mut x = vec![];
                                 for _ in 0..kv_length {
@@ -160,7 +160,7 @@ where
                                         x.push((k, v))
                                     }
                                 }
-                                InternalValue::Map(x)
+                                Value::Map(x)
                             },
                         )
                     })
@@ -170,7 +170,7 @@ where
                         // + 1 is for data!
                         let length = kv_length as usize * 2 + 1;
                         combine::count_min_max(length, length, value(Some(count + 1))).map(
-                            move |result: Vec<InternalValue>| {
+                            move |result: Vec<Value>| {
                                 let mut it = result.into_iter();
                                 let mut attributes = vec![];
                                 for _ in 0..kv_length {
@@ -178,7 +178,7 @@ where
                                         attributes.push((k, v))
                                     }
                                 }
-                                InternalValue::Attribute {
+                                Value::Attribute {
                                     data: Box::new(it.next().unwrap()),
                                     attributes,
                                 }
@@ -189,11 +189,11 @@ where
                 let set = || {
                     int().then_partial(move |&mut length| {
                         if length < 0 {
-                            combine::produce(|| InternalValue::Nil).left()
+                            combine::produce(|| Value::Nil).left()
                         } else {
                             let length = length as usize;
                             combine::count_min_max(length, length, value(Some(count + 1)))
-                                .map(InternalValue::Set)
+                                .map(Value::Set)
                                 .right()
                         }
                     })
@@ -201,7 +201,7 @@ where
                 let push = || {
                     int().then_partial(move |&mut length| {
                         if length <= 0 {
-                            combine::produce(|| InternalValue::Push {
+                            combine::produce(|| Value::Push {
                                 kind: PushKind::Other("".to_string()),
                                 data: vec![],
                             })
@@ -209,18 +209,18 @@ where
                         } else {
                             let length = length as usize;
                             combine::count_min_max(length, length, value(Some(count + 1)))
-                                .and_then(|result: Vec<InternalValue>| {
+                                .and_then(|result: Vec<Value>| {
                                     let mut it = result.into_iter();
-                                    let first = it.next().unwrap_or(InternalValue::Nil);
-                                    if let InternalValue::BulkString(kind) = first {
+                                    let first = it.next().unwrap_or(Value::Nil);
+                                    if let Value::BulkString(kind) = first {
                                         let push_kind = String::from_utf8(kind)
                                             .map_err(StreamErrorFor::<I>::other)?;
-                                        Ok(InternalValue::Push {
+                                        Ok(Value::Push {
                                             kind: get_push_kind(push_kind),
                                             data: it.collect(),
                                         })
-                                    } else if let InternalValue::SimpleString(kind) = first {
-                                        Ok(InternalValue::Push {
+                                    } else if let Value::SimpleString(kind) = first {
+                                        Ok(Value::Push {
                                             kind: get_push_kind(kind),
                                             data: it.collect(),
                                         })
@@ -234,7 +234,7 @@ where
                         }
                     })
                 };
-                let null = || line().map(|_| InternalValue::Nil);
+                let null = || line().map(|_| Value::Nil);
                 let double = || {
                     line().and_then(|line| {
                         line.trim()
@@ -260,7 +260,7 @@ where
                                 "mkd" => VerbatimFormat::Markdown,
                                 x => VerbatimFormat::Unknown(x.to_string()),
                             };
-                            Ok(InternalValue::VerbatimString {
+                            Ok(Value::VerbatimString {
                                 format,
                                 text: text.to_string(),
                             })
@@ -282,19 +282,19 @@ where
                 };
                 combine::dispatch!(b;
                     b'+' => simple_string(),
-                    b':' => int().map(InternalValue::Int),
+                    b':' => int().map(Value::Int),
                     b'$' => bulk_string(),
                     b'*' => array(),
                     b'%' => map(),
                     b'|' => attribute(),
                     b'~' => set(),
-                    b'-' => error().map(InternalValue::ServerError),
+                    b'-' => error().map(Value::ServerError),
                     b'_' => null(),
-                    b',' => double().map(InternalValue::Double),
-                    b'#' => boolean().map(InternalValue::Boolean),
-                    b'!' => blob_error().map(InternalValue::ServerError),
+                    b',' => double().map(Value::Double),
+                    b'#' => boolean().map(Value::Boolean),
+                    b'!' => blob_error().map(Value::ServerError),
                     b'=' => verbatim(),
-                    b'(' => big_number().map(InternalValue::BigNumber),
+                    b'(' => big_number().map(Value::BigNumber),
                     b'>' => push(),
                     b => combine::unexpected_any(combine::error::Token(b))
                 )
@@ -343,7 +343,7 @@ mod aio_support {
 
             bytes.advance(removed_len);
             match opt {
-                Some(result) => Ok(Some(result.try_into())),
+                Some(result) => Ok(Some(Ok(result))),
                 None => Ok(None),
             }
         }
@@ -396,7 +396,7 @@ mod aio_support {
                     }
                 }
             }),
-            Ok(result) => result.try_into(),
+            Ok(result) => Ok(result),
         }
     }
 }
@@ -454,7 +454,7 @@ impl Parser {
                     }
                 }
             }),
-            Ok(result) => result.try_into(),
+            Ok(result) => Ok(result),
         }
     }
 }
@@ -500,7 +500,7 @@ mod tests {
         let result = codec.decode_eof(&mut bytes).unwrap().unwrap();
 
         assert_eq!(
-            result,
+            result.unwrap().extract_error(),
             Err(RedisError::from((
                 ErrorKind::BusyLoadingError,
                 "An error was signalled by the server",
@@ -523,7 +523,7 @@ mod tests {
         let result = parse_redis_value(bytes);
 
         assert_eq!(
-            result,
+            result.unwrap().extract_error(),
             Err(RedisError::from((
                 ErrorKind::BusyLoadingError,
                 "An error was signalled by the server",
@@ -601,7 +601,7 @@ mod tests {
     fn decode_resp3_blob_error() {
         let val = parse_redis_value(b"!21\r\nSYNTAX invalid syntax\r\n");
         assert_eq!(
-            val.err(),
+            val.unwrap().extract_error().err(),
             Some(make_extension_error(
                 "SYNTAX".to_string(),
                 Some("invalid syntax".to_string())

--- a/glide-core/redis-rs/redis/src/pipeline.rs
+++ b/glide-core/redis-rs/redis/src/pipeline.rs
@@ -82,11 +82,11 @@ impl Pipeline {
     }
 
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
-        Ok(self.make_pipeline_results(con.req_packed_commands(
+        self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),
             0,
             self.commands.len(),
-        )?)?)
+        )?)
     }
 
     fn execute_transaction(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
@@ -147,7 +147,7 @@ impl Pipeline {
         let value = con
             .req_packed_commands(self, 0, self.commands.len())
             .await?;
-        Ok(self.make_pipeline_results(value)?)
+        self.make_pipeline_results(value)
     }
 
     #[cfg(feature = "aio")]

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -539,7 +539,8 @@ impl Value {
         }
     }
 
-    pub(crate) fn extract_error_vec(vec: Vec<Self>) -> RedisResult<Vec<Self>> {
+    /// Extract an error from vec of Values
+    pub fn extract_error_vec(vec: Vec<Self>) -> RedisResult<Vec<Self>> {
         vec.into_iter()
             .map(Self::extract_error)
             .collect::<RedisResult<Vec<_>>>()

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -11,6 +11,7 @@ use std::string::FromUtf8Error;
 use num_bigint::BigInt;
 pub(crate) use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
+use strum_macros::Display;
 
 macro_rules! invalid_type_error {
     ($v:expr, $det:expr) => {{
@@ -159,8 +160,8 @@ pub enum ErrorKind {
     UserOperationError,
 }
 
-#[derive(PartialEq, Debug)]
-pub(crate) enum ServerErrorKind {
+#[derive(PartialEq, Debug, Clone, Display)]
+pub enum ServerErrorKind {
     ResponseError,
     ExecAbortError,
     BusyLoadingError,
@@ -175,8 +176,8 @@ pub(crate) enum ServerErrorKind {
     NotBusy,
 }
 
-#[derive(PartialEq, Debug)]
-pub(crate) enum ServerError {
+#[derive(PartialEq, Debug, Clone, Display)]
+pub enum ServerError {
     ExtensionError {
         code: String,
         detail: Option<String>,
@@ -185,6 +186,35 @@ pub(crate) enum ServerError {
         kind: ServerErrorKind,
         detail: Option<String>,
     },
+}
+
+impl ServerError {
+    pub fn code(&self) -> &str {
+        match self {
+            ServerError::ExtensionError { code, .. } => code,
+            ServerError::KnownError { kind, .. } => match kind {
+                ServerErrorKind::ResponseError => "ERR",
+                ServerErrorKind::ExecAbortError => "EXECABORT",
+                ServerErrorKind::BusyLoadingError => "LOADING",
+                ServerErrorKind::NoScriptError => "NOSCRIPT",
+                ServerErrorKind::Moved => "MOVED",
+                ServerErrorKind::Ask => "ASK",
+                ServerErrorKind::TryAgain => "TRYAGAIN",
+                ServerErrorKind::ClusterDown => "CLUSTERDOWN",
+                ServerErrorKind::CrossSlot => "CROSSSLOT",
+                ServerErrorKind::MasterDown => "MASTERDOWN",
+                ServerErrorKind::ReadOnly => "READONLY",
+                ServerErrorKind::NotBusy => "NOTBUSY",
+            },
+        }
+    }
+
+    pub fn details(&self) -> Option<&str> {
+        match self {
+            ServerError::ExtensionError { detail, .. } => detail.as_ref().map(|str| str.as_str()),
+            ServerError::KnownError { detail, .. } => detail.as_ref().map(|str| str.as_str()),
+        }
+    }
 }
 
 impl From<tokio::time::error::Elapsed> for RedisError {
@@ -220,105 +250,6 @@ impl From<ServerError> for RedisError {
                 }
             }
         }
-    }
-}
-
-/// Internal low-level redis value enum.
-#[derive(PartialEq, Debug)]
-pub(crate) enum InternalValue {
-    /// A nil response from the server.
-    Nil,
-    /// An integer response.  Note that there are a few situations
-    /// in which redis actually returns a string for an integer which
-    /// is why this library generally treats integers and strings
-    /// the same for all numeric responses.
-    Int(i64),
-    /// An arbitrary binary data, usually represents a binary-safe string.
-    BulkString(Vec<u8>),
-    /// A response containing an array with more data. This is generally used by redis
-    /// to express nested structures.
-    Array(Vec<InternalValue>),
-    /// A simple string response, without line breaks and not binary safe.
-    SimpleString(String),
-    /// A status response which represents the string "OK".
-    Okay,
-    /// Unordered key,value list from the server. Use `as_map_iter` function.
-    Map(Vec<(InternalValue, InternalValue)>),
-    /// Attribute value from the server. Client will give data instead of whole Attribute type.
-    Attribute {
-        /// Data that attributes belong to.
-        data: Box<InternalValue>,
-        /// Key,Value list of attributes.
-        attributes: Vec<(InternalValue, InternalValue)>,
-    },
-    /// Unordered set value from the server.
-    Set(Vec<InternalValue>),
-    /// A floating number response from the server.
-    Double(f64),
-    /// A boolean response from the server.
-    Boolean(bool),
-    /// First String is format and other is the string
-    VerbatimString {
-        /// Text's format type
-        format: VerbatimFormat,
-        /// Remaining string check format before using!
-        text: String,
-    },
-    /// Very large number that out of the range of the signed 64 bit numbers
-    BigNumber(BigInt),
-    /// Push data from the server.
-    Push {
-        /// Push Kind
-        kind: PushKind,
-        /// Remaining data from push message
-        data: Vec<InternalValue>,
-    },
-    ServerError(ServerError),
-}
-
-impl InternalValue {
-    pub(crate) fn try_into(self) -> RedisResult<Value> {
-        match self {
-            InternalValue::Nil => Ok(Value::Nil),
-            InternalValue::Int(val) => Ok(Value::Int(val)),
-            InternalValue::BulkString(val) => Ok(Value::BulkString(val)),
-            InternalValue::Array(val) => Ok(Value::Array(Self::try_into_vec(val)?)),
-            InternalValue::SimpleString(val) => Ok(Value::SimpleString(val)),
-            InternalValue::Okay => Ok(Value::Okay),
-            InternalValue::Map(map) => Ok(Value::Map(Self::try_into_map(map)?)),
-            InternalValue::Attribute { data, attributes } => {
-                let data = Box::new((*data).try_into()?);
-                let attributes = Self::try_into_map(attributes)?;
-                Ok(Value::Attribute { data, attributes })
-            }
-            InternalValue::Set(set) => Ok(Value::Set(Self::try_into_vec(set)?)),
-            InternalValue::Double(double) => Ok(Value::Double(double)),
-            InternalValue::Boolean(boolean) => Ok(Value::Boolean(boolean)),
-            InternalValue::VerbatimString { format, text } => {
-                Ok(Value::VerbatimString { format, text })
-            }
-            InternalValue::BigNumber(number) => Ok(Value::BigNumber(number)),
-            InternalValue::Push { kind, data } => Ok(Value::Push {
-                kind,
-                data: Self::try_into_vec(data)?,
-            }),
-
-            InternalValue::ServerError(err) => Err(err.into()),
-        }
-    }
-
-    fn try_into_vec(vec: Vec<InternalValue>) -> RedisResult<Vec<Value>> {
-        vec.into_iter()
-            .map(InternalValue::try_into)
-            .collect::<RedisResult<Vec<_>>>()
-    }
-
-    fn try_into_map(map: Vec<(InternalValue, InternalValue)>) -> RedisResult<Vec<(Value, Value)>> {
-        let mut vec = Vec::with_capacity(map.len());
-        for (key, value) in map.into_iter() {
-            vec.push((key.try_into()?, value.try_into()?));
-        }
-        Ok(vec)
     }
 }
 
@@ -372,6 +303,8 @@ pub enum Value {
         /// Remaining data from push message
         data: Vec<Value>,
     },
+    /// Error from the server.
+    ServerError(ServerError),
 }
 
 /// `VerbatimString`'s format types defined by spec
@@ -585,6 +518,40 @@ impl Value {
             _ => Err(self),
         }
     }
+
+    /// If value contains a server error, return it as an Err. Otherwise wrap the value in Ok.
+    pub fn extract_error(self) -> RedisResult<Self> {
+        match self {
+            Self::Array(val) => Ok(Self::Array(Self::extract_error_vec(val)?)),
+            Self::Map(map) => Ok(Self::Map(Self::extract_error_map(map)?)),
+            Self::Attribute { data, attributes } => {
+                let data = Box::new((*data).extract_error()?);
+                let attributes = Self::extract_error_map(attributes)?;
+                Ok(Value::Attribute { data, attributes })
+            }
+            Self::Set(set) => Ok(Self::Set(Self::extract_error_vec(set)?)),
+            Self::Push { kind, data } => Ok(Self::Push {
+                kind,
+                data: Self::extract_error_vec(data)?,
+            }),
+            Value::ServerError(err) => Err(err.into()),
+            _ => Ok(self),
+        }
+    }
+
+    pub(crate) fn extract_error_vec(vec: Vec<Self>) -> RedisResult<Vec<Self>> {
+        vec.into_iter()
+            .map(Self::extract_error)
+            .collect::<RedisResult<Vec<_>>>()
+    }
+
+    fn extract_error_map(map: Vec<(Self, Self)>) -> RedisResult<Vec<(Self, Self)>> {
+        let mut vec = Vec::with_capacity(map.len());
+        for (key, value) in map.into_iter() {
+            vec.push((key.extract_error()?, value.extract_error()?));
+        }
+        Ok(vec)
+    }
 }
 
 impl fmt::Debug for Value {
@@ -615,6 +582,7 @@ impl fmt::Debug for Value {
                 write!(fmt, "verbatim-string({:?},{:?})", format, text)
             }
             Value::BigNumber(ref m) => write!(fmt, "big-number({:?})", m),
+            Value::ServerError(ref err) => write!(fmt, "server-error({:?})", err),
         }
     }
 }

--- a/glide-core/redis-rs/redis/tests/parser.rs
+++ b/glide-core/redis-rs/redis/tests/parser.rs
@@ -84,6 +84,9 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
                 })]
                 .into_iter(),
             ),
+            Value::ServerError(ref s) => {
+                Box::new(vec![ArbitraryValue(Value::ServerError(s.clone()))].into_iter())
+            }
         }
     }
 }

--- a/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
@@ -351,6 +351,7 @@ impl aio::ConnectionLike for MockConnection {
     fn req_packed_command<'a>(&'a mut self, cmd: &'a redis::Cmd) -> RedisFuture<'a, Value> {
         Box::pin(future::ready(
             (self.handler)(&cmd.get_packed_command(), self.port)
+                .map_err(|err| err.and_then(|v| v.extract_error()))
                 .expect_err("Handler did not specify a response"),
         ))
     }
@@ -375,7 +376,9 @@ impl aio::ConnectionLike for MockConnection {
 
 impl redis::ConnectionLike for MockConnection {
     fn req_packed_command(&mut self, cmd: &[u8]) -> RedisResult<Value> {
-        (self.handler)(cmd, self.port).expect_err("Handler did not specify a response")
+        (self.handler)(cmd, self.port)
+            .map_err(|err| err.and_then(|v| v.extract_error()))
+            .expect_err("Handler did not specify a response")
     }
 
     fn req_packed_commands(

--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -612,8 +612,8 @@ where
             Ok(())
         }
         Value::ServerError(ref err) => match err.details() {
-            Some(details) => write!(writer, "-{} {details}\r\n", err.code()),
-            None => write!(writer, "-{}\r\n", err.code()),
+            Some(details) => write!(writer, "-{} {details}\r\n", err.err_code()),
+            None => write!(writer, "-{}\r\n", err.err_code()),
         },
     }
 }

--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -611,6 +611,10 @@ where
             }
             Ok(())
         }
+        Value::ServerError(ref err) => match err.details() {
+            Some(details) => write!(writer, "-{} {details}\r\n", err.code()),
+            None => write!(writer, "-{}\r\n", err.code()),
+        },
     }
 }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -424,7 +424,7 @@ mod cluster_async {
     #[tokio::test]
     async fn test_az_affinity_replicas_and_primary_prefers_local_primary() {
         // Skip test if version is less than Valkey 8.0
-        if crate::engine_version_less_than("8.0").await {
+        if engine_version_less_than("8.0").await {
             return;
         }
 

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1559,7 +1559,7 @@ pub(crate) fn get_value_type<'a>(value: &Value) -> &'a str {
         Value::VerbatimString { .. } => "VerbatimString",
         Value::BigNumber(_) => "BigNumber",
         Value::Push { .. } => "Push",
-        // TODO Value::ServerError from https://github.com/redis-rs/redis-rs/pull/1093
+        Value::ServerError(_) => "ServerError",
     }
 }
 

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -331,6 +331,7 @@ where
             }
             Ok(())
         }
+        Value::ServerError(ref err) => write!(writer, "server-error({err})\r\n"),
     }
 }
 

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+use glide_core::errors::error_message;
 use glide_core::start_socket_listener as start_socket_listener_core;
-
 // Protocol constants to expose to Java.
 use glide_core::client::FINISHED_SCAN_CURSOR;
 use glide_core::HASH as TYPE_HASH;
@@ -134,6 +134,15 @@ fn resp_value_to_java<'local>(
             )?;
 
             Ok(hash_map)
+        }
+        Value::ServerError(server_error) => {
+            let err_msg = error_message(&server_error.into());
+            let java_exception = env.new_object(
+                "glide/api/models/exceptions/RequestException",
+                "(Ljava/lang/String;)V",
+                &[(&env.new_string(err_msg)?).into()],
+            )?;
+            Ok(java_exception)
         }
     }
 }

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -24,6 +24,7 @@ use num_traits::sign::Signed;
 use redis::{aio::MultiplexedConnection, AsyncCommands, Value};
 #[cfg(feature = "testing_utilities")]
 use std::collections::HashMap;
+use std::f32::consts::E;
 use std::ptr::from_mut;
 use std::str;
 use tokio::runtime::{Builder, Runtime};
@@ -277,6 +278,11 @@ fn resp_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<JsU
             obj.set_named_property("values", js_array_view)?;
             Ok(obj.into_unknown())
         }
+        Value::ServerError(_) => Err(Error::new(
+            // TODO: implement with napi 3
+            Status::GenericFailure,
+            "ServerError is not supported",
+        )),
     }
 }
 

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -278,7 +278,7 @@ fn resp_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<JsU
             Ok(obj.into_unknown())
         }
         Value::ServerError(_) => Err(Error::new(
-            // TODO: implement with napi 3
+            // TODO: add ServerError support
             Status::GenericFailure,
             "ServerError is not supported",
         )),

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -24,7 +24,6 @@ use num_traits::sign::Signed;
 use redis::{aio::MultiplexedConnection, AsyncCommands, Value};
 #[cfg(feature = "testing_utilities")]
 use std::collections::HashMap;
-use std::f32::consts::E;
 use std::ptr::from_mut;
 use std::str;
 use tokio::runtime::{Builder, Runtime};

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -313,13 +313,13 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             }
             Value::ServerError(error) => {
                 let err_msg = error_message(&error.into());
-                // Import the module containing your custom error.
+                // Load the module that defines the request error.
                 let module = py.import_bound("glide.exceptions")?;
-                // Get the custom error type from the module.
-                let custom_error_type = module.getattr("RequestError")?;
-                // Create an instance of your custom error with the error message.
-                let instance = custom_error_type.call1((err_msg,))?;
-                // Return the instance as a PyObject.
+                // Retrieve the request error type.
+                let request_error_type = module.getattr("RequestError")?;
+                // Create an instance of the request error with the error message.
+                let instance = request_error_type.call1((err_msg,))?;
+                // Return the error instance as a PyObject.
                 Ok(instance.into_py(py))
             }
         }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -320,7 +320,11 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
                 // Create an instance of the request error with the error message.
                 let instance = request_error_type.call1((err_msg,))?;
                 // Return the error instance as a PyObject.
-                Ok(instance.into_pyobject(py))
+                Ok(instance
+                    .into_pyobject(py)
+                    .expect("ServerError: expected a proper conversion into a Python int.")
+                    .into_any()
+                    .unbind())
             }
         }
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -314,7 +314,6 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             Value::ServerError(error) => {
                 let err_msg = error_message(&error.into());
                 // Load the module that defines the request error.
-
                 let module = py.import("glide.exceptions")?;
                 // Retrieve the request error type.
                 let request_error_type = module.getattr("RequestError")?;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -320,7 +320,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
                 // Create an instance of the request error with the error message.
                 let instance = request_error_type.call1((err_msg,))?;
                 // Return the error instance as a PyObject.
-                Ok(instance.into_py(py))
+                Ok(instance.into_pyobject(py))
             }
         }
     }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -10,7 +10,6 @@ use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBool, PyBytes, PyDict, PyFloat, PyList, PySet, PyString};
 use pyo3::Python;
-use redis::RedisError;
 use redis::Value;
 use std::collections::HashMap;
 use std::ptr::from_mut;
@@ -313,7 +312,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
                     .unbind())
             }
             Value::ServerError(error) => {
-                let err_msg = error_message(&server_error.into());
+                let err_msg = error_message(&error.into());
                 // Import the module containing your custom error.
                 let module = py.import_bound("glide.exceptions")?;
                 // Get the custom error type from the module.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -314,7 +314,8 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             Value::ServerError(error) => {
                 let err_msg = error_message(&error.into());
                 // Load the module that defines the request error.
-                let module = py.import_bound("glide.exceptions")?;
+
+                let module = py.import("glide.exceptions")?;
                 // Retrieve the request error type.
                 let request_error_type = module.getattr("RequestError")?;
                 // Create an instance of the request error with the error message.


### PR DESCRIPTION
This PR refactors the handling of `ServerError` by moving it into the `redis::Value` enum, which eliminates the need for the InternalValue type. This change simplifies error handling and lays the foundation for returning failed commands in batch operations without raising errors.


<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
