### PR TITLE
Increase default connection attempt timeout to 2000ms

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use tokio_util::codec::Decoder;
 
 // Default connection timeout in ms
-const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(250);
+const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2000);
 
 // Senders which the result of a single request are sent through
 type PipelineOutput = oneshot::Sender<RedisResult<Value>>;

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -498,9 +498,9 @@ func NewAdvancedClientConfiguration() *AdvancedClientConfiguration {
 
 // WithConnectionTimeout sets the duration to wait for a TCP/TLS connection to complete.
 // The duration in milliseconds to wait for a TCP/TLS connection to complete. This applies both
-// during initial client creation and any reconnections that may occur during request processing.
+// during initial client creation and any reconnection that may occur during request processing.
 // Note: A high connection timeout may lead to prolonged blocking of the entire command
-// pipeline. If not explicitly set, a default value of 250 milliseconds will be used.
+// pipeline. If not explicitly set, a default value of 2000 milliseconds will be used.
 //
 // Using a negative value or a value that exceeds the max duration of 2^32 - 1 milliseconds will lead to an invalid
 // configuration.

--- a/java/README.md
+++ b/java/README.md
@@ -216,6 +216,8 @@ public class Main {
                 GlideClientConfiguration.builder()
                         .address(NodeAddress.builder().host(host).port(port).build())
                         .useTLS(useSsl)
+                        // It is recommended to set a timeout for your specific use case
+                        .requestTimeout(500) // 500ms timeout
                         .build();
 
         try (GlideClient client = GlideClient.createClient(config).get()) {
@@ -266,6 +268,8 @@ public class Main {
                 GlideClusterClientConfiguration.builder()
                         .address(NodeAddress.builder().host(host).port(port1).port(port2).port(port3).port(port4).port(port5).port(port6).build())
                         .useTLS(useSsl)
+                        // It is recommended to set a timeout for your specific use case
+                        .requestTimeout(500) // 500ms timeout
                         .build();
 
         try (GlideClusterClient client = GlideClusterClient.createClient(config).get()) {

--- a/java/client/src/main/java/glide/api/models/configuration/AdvancedBaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/AdvancedBaseClientConfiguration.java
@@ -15,9 +15,9 @@ public abstract class AdvancedBaseClientConfiguration {
 
     /**
      * The duration in milliseconds to wait for a TCP/TLS connection to complete. This applies both
-     * during initial client creation and any reconnections that may occur during request processing.
+     * during initial client creation and any reconnection that may occur during request processing.
      *
-     * <p>If not explicitly set, a default value of 250 milliseconds will be used by the Rust core.
+     * <p>If not explicitly set, a default value of 2000 milliseconds will be used by the Rust core.
      *
      * <p>**Note**: A high connection timeout may lead to prolonged blocking of the entire command
      * pipeline.

--- a/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
@@ -47,7 +47,7 @@ public abstract class BaseClientConfiguration {
     /**
      * The duration in milliseconds that the client should wait for a request to complete. This
      * duration encompasses sending the request, awaiting for a response from the server, and any
-     * required reconnections or retries. If the specified timeout is exceeded for a pending request,
+     * required reconnection or retries. If the specified timeout is exceeded for a pending request,
      * it will result in a timeout error. If not explicitly set, a default value of 250 milliseconds
      * will be used.
      */

--- a/node/README.md
+++ b/node/README.md
@@ -82,6 +82,8 @@ const client = await GlideClient.createClient({
     addresses: addresses,
     // if the server uses TLS, you'll need to enable it. Otherwise, the connection attempt will time out silently.
     // useTLS: true,
+    // It is recommended to set a timeout for your specific use case
+    requestTimeout: 500, // 500ms timeout
     clientName: "test_standalone_client",
 });
 // The empty array signifies that there are no additional arguments.
@@ -109,6 +111,8 @@ const client = await GlideClusterClient.createClient({
     addresses: addresses,
     // if the cluster nodes use TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
     // useTLS: true,
+    // It is recommended to set a timeout for your specific use case
+    requestTimeout: 500, // 500ms timeout
     clientName: "test_cluster_client",
 });
 // The empty array signifies that there are no additional arguments.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -652,7 +652,7 @@ export interface BaseClientConfiguration {
     credentials?: ServerCredentials;
     /**
      * The duration in milliseconds that the client should wait for a request to complete.
-     * This duration encompasses sending the request, awaiting for a response from the server, and any required reconnections or retries.
+     * This duration encompasses sending the request, awaiting for a response from the server, and any required reconnection or retries.
      * If the specified timeout is exceeded for a pending request, it will result in a timeout error.
      * If not explicitly set, a default value of 250 milliseconds will be used.
      * Value must be an integer.
@@ -756,9 +756,9 @@ export interface BaseClientConfiguration {
 export interface AdvancedBaseClientConfiguration {
     /**
      * The duration in milliseconds to wait for a TCP/TLS connection to complete.
-     * This applies both during initial client creation and any reconnections that may occur during request processing.
+     * This applies both during initial client creation and any reconnection that may occur during request processing.
      * **Note**: A high connection timeout may lead to prolonged blocking of the entire command pipeline.
-     * If not explicitly set, a default value of 250 milliseconds will be used.
+     * If not explicitly set, a default value of 2000 milliseconds will be used.
      */
     connectionTimeout?: number;
 

--- a/python/README.md
+++ b/python/README.md
@@ -77,7 +77,8 @@ To install Valkey GLIDE using `pip`, follow these steps:
 >>> from glide import GlideClusterClientConfiguration, NodeAddress, GlideClusterClient
 >>> async def test_cluster_client():
 ...     addresses = [NodeAddress("address.example.com", 6379)]
-...     config = GlideClusterClientConfiguration(addresses)
+...     # It is recommended to set a timeout for your specific use case
+...     config = GlideClusterClientConfiguration(addresses, request_timeout=500)  # 500ms timeout
 ...     client = await GlideClusterClient.create(config)
 ...     set_result = await client.set("foo", "bar")
 ...     print(f"Set response is {set_result}")
@@ -99,7 +100,8 @@ Get response is bar
 ...             NodeAddress("server_primary.example.com", 6379),
 ...             NodeAddress("server_replica.example.com", 6379)
 ...     ]
-...     config = GlideClientConfiguration(addresses)
+...     # It is recommended to set a timeout for your specific use case
+...     config = GlideClientConfiguration(addresses, request_timeout=500)  # 500ms timeout
 ...     client = await GlideClient.create(config)
 ...     set_result = await client.set("foo", "bar")
 ...     print(f"Set response is {set_result}")

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -177,9 +177,9 @@ class AdvancedBaseClientConfiguration:
 
     Attributes:
         connection_timeout (Optional[int]): The duration in milliseconds to wait for a TCP/TLS connection to complete.
-            This applies both during initial client creation and any reconnections that may occur during request processing.
+            This applies both during initial client creation and any reconnection that may occur during request processing.
             **Note**: A high connection timeout may lead to prolonged blocking of the entire command pipeline.
-            If not explicitly set, a default value of 250 milliseconds will be used.
+            If not explicitly set, a default value of 2000 milliseconds will be used.
         tls_config (Optional[TlsAdvancedConfiguration]): The advanced TLS configuration settings.
             This allows for more granular control of TLS behavior, such as enabling an insecure mode
             that bypasses certificate validation.
@@ -236,7 +236,7 @@ class BaseClientConfiguration:
         request_timeout (Optional[int]): The duration in milliseconds that the client should wait for a request to
             complete.
             This duration encompasses sending the request, awaiting for a response from the server, and any required
-            reconnections or retries.
+            reconnection or retries.
             If the specified timeout is exceeded for a pending request, it will result in a timeout error. If not
             explicitly set, a default value of 250 milliseconds will be used.
         reconnect_strategy (Optional[BackoffStrategy]): Strategy used to determine how and when to reconnect, in case of
@@ -389,7 +389,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         read_from (ReadFrom): If not set, `PRIMARY` will be used.
         request_timeout (Optional[int]):  The duration in milliseconds that the client should wait for a request to complete.
                 This duration encompasses sending the request, awaiting for a response from the server, and any required
-                reconnections or retries.
+                reconnection or retries.
                 If the specified timeout is exceeded for a pending request, it will result in a timeout error.
                 If not explicitly set, a default value of 250 milliseconds will be used.
         reconnect_strategy (Optional[BackoffStrategy]): Strategy used to determine how and when to reconnect, in case of
@@ -554,7 +554,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         read_from (ReadFrom): If not set, `PRIMARY` will be used.
         request_timeout (Optional[int]):  The duration in milliseconds that the client should wait for a request to complete.
             This duration encompasses sending the request, awaiting for a response from the server, and any required
-            reconnections or retries.
+            reconnection or retries.
             If the specified timeout is exceeded for a pending request, it will result in a timeout error. If not explicitly
             set, a default value of 250 milliseconds will be used.
         reconnect_strategy (Optional[BackoffStrategy]): Strategy used to determine how and when to reconnect, in case of


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This pull request includes updates to improve timeout configurations across multiple client implementations and examples, as well as a modification to the default connection timeout in the Redis library. The most important changes are grouped below by theme.

### Timeout Configuration Updates in Documentation

* Added a `requestTimeout` parameter with a recommended value of 500ms to the `GlideClient` and `GlideClusterClient` examples in the Java documentation (`java/README.md`). [[1]](diffhunk://#diff-0c997611c3c5fb9fa0641cb88e5aaa485b5fbc7293676fc28afab310dd430812R219-R220) [[2]](diffhunk://#diff-0c997611c3c5fb9fa0641cb88e5aaa485b5fbc7293676fc28afab310dd430812R271-R272)
* Added a `requestTimeout` parameter with a recommended value of 500ms to the `GlideClient` and `GlideClusterClient` examples in the Node.js documentation (`node/README.md`). [[1]](diffhunk://#diff-95adbe91db0012126446d6fb788336941b4d6205a7b8da98f1a04991acc410a7R85-R86) [[2]](diffhunk://#diff-95adbe91db0012126446d6fb788336941b4d6205a7b8da98f1a04991acc410a7R114-R115)
* Added a `request_timeout` parameter with a recommended value of 500ms to the `GlideClientConfiguration` and `GlideClusterClientConfiguration` examples in the Python documentation (`python/README.md`). [[1]](diffhunk://#diff-217ed82f87b78b399e304b07a159b27dff327c0f83adf4a2fc30b03bcbf84b01L80-R81) [[2]](diffhunk://#diff-217ed82f87b78b399e304b07a159b27dff327c0f83adf4a2fc30b03bcbf84b01L102-R104)

### Library Timeout Adjustment

* Increased the default connection attempt timeout in the Redis library from 250ms to 2000ms in `glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs`.
### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
