### PR TITLE
Go: Fix Makefile Path for Unit Test

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -134,7 +134,7 @@ unit-test:
 	mkdir -p reports
 	set -o pipefail; \
 	go test -v ./... -skip 'Example|TestGlideTestSuite' $(if $(test-filter), -run $(test-filter)) \
-	| tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/v2 utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
+	| tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/v2/internal/utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
 
 # example tests - skip complete IT suite (including MT)
 example-test:


### PR DESCRIPTION
Running unit-test locally would return Makefile Error 141 (which I think stems from the command treating `utils` as a different package. This patch makes it work on both CI and local testing.

```bash
~ make unit-test
mkdir -p reports
set -o pipefail; \
        go test -v ./... -skip 'Example|TestGlideTestSuite'  \
        | tee >(go tool test2json -t -p github.com/valkey-io/valkey-glide/go/v2 utils | go-test-report -o reports/unit-tests.html -t unit-test > /dev/null)
make: *** [unit-test] Error 141
```

### Issue link

This Pull Request is linked to issue (URL): #3960 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
