### PR TITLE
Node Wrapper - Support TLS insecure

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -522,6 +522,26 @@ export interface ServerCredentials {
     password: string;
 }
 
+/**  Represents advanced TLS configuration settings. */
+export interface TlsAdvancedConfiguration {
+    /**
+     * Whether to bypass TLS certificate verification.
+     *
+     * - When set to `true`, the client skips certificate validation.
+     *   This is useful when connecting to servers or clusters using self-signed certificates,
+     *   or when DNS entries (e.g., CNAMEs) don't match certificate hostnames.
+     *
+     * - This setting is typically used in development or testing environments.
+     *   **It is strongly discouraged in production**, as it introduces security risks such as man-in-the-middle attacks.
+     *
+     * - Only valid if TLS is already enabled in the base client configuration.
+     *   Enabling it without TLS will result in a `ConfigurationError`.
+     *
+     * - Default: false (verification is enforced).
+     */
+    insecure?: boolean;
+}
+
 /** Represents the client's read from strategy. */
 export type ReadFrom =
     /** Always get from primary, in order to get the freshest data.*/
@@ -551,6 +571,8 @@ export type ReadFrom =
  * ### Security Settings
  *
  * - **TLS**: Enable secure communication using `useTLS`.
+ *      Should match the TLS configuration of the server/cluster, otherwise the connection attempt will fail.
+ *      For advanced tls configuration, please use `AdvancedBaseClientConfiguration`.
  * - **Authentication**: Provide `credentials` to authenticate with the server.
  *
  * ### Communication Settings
@@ -740,6 +762,10 @@ export interface BaseClientConfiguration {
  *
  * - **Connection Timeout**: The `connectionTimeout` property specifies the duration (in milliseconds) the client should wait for a connection to be established.
  *
+ * ### TLS config
+ *
+ * - **TLS Configuration**: The `tlsConfig` property allows for advanced TLS settings, such as enabling insecure mode.
+ *
  * @example
  * ```typescript
  * const config: AdvancedBaseClientConfiguration = {
@@ -755,6 +781,12 @@ export interface AdvancedBaseClientConfiguration {
      * If not explicitly set, a default value of 250 milliseconds will be used.
      */
     connectionTimeout?: number;
+
+    /**
+     * The advanced TLS configuration settings. This allows for more granular control of TLS behavior,
+     * such as enabling an insecure mode that bypasses certificate validation.
+     */
+    tlsConfig?: TlsAdvancedConfiguration;
 }
 
 /**
@@ -7875,6 +7907,17 @@ export class BaseClient {
         request.connectionTimeout =
             options.connectionTimeout ??
             DEFAULT_CONNECTION_TIMEOUT_IN_MILLISECONDS;
+
+        // Apply TLS configuration if present
+        if (options.tlsConfig?.insecure) {
+            if (request.tlsMode === connection_request.TlsMode.SecureTls) {
+                request.tlsMode = connection_request.TlsMode.InsecureTls;
+            } else if (request.tlsMode === connection_request.TlsMode.NoTls) {
+                throw new ConfigurationError(
+                    "TLS is configured as insecure, but TLS is not enabled.",
+                );
+            }
+        }
     }
 
     /**

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -552,7 +552,7 @@ export type ReadFrom =
  *
  * - **TLS**: Enable secure communication using `useTLS`.
  *      Should match the TLS configuration of the server/cluster, otherwise the connection attempt will fail.
- *      For advanced tls configuration, please use `AdvancedBaseClientConfiguration`.
+ *      For advanced tls configuration, , see {@link AdvancedBaseClientConfiguration}.
  * - **Authentication**: Provide `credentials` to authenticate with the server.
  *
  * ### Communication Settings
@@ -744,7 +744,7 @@ export interface BaseClientConfiguration {
  *
  * ### TLS config
  *
- * - **TLS Configuration**: The `tlsConfig` property allows for advanced TLS settings, such as enabling insecure mode.
+ * - **TLS Configuration**: The `tlsAdvancedConfiguration` property allows for advanced TLS settings, such as enabling insecure mode.
  *
  * @example
  * ```typescript
@@ -782,7 +782,7 @@ export interface AdvancedBaseClientConfiguration {
          *
          * - Default: false (verification is enforced).
          */
-        insecure: boolean;
+        insecure?: boolean;
     };
 }
 
