### PR TITLE
Go: Fix `ZRangeWithScores` Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 #### Fixes
 
 * Go, Java: Fix response handling for `customCommand` API for cluster client ([#3593](https://github.com/valkey-io/valkey-glide/pull/3593))
+* Go: Fix response handler for `ZRangeWithScores` to return an ordered result ([#3694](https://github.com/valkey-io/valkey-glide/pull/3694))
 
 #### Operational Enhancements
 

--- a/go/api/base_client.go
+++ b/go/api/base_client.go
@@ -4219,14 +4219,14 @@ func (client *baseClient) ZRange(key string, rangeQuery options.ZRangeQuery) ([]
 //
 // Return value:
 //
-//	A map of elements and their scores within the specified range.
-//	If `key` does not exist, it is treated as an empty sorted set, and the command returns an empty map.
+//	An array of elements and their scores within the specified range.
+//	If `key` does not exist, it is treated as an empty sorted set, and the command returns an empty array.
 //
 // [valkey.io]: https://valkey.io/commands/zrange/
 func (client *baseClient) ZRangeWithScores(
 	key string,
 	rangeQuery options.ZRangeQueryWithScores,
-) (map[string]float64, error) {
+) ([]MemberAndScore, error) {
 	args := make([]string, 0, 10)
 	args = append(args, key)
 	queryArgs, err := rangeQuery.ToArgs()
@@ -4240,7 +4240,15 @@ func (client *baseClient) ZRangeWithScores(
 		return nil, err
 	}
 
-	return handleStringDoubleMapResponse(result)
+	needsReverse := false
+	for _, arg := range args {
+		if arg == "REV" {
+			needsReverse = true
+			break
+		}
+	}
+
+	return handleZRangeWithScoresResponse(result, needsReverse)
 }
 
 // Stores a specified range of elements from the sorted set at `key`, into a new

--- a/go/api/response_handlers.go
+++ b/go/api/response_handlers.go
@@ -1687,10 +1687,16 @@ func handleZRangeWithScoresResponse(response *C.struct_CommandResponse, reverse 
 
 	if !reverse {
 		sort.Slice(zRangeResponseArray, func(i, j int) bool {
+			if zRangeResponseArray[i].Score == zRangeResponseArray[j].Score {
+				return zRangeResponseArray[i].Member < zRangeResponseArray[j].Member
+			}
 			return zRangeResponseArray[i].Score < zRangeResponseArray[j].Score
 		})
 	} else {
 		sort.Slice(zRangeResponseArray, func(i, j int) bool {
+			if zRangeResponseArray[i].Score == zRangeResponseArray[j].Score {
+				return zRangeResponseArray[i].Member > zRangeResponseArray[j].Member
+			}
 			return zRangeResponseArray[i].Score > zRangeResponseArray[j].Score
 		})
 	}

--- a/go/api/sorted_set_commands.go
+++ b/go/api/sorted_set_commands.go
@@ -57,7 +57,7 @@ type SortedSetCommands interface {
 		opts options.ZPopOptions,
 	) (Result[KeyWithArrayOfMembersAndScores], error)
 
-	ZRangeWithScores(key string, rangeQuery options.ZRangeQueryWithScores) (map[string]float64, error)
+	ZRangeWithScores(key string, rangeQuery options.ZRangeQueryWithScores) ([]MemberAndScore, error)
 
 	ZRangeStore(destination string, key string, rangeQuery options.ZRangeQuery) (int64, error)
 

--- a/go/api/sorted_set_commands_test.go
+++ b/go/api/sorted_set_commands_test.go
@@ -459,8 +459,8 @@ func ExampleGlideClient_ZRangeWithScores() {
 
 	// Output:
 	// 3
-	// map[one:1 three:3 two:2]
-	// map[one:1 two:2]
+	// [{one 1} {two 2} {three 3}]
+	// [{two 2} {one 1}]
 }
 
 func ExampleGlideClusterClient_ZRangeWithScores() {
@@ -482,8 +482,8 @@ func ExampleGlideClusterClient_ZRangeWithScores() {
 
 	// Output:
 	// 3
-	// map[one:1 three:3 two:2]
-	// map[one:1 two:2]
+	// [{one 1} {two 2} {three 3}]
+	// [{two 2} {one 1}]
 }
 
 func ExampleGlideClient_ZRangeStore() {

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -5246,26 +5246,32 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 		t := suite.T()
 		key := uuid.New().String()
 		memberScoreMap := map[string]float64{
-			"a": 1.0,
-			"b": 2.0,
+			"a": 2.0,
+			"b": 4.0,
 			"c": 3.0,
+			"d": 8.0,
+			"e": 5.0,
+			"f": 1.0,
 		}
 		_, err := client.ZAdd(key, memberScoreMap)
 		assert.NoError(t, err)
 		// index [0:1]
 		res, err := client.ZRangeWithScores(key, options.NewRangeByIndexQuery(0, 1))
-		expected := map[string]float64{
-			"a": float64(1.0),
-			"b": float64(2.0),
+		expected := []api.MemberAndScore{
+			{Member: "f", Score: float64(1.0)},
+			{Member: "a", Score: float64(2.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
 		// index [0:-1] (all)
 		res, err = client.ZRangeWithScores(key, options.NewRangeByIndexQuery(0, -1))
-		expected = map[string]float64{
-			"a": float64(1.0),
-			"b": float64(2.0),
-			"c": float64(3.0),
+		expected = []api.MemberAndScore{
+			{Member: "f", Score: float64(1.0)},
+			{Member: "a", Score: float64(2.0)},
+			{Member: "c", Score: float64(3.0)},
+			{Member: "b", Score: float64(4.0)},
+			{Member: "e", Score: float64(5.0)},
+			{Member: "d", Score: float64(8.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -5278,10 +5284,10 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewScoreBoundary(3, true))
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[string]float64{
-			"a": float64(1.0),
-			"b": float64(2.0),
-			"c": float64(3.0),
+		expected = []api.MemberAndScore{
+			{Member: "f", Score: float64(1.0)},
+			{Member: "a", Score: float64(2.0)},
+			{Member: "c", Score: float64(3.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -5290,9 +5296,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewScoreBoundary(3, false))
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[string]float64{
-			"a": float64(1.0),
-			"b": float64(2.0),
+		expected = []api.MemberAndScore{
+			{Member: "f", Score: float64(1.0)},
+			{Member: "a", Score: float64(2.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -5302,9 +5308,25 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
 			SetReverse()
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[string]float64{
-			"b": float64(2.0),
-			"a": float64(1.0),
+		expected = []api.MemberAndScore{
+			{Member: "a", Score: float64(2.0)},
+			{Member: "f", Score: float64(1.0)},
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+		// score [inf:-inf] reverse
+		query = options.NewRangeByScoreQuery(
+			options.NewInfiniteScoreBoundary(options.PositiveInfinity),
+			options.NewInfiniteScoreBoundary(options.NegativeInfinity)).
+			SetReverse()
+		res, err = client.ZRangeWithScores(key, query)
+		expected = []api.MemberAndScore{
+			{Member: "d", Score: float64(8.0)},
+			{Member: "e", Score: float64(5.0)},
+			{Member: "b", Score: float64(4.0)},
+			{Member: "c", Score: float64(3.0)},
+			{Member: "a", Score: float64(2.0)},
+			{Member: "f", Score: float64(1.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -5314,9 +5336,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			options.NewInfiniteScoreBoundary(options.PositiveInfinity)).
 			SetLimit(1, 2)
 		res, err = client.ZRangeWithScores(key, query)
-		expected = map[string]float64{
-			"b": float64(2.0),
-			"c": float64(3.0),
+		expected = []api.MemberAndScore{
+			{Member: "a", Score: float64(2.0)},
+			{Member: "c", Score: float64(3.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -8852,7 +8874,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 		// checking stored intersection result
 		zrangeResult, err := client.ZRangeWithScores(key3, query)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64{"one": 2.5, "two": 4.5}, zrangeResult)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "one", Score: 2.5}, {Member: "two", Score: 4.5}}, zrangeResult)
 
 		// Store the intersection of key1 and key2 in key4 with max aggregate
 		res, err = client.ZInterStoreWithOptions(key3, options.KeyArray{Keys: []string{key1, key2}},
@@ -8864,7 +8886,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 		// checking stored intersection result with max aggregate
 		zrangeResult, err = client.ZRangeWithScores(key3, query)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.5, "two": 2.5}, zrangeResult)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "one", Score: 1.5}, {Member: "two", Score: 2.5}}, zrangeResult)
 
 		// Store the intersection of key1 and key2 in key5 with min aggregate
 		res, err = client.ZInterStoreWithOptions(key3, options.KeyArray{Keys: []string{key1, key2}},
@@ -8876,7 +8898,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 		// checking stored intersection result with min aggregate
 		zrangeResult, err = client.ZRangeWithScores(key3, query)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.0, "two": 2.0}, zrangeResult)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "two", Score: 2.0}}, zrangeResult)
 
 		// Store the intersection of key1 and key2 in key6 with sum aggregate
 		res, err = client.ZInterStoreWithOptions(key3, options.KeyArray{Keys: []string{key1, key2}},
@@ -8888,7 +8910,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 		// checking stored intersection result with sum aggregate (same as default aggregate)
 		zrangeResult, err = client.ZRangeWithScores(key3, query)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64{"one": 2.5, "two": 4.5}, zrangeResult)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "one", Score: 2.5}, {Member: "two", Score: 4.5}}, zrangeResult)
 
 		// Store the intersection of key1 and key2 in key3 with 2.0 weights
 		res, err = client.ZInterStore(key3, options.WeightedKeys{
@@ -8903,7 +8925,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 		// checking stored intersection result with weighted keys
 		zrangeResult, err = client.ZRangeWithScores(key3, query)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64{"one": 5.0, "two": 9.0}, zrangeResult)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "one", Score: 5.0}, {Member: "two", Score: 9.0}}, zrangeResult)
 
 		// Store the intersection of key1 with 1.0 weight and key2 with -2.0 weight in key3 with 2.0 weights
 		// and min aggregate
@@ -8921,7 +8943,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 		// checking stored intersection result with weighted keys
 		zrangeResult, err = client.ZRangeWithScores(key3, query)
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64{"one": -3.0, "two": -5.0}, zrangeResult)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "two", Score: -5.0}, {Member: "one", Score: -3.0}}, zrangeResult)
 
 		// key exists but not a set
 		_, err = client.Set(key4, "value")
@@ -9045,21 +9067,25 @@ func (suite *GlideTestSuite) TestZDiffStore() {
 		assert.Equal(t, zDiffStoreResult, int64(2))
 		zRangeWithScoreResult, err := client.ZRangeWithScores(key4, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]float64{"one": 1.0, "three": 3.0}, zRangeWithScoreResult)
+		assert.Equal(
+			t,
+			[]api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "three", Score: 3.0}},
+			zRangeWithScoreResult,
+		)
 
 		zDiffStoreResult, err = client.ZDiffStore(key4, []string{key3, key2, key1})
 		assert.NoError(t, err)
 		assert.Equal(t, zDiffStoreResult, int64(1))
 		zRangeWithScoreResult, err = client.ZRangeWithScores(key4, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]float64{"four": 4.0}, zRangeWithScoreResult)
+		assert.Equal(t, []api.MemberAndScore{{Member: "four", Score: 4.0}}, zRangeWithScoreResult)
 
 		zDiffStoreResult, err = client.ZDiffStore(key4, []string{key1, key3})
 		assert.NoError(t, err)
 		assert.Equal(t, zDiffStoreResult, int64(0))
 		zRangeWithScoreResult, err = client.ZRangeWithScores(key4, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]float64{}, zRangeWithScoreResult)
+		assert.Equal(t, []api.MemberAndScore{}, zRangeWithScoreResult)
 
 		// Non-Existing key
 		zDiffStoreResult, err = client.ZDiffStore(key4, []string{key5, key1})
@@ -9067,7 +9093,7 @@ func (suite *GlideTestSuite) TestZDiffStore() {
 		assert.Equal(t, zDiffStoreResult, int64(0))
 		zRangeWithScoreResult, err = client.ZRangeWithScores(key4, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(t, err)
-		assert.Equal(t, map[string]float64{}, zRangeWithScoreResult)
+		assert.Equal(t, []api.MemberAndScore{}, zRangeWithScoreResult)
 
 		// Key exists, but it is not a set
 		setResult, err := client.Set(key5, "bar")
@@ -9223,7 +9249,11 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 		zRangeDest, err := client.ZRangeWithScores(dest, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(3), zUnionStoreWithScoresResult)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.0, "two": 5.5, "three": 3.0}, zRangeDest)
+		assert.Equal(
+			suite.T(),
+			[]api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "three", Score: 3.0}, {Member: "two", Score: 5.5}},
+			zRangeDest,
+		)
 
 		// Union results with max aggregate
 		zUnionStoreWithMaxAggregateResult, err := client.ZUnionStoreWithOptions(
@@ -9235,7 +9265,11 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 		zRangeDest, err = client.ZRangeWithScores(dest, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(3), zUnionStoreWithMaxAggregateResult)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.0, "two": 3.5, "three": 3.0}, zRangeDest)
+		assert.Equal(
+			suite.T(),
+			[]api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "three", Score: 3.0}, {Member: "two", Score: 3.5}},
+			zRangeDest,
+		)
 
 		// Union results with min aggregate
 		zUnionStoreWithMinAggregateResult, err := client.ZUnionStoreWithOptions(
@@ -9247,7 +9281,11 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 		zRangeDest, err = client.ZRangeWithScores(dest, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(3), zUnionStoreWithMinAggregateResult)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.0, "two": 2.0, "three": 3.0}, zRangeDest)
+		assert.Equal(
+			suite.T(),
+			[]api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "two", Score: 2.0}, {Member: "three", Score: 3.0}},
+			zRangeDest,
+		)
 
 		// Union results with sum aggregate
 		zUnionStoreWithSumAggregateResult, err := client.ZUnionStoreWithOptions(
@@ -9259,7 +9297,11 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 		zRangeDest, err = client.ZRangeWithScores(dest, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(3), zUnionStoreWithSumAggregateResult)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.0, "two": 5.5, "three": 3.0}, zRangeDest)
+		assert.Equal(
+			suite.T(),
+			[]api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "three", Score: 3.0}, {Member: "two", Score: 5.5}},
+			zRangeDest,
+		)
 
 		// Scores are multiplied by a 2.0 weight for key1 and key2 during aggregation
 		zUnionStoreWithWeightedKeysResult, err := client.ZUnionStoreWithOptions(
@@ -9276,7 +9318,11 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 		zRangeDest, err = client.ZRangeWithScores(dest, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(3), zUnionStoreWithWeightedKeysResult)
-		assert.Equal(suite.T(), map[string]float64{"one": 3.0, "two": 13.0, "three": 6.0}, zRangeDest)
+		assert.Equal(
+			suite.T(),
+			[]api.MemberAndScore{{Member: "one", Score: 3.0}, {Member: "three", Score: 6.0}, {Member: "two", Score: 13.0}},
+			zRangeDest,
+		)
 
 		// non-existent key - empty union
 		zUnionStoreWithNonExistentKeyResult, err := client.ZUnionStoreWithOptions(
@@ -9288,7 +9334,7 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 		zRangeDest, err = client.ZRangeWithScores(dest, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(2), zUnionStoreWithNonExistentKeyResult)
-		assert.Equal(suite.T(), map[string]float64{"one": 1.0, "two": 2.0}, zRangeDest)
+		assert.Equal(suite.T(), []api.MemberAndScore{{Member: "one", Score: 1.0}, {Member: "two", Score: 2.0}}, zRangeDest)
 
 		// empty key list - empty union
 		_, err = client.ZRem(dest, []string{"one", "two"}) // Flush previous results
@@ -9994,22 +10040,22 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			"edge2":   {Longitude: 17.241510, Latitude: 38.788135},
 			"edge1":   {Longitude: 12.758489, Latitude: 38.788135},
 		}
-		// Expected results maps
-		expectedMap := map[string]float64{
-			"Catania": 3479447370796909.0,
-			"Palermo": 3479099956230698.0,
-			"edge2":   3481342659049484.0,
-			"edge1":   3479273021651468.0,
+		// Expected results arrays
+		expectedArray := []api.MemberAndScore{
+			{Member: "Palermo", Score: 3479099956230698.0},
+			{Member: "edge1", Score: 3479273021651468.0},
+			{Member: "Catania", Score: 3479447370796909.0},
+			{Member: "edge2", Score: 3481342659049484.0},
 		}
-		expectedMap2 := map[string]float64{
-			"Catania": 56.4412578701582,
-			"Palermo": 190.44242984775784,
-			"edge2":   279.7403417843143,
-			"edge1":   279.7404521356343,
+		expectedArray2 := []api.MemberAndScore{
+			{Member: "Catania", Score: 56.4412578701582},
+			{Member: "Palermo", Score: 190.44242984775784},
+			{Member: "edge2", Score: 279.7403417843143},
+			{Member: "edge1", Score: 279.7404521356343},
 		}
-		expectedMap3 := map[string]float64{
-			"Catania": 3479447370796909.0,
-			"Palermo": 3479099956230698.0,
+		expectedArray3 := []api.MemberAndScore{
+			{Member: "Palermo", Score: 3479099956230698.0},
+			{Member: "Catania", Score: 3479447370796909.0},
 		}
 		// Add geospatial data
 		result, err := client.GeoAdd(sourceKey, membersToCoordinates)
@@ -10029,7 +10075,7 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		// Verify stored results
 		zRangeResult, err := client.ZRangeWithScores(destinationKey, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), expectedMap, zRangeResult)
+		assert.Equal(suite.T(), expectedArray, zRangeResult)
 
 		// Test storing results of a box search, unit: kilometers, from a geospatial data point, with distance
 		count, err = client.GeoSearchStoreWithInfoOptions(
@@ -10045,7 +10091,9 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		// Verify stored results with distance
 		zRangeResultWithDist, err := client.ZRangeWithScores(destinationKey, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
-		assert.InDeltaMapValues(suite.T(), expectedMap2, zRangeResultWithDist, 1e-6)
+		for i := range expectedArray2 {
+			assert.InDelta(suite.T(), expectedArray2[i].Score, zRangeResultWithDist[i].Score, 1e-6)
+		}
 
 		// Test storing results of a box search, unit: kilometers, from a geospatial data point, with count
 		count, err = client.GeoSearchStoreWithResultOptions(
@@ -10063,7 +10111,7 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(
 			suite.T(),
-			map[string]float64{"Catania": 3479447370796909, "Palermo": 3479099956230698},
+			[]api.MemberAndScore{{Member: "Palermo", Score: 3479099956230698}, {Member: "Catania", Score: 3479447370796909}},
 			zRangeResultWithCount,
 		)
 
@@ -10082,7 +10130,7 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		// Verify stored results with count
 		zRangeResultWithCount, err = client.ZRangeWithScores(destinationKey, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), expectedMap3, zRangeResultWithCount)
+		assert.Equal(suite.T(), expectedArray3, zRangeResultWithCount)
 
 		// Test storing results of a search that returns 0 results
 		count, err = client.GeoSearchStore(
@@ -10095,7 +10143,7 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		assert.Equal(suite.T(), int64(0), count)
 		zRangeResultZero, err := client.ZRangeWithScores(destinationKey, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), map[string]float64(map[string]float64{}), zRangeResultZero)
+		assert.Equal(suite.T(), []api.MemberAndScore{}, zRangeResultZero)
 
 		// Test storing results of a search with ANY option
 		count, err = client.GeoSearchStoreWithResultOptions(
@@ -10109,11 +10157,11 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		assert.Equal(suite.T(), int64(4), count)
 		zRangeResultANY, err := client.ZRangeWithScores(destinationKey, options.NewRangeByIndexQuery(0, -1))
 		assert.NoError(suite.T(), err)
-		expectedANYResults := map[string]float64{
-			"Catania": 3479447370796909.0,
-			"Palermo": 3479099956230698.0,
-			"edge1":   3479273021651468.0,
-			"edge2":   3481342659049484.0,
+		expectedANYResults := []api.MemberAndScore{
+			{Member: "Palermo", Score: 3479099956230698.0},
+			{Member: "edge1", Score: 3479273021651468.0},
+			{Member: "Catania", Score: 3479447370796909.0},
+			{Member: "edge2", Score: 3481342659049484.0},
 		}
 		assert.Equal(suite.T(), expectedANYResults, zRangeResultANY)
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -5246,12 +5246,15 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 		t := suite.T()
 		key := uuid.New().String()
 		memberScoreMap := map[string]float64{
-			"a": 2.0,
-			"b": 4.0,
-			"c": 3.0,
-			"d": 8.0,
-			"e": 5.0,
-			"f": 1.0,
+			"a":  2.0,
+			"ab": 2.0,
+			"b":  4.0,
+			"c":  3.0,
+			"d":  8.0,
+			"e":  5.0,
+			"f":  1.0,
+			"ac": 2.0,
+			"g":  2.0,
 		}
 		_, err := client.ZAdd(key, memberScoreMap)
 		assert.NoError(t, err)
@@ -5268,6 +5271,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 		expected = []api.MemberAndScore{
 			{Member: "f", Score: float64(1.0)},
 			{Member: "a", Score: float64(2.0)},
+			{Member: "ab", Score: float64(2.0)},
+			{Member: "ac", Score: float64(2.0)},
+			{Member: "g", Score: float64(2.0)},
 			{Member: "c", Score: float64(3.0)},
 			{Member: "b", Score: float64(4.0)},
 			{Member: "e", Score: float64(5.0)},
@@ -5287,6 +5293,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 		expected = []api.MemberAndScore{
 			{Member: "f", Score: float64(1.0)},
 			{Member: "a", Score: float64(2.0)},
+			{Member: "ab", Score: float64(2.0)},
+			{Member: "ac", Score: float64(2.0)},
+			{Member: "g", Score: float64(2.0)},
 			{Member: "c", Score: float64(3.0)},
 		}
 		assert.NoError(t, err)
@@ -5299,6 +5308,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 		expected = []api.MemberAndScore{
 			{Member: "f", Score: float64(1.0)},
 			{Member: "a", Score: float64(2.0)},
+			{Member: "ab", Score: float64(2.0)},
+			{Member: "ac", Score: float64(2.0)},
+			{Member: "g", Score: float64(2.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -5309,6 +5321,9 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			SetReverse()
 		res, err = client.ZRangeWithScores(key, query)
 		expected = []api.MemberAndScore{
+			{Member: "g", Score: float64(2.0)},
+			{Member: "ac", Score: float64(2.0)},
+			{Member: "ab", Score: float64(2.0)},
 			{Member: "a", Score: float64(2.0)},
 			{Member: "f", Score: float64(1.0)},
 		}
@@ -5325,19 +5340,22 @@ func (suite *GlideTestSuite) TestZRangeWithScores() {
 			{Member: "e", Score: float64(5.0)},
 			{Member: "b", Score: float64(4.0)},
 			{Member: "c", Score: float64(3.0)},
+			{Member: "g", Score: float64(2.0)},
+			{Member: "ac", Score: float64(2.0)},
+			{Member: "ab", Score: float64(2.0)},
 			{Member: "a", Score: float64(2.0)},
 			{Member: "f", Score: float64(1.0)},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
-		// score [-inf:+inf] limit 1 2
+		// score [-inf:+inf] limit 4 2
 		query = options.NewRangeByScoreQuery(
 			options.NewInfiniteScoreBoundary(options.NegativeInfinity),
 			options.NewInfiniteScoreBoundary(options.PositiveInfinity)).
-			SetLimit(1, 2)
+			SetLimit(4, 2)
 		res, err = client.ZRangeWithScores(key, query)
 		expected = []api.MemberAndScore{
-			{Member: "a", Score: float64(2.0)},
+			{Member: "g", Score: float64(2.0)},
 			{Member: "c", Score: float64(3.0)},
 		}
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes the issue of using maps (unordered) in Go to return the result from `ZRangeWithScores`.

### Issue link

This Pull Request is linked to issue (URL): #3639 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
