### PR TITLE
Python/sync: Cleanup the sync client

### DIFF
--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,6 +1,5 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-from glide.commands.async_commands.core import CoreCommands
 from glide.commands.batch import (
     Batch,
     ClusterBatch,
@@ -38,6 +37,7 @@ from glide.commands.core_options import (
     InfoSection,
     InsertPosition,
     OnlyIfEqual,
+    PubSubMsg,
     UpdateOptions,
 )
 from glide.commands.server_modules import ft, glide_json, json_batch
@@ -169,8 +169,6 @@ from glide.routes import (
 )
 
 from .glide import ClusterScanCursor, Script
-
-PubSubMsg = CoreCommands.PubSubMsg
 
 __all__ = [
     # Client

--- a/python/python/glide/commands/async_commands/core.py
+++ b/python/python/glide/commands/async_commands/core.py
@@ -1,5 +1,4 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional, Protocol, Set, Tuple, Union, cast
 
 from glide.commands.bitmap import (
@@ -18,6 +17,7 @@ from glide.commands.core_options import (
     ExpirySet,
     InsertPosition,
     OnlyIfEqual,
+    PubSubMsg,
     UpdateOptions,
     _build_sort_args,
 )
@@ -6651,21 +6651,6 @@ class CoreCommands(Protocol):
             TOK,
             await self._execute_command(RequestType.Watch, keys),
         )
-
-    @dataclass
-    class PubSubMsg:
-        """
-        Describes the incoming pubsub message
-
-        Attributes:
-            message (TEncodable): Incoming message.
-            channel (TEncodable): Name of an channel that triggered the message.
-            pattern (Optional[TEncodable]): Pattern that triggered the message.
-        """
-
-        message: TEncodable
-        channel: TEncodable
-        pattern: Optional[TEncodable]
 
     async def get_pubsub_message(self) -> PubSubMsg:
         """

--- a/python/python/glide/commands/core_options.py
+++ b/python/python/glide/commands/core_options.py
@@ -8,6 +8,22 @@ from glide.commands.command_args import Limit, OrderBy
 from glide.constants import TEncodable
 
 
+@dataclass
+class PubSubMsg:
+    """
+    Describes the incoming pubsub message
+
+    Attributes:
+        message (TEncodable): Incoming message.
+        channel (TEncodable): Name of an channel that triggered the message.
+        pattern (Optional[TEncodable]): Pattern that triggered the message.
+    """
+
+    message: TEncodable
+    channel: TEncodable
+    pattern: Optional[TEncodable]
+
+
 class ConditionalChange(Enum):
     """
     A condition to the `SET`, `ZADD` and `GEOADD` commands.

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from glide.commands.async_commands.core import CoreCommands
+from glide.commands.core_options import PubSubMsg
 from glide.exceptions import ConfigurationError
 from glide.protobuf.connection_request_pb2 import ConnectionRequest
 from glide.protobuf.connection_request_pb2 import ProtocolVersion as SentProtocolVersion
@@ -308,7 +308,7 @@ class BaseClientConfiguration:
 
     def _get_pubsub_callback_and_context(
         self,
-    ) -> Tuple[Optional[Callable[[CoreCommands.PubSubMsg, Any], None]], Any]:
+    ) -> Tuple[Optional[Callable[[PubSubMsg, Any], None]], Any]:
         return None, None
 
 
@@ -387,7 +387,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         Attributes:
             channels_and_patterns (Dict[GlideClientConfiguration.PubSubChannelModes, Set[str]]):
                 Channels and patterns by modes.
-            callback (Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]):
+            callback (Optional[Callable[[PubSubMsg, Any], None]]):
                 Optional callback to accept the incomming messages.
             context (Any):
                 Arbitrary context to pass to the callback.
@@ -396,7 +396,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         channels_and_patterns: Dict[
             GlideClientConfiguration.PubSubChannelModes, Set[str]
         ]
-        callback: Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]
+        callback: Optional[Callable[[PubSubMsg, Any], None]]
         context: Any
 
     def __init__(
@@ -468,7 +468,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
 
     def _get_pubsub_callback_and_context(
         self,
-    ) -> Tuple[Optional[Callable[[CoreCommands.PubSubMsg, Any], None]], Any]:
+    ) -> Tuple[Optional[Callable[[PubSubMsg, Any], None]], Any]:
         if self.pubsub_subscriptions:
             return self.pubsub_subscriptions.callback, self.pubsub_subscriptions.context
         return None, None
