### PR TITLE
Move npmignore to dev dependencies

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -13,7 +13,6 @@
     "dependencies": {
         "glide-rs": "file:rust-client",
         "long": "^5.3.0",
-        "npmignore": "^0.3.1",
         "protobufjs": "^7.4.0"
     },
     "bundleDependencies": [
@@ -58,6 +57,7 @@
         "find-free-port": "^2.0.0",
         "jest": "^29.7.0",
         "jest-html-reporter": "^3.10.2",
+        "npmignore": "^0.3.1",
         "protobufjs-cli": "^1.1.3",
         "replace": "^1.2.2",
         "semver": "7.7.1",


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

Unless I am overlooking something, `npmignore` should be in `devDependencies` instead of a `dependencies` so that it isn't added as a dependency in consuming applications.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
