### PR TITLE
Node: Fix comment for `keepExisting` in `SetOptions`

### DIFF
--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -157,12 +157,12 @@ export type SetOptions = (
     returnOldValue?: boolean;
     /**
      * If not set, no expiry time will be set for the value.
+     *
+     * `keepExisting` - Retain the time to live associated with the key.
+     * Equivalent to `KEEPTTL` in the Valkey API.
      */
-    expiry?: /**
-     * Retain the time to live associated with the key. Equivalent to
-     * `KEEPTTL` in the Valkey API.
-     */
-    | "keepExisting"
+    expiry?:
+        | "keepExisting"
         | {
               type: TimeUnit;
               count: number;


### PR DESCRIPTION
The comment for `keepExisting` is not included in the `Command.d.ts` declaration file.

https://www.runpkg.com/?@valkey/valkey-glide@1.3.2/build-ts/src/Commands.d.ts#51

![SetOptions](https://github.com/user-attachments/assets/bdfb0153-ce09-4be3-b774-5b7228caf5fc)

### Issue link

Fixes https://github.com/valkey-io/valkey-glide/issues/3652

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
