### PR TITLE
Python: bump package build tooling

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -102,7 +102,7 @@ jobs:
               shell: bash
               run: |
                   if ${{ env.EVENT_NAME == 'pull_request' }}; then
-                    R_VERSION="255.255.255"
+                    R_VERSION="0.1.0"
                   elif ${{ env.EVENT_NAME == 'workflow_dispatch' }}; then
                     R_VERSION="${{ env.INPUT_VERSION }}"
                   else
@@ -125,7 +125,7 @@ jobs:
               working-directory: ./python
               run: |
                   SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
-                  sed -i $SED_FOR_MACOS "s|255.255.255|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
+                  sed -i $SED_FOR_MACOS "s|0.1.0|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
                   # Log the edited Cargo.toml file
                   cat Cargo.toml
 
@@ -228,7 +228,7 @@ jobs:
             - name: Set the package version for Python
               working-directory: ./python
               run: |
-                  sed -i "s|255.255.255|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
+                  sed -i "s|0.1.0|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
 
             - name: Build source distributions
               uses: PyO3/maturin-action@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,7 +86,7 @@ jobs:
         name: Python Tests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: get-matrices
-        timeout-minutes: 35
+        timeout-minutes: 45
         strategy:
             fail-fast: false
             matrix:
@@ -284,7 +284,7 @@ jobs:
     test-python-container:
         runs-on: ${{ matrix.host.RUNNER }}
         needs: [get-containers]
-        timeout-minutes: 25
+        timeout-minutes: 35
         strategy:
             fail-fast: false
             matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ utils/TestUtils.js
 
 # generaged files (e.g. protobuf)
 generated/
+protoc-*.zip
 
 # docs
 docs/markdown/node/**

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -22,9 +22,6 @@ redis = { path = "../glide-core/redis-rs/redis", features = [
 glide-core = { path = "../glide-core", features = ["socket-layer"] }
 logger_core = { path = "../logger_core" }
 
-[package.metadata.maturin]
-python-source = "python"
-
 [profile.release]
 lto = true
 strip = "symbols"

--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,4 +1,4 @@
-maturin==0.14.17 # higher version break the needs structure changes, the name of the project is not the same as the package name, and the naming both glide create a circular dependency - TODO: fix this 
+maturin==1.8.6
 anyio[trio]>=4.9.0
 uvloop
 pytest

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["maturin==0.14.17"]
+requires = ["maturin==1.8.6"]
 build-backend = "maturin"
 
 [project]
 name = "valkey-glide"
+dynamic = ["version"]
 description = "An open source Valkey client library that supports Valkey and Redis open source 6.2, 7.0, 7.2 and 8.0."
 requires-python = ">=3.9"
 dependencies = [
@@ -23,6 +24,9 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Framework :: AsyncIO",
+    "Framework :: Trio",
+    "Framework :: AnyIO",
 ]
 
 [tool.isort]
@@ -35,3 +39,6 @@ target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.mypy]
 exclude = "^(.*\\/)?(\\.env|python/python/glide/protobuf|utils/release-candidate-testing|target|ort)(\\/|$)"
+
+[tool.maturin]
+python-source = "python"


### PR DESCRIPTION
Bump the `maturin` version to current stable, and fix the bad `sed` version match in the release CI introduced in https://github.com/valkey-io/valkey-glide/pull/3795. 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