@@ -7911,7 +7911,7 @@ export class BaseClient {
                 request.tlsMode = connection_request.TlsMode.InsecureTls;
             } else if (request.tlsMode === connection_request.TlsMode.NoTls) {
                 throw new ConfigurationError(
-                    "TLS is configured as insecure, but TLS is not enabled.",
+                    "InsecureTls cannot be enabled when useTLS is disabled.",
                 );
             }
         }

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -522,26 +522,6 @@ export interface ServerCredentials {
     password: string;
 }
 
-/**  Represents advanced TLS configuration settings. */
-export interface TlsAdvancedConfiguration {
-    /**
-     * Whether to bypass TLS certificate verification.
-     *
-     * - When set to `true`, the client skips certificate validation.
-     *   This is useful when connecting to servers or clusters using self-signed certificates,
-     *   or when DNS entries (e.g., CNAMEs) don't match certificate hostnames.
-     *
-     * - This setting is typically used in development or testing environments.
-     *   **It is strongly discouraged in production**, as it introduces security risks such as man-in-the-middle attacks.
-     *
-     * - Only valid if TLS is already enabled in the base client configuration.
-     *   Enabling it without TLS will result in a `ConfigurationError`.
-     *
-     * - Default: false (verification is enforced).
-     */
-    insecure?: boolean;
-}
-
 /** Represents the client's read from strategy. */
 export type ReadFrom =
     /** Always get from primary, in order to get the freshest data.*/
