### PR TITLE
Python: Move PubSubMsg into a shared file

### DIFF
--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,6 +1,5 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-from glide.commands.async_commands.core import CoreCommands
 from glide.commands.batch import (
     Batch,
     ClusterBatch,
@@ -38,6 +37,7 @@ from glide.commands.core_options import (
     InfoSection,
     InsertPosition,
     OnlyIfEqual,
+    PubSubMsg,
     UpdateOptions,
 )
 from glide.commands.server_modules import ft, glide_json, json_batch
@@ -169,8 +169,6 @@ from glide.routes import (
 )
 
 from .glide import ClusterScanCursor, Script
-
-PubSubMsg = CoreCommands.PubSubMsg
 
 __all__ = [
     # Client

--- a/python/python/glide/commands/async_commands/core.py
+++ b/python/python/glide/commands/async_commands/core.py
@@ -1,5 +1,4 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional, Protocol, Set, Tuple, Union, cast
 
 from glide.commands.bitmap import (
@@ -18,6 +17,7 @@ from glide.commands.core_options import (
     ExpirySet,
     InsertPosition,
     OnlyIfEqual,
+    PubSubMsg,
     UpdateOptions,
     _build_sort_args,
 )
@@ -6651,21 +6651,6 @@ class CoreCommands(Protocol):
             TOK,
             await self._execute_command(RequestType.Watch, keys),
         )
-
-    @dataclass
-    class PubSubMsg:
-        """
-        Describes the incoming pubsub message
-
-        Attributes:
-            message (TEncodable): Incoming message.
-            channel (TEncodable): Name of an channel that triggered the message.
-            pattern (Optional[TEncodable]): Pattern that triggered the message.
-        """
-
-        message: TEncodable
-        channel: TEncodable
-        pattern: Optional[TEncodable]
 
     async def get_pubsub_message(self) -> PubSubMsg:
         """

--- a/python/python/glide/commands/core_options.py
+++ b/python/python/glide/commands/core_options.py
@@ -8,6 +8,22 @@ from glide.commands.command_args import Limit, OrderBy
 from glide.constants import TEncodable
 
 
+@dataclass
+class PubSubMsg:
+    """
+    Describes the incoming pubsub message
+
+    Attributes:
+        message (TEncodable): Incoming message.
+        channel (TEncodable): Name of an channel that triggered the message.
+        pattern (Optional[TEncodable]): Pattern that triggered the message.
+    """
+
+    message: TEncodable
+    channel: TEncodable
+    pattern: Optional[TEncodable]
+
+
 class ConditionalChange(Enum):
     """
     A condition to the `SET`, `ZADD` and `GEOADD` commands.

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from glide.commands.async_commands.core import CoreCommands
+from glide.commands.core_options import PubSubMsg
 from glide.exceptions import ConfigurationError
 from glide.protobuf.connection_request_pb2 import ConnectionRequest
 from glide.protobuf.connection_request_pb2 import ProtocolVersion as SentProtocolVersion
@@ -308,7 +308,7 @@ class BaseClientConfiguration:
 
     def _get_pubsub_callback_and_context(
         self,
-    ) -> Tuple[Optional[Callable[[CoreCommands.PubSubMsg, Any], None]], Any]:
+    ) -> Tuple[Optional[Callable[[PubSubMsg, Any], None]], Any]:
         return None, None
 
 
@@ -387,7 +387,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         Attributes:
             channels_and_patterns (Dict[GlideClientConfiguration.PubSubChannelModes, Set[str]]):
                 Channels and patterns by modes.
-            callback (Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]):
+            callback (Optional[Callable[[PubSubMsg, Any], None]]):
                 Optional callback to accept the incomming messages.
             context (Any):
                 Arbitrary context to pass to the callback.
@@ -396,7 +396,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         channels_and_patterns: Dict[
             GlideClientConfiguration.PubSubChannelModes, Set[str]
         ]
