### PR TITLE
Go: Add Batch Generic Cluster Commands Tests

### DIFF
--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -492,7 +492,7 @@ func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic boo
 
 	// TODO: add Move in separate standalone batch tests
 
-	return BatchTestData{CommandTestData: testData, TestName: "Generic Cluster commands"}
+	return BatchTestData{CommandTestData: testData, TestName: "Generic commands"}
 }
 
 func CreateHashTest(batch *pipeline.ClusterBatch, isAtomic bool, serverVer string) BatchTestData {

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -476,7 +476,11 @@ func CreateGenericBaseTests(batch *pipeline.ClusterBatch, isAtomic bool, serverV
 
 func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic bool) BatchTestData {
 	testData := make([]CommandTestData, 0)
-	key := "{key}-1-" + uuid.NewString()
+	prefix := "{key}-"
+	if !isAtomic {
+		prefix = ""
+	}
+	key := prefix + "1-" + uuid.NewString()
 
 	// Start clean
 	batch.FlushAll()

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -218,7 +218,7 @@ func CreateBitmapTest(batch *pipeline.ClusterBatch, isAtomic bool, serverVer str
 	return BatchTestData{CommandTestData: testData, TestName: "BitMap commands"}
 }
 
-func CreateGenericBaseTests(batch *pipeline.ClusterBatch, isAtomic bool, serverVer string) BatchTestData {
+func CreateGenericCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serverVer string) BatchTestData {
 	testData := make([]CommandTestData, 0)
 	prefix := "{baseKey}-"
 	atomicPrefix := prefix
@@ -471,28 +471,17 @@ func CreateGenericBaseTests(batch *pipeline.ClusterBatch, isAtomic bool, serverV
 		CommandTestData{ExpectedResponse: "value1", TestName: "Get(slotHashedKey2) after CopyWithOptions"},
 	)
 
-	return BatchTestData{CommandTestData: testData, TestName: "Generic Base commands"}
-}
-
-func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serverVer string) BatchTestData {
-	testData := make([]CommandTestData, 0)
-	prefix := "{key}-"
-	if !isAtomic {
-		prefix = ""
-	}
-	key := prefix + "1-" + uuid.NewString()
-
-	// Start clean
+	// GenericClusterCommands
 	batch.FlushAll()
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "CustomCommand: FlushAll()"})
 
-	batch.CustomCommand([]string{"SET", key, "1"})
+	batch.CustomCommand([]string{"SET", slotHashedKey1, "1"})
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "CustomCommand: Set(key, 1)"})
-	batch.Get(key)
+	batch.Get(slotHashedKey1)
 	testData = append(testData, CommandTestData{ExpectedResponse: "1", TestName: "Get(key1)"})
 
 	batch.RandomKey()
-	testData = append(testData, CommandTestData{ExpectedResponse: key, TestName: "RandomKey()"})
+	testData = append(testData, CommandTestData{ExpectedResponse: slotHashedKey1, TestName: "RandomKey()"})
 
 	// TODO: add Move in separate standalone batch tests
 
@@ -624,8 +613,7 @@ func GetCommandGroupTestProviders() []BatchTestDataProvider {
 		CreateStringTest,
 		// more command groups here
 		CreateBitmapTest,
-		CreateGenericBaseTests,
-		CreateGenericClusterCommandTests,
+		CreateGenericCommandTests,
 		CreateHashTest,
 		CreateHyperLogLogTest,
 	}

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -474,7 +474,7 @@ func CreateGenericBaseTests(batch *pipeline.ClusterBatch, isAtomic bool, serverV
 	return BatchTestData{CommandTestData: testData, TestName: "Generic Base commands"}
 }
 
-func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic bool) BatchTestData {
+func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serverVer string) BatchTestData {
 	testData := make([]CommandTestData, 0)
 	prefix := "{key}-"
 	if !isAtomic {

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -474,6 +474,25 @@ func CreateGenericBaseTests(batch *pipeline.ClusterBatch, isAtomic bool, serverV
 	return BatchTestData{CommandTestData: testData, TestName: "Generic Base commands"}
 }
 
+func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic bool) BatchTestData {
+	testData := make([]CommandTestData, 0)
+	key := "{key}-1-" + uuid.NewString()
+
+	// Start clean
+	batch.FlushAll()
+	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "CustomCommand: FlushAll()"})
+
+	batch.CustomCommand([]string{"SET", key, "1"})
+	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "CustomCommand: Set(key, 1)"})
+	batch.Get(key)
+	testData = append(testData, CommandTestData{ExpectedResponse: "1", TestName: "Get(key1)"})
+
+	batch.RandomKey()
+	testData = append(testData, CommandTestData{ExpectedResponse: key, TestName: "RandomKey()"})
+
+	return BatchTestData{CommandTestData: testData, TestName: "Generic Cluster commands"}
+}
+
 func CreateHashTest(batch *pipeline.ClusterBatch, isAtomic bool, serverVer string) BatchTestData {
 	// TODO: After adding and fixing converters, remove 'any' typing in ExpectedResponse
 	testData := make([]CommandTestData, 0)
@@ -600,6 +619,7 @@ func GetCommandGroupTestProviders() []BatchTestDataProvider {
 		// more command groups here
 		CreateBitmapTest,
 		CreateGenericBaseTests,
+		CreateGenericClusterCommandTests,
 		CreateHashTest,
 		CreateHyperLogLogTest,
 	}

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -490,6 +490,8 @@ func CreateGenericClusterCommandTests(batch *pipeline.ClusterBatch, isAtomic boo
 	batch.RandomKey()
 	testData = append(testData, CommandTestData{ExpectedResponse: key, TestName: "RandomKey()"})
 
+	// TODO: add Move in separate standalone batch tests
+
 	return BatchTestData{CommandTestData: testData, TestName: "Generic Cluster commands"}
 }
 


### PR DESCRIPTION
Adding Generic Cluster Commands Tests (only look at `batch_test.go`)

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/3547, https://github.com/valkey-io/valkey-glide/issues/2791

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
