### PR TITLE
Python: increase request timeout of ACL client in python tests

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -339,6 +339,7 @@ async def acl_glide_client(
         cluster_mode,
         protocol=protocol,
         credentials=ServerCredentials(username=USERNAME, password=INITIAL_PASSWORD),
+        request_timeout=2000,
     )
     yield client
     await test_teardown(request, cluster_mode, protocol)

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -257,6 +257,9 @@ class TestAuthCommands:
         # Sleep to allow enough time for reconnecting
         await anyio.sleep(2)
 
+        # This command right after disconnection requires the acl_glide_client to have a request timeout of 2000 ms
+        # for full matrix tests to pass (otherwise failing on linux-aarch64 architecture).
+        # TODO: We do not fully understand why such a long timeout is required.
         result = await acl_glide_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=True
         )


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

#3896 


This PR fixes the issue of failing full matrix tests on `aarch66-unknown-linux-gnu` on the `test_update_connection_password_reconnection_with_immediate_auth_with_acl_user` test -  see example https://github.com/valkey-io/valkey-glide/actions/runs/15245515201

the test started failing right after the Anyio integration, in the point where we are trying to reconnect using `update_connection_password` with the new password, which started to fail on timeouts. Hence we increase the timeout for the `acl_glide_client` which fixes the issue.


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
