### PR TITLE
Core: Added reference counting to the Script container to support multiple instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * Go: Remove redundant implementations of echo ([#3859](https://github.com/valkey-io/valkey-glide/pull/3859))
 * Java: Add toArgs() to restore batch command ([#3883](https://github.com/valkey-io/valkey-glide/pull/3883))
 * Java: Add error restore command ([#3905](https://github.com/valkey-io/valkey-glide/pull/3905))
+* Core: Add reference counting to Script container to support multiple instances ([#3897](https://github.com/valkey-io/valkey-glide/pull/3897))
 
 #### Breaking Changes
 

--- a/glide-core/src/scripts_container.rs
+++ b/glide-core/src/scripts_container.rs
@@ -1,13 +1,20 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 use bytes::BytesMut;
-use logger_core::log_info;
+use logger_core::{log_info, log_warn};
 use once_cell::sync::Lazy;
 use sha1_smol::Sha1;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-static CONTAINER: Lazy<Mutex<HashMap<String, Arc<BytesMut>>>> =
+#[derive(Clone)]
+struct ScriptEntry {
+    script: Arc<BytesMut>,
+    ref_count: Arc<AtomicUsize>,
+}
+
+static CONTAINER: Lazy<Mutex<HashMap<String, ScriptEntry>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 pub fn add_script(script: &[u8]) -> String {
@@ -18,21 +25,89 @@ pub fn add_script(script: &[u8]) -> String {
         "script lifetime",
         format!("Added script with hash: `{hash}`"),
     );
-    CONTAINER
-        .lock()
-        .unwrap()
-        .insert(hash.clone(), Arc::new(script.into()));
+
+    let mut container = CONTAINER.lock().unwrap();
+    let entry = container
+        .entry(hash.clone())
+        .or_insert_with(|| ScriptEntry {
+            script: Arc::new(BytesMut::from(script)),
+            ref_count: Arc::new(AtomicUsize::new(0)),
+        });
+    let new_count = entry.ref_count.fetch_add(1, Ordering::SeqCst) + 1;
+    log_info(
+        "script_lifetime",
+        format!("Added script with hash: `{hash}`, ref_count = {new_count}"),
+    );
     hash
 }
 
 pub fn get_script(hash: &str) -> Option<Arc<BytesMut>> {
-    CONTAINER.lock().unwrap().get(hash).cloned()
+    CONTAINER
+        .lock()
+        .unwrap()
+        .get(hash)
+        .map(|entry| entry.script.clone())
 }
 
 pub fn remove_script(hash: &str) {
-    log_info(
-        "script lifetime",
-        format!("Removed script with hash: `{hash}`"),
-    );
-    CONTAINER.lock().unwrap().remove(hash);
+    let mut container = CONTAINER.lock().unwrap();
+    if let Some(entry) = container.get(hash) {
+        let new_count = entry.ref_count.fetch_sub(1, Ordering::SeqCst) - 1;
+
+        if new_count == 0 {
+            container.remove(hash);
+            log_info(
+                "script_lifetime",
+                format!("Removed script with hash `{hash}` (ref_count reached 0)."),
+            );
+        } else {
+            log_info(
+                "script_lifetime",
+                format!("Decremented ref_count for script `{hash}`: new ref_count = {new_count}."),
+            );
+        }
+    } else {
+        log_warn(
+            "script_lifetime",
+            format!("Attempted to remove non-existent script with hash `{hash}`."),
+        );
+    }
+}
+
+#[cfg(test)]
+mod script_tests {
+    use super::*;
+
+    #[test]
+    fn test_add_and_get_script() {
+        let script = b"print('Hello, World!')";
+        let hash = add_script(script);
+
+        let retrieved = get_script(&hash);
+        assert!(retrieved.is_some());
+        assert_eq!(&retrieved.unwrap()[..], script);
+    }
+
+    #[test]
+    fn test_reference_counting_and_removal() {
+        let script_1 = b"print('ref count test')";
+        let script_2 = b"print('ref count test')";
+        let hash = add_script(script_1);
+        let hash_2 = add_script(script_2); // Increase ref count to 2
+        assert_eq!(hash, hash_2);
+
+        // First removal should decrement but not remove
+        remove_script(&hash);
+        assert!(get_script(&hash).is_some());
+
+        // Second removal should remove the script
+        remove_script(&hash);
+        assert!(get_script(&hash).is_none());
+    }
+
+    #[test]
+    fn test_remove_non_existent_script() {
+        let fake_hash = "nonexistenthash";
+        remove_script(fake_hash); // Should not panic
+    }
 }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -3559,4 +3559,52 @@ public class CommandTests {
             }
         }
     }
+
+    /**
+     * Verifies that a script is retained in the local scripts container and not removed while another
+     * instance with the same hash still exists, even after the original reference is dropped and the
+     * server cache is flushed.
+     */
+    @ParameterizedTest
+    @MethodSource("getClients")
+    @SneakyThrows
+    public void test_script_is_not_removed_while_another_instance_exists(
+            GlideClusterClient clusterClient) {
+        String code = "return 'Script Exists'";
+        Script script1 = new Script(code, false);
+        Script script2 = new Script(code, false);
+
+        // Assert both have the same SHA1
+        assertEquals(script1.getHash(), script2.getHash());
+
+        // Run first script and drop reference
+        assertEquals("Script Exists", clusterClient.invokeScript(script1).get());
+
+        // Manually simulate release of script1 reference
+        script1.close();
+
+        // Flush script from server
+        assertEquals("OK", clusterClient.scriptFlush().get());
+
+        // Server should now report that the script doesn't exist
+        Boolean[] exists = clusterClient.scriptExists(new String[] {script1.getHash()}).get();
+        assertArrayEquals(new Boolean[] {false}, exists);
+
+        // Invoke again using script2 (same hash, still in local cache)
+        assertEquals("Script Exists", clusterClient.invokeScript(script2).get());
+
+        // Manually simulate release of script2 reference
+        script2.close();
+
+        // Flush the script from server agains
+        assertEquals("OK", clusterClient.scriptFlush().get());
+
+        // Make sure the script doesn't exist on the local container anymore
+        ExecutionException exception =
+                assertThrows(ExecutionException.class, () -> clusterClient.invokeScript(script2).get());
+        assertInstanceOf(RequestException.class, exception.getCause());
+        assertTrue(
+                exception.getMessage().toUpperCase().contains("NOSCRIPT"),
+                "Expected NOSCRIPT error after script is fully released and flushed");
+    }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1894,4 +1894,51 @@ public class CommandTests {
             }
         }
     }
+
+    /**
+     * Verifies that a script is retained in the local scripts container and not removed while another
+     * instance with the same hash still exists, even after the original reference is dropped and the
+     * server cache is flushed.
+     */
+    @ParameterizedTest
+    @MethodSource("getClients")
+    @SneakyThrows
+    public void test_script_is_not_removed_while_another_instance_exists(GlideClient regularClient) {
+        String code = "return 'Script Exists'";
+        Script script1 = new Script(code, false);
+        Script script2 = new Script(code, false);
+
+        // Assert both have the same SHA1
+        assertEquals(script1.getHash(), script2.getHash());
+
+        // Run first script and drop reference
+        assertEquals("Script Exists", regularClient.invokeScript(script1).get());
+
+        // Manually simulate release of script1 reference
+        script1.close();
+
+        // Flush script from server
+        assertEquals("OK", regularClient.scriptFlush().get());
+
+        // Server should now report that the script doesn't exist
+        Boolean[] exists = regularClient.scriptExists(new String[] {script1.getHash()}).get();
+        assertArrayEquals(new Boolean[] {false}, exists);
+
+        // Invoke again using script2 (same hash, still in local cache)
+        assertEquals("Script Exists", regularClient.invokeScript(script2).get());
+
+        // Manually simulate release of script2 reference
+        script2.close();
+
+        // Flush the script from server agains
+        assertEquals("OK", regularClient.scriptFlush().get());
+
+        // Make sure the script doesn't exist on the local container anymore
+        ExecutionException exception =
+                assertThrows(ExecutionException.class, () -> regularClient.invokeScript(script2).get());
+        assertInstanceOf(RequestException.class, exception.getCause());
+        assertTrue(
+                exception.getMessage().toUpperCase().contains("NOSCRIPT"),
+                "Expected NOSCRIPT error after script is fully released and flushed");
+    }
 }

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -604,11 +604,28 @@ impl Script {
     pub fn get_hash(&self) -> String {
         self.hash.clone()
     }
+
+    /// Internal release logic used both by Drop and napi-exposed `release()`.
+    fn release_internal(&self) {
+        glide_core::scripts_container::remove_script(&self.hash);
+    }
+
+    /// Decrements the script's reference count in the local container.  
+    /// Removes the script when the count reaches zero.
+    ///
+    /// This method is primarily intended for testing or manual cleanup.
+    /// It does not need to be called explicitly, as the script will be automatically
+    /// released when dropped.
+    #[napi]
+    #[allow(dead_code)]
+    pub fn release(&self) {
+        self.release_internal();
+    }
 }
 
 impl Drop for Script {
     fn drop(&mut self) {
-        glide_core::scripts_container::remove_script(&self.hash);
+        self.release_internal();
     }
 }
 

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -3925,6 +3925,7 @@ export function runBaseTests(config: {
                         decoder: Decoder.Bytes,
                     }),
                 ).toEqual(Buffer.from("Hello"));
+                script.release();
 
                 script = new Script(
                     Buffer.from("return redis.call('SET', KEYS[1], ARGV[1])"),
@@ -3944,6 +3945,7 @@ export function runBaseTests(config: {
                         args: [Buffer.from("value2")],
                     }),
                 ).toEqual("OK");
+                script.release();
 
                 script = new Script(
                     Buffer.from("return redis.call('GET', KEYS[1])"),
@@ -3969,6 +3971,7 @@ export function runBaseTests(config: {
                         decoder: Decoder.Bytes,
                     }),
                 ).toEqual(Buffer.from("value2"));
+                script.release();
             }, protocol);
         },
         config.timeout,
