### PR TITLE
Docs: fixed mkdocs workflow trigger, fixed transaction/batch sections

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,20 +1,12 @@
 name: Deploy mkdocs website to GitHub Pages
 
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - python/**
-            - node/**
-            - docs/**
-            - .github/workflows/mkdocs-deploy.yml
     workflow_dispatch:
 
 jobs:
     build-and-deploy-docs:
         runs-on: ubuntu-latest
-        if: github.repository_owner == 'valkey-io'
+        if: github.repository_owner == 'valkey-io' && startsWith(github.ref, 'refs/heads/release-')
 
         steps:
             - name: Checkout your branch

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ To **build and serve** the site locally (deploy to localhost), run the following
 ```
 
 ## Deployment
-Documentation deployment is handled through GitHub Actions using our "Deploy mkdocs website to GitHub Pages" workflow:
+Documentation deployment is handled through GitHub Actions using our ["Deploy mkdocs website to GitHub Pages" workflow](../.github/workflows/mkdocs-deploy.yml):
 
 1. The workflow can only be triggered manually (workflow_dispatch), and should be triggered after right after new version releases.
 2. It only accepts triggers from release branches (branches starting with `release-`), to ensure only released versions are documented

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,13 @@ To **build and serve** the site locally (deploy to localhost), run the following
 ./build-docs.sh serve
 ```
 
+## Deployment
+Documentation deployment is handled through GitHub Actions using our "Deploy mkdocs website to GitHub Pages" workflow:
+
+1. The workflow can only be triggered manually (workflow_dispatch), and should be triggered after right after new version releases.
+2. It only accepts triggers from release branches (branches starting with `release-`), to ensure only released versions are documented
+
+
 ## Community Support and Feedback
 
 We encourage you to join our community to support, share feedback, and ask questions. You can approach us for anything on our Valkey Slack: [Join Valkey Slack](https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ).

--- a/docs/markdown/python/base_batch.md
+++ b/docs/markdown/python/base_batch.md
@@ -1,2 +1,2 @@
-Note - Starting version 2.0.0, the Batch class will be available and replace the Transaction class.
+Note - Starting version `2.0.0`, the `Batch` class will be available and replace the `Transaction` class.
 ::: glide.async_commands.batch.BaseBatch

--- a/docs/markdown/python/base_batch.md
+++ b/docs/markdown/python/base_batch.md
@@ -1,1 +1,2 @@
+Note - Starting version 2.0.0, the Batch class will be available and replace the Transaction class.
 ::: glide.async_commands.batch.BaseBatch

--- a/docs/markdown/python/cluster_batch.md
+++ b/docs/markdown/python/cluster_batch.md
@@ -1,1 +1,2 @@
+Note - Starting version 2.0.0, the Batch class will be available and replace the Transaction class.
 ::: glide.async_commands.batch.ClusterBatch

--- a/docs/markdown/python/cluster_batch.md
+++ b/docs/markdown/python/cluster_batch.md
@@ -1,2 +1,2 @@
-Note - Starting version 2.0.0, the Batch class will be available and replace the Transaction class.
+Note - Starting version `2.0.0`, the `Batch` class will be available and replace the `Transaction` class.
 ::: glide.async_commands.batch.ClusterBatch

--- a/docs/markdown/python/cluster_transaction.md
+++ b/docs/markdown/python/cluster_transaction.md
@@ -1,2 +1,2 @@
-Note - The Transaction class will be dperecated starting version 2.0.0, and will be replaced with the Batch class.
+Note - The `Transaction` class will be dperecated starting version `2.0.0`, and will be replaced with the `Batch` class.
 ::: glide.async_commands.batch.ClusterTransaction

--- a/docs/markdown/python/cluster_transaction.md
+++ b/docs/markdown/python/cluster_transaction.md
@@ -1,1 +1,2 @@
+Note - The Transaction class will be dperecated starting version 2.0.0, and will be replaced with the Batch class.
 ::: glide.async_commands.batch.ClusterTransaction

--- a/docs/markdown/python/standalone_batch.md
+++ b/docs/markdown/python/standalone_batch.md
@@ -1,2 +1,2 @@
-Note - Starting version 2.0.0, the Batch class will be available and replace the Transaction class.
+Note - Starting version `2.0.0`, the `Batch` class will be available and replace the `Transaction` class.
 ::: glide.async_commands.batch.Batch

--- a/docs/markdown/python/standalone_batch.md
+++ b/docs/markdown/python/standalone_batch.md
@@ -1,1 +1,2 @@
+Note - Starting version 2.0.0, the Batch class will be available and replace the Transaction class.
 ::: glide.async_commands.batch.Batch

--- a/docs/markdown/python/standalone_transaction.md
+++ b/docs/markdown/python/standalone_transaction.md
@@ -1,2 +1,2 @@
-Note - The Transaction class will be dperecated starting version 2.0.0, and will be replaced with the Batch class.
+Note - The `Transaction` class will be dperecated starting version `2.0.0`, and will be replaced with the `Batch` class.
 ::: glide.async_commands.batch.Transaction

--- a/docs/markdown/python/standalone_transaction.md
+++ b/docs/markdown/python/standalone_transaction.md
@@ -1,1 +1,2 @@
+Note - The Transaction class will be dperecated starting version 2.0.0, and will be replaced with the Batch class.
 ::: glide.async_commands.batch.Transaction

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GLIDE for Valkey - API Documentation
-site_url: https://valkey.io/valkey-glide
+site_url: https://valkey-io/valkey-glide
 repo_url: https://github.com/valkey-io/valkey-glide
 repo_name: GitHub
 docs_dir: markdown
@@ -14,11 +14,11 @@ nav:
           - Core Commands: python/core.md
           - Cluster Commands: python/cluster_commands.md
           - Standalone Commands: python/standalone_commands.md
-          - Base Batch: python/base_batch.md
-          - Standalone Batch: python/standalone_batch.md
-          - Cluster Batch: python/cluster_batch.md
-          - Standalone Transaction (Deprecated): python/standalone_transaction.md
-          - Cluster Transaction (Deprecated): python/cluster_transaction.md
+          - Base Batch (coming soon): python/base_batch.md
+          - Standalone Batch (coming soon): python/standalone_batch.md
+          - Cluster Batch (coming soon): python/cluster_batch.md
+          - Standalone Transaction (soon to be deprecated): python/standalone_transaction.md
+          - Cluster Transaction (soon to be deprecated): python/cluster_transaction.md
       - Exceptions: python/exceptions.md
       - Logger: python/logger.md
   - TypeScript:
@@ -26,11 +26,11 @@ nav:
           - Standalone: node/GlideClient/classes/GlideClient.md
           - Cluster: node/GlideClusterClient/classes/GlideClusterClient.md
           - Base: node/BaseClient/classes/BaseClient.md
-          - Base Batch: node/Batch/classes/BaseBatch.md
-          - Standalone Batch: node/Batch/classes/Batch.md
-          - Cluster Batch: node/Batch/classes/ClusterBatch.md
-          - Transaction (Deprecated): node/Batch/classes/Transaction.md
-          - Cluster Transaction (Deprecated): node/Batch/classes/ClusterTransaction.md
+          - Base Batch (coming soon): node/Batch/classes/BaseBatch.md
+          - Standalone Batch (coming soon): node/Batch/classes/Batch.md
+          - Cluster Batch (coming soon): node/Batch/classes/ClusterBatch.md
+          - Transaction (soon to be deprecated): node/Batch/classes/Transaction.md
+          - Cluster Transaction (soon to be deprecated): node/Batch/classes/ClusterTransaction.md
       - config: node/BaseClient/interfaces/BaseClientConfiguration.md
       - Modules:
           - JSON: node/server-modules/GlideJson/classes/GlideJson.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GLIDE for Valkey - API Documentation
-site_url: https://valkey-io/valkey-glide
+site_url: https://valkey.io/valkey-glide
 repo_url: https://github.com/valkey-io/valkey-glide
 repo_name: GitHub
 docs_dir: markdown
@@ -14,11 +14,11 @@ nav:
           - Core Commands: python/core.md
           - Cluster Commands: python/cluster_commands.md
           - Standalone Commands: python/standalone_commands.md
-          - Base Batch (coming soon): python/base_batch.md
-          - Standalone Batch (coming soon): python/standalone_batch.md
-          - Cluster Batch (coming soon): python/cluster_batch.md
-          - Standalone Transaction (soon to be deprecated): python/standalone_transaction.md
-          - Cluster Transaction (soon to be deprecated): python/cluster_transaction.md
+          - Base Batch (from version 2.0.0): python/base_batch.md
+          - Standalone Batch (from version 2.0.0): python/standalone_batch.md
+          - Cluster Batch (from version 2.0.0): python/cluster_batch.md
+          - Standalone Transaction (deprecated): python/standalone_transaction.md
+          - Cluster Transaction (deprecated): python/cluster_transaction.md
       - Exceptions: python/exceptions.md
       - Logger: python/logger.md
   - TypeScript:
@@ -26,11 +26,11 @@ nav:
           - Standalone: node/GlideClient/classes/GlideClient.md
           - Cluster: node/GlideClusterClient/classes/GlideClusterClient.md
           - Base: node/BaseClient/classes/BaseClient.md
-          - Base Batch (coming soon): node/Batch/classes/BaseBatch.md
-          - Standalone Batch (coming soon): node/Batch/classes/Batch.md
-          - Cluster Batch (coming soon): node/Batch/classes/ClusterBatch.md
-          - Transaction (soon to be deprecated): node/Batch/classes/Transaction.md
-          - Cluster Transaction (soon to be deprecated): node/Batch/classes/ClusterTransaction.md
+          - Base Batch (from version 2.0.0): node/Batch/classes/BaseBatch.md
+          - Standalone Batch (from version 2.0.0): node/Batch/classes/Batch.md
+          - Cluster Batch (from version 2.0.0): node/Batch/classes/ClusterBatch.md
+          - Transaction (deprecated): node/Batch/classes/Transaction.md
+          - Cluster Transaction (deprecated): node/Batch/classes/ClusterTransaction.md
       - config: node/BaseClient/interfaces/BaseClientConfiguration.md
       - Modules:
           - JSON: node/server-modules/GlideJson/classes/GlideJson.md


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue: #3882 

### Checklist

This PR partially addresses the issue by:

Changing the documentation deployment workflow to trigger only via workflow_dispatch, and restricting it to branches starting with release-*.

Adding notes indicating that transaction is deprecated and that Batch is coming soon in version 2.0.0.

Currently, the documentation is deployed from main, but the release-1.3 branch doesn't include the website structure at all. This creates a situation where including full docs for transaction would require merging all site additions into release-1.3—which is a relatively large effort given that the 2.0.0 release is imminent.

As a result, the docs are currently incomplete (missing transaction), but at least they’re not misleading. After merging this PR, we can cherry-pick it into the release-2.0 branch and trigger the workflow from there. Once the release is complete, I'll remove the deprecation notes and revert the workflow setup to its original state.

As a future step (after the release), we should look into using `mike` to have the mkdocs site be versioned - I started but it requires some effort, so after the release.


Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
