### PR TITLE
Go: Enable AddressSanitizer in integration tests

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -143,7 +143,7 @@ modules-test: __it
 __it:
 	mkdir -p reports
 	set -o pipefail; \
-	go test -v ./integTest/... \
+	CC="gcc -fsanitize=address" go test -v ./integTest/... \
 	$(TEST_FILTER) \
 	$(if $(filter true, $(tls)), --tls,) \
 	$(if $(standalone-endpoints), --standalone-endpoints=$(standalone-endpoints)) \


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR enables AddressSanitizer (ASAN) for integration tests for the Go client.

ASAN doesn't find any issues in our current integration tests.

To verify this change, I made a temporary modification to our Rust FFI layer, in which we dereference a synthesized pointer without proper provenance:
```
let a: *const u32 = 24 as *const u32;
println!("{}", unsafe { *a });
```

Re-running `make integ-test` with these changes causes ASAN to pipe up with the following report:
```
==59610==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000018 (pc 0x00010d628365 bp 0x70001675aea0 sp 0x70001675a580 T3)
==59610==The signal is caused by a READ memory access.
==59610==Hint: address points to the zero page.
    #0 0x00010d628365 in command+0x35 (integTest.test:x86_64+0x1006d3365)
    #1 0x00010d49345f in _cgo_18c3bdbe5458_Cfunc_command+0x1df (integTest.test:x86_64+0x10053e45f)
    #2 0x00010cfce3c3  (integTest.test:x86_64+0x1000793c3)

==59610==Register values:
rax = 0x000000c0000ef9e7  rbx = 0x000060b0000059b0  rcx = 0x0000000000000001  rdx = 0x000000000000046a  
rdi = 0x000060b0000059b0  rsi = 0x000000c000130890  rbp = 0x000070001675aea0  rsp = 0x000070001675a580  
 r8 = 0x000000c000129420   r9 = 0x000000c000129428  r10 = 0x0000000000000000  r11 = 0x0000000000000000  
r12 = 0x000000c000129420  r13 = 0x0000000000000000  r14 = 0x000000c000129428  r15 = 0x00000001ffffffff  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (integTest.test:x86_64+0x1006d3365) in command+0x35
Thread T3 created by T0 here:
    #0 0x00010e5f133d in pthread_create+0x5d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x8f33d)
    #1 0x00010d4949f3 in _cgo_try_pthread_create+0xd3 (integTest.test:x86_64+0x10053f9f3)
    #2 0x00010d4945a3 in _cgo_sys_thread_start+0x173 (integTest.test:x86_64+0x10053f5a3)
    #3 0x00010cfce3fc  (integTest.test:x86_64+0x1000793fc)
    #4 0x00010cf9a644  (integTest.test:x86_64+0x100045644)
    #5 0x00010cf9a544  (integTest.test:x86_64+0x100045544)
    #6 0x00010cf9ab37  (integTest.test:x86_64+0x100045b37)
    #7 0x00010cf9aff5  (integTest.test:x86_64+0x100045ff5)
    #8 0x00010cf9b1b1  (integTest.test:x86_64+0x1000461b1)
    #9 0x00010cf9d4f9  (integTest.test:x86_64+0x1000484f9)
    #10 0x00010cf9db4b  (integTest.test:x86_64+0x100048b4b)
    #11 0x00010cfcc6cd  (integTest.test:x86_64+0x1000776cd)
```

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3650

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
