### PR TITLE
Fix: Update CI Job names with required config params

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -75,6 +75,7 @@ jobs:
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
 
     test-csharp:
+        name: CSharp Tests - ${{ matrix.dotnet }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         needs: get-matrices
         timeout-minutes: 35
         strategy:
@@ -87,6 +88,11 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - name: Install Node on self-hosted runner
               if: ${{ contains(matrix.host.RUNNER, 'self-hosted') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -72,6 +72,7 @@ jobs:
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
 
     test-go:
+        name: Go Tests - ${{ matrix.go }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         needs: get-matrices
         timeout-minutes: 35
         strategy:
@@ -84,6 +85,11 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - name: Set up Go ${{ matrix.go }}
               uses: actions/setup-go@v5

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -71,6 +71,7 @@ jobs:
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
 
     test-java:
+        name: Java Tests - ${{ matrix.java }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         needs: get-matrices
         timeout-minutes: 35
         strategy:
@@ -83,6 +84,11 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - uses: gradle/actions/wrapper-validation@v3
 
@@ -133,6 +139,7 @@ jobs:
                       java/client/build/reports/spotbugs/**
 
     test-pubsub:
+        name: Java PubSubTests - ${{ matrix.java }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         needs: get-matrices
         timeout-minutes: 35
         strategy:
@@ -145,6 +152,11 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - name: Set up JDK ${{ matrix.java }}
               uses: actions/setup-java@v4

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -74,6 +74,7 @@ jobs:
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
 
     test-node:
+        name: Node Tests - ${{ matrix.node }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: [get-matrices]
         timeout-minutes: 25
@@ -85,6 +86,11 @@ jobs:
                 node: ${{ fromJson(needs.get-matrices.outputs.version-matrix-output) }}
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - name: Setup Node
               uses: actions/setup-node@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -80,6 +80,7 @@ jobs:
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
 
     test-python:
+        name: Python Tests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: get-matrices
         timeout-minutes: 35
@@ -91,6 +92,11 @@ jobs:
                 host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -149,6 +155,7 @@ jobs:
 
     # run pubsub tests in another job - they take too much time
     test-pubsub-python:
+        name: Python PubSubTests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: get-matrices
         timeout-minutes: 35
@@ -160,6 +167,11 @@ jobs:
                 host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
         steps:
             - uses: actions/checkout@v4
+
+            - name: Output Matrix Parameters for this job
+              run: |
+                  echo "Job running with the following matrix configuration:"
+                  echo "${{ toJson(matrix) }}"
 
             - name: Set up Python
               uses: actions/setup-python@v5


### PR DESCRIPTION
## Description
This PR updates the GitHub Actions workflow for python pub sub test to improve debugging by printing the full matrix configuration in the logs for each job. 

The previous job name was truncated, making it hard to track matrix parameters used in each job. This change ensures that the full matrix configuration is printed to the logs.

## Fixes
- Added a step to output the full matrix configuration to the logs using `toJson(matrix)`.
- Trimmed the job header with Language Version, Engine version and TARGET
- Above changes are done for Python, node, Go, CSharp, Java WF

### Issue link

This Pull Request is linked to issue ([URL](https://github.com/valkey-io/valkey-glide/issues/3398)): [3398]

## Notes for Reviewers
- Please review if the updated example aligns with the requirement.
- Let me know if any additional clarifications are needed.

### Checklist

Before submitting the PR make sure the following are checked:

-   [Yes] This Pull Request is related to one issue.
-   [Yes] Commit message has a detailed description of what changed and why.
-   [NA] Tests are added or updated.
-   [NA] CHANGELOG.md and documentation files are updated.
-   [Yes] Destination branch is correct - main or release
-   [Yes] Create merge commit if merging release branch into main, squash otherwise.
