### PR TITLE
C#: Give client an ID

### DIFF
--- a/csharp/sources/Valkey.Glide/BaseClient.cs
+++ b/csharp/sources/Valkey.Glide/BaseClient.cs
@@ -36,6 +36,10 @@ public abstract class BaseClient : IDisposable, IStringBaseCommands
         }
     }
 
+    public override string ToString() => $"{GetType().Name} {{ 0x{_clientPointer:X} }}";
+
+    public override int GetHashCode() => (int)_clientPointer;
+
     #endregion public methods
 
     #region protected methods


### PR DESCRIPTION
Minor change to help debugging tests. How we can track which exactly client is used in tests and how it was shared.

Before
```
  Passed Valkey.Glide.IntegrationTests.SharedCommandTests.GetReturnsLastSet(client: GlideClient { }) [1 ms]
  Passed Valkey.Glide.IntegrationTests.SharedCommandTests.GetReturnsLastSet(client: GlideClusterClient { }) [1 ms]
```
After
```
  Passed Valkey.Glide.IntegrationTests.SharedCommandTests.GetReturnsLastSet(client: GlideClient { 0x7EE8DC022CA0 }) [2 ms]
  Passed Valkey.Glide.IntegrationTests.SharedCommandTests.GetReturnsLastSet(client: GlideClusterClient { 0x7EE8DC024670 }) [2 ms]
```