### PR TITLE
C#: benchmark fix

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -100,7 +100,11 @@ public static class MainClass
 
     private static void PrintResults(string resultsFile)
     {
-        _ = Directory.CreateDirectory(Path.GetDirectoryName(resultsFile)!);
+        string? dir = Path.GetDirectoryName(resultsFile);
+        if (dir is not null && dir?.Length > 0)
+        {
+            _ = Directory.CreateDirectory(dir);
+        }
         using FileStream createStream = File.Create(resultsFile);
         JsonSerializer.Serialize(createStream, BenchJsonResults);
     }


### PR DESCRIPTION
As @jbrinkman noticed, benchmarking app crashes if `resultsFile` parameter has no directory path.
![image](https://github.com/user-attachments/assets/455c035d-7e17-4099-8670-a733042988e6)

It fails when `resultsFile = "test.json"`, but doesn't fail when `resultsFile = "./test.json"`. This PR offers a fix.