### PR TITLE
Java: Fix flaky `zscan` and `zscan_binary`

### DIFF
--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -14676,7 +14676,12 @@ public class SharedCommandTests {
 
         if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
-                    client.zscan(key1, initialCursor, ZScanOptions.builder().noScores(true).build()).get();
+                    client
+                            .zscan(
+                                    key1,
+                                    initialCursor,
+                                    ZScanOptions.builder().matchPattern("member*").noScores(true).build())
+                            .get();
             assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
             // Cast the result collection to a String array
             Object[] fieldsArray = (Object[]) result[resultCollectionIndex];
@@ -14885,7 +14890,10 @@ public class SharedCommandTests {
         if (SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0")) {
             result =
                     client
-                            .zscan(key1, initialCursor, ZScanOptionsBinary.builder().noScores(true).build())
+                            .zscan(
+                                    key1,
+                                    initialCursor,
+                                    ZScanOptionsBinary.builder().matchPattern(gs("member*")).noScores(true).build())
                             .get();
             assertTrue(Long.parseLong(result[resultCursorIndex].toString()) >= 0);
             // Cast the result collection to a String array


### PR DESCRIPTION
This PR addresses the issue where we were doing a regular `zscan` without acknowledging the fact that members `{ a b c d e }` may have been added beforehand causing the test to fail when asserting that each retrieved member needed to contain the string `"member"`.

Full matrix run (with Java 21 support): https://github.com/valkey-io/valkey-glide/actions/runs/14844001245

### Issue link

This Pull Request is linked to issue (URL): 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