-        callback: Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]
+        callback: Optional[Callable[[PubSubMsg, Any], None]]
         context: Any
 
     def __init__(
@@ -468,7 +468,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
 
     def _get_pubsub_callback_and_context(
         self,
-    ) -> Tuple[Optional[Callable[[CoreCommands.PubSubMsg, Any], None]], Any]:
+    ) -> Tuple[Optional[Callable[[PubSubMsg, Any], None]], Any]:
         if self.pubsub_subscriptions:
             return self.pubsub_subscriptions.callback, self.pubsub_subscriptions.context
         return None, None
@@ -557,7 +557,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         Attributes:
             channels_and_patterns (Dict[GlideClusterClientConfiguration.PubSubChannelModes, Set[str]]):
                 Channels and patterns by modes.
-            callback (Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]):
+            callback (Optional[Callable[[PubSubMsg, Any], None]]):
                 Optional callback to accept the incoming messages.
             context (Any):
                 Arbitrary context to pass to the callback.
@@ -566,7 +566,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         channels_and_patterns: Dict[
             GlideClusterClientConfiguration.PubSubChannelModes, Set[str]
         ]
-        callback: Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]
+        callback: Optional[Callable[[PubSubMsg, Any], None]]
         context: Any
 
     def __init__(
@@ -644,7 +644,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
 
     def _get_pubsub_callback_and_context(
         self,
-    ) -> Tuple[Optional[Callable[[CoreCommands.PubSubMsg, Any], None]], Any]:
+    ) -> Tuple[Optional[Callable[[PubSubMsg, Any], None]], Any]:
         if self.pubsub_subscriptions:
             return self.pubsub_subscriptions.callback, self.pubsub_subscriptions.context
         return None, None

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -24,6 +24,7 @@ from glide.commands.async_commands.cluster_commands import ClusterCommands
 from glide.commands.async_commands.core import CoreCommands
 from glide.commands.async_commands.standalone_commands import StandaloneCommands
 from glide.commands.command_args import ObjectType
+from glide.commands.core_options import PubSubMsg
 from glide.config import BaseClientConfiguration, ServerCredentials
 from glide.constants import DEFAULT_READ_BYTES_SIZE, OK, TEncodable, TRequest, TResult
 from glide.exceptions import (
@@ -496,7 +497,7 @@ class BaseClient(CoreCommands):
         set_protobuf_route(request, route)
         return await self._write_request_await_response(request)
 
-    async def get_pubsub_message(self) -> CoreCommands.PubSubMsg:
+    async def get_pubsub_message(self) -> PubSubMsg:
         if self._is_closed:
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
@@ -523,7 +524,7 @@ class BaseClient(CoreCommands):
         await response_future
         return response_future.result()
 
-    def try_get_pubsub_message(self) -> Optional[CoreCommands.PubSubMsg]:
+    def try_get_pubsub_message(self) -> Optional[PubSubMsg]:
         if self._is_closed:
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
@@ -540,7 +541,7 @@ class BaseClient(CoreCommands):
             )
 
         # locking might not be required
-        msg: Optional[CoreCommands.PubSubMsg] = None
+        msg: Optional[PubSubMsg] = None
         try:
             self._pubsub_lock.acquire()
             self._complete_pubsub_futures_safe()
@@ -558,7 +559,7 @@ class BaseClient(CoreCommands):
 
     def _notification_to_pubsub_message_safe(
         self, response: Response
-    ) -> Optional[CoreCommands.PubSubMsg]:
+    ) -> Optional[PubSubMsg]:
         pubsub_message = None
         push_notification = cast(
             Dict[str, Any], value_from_pointer(response.resp_pointer)
@@ -577,11 +578,11 @@ class BaseClient(CoreCommands):
         ):
             values: List = push_notification["values"]
             if message_kind == "PMessage":
