### PR TITLE
Go: Switch to `time.Duration` for timeouts

### DIFF
--- a/go/api/config.go
+++ b/go/api/config.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"errors"
+	"time"
 
 	"github.com/valkey-io/valkey-glide/go/protobuf"
 )
@@ -94,7 +95,7 @@ type baseClientConfiguration struct {
 	useTLS         bool
 	credentials    *ServerCredentials
 	readFrom       ReadFrom
-	requestTimeout int
+	requestTimeout time.Duration
 	clientName     string
 	clientAZ       string
 }
@@ -248,11 +249,11 @@ func (config *GlideClientConfiguration) WithReadFrom(readFrom ReadFrom) *GlideCl
 	return config
 }
 
-// WithRequestTimeout sets the duration in milliseconds that the client should wait for a request to complete. This duration
+// WithRequestTimeout sets the duration that the client should wait for a request to complete. This duration
 // encompasses sending the request, awaiting for a response from the server, and any required reconnections or retries. If the
 // specified timeout is exceeded for a pending request, it will result in a timeout error. If not set, a default value will be
 // used.
-func (config *GlideClientConfiguration) WithRequestTimeout(requestTimeout int) *GlideClientConfiguration {
+func (config *GlideClientConfiguration) WithRequestTimeout(requestTimeout time.Duration) *GlideClientConfiguration {
 	config.requestTimeout = requestTimeout
 	return config
 }
@@ -373,11 +374,11 @@ func (config *GlideClusterClientConfiguration) WithReadFrom(readFrom ReadFrom) *
 	return config
 }
 
-// WithRequestTimeout sets the duration in milliseconds that the client should wait for a request to complete. This duration
+// WithRequestTimeout sets the duration that the client should wait for a request to complete. This duration
 // encompasses sending the request, awaiting for a response from the server, and any required reconnections or retries. If the
 // specified timeout is exceeded for a pending request, it will result in a timeout error. If not set, a default value will be
 // used.
