### PR TITLE
CI: hotfix for matrix

### DIFF
--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -86,5 +86,5 @@ runs:
                   jq -c '[.[] | select(.language == "$LANGUAGE_NAME") | .["always-run-versions"]][0] // []' < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
               else
                   echo 'Pick language versions listed in 'versions' - on cron (schedule) or if manually triggered job requires a full matrix'
-                  jq -c '[.[] | select(.language == "$LANGUAGE_NAME") | .versions][0]' < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
+                  jq -c "[.[] | select(.language == \"$LANGUAGE_NAME\") | .versions][0]" < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
               fi

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -89,22 +89,21 @@ runs:
                   jq -c "[.[] | select(.language == \"$LANGUAGE_NAME\") | .versions][0]" < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
               fi
 
-        - name: Validate no empty matrices
+        - name: Validate no empty/incorrect matrices
           shell: bash
           run: |
-              ENGINES=${{ steps.load-engine-matrix.outputs.engine-matrix }}
-              if [[ -z $ENGINES || "$ENGINES" == "[]" ]]; then
+              ENGINES=`jq length <<< ${{ steps.load-engine-matrix.outputs.engine-matrix }}`
+              if [[ $ENGINES == 0 ]]; then
                   echo "Engine matrix is empty!"
                   exit 1
               fi
-              HOSTS=${{ steps.load-host-matrix.outputs.host-matrix }}
-              if [[ -z $HOSTS || "$HOSTS" == "[]" ]]; then
+              HOSTS=`jq length <<< ${{ steps.load-host-matrix.outputs.host-matrix }}`
+              if [[ $HOSTS == 0 ]]; then
                   echo "Host matrix is empty!"
                   exit 1
               fi
-              LANGS=${{ steps.create-lang-version-matrix.outputs.version-matrix }}
-              echo ${{ fromJson($LANGS) }}
-              if [[ (-z $LANGS || "$LANGS" == "[]") && $LANGUAGE_NAME != "rust" ]]; then
+              LANGS=`jq length <<< ${{ steps.create-lang-version-matrix.outputs.version-matrix }}`
+              if [[ $LANGS == 0 && $LANGUAGE_NAME != "rust" ]]; then
                   echo "Language matrix is empty!"
                   exit 1
               fi

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -88,3 +88,19 @@ runs:
                   echo 'Pick language versions listed in 'versions' - on cron (schedule) or if manually triggered job requires a full matrix'
                   jq -c "[.[] | select(.language == \"$LANGUAGE_NAME\") | .versions][0]" < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
               fi
+
+        - name: Validate no empty matrices
+          shell: bash
+          run: |
+              if [[ -z "${{ steps.load-engine-matrix.outputs.engine-matrix }}" ]]; then
+                  echo "Engine matrix is empty!"
+                  exit 1
+              fi
+              if [[ -z "${{ steps.load-host-matrix.outputs.host-matrix }}" ]]; then
+                  echo "Host matrix is empty!"
+                  exit 1
+              fi
+              if [[ -z "${{ steps.create-lang-version-matrix.outputs.version-matrix }}" && $LANGUAGE_NAME != "rust" ]]; then
+                  echo "Language matrix is empty!"
+                  exit 1
+              fi

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -83,7 +83,7 @@ runs:
               echo 'Select language (framework/SDK) versions to run tests on'
               if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" || "$RUN_FULL_MATRIX" == "false" ]]; then
                   echo 'Pick language versions listed in 'always-run-versions' only - on PR, push or manually triggered job which does not require full matrix'
-                  jq -c '[.[] | select(.language == "$LANGUAGE_NAME") | .["always-run-versions"]][0] // []' < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
+                  jq -c "[.[] | select(.language == \"$LANGUAGE_NAME\") | .[\"always-run-versions\"]][0] // []" < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT
               else
                   echo 'Pick language versions listed in 'versions' - on cron (schedule) or if manually triggered job requires a full matrix'
                   jq -c "[.[] | select(.language == \"$LANGUAGE_NAME\") | .versions][0]" < .github/json_matrices/supported-languages-versions.json | awk '{ printf "version-matrix=%s\n", $0 }' | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -92,17 +92,17 @@ runs:
         - name: Validate no empty/incorrect matrices
           shell: bash
           run: |
