### PR TITLE
Go: Refactor integration tests to use require assertions

### DIFF
--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
@@ -1468,7 +1469,7 @@ func (suite *GlideTestSuite) TestRandomKeyWithRoute() {
 }
 
 func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 	t := suite.T()
@@ -1625,7 +1626,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 }
 
 func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 	t := suite.T()
@@ -1686,7 +1687,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
 }
 
 func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 	t := suite.T()
@@ -1752,7 +1753,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 }
 
 func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 	t := suite.T()
@@ -1883,7 +1884,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 }
 
 func (suite *GlideTestSuite) TestFunctionKilWithoutRoute() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 
@@ -1899,7 +1900,7 @@ func (suite *GlideTestSuite) TestFunctionKilWithoutRoute() {
 }
 
 func (suite *GlideTestSuite) TestFunctionKillWithRoute() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 
@@ -1935,7 +1936,7 @@ func (suite *GlideTestSuite) TestLongTimeoutFunctionKillNoWriteWithRoute() {
 }
 
 func (suite *GlideTestSuite) testFunctionKillNoWrite(withRoute bool) {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 	libName := "functionKill_no_write"
@@ -1978,7 +1979,8 @@ func (suite *GlideTestSuite) testFunctionKillNoWrite(withRoute bool) {
 	assert.Equal(suite.T(), libName, result)
 
 	testConfig := suite.defaultClusterClientConfig().WithRequestTimeout(10 * time.Second)
-	testClient := suite.clusterClient(testConfig)
+	testClient, err := suite.clusterClient(testConfig)
+	require.NoError(suite.T(), err)
 	defer testClient.Close()
 
 	// Channel to signal when function is killed
@@ -2051,7 +2053,7 @@ func (suite *GlideTestSuite) TestLongTimeoutFunctionKillKeyBasedWriteFunction() 
 		suite.T().Skip("Timeout tests are disabled")
 	}
 
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClusterClient()
 	libName := "functionKill_key_based_write_function"
@@ -2080,7 +2082,8 @@ func (suite *GlideTestSuite) TestLongTimeoutFunctionKillKeyBasedWriteFunction() 
 	assert.Equal(suite.T(), libName, result)
 
 	testConfig := suite.defaultClusterClientConfig().WithRequestTimeout(10 * time.Second)
-	testClient := suite.clusterClient(testConfig)
+	testClient, err := suite.clusterClient(testConfig)
+	require.NoError(suite.T(), err)
 	defer testClient.Close()
 
 	// Channel to signal when unkillable error is found
@@ -2121,7 +2124,7 @@ func (suite *GlideTestSuite) TestLongTimeoutFunctionKillKeyBasedWriteFunction() 
 func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 	client := suite.defaultClusterClient()
 
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	// Flush all functions first
 	suite.verifyOK(client.FunctionFlushSync(context.Background()))
@@ -2415,11 +2418,12 @@ func (suite *GlideTestSuite) TestScriptFlushClusterClient() {
 }
 
 func (suite *GlideTestSuite) TestScriptKillWithoutRoute() {
-	invokeClient := suite.clusterClient(suite.defaultClusterClientConfig())
+	invokeClient, err := suite.clusterClient(suite.defaultClusterClientConfig())
+	require.NoError(suite.T(), err)
 	killClient := suite.defaultClusterClient()
 
 	// Ensure no script is running at the beginning
-	_, err := killClient.ScriptKill(context.Background())
+	_, err = killClient.ScriptKill(context.Background())
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 
@@ -2447,7 +2451,8 @@ func (suite *GlideTestSuite) TestScriptKillWithoutRoute() {
 func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 	suite.T().Skip("Flaky Test: Wait until #2277 is resolved")
 
-	invokeClient := suite.clusterClient(suite.defaultClusterClientConfig())
+	invokeClient, err := suite.clusterClient(suite.defaultClusterClientConfig())
+	require.NoError(suite.T(), err)
 	killClient := suite.defaultClusterClient()
 
 	// key for routing to a primary node
@@ -2457,7 +2462,7 @@ func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 	}
 
 	// Ensure no script is running at the beginning
-	_, err := killClient.ScriptKillWithRoute(context.Background(), route)
+	_, err = killClient.ScriptKillWithRoute(context.Background(), route)
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 
@@ -2484,11 +2489,12 @@ func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 
 func (suite *GlideTestSuite) TestScriptKillUnkillableWithoutRoute() {
 	key := uuid.NewString()
-	invokeClient := suite.clusterClient(suite.defaultClusterClientConfig())
+	invokeClient, err := suite.clusterClient(suite.defaultClusterClientConfig())
+	require.NoError(suite.T(), err)
 	killClient := suite.defaultClusterClient()
 
 	// Ensure no script is running at the beginning
-	_, err := killClient.ScriptKill(context.Background())
+	_, err = killClient.ScriptKill(context.Background())
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 
@@ -2517,7 +2523,8 @@ func (suite *GlideTestSuite) TestScriptKillUnkillableWithRoute() {
 	suite.T().Skip("Flaky Test: Wait until #2277 is resolved")
 
 	key := uuid.NewString()
-	invokeClient := suite.clusterClient(suite.defaultClusterClientConfig())
+	invokeClient, err := suite.clusterClient(suite.defaultClusterClientConfig())
+	require.NoError(suite.T(), err)
 	killClient := suite.defaultClusterClient()
 
 	// key for routing to a primary node
@@ -2526,7 +2533,7 @@ func (suite *GlideTestSuite) TestScriptKillUnkillableWithRoute() {
 	}
 
 	// Ensure no script is running at the beginning
-	_, err := killClient.ScriptKillWithRoute(context.Background(), route)
+	_, err = killClient.ScriptKillWithRoute(context.Background(), route)
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
@@ -333,17 +334,22 @@ func (suite *GlideTestSuite) defaultClientConfig() *config.ClientConfiguration {
 
 func (suite *GlideTestSuite) defaultClient() *glide.Client {
 	config := suite.defaultClientConfig()
-	return suite.client(config)
+	client, err := suite.client(config)
+	require.NoError(suite.T(), err)
+	return client
 }
 
-func (suite *GlideTestSuite) client(config *config.ClientConfiguration) *glide.Client {
+func (suite *GlideTestSuite) client(config *config.ClientConfiguration) (*glide.Client, error) {
 	client, err := glide.NewClient(config)
-
-	assert.Nil(suite.T(), err)
-	assert.NotNil(suite.T(), client)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, fmt.Errorf("client is nil")
+	}
 
 	suite.clients = append(suite.clients, client)
-	return client
+	return client, nil
 }
 
 func (suite *GlideTestSuite) defaultClusterClientConfig() *config.ClusterClientConfiguration {
@@ -355,17 +361,22 @@ func (suite *GlideTestSuite) defaultClusterClientConfig() *config.ClusterClientC
 
 func (suite *GlideTestSuite) defaultClusterClient() *glide.ClusterClient {
 	config := suite.defaultClusterClientConfig()
-	return suite.clusterClient(config)
+	client, err := suite.clusterClient(config)
+	require.NoError(suite.T(), err)
+	return client
 }
 
-func (suite *GlideTestSuite) clusterClient(config *config.ClusterClientConfiguration) *glide.ClusterClient {
+func (suite *GlideTestSuite) clusterClient(config *config.ClusterClientConfiguration) (*glide.ClusterClient, error) {
 	client, err := glide.NewClusterClient(config)
-
-	assert.Nil(suite.T(), err)
-	assert.NotNil(suite.T(), client)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, fmt.Errorf("cluster client is nil")
+	}
 
 	suite.clusterClients = append(suite.clusterClients, client)
-	return client
+	return client, nil
 }
 
 func (suite *GlideTestSuite) createConnectionTimeoutClient(
@@ -437,7 +448,7 @@ func (suite *GlideTestSuite) verifyOK(result string, err error) {
 	assert.Equal(suite.T(), glide.OK, result)
 }
 
-func (suite *GlideTestSuite) SkipIfServerVersionLowerThanBy(version string, t *testing.T) {
+func (suite *GlideTestSuite) SkipIfServerVersionLowerThan(version string, t *testing.T) {
 	if suite.serverVersion < version {
 		t.Skipf("This feature is added in version %s", version)
 	}
@@ -485,18 +496,47 @@ func (suite *GlideTestSuite) createAnyClient(clientType ClientType, subscription
 	}
 }
 
+func (suite *GlideTestSuite) createAnyClientWithTesting(clientType ClientType, subscription any) (interfaces.BaseClientCommands, error) {
+	switch clientType {
+	case StandaloneClient:
+		if sub, ok := subscription.(*config.StandaloneSubscriptionConfig); ok {
+			clientConfig := suite.defaultClientConfig().WithSubscriptionConfig(sub)
+			return suite.client(clientConfig)
+		} else {
+			return suite.client(suite.defaultClientConfig())
+		}
+	case ClusterClient:
+		if sub, ok := subscription.(*config.ClusterSubscriptionConfig); ok {
+			clientConfig := suite.defaultClusterClientConfig().WithSubscriptionConfig(sub)
+			return suite.clusterClient(clientConfig)
+		} else {
+			return suite.clusterClient(suite.defaultClusterClientConfig())
+		}
+	default:
+		return nil, fmt.Errorf("unsupported client type")
+	}
+}
+
 func (suite *GlideTestSuite) createStandaloneClientWithSubscriptions(
 	config *config.StandaloneSubscriptionConfig,
 ) *glide.Client {
 	clientConfig := suite.defaultClientConfig().WithSubscriptionConfig(config)
-	return suite.client(clientConfig)
+	client, err := suite.client(clientConfig)
+	if err != nil {
+		suite.T().Fatalf("Failed to create standalone client with subscriptions: %v", err)
+	}
+	return client
 }
 
 func (suite *GlideTestSuite) createClusterClientWithSubscriptions(
 	config *config.ClusterSubscriptionConfig,
 ) *glide.ClusterClient {
 	clientConfig := suite.defaultClusterClientConfig().WithSubscriptionConfig(config)
-	return suite.clusterClient(clientConfig)
+	client, err := suite.clusterClient(clientConfig)
+	if err != nil {
+		suite.T().Fatalf("Failed to create cluster client with subscriptions: %v", err)
+	}
+	return client
 }
 
 type TestChannelMode int
@@ -660,6 +700,7 @@ func (suite *GlideTestSuite) verifyPubsubMessages(
 //   - channels: A slice of ChannelDefn objects defining the channels to subscribe to
 //   - clientId: A unique identifier for this subscriber
 //   - withCallback: Whether to use callback-based message handling
+//   - t: The testing.T instance for proper error handling in subtests
 //
 // Returns:
 //   - The created client with the specified subscription configuration
@@ -668,6 +709,7 @@ func (suite *GlideTestSuite) CreatePubSubReceiver(
 	channels []ChannelDefn,
 	clientId int,
 	withCallback bool,
+	t *testing.T,
 ) interfaces.BaseClientCommands {
 	callback := func(message *models.PubSubMessage, context any) {
 		callbackCtx.Store(fmt.Sprintf("%d-%s", clientId, message.Channel), message)
@@ -675,7 +717,7 @@ func (suite *GlideTestSuite) CreatePubSubReceiver(
 	switch clientType {
 	case StandaloneClient:
 		if channels[0].Mode == ShardedMode {
-			assert.Fail(suite.T(), "Sharded mode is not supported for standalone client")
+			t.Fatalf("Sharded mode is not supported for standalone client")
 			return nil
 		}
 
@@ -687,7 +729,9 @@ func (suite *GlideTestSuite) CreatePubSubReceiver(
 		if withCallback {
 			sConfig = sConfig.WithCallback(callback, &callbackCtx)
 		}
-		return suite.createAnyClient(StandaloneClient, sConfig)
+		client, err := suite.createAnyClientWithTesting(StandaloneClient, sConfig)
+		require.NoError(t, err)
+		return client
 	case ClusterClient:
 		cConfig := config.NewClusterSubscriptionConfig()
 		for _, channel := range channels {
@@ -697,9 +741,11 @@ func (suite *GlideTestSuite) CreatePubSubReceiver(
 		if withCallback {
 			cConfig = cConfig.WithCallback(callback, &callbackCtx)
 		}
-		return suite.createAnyClient(ClusterClient, cConfig)
+		client, err := suite.createAnyClientWithTesting(ClusterClient, cConfig)
+		require.NoError(t, err)
+		return client
 	default:
-		assert.Fail(suite.T(), "Unsupported client type")
+		t.Fatalf("Unsupported client type")
 		return nil
 	}
 }

--- a/go/integTest/pubsub_basic_test.go
+++ b/go/integTest/pubsub_basic_test.go
@@ -139,7 +139,7 @@ func (suite *GlideTestSuite) TestPubSub_Basic_ChannelSubscription() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			if tt.sharded {
-				suite.SkipIfServerVersionLowerThanBy("7.0.0", t)
+				suite.SkipIfServerVersionLowerThan("7.0.0", t)
 			}
 			publisher := suite.createAnyClient(tt.clientType, nil)
 
@@ -153,12 +153,12 @@ func (suite *GlideTestSuite) TestPubSub_Basic_ChannelSubscription() {
 			var receiver interfaces.BaseClientCommands
 			queues := make(map[int]*glide.PubSubMessageQueue)
 			if !tt.useCallback {
-				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false)
+				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false, t)
 				queue, err := receiver.(PubSubQueuer).GetQueue()
 				assert.Nil(t, err)
 				queues[1] = queue
 			} else {
-				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true)
+				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true, t)
 			}
 
 			// Allow subscription to establish
@@ -314,7 +314,7 @@ func (suite *GlideTestSuite) TestPubSub_Basic_MultipleSubscribers() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			if tt.sharded {
-				suite.SkipIfServerVersionLowerThanBy("7.0.0", t)
+				suite.SkipIfServerVersionLowerThan("7.0.0", t)
 			}
 			publisher := suite.createAnyClient(tt.clientType, nil)
 
@@ -332,13 +332,13 @@ func (suite *GlideTestSuite) TestPubSub_Basic_MultipleSubscribers() {
 
 			for i := 0; i < numSubscribers; i++ {
 				if !tt.useCallback {
-					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, false)
+					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, false, t)
 					subscribers[i] = receiver
 					queue, err := receiver.(PubSubQueuer).GetQueue()
 					assert.Nil(t, err)
 					queues[i+1] = queue
 				} else {
-					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, true)
+					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, true, t)
 					subscribers[i] = receiver
 				}
 			}
@@ -470,12 +470,12 @@ func (suite *GlideTestSuite) TestPubSub_Basic_PatternSubscription() {
 			var receiver interfaces.BaseClientCommands
 			queues := make(map[int]*glide.PubSubMessageQueue)
 			if !tt.useCallback {
-				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false)
+				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false, t)
 				queue, err := receiver.(PubSubQueuer).GetQueue()
 				assert.Nil(t, err)
 				queues[1] = queue
 			} else {
-				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true)
+				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true, t)
 			}
 
 			// Allow subscription to establish
@@ -647,7 +647,7 @@ func (suite *GlideTestSuite) TestPubSub_Basic_ManyChannels() {
 	for _, tt := range tests {
 		suite.T().Run(tt.name, func(t *testing.T) {
 			if tt.sharded {
-				suite.SkipIfServerVersionLowerThanBy("7.0.0", t)
+				suite.SkipIfServerVersionLowerThan("7.0.0", t)
 			}
 			publisher := suite.createAnyClient(tt.clientType, nil)
 
@@ -666,12 +666,12 @@ func (suite *GlideTestSuite) TestPubSub_Basic_ManyChannels() {
 			var receiver interfaces.BaseClientCommands
 			queues := make(map[int]*glide.PubSubMessageQueue)
 			if !tt.useCallback {
-				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false)
+				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false, t)
 				queue, err := receiver.(PubSubQueuer).GetQueue()
 				assert.Nil(t, err)
 				queues[1] = queue
 			} else {
-				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true)
+				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true, t)
 			}
 
 			// Allow subscription to establish
@@ -805,12 +805,12 @@ func (suite *GlideTestSuite) TestPubSub_Basic_PatternManyChannels() {
 			var receiver interfaces.BaseClientCommands
 			queues := make(map[int]*glide.PubSubMessageQueue)
 			if !tt.useCallback {
-				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false)
+				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false, t)
 				queue, err := receiver.(PubSubQueuer).GetQueue()
 				assert.Nil(t, err)
 				queues[1] = queue
 			} else {
-				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true)
+				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true, t)
 			}
 
 			// Allow subscription to establish
@@ -970,12 +970,12 @@ func (suite *GlideTestSuite) TestPubSub_Basic_CombinedExactPattern() {
 			var receiver interfaces.BaseClientCommands
 			queues := make(map[int]*glide.PubSubMessageQueue)
 			if !tt.useCallback {
-				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false)
+				receiver = suite.CreatePubSubReceiver(tt.clientType, channels, 1, false, t)
 				queue, err := receiver.(PubSubQueuer).GetQueue()
 				assert.Nil(t, err)
 				queues[1] = queue
 			} else {
-				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true)
+				suite.CreatePubSubReceiver(tt.clientType, channels, 1, true, t)
 			}
 
 			// Allow subscription to establish
@@ -1153,13 +1153,13 @@ func (suite *GlideTestSuite) TestPubSub_Basic_CombinedExactPatternMultipleSubscr
 
 			for i := 0; i < numSubscribers; i++ {
 				if !tt.useCallback {
-					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, false)
+					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, false, t)
 					subscribers[i] = receiver
 					queue, err := receiver.(PubSubQueuer).GetQueue()
 					assert.Nil(t, err)
 					queues[i+1] = queue
 				} else {
-					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, true)
+					receiver := suite.CreatePubSubReceiver(tt.clientType, channels, i+1, true, t)
 					subscribers[i] = receiver
 				}
 			}

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
@@ -183,7 +184,7 @@ func (suite *GlideTestSuite) TestSetWithOptions_UpdateExistingExpiry() {
 }
 
 func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfEquals() {
-	suite.SkipIfServerVersionLowerThanBy("8.1.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("8.1.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, initialValue))
@@ -581,7 +582,7 @@ func (suite *GlideTestSuite) TestAppend_existingAndNonExistingKeys() {
 }
 
 func (suite *GlideTestSuite) TestLCS_existingAndNonExistingKeys() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}" + uuid.New().String()