@@ -3983,6 +3986,7 @@ export function runBaseTests(config: {
 
                 let script = new Script(Buffer.from("return 'Hello'"));
                 expect(await client.invokeScript(script)).toEqual("Hello");
+                script.release();
 
                 script = new Script(
                     Buffer.from("return redis.call('SET', KEYS[1], ARGV[1])"),
@@ -4001,6 +4005,7 @@ export function runBaseTests(config: {
                         args: [Buffer.from("value2")],
                     }),
                 ).toEqual("OK");
+                script.release();
 
                 script = new Script(
                     Buffer.from("return redis.call('GET', KEYS[1])"),
@@ -4012,6 +4017,7 @@ export function runBaseTests(config: {
                 expect(
                     await client.invokeScript(script, { keys: [key2] }),
                 ).toEqual("value2");
+                script.release();
             }, protocol);
         },
         config.timeout,
@@ -4026,6 +4032,7 @@ export function runBaseTests(config: {
 
                 let script = new Script("return 'Hello'");
                 expect(await client.invokeScript(script)).toEqual("Hello");
+                script.release();
 
                 script = new Script(
                     "return redis.call('SET', KEYS[1], ARGV[1])",
@@ -4044,6 +4051,7 @@ export function runBaseTests(config: {
                         args: ["value2"],
                     }),
                 ).toEqual("OK");
+                script.release();
 
                 script = new Script("return redis.call('GET', KEYS[1])");
                 expect(
@@ -4053,6 +4061,7 @@ export function runBaseTests(config: {
                 expect(
                     await client.invokeScript(script, { keys: [key2] }),
                 ).toEqual("value2");
+                script.release();
             }, protocol);
         },
         config.timeout,
@@ -4092,6 +4101,9 @@ export function runBaseTests(config: {
                 expect(results).toEqual([true, false, true, false]);
 
                 client.close();
+                script1.release();
+                script2.release();
+                script3.release();
             }, protocol);
         },
         config.timeout,
@@ -4124,6 +4136,7 @@ export function runBaseTests(config: {
                 expect(await client.scriptExists([script.getHash()])).toEqual([
                     false,
                 ]);
+                script.release();
             }, protocol);
         },
         config.timeout,
@@ -4151,6 +4164,56 @@ export function runBaseTests(config: {
                 await expect(
                     client.scriptShow("non existing sha1"),
                 ).rejects.toThrow(RequestError);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    // Verifies that a script is retained in the local scripts container and not removed while another
+    // instance with the same hash still exists, even after the original reference is released
+    // and the server-side script cache is flushed.
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "script is not removed while another instance exists - %p",
+        async (protocol) => {
+            await runTest(async (client: BaseClient) => {
+                const script1 = new Script("return 'Script Exists'");
+                const script2 = new Script("return 'Script Exists'");
+                expect(script1.getHash()).toEqual(script2.getHash());
+
+                // Invoke script1 and release reference
+                expect(await client.invokeScript(script1)).toEqual(
+                    "Script Exists",
+                );
+
+                // Manually simulate release of script1 reference
+                script1.release();
+
+                // Flush the script cache from the server
+                expect(await client.scriptFlush()).toEqual("OK");
+
+                // Script should not exist on the server anymore
+                expect(await client.scriptExists([script1.getHash()])).toEqual([
+                    false,
+                ]);
+
+                // Invoke script2 - should be available in the local script cache and reloaded
+                expect(await client.invokeScript(script2)).toEqual(
+                    "Script Exists",
+                );
+
+                // Release script2 and flush again
+                script2.release();
+                expect(await client.scriptFlush()).toEqual("OK");
+
+                // Script should not exist on the server anymore
+                expect(await client.scriptExists([script2.getHash()])).toEqual([
+                    false,
+                ]);
+
+                // Now it should throw a NOSCRIPT error
+                await expect(client.invokeScript(script2)).rejects.toThrowError(
+                    /NoScriptError/,
+                );
             }, protocol);
         },
         config.timeout,

--- a/python/tests/test_async_client.py
+++ b/python/tests/test_async_client.py
@@ -10662,3 +10662,40 @@ class TestScripts:
 
         with pytest.raises(RequestError):
             await glide_client.script_show("non existing sha1")
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_script_isnt_removed_while_another_instance_exists(
+        self, glide_client: TGlideClient
+    ):
+        """
+        Verifies that a script is retained in the local scripts container and not removed while another
+        instance with the same hash still exists, even after the original reference is released
+        and the server-side script cache is flushed.
+        """
+        script_1 = Script("return 'Script Exists'")
+        script_2 = Script("return 'Script Exists'")
+        assert script_1.get_hash() == script_2.get_hash()
+
+        # Run first script and drop reference
+        assert await glide_client.invoke_script(script_1) == b"Script Exists"
+        script_1.__del__()
+
+        # Flush the script from the server
+        assert await glide_client.script_flush() == OK
+
+        # Script should not exist on the server anymore
+        assert await glide_client.script_exists([script_1.get_hash()]) == [False]
+
+        # Run second script; it should not exist on the server but must be found in the local script cache
+        assert await glide_client.invoke_script(script_2) == b"Script Exists"
+
+        # Release script_2 and flush again
+        script_2.__del__()
+        assert await glide_client.script_flush() == OK
+
+        # Should now raise NOSCRIPT
+        with pytest.raises(RequestError) as exc_info:
+            await glide_client.invoke_script(script_2)
+
+        assert "NOSCRIPT" in str(exc_info.value).upper()


### PR DESCRIPTION
Scripts are now stored with a reference counter, and only removed from the local container when the count reaches zero. This allows multiple instances of the same script (with identical code) to coexist safely.
Added test to all wrappers that verifies a script is not removed from the local container while another instance with the same hash is still active, even after the original reference is released and the server-side cache is flushed.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): Closes https://github.com/valkey-io/valkey-glide/issues/3902

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
