### PR TITLE
Go: Add Test Timeout Functionality

### DIFF
--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -9952,12 +9952,15 @@ func (suite *GlideTestSuite) TestGeoHash() {
 
 func (suite *GlideTestSuite) TestGetSet_SendLargeValues() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
-		key := suite.GenerateLargeUuid()
-		value := suite.GenerateLargeUuid()
-		suite.verifyOK(client.Set(context.Background(), key, value))
-		result, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), value, result.Value())
+		// Run with a 5 second timeout
+		RunWithTimeout(suite.T(), 5, func(ctx context.Context) {
+			key := suite.GenerateLargeUuid()
+			value := suite.GenerateLargeUuid()
+			suite.verifyOK(client.Set(ctx, key, value))
+			result, err := client.Get(ctx, key)
+			assert.Nil(suite.T(), err)
+			assert.Equal(suite.T(), value, result.Value())
+		})
 	})
 }
 


### PR DESCRIPTION
This PR adds a simple mechanism to enable timeouts in our tests until `go test` natively starts supporting direct timeouts. https://github.com/golang/go/issues/48157

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
