### PR TITLE
Moving connection cloning to Arc in the cluster core reconnect path

### DIFF
--- a/glide-core/redis-rs/redis/tests/test_async_cluster_connections_logic.rs
+++ b/glide-core/redis-rs/redis/tests/test_async_cluster_connections_logic.rs
@@ -247,7 +247,7 @@ mod test_connect_and_check {
             ClusterParams::default(),
             None,
             RefreshConnectionType::OnlyManagementConnection,
-            Some(node),
+            Some(Arc::new(node)),
             GlideConnectionOptions::default(),
         )
         .await;
@@ -295,7 +295,7 @@ mod test_connect_and_check {
             ClusterParams::default(),
             None,
             RefreshConnectionType::OnlyManagementConnection,
-            Some(node),
+            Some(Arc::new(node)),
             GlideConnectionOptions::default(),
         )
         .await;
@@ -359,7 +359,7 @@ mod test_connect_and_check {
             ClusterParams::default(),
             None,
             RefreshConnectionType::OnlyUserConnection,
-            Some(node),
+            Some(Arc::new(node)),
             GlideConnectionOptions::default(),
         )
         .await;


### PR DESCRIPTION
An improvement for #3747 

Instead of cloning a connection in the refresh task, we clone it.