### PR TITLE
Add libasan to AL2 installed dependencies for CI

### DIFF
--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -60,7 +60,7 @@ runs:
           shell: bash
           if: "${{ inputs.os == 'amazon-linux' }}"
           run: |
-              yum install -y gcc pkgconfig openssl openssl-devel which curl gettext tar --allowerasing
+              yum install -y gcc pkgconfig openssl openssl-devel which curl gettext libasan tar --allowerasing
 
         - name: Install Rust toolchain and protoc
           if: "${{ !contains(inputs.target, 'musl') }}"


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This change fixes an issue where CI test runs on Amazon Linux 2 fail, as seen in this test run:
https://github.com/valkey-io/valkey-glide/actions/runs/14934337857/job/41958100815#step:8:654

### Issue link

This Pull Request is linked to issue (URL): 
https://github.com/valkey-io/valkey-glide/issues/3709
https://github.com/valkey-io/valkey-glide/issues/3650

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
