### PR TITLE
Rust: Fix rust bench latencies calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Go: Add Function Stats ([#3526](https://github.com/valkey-io/valkey-glide/pull/3526))
 * Go: Add Function Delete ([#3603](https://github.com/valkey-io/valkey-glide/pull/3603))
 * Go: Add Function Kill ([#3604](https://github.com/valkey-io/valkey-glide/pull/3604))
+* Benchmarks: Fix rust benchmark latencies calculation
 
 #### Breaking Changes
 


### PR DESCRIPTION
ATM, the Rust benchmark latencies calculation was off, as it didn't sort the latencies vector before calculating the latencies. 
### Issue link

This Pull Request is linked to issue (URL): closes #3637


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
