### PR TITLE
Core: Move UDS Socket Filename to tmp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### Changes
+* Core: Move UDS Socket Filename to tmp ([#3615](https://github.com/valkey-io/valkey-glide/pull/3615))
 * Core: Ensure UDS socket filename is truly unique. ([#3596](https://github.com/valkey-io/valkey-glide/pull/3596))
 * Node: Fix type declarations ([#3489](https://github.com/valkey-io/valkey-glide/pull/3489))
 * Core: Add `opentelemetry` protocols support ([#3191](https://github.com/valkey-io/valkey-glide/pull/3191))

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -818,7 +818,7 @@ struct ClosingError {
 /// For Windows, the socket file will be saved to %AppData%\Local.
 pub fn get_socket_path_from_name(socket_name: String) -> String {
     let base_dirs = BaseDirs::new().expect("Failed to create BaseDirs");
-    let folder: &std::path::Path = if cfg!(windows) {
+    let folder = if cfg!(windows) {
         base_dirs.data_local_dir()
     } else {
         std::path::Path::new(UNIX_SOCKER_DIR)

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -810,11 +810,12 @@ struct ClosingError {
 }
 
 /// Get the socket full path.
-/// The socket file name will contain the process ID and will try to be saved into the user's runtime directory
-/// (e.g. /run/user/1000) in Unix systems. If the runtime dir isn't found, the socket file will be saved to the temp dir.
+/// On Unix-based systems, we use the /tmp directory for the socket file to ensure a predictable and short path,
+/// avoiding issues with the ~100-character limit on Unix domain socket paths.
+/// While placing the socket in /tmp has known security concerns, they are less relevant here since the socket is used for intraprocess communication only.
+/// To further enhance security, we include a UUID in the socket filename and restrict socket permissions to the owner after binding.
+/// 
 /// For Windows, the socket file will be saved to %AppData%\Local.
-/// We add a UUID to ensure uniqueness in environments where PIDs can be reused (like containers).
-/// We use /tmp because it is short and has a static size, which helps avoid issues with socket path length limits.
 pub fn get_socket_path_from_name(socket_name: String) -> String {
     let base_dirs = BaseDirs::new().expect("Failed to create BaseDirs");
     let folder = if cfg!(windows) {

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -818,10 +818,10 @@ struct ClosingError {
 /// For Windows, the socket file will be saved to %AppData%\Local.
 pub fn get_socket_path_from_name(socket_name: String) -> String {
     let base_dirs = BaseDirs::new().expect("Failed to create BaseDirs");
-    let folder = if cfg!(windows) {
-        base_dirs.data_local_dir().to_path_buf()
+    let folder: &std::path::Path = if cfg!(windows) {
+        base_dirs.data_local_dir()
     } else {
-        UNIX_SOCKER_DIR.into()
+        std::path::Path::new(UNIX_SOCKER_DIR)
     };
     folder
         .join(socket_name)

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -814,7 +814,7 @@ struct ClosingError {
 /// avoiding issues with the ~100-character limit on Unix domain socket paths.
 /// While placing the socket in /tmp has known security concerns, they are less relevant here since the socket is used for intraprocess communication only.
 /// To further enhance security, we include a UUID in the socket filename and restrict socket permissions to the owner after binding.
-/// 
+///
 /// For Windows, the socket file will be saved to %AppData%\Local.
 pub fn get_socket_path_from_name(socket_name: String) -> String {
     let base_dirs = BaseDirs::new().expect("Failed to create BaseDirs");

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -811,12 +811,16 @@ def is_address_already_in_use(
 ):
     logging.debug(f"checking is address already bind for: {server}")
     timeout_start = time.time()
+    address_in_use_errors = [
+        "Address already in use",
+        "Address in use",
+        "address in use",
+    ]
     while time.time() < timeout_start + timeout:
         with open(log_file, "r") as f:
             server_log = f.read()
-            # Check for both error message variants because different C libraries (musl vs glibc)
-            # write slightly different error messages when a port is already in use
-            if "Address already in use" in server_log or "Address in use" in server_log:
+            # Check for known error message variants because different C libraries
+            if any(error_msg in server_log for error_msg in address_in_use_errors):
                 logging.debug(f"Address is already bind for server {server}")
                 return True
             elif "Ready" in server_log:


### PR DESCRIPTION
In the Full Matrix Tests, We encountered errors on macOS instances, that clusters couldn't be created in the node client.
You can see such errors in this [run](https://github.com/valkey-io/valkey-glide/actions/runs/14483970827/job/40626124407)
Thus, we realized that on macOS instances, the UDS socket filename is too long when using the base directory.
So, our solution is to save the filename in the tmp dir, and to restrict it's permissions for security measures


### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3441
### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
