### PR TITLE
Remove oncecell dependency in favor of std once cell

### DIFF
--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -35,7 +35,6 @@ thiserror = "2"
 rand = { version = "0.8" }
 futures-intrusive = "0.5"
 directories = { version = "6", optional = true }
-once_cell = "1"
 sha1_smol = "1"
 nanoid = "0.4"
 async-trait = { version = "0.1" }

--- a/glide-core/redis-rs/afl/parser/Cargo.toml
+++ b/glide-core/redis-rs/afl/parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzz-target-parser"
 version = "0.1.0"
 authors = ["redis-rs developers"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "fuzz-target"

--- a/glide-core/redis-rs/redis-test/Cargo.toml
+++ b/glide-core/redis-rs/redis-test/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.65"
 bench = false
 
 [dependencies]
-redis = { version = "0.25.0", path = "../redis" }
+redis = { version = "0.25.2", path = "../redis" }
 
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
@@ -22,5 +22,5 @@ futures = { version = "0.3", optional = true }
 aio = ["futures", "redis/aio"]
 
 [dev-dependencies]
-redis = { version = "0.25.0", path = "../redis", features = ["aio", "tokio-comp"] }
+redis = { version = "0.25.2", path = "../redis", features = ["aio", "tokio-comp"] }
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.80"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
@@ -175,13 +175,12 @@ tokio = { version = "1", features = [
     "rt-multi-thread",
     "time",
 ] }
-tempfile = "=3.6.0"
-once_cell = "1"
+tempfile = "=3"
 anyhow = "1"
-sscanf = "0.4.1"
-serial_test = "^2"
-versions = "6.3"
-which = "7.0.1"
+sscanf = "0.4"
+serial_test = "^3"
+versions = "7"
+which = "7"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [[test]]

--- a/glide-core/redis-rs/redis/src/cluster_slotmap.rs
+++ b/glide-core/redis-rs/redis/src/cluster_slotmap.rs
@@ -122,7 +122,7 @@ impl SlotMap {
     pub fn is_primary(&self, address: &String) -> bool {
         self.nodes_map
             .get(address)
-            .map_or(false, |shard_addrs| *shard_addrs.primary() == *address)
+            .is_some_and(|shard_addrs| *shard_addrs.primary() == *address)
     }
 
     pub fn slot_value_for_route(&self, route: &Route) -> Option<&SlotMapValue> {

--- a/glide-core/redis-rs/redis/src/sentinel.rs
+++ b/glide-core/redis-rs/redis/src/sentinel.rs
@@ -190,7 +190,7 @@ fn is_master_valid(master_info: &HashMap<String, String>, service_name: &str) ->
     master_info.get("name").map(|s| s.as_str()) == Some(service_name)
         && master_info.contains_key("ip")
         && master_info.contains_key("port")
-        && master_info.get("flags").map_or(false, |flags| {
+        && master_info.get("flags").is_some_and(|flags| {
             flags.contains("master") && !flags.contains("s_down") && !flags.contains("o_down")
         })
         && master_info["port"].parse::<u16>().is_ok()
@@ -199,9 +199,9 @@ fn is_master_valid(master_info: &HashMap<String, String>, service_name: &str) ->
 fn is_replica_valid(replica_info: &HashMap<String, String>) -> bool {
     replica_info.contains_key("ip")
         && replica_info.contains_key("port")
-        && replica_info.get("flags").map_or(false, |flags| {
-            !flags.contains("s_down") && !flags.contains("o_down")
-        })
+        && replica_info
+            .get("flags")
+            .is_some_and(|flags| !flags.contains("s_down") && !flags.contains("o_down"))
         && replica_info["port"].parse::<u16>().is_ok()
 }
 

--- a/glide-core/redis-rs/redis/src/streams.rs
+++ b/glide-core/redis-rs/redis/src/streams.rs
@@ -4,7 +4,7 @@ use crate::{
     from_redis_value, types::HashMap, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, Value,
 };
 
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 
 // Stream Maxlen Enum
 
@@ -522,19 +522,11 @@ impl FromRedisValue for StreamPendingReply {
         } else {
             let mut result = StreamPendingData::default();
 
-            let start_id = start.ok_or_else(|| {
-                Error::new(
-                    ErrorKind::Other,
-                    "IllegalState: Non-zero pending expects start id",
-                )
-            })?;
+            let start_id = start
+                .ok_or_else(|| Error::other("IllegalState: Non-zero pending expects start id"))?;
 
-            let end_id = end.ok_or_else(|| {
-                Error::new(
-                    ErrorKind::Other,
-                    "IllegalState: Non-zero pending expects end id",
-                )
-            })?;
+            let end_id =
+                end.ok_or_else(|| Error::other("IllegalState: Non-zero pending expects end id"))?;
 
             result.count = count;
             result.start_id = start_id;

--- a/glide-core/redis-rs/redis/src/tls.rs
+++ b/glide-core/redis-rs/redis/src/tls.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Error, ErrorKind as IOErrorKind};
+use std::io::{BufRead, Error};
 
 use rustls::RootCertStore;
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
@@ -75,12 +75,7 @@ pub(crate) fn retrieve_tls_certificates(
 
         let client_key =
             rustls_pemfile::private_key(&mut client_key.as_slice() as &mut dyn BufRead)?
-                .ok_or_else(|| {
-                    Error::new(
-                        IOErrorKind::Other,
-                        "Unable to extract private key from PEM file",
-                    )
-                })?;
+                .ok_or_else(|| Error::other("Unable to extract private key from PEM file"))?;
 
         Some(ClientTlsParams {
             client_cert_chain,
@@ -96,9 +91,7 @@ pub(crate) fn retrieve_tls_certificates(
         let mut root_cert_store = RootCertStore::empty();
         for result in certs {
             if root_cert_store.add(result?.to_owned()).is_err() {
-                return Err(
-                    Error::new(IOErrorKind::Other, "Unable to parse TLS trust anchors").into(),
-                );
+                return Err(Error::other("Unable to parse TLS trust anchors").into());
             }
         }
 

--- a/glide-core/redis-rs/redis/tests/support/cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/cluster.rs
@@ -222,7 +222,7 @@ impl RedisCluster {
         let cli_command = ["valkey-cli", "redis-cli"]
             .iter()
             .find(|cmd| which::which(cmd).is_ok())
-            .map(|&cmd| cmd)
+            .copied()
             .unwrap_or_else(|| panic!("Neither valkey-cli nor redis-cli exists in the system."));
 
         let mut cmd = process::Command::new(cli_command);
@@ -909,7 +909,7 @@ impl TestClusterContext {
                 let host = host_and_port.clone().next().unwrap();
                 let port = host_and_port
                     .clone()
-                    .last()
+                    .next_back()
                     .unwrap()
                     .split('@')
                     .next()
@@ -933,7 +933,7 @@ impl TestClusterContext {
                 let host = host_and_port.clone().next().unwrap();
                 let port = host_and_port
                     .clone()
-                    .last()
+                    .next_back()
                     .unwrap()
                     .split('@')
                     .next()

--- a/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
@@ -14,8 +14,8 @@ use std::{
 };
 
 use {
-    once_cell::sync::Lazy,
     redis::{IntoConnectionInfo, RedisResult, Value},
+    std::sync::LazyLock,
 };
 
 #[cfg(feature = "cluster-async")]
@@ -88,8 +88,8 @@ pub fn get_mock_connection_with_port(name: &str, id: usize, port: u16) -> MockCo
     }
 }
 
-static MOCK_CONN_BEHAVIORS: Lazy<RwLock<HashMap<String, MockConnectionBehavior>>> =
-    Lazy::new(Default::default);
+static MOCK_CONN_BEHAVIORS: LazyLock<RwLock<HashMap<String, MockConnectionBehavior>>> =
+    LazyLock::new(Default::default);
 
 fn get_behaviors() -> std::sync::RwLockWriteGuard<'static, HashMap<String, MockConnectionBehavior>>
 {

--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -229,7 +229,7 @@ impl RedisServer {
         let server_command = ["valkey-server", "redis-server"]
             .iter()
             .find(|cmd| which::which(cmd).is_ok())
-            .map(|&cmd| cmd)
+            .copied()
             .unwrap_or_else(|| {
                 panic!("Neither valkey-server nor redis-server exists in the system.")
             });

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -17,9 +17,7 @@ mod cluster_async {
 
     use futures::prelude::*;
     use futures_time::{future::FutureExt, task::sleep};
-    use once_cell::sync::Lazy;
-    use std::ops::Add;
-    use std::str::FromStr;
+    use std::{ops::Add, str::FromStr, sync::LazyLock};
     use telemetrylib::*;
 
     use redis::{
@@ -135,7 +133,7 @@ mod cluster_async {
                 GlideOpenTelemetrySignalsExporter::from_str("http://valid-url.com").unwrap(),
             )
             .build();
-        let result = GlideOpenTelemetry::initialise(glide_ot_config.clone());
+        let result = GlideOpenTelemetry::initialize(glide_ot_config.clone());
         assert!(result.is_ok(), "Expected Ok(()), but got Err: {:?}", result);
     }
 
@@ -918,7 +916,7 @@ mod cluster_async {
         );
     }
 
-    static ERROR: Lazy<AtomicBool> = Lazy::new(Default::default);
+    static ERROR: LazyLock<AtomicBool> = LazyLock::new(Default::default);
 
     #[derive(Clone)]
     struct ErrorConnection {
@@ -1724,7 +1722,7 @@ mod cluster_async {
             // Get node IDs for migration
             let shards_info = client1
                 .route_command(
-                    &cmd("CLUSTER").arg("SHARDS"),
+                    cmd("CLUSTER").arg("SHARDS"),
                     RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
                         0,
                         SlotAddr::Master,

--- a/glide-core/redis-rs/redis/tests/test_cluster_scan.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_scan.rs
@@ -582,7 +582,7 @@ mod test_cluster_scan_async {
             let host = host_and_port.clone().next().unwrap().to_string();
             let port = host_and_port
                 .clone()
-                .last()
+                .next_back()
                 .unwrap()
                 .parse::<u16>()
                 .unwrap();

--- a/glide-core/src/cluster_scan_container.rs
+++ b/glide-core/src/cluster_scan_container.rs
@@ -2,9 +2,11 @@
 
 use logger_core::log_debug;
 use nanoid::nanoid;
-use once_cell::sync::Lazy;
 use redis::{RedisResult, ScanStateRC};
-use std::{collections::HashMap, sync::Mutex};
+use std::{
+    collections::HashMap,
+    sync::{LazyLock, Mutex},
+};
 
 // This is a container for storing the cursor of a cluster scan.
 // The cursor for a cluster scan is a ref to the actual ScanState struct in redis-rs.
@@ -14,8 +16,8 @@ use std::{collections::HashMap, sync::Mutex};
 // In wrapper layer we wrap the id in an object, which, when dropped, trigger the removal of the cursor from the container.
 // When the ref is removed from the container, the actual ScanState struct is dropped by Rust GC.
 
-static CONTAINER: Lazy<Mutex<HashMap<String, ScanStateRC>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+static CONTAINER: LazyLock<Mutex<HashMap<String, ScanStateRC>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub fn insert_cluster_scan_cursor(scan_state: ScanStateRC) -> String {
     let id = nanoid!();

--- a/glide-core/src/scripts_container.rs
+++ b/glide-core/src/scripts_container.rs
@@ -2,11 +2,10 @@
 
 use bytes::BytesMut;
 use logger_core::{log_info, log_warn};
-use once_cell::sync::Lazy;
 use sha1_smol::Sha1;
 use std::cell::Cell;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 const LOCK_ERR: &str = "Failed to acquire the scripts container lock";
 
@@ -19,8 +18,8 @@ struct ScriptEntry {
     ref_count: Cell<u32>,
 }
 
-static CONTAINER: Lazy<Mutex<HashMap<String, ScriptEntry>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+static CONTAINER: LazyLock<Mutex<HashMap<String, ScriptEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub fn add_script(script: &[u8]) -> String {
     let mut hash = Sha1::new();

--- a/glide-core/telemetry/Cargo.toml
+++ b/glide-core/telemetry/Cargo.toml
@@ -18,7 +18,6 @@ async-trait = "0.1"
 opentelemetry = { version = "0.27", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.27.x", features = ["rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-client"] }
-once_cell = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -6,13 +6,13 @@ use glide_core::{
     client::{Client, StandaloneClient},
     connection_request::{self, AuthenticationInfo, NodeAddress, ProtocolVersion},
 };
-use once_cell::sync::Lazy;
 use rand::{Rng, distributions::Alphanumeric};
 use redis::{
     ConnectionAddr, GlideConnectionOptions, PushInfo, RedisConnectionInfo, RedisResult, Value,
     cluster_routing::{MultipleNodeRoutingInfo, RoutingInfo},
 };
 use socket2::{Domain, Socket, Type};
+use std::sync::LazyLock;
 use std::{
     env, fs, io, net::SocketAddr, net::TcpListener, ops::Deref, path::PathBuf, process,
     sync::Mutex, time::Duration,
@@ -34,14 +34,14 @@ pub enum ServerType {
     Unix,
 }
 
-type SharedServer = Lazy<Mutex<Option<RedisServer>>>;
+type SharedServer = LazyLock<Mutex<Option<RedisServer>>>;
 static SHARED_SERVER: SharedServer =
-    Lazy::new(|| Mutex::new(Some(RedisServer::new(ServerType::Tcp { tls: false }))));
+    LazyLock::new(|| Mutex::new(Some(RedisServer::new(ServerType::Tcp { tls: false }))));
 
 static SHARED_TLS_SERVER: SharedServer =
-    Lazy::new(|| Mutex::new(Some(RedisServer::new(ServerType::Tcp { tls: true }))));
+    LazyLock::new(|| Mutex::new(Some(RedisServer::new(ServerType::Tcp { tls: true }))));
 
-static SHARED_SERVER_ADDRESS: Lazy<ConnectionAddr> = Lazy::new(|| {
+static SHARED_SERVER_ADDRESS: LazyLock<ConnectionAddr> = LazyLock::new(|| {
     SHARED_SERVER
         .lock()
         .unwrap()
@@ -50,7 +50,7 @@ static SHARED_SERVER_ADDRESS: Lazy<ConnectionAddr> = Lazy::new(|| {
         .get_client_addr()
 });
 
-static SHARED_TLS_SERVER_ADDRESS: Lazy<ConnectionAddr> = Lazy::new(|| {
+static SHARED_TLS_SERVER_ADDRESS: LazyLock<ConnectionAddr> = LazyLock::new(|| {
     SHARED_TLS_SERVER
         .lock()
         .unwrap()
@@ -69,12 +69,8 @@ pub fn get_shared_server_address(use_tls: bool) -> ConnectionAddr {
 
 #[ctor::dtor]
 fn clean_shared_clusters() {
-    if let Some(mutex) = SharedServer::get(&SHARED_SERVER) {
-        drop(mutex.lock().unwrap().take());
-    }
-    if let Some(mutex) = SharedServer::get(&SHARED_TLS_SERVER) {
-        drop(mutex.lock().unwrap().take());
-    }
+    drop(SHARED_SERVER.lock().unwrap().take());
+    drop(SHARED_TLS_SERVER.lock().unwrap().take());
 }
 
 pub struct RedisServer {

--- a/logger_core/Cargo.toml
+++ b/logger_core/Cargo.toml
@@ -8,12 +8,11 @@ authors = ["Valkey GLIDE Maintainers"]
 [lib]
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = "0.8"
 test-env-helpers = "0.2.2"
 
 [dependencies]
 tracing = "0.1"
-tracing-appender = { version = "0.2.3", default-features = false }
-once_cell = "1.16.0"
-file-rotate = "0.7.1"
-tracing-subscriber = "0.3.17"
+tracing-appender = { version = "0.2", default-features = false }
+file-rotate = "0.8"
+tracing-subscriber = "0.3"

--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -1,10 +1,9 @@
 /**
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
-use once_cell::sync::OnceCell;
 use std::{
     path::{Path, PathBuf},
-    sync::RwLock,
+    sync::{OnceLock, RwLock},
 };
 use tracing::{self, event};
 use tracing_appender::rolling::{RollingFileAppender, RollingWriter, Rotation};
@@ -47,11 +46,11 @@ pub struct Reloads {
 }
 
 pub struct InitiateOnce {
-    init_once: OnceCell<Reloads>,
+    init_once: OnceLock<Reloads>,
 }
 
 pub static INITIATE_ONCE: InitiateOnce = InitiateOnce {
-    init_once: OnceCell::new(),
+    init_once: OnceLock::new(),
 };
 
 const FILE_DIRECTORY: &str = "glide-logs";
@@ -61,7 +60,7 @@ const ENV_GLIDE_LOG_DIR: &str = "GLIDE_LOG_DIR";
 /// allowing [init] to disable file logging on read-only filesystems.
 /// This is needed because [RollingFileAppender] tries to create the log directory on initialization.
 struct LazyRollingFileAppender {
-    file_appender: OnceCell<RollingFileAppender>,
+    file_appender: OnceLock<RollingFileAppender>,
     rotation: Rotation,
     directory: PathBuf,
     filename_prefix: PathBuf,
@@ -74,7 +73,7 @@ impl LazyRollingFileAppender {
         filename_prefix: impl AsRef<Path>,
     ) -> LazyRollingFileAppender {
         LazyRollingFileAppender {
-            file_appender: OnceCell::new(),
+            file_appender: OnceLock::new(),
             rotation,
             directory: directory.as_ref().to_path_buf(),
             filename_prefix: filename_prefix.as_ref().to_path_buf(),

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -253,7 +253,7 @@ pub fn init_open_telemetry(open_telemetry_config: OpenTelemetryConfig) -> Result
     };
 
     glide_rt.runtime.block_on(async {
-        if let Err(e) = GlideOpenTelemetry::initialise(config.build()) {
+        if let Err(e) = GlideOpenTelemetry::initialize(config.build()) {
             log(
                 Level::Error,
                 "OpenTelemetry".to_string(),


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

Part of the effort to clean up redis-rs and shrink code size, oncell is part of std now and we dont need it as dependency.

### Issue link

This Pull Request is linked to issue #2710 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
