### PR TITLE
Ensure the UDS socket filename is truly unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### Changes
-
+* Core: Ensure UDS socket filename is truly unique. ([#3596](https://github.com/valkey-io/valkey-glide/pull/3596))
 * Node: Fix type declarations ([#3489](https://github.com/valkey-io/valkey-glide/pull/3489))
 * Core: Add `opentelemetry` protocols support ([#3191](https://github.com/valkey-io/valkey-glide/pull/3191))
 * Node: Fix ZADD, enabling `+inf` and `-inf` as score ([#3370](https://github.com/valkey-io/valkey-glide/pull/3370))

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Valkey GLIDE Maintainers"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uuid = { version = "1.3", features = ["v4", "fast-rng"] }
 bytes = "1"
 futures = "^0.3"
 redis = { path = "./redis-rs/redis", features = [

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -37,6 +37,7 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio::sync::Mutex;
 use tokio::task;
 use tokio_util::task::LocalPoolHandle;
+use uuid::Uuid;
 use ClosingReason::*;
 use PipeListeningResult::*;
 
@@ -829,8 +830,17 @@ pub fn get_socket_path_from_name(socket_name: String) -> String {
 
 /// Get the socket path as a string
 pub fn get_socket_path() -> String {
-    let socket_name = format!("{}-{}", SOCKET_FILE_NAME, std::process::id());
-    get_socket_path_from_name(socket_name)
+    // Ensure the socket name is unique by appending the process ID and a random UUID
+    // to the socket name. The UUID is used to ensure that the socket name is unique for situations in which PID can be resused such as with dockers.
+    static SOCKET_NAME: Lazy<String> = Lazy::new(|| {
+        format!(
+            "{}-{}-{}.sock",
+            SOCKET_FILE_NAME,
+            std::process::id(),
+            Uuid::new_v4(),
+        )
+    });
+    get_socket_path_from_name(SOCKET_NAME.clone())
 }
 
 /// This function is exposed only for the sake of testing with a nonstandard `socket_path`.


### PR DESCRIPTION
Ensure the UDS socket filename is truly unique by appending a UUID as a suffix. This approach is preferred over relying solely on PID-based naming with manual file removal, as it avoids filesystem manipulation and eliminates the risk of collisions due to PID reuse such as docker usage.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/2985

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[ ] Tests are added or updated.
-   [X] CHANGELOG.md and documentation files are updated.
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
