### PR TITLE
Go: Fix `RunWithTimeout` time.Duration

### DIFF
--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -10126,7 +10126,7 @@ func (suite *GlideTestSuite) TestGeoHash() {
 func (suite *GlideTestSuite) TestGetSet_SendLargeValues() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		// Run with a 5 second timeout
-		RunWithTimeout(suite.T(), 5, func(ctx context.Context) {
+		RunWithTimeout(suite.T(), 5*time.Second, func(ctx context.Context) {
 			key := suite.GenerateLargeUuid()
 			value := suite.GenerateLargeUuid()
 			suite.verifyOK(client.Set(ctx, key, value))

--- a/go/integTest/test_utils.go
+++ b/go/integTest/test_utils.go
@@ -152,7 +152,7 @@ func CreateLongRunningLuaScript(timeout int, readonly bool) string {
 func RunWithTimeout(t assert.TestingT, requestedTimeout time.Duration, longTest contextFn) {
 	done := make(chan bool)
 
-	ctx, cancel := context.WithTimeout(context.Background(), requestedTimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), requestedTimeout)
 	defer cancel()
 
 	go func() {


### PR DESCRIPTION
Supersedes #4081 closed by mistake

Make sure we are setting `time.Duration` properly. We shouldn't be enforcing seconds to be used.

### Issue link

This Pull Request is linked to issue (URL): closes #4080 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
