### PR TITLE
CD: Add `publish` checkbox for node and python CD.

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -131,7 +131,7 @@ jobs:
                       go/protobuf/
 
     commit-auto-gen-files-with-tag:
-        if: ${{ github.event_name == 'push' || inputs.pkg_go_dev_publish }}
+        if: ${{ github.event_name == 'push' || inputs.pkg_go_dev_publish == true }}
         needs: [validate-release-version, create-binaries]
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -21,6 +21,11 @@ on:
             version:
                 description: "The release version of GLIDE, formatted as *.*.* or *.*.*-rc*"
                 required: true
+            publish:
+                description: "Publish"
+                required: true
+                type: boolean
+                default: false
 
 concurrency:
     group: node-cd-${{ github.head_ref || github.ref }}-${{ toJson(inputs) }}
@@ -184,7 +189,7 @@ jobs:
                   exit 1
 
             - name: Publish to NPM
-              if: github.event_name != 'pull_request'
+              if: ${{ github.event_name == 'push' || inputs.publish == true }}
               shell: bash
               working-directory: ./node
               run: |
@@ -209,20 +214,7 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
-            # Reset the repository to make sure we get the clean checkout of the action later in other actions.
-            # It is not required since in other actions we are cleaning before the action, but it is a good practice to do it here as well.
-            - name: Reset repository
-              if: ${{ matrix.build.ARCH == 'arm64' }}
-              shell: bash
-              run: |
-                  echo "Resetting repository"
-                  git clean -xdf
-                  git reset --hard
-                  git fetch
-                  git checkout ${{ github.sha }}
-
     publish-base-to-npm:
-        if: github.event_name != 'pull_request'
         name: Publish the base NPM package
         needs: publish-binaries
         runs-on: ubuntu-latest
@@ -287,7 +279,7 @@ jobs:
                   echo "NPM_TAG=${npm_tag}" >> $GITHUB_ENV
 
             - name: Publish the base package
-              if: github.event_name != 'pull_request'
+              if: ${{ github.event_name == 'push' || inputs.publish == true }}
               shell: bash
               working-directory: ./node/npm/glide
               run: |
@@ -300,7 +292,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     test-release:
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name == 'push' || inputs.publish == true }}
         name: Test the release
         needs: [publish-base-to-npm, load-platform-matrix]
         runs-on: ${{ matrix.build.RUNNER }}

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -20,6 +20,11 @@ on:
             version:
                 description: "The release version of GLIDE, formatted as *.*.* or *.*.*-rc*"
                 required: true
+            publish:
+                description: "Publish"
+                required: true
+                type: boolean
+                default: false
 
 concurrency:
     group: pypi-${{ github.head_ref || github.ref }}
@@ -203,7 +208,6 @@ jobs:
                   if-no-files-found: error
 
     build-source-dist-and-publish-to-pypi:
-        if: github.event_name != 'pull_request'
         name: Publish the base PyPi package
         runs-on: ubuntu-latest
         needs: publish-binaries
@@ -235,6 +239,7 @@ jobs:
                   merge-multiple: true
 
             - name: Publish binaries and source to PyPI
+              if: ${{ github.event_name == 'push' || inputs.publish == true }}
               uses: PyO3/maturin-action@v1
               env:
                   MATURIN_PYPI_TOKEN: ${{ secrets.LIVEPYPI_API_TOKEN }}
@@ -244,7 +249,7 @@ jobs:
                   args: --skip-existing python/wheels/* python/sdist/*
 
     test-release:
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name == 'push' || inputs.publish == true }}
         name: Test the release
         runs-on: ${{ matrix.build.RUNNER }}
         needs: [build-source-dist-and-publish-to-pypi, load-platform-matrix]


### PR DESCRIPTION
Add `publish` checkbox for node and python CD.

When CD started manually, but with unchecked `publish`, it will do everything except actually publishing. It allows to test and verify changes in CI/CD pipelines without publishing dummy RCs.

Already implemented for go and java.