### PR TITLE
Node: Fix Cluster Manager Timeout

### DIFF
--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -687,12 +687,9 @@ def wait_for_all_topology_views(
         ]
         logging.debug(f"Executing: {cmd_args}")
         retries = 80
-        print(f"Entering the loop with {retries} retries...")
         while retries >= 0:
             output = redis_cli_run_command(cmd_args)
-            print("Retrieved output first output!")
             if output is not None and output.count(f"{server.host}") == len(servers):
-                print("Server is ready!!")
                 # Server is ready, get the node's role
                 cmd_args = [
                     CLI_COMMAND,
@@ -704,11 +701,8 @@ def wait_for_all_topology_views(
                     "cluster",
                     "nodes",
                 ]
-                print("About to run cli_command")
                 cluster_slots_output = redis_cli_run_command(cmd_args)
-                print("Retrieved second output: " + cluster_slots_output)
                 node_info = parse_cluster_nodes(cluster_slots_output)
-                print("Retrieved node info: " + str(node_info))
                 if node_info:
                     server.set_primary(node_info["is_primary"])
                 logging.debug(f"Server {server} is ready!")

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -686,10 +686,13 @@ def wait_for_all_topology_views(
             "slots",
         ]
         logging.debug(f"Executing: {cmd_args}")
-        retries = 60
+        retries = 80
+        print(f"Entering the loop with {retries} retries...")
         while retries >= 0:
             output = redis_cli_run_command(cmd_args)
+            print("Retrieved output first output!")
             if output is not None and output.count(f"{server.host}") == len(servers):
+                print("Server is ready!!")
                 # Server is ready, get the node's role
                 cmd_args = [
                     CLI_COMMAND,
@@ -701,8 +704,11 @@ def wait_for_all_topology_views(
                     "cluster",
                     "nodes",
                 ]
+                print("About to run cli_command")
                 cluster_slots_output = redis_cli_run_command(cmd_args)
+                print("Retrieved second output: " + cluster_slots_output)
                 node_info = parse_cluster_nodes(cluster_slots_output)
+                print("Retrieved node info: " + str(node_info))
                 if node_info:
                     server.set_primary(node_info["is_primary"])
                 logging.debug(f"Server {server} is ready!")


### PR DESCRIPTION
When running the full matrix tests, we sometimes get a timeout error like: Timeout exceeded trying to wait for server 127.0.0.1:34011 to know all hosts. After this happens, lots of tests fail afterwards. This PR bumps up the value of retries which should give enough time for the clusters to be ready.

### Issue link

This Pull Request is linked to issue (URL): #3421 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
