### PR TITLE
Python: bug fix for PyPi CD workflow

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -125,7 +125,7 @@ jobs:
               working-directory: ./python
               run: |
                   SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
-                  sed -i $SED_FOR_MACOS "s|255.255.255|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
+                  sed -i $SED_FOR_MACOS "s|0.1.0|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
                   # Log the edited Cargo.toml file
                   cat Cargo.toml
 
@@ -228,7 +228,7 @@ jobs:
             - name: Set the package version for Python
               working-directory: ./python
               run: |
-                  sed -i "s|255.255.255|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
+                  sed -i "s|0.1.0|${{ env.RELEASE_VERSION }}|g" ./Cargo.toml
 
             - name: Build source distributions
               uses: PyO3/maturin-action@v1


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This PR fixes the CD workflow to correctly update the version in the Python Cargo.toml file. Previously, the script searched the python `Cargo.toml` for the placeholder version `255.255.255` to replace it with the release version. However, the placeholder was changed (in #3795 )  to 0.1.0 to align with the other wrappers. As a result, when triggering the workflow from main, the CD workflow published version 0.1.0 to PyPI instead of the intended rc version (see - https://github.com/valkey-io/valkey-glide/actions/runs/15043350660/job/42281149445). 


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