@@ -601,7 +602,7 @@ func (suite *GlideTestSuite) TestLCS_existingAndNonExistingKeys() {
 }
 
 func (suite *GlideTestSuite) TestLCSLen_existingAndNonExistingKeys() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}" + uuid.New().String()
@@ -621,7 +622,7 @@ func (suite *GlideTestSuite) TestLCSLen_existingAndNonExistingKeys() {
 }
 
 func (suite *GlideTestSuite) TestLCS_BasicIDXOption() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		_, err := client.Set(context.Background(), "{lcs}key1", "ohmytext")
@@ -656,7 +657,7 @@ func (suite *GlideTestSuite) TestLCS_BasicIDXOption() {
 }
 
 func (suite *GlideTestSuite) TestLCS_MinMatchLengthOption() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		_, err := client.Set(context.Background(), "{lcs}key1", "ohmytext")
@@ -688,7 +689,7 @@ func (suite *GlideTestSuite) TestLCS_MinMatchLengthOption() {
 }
 
 func (suite *GlideTestSuite) TestLCS_WithMatchLengthOption() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		_, err := client.Set(context.Background(), "{lcs}key1", "ohmytext")
@@ -1406,7 +1407,7 @@ func (suite *GlideTestSuite) TestHScan() {
 }
 
 func (suite *GlideTestSuite) TestHRandField() {
-	suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.NewString()
 
@@ -2173,7 +2174,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 }
 
 func (suite *GlideTestSuite) TestSInterCard() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-1-" + uuid.NewString()