-func (config *GlideClusterClientConfiguration) WithRequestTimeout(requestTimeout int) *GlideClusterClientConfiguration {
+func (config *GlideClusterClientConfiguration) WithRequestTimeout(requestTimeout time.Duration) *GlideClusterClientConfiguration {
 	config.requestTimeout = requestTimeout
 	return config
 }

--- a/go/api/config_test.go
+++ b/go/api/config_test.go
@@ -5,6 +5,7 @@ package api
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valkey-io/valkey-glide/go/protobuf"
@@ -56,7 +57,7 @@ func TestConfig_allFieldsSet(t *testing.T) {
 		WithUseTLS(true).
 		WithReadFrom(PreferReplica).
 		WithCredentials(NewServerCredentials(username, password)).
-		WithRequestTimeout(timeout).
+		WithRequestTimeout(timeout * time.Second).
 		WithClientName(clientName).
 		WithReconnectStrategy(NewBackoffStrategy(retries, factor, base)).
 		WithDatabaseId(databaseId)

--- a/go/api/create_client_test.go
+++ b/go/api/create_client_test.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"fmt"
+	"time"
 )
 
 func ExampleNewGlideClient() {
@@ -25,7 +26,7 @@ func ExampleNewGlideClient() {
 func ExampleNewGlideClusterClient() {
 	config := NewGlideClusterClientConfiguration().
 		WithAddress(&getClusterAddresses()[0]).
-		WithRequestTimeout(5000).
+		WithRequestTimeout(5 * time.Second).
 		WithUseTLS(false)
 	client, err := NewGlideClusterClient(config)
 	if err != nil {

--- a/go/api/example_utils.go
+++ b/go/api/example_utils.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/valkey-io/valkey-glide/go/api/config"
 	"github.com/valkey-io/valkey-glide/go/api/options"
@@ -82,7 +83,7 @@ func getExampleGlideClusterClient() *GlideClusterClient {
 	})
 	cConfig := NewGlideClusterClientConfiguration().
 		WithAddress(&clusterAddresses[0]).
-		WithRequestTimeout(5000)
+		WithRequestTimeout(5 * time.Second)
 
 	client, err := NewGlideClusterClient(cConfig)
 	if err != nil {

--- a/go/api/server-modules/glidejson/example_utils.go
+++ b/go/api/server-modules/glidejson/example_utils.go
@@ -3,6 +3,7 @@ package glidejson
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/valkey-io/valkey-glide/go/api"
 )
@@ -29,7 +30,7 @@ func getExampleGlideClient() *api.GlideClient {
 func getExampleGlideClusterClient() *api.GlideClusterClient {
 	config := api.NewGlideClusterClientConfiguration().
 		WithAddress(&api.NodeAddress{Host: "localhost", Port: 7001}).
-		WithRequestTimeout(5000)
+		WithRequestTimeout(5 * time.Second)
 
 	client, err := api.NewGlideClusterClient(config)
 	if err != nil {

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -1979,7 +1979,7 @@ func (suite *GlideTestSuite) testFunctionKillNoWrite(withRoute bool) {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), libName, result)
 
-	testConfig := suite.defaultClusterClientConfig().WithRequestTimeout(10000)
+	testConfig := suite.defaultClusterClientConfig().WithRequestTimeout(10 * time.Second)
 	testClient := suite.clusterClient(testConfig)
 	defer testClient.Close()
 
@@ -2083,7 +2083,7 @@ func (suite *GlideTestSuite) TestFunctionKillKeyBasedWriteFunction() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), libName, result)
 
-	testConfig := suite.defaultClusterClientConfig().WithRequestTimeout(10000)
+	testConfig := suite.defaultClusterClientConfig().WithRequestTimeout(10 * time.Second)
 	testClient := suite.clusterClient(testConfig)
 	defer testClient.Close()
 

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -157,7 +157,7 @@ func getServerVersion(suite *GlideTestSuite) string {
 		clientConfig := api.NewGlideClientConfiguration().
 			WithAddress(&suite.standaloneHosts[0]).
 			WithUseTLS(suite.tls).
-			WithRequestTimeout(5000)
+			WithRequestTimeout(5 * time.Second)
 
 		client, err := api.NewGlideClient(clientConfig)
 		if err == nil && client != nil {
@@ -176,7 +176,7 @@ func getServerVersion(suite *GlideTestSuite) string {
 	clientConfig := api.NewGlideClusterClientConfiguration().
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
-		WithRequestTimeout(5000)
+		WithRequestTimeout(5 * time.Second)
 
 	client, err := api.NewGlideClusterClient(clientConfig)
 	if err == nil && client != nil {
@@ -267,13 +267,13 @@ func (suite *GlideTestSuite) getDefaultClients() []api.BaseClient {
 
 func (suite *GlideTestSuite) getTimeoutClients() []api.BaseClient {
 	clients := []api.BaseClient{}
-	clusterTimeoutClient, err := suite.createConnectionTimeoutClient(250, 20000, nil)
+	clusterTimeoutClient, err := suite.createConnectionTimeoutClient(250, 20*time.Second, nil)
 	if err != nil {
 		suite.T().Fatalf("Failed to create cluster timeout client: %s", err.Error())
 	}
 	clients = append(clients, clusterTimeoutClient)
 
-	standaloneTimeoutClient, err := suite.createConnectionTimeoutClusterClient(250, 20000)
+	standaloneTimeoutClient, err := suite.createConnectionTimeoutClusterClient(250, 20*time.Second)
 	if err != nil {
 		suite.T().Fatalf("Failed to create standalone timeout client: %s", err.Error())
 	}
@@ -286,7 +286,7 @@ func (suite *GlideTestSuite) defaultClientConfig() *api.GlideClientConfiguration
 	return api.NewGlideClientConfiguration().
 		WithAddress(&suite.standaloneHosts[0]).
 		WithUseTLS(suite.tls).
-		WithRequestTimeout(5000)
+		WithRequestTimeout(5 * time.Second)
 }
 
 func (suite *GlideTestSuite) defaultClient() api.GlideClientCommands {
@@ -308,7 +308,7 @@ func (suite *GlideTestSuite) defaultClusterClientConfig() *api.GlideClusterClien
 	return api.NewGlideClusterClientConfiguration().
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
-		WithRequestTimeout(5000)
+		WithRequestTimeout(5 * time.Second)
 }
 
 func (suite *GlideTestSuite) defaultClusterClient() api.GlideClusterClientCommands {
@@ -327,7 +327,8 @@ func (suite *GlideTestSuite) clusterClient(config *api.GlideClusterClientConfigu
 }
 
 func (suite *GlideTestSuite) createConnectionTimeoutClient(
-	connectTimeout, requestTimeout int,
+	connectTimeout int,
+	requestTimeout time.Duration,
 	backoffStrategy *api.BackoffStrategy,
 ) (api.GlideClientCommands, error) {
 	clientConfig := suite.defaultClientConfig().
@@ -339,7 +340,8 @@ func (suite *GlideTestSuite) createConnectionTimeoutClient(
 }
 
 func (suite *GlideTestSuite) createConnectionTimeoutClusterClient(
-	connectTimeout, requestTimeout int,
+	connectTimeout int,
+	requestTimeout time.Duration,
 ) (api.GlideClusterClientCommands, error) {
 	clientConfig := suite.defaultClusterClientConfig().
 		WithAdvancedConfiguration(

--- a/go/integTest/readfrom_strategy_test.go
+++ b/go/integTest/readfrom_strategy_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valkey-io/valkey-glide/go/api"
@@ -19,7 +20,7 @@ func (suite *GlideTestSuite) TestRoutingWithAzAffinityStrategyTo1Replica() {
 	const GET_CALLS = 3
 	getCmdStat := "cmdstat_get:calls=" + fmt.Sprint(GET_CALLS)
 
-	clientForConfigSet := suite.clusterClient(suite.defaultClusterClientConfig().WithRequestTimeout(2000))
+	clientForConfigSet := suite.clusterClient(suite.defaultClusterClientConfig().WithRequestTimeout(2 * time.Second))
 
 	// Reset the availability zone for all nodes
 	_, err := clientForConfigSet.CustomCommandWithRoute(
@@ -35,7 +36,7 @@ func (suite *GlideTestSuite) TestRoutingWithAzAffinityStrategyTo1Replica() {
 	assert.NoError(suite.T(), err)
 
 	clientForTestingAz := suite.clusterClient(suite.defaultClusterClientConfig().
-		WithRequestTimeout(2000).
+		WithRequestTimeout(2 * time.Second).
 		WithReadFrom(api.AzAffinity).
 		WithClientAZ(az))
 
@@ -78,7 +79,7 @@ func (suite *GlideTestSuite) TestRoutingBySlotToReplicaWithAzAffinityStrategyToA
 	suite.SkipIfServerVersionLowerThanBy("8.0.0", suite.T())
 	az := "us-east-1a"
 
-	clientForConfigSet := suite.clusterClient(suite.defaultClusterClientConfig().WithRequestTimeout(2000))
+	clientForConfigSet := suite.clusterClient(suite.defaultClusterClientConfig().WithRequestTimeout(2 * time.Second))
 
 	// Reset the availability zone for all nodes
 	_, err := clientForConfigSet.CustomCommandWithRoute(
@@ -114,7 +115,7 @@ func (suite *GlideTestSuite) TestRoutingBySlotToReplicaWithAzAffinityStrategyToA
 
 	// Creating Client with AZ configuration for testing
 	clientForTestingAz := suite.clusterClient(suite.defaultClusterClientConfig().
-		WithRequestTimeout(2000).
+		WithRequestTimeout(2 * time.Second).
 		WithReadFrom(api.AzAffinity).
 		WithClientAZ(az))
 
@@ -165,7 +166,7 @@ func (suite *GlideTestSuite) TestAzAffinityNonExistingAz() {
 	clientForTestingAz := suite.clusterClient(api.NewGlideClusterClientConfiguration().
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
-		WithRequestTimeout(2000).
+		WithRequestTimeout(2 * time.Second).
 		WithReadFrom(api.AzAffinity).
 		WithClientAZ("non-existing-az"))
 
@@ -213,7 +214,7 @@ func (suite *GlideTestSuite) TestAzAffinityReplicasAndPrimaryRoutesToPrimary() {
 	clientForConfigSet := suite.clusterClient(api.NewGlideClusterClientConfiguration().
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
-		WithRequestTimeout(2000))
+		WithRequestTimeout(2 * time.Second))
 
 	// Reset stats and set all nodes to otherAz
 	resetStatResult, err := clientForConfigSet.CustomCommandWithRoute(
@@ -242,7 +243,7 @@ func (suite *GlideTestSuite) TestAzAffinityReplicasAndPrimaryRoutesToPrimary() {
 	clientForTestingAz := suite.clusterClient(api.NewGlideClusterClientConfiguration().
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
-		WithRequestTimeout(2000).
+		WithRequestTimeout(2 * time.Second).
 		WithReadFrom(api.AzAffinityReplicaAndPrimary).
 		WithClientAZ(az))
 

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -1111,7 +1111,7 @@ func (suite *GlideTestSuite) testFunctionKill(readOnly bool) {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), libName, result)
 
-	testConfig := suite.defaultClientConfig().WithRequestTimeout(10000)
+	testConfig := suite.defaultClientConfig().WithRequestTimeout(10 * time.Second)
 	testClient := suite.client(testConfig)
 	defer testClient.Close()
 


### PR DESCRIPTION
Using `time.Duration` allows for our code to be more readable and easier to understand.

### Issue link

This Pull Request is linked to issue (URL): #3809 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