-              ENGINES=`jq length <<< ${{ steps.load-engine-matrix.outputs.engine-matrix }}`
+              ENGINES=`jq length <<< '${{ steps.load-engine-matrix.outputs.engine-matrix }}'`
               if [[ $ENGINES == 0 ]]; then
                   echo "Engine matrix is empty!"
                   exit 1
               fi
-              HOSTS=`jq length <<< ${{ steps.load-host-matrix.outputs.host-matrix }}`
+              HOSTS=`jq length <<< '${{ steps.load-host-matrix.outputs.host-matrix }}'`
               if [[ $HOSTS == 0 ]]; then
                   echo "Host matrix is empty!"
                   exit 1
               fi
-              LANGS=`jq length <<< ${{ steps.create-lang-version-matrix.outputs.version-matrix }}`
+              LANGS=`jq length <<< '${{ steps.create-lang-version-matrix.outputs.version-matrix }}'`
               if [[ $LANGS == 0 && $LANGUAGE_NAME != "rust" ]]; then
                   echo "Language matrix is empty!"
                   exit 1

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -103,7 +103,7 @@ runs:
                   exit 1
               fi
               LANGS=${{ steps.create-lang-version-matrix.outputs.version-matrix }}
-              echo ${{ fromJson(LANGS) }}
+              echo ${{ fromJson($LANGS) }}
               if [[ (-z $LANGS || "$LANGS" == "[]") && $LANGUAGE_NAME != "rust" ]]; then
                   echo "Language matrix is empty!"
                   exit 1

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -92,15 +92,19 @@ runs:
         - name: Validate no empty matrices
           shell: bash
           run: |
-              if [[ -z "${{ steps.load-engine-matrix.outputs.engine-matrix }}" ]]; then
+              ENGINES=${{ steps.load-engine-matrix.outputs.engine-matrix }}
+              if [[ -z $ENGINES || "$ENGINES" == "[]" ]]; then
                   echo "Engine matrix is empty!"
                   exit 1
               fi
-              if [[ -z "${{ steps.load-host-matrix.outputs.host-matrix }}" ]]; then
+              HOSTS=${{ steps.load-host-matrix.outputs.host-matrix }}
+              if [[ -z $HOSTS || "$HOSTS" == "[]" ]]; then
                   echo "Host matrix is empty!"
                   exit 1
               fi
-              if [[ -z "${{ steps.create-lang-version-matrix.outputs.version-matrix }}" && $LANGUAGE_NAME != "rust" ]]; then
+              LANGS=${{ steps.create-lang-version-matrix.outputs.version-matrix }}
+              echo ${{ fromJson(LANGS) }}
+              if [[ (-z $LANGS || "$LANGS" == "[]") && $LANGUAGE_NAME != "rust" ]]; then
                   echo "Language matrix is empty!"
                   exit 1
               fi


### PR DESCRIPTION
Bash doesn't subtitute variables in single quotes, only in double quotes.
https://github.com/valkey-io/valkey-glide/actions/runs/14272482596?pr=3411
https://github.com/valkey-io/valkey-glide/actions/runs/14272482596/job/40008936070?pr=3411#step:3:86

With that mistake CI gets an empty matrix and doesn't run. It is weird that it isn't shown red on a PR page.

- [x] Typo fix for #3394
- [x] Validation ([example](https://github.com/Bit-Quill/valkey-glide/actions/runs/14273354428/job/40011373632#step:3:111))

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/8c94febb-a24f-4361-8bb7-b437713345cc)
![image](https://github.com/user-attachments/assets/d1a6a543-a1b4-491f-b588-3acca0c3cab5)
</details> 



Signed-off-by: Yury-Fridlyand <yury.fridlyand@improving.com>