@@ -2198,7 +2199,7 @@ func (suite *GlideTestSuite) TestSInterCard() {
 }
 
 func (suite *GlideTestSuite) TestSInterCardLimit() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-1-" + uuid.NewString()
@@ -3463,7 +3464,7 @@ func (suite *GlideTestSuite) TestExpire_KeyDoesNotExist() {
 }
 
 func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3487,7 +3488,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
 }
 
 func (suite *GlideTestSuite) TestExpireWithOptions_HasExistingExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3512,7 +3513,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasExistingExpiry() {
 }
 
 func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryGreaterThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3533,7 +3534,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryGreaterThanCurrent()
 }
 
 func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryLessThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3562,7 +3563,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryLessThanCurrent() {
 }
 
 func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3588,7 +3589,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 }
 
 func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3611,7 +3612,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 }
 
 func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3635,7 +3636,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent
 }
 
 func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3684,7 +3685,7 @@ func (suite *GlideTestSuite) TestPExpire() {
 }
 
 func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3715,7 +3716,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 }
 
 func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3741,7 +3742,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
 }
 
 func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3772,7 +3773,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 }
 
 func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3823,7 +3824,7 @@ func (suite *GlideTestSuite) TestPExpireAt() {
 }
 
 func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasNoExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3844,7 +3845,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasNoExpiry() {
 }
 
 func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3873,7 +3874,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
 }
 
 func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3904,7 +3905,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurren
 }
 
 func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3936,7 +3937,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent()
 }
 
 func (suite *GlideTestSuite) TestExpireTime() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -3965,7 +3966,7 @@ func (suite *GlideTestSuite) TestExpireTime() {
 }
 
 func (suite *GlideTestSuite) TestExpireTime_KeyDoesNotExist() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 
