### PR TITLE
Add request timeout configuration to client examples across multiple …

### DIFF
--- a/examples/java/src/main/java/glide/examples/ClusterExample.java
+++ b/examples/java/src/main/java/glide/examples/ClusterExample.java
@@ -1,11 +1,17 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.examples;
 
+import static glide.api.logging.Logger.log;
 import static glide.api.logging.Logger.Level.ERROR;
 import static glide.api.logging.Logger.Level.INFO;
 import static glide.api.logging.Logger.Level.WARN;
-import static glide.api.logging.Logger.log;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleMultiNodeRoute.ALL_NODES;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import glide.api.GlideClusterClient;
 import glide.api.logging.Logger;
@@ -16,12 +22,6 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConnectionException;
 import glide.api.models.exceptions.TimeoutException;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class ClusterExample {
 
@@ -43,6 +43,8 @@ public class ClusterExample {
         GlideClusterClientConfiguration config =
                 GlideClusterClientConfiguration.builder()
                         .addresses(nodeList)
+                        // Set request timeout - recommended to configure based on your use case.
+                        .requestTimeout(500)
                         // Enable this field if the servers are configured with TLS.
                         // .useTLS(true);
                         .build();

--- a/examples/java/src/main/java/glide/examples/GlideFtExample.java
+++ b/examples/java/src/main/java/glide/examples/GlideFtExample.java
@@ -1,29 +1,13 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.examples;
 
+import static glide.api.logging.Logger.log;
 import static glide.api.logging.Logger.Level.ERROR;
 import static glide.api.logging.Logger.Level.INFO;
 import static glide.api.logging.Logger.Level.WARN;
-import static glide.api.logging.Logger.log;
 import static glide.api.models.GlideString.gs;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleMultiNodeRoute.ALL_NODES;
 
-import glide.api.GlideClusterClient;
-import glide.api.commands.servermodules.FT;
-import glide.api.logging.Logger;
-import glide.api.models.ClusterValue;
-import glide.api.models.commands.FT.FTCreateOptions;
-import glide.api.models.commands.FT.FTCreateOptions.DataType;
-import glide.api.models.commands.FT.FTCreateOptions.DistanceMetric;
-import glide.api.models.commands.FT.FTCreateOptions.FieldInfo;
-import glide.api.models.commands.FT.FTCreateOptions.VectorFieldHnsw;
-import glide.api.models.commands.FT.FTSearchOptions;
-import glide.api.models.commands.InfoOptions.Section;
-import glide.api.models.configuration.GlideClusterClientConfiguration;
-import glide.api.models.configuration.NodeAddress;
-import glide.api.models.exceptions.ClosingException;
-import glide.api.models.exceptions.ConnectionException;
-import glide.api.models.exceptions.TimeoutException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +15,23 @@ import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import glide.api.GlideClusterClient;
+import glide.api.commands.servermodules.FT;
+import glide.api.logging.Logger;
+import glide.api.models.ClusterValue;
+import glide.api.models.commands.InfoOptions.Section;
+import glide.api.models.commands.FT.FTCreateOptions;
+import glide.api.models.commands.FT.FTCreateOptions.DataType;
+import glide.api.models.commands.FT.FTCreateOptions.DistanceMetric;
+import glide.api.models.commands.FT.FTCreateOptions.FieldInfo;
+import glide.api.models.commands.FT.FTCreateOptions.VectorFieldHnsw;
+import glide.api.models.commands.FT.FTSearchOptions;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.TimeoutException;
 
 public class GlideFtExample {
 
@@ -55,6 +56,8 @@ public class GlideFtExample {
         GlideClusterClientConfiguration config =
                 GlideClusterClientConfiguration.builder()
                         .addresses(nodeList)
+                        // Set request timeout - recommended to configure based on your use case.
+                        .requestTimeout(500)
                         // Enable this field if the servers are configured with TLS.
                         // .useTLS(true);
                         .build();

--- a/examples/java/src/main/java/glide/examples/GlideJsonExample.java
+++ b/examples/java/src/main/java/glide/examples/GlideJsonExample.java
@@ -1,11 +1,17 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.examples;
 
+import static glide.api.logging.Logger.log;
 import static glide.api.logging.Logger.Level.ERROR;
 import static glide.api.logging.Logger.Level.INFO;
 import static glide.api.logging.Logger.Level.WARN;
-import static glide.api.logging.Logger.log;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleMultiNodeRoute.ALL_NODES;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import glide.api.GlideClusterClient;
 import glide.api.commands.servermodules.Json;
@@ -17,11 +23,6 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConnectionException;
 import glide.api.models.exceptions.TimeoutException;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class GlideJsonExample {
 
@@ -43,6 +44,8 @@ public class GlideJsonExample {
         GlideClusterClientConfiguration config =
                 GlideClusterClientConfiguration.builder()
                         .addresses(nodeList)
+                        // Set request timeout - recommended to configure based on your use case.
+                        .requestTimeout(500)
                         // Enable this field if the servers are configured with TLS.
                         // .useTLS(true);
                         .build();

--- a/examples/java/src/main/java/glide/examples/StandaloneExample.java
+++ b/examples/java/src/main/java/glide/examples/StandaloneExample.java
@@ -1,10 +1,16 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.examples;
 
+import static glide.api.logging.Logger.log;
 import static glide.api.logging.Logger.Level.ERROR;
 import static glide.api.logging.Logger.Level.INFO;
 import static glide.api.logging.Logger.Level.WARN;
-import static glide.api.logging.Logger.log;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import glide.api.GlideClient;
 import glide.api.logging.Logger;
@@ -13,12 +19,6 @@ import glide.api.models.configuration.NodeAddress;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConnectionException;
 import glide.api.models.exceptions.TimeoutException;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public class StandaloneExample {
 
@@ -41,6 +41,8 @@ public class StandaloneExample {
         GlideClientConfiguration config =
                 GlideClientConfiguration.builder()
                         .addresses(nodeList)
+                        // Set request timeout - recommended to configure based on your use case.
+                        .requestTimeout(500)
                         // Enable this field if the servers are configured with TLS.
                         // .useTLS(true);
                         .build();

--- a/examples/kotlin/src/main/kotlin/ClusterExample.kt
+++ b/examples/kotlin/src/main/kotlin/ClusterExample.kt
@@ -33,6 +33,8 @@ object ClusterExample {
         val config = GlideClusterClientConfiguration.builder()
             .addresses(nodesList.map({ (host: String, port: Int) -> NodeAddress.builder().host(host).port(port).build() }))
             .clientName("test_cluster_client")
+            // Set request timeout - recommended to configure based on your use case.
+            .requestTimeout(500)
             // Enable this field if the servers are configured with TLS.
             //.useTLS(true)
             .build()

--- a/examples/kotlin/src/main/kotlin/StandaloneExample.kt
+++ b/examples/kotlin/src/main/kotlin/StandaloneExample.kt
@@ -31,6 +31,8 @@ object StandaloneExample {
         // Check `GlideClientConfiguration` for additional options.
         val config = GlideClientConfiguration.builder()
             .addresses(nodesList.map({ (host: String, port: Int) -> NodeAddress.builder().host(host).port(port).build() }))
+            // Set request timeout - recommended to configure based on your use case.
+            .requestTimeout(500)
             // Enable this field if the servers are configured with TLS.
             //.useTLS(true)
             .build()

--- a/examples/node/cluster_example.ts
+++ b/examples/node/cluster_example.ts
@@ -29,6 +29,8 @@ async function createClient(nodesList = [{ host: "localhost", port: 6379 }]) {
     // Check `GlideClusterClientConfiguration` for additional options.
     return await GlideClusterClient.createClient({
         addresses: addresses,
+        // Set request timeout - recommended to configure based on your use case.
+        requestTimeout: 500,
         // if the server uses TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
         // useTLS: true,
     });

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -15,6 +15,8 @@ async function sendPingToStandAloneNode() {
     // Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
     const client = await GlideClient.createClient({
         addresses: addresses,
+        // Set request timeout - recommended to configure based on your use case.
+        requestTimeout: 500,
         // if the server uses TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
         // useTLS: true,
         clientName: "test_standalone_client",
@@ -44,6 +46,8 @@ async function sendPingToRandomNodeInCluster() {
     // Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
     const client = await GlideClusterClient.createClient({
         addresses: addresses,
+        // Set request timeout - recommended to configure based on your use case.
+        requestTimeout: 500,
         // if the cluster nodes use TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
         // useTLS: true,
         clientName: "test_cluster_client",

--- a/examples/node/json_example.ts
+++ b/examples/node/json_example.ts
@@ -20,6 +20,8 @@ async function executeJsonCommands() {
     // Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
     const client = await GlideClient.createClient({
         addresses: addresses,
+        // Set request timeout - recommended to configure based on your use case.
+        requestTimeout: 500,
         // if the server uses TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
         // useTLS: true,
         clientName: "test_standalone_client",

--- a/examples/node/standalone_example.ts
+++ b/examples/node/standalone_example.ts
@@ -29,6 +29,8 @@ async function createClient(nodesList = [{ host: "localhost", port: 6379 }]) {
     // Check `GlideClientConfiguration` for additional options.
     return await GlideClient.createClient({
         addresses: addresses,
+        // Set request timeout - recommended to configure based on your use case.
+        requestTimeout: 500,
         // if the server uses TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
         // useTLS: true,
     });

--- a/examples/node/vector_search_example.ts
+++ b/examples/node/vector_search_example.ts
@@ -3,11 +3,11 @@
  */
 import {
     Decoder,
+    FtSearchOptions,
+    FtSearchReturnType,
     GlideClient,
     GlideClusterClient,
     GlideFt,
-    FtSearchOptions,
-    FtSearchReturnType,
     Logger,
     VectorField,
 } from "@valkey/valkey-glide";
@@ -28,6 +28,8 @@ async function executeVssCommands() {
     // Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
     const client = await GlideClient.createClient({
         addresses: addresses,
+        // Set request timeout - recommended to configure based on your use case.
+        requestTimeout: 500,
         // if the server uses TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
         // useTLS: true,
         clientName: "test_standalone_client",

--- a/examples/python/cluster_example.py
+++ b/examples/python/cluster_example.py
@@ -39,6 +39,8 @@ async def create_client(
     config = GlideClusterClientConfiguration(
         addresses=addresses,
         client_name="test_cluster_client",
+        # Set request timeout - recommended to configure based on your use case.
+        request_timeout=500,
         # Enable this field if the servers are configured with TLS.
         # use_tls=True
     )

--- a/examples/python/ft_example.py
+++ b/examples/python/ft_example.py
@@ -52,6 +52,8 @@ async def create_client(
     config = GlideClusterClientConfiguration(
         addresses=addresses,
         client_name="test_cluster_client",
+        # Set request timeout - recommended to configure based on your use case.
+        request_timeout=500,
         # Enable this field if the servers are configured with TLS.
         # use_tls=True
     )

--- a/examples/python/json_example.py
+++ b/examples/python/json_example.py
@@ -41,6 +41,8 @@ async def create_client(
     config = GlideClusterClientConfiguration(
         addresses=addresses,
         client_name="test_cluster_client",
+        # Set request timeout - recommended to configure based on your use case.
+        request_timeout=500,
         # Enable this field if the servers are configured with TLS.
         # use_tls=True
     )

--- a/examples/python/standalone_example.py
+++ b/examples/python/standalone_example.py
@@ -39,6 +39,8 @@ async def create_client(
     # Check `GlideClientConfiguration` for additional options.
     config = GlideClientConfiguration(
         addresses,
+        # Set request timeout - recommended to configure based on your use case.
+        request_timeout=500,
         # Enable this field if the servers are configured with TLS.
         # use_tls=True
     )

--- a/examples/scala/src/main/scala/ClusterExample.scala
+++ b/examples/scala/src/main/scala/ClusterExample.scala
@@ -30,6 +30,8 @@ object ClusterExample {
         // Check `GlideClientConfiguration` for additional options.
         val config = GlideClusterClientConfiguration.builder()
             .addresses(nodesList.map((host, port) => NodeAddress.builder().host(host).port(port).build()).asJava)
+            // Set request timeout - recommended to configure based on your use case.
+            .requestTimeout(500)
             // Enable this field if the servers are configured with TLS.
             //.useTLS(true)
             .build()

--- a/examples/scala/src/main/scala/StandaloneExample.scala
+++ b/examples/scala/src/main/scala/StandaloneExample.scala
@@ -31,6 +31,8 @@ object StandaloneExample {
         // Check `GlideClientConfiguration` for additional options.
         val config = GlideClientConfiguration.builder()
             .addresses(nodesList.map((host, port) => NodeAddress.builder().host(host).port(port).build()).asJava)
+            // Set request timeout - recommended to configure based on your use case.
+            .requestTimeout(500)
             // Enable this field if the servers are configured with TLS.
             //.useTLS(true)
             .build()


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link
This pull request standardizes the configuration of example client creation across multiple languages by adding a default request timeout setting. It also includes minor import reordering for better organization in Java examples.

### Configuration Standardization:

* Added a default `requestTimeout` of 500 milliseconds to client configuration in Java examples (`ClusterExample.java`, `GlideFtExample.java`, `GlideJsonExample.java`, `StandaloneExample.java`) to ensure consistent timeout handling. [[1]](diffhunk://#diff-0ddecf2ce4794d6cb13ad09a585dda0fc2bb43f53ca11792d261173d2e20d319R46-R47) [[2]](diffhunk://#diff-6c4f709ed6ed1cca99d8fed2782473a8d50b080bf096c78daaf71438a58ea5fcR59-R60) [[3]](diffhunk://#diff-65d4a066995ed5a4b33b20fadf7e133d0a11cdc4c6a1ba5810679b6919e86b20R47-R48) [[4]](diffhunk://#diff-737096b44e46405006e2ad85c3063a498b87d2ddcda6615e981a338ca042b069R44-R45)
* Applied the same `requestTimeout` setting to Kotlin examples (`ClusterExample.kt`, `StandaloneExample.kt`). [[1]](diffhunk://#diff-4fdc421067d4107d0a281f29c47dd5cc9c14c3c2a7913e89871cd662116002eaR36-R37) [[2]](diffhunk://#diff-ebe0f0ca3b9f23a50fa7dec62abded42a03f616dbaaecbb29cb406bb4e464cc0R34-R35)
* Updated Node.js examples (`cluster_example.ts`, `index.ts`, `json_example.ts`, `standalone_example.ts`, `vector_search_example.ts`) to include the `requestTimeout` in client creation. [[1]](diffhunk://#diff-6f4b19e6d44a6b2ad3faec4debd37ac5be42ed441dcfbabab70e652293cd1bbeR32-R33) [[2]](diffhunk://#diff-5f29bc88ceb0041502ad57df2bb78d64ee941bafdc6f5427e864183e9d01d89eR18-R19) [[3]](diffhunk://#diff-5f29bc88ceb0041502ad57df2bb78d64ee941bafdc6f5427e864183e9d01d89eR49-R50) [[4]](diffhunk://#diff-5b7277192d4e653a2b4d53be4dba67729bbebfbb7cf675def5c0b7df773f35dbR23-R24) [[5]](diffhunk://#diff-49c177a8dd69280bf6e368274849c7ac7dbe61b5abd190d244dc079b39ef6d71R31-R32) [[6]](diffhunk://#diff-2b5d3fc2d51d1fa3f4b60fa46184528d2e9061cfb8031054e9f945cf867fe31eR32-R33)
* Added the `request_timeout` parameter to Python examples (`cluster_example.py`, `ft_example.py`, `json_example.py`, `standalone_example.py`). [[1]](diffhunk://#diff-71d5be7e82a7670cac4333d47ed3802fb72cb351872372b1b3ad0543e732b3e3R42-R43) [[2]](diffhunk://#diff-32e504016d19cf26c64222ef21e79d2361a98dfeea2897f5a3131386de3e0f94R55-R56) [[3]](diffhunk://#diff-51ec1be3bb72e0dee37b99454853258b3d0adccc25f7533e088e03c3fe0d7846R44-R45) [[4]](diffhunk://#diff-22cd005fc277cc3fb9a953005d9f4554923dd08fc835f56ef71428dc5d901128R42-R43)
* Incorporated the `requestTimeout` setting in Scala examples (`ClusterExample.scala`, `StandaloneExample.scala`). [[1]](diffhunk://#diff-af35ac0cc6388ffa4c446808212111213a65a52a1680adbaee95a121751087f5R33-R34) [[2]](diffhunk://#diff-f2d8fbc80bb8b179edc5449f71fa14b15ed68a20daafdd6a04e7f8d3ac618ea7R34-R35)

### Code Cleanup:

* Reorganized imports in Java examples to improve readability and maintain consistency (`ClusterExample.java`, `GlideFtExample.java`, `GlideJsonExample.java`, `StandaloneExample.java`). [[1]](diffhunk://#diff-0ddecf2ce4794d6cb13ad09a585dda0fc2bb43f53ca11792d261173d2e20d319R4-R15) [[2]](diffhunk://#diff-0ddecf2ce4794d6cb13ad09a585dda0fc2bb43f53ca11792d261173d2e20d319L20-L25) [[3]](diffhunk://#diff-6c4f709ed6ed1cca99d8fed2782473a8d50b080bf096c78daaf71438a58ea5fcR4-L33) [[4]](diffhunk://#diff-65d4a066995ed5a4b33b20fadf7e133d0a11cdc4c6a1ba5810679b6919e86b20R4-R15) [[5]](diffhunk://#diff-65d4a066995ed5a4b33b20fadf7e133d0a11cdc4c6a1ba5810679b6919e86b20L20-L24) [[6]](diffhunk://#diff-737096b44e46405006e2ad85c3063a498b87d2ddcda6615e981a338ca042b069R4-R13) [[7]](diffhunk://#diff-737096b44e46405006e2ad85c3063a498b87d2ddcda6615e981a338ca042b069L17-L22)


This Pull Request is linked to issue #2747 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
