### PR TITLE
Go: add client library name and version identifiers

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -90,7 +90,7 @@ jobs:
                   echo "RELEASE_VERSION=${R_VERSION}" >> $GITHUB_OUTPUT
 
     create-binaries:
-        needs: [load-platform-matrix]
+        needs: [load-platform-matrix, validate-release-version]
         if: success()
         strategy:
             fail-fast: false
@@ -120,9 +120,11 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Build Go client
               working-directory: go
+              env:
+                  RELEASE_VERSION: ${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
               run: |
                   make install-build-tools
-                  make build
+                  make build GLIDE_VERSION="${RELEASE_VERSION}"
             - name: Upload artifacts
               continue-on-error: true
               uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Changes
 
+* Go: Add client name and version identifiers ([#3903](https://github.com/valkey-io/valkey-glide/pull/3903))
 * Python: Add support for Trio ([#3465](https://github.com/valkey-io/valkey-glide/pull/3465))
 * Core: Add an OK response type to FFI ([#3630](https://github.com/valkey-io/valkey-glide/pull/3630))
 * Core: Move UDS Socket Filename to tmp ([#3615](https://github.com/valkey-io/valkey-glide/pull/3615))

--- a/ffi/.cargo/config.toml
+++ b/ffi/.cargo/config.toml
@@ -1,5 +1,5 @@
 [env]
-GLIDE_NAME = { value = "GlideFFI", force = true }
+GLIDE_NAME = "GlideFFI"
 GLIDE_VERSION = "0.1.0"
 # Suppress error
 # > ... was built for newer 'macOS' version (14.5) than being linked (14.0)

--- a/ffi/DEVELOPER.md
+++ b/ffi/DEVELOPER.md
@@ -1,0 +1,8 @@
+## Note for developers - 
+When building a new wrapper using glide-ffi, be sure to specify the appropriate GLIDE_NAME and GLIDE_VERSION environment variables. These values define the client's name and version in the FFI crate.
+
+For example:
+
+```
+GLIDE_NAME=<your_client_name> GLIDE_VERSION=<your_client_version> cargo build
+```

--- a/ffi/DEVELOPER.md
+++ b/ffi/DEVELOPER.md
@@ -1,8 +1,7 @@
 ## Note for developers - 
-When building a new wrapper using glide-ffi, be sure to specify the appropriate GLIDE_NAME and GLIDE_VERSION environment variables. These values define the client's name and version in the FFI crate.
+When building a new wrapper using glide-ffi, be sure to specify the appropriate GLIDE_NAME and GLIDE_VERSION environment variables during the build process. This is especially important for production or deployment workflows. These values determine how the client identifies itself to the server and will appear in the `CLIENT INFO` output. If not set, the defaults are `"GlideFFI"` for the client name and `"unknown"` for the version.
 
 For example:
-
 ```
-GLIDE_NAME=<your_client_name> GLIDE_VERSION=<your_client_version> cargo build
+GLIDE_NAME=GlideGo GLIDE_VERSION=2.0.0 cargo build
 ```

--- a/go/Makefile
+++ b/go/Makefile
@@ -12,7 +12,8 @@ UNAME := $(shell uname)
 ARCH := $(shell uname -m)
 
 # Set default values for GLIDE_NAME and GLIDE_VERSION
-# GLIDE_VERSION is modifiable by changing the env var, to allow for changing it during CD
+# GLIDE_VERSION is automatically set during the deployment workflow based on the value defined in go-cd.yml.
+# For local builds, you can manually specify the version using `GLIDE_VERSION=<version> make build`
 GLIDE_NAME = GlideGo
 GLIDE_VERSION ?= unknown
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -11,6 +11,11 @@ TARGET_DIR := $(GLIDE_FFI_PATH)/target
 UNAME := $(shell uname)
 ARCH := $(shell uname -m)
 
+# Set default values for GLIDE_NAME and GLIDE_VERSION
+# GLIDE_VERSION is modifiable by changing the env var, to allow for changing it during CD
+GLIDE_NAME = GlideGo
+GLIDE_VERSION ?= unknown
+
 ifeq ($(UNAME), Darwin)
     TARGET_TRIPLET := $(if $(filter arm64,$(ARCH)),aarch64-apple-darwin,x86_64-apple-darwin)
 	# https://github.com/rust-lang/rust/issues/51009#issuecomment-2274649980
@@ -78,7 +83,7 @@ libglide_ffi:
 	mkdir -p $(DEST_PATH)
 	cd $(GLIDE_FFI_PATH) && \
 	$(CARGO_FIX_CMD) && \
-	cargo $(BUILD_CMD) $(BUILD_FLAGS) && \
+    GLIDE_NAME=$(GLIDE_NAME) GLIDE_VERSION=$(GLIDE_VERSION) cargo $(BUILD_CMD) $(BUILD_FLAGS) && \
 	$(CARGO_POSTFIX_CMD) && \
 	$(STRIP_CMD) $(TARGET_DIR)/libglide_ffi.a && \
 	cp $(TARGET_DIR)/libglide_ffi.a $(GO_DIR)/$(DEST_PATH)

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -10721,3 +10721,25 @@ func (suite *GlideTestSuite) TestScriptShow() {
 		script.Close()
 	})
 }
+
+func (suite *GlideTestSuite) TestRegisterClientNameAndVersion() {
+	suite.SkipIfServerVersionLowerThanBy("7.2.0", suite.T())
+	suite.runWithDefaultClients(func(client api.BaseClient) {
+		result := sendWithCustomCommand(
+			suite,
+			client,
+			[]string{"CLIENT", "INFO"},
+			"Can't send CLIENT INFO as a custom command",
+		)
+
+		var infoStr string
+		switch v := result.(type) {
+		case string:
+			infoStr = v
+		case api.ClusterValue[any]:
+			infoStr = v.SingleValue().(string)
+		}
+		assert.Contains(suite.T(), infoStr, "lib-name=GlideGo", "lib-name not found or incorrect")
+		assert.Contains(suite.T(), infoStr, "lib-ver=unknown", "lib-ver not found or incorrect")
+	})
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue: #3904
This PR modifies go makefile to use custom `lib-name` and `lib-ver` identifiers (defines how the client identifies it's client version to the server and appear in the CLIENT INFO output). The name is "GlideGo" and version "unknown", and the version is overriden while publishing a package in go-cd to the actual published version. Previously, these identifiers were taken from the glide-ffi `config.toml` file, which would give them a "GlideFFI" name and version "0.1.0", which is not indicative of the actual package. 

I left the `config.toml` file in the ffi dir there for now, so that running `cargo build` from the ffi dir would still be possible.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
