### PR TITLE
Java: fix addReturnField in FT.search 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Changes
 
+* Java: fix addReturnField method in FT module ([#4084]https://github.com/valkey-io/valkey-glide/pull/4084)
 * Python: Create openTelemetry span to measure command latency ([#3985](https://github.com/valkey-io/valkey-glide/pull/3985))
 * Go: Add client name and version identifiers ([#3903](https://github.com/valkey-io/valkey-glide/pull/3903))
 * Python: Add support for Trio ([#3465](https://github.com/valkey-io/valkey-glide/pull/3465))

--- a/java/client/src/main/java/glide/api/models/commands/FT/FTSearchOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/FT/FTSearchOptions.java
@@ -112,7 +112,6 @@ public class FTSearchOptions {
         /** Add a field with an alias to be returned. */
         public FTSearchOptionsBuilder addReturnField(
                 @NonNull GlideString field, @NonNull GlideString alias) {
-            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
             this.identifiers$value.put(field, alias);
             this.identifiers$set = true;
             return this;

--- a/java/client/src/main/java/glide/api/models/commands/FT/FTSearchOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/FT/FTSearchOptions.java
@@ -82,31 +82,43 @@ public class FTSearchOptions {
 
         void count(boolean count) {}
 
-        void identifiers(Map<GlideString, GlideString> identifiers) {}
+        public FTSearchOptionsBuilder identifiers(Map<GlideString, GlideString> identifiers) {
+            this.identifiers$value = identifiers;
+            this.identifiers$set = true;
+            return this;
+        }
+
+        public FTSearchOptionsBuilder() {
+            this.identifiers$value = new HashMap<>();
+        }
 
         /** Add a field to be returned. */
         public FTSearchOptionsBuilder addReturnField(@NonNull String field) {
-            this.identifiers$value.put(gs(field), null);
-            return this;
+            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
+            updatedMap.put(gs(field), null);
+            return this.identifiers(updatedMap);
         }
 
         /** Add a field with an alias to be returned. */
         public FTSearchOptionsBuilder addReturnField(@NonNull String field, @NonNull String alias) {
-            this.identifiers$value.put(gs(field), gs(alias));
-            return this;
+            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
+            updatedMap.put(gs(field), gs(alias));
+            return this.identifiers(updatedMap);
         }
 
         /** Add a field to be returned. */
         public FTSearchOptionsBuilder addReturnField(@NonNull GlideString field) {
-            this.identifiers$value.put(field, null);
-            return this;
+            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
+            updatedMap.put(field, null);
+            return this.identifiers(updatedMap);
         }
 
         /** Add a field with an alias to be returned. */
         public FTSearchOptionsBuilder addReturnField(
                 @NonNull GlideString field, @NonNull GlideString alias) {
-            this.identifiers$value.put(field, alias);
-            return this;
+            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
+            updatedMap.put(field, alias);
+            return this.identifiers(updatedMap);
         }
 
         /**

--- a/java/client/src/main/java/glide/api/models/commands/FT/FTSearchOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/FT/FTSearchOptions.java
@@ -82,11 +82,7 @@ public class FTSearchOptions {
 
         void count(boolean count) {}
 
-        public FTSearchOptionsBuilder identifiers(Map<GlideString, GlideString> identifiers) {
-            this.identifiers$value = identifiers;
-            this.identifiers$set = true;
-            return this;
-        }
+        void identifiers(Map<GlideString, GlideString> identifiers) {}
 
         public FTSearchOptionsBuilder() {
             this.identifiers$value = new HashMap<>();
@@ -94,31 +90,32 @@ public class FTSearchOptions {
 
         /** Add a field to be returned. */
         public FTSearchOptionsBuilder addReturnField(@NonNull String field) {
-            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
-            updatedMap.put(gs(field), null);
-            return this.identifiers(updatedMap);
+            this.identifiers$value.put(gs(field), null);
+            this.identifiers$set = true;
+            return this;
         }
 
         /** Add a field with an alias to be returned. */
         public FTSearchOptionsBuilder addReturnField(@NonNull String field, @NonNull String alias) {
-            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
-            updatedMap.put(gs(field), gs(alias));
-            return this.identifiers(updatedMap);
+            this.identifiers$value.put(gs(field), gs(alias));
+            this.identifiers$set = true;
+            return this;
         }
 
         /** Add a field to be returned. */
         public FTSearchOptionsBuilder addReturnField(@NonNull GlideString field) {
-            Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
-            updatedMap.put(field, null);
-            return this.identifiers(updatedMap);
+            this.identifiers$value.put(field, null);
+            this.identifiers$set = true;
+            return this;
         }
 
         /** Add a field with an alias to be returned. */
         public FTSearchOptionsBuilder addReturnField(
                 @NonNull GlideString field, @NonNull GlideString alias) {
             Map<GlideString, GlideString> updatedMap = new HashMap<>(this.identifiers$value);
-            updatedMap.put(field, alias);
-            return this.identifiers(updatedMap);
+            this.identifiers$value.put(field, alias);
+            this.identifiers$set = true;
+            return this;
         }
 
         /**

--- a/java/integTest/src/test/java/glide/modules/VectorSearchTests.java
+++ b/java/integTest/src/test/java/glide/modules/VectorSearchTests.java
@@ -274,6 +274,7 @@ public class VectorSearchTests {
                                                     (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0,
                                                     (byte) 0
                                                 })))
+                        .addReturnField("vec")
                         .build();
         var query = "*=>[KNN 2 @VEC $query_vec]";
         var ftsearch = FT.search(client, index, query, options).get();
@@ -283,11 +284,9 @@ public class VectorSearchTests {
                     2L,
                     Map.of(
                             gs(prefix + 0),
-                            Map.of(gs("__VEC_score"), gs("0"), gs("vec"), gs("\0\0\0\0\0\0\0\0")),
+                            Map.of(gs("vec"), gs("\0\0\0\0\0\0\0\0")),
                             gs(prefix + 1),
                             Map.of(
-                                    gs("__VEC_score"),
-                                    gs("1"),
                                     gs("vec"),
                                     gs(
                                             new byte[] {


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue: #4064 

There was a bug with the `lombok` handling in `FTSearchOptions` - to my understanding, setting a field with @Builder.default doesn't automatically initialize the field from the beginnig. What it does is, only when `build()` is called, checks the `field$set` flag, if it's set (meaning the generated `identifiers` setter was called), it takes the set value, otherwise it takes the default value that was defined. Before `build()` is called, the field is null.

So what happened was -  because we call `addReturnField` before `build()`, it was still null. 

The fix includes - 
- add a custom `FTSearchOptionsBuilder` builder that sets the identifiers field new a new hashMap (in order for it not to be null)
- add a custom `identifiers` setter that makes sure the `identifiers$set` flag is set (required since we're overriding the lombok generated setter that sets this flag by itself) 
 - update the `addReturnField` method to append to them map using this setter.
 - Includes this check in the `ft_search` test.


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
