### PR TITLE
Node: Re-enable `xpendingWithOptions` in Transaction Tests

### DIFF
--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -1528,16 +1528,15 @@ export async function transactionTest(
         "xpending(key9, groupName1)",
         [1, "0-2", "0-2", [[consumer.toString(), "1"]]],
     ]);
-    // TODO: uncomment once the flakiness in this test has been resolved
-    // baseTransaction.xpendingWithOptions(key9, groupName1, {
-    //     start: InfBoundary.NegativeInfinity,
-    //     end: InfBoundary.PositiveInfinity,
-    //     count: 10,
-    // });
-    // responseData.push([
-    //     "xpendingWithOptions(key9, groupName1, -, +, 10)",
-    //     [["0-2", consumer.toString(), 0, 1]],
-    // ]);
+    baseTransaction.xpendingWithOptions(key9, groupName1, {
+        start: InfBoundary.NegativeInfinity,
+        end: InfBoundary.PositiveInfinity,
+        count: 10,
+    });
+    responseData.push([
+        "xpendingWithOptions(key9, groupName1, -, +, 10)",
+        [["0-2", consumer.toString(), 0, 1]],
+    ]);
     baseTransaction.xclaim(key9, groupName1, consumer, 0, ["0-2"]);
     responseData.push([
         'xclaim(key9, groupName1, consumer, 0, ["0-2"])',


### PR DESCRIPTION
This PR re-enables `xpendingWithOptions` which was accidentally left disabled when the flakiness fix was merged.

### Issue link

This Pull Request is linked to issue (URL): #3327 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
