### PR TITLE
Java: Bump `netty`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 #### Fixes
 
 * Go, Java: Fix response handling for `customCommand` API for cluster client ([#3593](https://github.com/valkey-io/valkey-glide/pull/3593))
+* Java: Bump `netty` version ([#3804](https://github.com/valkey-io/valkey-glide/pull/3804))
 
 #### Operational Enhancements
 

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -22,12 +22,12 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '4.29.1'
     shadow group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
 
-    shadow group: 'io.netty', name: 'netty-handler', version: '4.1.115.Final'
+    shadow group: 'io.netty', name: 'netty-handler', version: '4.1.121.Final'
     // https://github.com/netty/netty/wiki/Native-transports
     // At the moment, Windows is not supported
-    shadow group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.115.Final', classifier: 'linux-x86_64'
-    shadow group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.115.Final', classifier: 'linux-aarch_64'
-    shadow group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.115.Final', classifier: 'osx-aarch_64'
+    shadow group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.121.Final', classifier: 'linux-x86_64'
+    shadow group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.121.Final', classifier: 'linux-aarch_64'
+    shadow group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.121.Final', classifier: 'osx-aarch_64'
 
     // junit
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.12.4'

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -17,9 +17,9 @@ dependencies {
 
     // https://github.com/netty/netty/wiki/Native-transports
     // At the moment, Windows is not supported
-    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.115.Final', classifier: 'linux-x86_64'
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.115.Final', classifier: 'osx-x86_64'
-    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.115.Final', classifier: 'osx-aarch_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: '4.1.121.Final', classifier: 'linux-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.121.Final', classifier: 'osx-x86_64'
+    implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: '4.1.121.Final', classifier: 'osx-aarch_64'
 
     // junit
     testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'


### PR DESCRIPTION
Bump netty to address secutiry issues
1. CVE-2025-24970 / GHSA-4g8c-wm8x-jfhw
2. CVE-2025-25193 / GHSA-389x-839f-4rhx

See also https://mvnrepository.com/artifact/io.valkey/valkey-glide/1.3.2