### PR TITLE
Go: Fix `GeoHash` Return Type to include Nillable Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 * Add support for Intel MAC (x86_64/amd64) ([#3482](https://github.com/valkey-io/valkey-glide/pull/3482))
 * Go, Java: Fix response handling for `customCommand` API for cluster client ([#3593](https://github.com/valkey-io/valkey-glide/pull/3593))
 * Java: Bump `netty` version ([#3804](https://github.com/valkey-io/valkey-glide/pull/3804))
+* Go: Fix `GeoHash`'s return type to allow for both strings and null ([#4098](https://github.com/valkey-io/valkey-glide/pull/4098))
 
 #### Operational Enhancements
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -7819,12 +7819,12 @@ func (client *baseClient) GeoAddWithOptions(
 //
 // Returns value:
 //
-//	An array of GeoHash strings representing the positions of the specified members stored
-//	at key. If a member does not exist in the sorted set, a `nil` value is returned
+//	An array of GeoHash strings (of type models.Result[string]) representing the positions of the specified
+//	members stored at key. If a member does not exist in the sorted set, a `nil` value is returned
 //	for that member.
 //
 // [valkey.io]: https://valkey.io/commands/geohash/
-func (client *baseClient) GeoHash(ctx context.Context, key string, members []string) ([]string, error) {
+func (client *baseClient) GeoHash(ctx context.Context, key string, members []string) ([]models.Result[string], error) {
 	result, err := client.executeCommand(ctx,
 		C.GeoHash,
 		append([]string{key}, members...),
@@ -7832,7 +7832,7 @@ func (client *baseClient) GeoHash(ctx context.Context, key string, members []str
 	if err != nil {
 		return nil, err
 	}
-	return handleStringArrayResponse(result)
+	return handleStringOrNilArrayResponse(result)
 }
 
 // Returns the positions (longitude,latitude) of all the specified members of the

--- a/go/geospacial_commands_test.go
+++ b/go/geospacial_commands_test.go
@@ -74,7 +74,7 @@ func ExampleClient_GeoHash() {
 	fmt.Println(geoHashResults)
 
 	// Output:
-	// [sqc8b49rny0 sqdtr74hyu0]
+	// [{sqc8b49rny0 false} {sqdtr74hyu0 false}]
 }
 
 func ExampleClusterClient_GeoHash() {
@@ -99,7 +99,7 @@ func ExampleClusterClient_GeoHash() {
 	fmt.Println(geoHashResults)
 
 	// Output:
-	// [sqc8b49rny0 sqdtr74hyu0]
+	// [{sqc8b49rny0 false} {sqdtr74hyu0 false}]
 }
 
 func ExampleClient_GeoPos() {

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -10102,11 +10102,16 @@ func (suite *GlideTestSuite) TestGeoHash() {
 
 		// Test getting geohash for multiple members
 		geoHashResults, err := client.GeoHash(context.Background(), key1, []string{"Palermo", "Catania"})
-		fmt.Println(geoHashResults)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(geoHashResults))
-		assert.Equal(t, geoHashResults[0], "sqc8b49rny0")
-		assert.Equal(t, geoHashResults[1], "sqdtr74hyu0")
+		assert.Equal(t, "sqc8b49rny0", geoHashResults[0].Value())
+		assert.Equal(t, "sqdtr74hyu0", geoHashResults[1].Value())
+
+		// Test getting geohash for non-existent members
+		geoHashResults, err = client.GeoHash(context.Background(), key1, []string{"Gotham City"})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(geoHashResults))
+		assert.True(t, geoHashResults[0].IsNil())
 
 		// Test getting geohash for empty members
 		geoHashResults, err = client.GeoHash(context.Background(), key1, []string{})

--- a/go/internal/interfaces/geospacial_commands.go
+++ b/go/internal/interfaces/geospacial_commands.go
@@ -26,7 +26,7 @@ type GeoSpatialCommands interface {
 		options options.GeoAddOptions,
 	) (int64, error)
 
-	GeoHash(ctx context.Context, key string, members []string) ([]string, error)
+	GeoHash(ctx context.Context, key string, members []string) ([]models.Result[string], error)
 
 	GeoPos(ctx context.Context, key string, members []string) ([][]float64, error)
 

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -5440,8 +5440,8 @@ func (b *BaseBatch[T]) GeoAddWithOptions(
 //
 // Command Response:
 //
-//	An array of GeoHash strings representing the positions of the specified members stored
-//	at key. If a member does not exist in the sorted set, a `nil` value is returned
+//	An array of GeoHash strings (of type models.Result[string]) representing the positions of the specified
+//	members stored at key. If a member does not exist in the sorted set, a `nil` value is returned
 //	for that member.
 //
 // [valkey.io]: https://valkey.io/commands/geohash/


### PR DESCRIPTION
Supersedes #4098 with was messed up by mistake

`GeoHash` returns an array which contains strings and/or nulls.

### Issue link

This Pull Request is linked to issue (URL): closes #4097 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
