### PR TITLE
Opentelemetry - set status, moved counter, retry_attempts counter 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,7 @@ jobs:
             - name: Run glide-core telemetry tests
               working-directory: ./glide-core/telemetry
               run: cargo test --all-features -- --test-threads=1
+              # TODO: Remove `--test-threads=1` once https://github.com/valkey-io/valkey-glide/issues/4057 is resolved
 
             - name: Run glide-ffi tests
               working-directory: ./ffi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,7 +111,7 @@ jobs:
 
             - name: Run glide-core telemetry tests
               working-directory: ./glide-core/telemetry
-              run: cargo test --all-features
+              run: cargo test --all-features -- --test-threads=1
 
             - name: Run glide-ffi tests
               working-directory: ./ffi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Core/Node: Make OpenTelemetry config to be global per process ([#3771](https://github.com/valkey-io/valkey-glide/pull/3771))
 * Core/Node: Create openTelemetry span to measure command latency ([#3391](https://github.com/valkey-io/valkey-glide/pull/3391))
 * Core: Add `opentelemetry` metrics support ([#3466](https://github.com/valkey-io/valkey-glide/pull/3466))
+* Core: Add `opentelemetry` moved, retry attemps counters and set_status ([#3944](https://github.com/valkey-io/valkey-glide/pull/3944))
 * Node: Fix ZADD, enabling `+inf` and `-inf` as score ([#3370](https://github.com/valkey-io/valkey-glide/pull/3370))
 * Go: Add JSON.SET and JSON.GET ([#3115](https://github.com/valkey-io/valkey-glide/pull/3115))
 * Csharp: updating xUnit, adding xUnit analyser rules and guidelines ([#3035](https://github.com/valkey-io/valkey-glide/pull/3035))

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -96,6 +96,8 @@ uuid = { version = "1.6", optional = true }
 
 telemetrylib = { path = "../../telemetry" }
 
+logger_core = { path = "../../../logger_core" } 
+
 lazy_static = "1"
 
 [features]

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -191,7 +191,7 @@ required-features = ["json", "serde/derive"]
 
 [[test]]
 name = "test_cluster_async"
-required-features = ["cluster-async", "tokio-comp"]
+required-features = ["cluster-async", "tokio-comp", "json"]
 
 [[test]]
 name = "test_async_cluster_connections_logic"

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2951,7 +2951,7 @@ where
                     let future: Option<
                         RequestState<Pin<Box<dyn Future<Output = OperationResult> + Send>>>,
                     > = if let Some(moved_redirect) = moved_redirect {
-                        // record moved error metric if telemetry is initialized
+                            // record moved error metric if telemetry is initialized
                             if let Err(e) = GlideOpenTelemetry::record_moved_error() {
                                 log_error(
                                     "OpenTelemetry:moved_error",

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2951,13 +2951,13 @@ where
                     let future: Option<
                         RequestState<Pin<Box<dyn Future<Output = OperationResult> + Send>>>,
                     > = if let Some(moved_redirect) = moved_redirect {
-                            // record moved error metric if telemetry is initialized
-                            if let Err(e) = GlideOpenTelemetry::record_moved_error() {
-                                log_error(
-                                    "OpenTelemetry:moved_error",
-                                    format!("Failed to record moved error: {}", e),
-                                );
-                            }
+                        // record moved error metric if telemetry is initialized
+                        if let Err(e) = GlideOpenTelemetry::record_moved_error() {
+                            log_error(
+                                "OpenTelemetry:moved_error",
+                                format!("Failed to record moved error: {}", e),
+                            );
+                        }
                         Some(RequestState::UpdateMoved {
                             future: Box::pin(ClusterConnInner::update_upon_moved_error(
                                 self.inner.clone(),

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -921,13 +921,7 @@ impl<C> Future for Request<C> {
                 Next::Done.into()
             }
             Err((target, err)) => {
-                println!("Request error: {:?}", err);
-
                 let request = this.request.as_mut().unwrap();
-                print!(
-                    "Retry {}, max {}",
-                    request.retry, this.retry_params.number_of_retries
-                );
                 // TODO - would be nice if we didn't need to repeat this code twice, with & without retries.
                 if request.retry >= this.retry_params.number_of_retries {
                     let retry_method = err.retry_method();

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -48,6 +48,9 @@ use pipeline_routing::{
     collect_and_send_pending_requests, map_pipeline_to_nodes, process_and_retry_pipeline_responses,
     route_for_pipeline, PipelineResponses, ResponsePoliciesMap,
 };
+
+use logger_core::log_error;
+
 use std::{
     collections::{HashMap, HashSet},
     fmt, io, mem,
@@ -66,7 +69,7 @@ use tokio::task::JoinHandle;
 
 #[cfg(feature = "tokio-comp")]
 use crate::aio::DisconnectNotifier;
-use telemetrylib::Telemetry;
+use telemetrylib::{GlideOpenTelemetry, Telemetry};
 
 use crate::{
     aio::{get_socket_addrs, ConnectionLike, MultiplexedConnection, Runtime},
@@ -2898,6 +2901,13 @@ where
             match result {
                 Next::Done => {}
                 Next::Retry { request } => {
+                    // Record retries error metric if telemetry is initialized
+                    if let Err(e) = GlideOpenTelemetry::record_retries() {
+                        log_error(
+                            "OpenTelemetry:retry_error",
+                            format!("Failed to record retry attempt: {}", e),
+                        );
+                    }
                     let future = Self::try_request(request.info.clone(), self.inner.clone());
                     self.in_flight_requests.push(Box::pin(Request {
                         retry_params: retry_params.clone(),
@@ -2908,6 +2918,13 @@ where
                     }));
                 }
                 Next::RetryBusyLoadingError { request, address } => {
+                    // Record retry attempt metric if telemetry is initialized
+                    if let Err(e) = GlideOpenTelemetry::record_retries() {
+                        log_error(
+                            "OpenTelemetry:retry_error",
+                            format!("Failed to record retry attempt: {}", e),
+                        );
+                    }
                     // TODO - do we also want to try and reconnect to replica if it is loading?
                     let future = Self::handle_loading_error_and_retry(
                         self.inner.clone(),
@@ -2934,6 +2951,13 @@ where
                     let future: Option<
                         RequestState<Pin<Box<dyn Future<Output = OperationResult> + Send>>>,
                     > = if let Some(moved_redirect) = moved_redirect {
+                        // record moved error metric if telemetry is initialized
+                            if let Err(e) = GlideOpenTelemetry::record_moved_error() {
+                                log_error(
+                                    "OpenTelemetry:moved_error",
+                                    format!("Failed to record moved error: {}", e),
+                                );
+                            }
                         Some(RequestState::UpdateMoved {
                             future: Box::pin(ClusterConnInner::update_upon_moved_error(
                                 self.inner.clone(),

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2908,7 +2908,7 @@ where
                 Next::Done => {}
                 Next::Retry { request } => {
                     // Record retries error metric if telemetry is initialized
-                    if let Err(e) = GlideOpenTelemetry::record_retries() {
+                    if let Err(e) = GlideOpenTelemetry::record_retry_attempt() {
                         log_error(
                             "OpenTelemetry:retry_error",
                             format!("Failed to record retry attempt: {}", e),
@@ -2925,7 +2925,7 @@ where
                 }
                 Next::RetryBusyLoadingError { request, address } => {
                     // Record retry attempt metric if telemetry is initialized
-                    if let Err(e) = GlideOpenTelemetry::record_retries() {
+                    if let Err(e) = GlideOpenTelemetry::record_retry_attempt() {
                         log_error(
                             "OpenTelemetry:retry_error",
                             format!("Failed to record retry attempt: {}", e),

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -921,7 +921,13 @@ impl<C> Future for Request<C> {
                 Next::Done.into()
             }
             Err((target, err)) => {
+                println!("Request error: {:?}", err);
+
                 let request = this.request.as_mut().unwrap();
+                print!(
+                    "Retry {}, max {}",
+                    request.retry, this.retry_params.number_of_retries
+                );
                 // TODO - would be nice if we didn't need to repeat this code twice, with & without retries.
                 if request.retry >= this.retry_params.number_of_retries {
                     let retry_method = err.retry_method();

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -98,6 +98,7 @@ pub(crate) type ResponsePoliciesMap =
 ///
 /// `add_asking` is a boolean flag that determines whether to add an `ASKING` command before the command.
 /// `is_retrying` is a boolean flag that indicates whether this is a retry attempt.
+#[allow(clippy::too_many_arguments)]
 fn add_command_to_node_pipeline_map<C>(
     pipeline_map: &mut NodePipelineMap<C>,
     address: String,
@@ -111,8 +112,8 @@ fn add_command_to_node_pipeline_map<C>(
     C: Clone,
 {
     if is_retrying {
-         // Record retry attempt metric if telemetry is initialized
-         if let Err(e) = GlideOpenTelemetry::record_retry_attempt() {
+        // Record retry attempt metric if telemetry is initialized
+        if let Err(e) = GlideOpenTelemetry::record_retry_attempt() {
             log_error(
                 "OpenTelemetry:retry_error",
                 format!("Failed to record retry attempt: {}", e),
@@ -1220,7 +1221,6 @@ where
                     false,
                     true,
                 );
-
             }
             Err(redis_error) => {
                 error.append_detail(&redis_error.into());

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -1058,13 +1058,6 @@ where
 
         // Handle MOVED redirect by updating the topology
         if matches!(retry_method, RetryMethod::MovedRedirect) {
-            // record moved error metric if telemetry is initialized
-            if let Err(e) = GlideOpenTelemetry::record_moved_error() {
-                log_error(
-                    "OpenTelemetry:moved_error",
-                    format!("Failed to record moved error: {}", e),
-                );
-            }
             if let Err(server_error) =
                 pipeline_handle_moved_redirect(core.clone(), &redis_error).await
             {

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -112,7 +112,7 @@ fn add_command_to_node_pipeline_map<C>(
 {
     if is_retrying {
          // Record retry attempt metric if telemetry is initialized
-         if let Err(e) = GlideOpenTelemetry::record_retries() {
+         if let Err(e) = GlideOpenTelemetry::record_retry_attempt() {
             log_error(
                 "OpenTelemetry:retry_error",
                 format!("Failed to record retry attempt: {}", e),

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -8,6 +8,9 @@ use crate::types::{
     VerbatimFormat,
 };
 
+use logger_core::log_error;
+use telemetrylib::GlideOpenTelemetry;
+
 use combine::{
     any,
     error::StreamError,
@@ -31,7 +34,16 @@ fn err_parser(line: &str) -> ServerError {
         "EXECABORT" => ServerErrorKind::ExecAbortError,
         "LOADING" => ServerErrorKind::BusyLoadingError,
         "NOSCRIPT" => ServerErrorKind::NoScriptError,
-        "MOVED" => ServerErrorKind::Moved,
+        "MOVED" => {
+            // record moved error metric if telemetry is initialized
+            if let Err(e) = GlideOpenTelemetry::record_moved_error() {
+                log_error(
+                    "OpenTelemetry:moved_error",
+                    format!("Failed to record moved error: {}", e),
+                );
+            }
+            ServerErrorKind::Moved
+        }
         "ASK" => ServerErrorKind::Ask,
         "TRYAGAIN" => ServerErrorKind::TryAgain,
         "CLUSTERDOWN" => ServerErrorKind::ClusterDown,

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -34,7 +34,7 @@ use std::ptr::from_mut;
 use std::rc::Rc;
 use std::str;
 use std::sync::{Arc, RwLock};
-use telemetrylib::GlideSpan;
+use telemetrylib::{GlideSpan, GlideSpanStatus};
 use thiserror::Error;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Mutex;
@@ -193,11 +193,15 @@ async fn write_result(
     response.callback_idx = callback_index;
     response.is_push = false;
     response.root_span_ptr = command_span_ptr;
+    let otel_command_span: Option<GlideSpan> = get_unsafe_span_from_ptr(command_span_ptr);
     response.value = match resp_result {
         Ok(Value::Okay) => Some(response::response::Value::ConstantResponse(
             response::ConstantResponse::OK.into(),
         )),
         Ok(value) => {
+            if let Some(span) = otel_command_span {
+                span.set_status(GlideSpanStatus::Ok);
+            }
             if value != Value::Nil {
                 // Since null values don't require any additional data, they can be sent without any extra effort.
                 // Move the value to the heap and leak it. The wrapper should use `Box::from_raw` to recreate the box, use the value, and drop the allocation.
@@ -210,12 +214,18 @@ async fn write_result(
         }
         Err(ClientUsageError::Internal(error_message)) => {
             log_error("internal error", &error_message);
+            if let Some(span) = otel_command_span {
+                span.set_status(GlideSpanStatus::Error((&error_message).into()));
+            }
             Some(response::response::Value::ClosingError(
                 error_message.into(),
             ))
         }
         Err(ClientUsageError::User(error_message)) => {
             log_error("user error", &error_message);
+            if let Some(span) = otel_command_span {
+                span.set_status(GlideSpanStatus::Error((&error_message).into()));
+            }
             let request_error = response::RequestError {
                 type_: response::RequestErrorType::Unspecified.into(),
                 message: error_message.into(),
@@ -227,6 +237,9 @@ async fn write_result(
             let error_message = error_message(&err);
             log_warn("received error", error_message.as_str());
             log_debug("received error", format!("for callback {}", callback_index));
+            if let Some(span) = otel_command_span {
+                span.set_status(GlideSpanStatus::Error((&error_message).into()));
+            }
             let request_error = response::RequestError {
                 type_: match error_type(&err) {
                     RequestErrorType::Unspecified => response::RequestErrorType::Unspecified,

--- a/glide-core/telemetry/Cargo.toml
+++ b/glide-core/telemetry/Cargo.toml
@@ -22,5 +22,4 @@ opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-clie
 once_cell = "1"
 
 [dev-dependencies]
-serial_test = "3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }

--- a/glide-core/telemetry/Cargo.toml
+++ b/glide-core/telemetry/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1"
 chrono = "0.4"
 futures-util = "0.3"
 tokio = { version = "1", features = ["macros", "time"] }
+
 thiserror = "2"
 url = "2"
 async-trait = "0.1"
@@ -21,4 +22,5 @@ opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-clie
 once_cell = "1"
 
 [dev-dependencies]
+serial_test = "3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -831,9 +831,9 @@ mod tests {
                 .split('\n')
                 .filter(|l| !l.trim().is_empty())
                 .collect();
-            assert_eq!(lines.len(), 4, "file content: {file_content:?}");
+            assert_eq!(lines.len(), 3, "file content: {file_content:?}");
 
-            let span_json: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+            let span_json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
             assert_eq!(span_json["name"], "Network_Span");
             let network_span_id = span_json["span_id"].to_string();
             let network_span_start_time = string_property_to_u64(&span_json, "start_time");
@@ -842,7 +842,7 @@ mod tests {
             // Because of the sleep above, the network span should be at least 100ms (units are microseconds)
             assert!(network_span_end_time - network_span_start_time >= 100_000);
 
-            let span_json: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+            let span_json: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
             assert_eq!(span_json["name"], "Root_Span_1");
             assert_eq!(span_json["links"].as_array().unwrap().len(), 1); // we expect 1 child
             let root_1_span_start_time = string_property_to_u64(&span_json, "start_time");
@@ -857,7 +857,7 @@ mod tests {
             let child_span_id = span_json["links"][0]["span_id"].to_string();
             assert_eq!(child_span_id, network_span_id);
 
-            let span_json: serde_json::Value = serde_json::from_str(lines[3]).unwrap();
+            let span_json: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
             assert_eq!(span_json["name"], "Root_Span_2");
             assert_eq!(span_json["events"].as_array().unwrap().len(), 2); // we expect 2 events
         });
@@ -1021,7 +1021,6 @@ mod tests {
             sleep(Duration::from_millis(2100)).await;
 
             let file_content = std::fs::read_to_string(SPANS_JSON).unwrap();
-            println!("File content: {file_content:?}");
             let lines: Vec<&str> = file_content
                 .split('\n')
                 .filter(|l| !l.trim().is_empty())

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -994,48 +994,46 @@ mod tests {
     fn test_set_status_ok() {
         let rt = shared_runtime();
         rt.block_on(async {
-        // Clear the file
-        let _ = std::fs::remove_file(SPANS_JSON);
+            // Clear the file
+            let _ = std::fs::remove_file(SPANS_JSON);
 
-        init_otel().await.unwrap();
-        let span = GlideOpenTelemetry::new_span("Root_Span_1");
-        span.add_event("Event1");
-        span.set_status(GlideSpanStatus::Ok);
+            init_otel().await.unwrap();
+            let span = GlideOpenTelemetry::new_span("Root_Span_1");
+            span.add_event("Event1");
+            span.set_status(GlideSpanStatus::Ok);
 
-        let child1 = span.add_span("Network_Span").unwrap();
+            let child1 = span.add_span("Network_Span").unwrap();
 
-        // Simulate some work
-        sleep(Duration::from_millis(100)).await;
-        child1.end();
+            // Simulate some work
+            sleep(Duration::from_millis(100)).await;
+            child1.end();
 
-        // Simulate that the parent span is still doing some work
-        sleep(Duration::from_millis(100)).await;
-        span.end();
+            // Simulate that the parent span is still doing some work
+            sleep(Duration::from_millis(100)).await;
+            span.end();
 
-        let span = GlideOpenTelemetry::new_span("Root_Span_2");
-        span.add_event("Event1");
-        span.add_event("Event2");
-        span.set_status(GlideSpanStatus::Error("simple error".to_string()));  // Fixed typo in "simple"
-        drop(span); // writes the span
+            let span = GlideOpenTelemetry::new_span("Root_Span_2");
+            span.add_event("Event1");
+            span.add_event("Event2");
+            span.set_status(GlideSpanStatus::Error("simple error".to_string())); // Fixed typo in "simple"
+            drop(span); // writes the span
 
-        sleep(Duration::from_millis(2100)).await;
+            sleep(Duration::from_millis(2100)).await;
 
-        let file_content = std::fs::read_to_string(SPANS_JSON).unwrap();
+            let file_content = std::fs::read_to_string(SPANS_JSON).unwrap();
             println!("File content: {file_content:?}");
-        let lines: Vec<&str> = file_content
-            .split('\n')
-            .filter(|l| !l.trim().is_empty())
-            .collect();
+            let lines: Vec<&str> = file_content
+                .split('\n')
+                .filter(|l| !l.trim().is_empty())
+                .collect();
 
-        let span_json: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
-        assert_eq!(span_json["status"], "Ok");
-        
-        let span_json: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
-        let status = span_json["status"].as_str().unwrap_or("");
-        assert!(status.starts_with("Error"));
-        assert!(status.contains("simple error"));
+            let span_json: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+            assert_eq!(span_json["status"], "Ok");
 
+            let span_json: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+            let status = span_json["status"].as_str().unwrap_or("");
+            assert!(status.starts_with("Error"));
+            assert!(status.contains("simple error"));
         });
-
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)å

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3812 , https://github.com/valkey-io/valkey-glide/issues/3629


* Set Spans status to `ok` and `Error` according to the request's result.
Test for `set_status` options.

* Add metrics of `moved` and `retry_attempt`.
Tests for the new metrics recorded on regular command, atomic pipepline, and non atomic pipeline.
- If `moved` happend it will record `retry` and `moved` metrics. 
- If different `retry` it will record only `retry` metric

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
