### PR TITLE
Java: Change `ZMPOP` and `BZMPOP` Return Type

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -180,21 +180,7 @@ import static glide.api.models.commands.stream.StreamReadOptions.READ_COUNT_VALK
 import static glide.api.models.commands.stream.XInfoStreamOptions.COUNT;
 import static glide.api.models.commands.stream.XInfoStreamOptions.FULL;
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
-import static glide.utils.ArrayTransformUtils.cast3DArray;
-import static glide.utils.ArrayTransformUtils.castArray;
-import static glide.utils.ArrayTransformUtils.castArrayofArrays;
-import static glide.utils.ArrayTransformUtils.castBinaryStringMapOfArrays;
-import static glide.utils.ArrayTransformUtils.castMapOf2DArray;
-import static glide.utils.ArrayTransformUtils.castMapOfArrays;
-import static glide.utils.ArrayTransformUtils.concatenateArrays;
-import static glide.utils.ArrayTransformUtils.convertMapToKeyValueGlideStringArray;
-import static glide.utils.ArrayTransformUtils.convertMapToKeyValueStringArray;
-import static glide.utils.ArrayTransformUtils.convertMapToValueKeyStringArray;
-import static glide.utils.ArrayTransformUtils.convertMapToValueKeyStringArrayBinary;
-import static glide.utils.ArrayTransformUtils.convertNestedArrayToKeyValueGlideStringArray;
-import static glide.utils.ArrayTransformUtils.convertNestedArrayToKeyValueStringArray;
-import static glide.utils.ArrayTransformUtils.mapGeoDataToArray;
-import static glide.utils.ArrayTransformUtils.mapGeoDataToGlideStringArray;
+import static glide.utils.ArrayTransformUtils.*;
 
 import glide.api.commands.BitmapBaseCommands;
 import glide.api.commands.GenericBaseCommands;