@@ -3977,7 +3978,7 @@ func (suite *GlideTestSuite) TestExpireTime_KeyDoesNotExist() {
 }
 
 func (suite *GlideTestSuite) TestPExpireTime() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := uuid.New().String()
@@ -4033,7 +4034,7 @@ func (suite *GlideTestSuite) Test_ZCard() {
 }
 
 func (suite *GlideTestSuite) TestPExpireTime_KeyDoesNotExist() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 
@@ -4401,7 +4402,7 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_Limit() {
 }
 
 func (suite *GlideTestSuite) TestSortReadOnly_SuccessfulSort() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		client.LPush(context.Background(), key, []string{"3", "1", "2"})
@@ -4421,7 +4422,7 @@ func (suite *GlideTestSuite) TestSortReadOnly_SuccessfulSort() {
 }
 
 func (suite *GlideTestSuite) TestSortReadyOnlyWithOptions_DescendingOrder() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		client.LPush(context.Background(), key, []string{"b", "a", "c"})
@@ -5012,13 +5013,15 @@ func (suite *GlideTestSuite) TestXRead() {
 		// ensure that commands doesn't time out even if timeout > request timeout
 		var testClient interfaces.BaseClientCommands
 		if _, ok := client.(interfaces.GlideClientCommands); ok {
-			testClient = suite.client(config.NewClientConfiguration().
+			testClient, err = suite.client(config.NewClientConfiguration().
 				WithAddress(&suite.standaloneHosts[0]).
 				WithUseTLS(suite.tls))
+			require.NoError(suite.T(), err)
 		} else {
-			testClient = suite.clusterClient(config.NewClusterClientConfiguration().
+			testClient, err = suite.clusterClient(config.NewClusterClientConfiguration().
 				WithAddress(&suite.clusterHosts[0]).
 				WithUseTLS(suite.tls))
+			require.NoError(suite.T(), err)
 		}
 		read, err = testClient.XReadWithOptions(context.Background(),
 			map[string]string{key1: "0-1"},
@@ -7144,7 +7147,7 @@ func (suite *GlideTestSuite) TestZRemRangeByScore() {
 }
 
 func (suite *GlideTestSuite) TestZMScore() {
-	suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.NewString()
 
@@ -7324,7 +7327,7 @@ func (suite *GlideTestSuite) TestObjectFreq() {
 }
 
 func (suite *GlideTestSuite) TestSortWithOptions_ExternalWeights() {
-	suite.SkipIfServerVersionLowerThanBy("8.1.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("8.1.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := "{key}-1"
 		client.LPush(context.Background(), key, []string{"item1", "item2", "item3"})
@@ -7352,7 +7355,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_ExternalWeights() {
 }
 
 func (suite *GlideTestSuite) TestSortWithOptions_GetPatterns() {
-	suite.SkipIfServerVersionLowerThanBy("8.1.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("8.1.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := "{key}-1"
 		client.LPush(context.Background(), key, []string{"item1", "item2", "item3"})
@@ -7382,7 +7385,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_GetPatterns() {
 }
 
 func (suite *GlideTestSuite) TestSortWithOptions_SuccessfulSortByWeightAndGet() {
-	suite.SkipIfServerVersionLowerThanBy("8.1.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("8.1.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := "{key}-1"
 		client.LPush(context.Background(), key, []string{"item1", "item2", "item3"})
@@ -7436,7 +7439,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_SuccessfulSortByWeightAndGet() 
 }
 
 func (suite *GlideTestSuite) TestSortStoreWithOptions_ByPattern() {
-	suite.SkipIfServerVersionLowerThanBy("8.1.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("8.1.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := "{listKey}" + uuid.New().String()
 		sortedKey := "{listKey}" + uuid.New().String()
@@ -8071,7 +8074,7 @@ func (suite *GlideTestSuite) TestBitCountWithOptions_StartEnd() {
 }
 
 func (suite *GlideTestSuite) TestBitCountWithOptions_StartEndByte() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := "TestBitCountWithOptions_StartEnd"
@@ -8090,7 +8093,7 @@ func (suite *GlideTestSuite) TestBitCountWithOptions_StartEndByte() {
 }
 
 func (suite *GlideTestSuite) TestBitCountWithOptions_StartEndBit() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		value := "TestBitCountWithOptions_StartEnd"
@@ -8952,7 +8955,7 @@ func (suite *GlideTestSuite) TestBitPosWithOptions_StartEnd() {
 }
 
 func (suite *GlideTestSuite) TestBitPosWithOptions_BitmapIndexType() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		client.Set(context.Background(), key, "\x00\x02\x00")
@@ -8969,7 +8972,7 @@ func (suite *GlideTestSuite) TestBitPosWithOptions_BitmapIndexType() {
 }
 
 func (suite *GlideTestSuite) TestBitPosWithOptions_BitIndexType() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		client.Set(context.Background(), key, "\x00\x10\x00")
@@ -9100,7 +9103,7 @@ func (suite *GlideTestSuite) TestBitFieldRO_MultipleGets() {
 }
 
 func (suite *GlideTestSuite) TestZInter() {
-	suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-" + uuid.New().String()
 		key2 := "{key}-" + uuid.New().String()
@@ -9347,7 +9350,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 
 func (suite *GlideTestSuite) TestZDiff() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
-		suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+		suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 		t := suite.T()
 		key1 := "{testKey}:1-" + uuid.NewString()
 		key2 := "{testKey}:2-" + uuid.NewString()
@@ -9421,7 +9424,7 @@ func (suite *GlideTestSuite) TestZDiff() {
 
 func (suite *GlideTestSuite) TestZDiffStore() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
-		suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+		suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 		t := suite.T()
 		key1 := "{testKey}:1-" + uuid.NewString()
 		key2 := "{testKey}:2-" + uuid.NewString()
@@ -9500,7 +9503,7 @@ func (suite *GlideTestSuite) TestZDiffStore() {
 }
 
 func (suite *GlideTestSuite) TestZUnionAndZUnionWithScores() {
-	suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-" + uuid.New().String()
 		key2 := "{key}-" + uuid.New().String()
@@ -9630,7 +9633,7 @@ func (suite *GlideTestSuite) TestZUnionAndZUnionWithScores() {
 }
 
 func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
-	suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-" + uuid.New().String()
 		key2 := "{key}-" + uuid.New().String()
@@ -9792,7 +9795,7 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 }
 
 func (suite *GlideTestSuite) TestZInterCard() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}:1-" + uuid.NewString()
 		key2 := "{key}:2-" + uuid.NewString()
@@ -9865,7 +9868,7 @@ func (suite *GlideTestSuite) TestZInterCard() {
 
 func (suite *GlideTestSuite) TestZLexCount() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
-		suite.SkipIfServerVersionLowerThanBy("6.2.0", suite.T())
+		suite.SkipIfServerVersionLowerThan("6.2.0", suite.T())
 		t := suite.T()
 		key1 := "{testKey}:1-" + uuid.New().String()
 		key2 := "{testKey}:3-" + uuid.New().String()
@@ -10659,7 +10662,7 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 }
 
 func (suite *GlideTestSuite) TestBZPopMax() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-1" + uuid.NewString()
@@ -10685,7 +10688,7 @@ func (suite *GlideTestSuite) TestBZPopMax() {
 }
 
 func (suite *GlideTestSuite) TestZMPop() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-1" + uuid.NewString()
@@ -10744,7 +10747,7 @@ func (suite *GlideTestSuite) TestZMPop() {
 }
 
 func (suite *GlideTestSuite) TestZMPopWithOptions() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := "{key}-1" + uuid.NewString()
@@ -10909,7 +10912,7 @@ func (suite *GlideTestSuite) TestScriptFlush() {
 }
 
 func (suite *GlideTestSuite) TestScriptShow() {
-	suite.SkipIfServerVersionLowerThanBy("8.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("8.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		// Create a unique script code
@@ -10940,7 +10943,7 @@ func (suite *GlideTestSuite) TestScriptShow() {
 }
 
 func (suite *GlideTestSuite) TestRegisterClientNameAndVersion() {
-	suite.SkipIfServerVersionLowerThanBy("7.2.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.2.0", suite.T())
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		result := sendWithCustomCommand(
 			suite,

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (suite *GlideTestSuite) TestCustomCommandInfo() {
@@ -44,7 +45,8 @@ func (suite *GlideTestSuite) TestCustomCommandClientInfo() {
 	config := config.NewClientConfiguration().
 		WithAddress(&suite.standaloneHosts[0]).
 		WithClientName(clientName)
-	client := suite.client(config)
+	client, err := suite.client(config)
+	require.NoError(suite.T(), err)
 
 	result, err := client.CustomCommand(context.Background(), []string{"CLIENT", "INFO"})
 
@@ -103,7 +105,8 @@ func (suite *GlideTestSuite) TestCustomCommandMGet_ArrayResponse() {
 	config := config.NewClientConfiguration().
 		WithAddress(&suite.standaloneHosts[0]).
 		WithClientName(clientName)
-	client := suite.client(config)
+	client, err := suite.client(config)
+	require.NoError(suite.T(), err)
 
 	key1 := uuid.New().String()
 	key2 := uuid.New().String()
@@ -127,7 +130,7 @@ func (suite *GlideTestSuite) TestCustomCommandMGet_ArrayResponse() {
 func (suite *GlideTestSuite) TestCustomCommandConfigGet_MapResponse() {
 	client := suite.defaultClient()
 
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	configMap := map[string]string{"timeout": "1000", "maxmemory": "1GB"}
 	suite.verifyOK(client.ConfigSet(context.Background(), configMap))
@@ -183,7 +186,7 @@ func (suite *GlideTestSuite) TestCustomCommand_closedClient() {
 func (suite *GlideTestSuite) TestConfigSetAndGet_multipleArgs() {
 	client := suite.defaultClient()
 
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	configMap := map[string]string{"timeout": "1000", "maxmemory": "1GB"}
 	resultConfigMap := map[string]string{"timeout": "1000", "maxmemory": "1073741824"}
@@ -279,7 +282,7 @@ func (suite *GlideTestSuite) TestSelect_SwitchBetweenDatabases() {
 
 func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_ExternalWeights() {
 	client := suite.defaultClient()
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	key := uuid.New().String()
 	client.LPush(context.Background(), key, []string{"item1", "item2", "item3"})
@@ -306,7 +309,7 @@ func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_ExternalWeights() {
 
 func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_GetPatterns() {
 	client := suite.defaultClient()
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	key := uuid.New().String()
 	client.LPush(context.Background(), key, []string{"item1", "item2", "item3"})
@@ -336,7 +339,7 @@ func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_GetPatterns() {
 
 func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_SuccessfulSortByWeightAndGet() {
 	client := suite.defaultClient()
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	key := uuid.New().String()
 	client.LPush(context.Background(), key, []string{"item1", "item2", "item3"})
@@ -914,7 +917,7 @@ func (suite *GlideTestSuite) TestRandomKey() {
 }
 
 func (suite *GlideTestSuite) TestFunctionCommandsStandalone() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClient()
 
@@ -1000,7 +1003,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsStandalone() {
 }
 
 func (suite *GlideTestSuite) TestFunctionStats() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClient()
 
@@ -1068,7 +1071,7 @@ func (suite *GlideTestSuite) TestFunctionStats() {
 }
 
 func (suite *GlideTestSuite) TestFunctionKill() {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClient()
 
@@ -1084,7 +1087,7 @@ func (suite *GlideTestSuite) TestFunctionKill() {
 }
 
 func (suite *GlideTestSuite) testFunctionKill(readOnly bool) {
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	client := suite.defaultClient()
 	libName := "functionKill_no_write"
@@ -1108,7 +1111,8 @@ func (suite *GlideTestSuite) testFunctionKill(readOnly bool) {
 	assert.Equal(suite.T(), libName, result)
 
 	testConfig := suite.defaultClientConfig().WithRequestTimeout(10 * time.Second)
-	testClient := suite.client(testConfig)
+	testClient, err := suite.client(testConfig)
+	require.NoError(suite.T(), err)
 	defer testClient.Close()
 
 	// Channel to signal when function is killed
@@ -1173,7 +1177,7 @@ func (suite *GlideTestSuite) TestLongTimeoutFunctionKillWrite() {
 func (suite *GlideTestSuite) TestFunctionDumpAndRestore() {
 	client := suite.defaultClient()
 
-	suite.SkipIfServerVersionLowerThanBy("7.0.0", suite.T())
+	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	// Flush all functions first
 	suite.verifyOK(client.FunctionFlushSync(context.Background()))
@@ -1292,11 +1296,12 @@ func (suite *GlideTestSuite) TestScriptExists() {
 }
 
 func (suite *GlideTestSuite) TestScriptKill() {
-	invokeClient := suite.client(suite.defaultClientConfig())
+	invokeClient, err := suite.client(suite.defaultClientConfig())
+	require.NoError(suite.T(), err)
 	killClient := suite.defaultClient()
 
 	// Ensure no script is running at the beginning
-	_, err := killClient.ScriptKill(context.Background())
+	_, err = killClient.ScriptKill(context.Background())
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 


### PR DESCRIPTION
- Replaced assert statements with require statements in multiple test files for better error handling.
- Modified CreatePubSubReceiver calls to include the testing context.
- Ensured proper error handling when creating clients in standalone and routing tests.

These changes were needed to ensure that client creation errors would properly terminate an integration test to prevent panics in tests from trying to execute commands on a nil reference. Errors needed to be surfaced so that the proper testing context could be skipped in the case of Sub-tests, allowing other sub-tests to be executed.

### Issue link

This Pull Request is linked to issue (#3704):

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
