### PR TITLE
C#: CI - fix dotnet installation on mac runners

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -102,7 +102,7 @@ jobs:
 
             # As per https://github.com/actions/setup-dotnet/issues/608, it is nice to have (but mandatory for mac runners)
             - name: Create global.json
-              run: echo '{ "sdk": { "rollForward": "latestFeature", "version": "${{ matrix.dotnet }}.0" } }' > global.json
+              run: echo "{ \"sdk\": { \"rollForward\": \"latestFeature\", \"version\": \"${{ matrix.dotnet }}.0\" } }" > global.json
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -107,6 +107,11 @@ jobs:
               env:
                   DOTNET_INSTALL_DIR: ~/.dotnet
 
+            # workaround for https://github.com/actions/setup-dotnet/issues/608
+            - name: Fix dotnet installation on mac
+              if: ${{ matrix.host.OS == "macos" }}
+              run: dotnet new globaljson --sdk-version ${{ matrix.dotnet }}.0 --roll-forward latestFeature
+
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -102,7 +102,7 @@ jobs:
 
             # As per https://github.com/actions/setup-dotnet/issues/608, it is nice to have (but mandatory for mac runners)
             - name: Create global.json
-              run: dotnet new globaljson --sdk-version ${{ matrix.dotnet }}.0 --roll-forward latestFeature
+              run: echo '{ "sdk": { "rollForward": "latestFeature", "version": "${{ matrix.dotnet }}.0" } }' > global.json
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -100,17 +100,16 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y npm
 
+            # As per https://github.com/actions/setup-dotnet/issues/608, it is nice to have (but mandatory for mac runners)
+            - name: Create global.json
+              run: dotnet new globaljson --sdk-version ${{ matrix.dotnet }}.0 --roll-forward latestFeature
+
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: ${{ matrix.dotnet }}
               env:
                   DOTNET_INSTALL_DIR: ~/.dotnet
-
-            # workaround for https://github.com/actions/setup-dotnet/issues/608
-            - name: Fix dotnet installation on mac
-              if: ${{ matrix.host.OS == 'macos' }}
-              run: dotnet new globaljson --sdk-version ${{ matrix.dotnet }}.0 --roll-forward latestFeature
 
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -102,7 +102,15 @@ jobs:
 
             # As per https://github.com/actions/setup-dotnet/issues/608, it is nice to have (but mandatory for mac runners)
             - name: Create global.json
-              run: echo "{ \"sdk\": { \"rollForward\": \"latestFeature\", \"version\": \"${{ matrix.dotnet }}.0\" } }" > global.json
+              run: |
+                  cat << EOF > global.json
+                  {
+                     "sdk": {
+                         "rollForward": "latestFeature",
+                         "version": "${{ matrix.dotnet }}.0"
+                     }
+                  }
+                  EOF
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -109,7 +109,7 @@ jobs:
 
             # workaround for https://github.com/actions/setup-dotnet/issues/608
             - name: Fix dotnet installation on mac
-              if: ${{ matrix.host.OS == "macos" }}
+              if: ${{ matrix.host.OS == 'macos' }}
               run: dotnet new globaljson --sdk-version ${{ matrix.dotnet }}.0 --roll-forward latestFeature
 
             - name: Install shared software dependencies


### PR DESCRIPTION
Without creating a `global.json`, dotnet didn't use correct version of SDK on mac runners.