### PR TITLE
Java: Fix compiler warning

### DIFF
--- a/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java
@@ -16,7 +16,7 @@ import lombok.experimental.SuperBuilder;
  * @see <a href="https://valkey.io/commands/scan/">valkey.io</a>
  */
 @SuperBuilder
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class ScanOptions extends BaseScanOptions {
     /** <code>TYPE</code> option string to include in the <code>SCAN</code> commands. */
     public static final String TYPE_OPTION_STRING = "TYPE";


### PR DESCRIPTION
Fix small compiler warning
```
> Task :client:compileJava
.../glide/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java:19: warning: Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.
@EqualsAndHashCode
```