### PR TITLE
Core/Batch: Add handling for server errors in value conversion

### DIFF
--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -54,6 +54,11 @@ pub(crate) fn convert_to_expected_type(
         return Ok(value);
     };
 
+    // If the value is a server error, return it as is, without conversion.
+    if let Value::ServerError(_) = value {
+        return Ok(value);
+    }
+
     match expected {
         ExpectedReturnType::Map {
             key_type,


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
Prevents commands that encountered a ServerError from being converted to their expected types (e.g., HGETALL to Map). This ensures that batch responses with errors are handled safely and do not cause type conversion issues.

### Issue link

This Pull Request is linked to issue (URL): #3937

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
