### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '35 00 * * *'
+  
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - name: Close Stale Issues
+      uses: actions/stale@v9.1.0
+      with:
+        repo-token: ${{ github.token }}
+        stale-issue-message: "This issue is inactive for 90 days, hence marked as stale, if the issue is still relevant please perform some activity"
+        stale-pr-message: "This PR is inactive for 60 days, hence marked as stale, if the PR is still relevant please perform some activity"
+        close-issue-message: "Since issue was marked as stale and no activity perfomed for 14 days after it was mark, this issue is closed automatically"
+        close-pr-message: "Since PR was marked as stale and no activity perfomed for 10 days after it was mark, this PR is closed automatically"
+        days-before-stale: 90
+        days-before-pr-stale: 60
+        days-before-close: 14
+        days-before-pr-close: 10
+        exempt-issue-labels: "bug,Users Pain,Epic,User issue,Unatriaged user issue"
+        exempt-all-milestones: true
+        operations-per-run: 50
+        labels-to-add-when-unstale: "Unstaled"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,8 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '35 00 * * *'
+  - cron: '35 00 * * *' 
+  workflow_dispatch:
   
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,9 +2,8 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '35 00 * * *' 
+  - cron: '35 00 * * *'
   workflow_dispatch:
-  
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,31 +1,30 @@
 name: Mark stale issues and pull requests
 
 on:
-  schedule:
-  - cron: '35 00 * * *'
-  workflow_dispatch:
+    schedule:
+        - cron: "35 00 * * *"
+    workflow_dispatch:
 
 jobs:
-  stale:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-
-    steps:
-    - name: Close Stale Issues
-      uses: actions/stale@v9.1.0
-      with:
-        repo-token: ${{ github.token }}
-        stale-issue-message: "This issue is inactive for 90 days, hence marked as stale, if the issue is still relevant please perform some activity"
-        stale-pr-message: "This PR is inactive for 60 days, hence marked as stale, if the PR is still relevant please perform some activity"
-        close-issue-message: "Since issue was marked as stale and no activity perfomed for 14 days after it was mark, this issue is closed automatically"
-        close-pr-message: "Since PR was marked as stale and no activity perfomed for 10 days after it was mark, this PR is closed automatically"
-        days-before-stale: 90
-        days-before-pr-stale: 60
-        days-before-close: 14
-        days-before-pr-close: 10
-        exempt-issue-labels: "bug,Users Pain,Epic,User issue,Unatriaged user issue"
-        exempt-all-milestones: true
-        operations-per-run: 50
-        labels-to-add-when-unstale: "Unstaled"
+    stale:
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+            pull-requests: write
+        steps:
+            - name: Close Stale Issues
+              uses: actions/stale@v9.1.0
+              with:
+                  repo-token: ${{ github.token }}
+                  stale-issue-message: "This issue is inactive for 90 days, hence marked as stale, if the issue is still relevant please perform some activity"
+                  stale-pr-message: "This PR is inactive for 60 days, hence marked as stale, if the PR is still relevant please perform some activity"
+                  close-issue-message: "Since issue was marked as stale and no activity perfomed for 14 days after it was mark, this issue is closed automatically"
+                  close-pr-message: "Since PR was marked as stale and no activity perfomed for 10 days after it was mark, this PR is closed automatically"
+                  days-before-stale: 90
+                  days-before-pr-stale: 60
+                  days-before-close: 14
+                  days-before-pr-close: 10
+                  exempt-issue-labels: "bug,Users Pain,Epic,User issue,Unatriaged user issue"
+                  exempt-all-milestones: true
+                  operations-per-run: 50
+                  labels-to-add-when-unstale: "Unstaled"


### PR DESCRIPTION
To control accumulating issues and PRS, issues with no activity for 90 days, which are not a bug, user issue, or part of a milestone, will be marked as stale. Same as for PR but for 60 days. To unstaled, any activity is sufficient, like comment or anything similar. If after staling, the issue will not see any activity for 14 days, and PR for 10, it will be closed automatically. To not erase a work of a dev that missed the notification, the branch won't be deleted and the PR/issue can be re-opened.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
### New GitHub Actions Workflow for Stale Issues and PRs:

* `.github/workflows/stale.yml`: Added a workflow named "Mark stale issues and pull requests" that runs daily on a schedule. It uses the `actions/stale@v9.1.0` action to:
  - Mark issues as stale after 90 days of inactivity, and pull requests after 60 days. 
  - Close issues 14 days after being marked as stale, and pull requests 10 days after being marked as stale.
  - Exempt certain issue labels (e.g., "bug", "Users Pain", "Epic") and all milestones from being marked as stale.
  - Add a label (“Unstaled”) to issues and pull requests when activity resumes after being marked stale.
### Issue link

This Pull Request is linked to issue  #2732 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