@@ -3683,37 +3669,49 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<Object[]> zmpop(@NonNull String[] keys, @NonNull ScoreFilter modifier) {
+    public CompletableFuture<Map<String, Object>> zmpop(
+            @NonNull String[] keys, @NonNull ScoreFilter modifier) {
         String[] arguments =
                 concatenateArrays(
                         new String[] {Integer.toString(keys.length)}, keys, new String[] {modifier.toString()});
-        return commandManager.submitNewCommand(ZMPop, arguments, this::handleArrayOrNullResponse);
+        return commandManager.submitNewCommand(
+                ZMPop,
+                arguments,
+                response -> convertKeyValueArrayToMap(handleArrayOrNullResponse(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> zmpop(
+    public CompletableFuture<Map<GlideString, Object>> zmpop(
             @NonNull GlideString[] keys, @NonNull ScoreFilter modifier) {
         GlideString[] arguments =
                 concatenateArrays(
                         new GlideString[] {gs(Integer.toString(keys.length))},
                         keys,
                         new GlideString[] {gs(modifier.toString())});
-        return commandManager.submitNewCommand(ZMPop, arguments, this::handleArrayOrNullResponseBinary);
+        return commandManager.submitNewCommand(
+                ZMPop,
+                arguments,
+                response ->
+                        convertBinaryStringKeyValueArrayToMap(
+                                handleArrayOrNullResponseBinary(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> zmpop(
+    public CompletableFuture<Map<String, Object>> zmpop(
             @NonNull String[] keys, @NonNull ScoreFilter modifier, long count) {
         String[] arguments =
                 concatenateArrays(
                         new String[] {Integer.toString(keys.length)},
                         keys,
                         new String[] {modifier.toString(), COUNT_VALKEY_API, Long.toString(count)});
-        return commandManager.submitNewCommand(ZMPop, arguments, this::handleArrayOrNullResponse);
+        return commandManager.submitNewCommand(
+                ZMPop,
+                arguments,
+                response -> convertKeyValueArrayToMap(handleArrayOrNullResponse(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> zmpop(
+    public CompletableFuture<Map<GlideString, Object>> zmpop(
             @NonNull GlideString[] keys, @NonNull ScoreFilter modifier, long count) {
         GlideString[] arguments =
                 concatenateArrays(
@@ -3722,22 +3720,30 @@ public abstract class BaseClient
                         new GlideString[] {
                             gs(modifier.toString()), gs(COUNT_VALKEY_API), gs(Long.toString(count))
                         });
-        return commandManager.submitNewCommand(ZMPop, arguments, this::handleArrayOrNullResponseBinary);
+        return commandManager.submitNewCommand(
+                ZMPop,
+                arguments,
+                response ->
+                        convertBinaryStringKeyValueArrayToMap(
+                                handleArrayOrNullResponseBinary(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> bzmpop(
+    public CompletableFuture<Map<String, Object>> bzmpop(
             @NonNull String[] keys, @NonNull ScoreFilter modifier, double timeout) {
         String[] arguments =
                 concatenateArrays(
                         new String[] {Double.toString(timeout), Integer.toString(keys.length)},
                         keys,
                         new String[] {modifier.toString()});
-        return commandManager.submitNewCommand(BZMPop, arguments, this::handleArrayOrNullResponse);
+        return commandManager.submitNewCommand(
+                BZMPop,
+                arguments,
+                response -> convertKeyValueArrayToMap(handleArrayOrNullResponse(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> bzmpop(
+    public CompletableFuture<Map<GlideString, Object>> bzmpop(
             @NonNull GlideString[] keys, @NonNull ScoreFilter modifier, double timeout) {
         GlideString[] arguments =
                 concatenateArrays(
@@ -3745,22 +3751,29 @@ public abstract class BaseClient
                         keys,
                         new GlideString[] {gs(modifier.toString())});
         return commandManager.submitNewCommand(
-                BZMPop, arguments, this::handleArrayOrNullResponseBinary);
+                BZMPop,
+                arguments,
+                response ->
+                        convertBinaryStringKeyValueArrayToMap(
+                                handleArrayOrNullResponseBinary(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> bzmpop(
+    public CompletableFuture<Map<String, Object>> bzmpop(
             @NonNull String[] keys, @NonNull ScoreFilter modifier, double timeout, long count) {
         String[] arguments =
                 concatenateArrays(
                         new String[] {Double.toString(timeout), Integer.toString(keys.length)},
                         keys,
                         new String[] {modifier.toString(), COUNT_VALKEY_API, Long.toString(count)});
-        return commandManager.submitNewCommand(BZMPop, arguments, this::handleArrayOrNullResponse);
+        return commandManager.submitNewCommand(
+                BZMPop,
+                arguments,
+                response -> convertKeyValueArrayToMap(handleArrayOrNullResponse(response), Double.class));
     }
 
     @Override
-    public CompletableFuture<Object[]> bzmpop(
+    public CompletableFuture<Map<GlideString, Object>> bzmpop(
             @NonNull GlideString[] keys, @NonNull ScoreFilter modifier, double timeout, long count) {
         GlideString[] arguments =
                 concatenateArrays(
@@ -3770,7 +3783,11 @@ public abstract class BaseClient
                             gs(modifier.toString()), gs(COUNT_VALKEY_API), gs(Long.toString(count))
                         });
         return commandManager.submitNewCommand(
-                BZMPop, arguments, this::handleArrayOrNullResponseBinary);
+                BZMPop,
+                arguments,
+                response ->
+                        convertBinaryStringKeyValueArrayToMap(
+                                handleArrayOrNullResponseBinary(response), Double.class));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -1919,103 +1919,116 @@ public interface SortedSetBaseCommands {
      * Pops a member-score pair from the first non-empty sorted set, with the given <code>keys</code>
      * being checked in the order they are provided.
      *
-     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
      *     ScoreFilter#MAX} to pop the member with the lowest/highest score accordingly.
-     * @return A two-element <code>array</code> containing the key name of the set from which the
-     *     element was popped, and a member-score <code>Map</code> of the popped element.<br>
+     * @return A <code>map</code> containing the key name of the set from which the element was
+     *     popped, and a member-score <code>Map</code> of the popped element.<br>
      *     If no member could be popped, returns <code>null</code>.
+     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
      * @example
      *     <pre>{@code
-     * Object[] result = client.zmpop(new String[] { "zSet1", "zSet2" }, MAX).get();
-     * Map<String, Double> data = (Map<String, Double>)result[1];
+     * Map<String, Object> result = client.zmpop(new String[] { "zSet1", "zSet2" }, MAX).get();
+     * Map<String, Double> data = (Map<String, Double>)result.values().toArray()[0];
      * String element = data.keySet().toArray(String[]::new)[0];
      * System.out.printf("Popped '%s' with score %d from '%s'%n", element, data.get(element), result[0]);
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> zmpop(String[] keys, ScoreFilter modifier);
+    CompletableFuture<Map<String, Object>> zmpop(String[] keys, ScoreFilter modifier);
 
     /**
      * Pops a member-score pair from the first non-empty sorted set, with the given <code>keys</code>
      * being checked in the order they are provided.
      *
-     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
      *     ScoreFilter#MAX} to pop the member with the lowest/highest score accordingly.
-     * @return A two-element <code>array</code> containing the key name of the set from which the
-     *     element was popped, and a member-score <code>Map</code> of the popped element.<br>
+     * @return A <code>map</code> containing the key name of the set from which the element was
+     *     popped, and a member-score <code>Map</code> of the popped element.<br>
      *     If no member could be popped, returns <code>null</code>.
+     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
      * @example
      *     <pre>{@code
-     * Object[] result = client.zmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX).get();
-     * Map<GlideString, Double> data = (Map<GlideString, Double>)result[1];
+     * Map<GlideString, Object> result = client.zmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX).get();
+     * Map<GlideString, Double> data = (Map<GlideString, Double>)result.values().toArray()[0];
      * GlideString element = data.keySet().toArray(GlideString[]::new)[0];
      * System.out.printf("Popped '%s' with score %d from '%s'%n", element, data.get(element), result[0]);
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> zmpop(GlideString[] keys, ScoreFilter modifier);
+    CompletableFuture<Map<GlideString, Object>> zmpop(GlideString[] keys, ScoreFilter modifier);
 
     /**
      * Pops multiple member-score pairs from the first non-empty sorted set, with the given <code>keys
      * </code> being checked in the order they are provided.
      *
-     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
      *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
      * @param count The number of elements to pop.
-     * @return A two-element <code>array</code> containing the key name of the set from which elements
-     *     were popped, and a member-score <code>Map</code> of the popped elements.<br>
+     * @return A <code>map</code> containing the key name of the set from which elements were popped,
+     *     and a member-score <code>Map</code> of the popped elements.<br>
      *     If no member could be popped, returns <code>null</code>.
+     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
      * @example
      *     <pre>{@code
-     * Object[] result = client.zmpop(new String[] { "zSet1", "zSet2" }, MAX, 2).get();
-     * Map<String, Double> data = (Map<String, Double>)result[1];
+     * Map<String, Object> result = client.zmpop(new String[] { "zSet1", "zSet2" }, MAX, 2).get();
+     * Map<String, Double> data = (Map<String, Double>)result.values().toArray()[0];
      * for (Map.Entry<String, Double> entry : data.entrySet()) {
      *     System.out.printf("Popped '%s' with score %d from '%s'%n", entry.getKey(), entry.getValue(), result[0]);
      * }
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> zmpop(String[] keys, ScoreFilter modifier, long count);
+    CompletableFuture<Map<String, Object>> zmpop(String[] keys, ScoreFilter modifier, long count);
 
     /**
      * Pops multiple member-score pairs from the first non-empty sorted set, with the given <code>keys
      * </code> being checked in the order they are provided.
      *
-     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
      * @param keys The keys of the sorted sets.
      * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
      *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
      * @param count The number of elements to pop.
-     * @return A two-element <code>array</code> containing the key name of the set from which elements
-     *     were popped, and a member-score <code>Map</code> of the popped elements.<br>
+     * @return A <code>map</code> containing the key name of the set from which elements were popped,
+     *     and a member-score <code>Map</code> of the popped elements.<br>
      *     If no member could be popped, returns <code>null</code>.
+     * @apiNote When in cluster mode, all <code>keys</code> must map to the same hash slot.
      * @example
      *     <pre>{@code
-     * Object[] result = client.zmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX, 2).get();
-     * Map<GlideString, Double> data = (Map<GlideString, Double>)result[1];
+     * Map<GlideString, Object> result = client.zmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX, 2).get();
+     * Map<GlideString, Double> data = (Map<GlideString, Double>)result.values().toArray()[0];
      * for (Map.Entry<GlideString, Double> entry : data.entrySet()) {
      *     System.out.printf("Popped '%s' with score %d from '%s'%n", entry.getKey(), entry.getValue(), result[0]);
      * }
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/zmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> zmpop(GlideString[] keys, ScoreFilter modifier, long count);
+    CompletableFuture<Map<GlideString, Object>> zmpop(
+            GlideString[] keys, ScoreFilter modifier, long count);
 
     /**
      * Blocks the connection until it pops and returns a member-score pair from the first non-empty
      * sorted set, with the given <code>keys</code> being checked in the order they are provided.<br>
      * <code>BZMPOP</code> is the blocking variant of {@link #zmpop(String[], ScoreFilter)}.
      *
+     * @param keys The keys of the sorted sets.
+     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
+     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
+     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
+     *     <code>0</code> will block indefinitely.
+     * @return A <code>Map</code> containing the key name of the set from which an element was popped,
+     *     and a member-score <code>Map</code> of the popped elements.<br>
+     *     If no member could be popped and the timeout expired, returns <code>null</code>.
      * @apiNote
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
@@ -2024,31 +2037,33 @@ public interface SortedSetBaseCommands {
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
-     * @param keys The keys of the sorted sets.
-     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
-     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
-     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
-     *     <code>0</code> will block indefinitely.
-     * @return A two-element <code>array</code> containing the key name of the set from which an
-     *     element was popped, and a member-score <code>Map</code> of the popped elements.<br>
-     *     If no member could be popped and the timeout expired, returns <code>null</code>.
      * @example
      *     <pre>{@code
-     * Object[] result = client.bzmpop(new String[] { "zSet1", "zSet2" }, MAX, 0.1).get();
-     * Map<String, Double> data = (Map<String, Double>)result[1];
+     * Map<String, Object> result = client.bzmpop(new String[] { "zSet1", "zSet2" }, MAX, 0.1).get();
+     * Map<String, Double> data = (Map<String, Double>)result.values().toArray()[0];
      * String element = data.keySet().toArray(String[]::new)[0];
      * System.out.printf("Popped '%s' with score %d from '%s'%n", element, data.get(element), result[0]);
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> bzmpop(String[] keys, ScoreFilter modifier, double timeout);
+    CompletableFuture<Map<String, Object>> bzmpop(
+            String[] keys, ScoreFilter modifier, double timeout);
 
     /**
      * Blocks the connection until it pops and returns a member-score pair from the first non-empty
      * sorted set, with the given <code>keys</code> being checked in the order they are provided.<br>
      * <code>BZMPOP</code> is the blocking variant of {@link #zmpop(String[], ScoreFilter)}.
      *
+     * @param keys The keys of the sorted sets.
+     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
+     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
+     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
+     *     <code>0</code> will block indefinitely.
+     * @return A <code>map</code> containing the key name of the set from which an element was popped,
+     *     and a member-score <code>Map</code> of the popped elements.<br>
+     *     If no member could be popped and the timeout expired, returns <code>null</code>.
      * @apiNote
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
@@ -2057,25 +2072,19 @@ public interface SortedSetBaseCommands {
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
-     * @param keys The keys of the sorted sets.
-     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
-     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
-     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
-     *     <code>0</code> will block indefinitely.
-     * @return A two-element <code>array</code> containing the key name of the set from which an
-     *     element was popped, and a member-score <code>Map</code> of the popped elements.<br>
-     *     If no member could be popped and the timeout expired, returns <code>null</code>.
      * @example
      *     <pre>{@code
-     * Object[] result = client.bzmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX, 0.1).get();
-     * Map<GlideString, Double> data = (Map<GlideString, Double>)result[1];
+     * Map<GlideString, Object> result = client.bzmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX, 0.1).get();
+     * Map<GlideString, Double> data = (Map<GlideString, Double>)result.values().toArray()[0];
      * GlideString element = data.keySet().toArray(GlideString[]::new)[0];
      * System.out.printf("Popped '%s' with score %d from '%s'%n", element, data.get(element), result[0]);
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> bzmpop(GlideString[] keys, ScoreFilter modifier, double timeout);
+    CompletableFuture<Map<GlideString, Object>> bzmpop(
+            GlideString[] keys, ScoreFilter modifier, double timeout);
 
     /**
      * Blocks the connection until it pops and returns multiple member-score pairs from the first
@@ -2083,6 +2092,15 @@ public interface SortedSetBaseCommands {
      * provided.<br>
      * <code>BZMPOP</code> is the blocking variant of {@link #zmpop(String[], ScoreFilter, long)}.
      *
+     * @param keys The keys of the sorted sets.
+     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
+     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
+     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
+     *     <code>0</code> will block indefinitely.
+     * @param count The number of elements to pop.
+     * @return A <code>map</code> containing the key name of the set from which elements were popped,
+     *     and a member-score <code>Map</code> of the popped elements.<br>
+     *     If no members could be popped and the timeout expired, returns <code>null</code>.
      * @apiNote
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
@@ -2091,27 +2109,19 @@ public interface SortedSetBaseCommands {
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
-     * @param keys The keys of the sorted sets.
-     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
-     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
-     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
-     *     <code>0</code> will block indefinitely.
-     * @param count The number of elements to pop.
-     * @return A two-element <code>array</code> containing the key name of the set from which elements
-     *     were popped, and a member-score <code>Map</code> of the popped elements.<br>
-     *     If no members could be popped and the timeout expired, returns <code>null</code>.
      * @example
      *     <pre>{@code
-     * Object[] result = client.bzmpop(new String[] { "zSet1", "zSet2" }, MAX, 0.1, 2).get();
-     * Map<String, Double> data = (Map<String, Double>)result[1];
+     * Map<String, Object> result = client.bzmpop(new String[] { "zSet1", "zSet2" }, MAX, 0.1, 2).get();
+     * Map<String, Double> data = (Map<String, Double>)result.values().toArray()[0];
      * for (Map.Entry<String, Double> entry : data.entrySet()) {
      *     System.out.printf("Popped '%s' with score %d from '%s'%n", entry.getKey(), entry.getValue(), result[0]);
      * }
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> bzmpop(
+    CompletableFuture<Map<String, Object>> bzmpop(
             String[] keys, ScoreFilter modifier, double timeout, long count);
 
     /**
@@ -2120,6 +2130,15 @@ public interface SortedSetBaseCommands {
      * provided.<br>
      * <code>BZMPOP</code> is the blocking variant of {@link #zmpop(String[], ScoreFilter, long)}.
      *
+     * @param keys The keys of the sorted sets.
+     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
+     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
+     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
+     *     <code>0</code> will block indefinitely.
+     * @param count The number of elements to pop.
+     * @return A <code>map</code> containing the key name of the set from which elements were popped,
+     *     and a member-score <code>Map</code> of the popped elements.<br>
+     *     If no members could be popped and the timeout expired, returns <code>null</code>.
      * @apiNote
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
@@ -2128,27 +2147,19 @@ public interface SortedSetBaseCommands {
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
-     * @since Valkey 7.0 and above.
-     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
-     * @param keys The keys of the sorted sets.
-     * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
-     *     ScoreFilter#MAX} to pop members with the lowest/highest scores accordingly.
-     * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
-     *     <code>0</code> will block indefinitely.
-     * @param count The number of elements to pop.
-     * @return A two-element <code>array</code> containing the key name of the set from which elements
-     *     were popped, and a member-score <code>Map</code> of the popped elements.<br>
-     *     If no members could be popped and the timeout expired, returns <code>null</code>.
      * @example
      *     <pre>{@code
-     * Object[] result = client.bzmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX, 0.1, 2).get();
-     * Map<GlideString, Double> data = (Map<GlideString, Double>)result[1];
+     * Map<GlideString, Object> result = client.bzmpop(new GlideString[] { gs("zSet1"), gs("zSet2") }, MAX, 0.1, 2).get();
+     * Map<GlideString, Double> data = (Map<GlideString, Double>)result.values().toArray()[0];
      * for (Map.Entry<GlideString, Double> entry : data.entrySet()) {
      *     System.out.printf("Popped '%s' with score %d from '%s'%n", entry.getKey(), entry.getValue(), result[0]);
      * }
      * }</pre>
+     *
+     * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
+     * @since Valkey 7.0 and above.
      */
-    CompletableFuture<Object[]> bzmpop(
+    CompletableFuture<Map<GlideString, Object>> bzmpop(
             GlideString[] keys, ScoreFilter modifier, double timeout, long count);
 
     /**

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -187,6 +187,80 @@ public class ArrayTransformUtils {
     }
 
     /**
+     * Processes a two-element array where the first element is used as a key and the second element
+     * is either a Map or a regular object. If the second element is a Map, each value in that Map is
+     * cast to type U. If it's a regular object, it's directly cast to type U.
+     *
+     * @param outerObjectArr A two-element array with array[0] as the key, array[1] as the value(s).
+     * @param clazz The class to which values should be cast.
+     * @return A Map with a single entry with first element as the key, and second element of type U
+     *     or Map<String, U>
+     * @param <T> The base type from which the elements are being cast.
+     * @param <U> The type to which the elements are cast.
+     */
+    public static <T, U extends T> Map<String, Object> convertKeyValueArrayToMap(
+            T[] outerObjectArr, Class<U> clazz) {
+        if (outerObjectArr == null) {
+            return null;
+        }
+
+        String key = outerObjectArr[0].toString();
+
+        if (outerObjectArr[1] instanceof LinkedHashMap) {
+            Map<?, ?> values = (Map<?, ?>) outerObjectArr[1];
+            Map<String, U> innerMap = new LinkedHashMap<>();
+
+            // Ensure types are consistent
+            for (Map.Entry<?, ?> entry : values.entrySet()) {
+                String subKey = entry.getKey().toString();
+                U score = clazz.cast(entry.getValue());
+                innerMap.put(subKey, score);
+            }
+            return Map.of(key, innerMap);
+        }
+
+        // Value is a regular non-collection object
+        return Map.of(key, clazz.cast(outerObjectArr[1]));
+    }
+
+    /**
+     * Processes a two-element array where the first element is used as a key and the second element
+     * is either a Map or a regular object. If the second element is a Map, each value in that Map is
+     * cast to type U. If it's a regular object, it's directly cast to type U.
+     *
+     * @param outerObjectArr A two-element array with array[0] as the key, array[1] as the value(s).
+     * @param clazz The class to which values should be cast.
+     * @return A Map with a single entry with first element as the key, and second element of type U
+     *     or Map<GlideString, U>
+     * @param <T> The base type from which the elements are being cast.
+     * @param <U> The type to which the elements are cast.
+     */
+    public static <T, U extends T> Map<GlideString, Object> convertBinaryStringKeyValueArrayToMap(
+            T[] outerObjectArr, Class<U> clazz) {
+        if (outerObjectArr == null) {
+            return null;
+        }
+
+        GlideString key = gs(outerObjectArr[0].toString());
+
+        if (outerObjectArr[1] instanceof LinkedHashMap) {
+            Map<?, ?> values = (Map<?, ?>) outerObjectArr[1];
+            Map<GlideString, U> innerMap = new LinkedHashMap<>();
+
+            // Ensure types are consistent
+            for (Map.Entry<?, ?> entry : values.entrySet()) {
+                GlideString subKey = gs(entry.getKey().toString());
+                U score = clazz.cast(entry.getValue());
+                innerMap.put(subKey, score);
+            }
+            return Map.of(key, innerMap);
+        }
+
+        // Value is a regular non-collection object
+        return Map.of(key, clazz.cast(outerObjectArr[1]));
+    }
+
+    /**
      * Casts an <code>Object[][][]</code> to <code>T[][][]</code> by casting each nested array and
      * every array element.
      *

--- a/java/client/src/test/java/glide/api/GlideClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClientTest.java
@@ -4633,22 +4633,22 @@ public class GlideClientTest {
         String[] keys = new String[] {"key1", "key2"};
         ScoreFilter modifier = MAX;
         String[] arguments = {"2", "key1", "key2", "MAX"};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<String, Object> value = Map.of("key1", "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<String, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(ZMPop), eq(arguments), any()))
+        when(commandManager.<Map<String, Object>>submitNewCommand(eq(ZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.zmpop(keys, modifier);
-        Object[] payload = response.get();
+        CompletableFuture<Map<String, Object>> response = service.zmpop(keys, modifier);
+        Map<String, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4658,22 +4658,22 @@ public class GlideClientTest {
         GlideString[] keys = new GlideString[] {gs("key1"), gs("key2")};
         ScoreFilter modifier = MAX;
         GlideString[] arguments = {gs("2"), gs("key1"), gs("key2"), gs("MAX")};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<GlideString, Object> value = Map.of(gs("key1"), "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<GlideString, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(ZMPop), eq(arguments), any()))
+        when(commandManager.<Map<GlideString, Object>>submitNewCommand(eq(ZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.zmpop(keys, modifier);
-        Object[] payload = response.get();
+        CompletableFuture<Map<GlideString, Object>> response = service.zmpop(keys, modifier);
+        Map<GlideString, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4684,22 +4684,22 @@ public class GlideClientTest {
         ScoreFilter modifier = MAX;
         long count = 42;
         String[] arguments = {"2", "key1", "key2", "MAX", "COUNT", "42"};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<String, Object> value = Map.of("key1", "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<String, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(ZMPop), eq(arguments), any()))
+        when(commandManager.<Map<String, Object>>submitNewCommand(eq(ZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.zmpop(keys, modifier, count);
-        Object[] payload = response.get();
+        CompletableFuture<Map<String, Object>> response = service.zmpop(keys, modifier, count);
+        Map<String, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4710,22 +4710,22 @@ public class GlideClientTest {
         ScoreFilter modifier = MAX;
         long count = 42;
         GlideString[] arguments = {gs("2"), gs("key1"), gs("key2"), gs("MAX"), gs("COUNT"), gs("42")};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<GlideString, Object> value = Map.of(gs("key1"), "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<GlideString, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(ZMPop), eq(arguments), any()))
+        when(commandManager.<Map<GlideString, Object>>submitNewCommand(eq(ZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.zmpop(keys, modifier, count);
-        Object[] payload = response.get();
+        CompletableFuture<Map<GlideString, Object>> response = service.zmpop(keys, modifier, count);
+        Map<GlideString, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4736,22 +4736,22 @@ public class GlideClientTest {
         String[] keys = new String[] {"key1", "key2"};
         ScoreFilter modifier = MAX;
         String[] arguments = {"0.5", "2", "key1", "key2", "MAX"};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<String, Object> value = Map.of("key1", "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<String, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(BZMPop), eq(arguments), any()))
+        when(commandManager.<Map<String, Object>>submitNewCommand(eq(BZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.bzmpop(keys, modifier, timeout);
-        Object[] payload = response.get();
+        CompletableFuture<Map<String, Object>> response = service.bzmpop(keys, modifier, timeout);
+        Map<String, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4762,22 +4762,23 @@ public class GlideClientTest {
         GlideString[] keys = new GlideString[] {gs("key1"), gs("key2")};
         ScoreFilter modifier = MAX;
         GlideString[] arguments = {gs("0.5"), gs("2"), gs("key1"), gs("key2"), gs("MAX")};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<GlideString, Object> value = Map.of(gs("key1"), "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<GlideString, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(BZMPop), eq(arguments), any()))
+        when(commandManager.<Map<GlideString, Object>>submitNewCommand(
+                        eq(BZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.bzmpop(keys, modifier, timeout);
-        Object[] payload = response.get();
+        CompletableFuture<Map<GlideString, Object>> response = service.bzmpop(keys, modifier, timeout);
+        Map<GlideString, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4789,22 +4790,23 @@ public class GlideClientTest {
         ScoreFilter modifier = MAX;
         long count = 42;
         String[] arguments = {"0.5", "2", "key1", "key2", "MAX", "COUNT", "42"};
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<String, Object> value = Map.of("key1", "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<String, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(BZMPop), eq(arguments), any()))
+        when(commandManager.<Map<String, Object>>submitNewCommand(eq(BZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.bzmpop(keys, modifier, timeout, count);
-        Object[] payload = response.get();
+        CompletableFuture<Map<String, Object>> response =
+                service.bzmpop(keys, modifier, timeout, count);
+        Map<String, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows
@@ -4818,22 +4820,24 @@ public class GlideClientTest {
         GlideString[] arguments = {
             gs("0.5"), gs("2"), gs("key1"), gs("key2"), gs("MAX"), gs("COUNT"), gs("42")
         };
-        Object[] value = new Object[] {"key1", "elem"};
+        Map<GlideString, Object> value = Map.of(gs("key1"), "elem");
 
-        CompletableFuture<Object[]> testResponse = new CompletableFuture<>();
+        CompletableFuture<Map<GlideString, Object>> testResponse = new CompletableFuture<>();
         testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<Object[]>submitNewCommand(eq(BZMPop), eq(arguments), any()))
+        when(commandManager.<Map<GlideString, Object>>submitNewCommand(
+                        eq(BZMPop), eq(arguments), any()))
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<Object[]> response = service.bzmpop(keys, modifier, timeout, count);
-        Object[] payload = response.get();
+        CompletableFuture<Map<GlideString, Object>> response =
+                service.bzmpop(keys, modifier, timeout, count);
+        Map<GlideString, Object> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
-        assertArrayEquals(value, payload);
+        assertEquals(value, payload);
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -5600,10 +5600,11 @@ public class SharedCommandTests {
         assertEquals(2, client.zadd(key1, Map.of("a1", 1., "b1", 2.)).get());
         assertEquals(2, client.zadd(key2, Map.of("a2", .1, "b2", .2)).get());
 
-        assertArrayEquals(
-                new Object[] {key1, Map.of("b1", 2.)}, client.zmpop(new String[] {key1, key2}, MAX).get());
-        assertArrayEquals(
-                new Object[] {key2, Map.of("b2", .2, "a2", .1)},
+        assertEquals(
+                Map.of(key1, Map.of("b1", 2.)), client.zmpop(new String[] {key1, key2}, MAX).get());
+
+        assertEquals(
+                Map.of(key2, Map.of("b2", .2, "a2", .1)),
                 client.zmpop(new String[] {key2, key1}, MAX, 10).get());
 
         // nothing popped out
@@ -5636,7 +5637,7 @@ public class SharedCommandTests {
             entries.put("" + ('a' + i), (double) i);
         }
         assertEquals(10, client.zadd(key2, entries).get());
-        assertEquals(entries, client.zmpop(new String[] {key2}, MIN, 10).get()[1]);
+        assertEquals(entries, client.zmpop(new String[] {key2}, MIN, 10).get().values().toArray()[0]);
     }
 
     @SneakyThrows
@@ -5648,24 +5649,14 @@ public class SharedCommandTests {
         GlideString key2 = gs("{zmpop}-2-" + UUID.randomUUID());
         GlideString key3 = gs("{zmpop}-3-" + UUID.randomUUID());
 
-        assertEquals(
-                2,
-                client
-                        .zadd(key1.toString(), Map.of("a1", 1., "b1", 2.))
-                        .get()); // TODO: use the binary version of this function call once the binary version
-        // of zadd() is merged
-        assertEquals(
-                2,
-                client
-                        .zadd(key2.toString(), Map.of("a2", .1, "b2", .2))
-                        .get()); // TODO: use the binary version of this function call once the binary version
-        // of zadd() is merged
+        assertEquals(2, client.zadd(key1, Map.of(gs("a1"), 1., gs("b1"), 2.)).get());
+        assertEquals(2, client.zadd(key2, Map.of(gs("a2"), .1, gs("b2"), .2)).get());
 
-        assertArrayEquals(
-                new Object[] {key1, Map.of(gs("b1"), 2.)},
+        assertEquals(
+                Map.of(key1, Map.of(gs("b1"), 2.)),
                 client.zmpop(new GlideString[] {key1, key2}, MAX).get());
-        assertArrayEquals(
-                new Object[] {key2, Map.of(gs("b2"), .2, gs("a2"), .1)},
+        assertEquals(
+                Map.of(key2, Map.of(gs("b2"), .2, gs("a2"), .1)),
                 client.zmpop(new GlideString[] {key2, key1}, MAX, 10).get());
 
         // nothing popped out
@@ -5693,24 +5684,14 @@ public class SharedCommandTests {
         assertInstanceOf(RequestException.class, executionException.getCause());
 
         // check that order of entries in the response is preserved
-        var entries =
-                new LinkedHashMap<
-                        String, Double>(); // TODO: remove this once the binary version of zadd() is merged
         var entries_gs = new LinkedHashMap<GlideString, Double>();
         for (int i = 0; i < 10; i++) {
             // a => 1., b => 2. etc
-            entries.put(
-                    "" + ('a' + i),
-                    (double) i); // TODO: remove this once the binary version of zadd() is merged
             entries_gs.put(gs("" + ('a' + i)), (double) i);
         }
+        assertEquals(10, client.zadd(key2, entries_gs).get());
         assertEquals(
-                10,
-                client
-                        .zadd(key2.toString(), entries)
-                        .get()); // TODO: use the binary version of this function call once the binary version
-        // of zadd() is merged
-        assertEquals(entries_gs, client.zmpop(new GlideString[] {key2}, MIN, 10).get()[1]);
+                entries_gs, client.zmpop(new GlideString[] {key2}, MIN, 10).get().values().toArray()[0]);
     }
 
     @SneakyThrows
@@ -5725,11 +5706,10 @@ public class SharedCommandTests {
         assertEquals(2, client.zadd(key1, Map.of("a1", 1., "b1", 2.)).get());
         assertEquals(2, client.zadd(key2, Map.of("a2", .1, "b2", .2)).get());
 
-        assertArrayEquals(
-                new Object[] {key1, Map.of("b1", 2.)},
-                client.bzmpop(new String[] {key1, key2}, MAX, 0.1).get());
-        assertArrayEquals(
-                new Object[] {key2, Map.of("b2", .2, "a2", .1)},
+        assertEquals(
+                Map.of(key1, Map.of("b1", 2.)), client.bzmpop(new String[] {key1, key2}, MAX, 0.1).get());
+        assertEquals(
+                Map.of(key2, Map.of("b2", .2, "a2", .1)),
                 client.bzmpop(new String[] {key2, key1}, MAX, 0.1, 10).get());
 
         // nothing popped out
@@ -5760,7 +5740,8 @@ public class SharedCommandTests {
             entries.put("" + ('a' + i), (double) i);
         }
         assertEquals(10, client.zadd(key2, entries).get());
-        assertEquals(entries, client.bzmpop(new String[] {key2}, MIN, .1, 10).get()[1]);
+        assertEquals(
+                entries, client.bzmpop(new String[] {key2}, MIN, .1, 10).get().values().toArray()[0]);
     }
 
     @SneakyThrows
@@ -5772,24 +5753,14 @@ public class SharedCommandTests {
         GlideString key2 = gs("{bzmpop}-2-" + UUID.randomUUID());
         GlideString key3 = gs("{bzmpop}-3-" + UUID.randomUUID());
 
-        assertEquals(
-                2,
-                client
-                        .zadd(key1.toString(), Map.of("a1", 1., "b1", 2.))
-                        .get()); // TODO: use the binary version of this function call once the binary version
-        // of zadd() is merged
-        assertEquals(
-                2,
-                client
-                        .zadd(key2.toString(), Map.of("a2", .1, "b2", .2))
-                        .get()); // TODO: use the binary version of this function call once the binary version
-        // of zadd() is merged
+        assertEquals(2, client.zadd(key1, Map.of(gs("a1"), 1., gs("b1"), 2.)).get());
+        assertEquals(2, client.zadd(key2, Map.of(gs("a2"), .1, gs("b2"), .2)).get());
 
-        assertArrayEquals(
-                new Object[] {key1, Map.of(gs("b1"), 2.)},
+        assertEquals(
+                Map.of(key1, Map.of(gs("b1"), 2.)),
                 client.bzmpop(new GlideString[] {key1, key2}, MAX, 0.1).get());
-        assertArrayEquals(
-                new Object[] {key2, Map.of(gs("b2"), .2, gs("a2"), .1)},
+        assertEquals(
+                Map.of(key2, Map.of(gs("b2"), .2, gs("a2"), .1)),
                 client.bzmpop(new GlideString[] {key2, key1}, MAX, 0.1, 10).get());
 
         // nothing popped out
@@ -5816,24 +5787,15 @@ public class SharedCommandTests {
         assertInstanceOf(RequestException.class, executionException.getCause());
 
         // check that order of entries in the response is preserved
-        var entries =
-                new LinkedHashMap<
-                        String, Double>(); // TODO: remove this line once the binary version of zadd() is merged
         var entries_gs = new LinkedHashMap<GlideString, Double>();
         for (int i = 0; i < 10; i++) {
             // a => 1., b => 2. etc
-            entries.put(
-                    "" + ('a' + i),
-                    (double) i); // TODO: remove this line once the binary version of zadd() is merged
             entries_gs.put(gs("" + ('a' + i)), (double) i);
         }
+        assertEquals(10, client.zadd(key2, entries_gs).get());
         assertEquals(
-                10,
-                client
-                        .zadd(key2.toString(), entries)
-                        .get()); // TODO: use the binary version of this function call once the binary version
-        // of zadd() is merged
-        assertEquals(entries_gs, client.bzmpop(new GlideString[] {key2}, MIN, .1, 10).get()[1]);
+                entries_gs,
+                client.bzmpop(new GlideString[] {key2}, MIN, .1, 10).get().values().toArray()[0]);
     }
 
     @SneakyThrows


### PR DESCRIPTION
This PR aligns the response type of `BZMPOP` and `ZMPOP` to `LMPOP` ensuring a more specific type instead of a generic `Object[]`.

### Issue link

This Pull Request is linked to issue (URL): 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