-                pubsub_message = BaseClient.PubSubMsg(
+                pubsub_message = PubSubMsg(
                     message=values[2], channel=values[1], pattern=values[0]
                 )
             else:
-                pubsub_message = BaseClient.PubSubMsg(
+                pubsub_message = PubSubMsg(
                     message=values[1], channel=values[0], pattern=None
                 )
         elif (

--- a/python/tests/async_tests/test_pubsub.py
+++ b/python/tests/async_tests/test_pubsub.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 import anyio
 import pytest
 
-from glide.commands.async_commands.core import CoreCommands
+from glide.commands.core_options import PubSubMsg
 from glide.config import (
     GlideClientConfiguration,
     GlideClusterClientConfiguration,
@@ -85,20 +85,20 @@ async def create_two_clients_with_pubsub(
     return client1, client2
 
 
-def decode_pubsub_msg(msg: Optional[CoreCommands.PubSubMsg]) -> CoreCommands.PubSubMsg:
+def decode_pubsub_msg(msg: Optional[PubSubMsg]) -> PubSubMsg:
     if not msg:
-        return CoreCommands.PubSubMsg("", "", None)
+        return PubSubMsg("", "", None)
     string_msg = cast(bytes, msg.message).decode()
     string_channel = cast(bytes, msg.channel).decode()
     string_pattern = cast(bytes, msg.pattern).decode() if msg.pattern else None
-    decoded_msg = CoreCommands.PubSubMsg(string_msg, string_channel, string_pattern)
+    decoded_msg = PubSubMsg(string_msg, string_channel, string_pattern)
     return decoded_msg
 
 
 async def get_message_by_method(
     method: MethodTesting,
     client: TGlideClient,
-    messages: Optional[List[CoreCommands.PubSubMsg]] = None,
+    messages: Optional[List[PubSubMsg]] = None,
     index: Optional[int] = None,
 ):
     if method == MethodTesting.Async:
@@ -151,8 +151,8 @@ def create_pubsub_subscription(
     )
 
 
-def new_message(msg: CoreCommands.PubSubMsg, context: Any):
-    received_messages: List[CoreCommands.PubSubMsg] = context
+def new_message(msg: PubSubMsg, context: Any):
+    received_messages: List[PubSubMsg] = context
     received_messages.append(msg)
 
 
@@ -226,7 +226,7 @@ class TestPubSub:
             message = get_random_string(5)
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -349,7 +349,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -499,7 +499,7 @@ class TestPubSub:
             publish_response = 1
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -640,7 +640,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -725,7 +725,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -857,7 +857,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -944,7 +944,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1064,7 +1064,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1096,7 +1096,7 @@ class TestPubSub:
                 pub_sub_exact,
             )
 
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages_pattern
@@ -1224,7 +1224,7 @@ class TestPubSub:
             publish_response = 1
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1372,9 +1372,9 @@ class TestPubSub:
             publish_response = 1
 
             callback, context = None, None
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
-            callback_messages_sharded: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
+            callback_messages_sharded: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1581,9 +1581,9 @@ class TestPubSub:
             MESSAGE_SHARDED = get_random_string(5)
 
             callback, context = None, None
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
-            callback_messages_sharded: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
+            callback_messages_sharded: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1734,8 +1734,8 @@ class TestPubSub:
             MESSAGE_EXACT = get_random_string(10)
             MESSAGE_PATTERN = get_random_string(7)
             callback, context_exact, context_pattern = None, None, None
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1847,9 +1847,9 @@ class TestPubSub:
                 None,
                 None,
             )
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
-            callback_messages_sharded: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
+            callback_messages_sharded: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -2137,7 +2137,7 @@ class TestPubSub:
             channel = get_random_string(10)
             message = "0" * 12 * 1024 * 1024
 
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             callback, context = new_message, callback_messages
 
             pub_sub = create_pubsub_subscription(
@@ -2195,7 +2195,7 @@ class TestPubSub:
             channel = get_random_string(10)
             message = "0" * 512 * 1024 * 1024
 
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             callback, context = new_message, callback_messages
 
             pub_sub = create_pubsub_subscription(
@@ -2252,7 +2252,7 @@ class TestPubSub:
     ):
         """Tests that when creating a PUBSUB client in callback method with context but no callback raises an error"""
         channel = get_random_string(5)
-        context: List[CoreCommands.PubSubMsg] = []
+        context: List[PubSubMsg] = []
         pub_sub_exact = create_pubsub_subscription(
             cluster_mode,
             {GlideClusterClientConfiguration.PubSubChannelModes.Exact: {channel}},


### PR DESCRIPTION
Currently, PubSubMsg is found under the async_commands/core.py file, so it doesn't allow reusing it and seperating the sync and async modules as required. This PR places the ground work for splitting the sync and async python client builds.

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
