### PR TITLE
Go: removing imports of IntegTest from example tests in api

### DIFF
--- a/go/api/scripting_and_function_commands_test.go
+++ b/go/api/scripting_and_function_commands_test.go
@@ -4,16 +4,41 @@ package api
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/valkey-io/valkey-glide/go/api/config"
 	"github.com/valkey-io/valkey-glide/go/api/options"
-	"github.com/valkey-io/valkey-glide/go/integTest"
 )
 
+func generateExampleLuaLibCode(libName string, functions map[string]string, readonly bool) string {
+	var code strings.Builder
+
+	// Write header
+	code.WriteString("#!lua name=")
+	code.WriteString(libName)
+	code.WriteString("\n")
+
+	// Write each function
+	for name, function := range functions {
+		code.WriteString("redis.register_function{ function_name = '")
+		code.WriteString(name)
+		code.WriteString("', callback = function(keys, args) ")
+		code.WriteString(function)
+		code.WriteString(" end")
+
+		if readonly {
+			code.WriteString(", flags = { 'no-writes' }")
+		}
+		code.WriteString(" }\n")
+	}
+
+	return code.String()
+}
+
 var (
-	libraryCode         = integTest.GenerateLuaLibCode("mylib", map[string]string{"myfunc": "return 42"}, true)
-	libraryCodeWithArgs = integTest.GenerateLuaLibCode("mylib", map[string]string{"myfunc": "return args[1]"}, true)
+	libraryCode         = generateExampleLuaLibCode("mylib", map[string]string{"myfunc": "return 42"}, true)
+	libraryCodeWithArgs = generateExampleLuaLibCode("mylib", map[string]string{"myfunc": "return args[1]"}, true)
 )
 
 // FunctionLoad Examples


### PR DESCRIPTION
Removing a import of integTest in api

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