@@ -786,7 +766,24 @@ export interface AdvancedBaseClientConfiguration {
      * The advanced TLS configuration settings. This allows for more granular control of TLS behavior,
      * such as enabling an insecure mode that bypasses certificate validation.
      */
-    tlsConfig?: TlsAdvancedConfiguration;
+    tlsAdvancedConfiguration?: {
+        /**
+         * Whether to bypass TLS certificate verification.
+         *
+         * - When set to `true`, the client skips certificate validation.
+         *   This is useful when connecting to servers or clusters using self-signed certificates,
+         *   or when DNS entries (e.g., CNAMEs) don't match certificate hostnames.
+         *
+         * - This setting is typically used in development or testing environments.
+         *   **It is strongly discouraged in production**, as it introduces security risks such as man-in-the-middle attacks.
+         *
+         * - Only valid if TLS is already enabled in the base client configuration.
+         *   Enabling it without TLS will result in a `ConfigurationError`.
+         *
+         * - Default: false (verification is enforced).
+         */
+        insecure: boolean;
+    };
 }
 
 /**
@@ -7909,7 +7906,7 @@ export class BaseClient {
             DEFAULT_CONNECTION_TIMEOUT_IN_MILLISECONDS;
 
         // Apply TLS configuration if present
-        if (options.tlsConfig?.insecure) {
+        if (options.tlsAdvancedConfiguration?.insecure) {
             if (request.tlsMode === connection_request.TlsMode.SecureTls) {
                 request.tlsMode = connection_request.TlsMode.InsecureTls;
             } else if (request.tlsMode === connection_request.TlsMode.NoTls) {

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -150,7 +150,7 @@ export type GlideClientConfiguration = BaseClientConfiguration & {
  * ```typescript
  * const config: AdvancedGlideClientConfiguration = {
  *   connectionTimeout: 500, // Set the connection timeout to 500ms
- *   tlsConfig: {
+ *   tlsAdvancedConfiguration: {
  *     insecure: true, // Skip TLS certificate verification (use only in development)
  *   },
  * };

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -233,7 +233,8 @@ export class GlideClient extends BaseClient {
      * @remarks
      * - **Authentication**: If `credentials` are provided, the client will attempt to authenticate using the specified username and password.
      * - **TLS**: If `useTLS` is set to `true`, the client will establish a secure connection using TLS.
-     *      For advanced tls configuration, please use the AdvancedGlideClientConfiguration option.
+     *      Should match the TLS configuration of the server/cluster, otherwise the connection attempt will fail.
+     *      For advanced tls configuration, please use the {@link AdvancedGlideClientConfiguration} option.
      * - **Reconnection Strategy**: The `connectionBackoff` settings define how the client will attempt to reconnect in case of disconnections.
      * - **Pub/Sub Subscriptions**: Any channels or patterns specified in `pubsubSubscriptions` will be subscribed to upon connection.
      */

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -150,6 +150,9 @@ export type GlideClientConfiguration = BaseClientConfiguration & {
  * ```typescript
  * const config: AdvancedGlideClientConfiguration = {
  *   connectionTimeout: 500, // Set the connection timeout to 500ms
+ *   tlsConfig: {
+ *     insecure: true, // Skip TLS certificate verification (use only in development)
+ *   },
  * };
  * ```
  */
@@ -230,6 +233,7 @@ export class GlideClient extends BaseClient {
      * @remarks
      * - **Authentication**: If `credentials` are provided, the client will attempt to authenticate using the specified username and password.
      * - **TLS**: If `useTLS` is set to `true`, the client will establish a secure connection using TLS.
+     *      For advanced tls configuration, please use the AdvancedGlideClientConfiguration option.
      * - **Reconnection Strategy**: The `connectionBackoff` settings define how the client will attempt to reconnect in case of disconnections.
      * - **Pub/Sub Subscriptions**: Any channels or patterns specified in `pubsubSubscriptions` will be subscribed to upon connection.
      */

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -208,6 +208,9 @@ export type GlideClusterClientConfiguration = BaseClientConfiguration & {
  * ```typescript
  * const config: AdvancedGlideClusterClientConfiguration = {
  *   connectionTimeout: 500, // Set the connection timeout to 500ms
+ *   tlsAdvancedConfiguration: {
+ *     insecure: true, // Skip TLS certificate verification (use only in development)
+ *   },
  * };
  * ```
  */
@@ -588,6 +591,8 @@ export class GlideClusterClient extends BaseClient {
      * - **Cluster Topology Discovery**: The client will automatically discover the cluster topology based on the seed addresses provided.
      * - **Authentication**: If `credentials` are provided, the client will attempt to authenticate using the specified username and password.
      * - **TLS**: If `useTLS` is set to `true`, the client will establish secure connections using TLS.
+     *      Should match the TLS configuration of the server/cluster, otherwise the connection attempt will fail.
+     *      For advanced tls configuration, please use the {@link AdvancedGlideClusterClientConfiguration} option.
      * - **Periodic Checks**: The `periodicChecks` setting allows you to configure how often the client checks for cluster topology changes.
      * - **Pub/Sub Subscriptions**: Any channels or patterns specified in `pubsubSubscriptions` will be subscribed to upon connection.
      */

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -6,7 +6,7 @@ import { expect } from "@jest/globals";
 import { exec } from "child_process";
 import { Socket } from "net";
 import { promisify } from "util";
-import ValkeyCluster from "../../utils/TestUtils";
+import ValkeyCluster, { TestTLSConfig } from "../../utils/TestUtils";
 import {
     BaseClient,
     BaseClientConfiguration,
@@ -439,11 +439,13 @@ export async function flushAndCloseClient(
     cluster_mode: boolean,
     addresses: [string, number][],
     client?: BaseClient,
+    tlsConfig?: TestTLSConfig,
 ) {
     try {
         await testTeardown(
             cluster_mode,
             getClientConfigurationOption(addresses, ProtocolVersion.RESP3, {
+                ...tlsConfig,
                 requestTimeout: 2000,
             }),
         );
@@ -2184,17 +2186,24 @@ export async function CreateJsonBatchCommands(
 export async function getServerVersion(
     addresses: [string, number][],
     clusterMode = false,
+    tlsConfig?: TestTLSConfig,
 ): Promise<string> {
     let info = "";
 
     if (clusterMode) {
-        const glideClusterClient = await GlideClusterClient.createClient(
-            getClientConfigurationOption(addresses, ProtocolVersion.RESP2),
-        );
+        const glideClusterClient = await GlideClusterClient.createClient({
+            ...getClientConfigurationOption(addresses, ProtocolVersion.RESP2),
+            ...tlsConfig,
+        });
         info = getFirstResult(
             await glideClusterClient.info({ sections: [InfoOptions.Server] }),
         ).toString();
-        await flushAndCloseClient(clusterMode, addresses, glideClusterClient);
+        await flushAndCloseClient(
+            clusterMode,
+            addresses,
+            glideClusterClient,
+            tlsConfig,
+        );
     } else {
         const glideClient = await GlideClient.createClient(
             getClientConfigurationOption(addresses, ProtocolVersion.RESP2),

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -2205,11 +2205,17 @@ export async function getServerVersion(
             tlsConfig,
         );
     } else {
-        const glideClient = await GlideClient.createClient(
-            getClientConfigurationOption(addresses, ProtocolVersion.RESP2),
-        );
+        const glideClient = await GlideClient.createClient({
+            ...getClientConfigurationOption(addresses, ProtocolVersion.RESP2),
+            ...tlsConfig,
+        });
         info = await glideClient.info([InfoOptions.Server]);
-        await flushAndCloseClient(clusterMode, addresses, glideClient);
+        await flushAndCloseClient(
+            clusterMode,
+            addresses,
+            glideClient,
+            tlsConfig,
+        );
     }
 
     let version = "";

--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -4,7 +4,7 @@
 
 import { afterAll, afterEach, beforeAll, describe } from "@jest/globals";
 import { ValkeyCluster } from "../../utils/TestUtils.js";
-import { GlideClusterClient, ProtocolVersion } from "../build-ts";
+import { GlideClient, GlideClusterClient, ProtocolVersion } from "../build-ts";
 import {
     flushAndCloseClient,
     getClientConfigurationOption,
@@ -77,102 +77,67 @@ describe("tls GlideClusterClient", () => {
     );
 });
 
-// // tls cluster tests
-// describe("tls GlideClient", () => {
-//     let cluster: ValkeyCluster;
-//     let client: GlideClient;
+// tls cluster tests
+describe("tls GlideClient", () => {
+    let cluster: ValkeyCluster;
+    let client: GlideClient;
 
-//     beforeAll(async () => {
-//         cluster = await ValkeyCluster.createCluster(
-//             false,
-//             1,
-//             2,
-//             getServerVersion,
-//             true,
-//             {
-//                 advancedConfiguration: {
-//                     tlsAdvancedConfiguration: {
-//                         insecure: true,
-//                     },
-//                 },
-//                 useTLS: true,
-//             },
-//         );
-//     }, 40000);
+    beforeAll(async () => {
+        cluster = await ValkeyCluster.createCluster(
+            false,
+            1,
+            1,
+            getServerVersion,
+            true,
+            {
+                advancedConfiguration: {
+                    tlsAdvancedConfiguration: {
+                        insecure: true,
+                    },
+                },
+                useTLS: true,
+            },
+        );
+    }, 40000);
 
-//     afterEach(async () => {
-//         await flushAndCloseClient(true, cluster.getAddresses(), client, {
-//             advancedConfiguration: {
-//                 tlsAdvancedConfiguration: {
-//                     insecure: true,
-//                 },
-//             },
-//             useTLS: true,
-//         });
-//     });
+    afterEach(async () => {
+        await flushAndCloseClient(false, cluster.getAddresses(), client, {
+            advancedConfiguration: {
+                tlsAdvancedConfiguration: {
+                    insecure: true,
+                },
+            },
+            useTLS: true,
+        });
+    });
 
-//     afterAll(async () => {
-//         if (cluster) {
-//             await cluster.close();
-//         }
-//     });
+    afterAll(async () => {
+        if (cluster) {
+            await cluster.close();
+        }
+    });
 
-//     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
-//         "Standalone client connect with insecure TLS (protocol: %p)",
-//         async (protocol) => {
-//             const config = getClientConfigurationOption(
-//                 cluster.getAddresses(),
-//                 protocol,
-//                 { useTLS: true },
-//             );
-//             const c = {
-//                 advancedConfiguration: {
-//                     tlsAdvancedConfiguration: {
-//                         insecure: true,
-//                     },
-//                 },
-//                 ...config,
-//             };
-//             client = await GlideClient.createClient(c);
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "Standalone client connect with insecure TLS (protocol: %p)",
+        async (protocol) => {
+            const config = getClientConfigurationOption(
+                cluster.getAddresses(),
+                protocol,
+                { useTLS: true },
+            );
+            const c = {
+                advancedConfiguration: {
+                    tlsAdvancedConfiguration: {
+                        insecure: true,
+                    },
+                },
+                ...config,
+            };
+            client = await GlideClient.createClient(c);
 
-//             const result = await client.ping();
-//             expect(result.toString()).toBe("PONG");
-//         },
-//         TIMEOUT,
-//     );
-// });
-
-// // tls standalone tests
-// describe(`tls GlideClient %p`, () => {
-//     const testsFailed = 0;
-//     let cluster: ValkeyCluster;
-//     let client: GlideClient;
-
-//     beforeAll(async () => {
-
-//         const valkeyTlsStandalone = await ValkeyCluster.createCluster(false, 1, 2, getServerVersion, true);
-//     }, 40000);
-
-//     afterEach(async () => {
-//         await flushAndCloseClient(true, cluster.getAddresses(), client);
-//     });
-
-//     afterAll(async () => {
-//         if (testsFailed === 0) {
-//             await cluster.close();
-//         } else {
-//             await cluster.close(true);
-//         }
-//     });
-
-//     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
-//         `GlideClient connect with insecure TLS (protocol: %p)"`,
-//         async (protocol) => {
-//             client = await GlideClient.createClient(
-//                 getClientConfigurationOption(cluster.getAddresses(), protocol),
-//             );
-
-//         }, TIMEOUT,
-//     );
-
-// });
+            const result = await client.ping();
+            expect(result.toString()).toBe("PONG");
+        },
+        TIMEOUT,
+    );
+});

--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -11,6 +11,12 @@ import {
     getServerVersion,
 } from "./TestUtilities";
 const TIMEOUT = 50000;
+const TLS_OPTIONS = {
+    advancedConfiguration: {
+        tlsAdvancedConfiguration: { insecure: true },
+    },
+    useTLS: true,
+};
 
 // tls cluster tests
 describe("tls GlideClusterClient", () => {
@@ -24,26 +30,17 @@ describe("tls GlideClusterClient", () => {
             2,
             getServerVersion,
             true,
-            {
-                advancedConfiguration: {
-                    tlsAdvancedConfiguration: {
-                        insecure: true,
-                    },
-                },
-                useTLS: true,
-            },
+            TLS_OPTIONS,
         );
     }, 40000);
 
     afterEach(async () => {
-        await flushAndCloseClient(true, cluster.getAddresses(), client, {
-            advancedConfiguration: {
-                tlsAdvancedConfiguration: {
-                    insecure: true,
-                },
-            },
-            useTLS: true,
-        });
+        await flushAndCloseClient(
+            true,
+            cluster.getAddresses(),
+            client,
+            TLS_OPTIONS,
+        );
     });
 
     afterAll(async () => {
@@ -55,20 +52,15 @@ describe("tls GlideClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "clusterClient connect with insecure TLS (protocol: %p)",
         async (protocol) => {
-            const config = getClientConfigurationOption(
-                cluster.getAddresses(),
-                protocol,
-                { useTLS: true },
-            );
-            const c = {
-                advancedConfiguration: {
-                    tlsAdvancedConfiguration: {
-                        insecure: true,
-                    },
-                },
-                ...config,
+            const config = {
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+                ...TLS_OPTIONS,
             };
-            client = await GlideClusterClient.createClient(c);
+
+            client = await GlideClusterClient.createClient(config);
 
             const result = await client.ping();
             expect(result.toString()).toBe("PONG");
@@ -89,26 +81,17 @@ describe("tls GlideClient", () => {
             1,
             getServerVersion,
             true,
-            {
-                advancedConfiguration: {
-                    tlsAdvancedConfiguration: {
-                        insecure: true,
-                    },
-                },
-                useTLS: true,
-            },
+            TLS_OPTIONS,
         );
     }, 40000);
 
     afterEach(async () => {
-        await flushAndCloseClient(false, cluster.getAddresses(), client, {
-            advancedConfiguration: {
-                tlsAdvancedConfiguration: {
-                    insecure: true,
-                },
-            },
-            useTLS: true,
-        });
+        await flushAndCloseClient(
+            false,
+            cluster.getAddresses(),
+            client,
+            TLS_OPTIONS,
+        );
     });
 
     afterAll(async () => {
@@ -120,20 +103,15 @@ describe("tls GlideClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "Standalone client connect with insecure TLS (protocol: %p)",
         async (protocol) => {
-            const config = getClientConfigurationOption(
-                cluster.getAddresses(),
-                protocol,
-                { useTLS: true },
-            );
-            const c = {
-                advancedConfiguration: {
-                    tlsAdvancedConfiguration: {
-                        insecure: true,
-                    },
-                },
-                ...config,
+            const config = {
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+                ...TLS_OPTIONS,
             };
-            client = await GlideClient.createClient(c);
+
+            client = await GlideClient.createClient(config);
 
             const result = await client.ping();
             expect(result.toString()).toBe("PONG");

--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
+import { afterAll, afterEach, beforeAll, describe } from "@jest/globals";
+import { ValkeyCluster } from "../../utils/TestUtils.js";
+import { GlideClusterClient, ProtocolVersion } from "../build-ts";
+import {
+    flushAndCloseClient,
+    getClientConfigurationOption,
+    getServerVersion,
+} from "./TestUtilities";
+const TIMEOUT = 50000;
+
+// tls cluster tests
+describe("tls GlideClusterClient", () => {
+    let cluster: ValkeyCluster;
+    let client: GlideClusterClient;
+
+    beforeAll(async () => {
+        cluster = await ValkeyCluster.createCluster(
+            true,
+            3,
+            2,
+            getServerVersion,
+            true,
+            {
+                advancedConfiguration: {
+                    tlsAdvancedConfiguration: {
+                        insecure: true,
+                    },
+                },
+                useTLS: true,
+            },
+        );
+    }, 40000);
+
+    afterEach(async () => {
+        await flushAndCloseClient(true, cluster.getAddresses(), client, {
+            advancedConfiguration: {
+                tlsAdvancedConfiguration: {
+                    insecure: true,
+                },
+            },
+            useTLS: true,
+        });
+    });
+
+    afterAll(async () => {
+        if (cluster) {
+            await cluster.close();
+        }
+    });
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "clusterClient connect with insecure TLS (protocol: %p)",
+        async (protocol) => {
+            const config = getClientConfigurationOption(
+                cluster.getAddresses(),
+                protocol,
+                { useTLS: true },
+            );
+            const c = {
+                advancedConfiguration: {
+                    tlsAdvancedConfiguration: {
+                        insecure: true,
+                    },
+                },
+                ...config,
+            };
+            client = await GlideClusterClient.createClient(c);
+
+            const result = await client.ping();
+            expect(result.toString()).toBe("PONG");
+        },
+        TIMEOUT,
+    );
+});
+
+// // tls cluster tests
+// describe("tls GlideClient", () => {
+//     let cluster: ValkeyCluster;
+//     let client: GlideClient;
+
+//     beforeAll(async () => {
+//         cluster = await ValkeyCluster.createCluster(
+//             false,
+//             1,
+//             2,
+//             getServerVersion,
+//             true,
+//             {
+//                 advancedConfiguration: {
+//                     tlsAdvancedConfiguration: {
+//                         insecure: true,
+//                     },
+//                 },
+//                 useTLS: true,
+//             },
+//         );
+//     }, 40000);
+
+//     afterEach(async () => {
+//         await flushAndCloseClient(true, cluster.getAddresses(), client, {
+//             advancedConfiguration: {
+//                 tlsAdvancedConfiguration: {
+//                     insecure: true,
+//                 },
+//             },
+//             useTLS: true,
+//         });
+//     });
+
+//     afterAll(async () => {
+//         if (cluster) {
+//             await cluster.close();
+//         }
+//     });
+
+//     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+//         "Standalone client connect with insecure TLS (protocol: %p)",
+//         async (protocol) => {
+//             const config = getClientConfigurationOption(
+//                 cluster.getAddresses(),
+//                 protocol,
+//                 { useTLS: true },
+//             );
+//             const c = {
+//                 advancedConfiguration: {
+//                     tlsAdvancedConfiguration: {
+//                         insecure: true,
+//                     },
+//                 },
+//                 ...config,
+//             };
+//             client = await GlideClient.createClient(c);
+
+//             const result = await client.ping();
+//             expect(result.toString()).toBe("PONG");
+//         },
+//         TIMEOUT,
+//     );
+// });
+
+// // tls standalone tests
+// describe(`tls GlideClient %p`, () => {
+//     const testsFailed = 0;
+//     let cluster: ValkeyCluster;
+//     let client: GlideClient;
+
+//     beforeAll(async () => {
+
+//         const valkeyTlsStandalone = await ValkeyCluster.createCluster(false, 1, 2, getServerVersion, true);
+//     }, 40000);
+
+//     afterEach(async () => {
+//         await flushAndCloseClient(true, cluster.getAddresses(), client);
+//     });
+
+//     afterAll(async () => {
+//         if (testsFailed === 0) {
+//             await cluster.close();
+//         } else {
+//             await cluster.close(true);
+//         }
+//     });
+
+//     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+//         `GlideClient connect with insecure TLS (protocol: %p)"`,
+//         async (protocol) => {
+//             client = await GlideClient.createClient(
+//                 getClientConfigurationOption(cluster.getAddresses(), protocol),
+//             );
+
+//         }, TIMEOUT,
+//     );
+
+// });

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -11,7 +11,7 @@
         "esModuleInterop": true,
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
-        "allowJs": true,
+        "allowJs": false,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
@@ -29,5 +29,5 @@
         "esm": true
     },
     "include": ["src/**/*", "src/index.ts", "types/**/*.d.ts"],
-    "exclude": ["node_modules", "build-ts", "tests", "tests/**/*"]
+    "exclude": ["node_modules", "build-ts/**/*", "tests", "tests/**/*"]
 }

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -11,7 +11,7 @@
         "esModuleInterop": true,
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
-        "allowJs": false,
+        "allowJs": true,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
@@ -29,5 +29,11 @@
         "esm": true
     },
     "include": ["src/**/*", "src/index.ts", "types/**/*.d.ts"],
-    "exclude": ["node_modules", "build-ts/**/*", "tests", "tests/**/*"]
+    "exclude": [
+        "node_modules",
+        "build-ts",
+        "build-ts/**/*",
+        "tests",
+        "tests/**/*"
+    ]
 }

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -41,7 +41,7 @@ function parseOutput(input: string): {
 
 export type TestTLSConfig = {useTLS: boolean; advancedConfiguration?: {
                     tlsAdvancedConfiguration?: {
-                        insecure: boolean,
+                        insecure?: boolean,
                     },
                 },};
 

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -4,6 +4,10 @@
 
 import { execFile } from "child_process";
 import { lt } from "semver";
+import {
+    GlideClientConfiguration,
+    GlideClusterClientConfiguration,
+} from "../node/build-ts";
 
 const PY_SCRIPT_PATH = __dirname + "/cluster_manager.py";
 
@@ -35,6 +39,12 @@ function parseOutput(input: string): {
     };
 }
 
+export type TestTLSConfig = {useTLS: boolean; advancedConfiguration?: {
+                    tlsAdvancedConfiguration?: {
+                        insecure: boolean,
+                    },
+                },};
+
 export class ValkeyCluster {
     private addresses: [string, number][];
     private clusterFolder: string | undefined;
@@ -57,12 +67,21 @@ export class ValkeyCluster {
         getVersionCallback: (
             addresses: [string, number][],
             clusterMode: boolean,
+            tlsConfig?: TestTLSConfig,
         ) => Promise<string>,
+        tls: boolean = false,
+        tlsConfig?: TestTLSConfig,
         loadModule?: string[],
     ): Promise<ValkeyCluster> {
         return new Promise<ValkeyCluster>((resolve, reject) => {
-            let command = `start -r ${replicaCount} -n ${shardCount}`;
+            let command = ``;
 
+            if (tls) {
+                command += "--tls ";
+            }
+
+            command += `start -r ${replicaCount} -n ${shardCount}`;
+            
             if (cluster_mode) {
                 command += " --cluster-mode";
             }
@@ -89,7 +108,7 @@ export class ValkeyCluster {
                         const { clusterFolder, addresses } =
                             parseOutput(stdout);
                         resolve(
-                            getVersionCallback(addresses, cluster_mode).then(
+                            getVersionCallback(addresses, cluster_mode, tlsConfig).then(
                                 (ver) =>
                                     new ValkeyCluster(
                                         ver,


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue https://github.com/valkey-io/valkey-glide/issues/3376

Expose TlsMode::Insecure client option for the node wrapper using advanced config.

TLS state defaults to secured. When using this option, the client will bypass certificate verification, allowing connections to Valkey/Redis instances with self-signed or otherwise unauthorized certificates. This option is intended for local development or testing environments where a valid certificate may not be available. It is not recommended for production use, as disabling certificate validation exposes the connection to potential security risks such as man-in-the-middle attacks.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
