### PR TITLE
Node: Fix `xpendingWithOptions` Flaky Test

### DIFF
--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -572,13 +572,19 @@ export function checkFunctionStatsResponse(
 }
 
 /**
- * Specially test flaky cases. Returns false when the test is not a known flaky test or when errors arise.
+ * Checks if given test is a known flaky test, then handles it accordingly.
+ * 
+ * This function returns false in two cases:
+ *  1. The test is not a known flaky test (i.e., we don't have a case to specially test it).
+ *  2. An error occurs during the processing of the responses. Then, default back to regular testing instead.
+ * 
+ * Otherwise, returns true to prevent redundant testing.
  *
  * @param testName - The name of the test.
  * @param response - One of the transaction results received from `exec` call.
  * @param expectedResponse - One of the expected result data from {@link transactionTest}.
  */
-export function testFlakyCases(
+export function checkAndHandleFlakyTests(
     testName: string,
     response: GlideReturnType | undefined,
     expectedResponse: GlideReturnType,
@@ -631,7 +637,7 @@ export function validateTransactionResponse(
         const [testName, expectedResponse] = expectedResponseData[i];
 
         try {
-            if (!testFlakyCases(testName, response?.[i], expectedResponse)) {
+            if (!checkAndHandleFlakyTests(testName, response?.[i], expectedResponse)) {
                 expect(response?.[i]).toEqual(expectedResponse);
             }
         } catch {

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -572,12 +572,12 @@ export function checkFunctionStatsResponse(
 }
 
 /**
- * Checks if given test is a known flaky test, then handles it accordingly.
- * 
+ * Checks if the given test is a known flaky test. If it is, we test it accordingly.
+ *
  * This function returns false in two cases:
- *  1. The test is not a known flaky test (i.e., we don't have a case to specially test it).
- *  2. An error occurs during the processing of the responses. Then, default back to regular testing instead.
- * 
+ *  1. The test is not a known flaky test (i.e., we haven't created a case to specially test it).
+ *  2. An error occurs during the processing of the responses. Then, we default back to regular testing instead.
+ *
  * Otherwise, returns true to prevent redundant testing.
  *
  * @param testName - The name of the test.
@@ -637,7 +637,13 @@ export function validateTransactionResponse(
         const [testName, expectedResponse] = expectedResponseData[i];
 
         try {
-            if (!checkAndHandleFlakyTests(testName, response?.[i], expectedResponse)) {
+            if (
+                !checkAndHandleFlakyTests(
+                    testName,
+                    response?.[i],
+                    expectedResponse,
+                )
+            ) {
                 expect(response?.[i]).toEqual(expectedResponse);
             }
         } catch {


### PR DESCRIPTION
This PR fixes an issue with a flaky field in the `xpendingWithOptions` test and introduces a new function that can be used for future flaky tests.

### Issue link

This Pull Request is linked to issue (URL): #3066 #3327 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
