### PR TITLE
[Draft] Add binary data support to C++ client

### DIFF
--- a/cpp/examples/main.cc
+++ b/cpp/examples/main.cc
@@ -5,6 +5,24 @@
 
 using namespace glide;
 
+std::vector<std::byte> to_bytes(const std::string& s) {
+  std::vector<std::byte> result;
+  result.reserve(s.size());
+  for (char c : s) {
+    result.push_back(static_cast<std::byte>(c));
+  }
+  return result;
+}
+
+std::string to_string(const std::vector<std::byte>& bytes) {
+  std::string result;
+  result.reserve(bytes.size());
+  for (std::byte b : bytes) {
+    result.push_back(static_cast<char>(b));
+  }
+  return result;
+}
+
 int main() {
   Config g("localhost", 6379);
   Client c(g);
@@ -23,8 +41,22 @@ int main() {
     std::cout << "set failed!" << f1 << std::endl;
   }
 
+  // Set a key-value pair with a vector of bytes.
+  auto f1v = to_bytes("hello-world");
+  auto f1b = c.set("testb", f1v).get();
+  if (!f1b.ok()) {
+    std::cout << "set failed!" << f1b << std::endl;
+  }
+
+  auto f1g = c.get<std::vector<std::byte>>("testb").get();
+  if (f1g.ok()) {
+    std::cout << "get binary: " << to_string(*f1g) << std::endl;
+  } else {
+    std::cout << "get failed!" << f1g.status().message() << std::endl;
+  }
+
   // Get the value of the key.
-  auto f2 = c.get("test").get();
+  auto f2 = c.get<std::string>("test").get();
   if (f2.ok()) {
     std::cout << "get: " << f2 << std::endl;
   } else {
@@ -32,7 +64,7 @@ int main() {
   }
 
   // Get the value of the key and delete the key.
-  auto f3 = c.getdel("test").get();
+  auto f3 = c.getdel<std::string>("test").get();
   if (f3.ok()) {
     std::cout << "getdel: " << f3 << std::endl;
   } else {
@@ -48,17 +80,41 @@ int main() {
   }
 
   // Get the value of a field in a hash.
-  auto f5 = c.hget("test", "field1").get();
+  auto f5 = c.hget<std::string>("test", "field1").get();
   if (f5.ok()) {
     std::cout << "hget: " << f5 << std::endl;
   } else {
     std::cout << "hget failed!" << f5.status().message() << std::endl;
   }
-  auto f6 = c.hget("test", "field2").get();
+  auto f6 = c.hget<std::string>("test", "field2").get();
   if (f6.ok()) {
     std::cout << "hget: " << f6 << std::endl;
   } else {
     std::cout << "hget failed!" << f6.status().message() << std::endl;
+  }
+
+  // Set multiple field-value pairs in a hash - binary.
+  std::map<std::string, std::vector<std::byte>> field_values_b = {
+      {"field1", to_bytes("hello")},
+      {"field2", to_bytes("world")}
+  };
+  auto fb4 = c.hset("test-hset-b", field_values_b).get();
+  if (!fb4.ok()) {
+    std::cout << "hset failed!" << fb4 << std::endl;
+  }
+
+  // Get the value of a field in a hash - binary.
+  auto fb5 = c.hget<std::vector<std::byte>>("test-hset-b", "field1").get();
+  if (fb5.ok()) {
+    std::cout << "hget(b): " << to_string(*fb5) << std::endl;
+  } else {
+    std::cout << "hget failed!" << fb5.status().message() << std::endl;
+  }
+  auto fb6 = c.hget<std::vector<std::byte>>("test-hset-b", "field2").get();
+  if (fb6.ok()) {
+    std::cout << "hget(b): " << to_string(*fb6) << std::endl;
+  } else {
+    std::cout << "hget failed!" << fb6.status().message() << std::endl;
   }
 
   return 0;

--- a/cpp/include/glide/future.h
+++ b/cpp/include/glide/future.h
@@ -5,10 +5,12 @@
 #include <absl/status/statusor.h>
 
 #include <condition_variable>
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include "glide/glide_base.h"
 #include "helper.h"
@@ -146,6 +148,12 @@ class Future : public IFuture {
       result_ = absl::OkStatus();
     else if constexpr (std::is_same_v<T, absl::StatusOr<std::string>>)
       result_ = std::string(resp->string_value, resp->string_value_len);
+    else if constexpr (std::is_same_v<T,
+                                      absl::StatusOr<std::vector<std::byte>>>)
+      result_ = std::vector<std::byte>(
+          reinterpret_cast<const std::byte*>(resp->string_value),
+          reinterpret_cast<const std::byte*>(resp->string_value) +
+              resp->string_value_len);
     else if constexpr (std::is_same_v<T, absl::StatusOr<bool>>)
       result_ = resp->bool_value;
     else

--- a/cpp/src/client.cc
+++ b/cpp/src/client.cc
@@ -3,19 +3,26 @@
 #include <glide/future.h>
 #include <glide/glide_base.h>
 #include <glide/helper.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 
 namespace glide {
 
 /**
- * Constructs a Client with a const configuration.
+ * Constructs a Client with the provided configuration.
+ *
+ * @param config The configuration object to use for this client instance.
  */
 Client::Client(const Config &config) : config_(config) {}
 
 /**
- * Connects the client using the serialized configuration.
+ * Establishes a connection to the server using the client's configuration.
+ *
+ * @return true if the connection was successfully established, false otherwise.
  */
 bool Client::connect() {
   std::optional<std::vector<uint8_t>> serialized_conf = config_.serialize();
@@ -29,79 +36,101 @@ bool Client::connect() {
 }
 
 /**
- * Sets a key-value pair in the client's configuration.
+ * Sets a key-value pair in the Redis database with string values.
+ *
+ * @param key The key to set.
+ * @param value The string value to associate with the key.
+ * @return A Future containing the status of the operation.
  */
 Future<absl::Status> Client::set(const std::string &key,
                                  const std::string &value) {
-  std::vector<std::string> args = {key, value};
   Future<absl::Status> future;
   auto future_ptr = reinterpret_cast<uintptr_t>(&future);
+  std::vector<std::string> args = {key, value};
   exec_command(core::RequestType::Set, args, future_ptr);
   return future;
 }
 
 /**
- * Retrieves the value associated with the given key from the client's
- * configuration.
+ * Sets a key-value pair in the Redis database with binary values.
+ *
+ * @param key The key to set.
+ * @param value The binary value to associate with the key.
+ * @return A Future containing the status of the operation.
  */
-Future<absl::StatusOr<std::string>> Client::get(const std::string &key) {
-  std::vector<std::string> args = {key};
-
-  Future<absl::StatusOr<std::string>> future;
+Future<absl::Status> Client::set(const std::string &key,
+                                 const std::vector<std::byte> &value) {
+  Future<absl::Status> future;
   auto future_ptr = reinterpret_cast<uintptr_t>(&future);
-  exec_command(core::RequestType::Get, args, future_ptr);
+
+  std::vector<uintptr_t> args = {reinterpret_cast<uintptr_t>(key.data()),
+                                 reinterpret_cast<uintptr_t>(value.data())};
+  std::vector<unsigned long> args_len = {
+      static_cast<unsigned long>(key.size()),
+      static_cast<unsigned long>(value.size())};
+  exec_command_b(core::RequestType::Set, args, args_len, future_ptr);
   return future;
 }
 
 /**
- * Retrieves the value associated with the given key from the client's
- * configuration.
- */
-Future<absl::StatusOr<std::string>> Client::getdel(const std::string &key) {
-  std::vector<std::string> args = {key};
-  Future<absl::StatusOr<std::string>> future;
-  auto future_ptr = reinterpret_cast<uintptr_t>(&future);
-  exec_command(core::RequestType::GetDel, args, future_ptr);
-  return future;
-}
-
-/**
- * Sets multiple field-value pairs in a hash stored at the given key.
+ * Sets multiple field-value pairs in a hash stored at the given key with string
+ * values.
+ *
+ * @param key The key of the hash.
+ * @param values A map of field-value pairs to set in the hash.
+ * @return A Future containing the status of the operation.
  */
 Future<absl::Status> Client::hset(
-    const std::string &key,
-    const std::map<std::string, std::string> &field_values) {
+    const std::string &key, const std::map<std::string, std::string> &values) {
+  Future<absl::Status> future;
+  auto future_ptr = reinterpret_cast<uintptr_t>(&future);
   std::vector<std::string> args = {key};
-  for (const auto &pair : field_values) {
+  for (const auto &pair : values) {
     args.push_back(pair.first);
     args.push_back(pair.second);
   }
-  Future<absl::Status> future;
-  auto future_ptr = reinterpret_cast<uintptr_t>(&future);
   exec_command(core::RequestType::HSet, args, future_ptr);
   return future;
 }
 
 /**
- * Retrieves the value associated with a field in a hash stored at the given
- * key.
+ * Sets multiple field-value pairs in a hash stored at the given key with binary
+ * values.
+ *
+ * @param key The key of the hash.
+ * @param values A map of field-value pairs with binary values to set in the
+ * hash.
+ * @return A Future containing the status of the operation.
  */
-Future<absl::StatusOr<std::string>> Client::hget(const std::string &key,
-                                                 const std::string &field) {
-  std::vector<std::string> args = {key, field};
-  Future<absl::StatusOr<std::string>> future;
+Future<absl::Status> Client::hset(
+    const std::string &key,
+    const std::map<std::string, std::vector<std::byte>> &values) {
+  Future<absl::Status> future;
   auto future_ptr = reinterpret_cast<uintptr_t>(&future);
-  exec_command(core::RequestType::HGet, args, future_ptr);
+  std::vector<uintptr_t> args = {reinterpret_cast<uintptr_t>(key.data())};
+  std::vector<unsigned long> args_len;
+  args_len.reserve(values.size() + 1);
+  args_len.push_back(key.size());
+  for (const auto &pair : values) {
+    args.push_back(reinterpret_cast<uintptr_t>(pair.first.data()));
+    args.push_back(reinterpret_cast<uintptr_t>(pair.second.data()));
+    args_len.push_back(pair.first.size());
+    args_len.push_back(pair.second.size());
+  }
+  exec_command_b(core::RequestType::HSet, args, args_len, future_ptr);
   return future;
 }
 
 /**
- * Executes a command with the given request type and arguments.
+ * Executes a Redis command with string arguments.
+ *
+ * @param type The type of Redis command to execute.
+ * @param args Vector of string arguments for the command.
+ * @param channel_ptr Pointer to the channel for handling the response.
  */
 void Client::exec_command(core::RequestType type,
                           std::vector<std::string> &args,
                           uintptr_t channel_ptr) {
-  // Prepare arguments.
   std::vector<uintptr_t> cmd_args;
   cmd_args.reserve(args.size());
   std::vector<unsigned long> cmd_args_len;
@@ -117,7 +146,24 @@ void Client::exec_command(core::RequestType type,
 }
 
 /**
+ * Executes a Redis command with binary arguments.
+ *
+ * @param type The type of Redis command to execute.
+ * @param args Vector of pointers to binary argument data.
+ * @param args_len Vector containing the length of each argument.
+ * @param channel_ptr Pointer to the channel for handling the response.
+ */
+void Client::exec_command_b(core::RequestType type,
+                            std::vector<uintptr_t> &args,
+                            std::vector<unsigned long> &args_len,
+                            uintptr_t channel_ptr) {
+  core::command(connection_->conn_ptr, channel_ptr, type, args.size(),
+                args.data(), args_len.data(), nullptr, 0);
+}
+
+/**
  * Destructor for the Client class.
+ * Properly closes the connection and frees allocated resources.
  */
 Client::~Client() {
   if (connection_ && connection_->conn_ptr) {

--- a/cpp/tests/client_test.cc
+++ b/cpp/tests/client_test.cc
@@ -2,6 +2,7 @@
 #include <absl/status/statusor.h>
 #include <glide/client.h>
 #include <gtest/gtest.h>
+#include <string>
 
 using namespace glide;
 
@@ -16,7 +17,7 @@ TEST(ClientTest, SetGetTest) {
   Client c(g);
   EXPECT_TRUE(c.connect());
   EXPECT_TRUE(c.set("SetGetTest", "hello-world").get().ok());
-  EXPECT_EQ(*c.get("SetGetTest").get(), "hello-world");
+  EXPECT_EQ(*c.get<std::string>("SetGetTest").get(), "hello-world");
 }
 
 TEST(ClientTest, GetDelTest) {
@@ -24,6 +25,6 @@ TEST(ClientTest, GetDelTest) {
   Client c(g);
   EXPECT_TRUE(c.connect());
   EXPECT_TRUE(c.set("GetDelTest", "hello-world").get().ok());
-  EXPECT_EQ(*c.getdel("GetDelTest").get(), "hello-world");
-  EXPECT_EQ(*c.get("GetDelTest").get(), "");
+  EXPECT_EQ(*c.getdel<std::string>("GetDelTest").get(), "hello-world");
+  EXPECT_EQ(*c.get<std::string>("GetDelTest").get(), "");
 }


### PR DESCRIPTION
Extends the Client class to handle both string and binary data types:
- Add template methods for get(), getdel(), and hget() supporting std::string and std::vector<std::byte>
- Add overloaded set() and hset() methods for binary values
- Implement exec_command_b() for binary argument handling
- Update Future template to handle std::vector<std::byte> responses
- Add conversion utilities and example usage in main.cc

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
