### PR TITLE
Python - Remove Use of Deprecated Module

### DIFF
--- a/python/python/glide/async_commands/batch.py
+++ b/python/python/glide/async_commands/batch.py
@@ -1,6 +1,5 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-import sys
 import threading
 from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
@@ -56,11 +55,6 @@ from glide.async_commands.stream import (
 )
 from glide.constants import TEncodable
 from glide.protobuf.command_request_pb2 import RequestType
-
-if sys.version_info >= (3, 13):
-    from warnings import deprecated
-else:
-    from typing_extensions import deprecated
 
 TBatch = TypeVar("TBatch", bound="BaseBatch")
 

--- a/python/python/glide/async_commands/batch.py
+++ b/python/python/glide/async_commands/batch.py
@@ -5594,6 +5594,7 @@ def deprecated_class(reason):
 
         cls.__init__ = new_init
         return cls
+
     return decorator
 
 

--- a/python/python/glide/async_commands/batch.py
+++ b/python/python/glide/async_commands/batch.py
@@ -5584,13 +5584,26 @@ class ClusterBatch(BaseBatch):
     # TODO: add all CLUSTER commands
 
 
-@deprecated("Use ClusterBatch(is_atomic=True) instead.")
+def deprecated_class(reason):
+    def decorator(cls):
+        original_init = cls.__init__
+
+        def new_init(self, *args, **kwargs):
+            print(f"WARNING: {cls.__name__} is deprecated: {reason}")
+            original_init(self, *args, **kwargs)
+
+        cls.__init__ = new_init
+        return cls
+    return decorator
+
+
+@deprecated_class(reason="Use Batch(is_atomic=True) instead.")
 class Transaction(Batch):
     def __init__(self):
         super().__init__(is_atomic=True)
 
 
-@deprecated("Use ClusterBatch(is_atomic=True) instead.")
+@deprecated_class(reason="Use ClusterBatch(is_atomic=True) instead.")
 class ClusterTransaction(ClusterBatch):
     def __init__(self):
         super().__init__(is_atomic=True)


### PR DESCRIPTION
The use of the external module deprecated caused build errors when releasing versions. This fix is to remove the use of that external module, and implement something ourself.

### Issue link

This Pull Request is linked to issue (URL): [[3553](https://github.com/valkey-io/valkey-glide/issues/3553)]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
