### PR TITLE
Update dev doc for zigbuild.

### DIFF
--- a/csharp/DEVELOPER.md
+++ b/csharp/DEVELOPER.md
@@ -19,18 +19,29 @@ TODO: examples, UT, design docs
 
 Software Dependencies:
 
-- .Net SDK 6 or later
+- .Net SDK 8 and 9
 - git
-- rustup
-- valkey
+- valkey (for testing)
 
 Please also install the following packages to build [GLIDE core rust library](../glide-core/README.md):
 
+- rustup
 - GCC
-- protoc (protobuf compiler)
 - pkg-config
 - openssl
 - openssl-dev
+- ziglang and zigbuild (for GNU Linux only)
+
+**Valkey installation**
+
+See the [Valkey installation guide](https://valkey.io/topics/installation/) to install the Valkey server and CLI.
+
+**Install `ziglang` and `zigbuild`**
+
+```bash
+pip3 install ziglang
+cargo install --locked cargo-zigbuild
+```
 
 #### Prerequisites
 

--- a/go/DEVELOPER.md
+++ b/go/DEVELOPER.md
@@ -26,6 +26,8 @@ Software Dependencies
 - openssl
 - openssl-dev
 - rustup
+- ziglang and zigbuild (for GNU Linux only)
+- valkey (for testing)
 
 **Valkey installation**
 
@@ -44,14 +46,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
-# Install protobuf compiler
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
-unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
-export PATH="$PATH:$HOME/.local/bin"
-# Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
-protoc --version
 ```
+
+Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 **Dependencies installation for CentOS**
 
@@ -68,14 +65,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
-# Install protobuf compiler
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
-unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
-export PATH="$PATH:$HOME/.local/bin"
-# Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
-protoc --version
 ```
+
+Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 **Dependencies installation for MacOS**
 
@@ -87,6 +79,14 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
+```
+
+**Install protobuf compiler**
+
+To install protobuf for MacOS, run:
+
+```bash
+brew install protobuf@3
 # Verify the Protobuf compiler installation
 protoc --version
 
@@ -94,6 +94,24 @@ protoc --version
 echo 'export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"' >> /Users/$USER/.bash_profile
 source /Users/$USER/.bash_profile
 protoc --version
+```
+
+For the remaining systems, do the following:
+
+```bash
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
+unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
+export PATH="$PATH:$HOME/.local/bin"
+# Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
+protoc --version
+```
+
+**Install `ziglang` and `zigbuild`**
+
+```bash
+pip3 install ziglang
+cargo install --locked cargo-zigbuild
 ```
 
 #### Building and installation steps

--- a/java/DEVELOPER.md
+++ b/java/DEVELOPER.md
@@ -22,6 +22,12 @@ The Valkey GLIDE Java wrapper consists of both Java and Rust code. Rust bindings
 - openssl-dev
 - rustup
 - Java 11
+- ziglang and zigbuild (for GNU Linux only)
+- valkey (for testing)
+
+**Valkey installation**
+
+See the [Valkey installation guide](https://valkey.io/topics/installation/) to install the Valkey server and CLI.
 
 **Dependencies installation for Ubuntu**
 
@@ -35,7 +41,7 @@ source "$HOME/.cargo/env"
 rustc --version
 ```
 
-Continue with **Install protobuf compiler** below.
+Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 **Dependencies installation for CentOS**
 
@@ -46,7 +52,7 @@ sudo yum install -y java-11-openjdk-devel git gcc pkgconfig openssl openssl-deve
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Continue with **Install protobuf compiler** below.
+Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 **Dependencies installation for MacOS**
 
@@ -78,6 +84,13 @@ unzip protoc-29.1-linux-x86_64.zip -d $HOME/.local
 export PATH="$PATH:$HOME/.local/bin"
 # Check that the protobuf compiler version 29.1 or higher is installed
 protoc --version
+```
+
+**Install `ziglang` and `zigbuild`**
+
+```bash
+pip3 install ziglang
+cargo install --locked cargo-zigbuild
 ```
 
 #### Building and installation steps

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -24,6 +24,12 @@ If your Nodejs version is below the supported version specified in the client's 
 - openssl
 - openssl-dev
 - rustup
+- ziglang and zigbuild (for GNU Linux only)
+- valkey (for testing)
+
+**Valkey installation**
+
+See the [Valkey installation guide](https://valkey.io/topics/installation/) to install the Valkey server and CLI.
 
 **Dependencies installation for Ubuntu**
 
@@ -56,8 +62,12 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```
 
-**Valkey Server and CLI**
-See the [Valkey installation guide](https://valkey.io/topics/installation/) to install the Valkey server and CLI.
+**Install `ziglang` and `zigbuild`**
+
+```bash
+pip3 install ziglang
+cargo install --locked cargo-zigbuild
+```
 
 #### Building and installation steps
 

--- a/python/DEVELOPER.md
+++ b/python/DEVELOPER.md
@@ -10,14 +10,20 @@ The Valkey GLIDE Python wrapper consists of both Python and Rust code. Rust bind
 Before building the package from source, make sure that you have installed the listed dependencies below:
 
 
--   python3 virtualenv
--   git
--   GCC
--   pkg-config
--   protoc (protobuf compiler) >= v3.20.0
--   openssl
--   openssl-dev
--   rustup
+- python3 virtualenv
+- git
+- GCC
+- pkg-config
+- protoc (protobuf compiler) >= v3.20.0
+- openssl
+- openssl-dev
+- rustup
+- ziglang and zigbuild (for GNU Linux only)
+- valkey (for testing)
+
+**Valkey installation**
+
+See the [Valkey installation guide](https://valkey.io/topics/installation/) to install the Valkey server and CLI.
 
 For your convenience, we wrapped the steps in a "copy-paste" code blocks for common operating systems:
 
@@ -32,16 +38,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
-# Install protobuf compiler
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-# For other arch type from x86 example below, the signature of the curl url should be protoc-<version>-<os>-<arch>.zip,
-# e.g. protoc-3.20.3-linux-aarch_64.zip for ARM64.
-curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
-unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
-export PATH="$PATH:$HOME/.local/bin"
-# Check that the protobuf compiler is installed
-protoc --version
 ```
+Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 </details>
 
@@ -57,14 +55,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
-# Install protobuf compiler
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
-unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
-export PATH="$PATH:$HOME/.local/bin"
-# Check that the protobuf compiler is installed
-protoc --version
 ```
+Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 </details>
 
@@ -78,6 +70,18 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
+```
+Continue with **Install protobuf compiler** below.
+
+</details>
+
+<details>
+<summary>Install protobuf compiler</summary>
+
+To install protobuf for MacOS, run:
+
+```bash
+brew install protobuf@3
 # Verify the Protobuf compiler installation
 protoc --version
 
@@ -85,6 +89,27 @@ protoc --version
 echo 'export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"' >> /Users/$USER/.bash_profile
 source /Users/$USER/.bash_profile
 protoc --version
+```
+
+For the remaining systems, do the following:
+
+```bash
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
+unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
+export PATH="$PATH:$HOME/.local/bin"
+# Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
+protoc --version
+```
+
+</details>
+
+<details>
+<summary>Install `ziglang` and `zigbuild`</summary>
+
+```bash
+pip3 install ziglang
+cargo install --locked cargo-zigbuild
 ```
 
 </details>


### PR DESCRIPTION
Update dev docs for all clients. Even though zigbuild isn't used in build by all clients, it will be done soon.