@@ -557,7 +557,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         Attributes:
             channels_and_patterns (Dict[GlideClusterClientConfiguration.PubSubChannelModes, Set[str]]):
                 Channels and patterns by modes.
-            callback (Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]):
+            callback (Optional[Callable[[PubSubMsg, Any], None]]):
                 Optional callback to accept the incoming messages.
             context (Any):
                 Arbitrary context to pass to the callback.
@@ -566,7 +566,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         channels_and_patterns: Dict[
             GlideClusterClientConfiguration.PubSubChannelModes, Set[str]
         ]
-        callback: Optional[Callable[[CoreCommands.PubSubMsg, Any], None]]
+        callback: Optional[Callable[[PubSubMsg, Any], None]]
         context: Any
 
     def __init__(
@@ -644,7 +644,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
 
     def _get_pubsub_callback_and_context(
         self,
-    ) -> Tuple[Optional[Callable[[CoreCommands.PubSubMsg, Any], None]], Any]:
+    ) -> Tuple[Optional[Callable[[PubSubMsg, Any], None]], Any]:
         if self.pubsub_subscriptions:
             return self.pubsub_subscriptions.callback, self.pubsub_subscriptions.context
         return None, None

--- a/python/python/glide/exceptions.py
+++ b/python/python/glide/exceptions.py
@@ -1,6 +1,8 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-from typing import Optional
+from typing import Optional, Type
+
+from glide.protobuf.response_pb2 import RequestErrorType
 
 
 class GlideError(Exception):
@@ -60,3 +62,17 @@ class ConfigurationError(RequestError):
     """
     Errors that are thrown when a request cannot be completed in current configuration settings.
     """
+
+
+def get_request_error_class(
+    error_type: Optional[RequestErrorType.ValueType],
+) -> Type[RequestError]:
+    if error_type == RequestErrorType.Disconnect:
+        return ConnectionError
+    if error_type == RequestErrorType.ExecAbort:
+        return ExecAbortError
+    if error_type == RequestErrorType.Timeout:
+        return TimeoutError
+    if error_type == RequestErrorType.Unspecified:
+        return RequestError
+    return RequestError

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -24,6 +24,7 @@ from glide.commands.async_commands.cluster_commands import ClusterCommands
 from glide.commands.async_commands.core import CoreCommands
 from glide.commands.async_commands.standalone_commands import StandaloneCommands
 from glide.commands.command_args import ObjectType
+from glide.commands.core_options import PubSubMsg
 from glide.config import BaseClientConfiguration, ServerCredentials
 from glide.constants import DEFAULT_READ_BYTES_SIZE, OK, TEncodable, TRequest, TResult
 from glide.exceptions import (
@@ -496,7 +497,7 @@ class BaseClient(CoreCommands):
         set_protobuf_route(request, route)
         return await self._write_request_await_response(request)
 
-    async def get_pubsub_message(self) -> CoreCommands.PubSubMsg:
+    async def get_pubsub_message(self) -> PubSubMsg:
         if self._is_closed:
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
@@ -523,7 +524,7 @@ class BaseClient(CoreCommands):
         await response_future
         return response_future.result()
 
-    def try_get_pubsub_message(self) -> Optional[CoreCommands.PubSubMsg]:
+    def try_get_pubsub_message(self) -> Optional[PubSubMsg]:
         if self._is_closed:
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
@@ -540,7 +541,7 @@ class BaseClient(CoreCommands):
             )
 
         # locking might not be required
-        msg: Optional[CoreCommands.PubSubMsg] = None
+        msg: Optional[PubSubMsg] = None
         try:
             self._pubsub_lock.acquire()
             self._complete_pubsub_futures_safe()
@@ -558,7 +559,7 @@ class BaseClient(CoreCommands):
 
     def _notification_to_pubsub_message_safe(
         self, response: Response
-    ) -> Optional[CoreCommands.PubSubMsg]:
+    ) -> Optional[PubSubMsg]:
         pubsub_message = None
         push_notification = cast(
             Dict[str, Any], value_from_pointer(response.resp_pointer)
@@ -577,11 +578,11 @@ class BaseClient(CoreCommands):
         ):
             values: List = push_notification["values"]
             if message_kind == "PMessage":
