### PR TITLE
C#: Fix TLS

### DIFF
--- a/csharp/lib/Cargo.toml
+++ b/csharp/lib/Cargo.toml
@@ -12,7 +12,7 @@ name = "glide_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-redis = { path = "../../glide-core/redis-rs/redis", features = ["aio", "tokio-comp","tokio-native-tls-comp"] }
+redis = { path = "../../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "connection-manager", "tokio-rustls-comp"] }
 glide-core = { path = "../../glide-core" }
 tokio = { version = "^1", features = ["rt", "macros", "rt-multi-thread", "time"] }
 logger_core = {path = "../../logger_core"}


### PR DESCRIPTION
Connections to a cluster with TLS were failing with
```
thread '<unnamed>' panicked at src/lib.rs:51:68:
called `Result::unwrap()` on an `Err` value: Cluster(Failed to create initial connections - IoError: Failed to refresh both connections - IoError: Node: "clustercfg.memorydb-01.nra7gl.memorydb.us-east-1.amazonaws.com:6380" received errors: `invalid peer certificate: UnknownIssuer`, `invalid peer certificate: UnknownIssuer`)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at core/src/panicking.rs:223:5:
panic in a function that cannot unwind
```

With this fix (copied from go client) it doesn't fail anymore.