-                pubsub_message = BaseClient.PubSubMsg(
+                pubsub_message = PubSubMsg(
                     message=values[2], channel=values[1], pattern=values[0]
                 )
             else:
-                pubsub_message = BaseClient.PubSubMsg(
+                pubsub_message = PubSubMsg(
                     message=values[1], channel=values[0], pattern=None
                 )
         elif (

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -11,7 +11,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -31,15 +30,13 @@ from glide.exceptions import (
     ClosingError,
     ConfigurationError,
     ConnectionError,
-    ExecAbortError,
-    RequestError,
-    TimeoutError,
+    get_request_error_class,
 )
 from glide.logger import Level as LogLevel
 from glide.logger import Logger as ClientLogger
 from glide.protobuf.command_request_pb2 import Command, CommandRequest, RequestType
 from glide.protobuf.connection_request_pb2 import ConnectionRequest
-from glide.protobuf.response_pb2 import RequestErrorType, Response
+from glide.protobuf.response_pb2 import Response
 from glide.protobuf_codec import PartialMessageException, ProtobufCodec
 from glide.routes import Route, set_protobuf_route
 
@@ -65,20 +62,6 @@ if TYPE_CHECKING:
 
     TTask = Union[asyncio.Task[None], trio.lowlevel.Task]
     TFuture = Union[asyncio.Future[Any], "_CompatFuture"]
-
-
-def get_request_error_class(
-    error_type: Optional[RequestErrorType.ValueType],
-) -> Type[RequestError]:
-    if error_type == RequestErrorType.Disconnect:
-        return ConnectionError
-    if error_type == RequestErrorType.ExecAbort:
-        return ExecAbortError
-    if error_type == RequestErrorType.Timeout:
-        return TimeoutError
-    if error_type == RequestErrorType.Unspecified:
-        return RequestError
-    return RequestError
 
 
 class _CompatFuture:

--- a/python/python/glide/sync/glide_client.py
+++ b/python/python/glide/sync/glide_client.py
@@ -40,56 +40,56 @@ class BaseClient(CoreCommands):
         """
         To create a new client, use the `create` classmethod
         """
-        self.config: BaseClientConfiguration = config
+        self._config: BaseClientConfiguration = config
         self._is_closed: bool = False
 
     @classmethod
     def create(cls, config: BaseClientConfiguration) -> Self:
         self = cls(config)
         self._init_ffi()
-        self.config = config
+        self._config = config
         self._is_closed = False
         conn_req = config._create_a_protobuf_conn_request(
             cluster_mode=type(config) is GlideClusterClientConfiguration
         )
         conn_req_bytes = conn_req.SerializeToString()
-        client_type = self.ffi.new(
+        client_type = self._ffi.new(
             "ClientType*",
             {
-                "_type": self.ffi.cast("ClientTypeEnum", FFIClientTypeEnum.Sync),
+                "_type": self._ffi.cast("ClientTypeEnum", FFIClientTypeEnum.Sync),
             },
         )
-        client_response_ptr = self.lib.create_client(
+        client_response_ptr = self._lib.create_client(
             conn_req_bytes, len(conn_req_bytes), client_type
         )
         # Handle the connection response
-        if client_response_ptr != self.ffi.NULL:
+        if client_response_ptr != self._ffi.NULL:
             client_response = self._try_ffi_cast(
                 "ConnectionResponse*", client_response_ptr
             )
-            if client_response.conn_ptr != self.ffi.NULL:
-                self.core_client = client_response.conn_ptr
+            if client_response.conn_ptr != self._ffi.NULL:
+                self._core_client = client_response.conn_ptr
             else:
                 error_message = (
-                    self.ffi.string(client_response.connection_error_message).decode(
+                    self._ffi.string(client_response.connection_error_message).decode(
                         ENCODING
                     )
-                    if client_response.connection_error_message != self.ffi.NULL
+                    if client_response.connection_error_message != self._ffi.NULL
                     else "Unknown error"
                 )
                 raise ClosingError(error_message)
 
             # Free the connection response to avoid memory leaks
-            self.lib.free_connection_response(client_response_ptr)
+            self._lib.free_connection_response(client_response_ptr)
         else:
             raise ClosingError("Failed to create client, response pointer is NULL.")
         return self
 
     def _init_ffi(self):
-        self.ffi = FFI()
+        self._ffi = FFI()
 
         # Define the CommandResponse struct and related types
-        self.ffi.cdef(
+        self._ffi.cdef(
             """
             struct CommandResponse {
                 int response_type;
@@ -180,16 +180,16 @@ class BaseClient(CoreCommands):
         )
 
         # Load the shared library (adjust the path to your compiled Rust library)
-        self.lib = self.ffi.dlopen(str(LIB_FILE.resolve()))
+        self._lib = self._ffi.dlopen(str(LIB_FILE.resolve()))
 
     def _handle_response(self, message):
-        if message == self.ffi.NULL:
+        if message == self._ffi.NULL:
             raise RequestError("Received NULL message.")
 
-        message_type = self.ffi.typeof(message).cname
+        message_type = self._ffi.typeof(message).cname
         if message_type == "CommandResponse *":
             message = message[0]
-            message_type = self.ffi.typeof(message).cname
+            message_type = self._ffi.typeof(message).cname
 
         if message_type != "CommandResponse":
             raise RequestError(f"Unexpected message type = {message_type}")
@@ -230,7 +230,7 @@ class BaseClient(CoreCommands):
 
     def _handle_string_response(self, msg):
         try:
-            return self.ffi.buffer(msg.string_value, msg.string_value_len)[:]
+            return self._ffi.buffer(msg.string_value, msg.string_value_len)[:]
         except Exception as e:
             raise RequestError(f"Error decoding string value: {e}")
 
@@ -265,7 +265,7 @@ class BaseClient(CoreCommands):
 
     def _try_ffi_cast(self, type, source):
         try:
-            return self.ffi.cast(type, source)
+            return self._ffi.cast(type, source)
         except Exception as e:
             raise ClosingError(f"FFI casting failed: {e}")
 
@@ -290,26 +290,26 @@ class BaseClient(CoreCommands):
             # Use ffi.from_buffer for zero-copy conversion
             buffers.append(arg_bytes)  # Keep the byte buffer alive
             c_strings.append(
-                self._try_ffi_cast("size_t", self.ffi.from_buffer(arg_bytes))
+                self._try_ffi_cast("size_t", self._ffi.from_buffer(arg_bytes))
             )
             string_lengths.append(len(arg_bytes))
         # Return C-compatible arrays and keep buffers alive
         return (
-            self.ffi.new("size_t[]", c_strings),
-            self.ffi.new("unsigned long[]", string_lengths),
+            self._ffi.new("size_t[]", c_strings),
+            self._ffi.new("unsigned long[]", string_lengths),
             buffers,  # Ensure buffers stay alive
         )
 
     def _handle_cmd_result(self, command_result):
         try:
-            if command_result == self.ffi.NULL:
+            if command_result == self._ffi.NULL:
                 raise ClosingError("Internal error: Received NULL as a command result")
-            if command_result.command_error != self.ffi.NULL:
+            if command_result.command_error != self._ffi.NULL:
                 # Handle the error case
                 error = self._try_ffi_cast(
                     "CommandError*", command_result.command_error
                 )
-                error_message = self.ffi.string(error.command_error_message).decode(
+                error_message = self._ffi.string(error.command_error_message).decode(
                     ENCODING
                 )
                 error_class = get_request_error_class(error.command_error_type)
@@ -319,7 +319,7 @@ class BaseClient(CoreCommands):
                 return self._handle_response(command_result.response)
                 # Free the error message to avoid memory leaks
         finally:
-            self.lib.free_command_result(command_result)
+            self._lib.free_command_result(command_result)
 
     def _execute_command(
         self,
@@ -331,8 +331,8 @@ class BaseClient(CoreCommands):
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
             )
-        client_adapter_ptr = self.core_client
-        if client_adapter_ptr == self.ffi.NULL:
+        client_adapter_ptr = self._core_client
+        if client_adapter_ptr == self._ffi.NULL:
             raise ValueError("Invalid client pointer.")
 
         # Convert the arguments to C-compatible pointers
@@ -341,12 +341,12 @@ class BaseClient(CoreCommands):
         proto_route = build_protobuf_route(route)
         if proto_route:
             route_bytes = proto_route.SerializeToString()
-            route_ptr = self.ffi.from_buffer(route_bytes)
+            route_ptr = self._ffi.from_buffer(route_bytes)
         else:
             route_bytes = b""
-            route_ptr = self.ffi.NULL
+            route_ptr = self._ffi.NULL
 
-        result = self.lib.command(
+        result = self._lib.command(
             client_adapter_ptr,  # Client pointer
             1,  # Example channel (adjust as needed)
             request_type,  # Request type (e.g., GET or SET)
@@ -360,8 +360,8 @@ class BaseClient(CoreCommands):
 
     def close(self):
         if not self._is_closed:
-            self.lib.close_client(self.core_client)
-            self.core_client = self.ffi.NULL
+            self._lib.close_client(self._core_client)
+            self._core_client = self._ffi.NULL
             self._is_closed = True
 
 

--- a/python/python/glide/sync/glide_client.py
+++ b/python/python/glide/sync/glide_client.py
@@ -11,8 +11,7 @@ from glide.commands.sync_commands.core import CoreCommands
 from glide.commands.sync_commands.standalone_commands import StandaloneCommands
 from glide.config import BaseClientConfiguration, GlideClusterClientConfiguration
 from glide.constants import OK, TEncodable, TResult
-from glide.exceptions import ClosingError, RequestError
-from glide.glide_client import get_request_error_class
+from glide.exceptions import ClosingError, RequestError, get_request_error_class
 from glide.protobuf.command_request_pb2 import RequestType
 from glide.routes import Route, build_protobuf_route
 

--- a/python/tests/async_tests/test_pubsub.py
+++ b/python/tests/async_tests/test_pubsub.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 import anyio
 import pytest
 
-from glide.commands.async_commands.core import CoreCommands
+from glide.commands.core_options import PubSubMsg
 from glide.config import (
     GlideClientConfiguration,
     GlideClusterClientConfiguration,
@@ -85,20 +85,20 @@ async def create_two_clients_with_pubsub(
     return client1, client2
 
 
-def decode_pubsub_msg(msg: Optional[CoreCommands.PubSubMsg]) -> CoreCommands.PubSubMsg:
+def decode_pubsub_msg(msg: Optional[PubSubMsg]) -> PubSubMsg:
     if not msg:
-        return CoreCommands.PubSubMsg("", "", None)
+        return PubSubMsg("", "", None)
     string_msg = cast(bytes, msg.message).decode()
     string_channel = cast(bytes, msg.channel).decode()
     string_pattern = cast(bytes, msg.pattern).decode() if msg.pattern else None
-    decoded_msg = CoreCommands.PubSubMsg(string_msg, string_channel, string_pattern)
+    decoded_msg = PubSubMsg(string_msg, string_channel, string_pattern)
     return decoded_msg
 
 
 async def get_message_by_method(
     method: MethodTesting,
     client: TGlideClient,
-    messages: Optional[List[CoreCommands.PubSubMsg]] = None,
+    messages: Optional[List[PubSubMsg]] = None,
     index: Optional[int] = None,
 ):
     if method == MethodTesting.Async:
@@ -151,8 +151,8 @@ def create_pubsub_subscription(
     )
 
 
-def new_message(msg: CoreCommands.PubSubMsg, context: Any):
-    received_messages: List[CoreCommands.PubSubMsg] = context
+def new_message(msg: PubSubMsg, context: Any):
+    received_messages: List[PubSubMsg] = context
     received_messages.append(msg)
 
 
@@ -226,7 +226,7 @@ class TestPubSub:
             message = get_random_string(5)
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -349,7 +349,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -499,7 +499,7 @@ class TestPubSub:
             publish_response = 1
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -640,7 +640,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -725,7 +725,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -857,7 +857,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages
@@ -944,7 +944,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1064,7 +1064,7 @@ class TestPubSub:
             }
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1096,7 +1096,7 @@ class TestPubSub:
                 pub_sub_exact,
             )
 
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
             if method == MethodTesting.Callback:
                 callback = new_message
                 context = callback_messages_pattern
@@ -1224,7 +1224,7 @@ class TestPubSub:
             publish_response = 1
 
             callback, context = None, None
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1372,9 +1372,9 @@ class TestPubSub:
             publish_response = 1
 
             callback, context = None, None
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
-            callback_messages_sharded: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
+            callback_messages_sharded: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1581,9 +1581,9 @@ class TestPubSub:
             MESSAGE_SHARDED = get_random_string(5)
 
             callback, context = None, None
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
-            callback_messages_sharded: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
+            callback_messages_sharded: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1734,8 +1734,8 @@ class TestPubSub:
             MESSAGE_EXACT = get_random_string(10)
             MESSAGE_PATTERN = get_random_string(7)
             callback, context_exact, context_pattern = None, None, None
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -1847,9 +1847,9 @@ class TestPubSub:
                 None,
                 None,
             )
-            callback_messages_exact: List[CoreCommands.PubSubMsg] = []
-            callback_messages_pattern: List[CoreCommands.PubSubMsg] = []
-            callback_messages_sharded: List[CoreCommands.PubSubMsg] = []
+            callback_messages_exact: List[PubSubMsg] = []
+            callback_messages_pattern: List[PubSubMsg] = []
+            callback_messages_sharded: List[PubSubMsg] = []
 
             if method == MethodTesting.Callback:
                 callback = new_message
@@ -2137,7 +2137,7 @@ class TestPubSub:
             channel = get_random_string(10)
             message = "0" * 12 * 1024 * 1024
 
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             callback, context = new_message, callback_messages
 
             pub_sub = create_pubsub_subscription(
@@ -2195,7 +2195,7 @@ class TestPubSub:
             channel = get_random_string(10)
             message = "0" * 512 * 1024 * 1024
 
-            callback_messages: List[CoreCommands.PubSubMsg] = []
+            callback_messages: List[PubSubMsg] = []
             callback, context = new_message, callback_messages
 
             pub_sub = create_pubsub_subscription(
@@ -2252,7 +2252,7 @@ class TestPubSub:
     ):
         """Tests that when creating a PUBSUB client in callback method with context but no callback raises an error"""
         channel = get_random_string(5)
-        context: List[CoreCommands.PubSubMsg] = []
+        context: List[PubSubMsg] = []
         pub_sub_exact = create_pubsub_subscription(
             cluster_mode,
             {GlideClusterClientConfiguration.PubSubChannelModes.Exact: {channel}},

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -184,14 +184,14 @@ class TestGlideClients:
                 create_sync_client(
                     request,
                     is_cluster,
-                    addresses=glide_sync_client.config.addresses,
+                    addresses=glide_sync_client._config.addresses,
                 )
 
             auth_client = create_sync_client(
                 request,
                 is_cluster,
                 credentials,
-                addresses=glide_sync_client.config.addresses,
+                addresses=glide_sync_client._config.addresses,
             )
             key = get_random_string(10)
             assert auth_client.set(key, key) == OK
@@ -204,7 +204,7 @@ class TestGlideClients:
                 request,
                 is_cluster,
                 credentials,
-                addresses=glide_sync_client.config.addresses,
+                addresses=glide_sync_client._config.addresses,
             )
             auth_client.custom_command(["CONFIG", "SET", "requirepass", ""])
             auth_client.close()
@@ -244,7 +244,7 @@ class TestGlideClients:
                 request,
                 is_cluster,
                 credentials,
-                addresses=glide_sync_client.config.addresses,
+                addresses=glide_sync_client._config.addresses,
             )
             assert testuser_client.get(key) == key.encode()
             with pytest.raises(RequestError) as e:

--- a/python/tests/test_api_export.py
+++ b/python/tests/test_api_export.py
@@ -29,12 +29,13 @@ excluded_symbol_list = [
     "T",  # TypeVar
     "TRequest",  # Union
     # python/python/glide/glide_client.py
-    "get_request_error_class",  # FunctionDef
     "_CompatFuture",  # ClassDef
     "_get_new_future_instance",  # FunctionDef
     "BaseClient",  # ClassDef
     # python/python/glide/sync/glide_client.py
     "FFIClientTypeEnum",  # ClassDef
+    # python/python/glide/exceptions.py
+    "get_request_error_class",  # FunctionDef
     # python/python/glide/routes.py
     "to_protobuf_slot_type",  # FunctionDef
     "set_protobuf_route",  # FunctionDef


### PR DESCRIPTION
Contains two changes (separated by commit):

1. move get_request_error_class to a shared location
2. Change the client internal fields to private

This PR places the ground work for splitting the sync and async python client builds.

Rebased over #3998 

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
