### PR TITLE
Go: Use errors idiomatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 * Go: `WATCH` and `UNWATCH` ([#4054](https://github.com/valkey-io/valkey-glide/pull/4054))
 * Java: OTEL fix for script ([#4065](https://github.com/valkey-io/valkey-glide/pull/4065))
 * Go: Add Opentelemetry support of creating spans ([#3932](https://github.com/valkey-io/valkey-glide/pull/3932))
+* Go: Fix API to use errors idiomatically ([#4090](https://github.com/valkey-io/valkey-glide/pull/4090))
 
 #### Breaking Changes
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1785,6 +1785,7 @@ pub unsafe extern "C" fn batch(
     options_ptr: *const BatchOptionsInfo,
     span_ptr: u64,
 ) -> *mut CommandResult {
+    dbg!("raise_on_error: ", raise_on_error);
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_ptr);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1785,7 +1785,6 @@ pub unsafe extern "C" fn batch(
     options_ptr: *const BatchOptionsInfo,
     span_ptr: u64,
 ) -> *mut CommandResult {
-    dbg!("raise_on_error: ", raise_on_error);
     let client_adapter = unsafe {
         // we increment the strong count to ensure that the client is not dropped just because we turned it into an Arc.
         Arc::increment_strong_count(client_ptr);

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -3,6 +3,9 @@
 
 reports
 
+# Compiled Test binaries
+*.test
+
 # cbindgen generated header file
 lib.h
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -34,7 +34,6 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
@@ -155,7 +154,7 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 		(C.FailureCallback)(unsafe.Pointer(C.failureCallback)),
 	)
 	if err != nil {
-		return nil, glideErrors.NewClosingError(err.Error())
+		return nil, NewClosingError(err.Error())
 	}
 	client := &baseClient{pending: make(map[unsafe.Pointer]struct{})}
 
@@ -171,7 +170,7 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 	cErr := cResponse.connection_error_message
 	if cErr != nil {
 		message := C.GoString(cErr)
-		return nil, glideErrors.NewConnectionError(message)
+		return nil, NewConnectionError(message)
 	}
 
 	client.coreClient = cResponse.conn_ptr
@@ -200,7 +199,7 @@ func (client *baseClient) Close() {
 	// because holding the lock guarantees the owner of the unsafe.Pointer hasn't exit.
 	for channelPtr := range client.pending {
 		resultChannel := *(*chan payload)(channelPtr)
-		resultChannel <- payload{value: nil, error: glideErrors.NewClosingError("ExecuteCommand failed. The client is closed.")}
+		resultChannel <- payload{value: nil, error: NewClosingError("ExecuteCommand failed. The client is closed.")}
 	}
 	client.pending = nil
 }
@@ -344,7 +343,7 @@ func (client *baseClient) executeCommandWithRoute(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return nil, glideErrors.NewClosingError("ExecuteCommand failed. The client is closed.")
+		return nil, NewClosingError("ExecuteCommand failed. The client is closed.")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 	C.command(
@@ -447,7 +446,7 @@ func (client *baseClient) executeBatch(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return nil, glideErrors.NewClosingError("ExecuteBatch failed. The client is closed.")
+		return nil, NewClosingError("ExecuteBatch failed. The client is closed.")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 
@@ -625,7 +624,7 @@ func (client *baseClient) submitConnectionPasswordUpdate(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return models.DefaultStringResponse, glideErrors.NewClosingError("UpdatePassword failed. The client is closed.")
+		return models.DefaultStringResponse, NewClosingError("UpdatePassword failed. The client is closed.")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 
@@ -1320,9 +1319,6 @@ func (client *baseClient) LCSWithOptions(
 //
 // [valkey.io]: https://valkey.io/commands/getdel/
 func (client *baseClient) GetDel(ctx context.Context, key string) (models.Result[string], error) {
-	if key == "" {
-		return models.CreateNilStringResult(), errors.New("key is required")
-	}
 	result, err := client.executeCommand(ctx, C.GetDel, []string{key})
 	if err != nil {
 		return models.CreateNilStringResult(), err
@@ -8903,7 +8899,7 @@ func (client *baseClient) executeScriptWithRoute(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return nil, glideErrors.NewClosingError("ExecuteScript failed. The client is closed.")
+		return nil, NewClosingError("ExecuteScript failed. The client is closed.")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 	hash_cstring := C.CString(hash)

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/internal"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 	"github.com/valkey-io/valkey-glide/go/v2/models"

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1319,6 +1319,7 @@ func (client *baseClient) LCSWithOptions(
 //
 // [valkey.io]: https://valkey.io/commands/getdel/
 func (client *baseClient) GetDel(ctx context.Context, key string) (models.Result[string], error) {
+		return models.CreateNilStringResult(), glideErrors.NewRequestError("key is required")
 	result, err := client.executeCommand(ctx, C.GetDel, []string{key})
 	if err != nil {
 		return models.CreateNilStringResult(), err

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -421,8 +421,8 @@ func (client *baseClient) executeBatch(
 		// Continue with execution
 	}
 	if len(batch.Errors) > 0 {
-		return nil, errors.New(fmt.Sprintf("There were %d errors while preparing commands in this batch: %s",
-			len(batch.Errors), strings.Join(batch.Errors, ", ")))
+		return nil, fmt.Errorf("There were %d errors while preparing commands in this batch: %s",
+			len(batch.Errors), strings.Join(batch.Errors, ", "))
 	}
 
 	// Create span if OpenTelemetry is enabled and sampling is configured

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -319,7 +319,7 @@ func (client *baseClient) executeCommandWithRoute(
 	if route != nil {
 		routeProto, err := routeToProtobuf(route)
 		if err != nil {
-			return nil, errors.New("ExecuteCommand failed due to invalid route")
+			return nil, errors.New("executeCommand failed due to invalid route")
 		}
 		msg, err := proto.Marshal(routeProto)
 		if err != nil {
@@ -342,7 +342,7 @@ func (client *baseClient) executeCommandWithRoute(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return nil, NewClosingError("ExecuteCommand failed: the client is closed")
+		return nil, NewClosingError("executeCommand failed: the client is closed")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 	C.command(

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1319,7 +1319,6 @@ func (client *baseClient) LCSWithOptions(
 //
 // [valkey.io]: https://valkey.io/commands/getdel/
 func (client *baseClient) GetDel(ctx context.Context, key string) (models.Result[string], error) {
-		return models.CreateNilStringResult(), glideErrors.NewRequestError("key is required")
 	result, err := client.executeCommand(ctx, C.GetDel, []string{key})
 	if err != nil {
 		return models.CreateNilStringResult(), err

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -420,8 +420,7 @@ func (client *baseClient) executeBatch(
 		// Continue with execution
 	}
 	if len(batch.Errors) > 0 {
-		return nil, fmt.Errorf("there were %d errors while preparing commands in this batch: \n%s",
-			len(batch.Errors), ErrorsToString(batch.Errors))
+		return nil, NewBatchError(batch.Errors)
 	}
 
 	// Create span if OpenTelemetry is enabled and sampling is configured

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -4644,7 +4644,9 @@ func (client *baseClient) BZMPop(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
-		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), glideErrors.NewRequestError("Length overflow for the provided keys")
+		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), glideErrors.NewRequestError(
+			"Length overflow for the provided keys",
+		)
 	}
 
 	// args slice will have 3 more arguments with the keys provided.
@@ -4706,7 +4708,9 @@ func (client *baseClient) BZMPopWithOptions(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
-		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), glideErrors.NewRequestError("Length overflow for the provided keys")
+		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), glideErrors.NewRequestError(
+			"Length overflow for the provided keys",
+		)
 	}
 
 	// args slice will have 5 more arguments with the keys provided.

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -3016,7 +3016,7 @@ func (client *baseClient) LMPop(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-2 {
-		return nil, errors.New("Length overflow for the provided keys")
+		return nil, errors.New("length overflow for the provided keys")
 	}
 
 	// args slice will have 2 more arguments with the keys provided.
@@ -3070,7 +3070,7 @@ func (client *baseClient) LMPopCount(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-4 {
-		return nil, errors.New("Length overflow for the provided keys")
+		return nil, errors.New("length overflow for the provided keys")
 	}
 
 	// args slice will have 4 more arguments with the keys provided.
@@ -3126,7 +3126,7 @@ func (client *baseClient) BLMPop(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
-		return nil, errors.New("Length overflow for the provided keys")
+		return nil, errors.New("length overflow for the provided keys")
 	}
 
 	// args slice will have 3 more arguments with the keys provided.
@@ -3186,7 +3186,7 @@ func (client *baseClient) BLMPopCount(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
-		return nil, errors.New("Length overflow for the provided keys")
+		return nil, errors.New("length overflow for the provided keys")
 	}
 
 	// args slice will have 5 more arguments with the keys provided.
@@ -4638,7 +4638,7 @@ func (client *baseClient) BZMPop(
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
 		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), errors.New(
-			"Length overflow for the provided keys",
+			"length overflow for the provided keys",
 		)
 	}
 
@@ -4702,7 +4702,7 @@ func (client *baseClient) BZMPopWithOptions(
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
 		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), errors.New(
-			"Length overflow for the provided keys",
+			"length overflow for the provided keys",
 		)
 	}
 
@@ -6400,7 +6400,7 @@ func (client *baseClient) BitOp(
 	}
 	result, err := client.executeCommand(ctx, C.BitOp, args)
 	if err != nil {
-		return models.DefaultIntResponse, errors.New("Bitop command execution failed")
+		return models.DefaultIntResponse, errors.New("bitop command execution failed")
 	}
 	return handleIntResponse(result)
 }

--- a/go/callbacks.go
+++ b/go/callbacks.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 )
 
@@ -52,7 +51,7 @@ func successCallback(channelPtr unsafe.Pointer, cResponse *C.struct_CommandRespo
 func failureCallback(channelPtr unsafe.Pointer, cErrorMessage *C.char, cErrorType C.RequestErrorType) {
 	msg := C.GoString(cErrorMessage)
 	resultChannel := *(*chan payload)(getPinnedPtr(channelPtr))
-	resultChannel <- payload{value: nil, error: glideErrors.GoError(uint32(cErrorType), msg)}
+	resultChannel <- payload{value: nil, error: GoError(uint32(cErrorType), msg)}
 }
 
 //

--- a/go/callbacks.go
+++ b/go/callbacks.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 )
 
@@ -52,7 +52,7 @@ func successCallback(channelPtr unsafe.Pointer, cResponse *C.struct_CommandRespo
 func failureCallback(channelPtr unsafe.Pointer, cErrorMessage *C.char, cErrorType C.RequestErrorType) {
 	msg := C.GoString(cErrorMessage)
 	resultChannel := *(*chan payload)(getPinnedPtr(channelPtr))
-	resultChannel <- payload{value: nil, error: errors.GoError(uint32(cErrorType), msg)}
+	resultChannel <- payload{value: nil, error: glideErrors.GoError(uint32(cErrorType), msg)}
 }
 
 //

--- a/go/callbacks.go
+++ b/go/callbacks.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 )
 

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 )
 
@@ -244,7 +244,7 @@ func TestConfig_AzAffinity(t *testing.T) {
 }
 
 func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
-	var errorType *errors.ConfigurationError
+	var errorType *glideErrors.ConfigurationError
 
 	// RequestTimeout Negative duration
 	config := NewClientConfiguration().

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
+
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 )
 
@@ -244,15 +244,12 @@ func TestConfig_AzAffinity(t *testing.T) {
 }
 
 func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
-	var errorType *glideErrors.ConfigurationError
-
 	// RequestTimeout Negative duration
 	config := NewClientConfiguration().
 		WithRequestTimeout(-1 * time.Hour)
 
 	_, err := config.ToProtobuf()
 	assert.Error(t, err)
-	assert.ErrorAs(t, err, &errorType)
 	assert.Contains(t, err.Error(), "invalid duration was specified")
 
 	config2 := NewClusterClientConfiguration().
@@ -260,7 +257,6 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err2 := config2.ToProtobuf()
 	assert.Error(t, err2)
-	assert.ErrorAs(t, err2, &errorType)
 	assert.Contains(t, err2.Error(), "invalid duration was specified")
 
 	// RequestTimeout 50 days
@@ -269,7 +265,6 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err3 := config3.ToProtobuf()
 	assert.Error(t, err3)
-	assert.ErrorAs(t, err3, &errorType)
 	assert.Contains(t, err3.Error(), "invalid duration was specified")
 
 	config4 := NewClusterClientConfiguration().
@@ -277,7 +272,6 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err4 := config4.ToProtobuf()
 	assert.Error(t, err4)
-	assert.ErrorAs(t, err4, &errorType)
 	assert.Contains(t, err4.Error(), "invalid duration was specified")
 
 	// ConnectionTimeout Negative duration
@@ -286,7 +280,6 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err5 := config5.ToProtobuf()
 	assert.Error(t, err5)
-	assert.ErrorAs(t, err5, &errorType)
 	assert.Contains(t, err5.Error(), "invalid duration was specified")
 
 	config6 := NewClusterClientConfiguration().
@@ -294,7 +287,6 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err6 := config6.ToProtobuf()
 	assert.Error(t, err6)
-	assert.ErrorAs(t, err6, &errorType)
 	assert.Contains(t, err6.Error(), "invalid duration was specified")
 
 	// ConnectionTimeout 50 days
@@ -303,7 +295,6 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err7 := config7.ToProtobuf()
 	assert.Error(t, err7)
-	assert.ErrorAs(t, err7, &errorType)
 	assert.Contains(t, err7.Error(), "invalid duration was specified")
 
 	config8 := NewClusterClientConfiguration().
@@ -311,6 +302,5 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 
 	_, err8 := config8.ToProtobuf()
 	assert.Error(t, err8)
-	assert.ErrorAs(t, err8, &errorType)
 	assert.Contains(t, err8.Error(), "invalid duration was specified")
 }

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 )
 
@@ -244,7 +244,6 @@ func TestConfig_AzAffinity(t *testing.T) {
 }
 
 func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
-	var errorType *errors.ConfigurationError
 	// RequestTimeout Negative duration
 	config := NewClientConfiguration().
 		WithRequestTimeout(-1 * time.Hour)

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
+	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 )
 
@@ -244,6 +244,7 @@ func TestConfig_AzAffinity(t *testing.T) {
 }
 
 func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
+	var errorType *errors.ConfigurationError
 	// RequestTimeout Negative duration
 	config := NewClientConfiguration().
 		WithRequestTimeout(-1 * time.Hour)

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -249,58 +249,50 @@ func TestConfig_InvalidRequestAndConnectionTimeouts(t *testing.T) {
 		WithRequestTimeout(-1 * time.Hour)
 
 	_, err := config.ToProtobuf()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid duration was specified")
+	assert.EqualError(t, err, "invalid duration was specified")
 
 	config2 := NewClusterClientConfiguration().
 		WithRequestTimeout(-1 * time.Hour)
 
 	_, err2 := config2.ToProtobuf()
-	assert.Error(t, err2)
-	assert.Contains(t, err2.Error(), "invalid duration was specified")
+	assert.EqualError(t, err2, "invalid duration was specified")
 
 	// RequestTimeout 50 days
 	config3 := NewClientConfiguration().
 		WithRequestTimeout(1200 * time.Hour)
 
 	_, err3 := config3.ToProtobuf()
-	assert.Error(t, err3)
-	assert.Contains(t, err3.Error(), "invalid duration was specified")
+	assert.EqualError(t, err3, "invalid duration was specified")
 
 	config4 := NewClusterClientConfiguration().
 		WithRequestTimeout(1200 * time.Hour)
 
 	_, err4 := config4.ToProtobuf()
-	assert.Error(t, err4)
-	assert.Contains(t, err4.Error(), "invalid duration was specified")
+	assert.EqualError(t, err4, "invalid duration was specified")
 
 	// ConnectionTimeout Negative duration
 	config5 := NewClientConfiguration().
 		WithAdvancedConfiguration(NewAdvancedClientConfiguration().WithConnectionTimeout(-1 * time.Hour))
 
 	_, err5 := config5.ToProtobuf()
-	assert.Error(t, err5)
-	assert.Contains(t, err5.Error(), "invalid duration was specified")
+	assert.EqualError(t, err5, "invalid duration was specified")
 
 	config6 := NewClusterClientConfiguration().
 		WithAdvancedConfiguration(NewAdvancedClusterClientConfiguration().WithConnectionTimeout(-1 * time.Hour))
 
 	_, err6 := config6.ToProtobuf()
-	assert.Error(t, err6)
-	assert.Contains(t, err6.Error(), "invalid duration was specified")
+	assert.EqualError(t, err6, "invalid duration was specified")
 
 	// ConnectionTimeout 50 days
 	config7 := NewClientConfiguration().
 		WithAdvancedConfiguration(NewAdvancedClientConfiguration().WithConnectionTimeout(1200 * time.Hour))
 
 	_, err7 := config7.ToProtobuf()
-	assert.Error(t, err7)
-	assert.Contains(t, err7.Error(), "invalid duration was specified")
+	assert.EqualError(t, err7, "invalid duration was specified")
 
 	config8 := NewClusterClientConfiguration().
 		WithAdvancedConfiguration(NewAdvancedClusterClientConfiguration().WithConnectionTimeout(1200 * time.Hour))
 
 	_, err8 := config8.ToProtobuf()
-	assert.Error(t, err8)
-	assert.Contains(t, err8.Error(), "invalid duration was specified")
+	assert.EqualError(t, err8, "invalid duration was specified")
 }

--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -103,7 +103,9 @@ func NewByAddressRoute(host string, port int32) *ByAddressRoute {
 func NewByAddressRouteWithHost(host string) (*ByAddressRoute, error) {
 	split := strings.Split(host, ":")
 	if len(split) != 2 {
-		return nil, glideErrors.NewRequestError(fmt.Sprintf("no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host))
+		return nil, glideErrors.NewRequestError(
+			fmt.Sprintf("no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host),
+		)
 	}
 
 	port, err := strconv.ParseInt(split[1], 10, 32)

--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -3,11 +3,10 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 )
 
 // Request routing basic interface. Please use one of the following:
@@ -103,14 +102,14 @@ func NewByAddressRoute(host string, port int32) *ByAddressRoute {
 func NewByAddressRouteWithHost(host string) (*ByAddressRoute, error) {
 	split := strings.Split(host, ":")
 	if len(split) != 2 {
-		return nil, glideErrors.NewRequestError(
+		return nil, errors.New(
 			fmt.Sprintf("no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host),
 		)
 	}
 
 	port, err := strconv.ParseInt(split[1], 10, 32)
 	if err != nil {
-		return nil, glideErrors.NewRequestError(fmt.Sprintf("port must be a valid integer. Received: %s", split[1]))
+		return nil, errors.New(fmt.Sprintf("port must be a valid integer. Received: %s", split[1]))
 	}
 
 	return &ByAddressRoute{Host: split[0], Port: int32(port)}, nil

--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 )
 
 // Request routing basic interface. Please use one of the following:
@@ -103,20 +103,12 @@ func NewByAddressRoute(host string, port int32) *ByAddressRoute {
 func NewByAddressRouteWithHost(host string) (*ByAddressRoute, error) {
 	split := strings.Split(host, ":")
 	if len(split) != 2 {
-		return nil, &errors.RequestError{
-			Msg: fmt.Sprintf(
-				"no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host,
-			),
-		}
+		return nil, glideErrors.NewRequestError(fmt.Sprintf("no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host))
 	}
 
 	port, err := strconv.ParseInt(split[1], 10, 32)
 	if err != nil {
-		return nil, &errors.RequestError{
-			Msg: fmt.Sprintf(
-				"port must be a valid integer. Received: %s", split[1],
-			),
-		}
+		return nil, glideErrors.NewRequestError(fmt.Sprintf("port must be a valid integer. Received: %s", split[1]))
 	}
 
 	return &ByAddressRoute{Host: split[0], Port: int32(port)}, nil

--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -109,7 +109,7 @@ func NewByAddressRouteWithHost(host string) (*ByAddressRoute, error) {
 
 	port, err := strconv.ParseInt(split[1], 10, 32)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("port must be a valid integer. Received: %s", split[1]))
+		return nil, fmt.Errorf("port must be a valid integer. Received: %s", split[1])
 	}
 
 	return &ByAddressRoute{Host: split[0], Port: int32(port)}, nil

--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 )
 
 // Request routing basic interface. Please use one of the following:

--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -3,7 +3,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -102,9 +101,7 @@ func NewByAddressRoute(host string, port int32) *ByAddressRoute {
 func NewByAddressRouteWithHost(host string) (*ByAddressRoute, error) {
 	split := strings.Split(host, ":")
 	if len(split) != 2 {
-		return nil, errors.New(
-			fmt.Sprintf("no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host),
-		)
+		return nil, fmt.Errorf("no port provided, or host is not in the expected format 'hostname:port'. Received: %s", host)
 	}
 
 	port, err := strconv.ParseInt(split[1], 10, 32)

--- a/go/constants/constants.go
+++ b/go/constants/constants.go
@@ -2,7 +2,7 @@
 
 package constants
 
-import "github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+import "github.com/valkey-io/valkey-glide/go/v2/errors"
 
 const (
 	CountKeyword      string = "COUNT"      // Valkey API keyword used to extract specific number of matching indices from a list.

--- a/go/constants/constants.go
+++ b/go/constants/constants.go
@@ -2,7 +2,9 @@
 
 package constants
 
-import "github.com/valkey-io/valkey-glide/go/v2/glideErrors"
+import (
+	"errors"
+)
 
 const (
 	CountKeyword      string = "COUNT"      // Valkey API keyword used to extract specific number of matching indices from a list.
@@ -93,7 +95,7 @@ func (expireCondition ExpireCondition) ToString() (string, error) {
 	case NewExpiryLessThanCurrent:
 		return string(NewExpiryLessThanCurrent), nil
 	default:
-		return "", glideErrors.NewRequestError("Invalid expire condition")
+		return "", errors.New("Invalid expire condition")
 	}
 }
 
@@ -136,7 +138,7 @@ func (insertPosition InsertPosition) ToString() (string, error) {
 	case After:
 		return string(After), nil
 	default:
-		return "", glideErrors.NewRequestError("Invalid insert position")
+		return "", errors.New("Invalid insert position")
 	}
 }
 
@@ -157,7 +159,7 @@ func (listDirection ListDirection) ToString() (string, error) {
 	case Right:
 		return string(Right), nil
 	default:
-		return "", glideErrors.NewRequestError("Invalid list direction")
+		return "", errors.New("Invalid list direction")
 	}
 }
 
@@ -179,7 +181,7 @@ func (scoreFilter ScoreFilter) ToString() (string, error) {
 	case MIN:
 		return string(MIN), nil
 	default:
-		return "", glideErrors.NewRequestError("Invalid score filter")
+		return "", errors.New("Invalid score filter")
 	}
 }
 

--- a/go/constants/constants.go
+++ b/go/constants/constants.go
@@ -2,7 +2,7 @@
 
 package constants
 
-import "github.com/valkey-io/valkey-glide/go/v2/errors"
+import "github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 
 const (
 	CountKeyword      string = "COUNT"      // Valkey API keyword used to extract specific number of matching indices from a list.
@@ -93,7 +93,7 @@ func (expireCondition ExpireCondition) ToString() (string, error) {
 	case NewExpiryLessThanCurrent:
 		return string(NewExpiryLessThanCurrent), nil
 	default:
-		return "", &errors.RequestError{Msg: "Invalid expire condition"}
+		return "", glideErrors.NewRequestError("Invalid expire condition")
 	}
 }
 
@@ -136,7 +136,7 @@ func (insertPosition InsertPosition) ToString() (string, error) {
 	case After:
 		return string(After), nil
 	default:
-		return "", &errors.RequestError{Msg: "Invalid insert position"}
+		return "", glideErrors.NewRequestError("Invalid insert position")
 	}
 }
 
@@ -157,7 +157,7 @@ func (listDirection ListDirection) ToString() (string, error) {
 	case Right:
 		return string(Right), nil
 	default:
-		return "", &errors.RequestError{Msg: "Invalid list direction"}
+		return "", glideErrors.NewRequestError("Invalid list direction")
 	}
 }
 
@@ -179,7 +179,7 @@ func (scoreFilter ScoreFilter) ToString() (string, error) {
 	case MIN:
 		return string(MIN), nil
 	default:
-		return "", &errors.RequestError{Msg: "Invalid score filter"}
+		return "", glideErrors.NewRequestError("Invalid score filter")
 	}
 }
 

--- a/go/constants/constants.go
+++ b/go/constants/constants.go
@@ -95,7 +95,7 @@ func (expireCondition ExpireCondition) ToString() (string, error) {
 	case NewExpiryLessThanCurrent:
 		return string(NewExpiryLessThanCurrent), nil
 	default:
-		return "", errors.New("Invalid expire condition")
+		return "", errors.New("invalid expire condition")
 	}
 }
 
@@ -138,7 +138,7 @@ func (insertPosition InsertPosition) ToString() (string, error) {
 	case After:
 		return string(After), nil
 	default:
-		return "", errors.New("Invalid insert position")
+		return "", errors.New("invalid insert position")
 	}
 }
 
@@ -159,7 +159,7 @@ func (listDirection ListDirection) ToString() (string, error) {
 	case Right:
 		return string(Right), nil
 	default:
-		return "", errors.New("Invalid list direction")
+		return "", errors.New("invalid list direction")
 	}
 }
 
@@ -181,7 +181,7 @@ func (scoreFilter ScoreFilter) ToString() (string, error) {
 	case MIN:
 		return string(MIN), nil
 	default:
-		return "", errors.New("Invalid score filter")
+		return "", errors.New("invalid score filter")
 	}
 }
 

--- a/go/errors.go
+++ b/go/errors.go
@@ -4,7 +4,11 @@ package glide
 
 // #include "lib.h"
 import "C"
-import "errors"
+
+import (
+	"errors"
+	"strings"
+)
 
 // ConnectionError is a client error that occurs when there is an error while connecting or when a connection
 // disconnects.
@@ -92,4 +96,15 @@ func GoError(cErrorType uint32, errorMessage string) error {
 	default:
 		return errors.New(errorMessage)
 	}
+}
+
+// ErrorsToString converts a slice of errors into a single string.
+func ErrorsToString(errors []error) string {
+	sb := strings.Builder{}
+	for _, err := range errors {
+		sb.WriteString("- ")
+		sb.WriteString(err.Error())
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }

--- a/go/errors.go
+++ b/go/errors.go
@@ -1,8 +1,8 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-package glideErrors
+package glide
 
-// #include "../lib.h"
+// #include "lib.h"
 import "C"
 import "errors"
 
@@ -17,17 +17,6 @@ func NewConnectionError(message string) *ConnectionError {
 }
 
 func (e *ConnectionError) Error() string { return e.msg }
-
-// // RequestError is a client error that occurs when an error is reported during a request.
-// type RequestError struct {
-// 	msg string
-// }
-
-// func NewRequestError(message string) *RequestError {
-// 	return &RequestError{msg: message}
-// }
-
-// func (e *RequestError) Error() string { return e.msg }
 
 // ExecAbortError is a client error that occurs when a transaction is aborted.
 type ExecAbortError struct {

--- a/go/errors.go
+++ b/go/errors.go
@@ -7,6 +7,7 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -76,6 +77,19 @@ func NewConfigurationError(message string) *ConfigurationError {
 }
 
 func (e *ConfigurationError) Error() string { return e.msg }
+
+type BatchError struct {
+	errors []error
+}
+
+func NewBatchError(errs []error) *BatchError {
+	return &BatchError{errors: errs}
+}
+
+func (e *BatchError) Error() string {
+	return fmt.Sprintf("there were %d errors while preparing commands in this batch: \n%s",
+		len(e.errors), ErrorsToString(e.errors))
+}
 
 func IsError(val any) error {
 	if err, ok := val.(error); ok {

--- a/go/errors/errors.go
+++ b/go/errors/errors.go
@@ -2,7 +2,7 @@
 
 package errors
 
-// #include "../../lib.h"
+// #include "../lib.h"
 import "C"
 
 // ConnectionError is a client error that occurs when there is an error while connecting or when a connection

--- a/go/glideErrors/errors.go
+++ b/go/glideErrors/errors.go
@@ -4,6 +4,7 @@ package glideErrors
 
 // #include "../lib.h"
 import "C"
+import "errors"
 
 // ConnectionError is a client error that occurs when there is an error while connecting or when a connection
 // disconnects.
@@ -17,16 +18,16 @@ func NewConnectionError(message string) *ConnectionError {
 
 func (e *ConnectionError) Error() string { return e.msg }
 
-// RequestError is a client error that occurs when an error is reported during a request.
-type RequestError struct {
-	msg string
-}
+// // RequestError is a client error that occurs when an error is reported during a request.
+// type RequestError struct {
+// 	msg string
+// }
 
-func NewRequestError(message string) *RequestError {
-	return &RequestError{msg: message}
-}
+// func NewRequestError(message string) *RequestError {
+// 	return &RequestError{msg: message}
+// }
 
-func (e *RequestError) Error() string { return e.msg }
+// func (e *RequestError) Error() string { return e.msg }
 
 // ExecAbortError is a client error that occurs when a transaction is aborted.
 type ExecAbortError struct {
@@ -83,6 +84,13 @@ func NewConfigurationError(message string) *ConfigurationError {
 
 func (e *ConfigurationError) Error() string { return e.msg }
 
+func IsError(val any) error {
+	if err, ok := val.(error); ok {
+		return err
+	}
+	return nil
+}
+
 // GoError converts a C error type to a corresponding Go error.
 func GoError(cErrorType uint32, errorMessage string) error {
 	switch cErrorType {
@@ -93,6 +101,6 @@ func GoError(cErrorType uint32, errorMessage string) error {
 	case C.Disconnect:
 		return &DisconnectError{errorMessage}
 	default:
-		return &RequestError{errorMessage}
+		return errors.New(errorMessage)
 	}
 }

--- a/go/glideErrors/errors.go
+++ b/go/glideErrors/errors.go
@@ -1,6 +1,6 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-package errors
+package glideErrors
 
 // #include "../lib.h"
 import "C"
@@ -8,21 +8,33 @@ import "C"
 // ConnectionError is a client error that occurs when there is an error while connecting or when a connection
 // disconnects.
 type ConnectionError struct {
-	Msg string
+	msg string
 }
 
-func (e *ConnectionError) Error() string { return e.Msg }
+func NewConnectionError(message string) *ConnectionError {
+	return &ConnectionError{msg: message}
+}
+
+func (e *ConnectionError) Error() string { return e.msg }
 
 // RequestError is a client error that occurs when an error is reported during a request.
 type RequestError struct {
-	Msg string
+	msg string
 }
 
-func (e *RequestError) Error() string { return e.Msg }
+func NewRequestError(message string) *RequestError {
+	return &RequestError{msg: message}
+}
+
+func (e *RequestError) Error() string { return e.msg }
 
 // ExecAbortError is a client error that occurs when a transaction is aborted.
 type ExecAbortError struct {
 	msg string
+}
+
+func NewExecAbortError(message string) *ExecAbortError {
+	return &ExecAbortError{msg: message}
 }
 
 func (e *ExecAbortError) Error() string { return e.msg }
@@ -32,6 +44,10 @@ type TimeoutError struct {
 	msg string
 }
 
+func NewTimeoutError(message string) *TimeoutError {
+	return &TimeoutError{msg: message}
+}
+
 func (e *TimeoutError) Error() string { return e.msg }
 
 // DisconnectError is a client error that indicates a connection problem between Glide and server.
@@ -39,21 +55,33 @@ type DisconnectError struct {
 	msg string
 }
 
+func NewDisconnectError(message string) *DisconnectError {
+	return &DisconnectError{msg: message}
+}
+
 func (e *DisconnectError) Error() string { return e.msg }
 
 // ClosingError is a client error that indicates that the client has closed and is no longer usable.
 type ClosingError struct {
-	Msg string
+	msg string
 }
 
-func (e *ClosingError) Error() string { return e.Msg }
+func NewClosingError(message string) *ClosingError {
+	return &ClosingError{msg: message}
+}
+
+func (e *ClosingError) Error() string { return e.msg }
 
 // ConfigurationError is a client error that occurs when there is an issue with client configuration.
 type ConfigurationError struct {
-	Msg string
+	msg string
 }
 
-func (e *ConfigurationError) Error() string { return e.Msg }
+func NewConfigurationError(message string) *ConfigurationError {
+	return &ConfigurationError{msg: message}
+}
+
+func (e *ConfigurationError) Error() string { return e.msg }
 
 // GoError converts a C error type to a corresponding Go error.
 func GoError(cErrorType uint32, errorMessage string) error {

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -75,11 +75,11 @@ func NewClient(config *config.ClientConfiguration) (*Client, error) {
 //	ctx - The context for controlling the command execution
 //	batch - A `ClusterBatch` object containing a list of commands to be executed.
 //	raiseOnError - Determines how errors are handled within the batch response. When set to
-//	  `true`, the first encountered error in the batch will be raised as an Error
+//	  `true`, the first encountered error in the batch will be raised as an error
 //	  after all retries and reconnections have been executed. When set to `false`,
 //	  errors will be included as part of the batch response array, allowing the caller to process both
 //	  successful and failed commands together. In this case, error details will be provided as
-//	  instances of Error.
+//	  instances of error.
 //
 // Return value:
 //

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -7,7 +7,6 @@ import "C"
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -7,6 +7,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 
@@ -75,11 +76,11 @@ func NewClient(config *config.ClientConfiguration) (*Client, error) {
 //	ctx - The context for controlling the command execution
 //	batch - A `ClusterBatch` object containing a list of commands to be executed.
 //	raiseOnError - Determines how errors are handled within the batch response. When set to
-//	  `true`, the first encountered error in the batch will be raised as a `RequestError`
-//	  exception after all retries and reconnections have been executed. When set to `false`,
+//	  `true`, the first encountered error in the batch will be raised as an Error
+//	  after all retries and reconnections have been executed. When set to `false`,
 //	  errors will be included as part of the batch response array, allowing the caller to process both
 //	  successful and failed commands together. In this case, error details will be provided as
-//	  instances of `RequestError`.
+//	  instances of Error.
 //
 // Return value:
 //
@@ -102,8 +103,8 @@ func (client *Client) Exec(ctx context.Context, batch pipeline.StandaloneBatch, 
 //	ctx - The context for controlling the command execution
 //	batch - A `ClusterBatch` object containing a list of commands to be executed.
 //	raiseOnError - Determines how errors are handled within the batch response. When set to
-//	  `true`, the first encountered error in the batch will be raised as a `RequestError`
-//	  exception after all retries and reconnections have been executed. When set to `false`,
+//	  `true`, the first encountered error in the batch will be raised as an error
+//	  after all retries and reconnections have been executed. When set to `false`,
 //	  errors will be included as part of the batch response array, allowing the caller to process both
 //	  successful and failed commands together. In this case, error details will be provided as
 //	  instances of `RequestError`.

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -176,7 +176,7 @@ func (client *ClusterClient) ExecWithOptions(
 	options pipeline.ClusterBatchOptions,
 ) ([]any, error) {
 	if batch.Batch.IsAtomic && options.RetryStrategy != nil {
-		return nil, errors.New("Retry strategy is not supported for atomic batches (transactions).")
+		return nil, errors.New("retry strategy is not supported for atomic batches (transactions)")
 	}
 	converted := options.Convert()
 	return client.executeBatch(ctx, batch.Batch, raiseOnError, &converted)

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -7,6 +7,7 @@ import "C"
 
 import (
 	"context"
+	"errors"
 	"unsafe"
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
@@ -176,7 +177,7 @@ func (client *ClusterClient) ExecWithOptions(
 	options pipeline.ClusterBatchOptions,
 ) ([]any, error) {
 	if batch.Batch.IsAtomic && options.RetryStrategy != nil {
-		return nil, &errors.RequestError{Msg: "Retry strategy is not supported for atomic batches (transactions)."}
+		return nil, errors.New("Retry strategy is not supported for atomic batches (transactions).")
 	}
 	converted := options.Convert()
 	return client.executeBatch(ctx, batch.Batch, raiseOnError, &converted)

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
@@ -637,7 +636,7 @@ func (client *ClusterClient) clusterScan(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return nil, glideErrors.NewClosingError("Cluster Scan failed. The client is closed.")
+		return nil, NewClosingError("Cluster Scan failed. The client is closed.")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 	"github.com/valkey-io/valkey-glide/go/v2/models"

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
@@ -636,7 +636,7 @@ func (client *ClusterClient) clusterScan(
 	client.mu.Lock()
 	if client.coreClient == nil {
 		client.mu.Unlock()
-		return nil, &errors.ClosingError{Msg: "Cluster Scan failed. The client is closed."}
+		return nil, glideErrors.NewClosingError("Cluster Scan failed. The client is closed.")
 	}
 	client.pending[resultChannelPtr] = struct{}{}
 

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -101,8 +101,8 @@ func NewClusterClient(config *config.ClusterClientConfiguration) (*ClusterClient
 //	ctx - The context for controlling the command execution
 //	batch - A `ClusterBatch` object containing a list of commands to be executed.
 //	raiseOnError - Determines how errors are handled within the batch response. When set to
-//	  `true`, the first encountered error in the batch will be raised as a `RequestError`
-//	  exception after all retries and reconnections have been executed. When set to `false`,
+//	  `true`, the first encountered error in the batch will be raised as an error
+//	  after all retries and reconnections have been executed. When set to `false`,
 //	  errors will be included as part of the batch response array, allowing the caller to process both
 //	  successful and failed commands together. In this case, error details will be provided as
 //	  instances of `RequestError`.
@@ -154,8 +154,8 @@ func (client *ClusterClient) Exec(ctx context.Context, batch pipeline.ClusterBat
 //	ctx - The context for controlling the command execution
 //	batch - A `ClusterBatch` object containing a list of commands to be executed.
 //	raiseOnError - Determines how errors are handled within the batch response. When set to
-//	  `true`, the first encountered error in the batch will be raised as a `RequestError`
-//	  exception after all retries and reconnections have been executed. When set to `false`,
+//	  `true`, the first encountered error in the batch will be raised as an error
+//	  after all retries and reconnections have been executed. When set to `false`,
 //	  errors will be included as part of the batch response array, allowing the caller to process both
 //	  successful and failed commands together. In this case, error details will be provided as
 //	  instances of `RequestError`.

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -15,7 +15,6 @@ import (
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
@@ -41,7 +40,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout exception on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&glideErrors.TimeoutError{}, err)
+			suite.IsType(&glide.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 
@@ -56,7 +55,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout exception on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&glideErrors.TimeoutError{}, err)
+			suite.IsType(&glide.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 
@@ -70,7 +69,6 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 }
 
 func (suite *GlideTestSuite) TestBatchRaiseOnError() {
-	suite.T().Skip()
 	suite.runBatchTest(func(client interfaces.BaseClientCommands, isAtomic bool) {
 		key1 := "{BatchRaiseOnError}" + uuid.NewString()
 		key2 := "{BatchRaiseOnError}" + uuid.NewString()
@@ -108,8 +106,8 @@ func (suite *GlideTestSuite) TestBatchRaiseOnError() {
 		suite.Len(res, 4)
 		suite.Equal("OK", res[0])
 		suite.Equal(int64(1), res[2])
-		suite.Error(glideErrors.IsError(res[1]))
-		suite.Error(glideErrors.IsError(res[3]))
+		suite.Error(glide.IsError(res[1]))
+		suite.Error(glide.IsError(res[3]))
 		suite.Contains(res[1].(error).Error(), "wrong kind of value")
 		suite.Contains(res[3].(error).Error(), "no such key")
 	})
@@ -296,7 +294,6 @@ func (suite *GlideTestSuite) TestBatchGeoSpatial() {
 }
 
 func (suite *GlideTestSuite) TestBatchComplexFunctionCommands() {
-	suite.T().Skip()
 	// TODO: Make tests that test the functionality. For now, we test that they can be sent and have responses received.
 	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
@@ -328,7 +325,6 @@ func (suite *GlideTestSuite) TestBatchComplexFunctionCommands() {
 			res, err = c.Exec(context.Background(), *batch, false)
 			suite.NoError(err)
 		}
-		fmt.Println("Responses:", res)
 
 		suite.Error(res[0].(error))
 		suite.Error(res[1].(error))
@@ -457,9 +453,9 @@ func (suite *GlideTestSuite) TestBatchStandaloneAndClusterPubSub() {
 				suite.Equal(map[string]any{}, res[3])
 			} else {
 				// In 6.2.0, errors are raised instead
-				suite.Error(glideErrors.IsError(res[1]))
-				suite.Error(glideErrors.IsError(res[2]))
-				suite.Error(glideErrors.IsError(res[3]))
+				suite.Error(glide.IsError(res[1]))
+				suite.Error(glide.IsError(res[2]))
+				suite.Error(glide.IsError(res[3]))
 			}
 		case *glide.Client:
 			batch := pipeline.NewStandaloneBatch(isAtomic).

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -40,7 +40,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout exception on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&glide.TimeoutError{}, err)
+			suite.IsType(&errors.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 
@@ -55,7 +55,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout exception on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&glide.TimeoutError{}, err)
+			suite.IsType(&errors.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -37,7 +37,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 		case *glide.ClusterClient:
 			batch := pipeline.NewClusterBatch(isAtomic).CustomCommand([]string{"DEBUG", "sleep", "0.5"})
 			opts := pipeline.NewClusterBatchOptions().WithRoute(config.RandomRoute).WithTimeout(100)
-			// Expect a timeout exception on short timeout
+			// Expect a timeout error on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
 			suite.IsType(&glideErrors.TimeoutError{}, err)
@@ -52,7 +52,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 		case *glide.Client:
 			batch := pipeline.NewStandaloneBatch(isAtomic).CustomCommand([]string{"DEBUG", "sleep", "0.5"})
 			opts := pipeline.NewStandaloneBatchOptions().WithTimeout(100)
-			// Expect a timeout exception on short timeout
+			// Expect a timeout error on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
 			suite.IsType(&glideErrors.TimeoutError{}, err)
@@ -98,10 +98,10 @@ func (suite *GlideTestSuite) TestBatchRaiseOnError() {
 			_, err1 = c.Exec(context.Background(), *batch, true)
 			res, err2 = c.Exec(context.Background(), *batch, false)
 		}
-		// First exception is raised, all data lost
+		// First error is raised, all data lost
 		suite.Error(err1)
 
-		// Exceptions aren't raised, but stored in the result set
+		// Errors aren't raised, but stored in the result set
 		suite.NoError(err2)
 		suite.Len(res, 4)
 		suite.Equal("OK", res[0])

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -40,7 +40,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout error on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&glideErrors.TimeoutError{}, err)
+			suite.IsType(&glide.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 
@@ -55,7 +55,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout error on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&glideErrors.TimeoutError{}, err)
+			suite.IsType(&glide.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -106,10 +106,8 @@ func (suite *GlideTestSuite) TestBatchRaiseOnError() {
 		suite.Len(res, 4)
 		suite.Equal("OK", res[0])
 		suite.Equal(int64(1), res[2])
-		suite.Error(glide.IsError(res[1]))
-		suite.Error(glide.IsError(res[3]))
-		suite.Contains(res[1].(error).Error(), "wrong kind of value")
-		suite.Contains(res[3].(error).Error(), "no such key")
+		suite.ErrorContains(glide.IsError(res[1]), "wrong kind of value")
+		suite.ErrorContains(glide.IsError(res[3]), "no such key")
 	})
 }
 

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -40,7 +40,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout exception on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&errors.TimeoutError{}, err)
+			suite.IsType(&glideErrors.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 
@@ -55,7 +55,7 @@ func (suite *GlideTestSuite) TestBatchTimeout() {
 			// Expect a timeout exception on short timeout
 			_, err := c.ExecWithOptions(context.Background(), *batch, true, *opts)
 			suite.Error(err)
-			suite.IsType(&errors.TimeoutError{}, err)
+			suite.IsType(&glideErrors.TimeoutError{}, err)
 
 			time.Sleep(1 * time.Second)
 

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -25,7 +25,7 @@ func (suite *GlideTestSuite) TestClusterCustomCommandInfo() {
 	client := suite.defaultClusterClient()
 	result, err := client.CustomCommand(context.Background(), []string{"INFO"})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	// INFO is routed to all primary nodes by default
 	for _, value := range result.MultiValue() {
 		assert.True(suite.T(), strings.Contains(value.(string), "# Stats"))
@@ -36,7 +36,7 @@ func (suite *GlideTestSuite) TestClusterCustomCommandEcho() {
 	client := suite.defaultClusterClient()
 	result, err := client.CustomCommand(context.Background(), []string{"ECHO", "GO GLIDE GO"})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	// ECHO is routed to a single random node
 	assert.Equal(suite.T(), "GO GLIDE GO", result.SingleValue().(string))
 }
@@ -154,7 +154,7 @@ func (suite *GlideTestSuite) TestClusterCustomCommandWithRoute_Info() {
 	client := suite.defaultClusterClient()
 	route := config.SimpleNodeRoute(config.AllPrimaries)
 	result, err := client.CustomCommandWithRoute(context.Background(), []string{"INFO"}, route)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.True(suite.T(), result.IsMultiValue())
 	multiValue := result.MultiValue()
 	for _, value := range multiValue {
@@ -166,7 +166,7 @@ func (suite *GlideTestSuite) TestClusterCustomCommandWithRoute_Echo() {
 	client := suite.defaultClusterClient()
 	route := config.SimpleNodeRoute(config.RandomRoute)
 	result, err := client.CustomCommandWithRoute(context.Background(), []string{"ECHO", "GO GLIDE GO"}, route)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.True(suite.T(), result.IsSingleValue())
 	assert.Equal(suite.T(), "GO GLIDE GO", result.SingleValue().(string))
 }
@@ -183,7 +183,7 @@ func (suite *GlideTestSuite) TestClusterCustomCommandWithRoute_AllNodes() {
 	client := suite.defaultClusterClient()
 	route := config.SimpleNodeRoute(config.AllNodes)
 	result, err := client.CustomCommandWithRoute(context.Background(), []string{"PING"}, route)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.True(suite.T(), result.IsSingleValue())
 	assert.Equal(suite.T(), "PONG", result.SingleValue())
 }
@@ -197,7 +197,7 @@ func (suite *GlideTestSuite) TestPingWithOptions_NoRoute() {
 		RouteOption: nil,
 	}
 	result, err := client.PingWithOptions(context.Background(), options)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "hello", result)
 }
 
@@ -210,7 +210,7 @@ func (suite *GlideTestSuite) TestPingWithOptions_WithRoute() {
 		RouteOption: &options.RouteOption{Route: config.AllNodes},
 	}
 	result, err := client.PingWithOptions(context.Background(), options)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "hello", result)
 }
 
@@ -1054,8 +1054,8 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_InvalidParamete
 
 	// Test empty password
 	_, err := testClient.UpdateConnectionPassword(context.Background(), "", true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
+
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_NoServerAuth() {
@@ -1070,8 +1070,8 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_NoServerAuth() 
 	// Test immediate re-authentication fails when no server password is set
 	pwd := uuid.NewString()
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
+
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_LongPassword() {
@@ -1117,25 +1117,24 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_ImmediateAuthWr
 
 	// Test that re-authentication fails when using wrong password
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 
 	// But using correct password returns OK
 	_, err = testClient.UpdateConnectionPassword(context.Background(), notThePwd, true)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	// Cleanup: Reset password
 	_, err = adminClient.CustomCommand(context.Background(), []string{"CONFIG", "SET", "requirepass", ""})
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 }
 
 func (suite *GlideTestSuite) TestClusterLolwut() {
 	client := suite.defaultClusterClient()
 
 	result, err := client.Lolwut(context.Background())
-	assert.NoError(suite.T(), err)
-	assert.NotEmpty(suite.T(), result)
-	assert.Contains(suite.T(), result, "Redis ver.")
+	suite.NoError(err)
+	suite.NotEmpty(result)
+	suite.Contains(result, "Redis ver.")
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllNodes() {
@@ -1148,13 +1147,13 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllNodes() {
 		RouteOption: &options.RouteOption{Route: config.AllNodes},
 	}
 	result, err := client.LolwutWithOptions(context.Background(), options)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
-	assert.True(suite.T(), result.IsMultiValue())
+	suite.True(result.IsMultiValue())
 	multiValue := result.MultiValue()
 
 	for _, value := range multiValue {
-		assert.Contains(suite.T(), value, "Redis ver.")
+		suite.Contains(value, "Redis ver.")
 	}
 }
 
@@ -1167,9 +1166,9 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllPrimaries() {
 		RouteOption: &options.RouteOption{Route: config.AllPrimaries},
 	}
 	result, err := client.LolwutWithOptions(context.Background(), options)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
-	assert.True(suite.T(), result.IsMultiValue())
+	suite.True(result.IsMultiValue())
 	multiValue := result.MultiValue()
 
 	for _, value := range multiValue {
@@ -1594,7 +1593,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDeleteWithRoute(context.Background(), "anotherLib", route)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 
 	// Test with all primaries route
 	libName = "mylib1c_all"
@@ -1607,22 +1606,22 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 	// Flush all functions with SYNC option and all primaries route
 	route = options.RouteOption{Route: config.AllPrimaries}
 	result, err = client.FunctionFlushSyncWithRoute(context.Background(), route)
-	assert.NoError(t, err)
-	assert.Equal(t, "OK", result)
+	suite.NoError(err)
+	suite.Equal("OK", result)
 
 	// Load function with all primaries route
 	result, err = client.FunctionLoadWithRoute(context.Background(), code, false, route)
-	assert.NoError(t, err)
-	assert.Equal(t, libName, result)
+	suite.NoError(err)
+	suite.Equal(libName, result)
 
 	// Test FCALL with all primaries route
 	functionResult, err = client.FCallWithArgsWithRoute(context.Background(), funcName, []string{"one", "two"}, route)
-	assert.NoError(t, err)
+	suite.NoError(err)
 	if functionResult.IsSingleValue() {
-		assert.Equal(t, "one", functionResult.SingleValue())
+		suite.Equal("one", functionResult.SingleValue())
 	} else {
 		for _, value := range functionResult.MultiValue() {
-			assert.Equal(t, "one", value)
+			suite.Equal("one", value)
 		}
 	}
 
@@ -1669,7 +1668,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDeleteWithRoute(context.Background(), "anotherLib", route)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
@@ -1721,16 +1720,16 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
 	// load new lib and delete it - first lib remains loaded
 	anotherLib := GenerateLuaLibCode("anotherLib", map[string]string{"anotherFunc": ""}, false)
 	result, err = client.FunctionLoad(context.Background(), anotherLib, true)
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "anotherLib", result)
+	suite.NoError(err)
+	suite.Equal("anotherLib", result)
 
 	deleteResult, err := client.FunctionDelete(context.Background(), "anotherLib")
-	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), "OK", deleteResult)
+	suite.NoError(err)
+	suite.Equal("OK", deleteResult)
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDelete(context.Background(), "anotherLib")
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
@@ -1741,8 +1740,8 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 
 	// Flush all functions with SYNC option
 	result, err := client.FunctionFlushSync(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, "OK", result)
+	suite.NoError(err)
+	suite.Equal("OK", result)
 
 	// Load first function
 	libName := "functionStats_without_route"
@@ -1752,12 +1751,12 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 	}
 	code := GenerateLuaLibCode(libName, functions, false)
 	result, err = client.FunctionLoad(context.Background(), code, true)
-	assert.NoError(t, err)
-	assert.Equal(t, libName, result)
+	suite.NoError(err)
+	suite.Equal(libName, result)
 
 	// Check stats after loading first function
 	stats, err := client.FunctionStats(context.Background())
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(1), nodeStats.Engines["LUA"].FunctionCount)
@@ -1772,12 +1771,12 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 	}
 	code2 := GenerateLuaLibCode(libName2, functions2, false)
 	result, err = client.FunctionLoad(context.Background(), code2, true)
-	assert.NoError(t, err)
-	assert.Equal(t, libName2, result)
+	suite.NoError(err)
+	suite.Equal(libName2, result)
 
 	// Check stats after loading second function
 	stats, err = client.FunctionStats(context.Background())
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(3), nodeStats.Engines["LUA"].FunctionCount)
@@ -1786,12 +1785,12 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 
 	// Flush all functions
 	result, err = client.FunctionFlushSync(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, "OK", result)
+	suite.NoError(err)
+	suite.Equal("OK", result)
 
 	// Check stats after flushing
 	stats, err = client.FunctionStats(context.Background())
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(0), nodeStats.Engines["LUA"].FunctionCount)
@@ -1816,17 +1815,17 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 	// Flush all functions with SYNC option and single node route
 	route := options.RouteOption{Route: config.NewSlotKeyRoute(config.SlotTypePrimary, "1")}
 	result, err := client.FunctionFlushSyncWithRoute(context.Background(), route)
-	assert.NoError(t, err)
-	assert.Equal(t, "OK", result)
+	suite.NoError(err)
+	suite.Equal("OK", result)
 
 	// Load function with single node route
 	result, err = client.FunctionLoadWithRoute(context.Background(), code, true, route)
-	assert.NoError(t, err)
-	assert.Equal(t, libName, result)
+	suite.NoError(err)
+	suite.Equal(libName, result)
 
 	// Check stats with single node route
 	stats, err := client.FunctionStatsWithRoute(context.Background(), route)
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats.MultiValue() {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(1), nodeStats.Engines["LUA"].FunctionCount)
@@ -1841,12 +1840,12 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 	}
 	code2 := GenerateLuaLibCode(libName2, functions2, false)
 	result, err = client.FunctionLoadWithRoute(context.Background(), code2, true, route)
-	assert.NoError(t, err)
-	assert.Equal(t, libName2, result)
+	suite.NoError(err)
+	suite.Equal(libName2, result)
 
 	// Check stats after loading second function
 	stats, err = client.FunctionStatsWithRoute(context.Background(), route)
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats.MultiValue() {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(3), nodeStats.Engines["LUA"].FunctionCount)
@@ -1855,12 +1854,12 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 
 	// Flush all functions
 	result, err = client.FunctionFlushSyncWithRoute(context.Background(), route)
-	assert.NoError(t, err)
-	assert.Equal(t, "OK", result)
+	suite.NoError(err)
+	suite.Equal("OK", result)
 
 	// Check stats after flushing
 	stats, err = client.FunctionStatsWithRoute(context.Background(), route)
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats.MultiValue() {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(0), nodeStats.Engines["LUA"].FunctionCount)
@@ -1878,17 +1877,17 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 	// Flush all functions with SYNC option and all primaries route
 	route = options.RouteOption{Route: config.AllPrimaries}
 	result, err = client.FunctionFlushSyncWithRoute(context.Background(), route)
-	assert.NoError(t, err)
-	assert.Equal(t, "OK", result)
+	suite.NoError(err)
+	suite.Equal("OK", result)
 
 	// Load function with all primaries route
 	result, err = client.FunctionLoadWithRoute(context.Background(), code, true, route)
-	assert.NoError(t, err)
-	assert.Equal(t, libName, result)
+	suite.NoError(err)
+	suite.Equal(libName, result)
 
 	// Check stats with all primaries route
 	stats, err = client.FunctionStatsWithRoute(context.Background(), route)
-	assert.NoError(t, err)
+	suite.NoError(err)
 	for _, nodeStats := range stats.MultiValue() {
 		assert.Empty(t, nodeStats.RunningScript.Name)
 		assert.Equal(t, int64(1), nodeStats.Engines["LUA"].FunctionCount)
@@ -2178,7 +2177,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 
 	// Dumping an empty lib
 	emptyDump, err := client.FunctionDump(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.NotNil(suite.T(), emptyDump)
 	assert.Greater(suite.T(), len(emptyDump), 0)
 
@@ -2196,12 +2195,12 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 
 	// Load the functions
 	loadResult, err := client.FunctionLoad(context.Background(), code, true)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), libname1, loadResult)
 
 	// Dump the library
 	dump, err := client.FunctionDump(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Restore without cleaning the lib and/or overwrite option causes an error
 	_, err = client.FunctionRestore(context.Background(), dump)
@@ -2218,7 +2217,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 
 	// Verify functions still work after replace
 	result1, err := client.FCallReadOnlyWithArgs(context.Background(), name1, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	if result1.IsSingleValue() {
 		assert.Equal(suite.T(), "meow", result1.SingleValue())
 	} else {
@@ -2228,7 +2227,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 	}
 
 	result2, err := client.FCallReadOnlyWithArgs(context.Background(), name2, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	if result2.IsSingleValue() {
 		assert.Equal(suite.T(), int64(2), result2.SingleValue())
 	} else {
@@ -2244,7 +2243,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 		name2: "return #args",
 	}, true)
 	loadResult, err = client.FunctionLoad(context.Background(), code, true)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), libname2, loadResult)
 
 	// REPLACE policy now fails due to a name collision
@@ -2261,7 +2260,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 
 	// Verify original functions work again
 	result1, err = client.FCallReadOnlyWithArgs(context.Background(), name1, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	if result1.IsSingleValue() {
 		assert.Equal(suite.T(), "meow", result1.SingleValue())
 	} else {
@@ -2271,7 +2270,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestoreCluster() {
 	}
 
 	result2, err = client.FCallReadOnlyWithArgs(context.Background(), name2, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	if result2.IsSingleValue() {
 		assert.Equal(suite.T(), int64(2), result2.SingleValue())
 	} else {
@@ -2290,7 +2289,7 @@ func (suite *GlideTestSuite) TestInvokeScript() {
 	routeOption := options.RouteOption{Route: config.AllPrimaries}
 	// Test simple script that returns a string
 	clusterResponse, err := clusterClient.InvokeScriptWithRoute(context.Background(), *script1, routeOption)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	for _, value := range clusterResponse.MultiValue() {
 		assert.Equal(suite.T(), "Hello", value)
 	}
@@ -2303,7 +2302,7 @@ func (suite *GlideTestSuite) TestInvokeScript() {
 	scriptOptions := options.NewScriptOptions()
 	scriptOptions.WithKeys([]string{key1}).WithArgs([]string{"value1"})
 	setResponse, err := clusterClient.InvokeScriptWithOptions(context.Background(), *script2, *scriptOptions)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", setResponse)
 
 	// Set another key with the same script
@@ -2311,7 +2310,7 @@ func (suite *GlideTestSuite) TestInvokeScript() {
 	scriptOptions2.WithKeys([]string{key2}).WithArgs([]string{"value2"})
 	setResponse2, err := clusterClient.InvokeScriptWithOptions(context.Background(), *script2, *scriptOptions2)
 	assert.Equal(suite.T(), "OK", setResponse2)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	script2.Close()
 
 	// Test script that gets a key's value
@@ -2321,7 +2320,7 @@ func (suite *GlideTestSuite) TestInvokeScript() {
 	scriptOptions3 := options.NewScriptOptions()
 	scriptOptions3.WithKeys([]string{key1})
 	getResponse1, err := clusterClient.InvokeScriptWithOptions(context.Background(), *script3, *scriptOptions3)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "value1", getResponse1)
 
 	// Get another key's value
@@ -2329,7 +2328,7 @@ func (suite *GlideTestSuite) TestInvokeScript() {
 	scriptOptions4.WithKeys([]string{key2})
 	getResponse2, err := clusterClient.InvokeScriptWithOptions(context.Background(), *script3, *scriptOptions4)
 	assert.Equal(suite.T(), "value2", getResponse2)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	script3.Close()
 }
 
@@ -2404,17 +2403,17 @@ func (suite *GlideTestSuite) TestScriptFlushClusterClient() {
 
 	// Load script
 	_, err := client.InvokeScript(context.Background(), *script)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Check existence of script
 	scriptHash := script.GetHash()
 	result, err := client.ScriptExists(context.Background(), []string{scriptHash})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), []bool{true}, result)
 
 	// Flush the script cache
 	flushResult, err := client.ScriptFlush(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", flushResult)
 
 	// Create a script
@@ -2423,12 +2422,12 @@ func (suite *GlideTestSuite) TestScriptFlushClusterClient() {
 
 	// Load script
 	_, err = client.InvokeScriptWithRoute(context.Background(), *script, routeOption)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Check existence of script
 	scriptHash = script.GetHash()
 	result, err = client.ScriptExistsWithRoute(context.Background(), []string{scriptHash}, routeOption)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), []bool{true}, result)
 
 	// Create ScriptFlushOptions with default mode (SYNC) and route
@@ -2436,17 +2435,17 @@ func (suite *GlideTestSuite) TestScriptFlushClusterClient() {
 
 	// Flush the script cache
 	flushResult, err = client.ScriptFlushWithOptions(context.Background(), *scriptFlushOptions)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", flushResult)
 
 	// Check that the script no longer exists
 	result, err = client.ScriptExistsWithRoute(context.Background(), []string{scriptHash}, routeOption)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), []bool{false}, result)
 
 	// Test with ASYNC mode
 	_, err = client.InvokeScriptWithRoute(context.Background(), *script, routeOption)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Create ScriptFlushOptions with ASYNC mode and route
 	scriptFlushOptions = options.NewScriptFlushOptions().
@@ -2454,11 +2453,11 @@ func (suite *GlideTestSuite) TestScriptFlushClusterClient() {
 		WithRoute(&routeOption)
 
 	flushResult, err = client.ScriptFlushWithOptions(context.Background(), *scriptFlushOptions)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", flushResult)
 
 	result, err = client.ScriptExistsWithRoute(context.Background(), []string{scriptHash}, routeOption)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), []bool{false}, result)
 
 	script.Close()
@@ -2598,8 +2597,7 @@ func (suite *GlideTestSuite) TestRetryStrategyIsNotSupportedForTransactions() {
 		true,
 		*pipeline.NewClusterBatchOptions().WithRetryStrategy(*pipeline.NewClusterBatchRetryStrategy()),
 	)
-	assert.Error(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestBatchWithSingleNodeRoute() {

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 )
@@ -784,7 +784,7 @@ func (suite *GlideTestSuite) TestFlushDB_Failure() {
 	result, err := client.FlushDB(context.Background())
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAll_Success() {
@@ -810,7 +810,7 @@ func (suite *GlideTestSuite) TestFlushAll_Failure() {
 	result, err := client.FlushAll(context.Background())
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAllWithOptions_AllNodes() {
@@ -1055,7 +1055,7 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_InvalidParamete
 	// Test empty password
 	_, err := testClient.UpdateConnectionPassword(context.Background(), "", true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_NoServerAuth() {
@@ -1071,7 +1071,7 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_NoServerAuth() 
 	pwd := uuid.NewString()
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_LongPassword() {
@@ -1118,7 +1118,7 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_ImmediateAuthWr
 	// Test that re-authentication fails when using wrong password
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 	// But using correct password returns OK
 	_, err = testClient.UpdateConnectionPassword(context.Background(), notThePwd, true)
@@ -1594,7 +1594,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDeleteWithRoute(context.Background(), "anotherLib", route)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 	// Test with all primaries route
 	libName = "mylib1c_all"
@@ -1669,7 +1669,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDeleteWithRoute(context.Background(), "anotherLib", route)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
@@ -1730,7 +1730,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDelete(context.Background(), "anotherLib")
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -1604,8 +1604,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithRoute() {
 	// Flush all functions with SYNC option and all primaries route
 	route = options.RouteOption{Route: config.AllPrimaries}
 	result, err = client.FunctionFlushSyncWithRoute(context.Background(), route)
-	suite.NoError(err)
-	suite.Equal("OK", result)
+	suite.verifyOK(result, err)
 
 	// Load function with all primaries route
 	result, err = client.FunctionLoadWithRoute(context.Background(), code, false, route)
@@ -1722,8 +1721,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsWithoutKeysAndWithoutRoute() {
 	suite.Equal("anotherLib", result)
 
 	deleteResult, err := client.FunctionDelete(context.Background(), "anotherLib")
-	suite.NoError(err)
-	suite.Equal("OK", deleteResult)
+	suite.verifyOK(deleteResult, err)
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDelete(context.Background(), "anotherLib")
@@ -1738,8 +1736,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 
 	// Flush all functions with SYNC option
 	result, err := client.FunctionFlushSync(context.Background())
-	suite.NoError(err)
-	suite.Equal("OK", result)
+	suite.verifyOK(result, err)
 
 	// Load first function
 	libName := "functionStats_without_route"
@@ -1783,8 +1780,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithoutRoute() {
 
 	// Flush all functions
 	result, err = client.FunctionFlushSync(context.Background())
-	suite.NoError(err)
-	suite.Equal("OK", result)
+	suite.verifyOK(result, err)
 
 	// Check stats after flushing
 	stats, err = client.FunctionStats(context.Background())
@@ -1813,8 +1809,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 	// Flush all functions with SYNC option and single node route
 	route := options.RouteOption{Route: config.NewSlotKeyRoute(config.SlotTypePrimary, "1")}
 	result, err := client.FunctionFlushSyncWithRoute(context.Background(), route)
-	suite.NoError(err)
-	suite.Equal("OK", result)
+	suite.verifyOK(result, err)
 
 	// Load function with single node route
 	result, err = client.FunctionLoadWithRoute(context.Background(), code, true, route)
@@ -1852,8 +1847,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 
 	// Flush all functions
 	result, err = client.FunctionFlushSyncWithRoute(context.Background(), route)
-	suite.NoError(err)
-	suite.Equal("OK", result)
+	suite.verifyOK(result, err)
 
 	// Check stats after flushing
 	stats, err = client.FunctionStatsWithRoute(context.Background(), route)
@@ -1875,8 +1869,7 @@ func (suite *GlideTestSuite) TestFunctionStatsWithRoute() {
 	// Flush all functions with SYNC option and all primaries route
 	route = options.RouteOption{Route: config.AllPrimaries}
 	result, err = client.FunctionFlushSyncWithRoute(context.Background(), route)
-	suite.NoError(err)
-	suite.Equal("OK", result)
+	suite.verifyOK(result, err)
 
 	// Load function with all primaries route
 	result, err = client.FunctionLoadWithRoute(context.Background(), code, true, route)

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 )

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 )
@@ -784,7 +784,7 @@ func (suite *GlideTestSuite) TestFlushDB_Failure() {
 	result, err := client.FlushDB(context.Background())
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAll_Success() {
@@ -810,7 +810,7 @@ func (suite *GlideTestSuite) TestFlushAll_Failure() {
 	result, err := client.FlushAll(context.Background())
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAllWithOptions_AllNodes() {
@@ -1055,7 +1055,6 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_InvalidParamete
 	// Test empty password
 	_, err := testClient.UpdateConnectionPassword(context.Background(), "", true)
 	suite.Error(err)
-
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_NoServerAuth() {
@@ -1071,7 +1070,6 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_NoServerAuth() 
 	pwd := uuid.NewString()
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
 	suite.Error(err)
-
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordCluster_LongPassword() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -20,7 +20,7 @@ func (suite *GlideTestSuite) TestStandaloneConnect() {
 		WithAddress(&suite.standaloneHosts[0])
 	client, err := glide.NewClient(config)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.NotNil(suite.T(), client)
 
 	client.Close()
@@ -34,7 +34,7 @@ func (suite *GlideTestSuite) TestClusterConnect() {
 
 	client, err := glide.NewClusterClient(config)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.NotNil(suite.T(), client)
 
 	client.Close()
@@ -46,7 +46,7 @@ func (suite *GlideTestSuite) TestClusterConnect_singlePort() {
 
 	client, err := glide.NewClusterClient(config)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.NotNil(suite.T(), client)
 
 	client.Close()

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -56,9 +56,10 @@ func (suite *GlideTestSuite) TestConnectWithInvalidAddress() {
 		WithAddress(&config.NodeAddress{Host: "invalid-host"})
 	client, err := glide.NewClient(config)
 
-	assert.Nil(suite.T(), client)
-	assert.NotNil(suite.T(), err)
-	assert.ErrorAs(suite.T(), err, &glide.ConnectionError{})
+	suite.Nil(client)
+	suite.Error(err)
+	var connErr *glide.ConnectionError
+	suite.ErrorAs(err, &connErr)
 }
 
 func (suite *GlideTestSuite) TestConnectionTimeout() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 )
 

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 )
 
@@ -59,7 +59,7 @@ func (suite *GlideTestSuite) TestConnectWithInvalidAddress() {
 
 	assert.Nil(suite.T(), client)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.ConnectionError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ConnectionError{}, err)
 }
 
 func (suite *GlideTestSuite) TestConnectionTimeout() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -58,7 +58,7 @@ func (suite *GlideTestSuite) TestConnectWithInvalidAddress() {
 
 	assert.Nil(suite.T(), client)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glide.ConnectionError{}, err)
+	assert.ErrorAs(suite.T(), err, &glide.ConnectionError{})
 }
 
 func (suite *GlideTestSuite) TestConnectionTimeout() {

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 )
 
@@ -59,7 +58,7 @@ func (suite *GlideTestSuite) TestConnectWithInvalidAddress() {
 
 	assert.Nil(suite.T(), client)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.ConnectionError{}, err)
+	assert.IsType(suite.T(), &glide.ConnectionError{}, err)
 }
 
 func (suite *GlideTestSuite) TestConnectionTimeout() {

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -473,7 +473,7 @@ func (suite *GlideTestSuite) runParallelizedWithClients(
 }
 
 func (suite *GlideTestSuite) verifyOK(result string, err error) {
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), glide.OK, result)
 }
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -2510,12 +2510,12 @@ func (suite *GlideTestSuite) TestSUnion() {
 		suite.NoError(err)
 		suite.True(reflect.DeepEqual(res5, expected2))
 
-		// Exceptions with empty keys
+		// Errors with empty keys
 		res6, err := client.SUnion(context.Background(), []string{})
 		suite.Nil(res6)
 		suite.Error(err)
 
-		// Exception with a non-set key
+		// Error with a non-set key
 		suite.verifyOK(client.Set(context.Background(), nonSetKey, "value"))
 		res7, err := client.SUnion(context.Background(), []string{nonSetKey, key1})
 		suite.Nil(res7)
@@ -2713,7 +2713,7 @@ func (suite *GlideTestSuite) TestSScan() {
 		assert.NotEqual(t, initialCursor, resCursor)
 		assert.GreaterOrEqual(t, len(resCollection), 0)
 
-		// exceptions
+		// error cases
 		// non-set key
 		_, err = client.Set(context.Background(), key2, "test")
 		suite.NoError(err)
@@ -5244,7 +5244,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		assert.Nil(t, err)
 		assert.Equal(t, float64(3), resIncr.Value())
 
-		// exceptions
+		// error cases
 		// non-sortedset key
 		_, err = client.Set(context.Background(), key2, "test")
 		assert.NoError(t, err)
@@ -6039,7 +6039,7 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 		assert.NoError(t, err)
 		assert.Equal(t, int64(0), xLenResult)
 
-		// Throw Exception: Key exists - but it is not a stream
+		// Throw error: Key exists - but it is not a stream
 		suite.verifyOK(client.Set(context.Background(), key2, "xtrimtest"))
 		_, err = client.XTrim(context.Background(), key2, *options.NewXTrimOptionsWithMinId("0-1"))
 		suite.Error(err)
@@ -6345,7 +6345,7 @@ func (suite *GlideTestSuite) TestZScan() {
 			}
 		}
 
-		// Test exceptions
+		// Test errors
 		// Non-set key
 		stringKey := uuid.New().String()
 		setRes, err := client.Set(context.Background(), stringKey, "test")

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -725,11 +725,11 @@ func (suite *GlideTestSuite) TestGetDel_ExistingKey() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 		result, err := client.GetDel(context.Background(), key)
 		suite.NoError(err)
-		assert.Equal(suite.T(), value, result.Value())
+		suite.Equal(value, result.Value())
 
 		result, err = client.Get(context.Background(), key)
 		suite.NoError(err)
-		assert.Equal(suite.T(), "", result.Value())
+		suite.Equal("", result.Value())
 	})
 }
 
@@ -740,7 +740,7 @@ func (suite *GlideTestSuite) TestGetDel_NonExistingKey() {
 		result, err := client.GetDel(context.Background(), key)
 
 		suite.NoError(err)
-		assert.Equal(suite.T(), "", result.Value())
+		suite.Equal("", result.Value())
 	})
 }
 
@@ -748,8 +748,8 @@ func (suite *GlideTestSuite) TestGetDel_EmptyKey() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		result, err := client.GetDel(context.Background(), "")
 
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), "", result.Value())
+		suite.NoError(err)
+		suite.Equal("", result.Value())
 	})
 }
 
@@ -1515,7 +1515,7 @@ func (suite *GlideTestSuite) TestLPushLPop_typeError() {
 		suite.Error(err)
 
 		res2, err := client.LPopCount(context.Background(), key, 2)
-		suite.NoError(err)
+		suite.Error(err)
 		suite.Nil(res2)
 	})
 }
@@ -2744,7 +2744,7 @@ func (suite *GlideTestSuite) TestLRange() {
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res4, err := client.LRange(context.Background(), key2, int64(0), int64(1))
-		suite.NoError(err)
+		suite.Error(err)
 		suite.Empty(res4)
 	})
 }
@@ -2756,27 +2756,27 @@ func (suite *GlideTestSuite) TestLIndex() {
 
 		res1, err := client.LPush(context.Background(), key, list)
 		suite.NoError(err)
-		assert.Equal(suite.T(), int64(4), res1)
+		suite.Equal(int64(4), res1)
 
 		res2, err := client.LIndex(context.Background(), key, int64(0))
 		suite.NoError(err)
-		assert.Equal(suite.T(), "value1", res2.Value())
-		assert.False(suite.T(), res2.IsNil())
+		suite.Equal("value1", res2.Value())
+		suite.False(res2.IsNil())
 
 		res3, err := client.LIndex(context.Background(), key, int64(-1))
 		suite.NoError(err)
-		assert.Equal(suite.T(), "value4", res3.Value())
-		assert.False(suite.T(), res3.IsNil())
+		suite.Equal("value4", res3.Value())
+		suite.False(res3.IsNil())
 
 		res4, err := client.LIndex(context.Background(), "non_existing_key", int64(0))
 		suite.NoError(err)
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res4)
+		suite.Equal(models.CreateNilStringResult(), res4)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res5, err := client.LIndex(context.Background(), key2, int64(0))
-		suite.NoError(err)
+		suite.Error(err)
 		suite.Equal(models.CreateNilStringResult(), res5)
 	})
 }
@@ -2806,7 +2806,7 @@ func (suite *GlideTestSuite) TestLTrim() {
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res4, err := client.LIndex(context.Background(), key2, int64(0))
-		suite.NoError(err)
+		suite.Error(err)
 		suite.Equal(models.CreateNilStringResult(), res4)
 	})
 }
@@ -2832,7 +2832,7 @@ func (suite *GlideTestSuite) TestLLen() {
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res4, err := client.LLen(context.Background(), key2)
-		suite.NoError(err)
+		suite.Error(err)
 		suite.Equal(int64(0), res4)
 	})
 }
@@ -8644,7 +8644,6 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		suite.NoError(err)
 		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
 		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimWithOptions(context.Background(),
 			stringKey,
@@ -8655,7 +8654,6 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			*claimOptions,
 		)
 		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustId(
 			context.Background(),
@@ -8666,7 +8664,6 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 		)
 		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustIdWithOptions(context.Background(),
 			stringKey,
@@ -8677,7 +8674,6 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			*claimOptions,
 		)
 		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
 	})
 }
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
@@ -34,7 +33,7 @@ func (suite *GlideTestSuite) TestSetAndGet_noOptions() {
 		suite.verifyOK(client.Set(context.Background(), keyName, initialValue))
 		result, err := client.Get(context.Background(), keyName)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 	})
 }
@@ -45,7 +44,7 @@ func (suite *GlideTestSuite) TestSetAndGet_byteString() {
 		suite.verifyOK(client.Set(context.Background(), keyName, invalidUTF8Value))
 		result, err := client.Get(context.Background(), keyName)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), invalidUTF8Value, result.Value())
 	})
 }
@@ -57,7 +56,7 @@ func (suite *GlideTestSuite) TestSetWithOptions_ReturnOldValue() {
 		opts := options.NewSetOptions().SetReturnOldValue(true)
 		result, err := client.SetWithOptions(context.Background(), keyName, anotherValue, *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 	})
 }
@@ -69,11 +68,11 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfExists_overwrite() {
 
 		opts := options.NewSetOptions().SetOnlyIfExists()
 		result, err := client.SetWithOptions(context.Background(), key, anotherValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 	})
 }
@@ -84,7 +83,7 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfExists_missingKey() {
 		opts := options.NewSetOptions().SetOnlyIfExists()
 		result, err := client.SetWithOptions(context.Background(), key, anotherValue, *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -94,11 +93,11 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfDoesNotExist_missingKey() 
 		key := uuid.New().String()
 		opts := options.NewSetOptions().SetOnlyIfDoesNotExist()
 		result, err := client.SetWithOptions(context.Background(), key, anotherValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 	})
 }
@@ -111,12 +110,12 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfDoesNotExist_existingKey()
 
 		result, err := client.SetWithOptions(context.Background(), key, anotherValue, *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 
 		result, err = client.Get(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 	})
 }
@@ -127,27 +126,27 @@ func (suite *GlideTestSuite) TestSetWithOptions_KeepExistingExpiry() {
 		opts := options.NewSetOptions().
 			SetExpiry(options.NewExpiryIn(2000 * time.Millisecond))
 		result, err := client.SetWithOptions(context.Background(), key, initialValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		opts = options.NewSetOptions().SetExpiry(options.NewExpiryKeepExisting())
 		result, err = client.SetWithOptions(context.Background(), key, anotherValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 
 		time.Sleep(2222 * time.Millisecond)
 		result, err = client.Get(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -158,27 +157,27 @@ func (suite *GlideTestSuite) TestSetWithOptions_UpdateExistingExpiry() {
 		opts := options.NewSetOptions().
 			SetExpiry(options.NewExpiryIn(100500 * time.Millisecond))
 		result, err := client.SetWithOptions(context.Background(), key, initialValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		opts = options.NewSetOptions().
 			SetExpiry(options.NewExpiryIn(2000 * time.Millisecond))
 		result, err = client.SetWithOptions(context.Background(), key, anotherValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 
 		time.Sleep(2222 * time.Millisecond)
 		result, err = client.Get(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -192,17 +191,17 @@ func (suite *GlideTestSuite) TestSetWithOptions_OnlyIfEquals() {
 		// successful set
 		opts := options.NewSetOptions().SetOnlyIfEquals(initialValue)
 		result, err := client.SetWithOptions(context.Background(), key, anotherValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), anotherValue, result.Value())
 
 		// unsuccessful set
 		opts = options.NewSetOptions().SetOnlyIfEquals(initialValue)
 		result, err = client.SetWithOptions(context.Background(), key, initialValue, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), result.IsNil())
 	})
 }
@@ -213,12 +212,12 @@ func (suite *GlideTestSuite) TestGetEx_existingAndNonExistingKeys() {
 		suite.verifyOK(client.Set(context.Background(), key, initialValue))
 
 		result, err := client.GetEx(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		key = uuid.New().String()
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -231,18 +230,18 @@ func (suite *GlideTestSuite) TestGetExWithOptions_PersistKey() {
 		opts := options.NewGetExOptions().
 			SetExpiry(options.NewExpiryIn(2000 * time.Millisecond))
 		result, err := client.GetExWithOptions(context.Background(), key, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		time.Sleep(1000 * time.Millisecond)
 
 		opts = options.NewGetExOptions().SetExpiry(options.NewExpiryPersist())
 		result, err = client.GetExWithOptions(context.Background(), key, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 	})
 }
@@ -255,17 +254,17 @@ func (suite *GlideTestSuite) TestGetExWithOptions_UpdateExpiry() {
 		opts := options.NewGetExOptions().
 			SetExpiry(options.NewExpiryIn(2000 * time.Millisecond))
 		result, err := client.GetExWithOptions(context.Background(), key, *opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), initialValue, result.Value())
 
 		time.Sleep(2222 * time.Millisecond)
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -277,7 +276,7 @@ func (suite *GlideTestSuite) TestSetWithOptions_ReturnOldValue_nonExistentKey() 
 
 		result, err := client.SetWithOptions(context.Background(), key, anotherValue, *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -301,7 +300,7 @@ func (suite *GlideTestSuite) TestMSetAndMGet_existingAndNonExistingKeys() {
 		values := []models.Result[string]{stringValue, stringValue, nullResult}
 		result, err := client.MGet(context.Background(), keys)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), values, result)
 	})
 }
@@ -318,14 +317,14 @@ func (suite *GlideTestSuite) TestMSetNXAndMGet_nonExistingKey_valuesSet() {
 			key3: value,
 		}
 		res, err := client.MSetNX(context.Background(), keyValueMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 		keys := []string{key1, key2, key3}
 		stringValue := models.CreateStringResult(value)
 		values := []models.Result[string]{stringValue, stringValue, stringValue}
 		result, err := client.MGet(context.Background(), keys)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), values, result)
 	})
 }
@@ -344,7 +343,7 @@ func (suite *GlideTestSuite) TestMSetNXAndMGet_existingKey_valuesNotUpdated() {
 			key3: value,
 		}
 		res, err := client.MSetNX(context.Background(), keyValueMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res)
 		keys := []string{key1, key2, key3}
 		oldResult := models.CreateStringResult(oldValue)
@@ -352,7 +351,7 @@ func (suite *GlideTestSuite) TestMSetNXAndMGet_existingKey_valuesNotUpdated() {
 		values := []models.Result[string]{oldResult, nullResult, nullResult}
 		result, err := client.MGet(context.Background(), keys)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), values, result)
 	})
 }
@@ -363,15 +362,15 @@ func (suite *GlideTestSuite) TestIncrCommands_existingKey() {
 		suite.verifyOK(client.Set(context.Background(), key, "10"))
 
 		res1, err := client.Incr(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(11), res1)
 
 		res2, err := client.IncrBy(context.Background(), key, 10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(21), res2)
 
 		res3, err := client.IncrByFloat(context.Background(), key, float64(10.1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), float64(31.1), res3)
 	})
 }
@@ -380,17 +379,17 @@ func (suite *GlideTestSuite) TestIncrCommands_nonExistingKey() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := uuid.New().String()
 		res1, err := client.Incr(context.Background(), key1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res1)
 
 		key2 := uuid.New().String()
 		res2, err := client.IncrBy(context.Background(), key2, 10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(10), res2)
 
 		key3 := uuid.New().String()
 		res3, err := client.IncrByFloat(context.Background(), key3, float64(10.1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), float64(10.1), res3)
 	})
 }
@@ -402,18 +401,15 @@ func (suite *GlideTestSuite) TestIncrCommands_TypeError() {
 
 		res1, err := client.Incr(context.Background(), key)
 		assert.Equal(suite.T(), int64(0), res1)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		res2, err := client.IncrBy(context.Background(), key, 10)
 		assert.Equal(suite.T(), int64(0), res2)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		res3, err := client.IncrByFloat(context.Background(), key, float64(10.1))
 		assert.Equal(suite.T(), float64(0), res3)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -423,11 +419,11 @@ func (suite *GlideTestSuite) TestDecrCommands_existingKey() {
 		suite.verifyOK(client.Set(context.Background(), key, "10"))
 
 		res1, err := client.Decr(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(9), res1)
 
 		res2, err := client.DecrBy(context.Background(), key, 10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-1), res2)
 	})
 }
@@ -436,12 +432,12 @@ func (suite *GlideTestSuite) TestDecrCommands_nonExistingKey() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := uuid.New().String()
 		res1, err := client.Decr(context.Background(), key1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-1), res1)
 
 		key2 := uuid.New().String()
 		res2, err := client.DecrBy(context.Background(), key2, 10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-10), res2)
 	})
 }
@@ -453,7 +449,7 @@ func (suite *GlideTestSuite) TestStrlen_existingKey() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		res, err := client.Strlen(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(len(value)), res)
 	})
 }
@@ -462,7 +458,7 @@ func (suite *GlideTestSuite) TestStrlen_nonExistingKey() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		res, err := client.Strlen(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 	})
 }
@@ -471,27 +467,26 @@ func (suite *GlideTestSuite) TestSetRange_existingAndNonExistingKeys() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		res, err := client.SetRange(context.Background(), key, 0, "Dummy string")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(12), res)
 
 		res, err = client.SetRange(context.Background(), key, 6, "values")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(12), res)
 		res1, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Dummy values", res1.Value())
 
 		res, err = client.SetRange(context.Background(), key, 15, "test")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(19), res)
 		res1, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Dummy values\x00\x00\x00test", res1.Value())
 
 		res, err = client.SetRange(context.Background(), key, math.MaxInt32, "test")
 		assert.Equal(suite.T(), int64(0), res)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -500,21 +495,21 @@ func (suite *GlideTestSuite) TestSetRange_existingAndNonExistingKeys_binaryStrin
 		nonUtf8String := "Dummy \xFF string"
 		key := uuid.New().String()
 		res, err := client.SetRange(context.Background(), key, 0, nonUtf8String)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(14), res)
 
 		res, err = client.SetRange(context.Background(), key, 6, "values ")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(14), res)
 		res1, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Dummy values g", res1.Value())
 
 		res, err = client.SetRange(context.Background(), key, 15, "test")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(19), res)
 		res1, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Dummy values g\x00test", res1.Value())
 	})
 }
@@ -525,24 +520,24 @@ func (suite *GlideTestSuite) TestGetRange_existingAndNonExistingKeys() {
 		suite.verifyOK(client.Set(context.Background(), key, "Dummy string"))
 
 		res, err := client.GetRange(context.Background(), key, 0, 4)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Dummy", res)
 
 		res, err = client.GetRange(context.Background(), key, -6, -1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "string", res)
 
 		res, err = client.GetRange(context.Background(), key, -1, -6)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", res)
 
 		res, err = client.GetRange(context.Background(), key, 15, 16)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", res)
 
 		nonExistingKey := uuid.New().String()
 		res, err = client.GetRange(context.Background(), nonExistingKey, 0, 5)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", res)
 	})
 }
@@ -554,7 +549,7 @@ func (suite *GlideTestSuite) TestGetRange_binaryString() {
 		suite.verifyOK(client.Set(context.Background(), key, nonUtf8String))
 
 		res, err := client.GetRange(context.Background(), key, 4, 6)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "y \xFF", res)
 	})
 }
@@ -566,17 +561,17 @@ func (suite *GlideTestSuite) TestAppend_existingAndNonExistingKeys() {
 		value2 := uuid.New().String()
 
 		res, err := client.Append(context.Background(), key, value1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(len(value1)), res)
 		res1, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), value1, res1.Value())
 
 		res, err = client.Append(context.Background(), key, value2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(len(value1)+len(value2)), res)
 		res1, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), value1+value2, res1.Value())
 	})
 }
@@ -589,14 +584,14 @@ func (suite *GlideTestSuite) TestLCS_existingAndNonExistingKeys() {
 		key2 := "{key}" + uuid.New().String()
 
 		res, err := client.LCS(context.Background(), key1, key2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", res)
 
 		suite.verifyOK(client.Set(context.Background(), key1, "Dummy string"))
 		suite.verifyOK(client.Set(context.Background(), key2, "Dummy value"))
 
 		res, err = client.LCS(context.Background(), key1, key2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Dummy ", res)
 	})
 }
@@ -609,14 +604,14 @@ func (suite *GlideTestSuite) TestLCSLen_existingAndNonExistingKeys() {
 		key2 := "{key}" + uuid.New().String()
 
 		res, err := client.LCSLen(context.Background(), key1, key2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 
 		suite.verifyOK(client.Set(context.Background(), key1, "ohmytext"))
 		suite.verifyOK(client.Set(context.Background(), key2, "mynewtext"))
 
 		res, err = client.LCSLen(context.Background(), key1, key2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(6), res)
 	})
 }
@@ -626,15 +621,15 @@ func (suite *GlideTestSuite) TestLCS_BasicIDXOption() {
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		_, err := client.Set(context.Background(), "{lcs}key1", "ohmytext")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.Set(context.Background(), "{lcs}key2", "mynewtext")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		opts := options.NewLCSIdxOptions()
 		lcsIdxResult, err := client.LCSWithOptions(context.Background(), "{lcs}key1", "{lcs}key2", *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), lcsIdxResult)
 
 		assert.Equal(suite.T(), int64(6), lcsIdxResult["len"])
@@ -661,10 +656,10 @@ func (suite *GlideTestSuite) TestLCS_MinMatchLengthOption() {
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		_, err := client.Set(context.Background(), "{lcs}key1", "ohmytext")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.Set(context.Background(), "{lcs}key2", "mynewtext")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		opts := options.NewLCSIdxOptions()
 		minMatchLen := int64(4)
@@ -672,7 +667,7 @@ func (suite *GlideTestSuite) TestLCS_MinMatchLengthOption() {
 
 		lcsIdxMinMatchResult, err := client.LCSWithOptions(context.Background(), "{lcs}key1", "{lcs}key2", *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), lcsIdxMinMatchResult)
 
 		assert.Equal(suite.T(), int64(6), lcsIdxMinMatchResult["len"])
@@ -693,10 +688,10 @@ func (suite *GlideTestSuite) TestLCS_WithMatchLengthOption() {
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		_, err := client.Set(context.Background(), "{lcs}key1", "ohmytext")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.Set(context.Background(), "{lcs}key2", "mynewtext")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		opts := options.NewLCSIdxOptions()
 		minMatchLen := int64(4)
@@ -705,7 +700,7 @@ func (suite *GlideTestSuite) TestLCS_WithMatchLengthOption() {
 
 		lcsIdxFullOptionsResult, err := client.LCSWithOptions(context.Background(), "{lcs}key1", "{lcs}key2", *opts)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), lcsIdxFullOptionsResult)
 
 		assert.Equal(suite.T(), int64(6), lcsIdxFullOptionsResult["len"])
@@ -729,11 +724,11 @@ func (suite *GlideTestSuite) TestGetDel_ExistingKey() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 		result, err := client.GetDel(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), value, result.Value())
 
 		result, err = client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -744,7 +739,7 @@ func (suite *GlideTestSuite) TestGetDel_NonExistingKey() {
 
 		result, err := client.GetDel(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", result.Value())
 	})
 }
@@ -764,11 +759,11 @@ func (suite *GlideTestSuite) TestHSet_WithExistingKey() {
 		key := uuid.New().String()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
@@ -787,11 +782,11 @@ func (suite *GlideTestSuite) TestHSet_byteString() {
 		key := string([]byte{0x01, 0x02, 0x03, 0xFE})
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGetAll(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), fields, res2)
 	})
 }
@@ -802,16 +797,16 @@ func (suite *GlideTestSuite) TestHSet_WithAddNewField() {
 		key := uuid.New().String()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 
 		fields["field3"] = "value3"
 		res3, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res3)
 	})
 }
@@ -822,11 +817,11 @@ func (suite *GlideTestSuite) TestHGet_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGet(context.Background(), key, "field1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "value1", res2.Value())
 	})
 }
@@ -836,7 +831,7 @@ func (suite *GlideTestSuite) TestHGet_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HGet(context.Background(), key, "field1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res1)
 	})
 }
@@ -847,11 +842,11 @@ func (suite *GlideTestSuite) TestHGet_WithNotExistingField() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGet(context.Background(), key, "foo")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res2)
 	})
 }
@@ -862,11 +857,11 @@ func (suite *GlideTestSuite) TestHGetAll_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HGetAll(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), fields, res2)
 	})
 }
@@ -876,7 +871,7 @@ func (suite *GlideTestSuite) TestHGetAll_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.HGetAll(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res)
 	})
 }
@@ -887,14 +882,14 @@ func (suite *GlideTestSuite) TestHMGet() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HMGet(context.Background(), key, []string{"field1", "field2", "field3"})
 		value1 := models.CreateStringResult("value1")
 		value2 := models.CreateStringResult("value2")
 		nullValue := models.CreateNilStringResult()
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []models.Result[string]{value1, value2, nullValue}, res2)
 	})
 }
@@ -905,7 +900,7 @@ func (suite *GlideTestSuite) TestHMGet_WithNotExistingKey() {
 
 		res, err := client.HMGet(context.Background(), key, []string{"field1", "field2", "field3"})
 		nullValue := models.CreateNilStringResult()
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []models.Result[string]{nullValue, nullValue, nullValue}, res)
 	})
 }
@@ -916,12 +911,12 @@ func (suite *GlideTestSuite) TestHMGet_WithNotExistingField() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HMGet(context.Background(), key, []string{"field3", "field4"})
 		nullValue := models.CreateNilStringResult()
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []models.Result[string]{nullValue, nullValue}, res2)
 	})
 }
@@ -932,11 +927,11 @@ func (suite *GlideTestSuite) TestHSetNX_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSetNX(context.Background(), key, "field1", "value1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res2)
 	})
 }
@@ -946,11 +941,11 @@ func (suite *GlideTestSuite) TestHSetNX_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSetNX(context.Background(), key, "field1", "value1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1)
 
 		res2, err := client.HGetAll(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]string{"field1": "value1"}, res2)
 	})
 }
@@ -961,11 +956,11 @@ func (suite *GlideTestSuite) TestHSetNX_WithExistingField() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HSetNX(context.Background(), key, "field1", "value1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res2)
 	})
 }
@@ -976,19 +971,19 @@ func (suite *GlideTestSuite) TestHDel() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HDel(context.Background(), key, []string{"field1", "field2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res2)
 
 		res3, err := client.HGetAll(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res3)
 
 		res4, err := client.HDel(context.Background(), key, []string{"field1", "field2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res4)
 	})
 }
@@ -997,7 +992,7 @@ func (suite *GlideTestSuite) TestHDel_WithNotExistingKey() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.NewString()
 		res, err := client.HDel(context.Background(), key, []string{"field1", "field2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 	})
 }
@@ -1008,11 +1003,11 @@ func (suite *GlideTestSuite) TestHDel_WithNotExistingField() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HDel(context.Background(), key, []string{"field3", "field4"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
@@ -1023,11 +1018,11 @@ func (suite *GlideTestSuite) TestHLen() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HLen(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res2)
 	})
 }
@@ -1037,7 +1032,7 @@ func (suite *GlideTestSuite) TestHLen_WithNotExistingKey() {
 		key := uuid.NewString()
 		res, err := client.HLen(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 	})
 }
@@ -1048,11 +1043,11 @@ func (suite *GlideTestSuite) TestHVals_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HVals(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.ElementsMatch(suite.T(), []string{"value1", "value2"}, res2)
 	})
 }
@@ -1062,7 +1057,7 @@ func (suite *GlideTestSuite) TestHVals_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.HVals(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res)
 	})
 }
@@ -1073,11 +1068,11 @@ func (suite *GlideTestSuite) TestHExists_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HExists(context.Background(), key, "field1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res2)
 	})
 }
@@ -1087,7 +1082,7 @@ func (suite *GlideTestSuite) TestHExists_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.HExists(context.Background(), key, "field1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res)
 	})
 }
@@ -1098,11 +1093,11 @@ func (suite *GlideTestSuite) TestHExists_WithNotExistingField() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HExists(context.Background(), key, "field3")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res2)
 	})
 }
@@ -1113,11 +1108,11 @@ func (suite *GlideTestSuite) TestHKeys_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HKeys(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.ElementsMatch(suite.T(), []string{"field1", "field2"}, res2)
 	})
 }
@@ -1127,7 +1122,7 @@ func (suite *GlideTestSuite) TestHKeys_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.HKeys(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res)
 	})
 }
@@ -1138,11 +1133,11 @@ func (suite *GlideTestSuite) TestHStrLen_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HStrLen(context.Background(), key, "field1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(6), res2)
 	})
 }
@@ -1152,7 +1147,7 @@ func (suite *GlideTestSuite) TestHStrLen_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.HStrLen(context.Background(), key, "field1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 	})
 }
@@ -1163,11 +1158,11 @@ func (suite *GlideTestSuite) TestHStrLen_WithNotExistingField() {
 		key := uuid.NewString()
 
 		res1, err := client.HSet(context.Background(), key, fields)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.HStrLen(context.Background(), key, "field3")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
@@ -1179,7 +1174,7 @@ func (suite *GlideTestSuite) TestHIncrBy_WithExistingField() {
 		fieldValueMap := map[string]string{field: "10"}
 
 		hsetResult, err := client.HSet(context.Background(), key, fieldValueMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByResult, hincrByErr := client.HIncrBy(context.Background(), key, field, 1)
@@ -1196,7 +1191,7 @@ func (suite *GlideTestSuite) TestHIncrBy_WithNonExistingField() {
 		fieldValueMap := map[string]string{field2: "1"}
 
 		hsetResult, err := client.HSet(context.Background(), key, fieldValueMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByResult, hincrByErr := client.HIncrBy(context.Background(), key, field, 2)
@@ -1212,7 +1207,7 @@ func (suite *GlideTestSuite) TestHIncrByFloat_WithExistingField() {
 		fieldValueMap := map[string]string{field: "10"}
 
 		hsetResult, err := client.HSet(context.Background(), key, fieldValueMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByFloatResult, hincrByFloatErr := client.HIncrByFloat(context.Background(), key, field, 1.5)
@@ -1229,11 +1224,11 @@ func (suite *GlideTestSuite) TestHIncrByFloat_WithNonExistingField() {
 		fieldValueMap := map[string]string{field2: "1"}
 
 		hsetResult, err := client.HSet(context.Background(), key, fieldValueMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), hsetResult)
 
 		hincrByFloatResult, hincrByFloatErr := client.HIncrByFloat(context.Background(), key, field, 1.5)
-		assert.Nil(suite.T(), hincrByFloatErr)
+		suite.NoError(hincrByFloatErr)
 		assert.Equal(suite.T(), float64(1.5), hincrByFloatResult)
 	})
 }
@@ -1262,7 +1257,7 @@ func (suite *GlideTestSuite) TestHScan() {
 
 		// Check for empty set.
 		resCursor, resCollection, err := client.HScan(context.Background(), key1, initialCursor)
-		assert.NoError(t, err)
+		suite.NoError(err)
 		assert.Equal(t, initialCursor, resCursor)
 		assert.Empty(t, resCollection)
 
@@ -1469,11 +1464,11 @@ func (suite *GlideTestSuite) TestHRandField() {
 		key = uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, "HRandField"))
 		_, err = client.HRandField(context.Background(), key)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		_, err = client.HRandFieldWithCount(context.Background(), key, 42)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		_, err = client.HRandFieldWithCountWithValues(context.Background(), key, 42)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -1483,15 +1478,15 @@ func (suite *GlideTestSuite) TestLPushLPop_WithExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LPop(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "value1", res2.Value())
 
 		res3, err := client.LPopCount(context.Background(), key, 2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value2", "value3"}, res3)
 	})
 }
@@ -1501,11 +1496,11 @@ func (suite *GlideTestSuite) TestLPop_nonExistingKey() {
 		key := uuid.NewString()
 
 		res1, err := client.LPop(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res1)
 
 		res2, err := client.LPopCount(context.Background(), key, 2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res2)
 	})
 }
@@ -1516,14 +1511,12 @@ func (suite *GlideTestSuite) TestLPushLPop_typeError() {
 		suite.verifyOK(client.Set(context.Background(), key, "value"))
 
 		res1, err := client.LPush(context.Background(), key, []string{"value1"})
-		assert.Equal(suite.T(), int64(0), res1)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(int64(0), res1)
+		suite.Error(err)
 
 		res2, err := client.LPopCount(context.Background(), key, 2)
-		assert.Nil(suite.T(), res2)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.NoError(err)
+		suite.Nil(res2)
 	})
 }
 
@@ -1531,25 +1524,25 @@ func (suite *GlideTestSuite) TestLPos_withAndWithoutOptions() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.NewString()
 		res1, err := client.RPush(context.Background(), key, []string{"a", "a", "b", "c", "a", "b"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(6), res1)
 
 		res2, err := client.LPos(context.Background(), key, "a")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2.Value())
 
 		res3, err := client.LPosWithOptions(context.Background(), key, "b", *options.NewLPosOptions().SetRank(2))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res3.Value())
 
 		// element doesn't exist
 		res4, err := client.LPos(context.Background(), key, "e")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res4)
 
 		// reverse traversal
 		res5, err := client.LPosWithOptions(context.Background(), key, "b", *options.NewLPosOptions().SetRank(-2))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res5.Value())
 
 		// unlimited comparisons
@@ -1558,7 +1551,7 @@ func (suite *GlideTestSuite) TestLPos_withAndWithoutOptions() {
 			"a",
 			*options.NewLPosOptions().SetRank(1).SetMaxLen(0),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res6.Value())
 
 		// limited comparisons
@@ -1567,33 +1560,30 @@ func (suite *GlideTestSuite) TestLPos_withAndWithoutOptions() {
 			"c",
 			*options.NewLPosOptions().SetRank(1).SetMaxLen(2),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res7)
 
 		// invalid rank value
 		res8, err := client.LPosWithOptions(context.Background(), key, "a", *options.NewLPosOptions().SetRank(0))
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res8)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// invalid maxlen value
 		res9, err := client.LPosWithOptions(context.Background(), key, "a", *options.NewLPosOptions().SetMaxLen(-1))
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res9)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// non-existent key
 		res10, err := client.LPos(context.Background(), "non_existent_key", "a")
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		// wrong key data type
 		keyString := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), keyString, "value"))
 		res11, err := client.LPos(context.Background(), keyString, "a")
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res11)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -1603,34 +1593,32 @@ func (suite *GlideTestSuite) TestLPosCount() {
 
 		res1, err := client.RPush(context.Background(), key, []string{"a", "a", "b", "c", "a", "b"})
 		assert.Equal(suite.T(), int64(6), res1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res2, err := client.LPosCount(context.Background(), key, "a", int64(2))
 		assert.Equal(suite.T(), []int64{0, 1}, res2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res3, err := client.LPosCount(context.Background(), key, "a", int64(0))
 		assert.Equal(suite.T(), []int64{0, 1, 4}, res3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		// invalid count value
 		res4, err := client.LPosCount(context.Background(), key, "a", int64(-1))
-		assert.Nil(suite.T(), res4)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Nil(res4)
+		suite.Error(err)
 
 		// non-existent key
 		res5, err := client.LPosCount(context.Background(), "non_existent_key", "a", int64(1))
-		assert.Empty(suite.T(), res5)
-		assert.Nil(suite.T(), err)
+		suite.Empty(res5)
+		suite.NoError(err)
 
 		// wrong key data type
 		keyString := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), keyString, "value"))
 		res6, err := client.LPosCount(context.Background(), keyString, "a", int64(1))
 		assert.Nil(suite.T(), res6)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -1640,7 +1628,7 @@ func (suite *GlideTestSuite) TestLPosCount_withOptions() {
 
 		res1, err := client.RPush(context.Background(), key, []string{"a", "a", "b", "c", "a", "b"})
 		assert.Equal(suite.T(), int64(6), res1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res2, err := client.LPosCountWithOptions(
 			context.Background(),
@@ -1650,7 +1638,7 @@ func (suite *GlideTestSuite) TestLPosCount_withOptions() {
 			*options.NewLPosOptions().SetRank(1),
 		)
 		assert.Equal(suite.T(), []int64{0, 1, 4}, res2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res3, err := client.LPosCountWithOptions(
 			context.Background(),
@@ -1660,7 +1648,7 @@ func (suite *GlideTestSuite) TestLPosCount_withOptions() {
 			*options.NewLPosOptions().SetRank(2),
 		)
 		assert.Equal(suite.T(), []int64{1, 4}, res3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		// reverse traversal
 		res4, err := client.LPosCountWithOptions(
@@ -1671,7 +1659,7 @@ func (suite *GlideTestSuite) TestLPosCount_withOptions() {
 			*options.NewLPosOptions().SetRank(-1),
 		)
 		assert.Equal(suite.T(), []int64{4, 1, 0}, res4)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 	})
 }
 
@@ -1681,16 +1669,15 @@ func (suite *GlideTestSuite) TestRPush() {
 		key := uuid.NewString()
 
 		res1, err := client.RPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res2, err := client.RPush(context.Background(), key2, []string{"value1"})
-		assert.Equal(suite.T(), int64(0), res2)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(int64(0), res2)
+		suite.Error(err)
 	})
 }
 
@@ -1700,7 +1687,7 @@ func (suite *GlideTestSuite) TestSAdd() {
 		members := []string{"member1", "member2"}
 
 		res, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res)
 	})
 }
@@ -1711,11 +1698,11 @@ func (suite *GlideTestSuite) TestSAdd_WithExistingKey() {
 		members := []string{"member1", "member2"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
@@ -1726,11 +1713,11 @@ func (suite *GlideTestSuite) TestSRem() {
 		members := []string{"member1", "member2", "member3"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SRem(context.Background(), key, []string{"member1", "member2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res2)
 	})
 }
@@ -1741,11 +1728,11 @@ func (suite *GlideTestSuite) TestSRem_WithExistingKey() {
 		members := []string{"member1", "member2"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.SRem(context.Background(), key, []string{"member3", "member4"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
@@ -1755,7 +1742,7 @@ func (suite *GlideTestSuite) TestSRem_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res2, err := client.SRem(context.Background(), key, []string{"member1", "member2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res2)
 	})
 }
@@ -1766,11 +1753,11 @@ func (suite *GlideTestSuite) TestSRem_WithExistingKeyAndDifferentMembers() {
 		members := []string{"member1", "member2", "member3"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SRem(context.Background(), key, []string{"member1", "member3", "member4"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res2)
 	})
 }
@@ -1860,28 +1847,26 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		// invalid argument - key list must not be empty
 		res11, err := client.SUnionStore(context.Background(), key4, []string{})
 		assert.Equal(suite.T(), int64(0), res11)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// non-set key
 		_, err = client.Set(context.Background(), stringKey, "value")
-		assert.NoError(t, err)
+		suite.NoError(err)
 
 		res12, err := client.SUnionStore(context.Background(), key4, []string{stringKey, key1})
-		assert.Equal(suite.T(), int64(0), res12)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(int64(0), res12)
+		suite.Error(err)
 
 		// overwrite destination when destination is not a set
 		res13, err := client.SUnionStore(context.Background(), stringKey, []string{key1, key3})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(7), res13)
+		suite.NoError(err)
+		suite.Equal(int64(7), res13)
 
 		// check that the key is now empty
 		res14, err := client.SMembers(context.Background(), stringKey)
-		assert.NoError(t, err)
-		assert.Len(t, res14, 7)
-		assert.True(t, reflect.DeepEqual(res14, expected2))
+		suite.NoError(err)
+		suite.Len(res14, 7)
+		suite.True(reflect.DeepEqual(res14, expected2))
 	})
 }
 
@@ -1891,12 +1876,12 @@ func (suite *GlideTestSuite) TestSMembers() {
 		members := []string{"member1", "member2", "member3"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1)
+		suite.NoError(err)
+		suite.Equal(int64(3), res1)
 
 		res2, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
-		assert.Len(suite.T(), res2, 3)
+		suite.NoError(err)
+		suite.Len(res2, 3)
 	})
 }
 
@@ -1905,7 +1890,7 @@ func (suite *GlideTestSuite) TestSMembers_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res)
 	})
 }
@@ -1916,11 +1901,11 @@ func (suite *GlideTestSuite) TestSCard() {
 		members := []string{"member1", "member2", "member3"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SCard(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res2)
 	})
 }
@@ -1930,7 +1915,7 @@ func (suite *GlideTestSuite) TestSCard_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.SCard(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 	})
 }
@@ -1941,11 +1926,11 @@ func (suite *GlideTestSuite) TestSIsMember() {
 		members := []string{"member1", "member2", "member3"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SIsMember(context.Background(), key, "member2")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res2)
 	})
 }
@@ -1955,7 +1940,7 @@ func (suite *GlideTestSuite) TestSIsMember_WithNotExistingKey() {
 		key := uuid.NewString()
 
 		res, err := client.SIsMember(context.Background(), key, "member2")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res)
 	})
 }
@@ -1966,11 +1951,11 @@ func (suite *GlideTestSuite) TestSIsMember_WithNotExistingMember() {
 		members := []string{"member1", "member2", "member3"}
 
 		res1, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SIsMember(context.Background(), key, "nonExistingMember")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res2)
 	})
 }
@@ -1981,15 +1966,15 @@ func (suite *GlideTestSuite) TestSDiff() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key1, []string{"a", "b", "c", "d"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.SAdd(context.Background(), key2, []string{"c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res2)
 
 		result, err := client.SDiff(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]struct{}{"a": {}, "b": {}}, result)
 	})
 }
@@ -2000,7 +1985,7 @@ func (suite *GlideTestSuite) TestSDiff_WithNotExistingKey() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		result, err := client.SDiff(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), result)
 	})
 }
@@ -2011,11 +1996,11 @@ func (suite *GlideTestSuite) TestSDiff_WithSingleKeyExist() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key1, []string{"a", "b", "c"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SDiff(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]struct{}{"a": {}, "b": {}, "c": {}}, res2)
 	})
 }
@@ -2027,19 +2012,19 @@ func (suite *GlideTestSuite) TestSDiffStore() {
 		key3 := "{key}-3-" + uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key1, []string{"a", "b", "c"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res1)
 
 		res2, err := client.SAdd(context.Background(), key2, []string{"c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res2)
 
 		res3, err := client.SDiffStore(context.Background(), key3, []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res3)
 
 		members, err := client.SMembers(context.Background(), key3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]struct{}{"a": {}, "b": {}}, members)
 	})
 }
@@ -2051,11 +2036,11 @@ func (suite *GlideTestSuite) TestSDiffStore_WithNotExistingKeys() {
 		key3 := "{key}-3-" + uuid.NewString()
 
 		res, err := client.SDiffStore(context.Background(), key3, []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 
 		members, err := client.SMembers(context.Background(), key3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), members)
 	})
 }
@@ -2066,15 +2051,15 @@ func (suite *GlideTestSuite) TestSinter() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key1, []string{"a", "b", "c", "d"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.SAdd(context.Background(), key2, []string{"c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res2)
 
 		members, err := client.SInter(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]struct{}{"c": {}, "d": {}}, members)
 	})
 }
@@ -2085,7 +2070,7 @@ func (suite *GlideTestSuite) TestSinter_WithNotExistingKeys() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		members, err := client.SInter(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), members)
 	})
 }
@@ -2148,28 +2133,26 @@ func (suite *GlideTestSuite) TestSinterStore() {
 
 		// invalid argument - key list must not be empty
 		res10, err := client.SInterStore(context.Background(), key3, []string{})
-		assert.Equal(suite.T(), int64(0), res10)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(int64(0), res10)
+		suite.Error(err)
 
 		// non-set key
 		_, err = client.Set(context.Background(), stringKey, "value")
-		assert.NoError(t, err)
+		suite.NoError(err)
 
 		res11, err := client.SInterStore(context.Background(), key3, []string{stringKey})
-		assert.Equal(suite.T(), int64(0), res11)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(int64(0), res11)
+		suite.Error(err)
 
 		// overwrite the non-set key
 		res12, err := client.SInterStore(context.Background(), stringKey, []string{key2})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1), res12)
+		suite.NoError(err)
+		suite.Equal(int64(1), res12)
 
 		// check that the key is now empty
 		res13, err := client.SMembers(context.Background(), stringKey)
-		assert.NoError(t, err)
-		assert.Equal(t, map[string]struct{}{"c": {}}, res13)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"c": {}}, res13)
 	})
 }
 
@@ -2181,19 +2164,19 @@ func (suite *GlideTestSuite) TestSInterCard() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key1, []string{"one", "two", "three", "four"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		result1, err := client.SInterCard(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), result1)
 
 		res2, err := client.SAdd(context.Background(), key2, []string{"two", "three", "four", "five"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		result2, err := client.SInterCard(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), result2)
 	})
 }
@@ -2206,19 +2189,19 @@ func (suite *GlideTestSuite) TestSInterCardLimit() {
 		key2 := "{key}-2-" + uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key1, []string{"one", "two", "three", "four"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.SAdd(context.Background(), key2, []string{"two", "three", "four", "five"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		result1, err := client.SInterCardLimit(context.Background(), []string{key1, key2}, 2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), result1)
 
 		result2, err := client.SInterCardLimit(context.Background(), []string{key1, key2}, 4)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), result2)
 	})
 }
@@ -2228,11 +2211,11 @@ func (suite *GlideTestSuite) TestSRandMember() {
 		key := uuid.NewString()
 
 		res, err := client.SAdd(context.Background(), key, []string{"one"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res)
 
 		member, err := client.SRandMember(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "one", member.Value())
 		assert.False(suite.T(), member.IsNil())
 	})
@@ -2247,17 +2230,17 @@ func (suite *GlideTestSuite) TestSRandMemberCount() {
 
 		// Test with empty set
 		emptyResult, err := client.SRandMemberCount(context.Background(), nonExistingKey, 2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), emptyResult)
 
 		// Add members to the set
 		res, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res)
 
 		// Test with positive count (unique elements)
 		positiveResult, err := client.SRandMemberCount(context.Background(), key, 3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), 3, len(positiveResult))
 		// Verify all returned elements are unique and from the original set
 		uniqueElements := make(map[string]struct{})
@@ -2269,7 +2252,7 @@ func (suite *GlideTestSuite) TestSRandMemberCount() {
 
 		// Test with count larger than set size (should return all elements)
 		largeCountResult, err := client.SRandMemberCount(context.Background(), key, 10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), 5, len(largeCountResult))
 		// Verify all elements are returned
 		allElements := make(map[string]struct{})
@@ -2280,7 +2263,7 @@ func (suite *GlideTestSuite) TestSRandMemberCount() {
 
 		// Test with negative count (allows duplicates)
 		negativeResult, err := client.SRandMemberCount(context.Background(), key, -7)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), 7, len(negativeResult))
 		// Verify all elements are from the original set (may contain duplicates)
 		for _, element := range negativeResult {
@@ -2289,14 +2272,13 @@ func (suite *GlideTestSuite) TestSRandMemberCount() {
 
 		// Test with zero count (should return empty array)
 		zeroResult, err := client.SRandMemberCount(context.Background(), key, 0)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), zeroResult)
 
 		// Test with non-set key
 		suite.verifyOK(client.Set(context.Background(), stringKey, "value"))
 		_, err = client.SRandMemberCount(context.Background(), stringKey, 1)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -2306,16 +2288,16 @@ func (suite *GlideTestSuite) TestSPop() {
 		members := []string{"value1", "value2", "value3"}
 
 		res, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		popMember, err := client.SPop(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Contains(suite.T(), members, popMember.Value())
 		assert.False(suite.T(), popMember.IsNil())
 
 		remainingMembers, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), remainingMembers, 2)
 		assert.NotContains(suite.T(), remainingMembers, popMember)
 	})
@@ -2326,16 +2308,16 @@ func (suite *GlideTestSuite) TestSPop_LastMember() {
 		key := uuid.NewString()
 
 		res1, err := client.SAdd(context.Background(), key, []string{"lastValue"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res1)
 
 		popMember, err := client.SPop(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "lastValue", popMember.Value())
 		assert.False(suite.T(), popMember.IsNil())
 
 		remainingMembers, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), remainingMembers)
 	})
 }
@@ -2346,12 +2328,12 @@ func (suite *GlideTestSuite) TestSPopCount() {
 		members := []string{"value1", "value2", "value3", "value4", "value5"}
 
 		res, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res)
 
 		// Pop multiple members at once
 		popMembers, err := client.SPopCount(context.Background(), key, 3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), popMembers, 3)
 
 		// Verify all popped members were in the original set
@@ -2361,7 +2343,7 @@ func (suite *GlideTestSuite) TestSPopCount() {
 
 		// Verify remaining members count
 		remainingMembers, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), remainingMembers, 2)
 
 		// Verify no duplicates between popped and remaining
@@ -2377,12 +2359,12 @@ func (suite *GlideTestSuite) TestSPopCount_AllMembers() {
 		members := []string{"value1", "value2", "value3"}
 
 		res, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		// Pop all members
 		popMembers, err := client.SPopCount(context.Background(), key, 3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), popMembers, 3)
 
 		popMembersArray := []string{}
@@ -2397,7 +2379,7 @@ func (suite *GlideTestSuite) TestSPopCount_AllMembers() {
 
 		// Verify set is now empty
 		remainingMembers, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), remainingMembers)
 	})
 }
@@ -2408,12 +2390,12 @@ func (suite *GlideTestSuite) TestSPopCount_MoreThanExist() {
 		members := []string{"value1", "value2"}
 
 		res, err := client.SAdd(context.Background(), key, members)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res)
 
 		// Try to pop more members than exist
 		popMembers, err := client.SPopCount(context.Background(), key, 5)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), popMembers, 2) // Should only return existing members
 
 		popMembersArray := []string{}
@@ -2428,7 +2410,7 @@ func (suite *GlideTestSuite) TestSPopCount_MoreThanExist() {
 
 		// Verify set is now empty
 		remainingMembers, err := client.SMembers(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), remainingMembers)
 	})
 }
@@ -2439,7 +2421,7 @@ func (suite *GlideTestSuite) TestSPopCount_NonExistingKey() {
 
 		// Try to pop from non-existing key
 		popMembers, err := client.SPopCount(context.Background(), key, 3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), popMembers)
 	})
 }
@@ -2453,8 +2435,8 @@ func (suite *GlideTestSuite) TestSPopCount_WrongType() {
 
 		// Try to pop from a key that's not a set
 		_, err := client.SPopCount(context.Background(), key, 3)
-		assert.NotNil(suite.T(), err)
-		assert.Contains(suite.T(), err.Error(), "WRONGTYPE")
+		suite.Error(err)
+		suite.Contains(err.Error(), "WRONGTYPE")
 	})
 }
 
@@ -2478,14 +2460,12 @@ func (suite *GlideTestSuite) TestSMIsMember() {
 
 		// invalid argument - member list must not be empty
 		_, err4 := client.SMIsMember(context.Background(), key1, []string{})
-		assert.NotNil(suite.T(), err4)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err4)
+		suite.Error(err4)
 
 		// source key exists, but it is not a set
 		suite.verifyOK(client.Set(context.Background(), stringKey, "value"))
 		_, err5 := client.SMIsMember(context.Background(), stringKey, []string{"two"})
-		assert.NotNil(suite.T(), err5)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err5)
+		suite.Error(err5)
 	})
 }
 
@@ -2511,35 +2491,35 @@ func (suite *GlideTestSuite) TestSUnion() {
 		}
 
 		res1, err := client.SAdd(context.Background(), key1, memberList1)
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(3), res1)
+		suite.NoError(err)
+		suite.Equal(int64(3), res1)
 
 		res2, err := client.SAdd(context.Background(), key2, memberList2)
-		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), res2)
+		suite.NoError(err)
+		suite.Equal(int64(4), res2)
 
 		res3, err := client.SUnion(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), reflect.DeepEqual(res3, expected1))
+		suite.NoError(err)
+		suite.True(reflect.DeepEqual(res3, expected1))
 
 		res4, err := client.SUnion(context.Background(), []string{key3})
-		assert.Nil(suite.T(), err)
-		assert.Empty(suite.T(), res4)
+		suite.NoError(err)
+		suite.Empty(res4)
 
 		res5, err := client.SUnion(context.Background(), []string{key1, key3})
-		assert.Nil(suite.T(), err)
-		assert.True(suite.T(), reflect.DeepEqual(res5, expected2))
+		suite.NoError(err)
+		suite.True(reflect.DeepEqual(res5, expected2))
 
 		// Exceptions with empty keys
 		res6, err := client.SUnion(context.Background(), []string{})
-		assert.Nil(suite.T(), res6)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Nil(res6)
+		suite.Error(err)
 
 		// Exception with a non-set key
 		suite.verifyOK(client.Set(context.Background(), nonSetKey, "value"))
 		res7, err := client.SUnion(context.Background(), []string{nonSetKey, key1})
-		assert.Nil(suite.T(), res7)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Nil(res7)
+		suite.Error(err)
 	})
 }
 
@@ -2552,93 +2532,91 @@ func (suite *GlideTestSuite) TestSMove() {
 		nonExistingKey := "{key}-5-" + uuid.NewString()
 		memberArray1 := []string{"1", "2", "3"}
 		memberArray2 := []string{"2", "3"}
-		t := suite.T()
 
 		res1, err := client.SAdd(context.Background(), key1, memberArray1)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(3), res1)
+		suite.NoError(err)
+		suite.Equal(int64(3), res1)
 
 		res2, err := client.SAdd(context.Background(), key2, memberArray2)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(2), res2)
+		suite.NoError(err)
+		suite.Equal(int64(2), res2)
 
 		// move an element
 		res3, err := client.SMove(context.Background(), key1, key2, "1")
-		assert.NoError(t, err)
-		assert.True(t, res3)
+		suite.NoError(err)
+		suite.True(res3)
 
 		res4, err := client.SMembers(context.Background(), key1)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"2": {}, "3": {}}, res4)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"2": {}, "3": {}}, res4)
 
 		res5, err := client.SMembers(context.Background(), key2)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"1": {}, "2": {}, "3": {}}, res5)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"1": {}, "2": {}, "3": {}}, res5)
 
 		// moved element already exists in the destination set
 		res6, err := client.SMove(context.Background(), key2, key1, "2")
-		assert.NoError(t, err)
-		assert.True(t, res6)
+		suite.NoError(err)
+		suite.True(res6)
 
 		res7, err := client.SMembers(context.Background(), key1)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"2": {}, "3": {}}, res7)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"2": {}, "3": {}}, res7)
 
 		res8, err := client.SMembers(context.Background(), key2)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"1": {}, "3": {}}, res8)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"1": {}, "3": {}}, res8)
 
 		// attempt to move from a non-existing key
 		res9, err := client.SMove(context.Background(), nonExistingKey, key1, "4")
-		assert.NoError(t, err)
-		assert.False(t, res9)
+		suite.NoError(err)
+		suite.False(res9)
 
 		res10, err := client.SMembers(context.Background(), key1)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"2": {}, "3": {}}, res10)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"2": {}, "3": {}}, res10)
 
 		// move to a new set
 		res11, err := client.SMove(context.Background(), key1, key3, "2")
-		assert.NoError(t, err)
-		assert.True(t, res11)
+		suite.NoError(err)
+		suite.True(res11)
 
 		res12, err := client.SMembers(context.Background(), key1)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"3": {}}, res12)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"3": {}}, res12)
 
 		res13, err := client.SMembers(context.Background(), key3)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"2": {}}, res13)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"2": {}}, res13)
 
 		// attempt to move a missing element
 		res14, err := client.SMove(context.Background(), key1, key3, "42")
-		assert.NoError(t, err)
-		assert.False(t, res14)
+		suite.NoError(err)
+		suite.False(res14)
 
 		res12, err = client.SMembers(context.Background(), key1)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"3": {}}, res12)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"3": {}}, res12)
 
 		res13, err = client.SMembers(context.Background(), key3)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"2": {}}, res13)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"2": {}}, res13)
 
 		// moving missing element to missing key
 		res15, err := client.SMove(context.Background(), key1, nonExistingKey, "42")
-		assert.NoError(t, err)
-		assert.False(t, res15)
+		suite.NoError(err)
+		suite.False(res15)
 
 		res12, err = client.SMembers(context.Background(), key1)
-		assert.NoError(t, err)
-		assert.Equal(suite.T(), map[string]struct{}{"3": {}}, res12)
+		suite.NoError(err)
+		suite.Equal(map[string]struct{}{"3": {}}, res12)
 
 		// key exists but is not contain a set
 		_, err = client.Set(context.Background(), stringKey, "value")
-		assert.NoError(t, err)
+		suite.NoError(err)
 
 		_, err = client.SMove(context.Background(), stringKey, key1, "_")
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -2674,8 +2652,7 @@ func (suite *GlideTestSuite) TestSScan() {
 			assert.Empty(t, resCollection)
 		} else {
 			_, _, err = client.SScan(context.Background(), key1, "-1")
-			assert.NotNil(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 		}
 
 		// result contains the whole set
@@ -2739,11 +2716,10 @@ func (suite *GlideTestSuite) TestSScan() {
 		// exceptions
 		// non-set key
 		_, err = client.Set(context.Background(), key2, "test")
-		assert.NoError(t, err)
+		suite.NoError(err)
 
 		_, _, err = client.SScan(context.Background(), key2, initialCursor)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -2753,24 +2729,23 @@ func (suite *GlideTestSuite) TestLRange() {
 		key := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value1", "value2", "value3", "value4"}, res2)
 
 		res3, err := client.LRange(context.Background(), "non_existing_key", int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res3)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res4, err := client.LRange(context.Background(), key2, int64(0), int64(1))
-		assert.Nil(suite.T(), res4)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.NoError(err)
+		suite.Empty(res4)
 	})
 }
 
@@ -2780,30 +2755,29 @@ func (suite *GlideTestSuite) TestLIndex() {
 		key := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LIndex(context.Background(), key, int64(0))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "value1", res2.Value())
 		assert.False(suite.T(), res2.IsNil())
 
 		res3, err := client.LIndex(context.Background(), key, int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "value4", res3.Value())
 		assert.False(suite.T(), res3.IsNil())
 
 		res4, err := client.LIndex(context.Background(), "non_existing_key", int64(0))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res4)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res5, err := client.LIndex(context.Background(), key2, int64(0))
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res5)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.NoError(err)
+		suite.Equal(models.CreateNilStringResult(), res5)
 	})
 }
 
@@ -2813,28 +2787,27 @@ func (suite *GlideTestSuite) TestLTrim() {
 		key := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		suite.verifyOK(client.LTrim(context.Background(), key, int64(0), int64(1)))
 
 		res2, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value1", "value2"}, res2)
 
 		suite.verifyOK(client.LTrim(context.Background(), key, int64(4), int64(2)))
 
 		res3, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res3)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res4, err := client.LIndex(context.Background(), key2, int64(0))
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res4)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.NoError(err)
+		suite.Equal(models.CreateNilStringResult(), res4)
 	})
 }
 
@@ -2844,24 +2817,23 @@ func (suite *GlideTestSuite) TestLLen() {
 		key := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LLen(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LLen(context.Background(), "non_existing_key")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res3)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res4, err := client.LLen(context.Background(), key2)
-		assert.Equal(suite.T(), int64(0), res4)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.NoError(err)
+		suite.Equal(int64(0), res4)
 	})
 }
 
@@ -2871,32 +2843,32 @@ func (suite *GlideTestSuite) TestLRem() {
 		key := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res1)
 
 		res2, err := client.LRem(context.Background(), key, 2, "value1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res2)
 		res3, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value2", "value2", "value1"}, res3)
 
 		res4, err := client.LRem(context.Background(), key, -1, "value2")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res4)
 		res5, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value2", "value1"}, res5)
 
 		res6, err := client.LRem(context.Background(), key, 0, "value2")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res6)
 		res7, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value1"}, res7)
 
 		res8, err := client.LRem(context.Background(), "non_existing_key", 0, "value")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res8)
 	})
 }
@@ -2907,38 +2879,36 @@ func (suite *GlideTestSuite) TestRPopAndRPopCount() {
 		key := uuid.NewString()
 
 		res1, err := client.RPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.RPop(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "value4", res2.Value())
 		assert.False(suite.T(), res2.IsNil())
 
 		res3, err := client.RPopCount(context.Background(), key, int64(2))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value3", "value2"}, res3)
 
 		res4, err := client.RPop(context.Background(), "non_existing_key")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res4)
 
 		res5, err := client.RPopCount(context.Background(), "non_existing_key", int64(2))
 		assert.Nil(suite.T(), res5)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res6, err := client.RPop(context.Background(), key2)
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res6)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(models.CreateNilStringResult(), res6)
+		suite.Error(err)
 
 		res7, err := client.RPopCount(context.Background(), key2, int64(2))
-		assert.Nil(suite.T(), res7)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Nil(res7)
+		suite.Error(err)
 	})
 }
 
@@ -2948,36 +2918,35 @@ func (suite *GlideTestSuite) TestLInsert() {
 		key := uuid.NewString()
 
 		res1, err := client.RPush(context.Background(), key, list)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res1)
 
 		res2, err := client.LInsert(context.Background(), key, constants.Before, "value2", "value1.5")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res2)
 
 		res3, err := client.LInsert(context.Background(), key, constants.After, "value3", "value3.5")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(6), res3)
 
 		res4, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value1", "value1.5", "value2", "value3", "value3.5", "value4"}, res4)
 
 		res5, err := client.LInsert(context.Background(), "non_existing_key", constants.Before, "pivot", "elem")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res5)
 
 		res6, err := client.LInsert(context.Background(), key, constants.Before, "value5", "value6")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-1), res6)
 
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "value"))
 
 		res7, err := client.LInsert(context.Background(), key2, constants.Before, "value5", "value6")
-		assert.Equal(suite.T(), int64(0), res7)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(int64(0), res7)
 	})
 }
 
@@ -2987,24 +2956,23 @@ func (suite *GlideTestSuite) TestBLPop() {
 		listKey2 := "{listKey}-2-" + uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), listKey1, []string{"value1", "value2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.BLPop(context.Background(), []string{listKey1, listKey2}, 500*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{listKey1, "value2"}, res2)
 
 		res3, err := client.BLPop(context.Background(), []string{listKey2}, 1*time.Second)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res3)
 
 		key := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, "value"))
 
 		res4, err := client.BLPop(context.Background(), []string{key}, 1*time.Second)
-		assert.Nil(suite.T(), res4)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Nil(res4)
 	})
 }
 
@@ -3014,24 +2982,23 @@ func (suite *GlideTestSuite) TestBRPop() {
 		listKey2 := "{listKey}-2-" + uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), listKey1, []string{"value1", "value2"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res1)
 
 		res2, err := client.BRPop(context.Background(), []string{listKey1, listKey2}, 500*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{listKey1, "value1"}, res2)
 
 		res3, err := client.BRPop(context.Background(), []string{listKey2}, 1*time.Second)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res3)
 
 		key := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, "value"))
 
 		res4, err := client.BRPop(context.Background(), []string{key}, 1*time.Second)
-		assert.Nil(suite.T(), res4)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Nil(res4)
 	})
 }
 
@@ -3042,36 +3009,34 @@ func (suite *GlideTestSuite) TestRPushX() {
 		key3 := uuid.NewString()
 
 		res1, err := client.RPush(context.Background(), key1, []string{"value1"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res1)
 
 		res2, err := client.RPushX(context.Background(), key1, []string{"value2", "value3", "value4"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value1", "value2", "value3", "value4"}, res3)
 
 		res4, err := client.RPushX(context.Background(), key2, []string{"value1"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res4)
 
 		res5, err := client.LRange(context.Background(), key2, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res5)
 
 		suite.verifyOK(client.Set(context.Background(), key3, "value"))
 
 		res6, err := client.RPushX(context.Background(), key3, []string{"value1"})
-		assert.Equal(suite.T(), int64(0), res6)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(int64(0), res6)
 
 		res7, err := client.RPushX(context.Background(), key2, []string{})
-		assert.Equal(suite.T(), int64(0), res7)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(int64(0), res7)
 	})
 }
 
@@ -3082,36 +3047,34 @@ func (suite *GlideTestSuite) TestLPushX() {
 		key3 := uuid.NewString()
 
 		res1, err := client.LPush(context.Background(), key1, []string{"value1"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res1)
 
 		res2, err := client.LPushX(context.Background(), key1, []string{"value2", "value3", "value4"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"value4", "value3", "value2", "value1"}, res3)
 
 		res4, err := client.LPushX(context.Background(), key2, []string{"value1"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res4)
 
 		res5, err := client.LRange(context.Background(), key2, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), res5)
 
 		suite.verifyOK(client.Set(context.Background(), key3, "value"))
 
 		res6, err := client.LPushX(context.Background(), key3, []string{"value1"})
-		assert.Equal(suite.T(), int64(0), res6)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(int64(0), res6)
 
 		res7, err := client.LPushX(context.Background(), key2, []string{})
-		assert.Equal(suite.T(), int64(0), res7)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(int64(0), res7)
 	})
 }
 
@@ -3125,22 +3088,22 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		key3 := "{key}-3" + uuid.NewString()
 
 		res1, err := client.LMPop(context.Background(), []string{key1}, constants.Left)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res1)
 
 		res2, err := client.LMPopCount(context.Background(), []string{key1}, constants.Left, int64(1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res2)
 
 		res3, err := client.LPush(context.Background(), key1, []string{"one", "two", "three", "four", "five"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res3)
 		res4, err := client.LPush(context.Background(), key2, []string{"one", "two", "three", "four", "five"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res4)
 
 		res5, err := client.LMPop(context.Background(), []string{key1}, constants.Left)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
 			map[string][]string{key1: {"five"}},
@@ -3148,7 +3111,7 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		)
 
 		res6, err := client.LMPopCount(context.Background(), []string{key2, key1}, constants.Right, int64(2))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
 			map[string][]string{
@@ -3160,14 +3123,12 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		suite.verifyOK(client.Set(context.Background(), key3, "value"))
 
 		res7, err := client.LMPop(context.Background(), []string{key3}, constants.Left)
-		assert.Nil(suite.T(), res7)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Nil(res7)
 
 		res8, err := client.LMPop(context.Background(), []string{key3}, "Invalid")
-		assert.Nil(suite.T(), res8)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Nil(res8)
 	})
 }
 
@@ -3181,22 +3142,22 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		key3 := "{key}-3" + uuid.NewString()
 
 		res1, err := client.BLMPop(context.Background(), []string{key1}, constants.Left, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res1)
 
 		res2, err := client.BLMPopCount(context.Background(), []string{key1}, constants.Left, int64(1), 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Nil(suite.T(), res2)
 
 		res3, err := client.LPush(context.Background(), key1, []string{"one", "two", "three", "four", "five"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res3)
 		res4, err := client.LPush(context.Background(), key2, []string{"one", "two", "three", "four", "five"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), res4)
 
 		res5, err := client.BLMPop(context.Background(), []string{key1}, constants.Left, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
 			map[string][]string{key1: {"five"}},
@@ -3210,7 +3171,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 			int64(2),
 			100*time.Millisecond,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
 			map[string][]string{
@@ -3222,9 +3183,8 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		suite.verifyOK(client.Set(context.Background(), key3, "value"))
 
 		res7, err := client.BLMPop(context.Background(), []string{key3}, constants.Left, 100*time.Millisecond)
-		assert.Nil(suite.T(), res7)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Nil(res7)
 	})
 }
 
@@ -3238,7 +3198,7 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 		key3 := "{key}-3" + uuid.NewString()
 
 		res1, err := client.BZMPop(context.Background(), []string{key1}, constants.MIN, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1.IsNil())
 
 		membersScoreMap := map[string]float64{
@@ -3248,10 +3208,10 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 		}
 
 		res3, err := client.ZAdd(context.Background(), key1, membersScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res3)
 		res4, err := client.ZAdd(context.Background(), key2, membersScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res4)
 
 		// Try to pop the top 2 elements from key1
@@ -3261,7 +3221,7 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 			100*time.Millisecond,
 			*options.NewZMPopOptions().SetCount(2),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), key1, res5.Value().Key)
 		assert.ElementsMatch(
 			suite.T(),
@@ -3274,7 +3234,7 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 
 		// Try to pop the minimum value from key2
 		res6, err := client.BZMPop(context.Background(), []string{key2}, constants.MIN, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
 			models.CreateKeyWithArrayOfMembersAndScoresResult(
@@ -3290,7 +3250,7 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 
 		// Pop the minimum value from multiple keys
 		res7, err := client.BZMPop(context.Background(), []string{key1, key2}, constants.MIN, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
 			models.CreateKeyWithArrayOfMembersAndScoresResult(
@@ -3308,9 +3268,8 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 
 		// Popping a non-existent value in key3
 		res8, err := client.BZMPop(context.Background(), []string{key3}, constants.MIN, 100*time.Millisecond)
-		assert.True(suite.T(), res8.IsNil())
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.True(res8.IsNil())
 	})
 }
 
@@ -3320,27 +3279,25 @@ func (suite *GlideTestSuite) TestLSet() {
 		nonExistentKey := uuid.NewString()
 
 		_, err := client.LSet(context.Background(), nonExistentKey, int64(0), "zero")
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		res2, err := client.LPush(context.Background(), key, []string{"four", "three", "two", "one"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		_, err = client.LSet(context.Background(), key, int64(10), "zero")
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		suite.verifyOK(client.LSet(context.Background(), key, int64(0), "zero"))
 
 		res5, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"zero", "two", "three", "four"}, res5)
 
 		suite.verifyOK(client.LSet(context.Background(), key, int64(-1), "zero"))
 
 		res7, err := client.LRange(context.Background(), key, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"zero", "two", "three", "zero"}, res7)
 	})
 }
@@ -3357,60 +3314,58 @@ func (suite *GlideTestSuite) TestLMove() {
 
 		res1, err := client.LMove(context.Background(), key1, key2, constants.Left, constants.Right)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res2, err := client.LPush(context.Background(), key1, []string{"four", "three", "two", "one"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		// only source exists, only source elements gets popped, creates a list at nonExistingKey
 		res3, err := client.LMove(context.Background(), key1, nonExistentKey, constants.Right, constants.Left)
 		assert.Equal(suite.T(), "four", res3.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res4, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"one", "two", "three"}, res4)
 
 		// source and destination are the same, performing list rotation, "one" gets popped and added back
 		res5, err := client.LMove(context.Background(), key1, key1, constants.Left, constants.Left)
 		assert.Equal(suite.T(), "one", res5.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res6, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"one", "two", "three"}, res6)
 		// normal use case, "three" gets popped and added to the left of destination
 		res7, err := client.LPush(context.Background(), key2, []string{"six", "five", "four"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res7)
 
 		res8, err := client.LMove(context.Background(), key1, key2, constants.Right, constants.Left)
 		assert.Equal(suite.T(), "three", res8.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res9, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"one", "two"}, res9)
 		res10, err := client.LRange(context.Background(), key2, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"three", "four", "five", "six"}, res10)
 
 		// source exists but is not a list type key
 		suite.verifyOK(client.Set(context.Background(), nonListKey, "value"))
 
 		res11, err := client.LMove(context.Background(), nonListKey, key1, constants.Left, constants.Left)
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res11)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(models.CreateNilStringResult(), res11)
 
 		// destination exists but is not a list type key
 		suite.verifyOK(client.Set(context.Background(), nonListKey, "value"))
 
 		res12, err := client.LMove(context.Background(), key1, nonListKey, constants.Left, constants.Left)
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res12)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal(models.CreateNilStringResult(), res12)
 	})
 }
 
@@ -3421,12 +3376,12 @@ func (suite *GlideTestSuite) TestExists() {
 		// Test 1: Check if an existing key returns 1
 		suite.verifyOK(client.Set(context.Background(), key, initialValue))
 		result, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), result, "The key should exist")
 
 		// Test 2: Check if a non-existent key returns 0
 		result, err = client.Exists(context.Background(), []string{"nonExistentKey"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), result, "The non-existent key should not exist")
 
 		// Test 3: Multiple keys, some exist, some do not
@@ -3435,7 +3390,7 @@ func (suite *GlideTestSuite) TestExists() {
 		suite.verifyOK(client.Set(context.Background(), existingKey, value))
 		suite.verifyOK(client.Set(context.Background(), testKey, value))
 		result, err = client.Exists(context.Background(), []string{testKey, existingKey, "anotherNonExistentKey"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), result, "Two keys should exist")
 	})
 }
@@ -3464,7 +3419,7 @@ func (suite *GlideTestSuite) TestExpire_KeyDoesNotExist() {
 		key := uuid.New().String()
 		// Trying to set an expiry on a non-existent key
 		result, err := client.Expire(context.Background(), key, 1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), result)
 	})
 }
@@ -3478,17 +3433,17 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		result, err := client.ExpireWithOptions(context.Background(), key, 2, constants.HasNoExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), result)
 
 		time.Sleep(2500 * time.Millisecond)
 
 		resultGet, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", resultGet.Value())
 
 		result, err = client.ExpireWithOptions(context.Background(), key, 1, constants.HasNoExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), result)
 	})
 }
@@ -3502,17 +3457,17 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasExistingExpiry() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resexp, err := client.ExpireWithOptions(context.Background(), key, 20, constants.HasNoExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resexp)
 
 		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 1, constants.HasExistingExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		time.Sleep(2 * time.Second)
 
 		resultExpireTest, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.Equal(suite.T(), int64(0), resultExpireTest)
 	})
@@ -3526,15 +3481,15 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryGreaterThanCurrent()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 2, constants.HasNoExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 5, constants.NewExpiryGreaterThanCurrent)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 		time.Sleep(6 * time.Second)
 		resultExpireTest, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExpireTest)
 	})
 }
@@ -3548,22 +3503,22 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryLessThanCurrent() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 10, constants.HasNoExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 5, constants.NewExpiryLessThanCurrent)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.True(suite.T(), resultExpire)
 
 		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 15, constants.NewExpiryGreaterThanCurrent)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.True(suite.T(), resultExpire)
 
 		time.Sleep(16 * time.Second)
 		resultExpireTest, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExpireTest)
 	})
 }
@@ -3578,10 +3533,10 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 
 		resultExpire, err := client.ExpireAtWithOptions(context.Background(), key, futureTimestamp, constants.HasNoExpiry)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireAt)
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(
 			context.Background(),
@@ -3589,7 +3544,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 			futureTimestamp+10,
 			constants.HasNoExpiry,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), resultExpireWithOptions)
 	})
 }
@@ -3603,7 +3558,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireAt)
 
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(
@@ -3612,7 +3567,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 			futureTimestamp+10,
 			constants.HasExistingExpiry,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 	})
 }
@@ -3627,7 +3582,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireAt)
 
 		newFutureTimestamp := time.Now().Add(20 * time.Second).Unix()
@@ -3636,7 +3591,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent
 			newFutureTimestamp,
 			constants.NewExpiryGreaterThanCurrent,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 	})
 }
@@ -3651,7 +3606,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() 
 
 		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireAt)
 
 		newFutureTimestamp := time.Now().Add(5 * time.Second).Unix()
@@ -3661,12 +3616,12 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() 
 			newFutureTimestamp,
 			constants.NewExpiryLessThanCurrent,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(5 * time.Second)
 		resultExpireAtTest, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.Equal(suite.T(), int64(0), resultExpireAtTest)
 	})
@@ -3680,12 +3635,12 @@ func (suite *GlideTestSuite) TestPExpire() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resultExpire, err := client.PExpire(context.Background(), key, 500)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		time.Sleep(600 * time.Millisecond)
 		resultExpireCheck, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExpireCheck)
 	})
 }
@@ -3700,7 +3655,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		newExpire := 1000
@@ -3711,12 +3666,12 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 			int64(newExpire),
 			constants.HasExistingExpiry,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3737,12 +3692,12 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
 			int64(newExpire),
 			constants.HasNoExpiry,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(600 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3757,7 +3712,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		newExpire := 1000
@@ -3768,12 +3723,12 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 			int64(newExpire),
 			constants.NewExpiryGreaterThanCurrent,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3788,7 +3743,7 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
 
 		initialExpire := 500
 		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		newExpire := 200
@@ -3799,12 +3754,12 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
 			int64(newExpire),
 			constants.NewExpiryLessThanCurrent,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(600 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3817,14 +3772,14 @@ func (suite *GlideTestSuite) TestPExpireAt() {
 
 		expireAfterMilliseconds := time.Now().Unix() * 1000
 		resultPExpireAt, err := client.PExpireAt(context.Background(), key, expireAfterMilliseconds)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.True(suite.T(), resultPExpireAt)
 
 		time.Sleep(6 * time.Second)
 
 		resultpExists, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultpExists)
 	})
 }
@@ -3840,12 +3795,12 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasNoExpiry() {
 		timestamp := time.Now().Unix() * 1000
 		result, err := client.PExpireAtWithOptions(context.Background(), key, timestamp, constants.HasNoExpiry)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), result)
 
 		time.Sleep(2 * time.Second)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3859,7 +3814,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 		initialExpire := 500
 		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 		newExpire := time.Now().Unix()*1000 + 1000
 
@@ -3869,12 +3824,12 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
 			newExpire,
 			constants.HasExistingExpiry,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3889,7 +3844,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurren
 
 		initialExpire := time.Now().UnixMilli() + 1000
 		resultExpire, err := client.PExpireAt(context.Background(), key, initialExpire)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		newExpire := time.Now().UnixMilli() + 2000
@@ -3900,12 +3855,12 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurren
 			newExpire,
 			constants.NewExpiryGreaterThanCurrent,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(2100 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3920,7 +3875,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent()
 
 		initialExpire := 1000
 		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpire)
 
 		newExpire := time.Now().Unix()*1000 + 500
@@ -3931,13 +3886,13 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent()
 			newExpire,
 			constants.NewExpiryLessThanCurrent,
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.True(suite.T(), resultExpireWithOptions)
 
 		time.Sleep(1100 * time.Millisecond)
 		resultExist, err := client.Exists(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultExist)
 	})
 }
@@ -3951,22 +3906,22 @@ func (suite *GlideTestSuite) TestExpireTime() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		result, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), value, result.Value())
 
 		expireTime := time.Now().Unix() + 3
 		resultExpAt, err := client.ExpireAt(context.Background(), key, expireTime)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpAt)
 
 		resexptime, err := client.ExpireTime(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), expireTime, resexptime)
 
 		time.Sleep(4 * time.Second)
 
 		resultAfterExpiry, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", resultAfterExpiry.Value())
 	})
 }
@@ -3978,7 +3933,7 @@ func (suite *GlideTestSuite) TestExpireTime_KeyDoesNotExist() {
 
 		// Call ExpireTime on a key that doesn't exist
 		expiryResult, err := client.ExpireTime(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-2), expiryResult)
 	})
 }
@@ -3992,22 +3947,22 @@ func (suite *GlideTestSuite) TestPExpireTime() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		result, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), value, result.Value())
 
 		pexpireTime := time.Now().UnixMilli() + 3000
 		resultExpAt, err := client.PExpireAt(context.Background(), key, pexpireTime)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resultExpAt)
 
 		respexptime, err := client.PExpireTime(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), pexpireTime, respexptime)
 
 		time.Sleep(4 * time.Second)
 
 		resultAfterExpiry, err := client.Get(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "", resultAfterExpiry.Value())
 	})
 }
@@ -4046,7 +4001,7 @@ func (suite *GlideTestSuite) TestPExpireTime_KeyDoesNotExist() {
 
 		// Call ExpireTime on a key that doesn't exist
 		expiryResult, err := client.PExpireTime(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-2), expiryResult)
 	})
 }
@@ -4058,10 +4013,10 @@ func (suite *GlideTestSuite) TestTTL_WithValidKey() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resExpire, err := client.Expire(context.Background(), key, 1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resExpire)
 		resTTL, err := client.TTL(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), resTTL)
 	})
 }
@@ -4073,13 +4028,13 @@ func (suite *GlideTestSuite) TestTTL_WithExpiredKey() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resExpire, err := client.Expire(context.Background(), key, 1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resExpire)
 
 		time.Sleep(2 * time.Second)
 
 		resTTL, err := client.TTL(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(-2), resTTL)
 	})
 }
@@ -4091,11 +4046,11 @@ func (suite *GlideTestSuite) TestPTTL_WithValidKey() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resExpire, err := client.Expire(context.Background(), key, 1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resExpire)
 
 		resPTTL, err := client.PTTL(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Greater(suite.T(), resPTTL, int64(900))
 	})
 }
@@ -4107,13 +4062,13 @@ func (suite *GlideTestSuite) TestPTTL_WithExpiredKey() {
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		resExpire, err := client.Expire(context.Background(), key, 1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resExpire)
 
 		time.Sleep(2 * time.Second)
 
 		resPTTL, err := client.PTTL(context.Background(), key)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), resPTTL, int64(-2))
 	})
 }
@@ -4122,7 +4077,7 @@ func (suite *GlideTestSuite) TestPfAdd_SuccessfulAddition() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		res, err := client.PfAdd(context.Background(), key, []string{"a", "b", "c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 	})
 }
@@ -4133,25 +4088,25 @@ func (suite *GlideTestSuite) TestPfAdd_DuplicateElements() {
 
 		// case : Add elements and add same elements again
 		res, err := client.PfAdd(context.Background(), key, []string{"a", "b", "c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		res2, err := client.PfAdd(context.Background(), key, []string{"a", "b", "c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res2)
 
 		// case : (mixed elements) add new elements with 1 duplicate elements
 		res1, err := client.PfAdd(context.Background(), key, []string{"f", "g", "h"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1)
 
 		res2, err = client.PfAdd(context.Background(), key, []string{"i", "j", "g"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res2)
 
 		// case : add empty array(no elements to the HyperLogLog)
 		res, err = client.PfAdd(context.Background(), key, []string{})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res)
 	})
 }
@@ -4160,11 +4115,11 @@ func (suite *GlideTestSuite) TestPfCount_SingleKey() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		res, err := client.PfAdd(context.Background(), key, []string{"i", "j", "g"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		resCount, err := client.PfCount(context.Background(), []string{key})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), resCount)
 	})
 }
@@ -4175,15 +4130,15 @@ func (suite *GlideTestSuite) TestPfCount_MultipleKeys() {
 		key2 := uuid.New().String() + "{group}"
 
 		res, err := client.PfAdd(context.Background(), key1, []string{"a", "b", "c"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		res, err = client.PfAdd(context.Background(), key2, []string{"c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		resCount, err := client.PfCount(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), resCount)
 	})
 }
@@ -4194,7 +4149,7 @@ func (suite *GlideTestSuite) TestPfCount_NoExistingKeys() {
 		key2 := uuid.New().String() + "{group}"
 
 		resCount, err := client.PfCount(context.Background(), []string{key1, key2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resCount)
 	})
 }
@@ -4206,19 +4161,19 @@ func (suite *GlideTestSuite) TestPfMerge() {
 		destination := uuid.New().String() + "{group}"
 
 		res, err := client.PfAdd(context.Background(), source1, []string{"a", "b", "c"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		res, err = client.PfAdd(context.Background(), source2, []string{"c", "d", "e"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		result, err := client.PfMerge(context.Background(), destination, []string{source1, source2})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result)
 
 		count, err := client.PfCount(context.Background(), []string{destination})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(5), count)
 	})
 }
@@ -4229,15 +4184,15 @@ func (suite *GlideTestSuite) TestPfMerge_SingleSource() {
 		destination := uuid.New().String() + "{group}"
 
 		res, err := client.PfAdd(context.Background(), source, []string{"a", "b", "c"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res)
 
 		result, err := client.PfMerge(context.Background(), destination, []string{source})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result)
 
 		count, err := client.PfCount(context.Background(), []string{destination})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), count)
 	})
 }
@@ -4248,11 +4203,11 @@ func (suite *GlideTestSuite) TestPfMerge_NonExistentSource() {
 		destination := uuid.New().String() + "{group}"
 
 		result, err := client.PfMerge(context.Background(), destination, []string{nonExistentKey})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result)
 
 		count, err := client.PfCount(context.Background(), []string{destination})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), count)
 	})
 }
@@ -4268,7 +4223,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_AscendingOrder() {
 
 		sortResult, err := client.SortWithOptions(context.Background(), key, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("a"),
@@ -4291,7 +4246,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_DescendingOrder() {
 
 		sortResult, err := client.SortWithOptions(context.Background(), key, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("c"),
@@ -4310,7 +4265,7 @@ func (suite *GlideTestSuite) TestSort_SuccessfulSort() {
 
 		sortResult, err := client.Sort(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("1"),
@@ -4330,12 +4285,12 @@ func (suite *GlideTestSuite) TestSortStore_BasicSorting() {
 
 		result, err := client.SortStore(context.Background(), key, sortedKey)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), result)
 		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(context.Background(), sortedKey, 0, -1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"1", "2", "4", "5", "10"}, sortedValues)
 	})
 }
@@ -4344,7 +4299,7 @@ func (suite *GlideTestSuite) TestSortStore_ErrorHandling() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		result, err := client.SortStore(context.Background(), "{listKey}nonExistingKey", "{listKey}mydestinationKey")
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), result)
 	})
 }
@@ -4358,12 +4313,12 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_DescendingOrder() {
 		options := options.NewSortOptions().SetOrderBy(options.DESC).SetIsAlpha(false)
 		result, err := client.SortStoreWithOptions(context.Background(), key, sortedKey, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), result)
 		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(context.Background(), sortedKey, 0, -1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"50", "40", "30", "20", "10"}, sortedValues)
 	})
 }
@@ -4377,13 +4332,13 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_AlphaSorting() {
 		options := options.NewSortOptions().SetIsAlpha(true)
 		result, err := client.SortStoreWithOptions(context.Background(), key, sortedKey, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), result)
 		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(context.Background(), sortedKey, 0, -1)
 		resultList := []string{"apple", "banana", "cherry", "date", "elderberry"}
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), resultList, sortedValues)
 	})
 }
@@ -4397,12 +4352,12 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_Limit() {
 		options := options.NewSortOptions().SetSortLimit(1, 3)
 		result, err := client.SortStoreWithOptions(context.Background(), key, sortedKey, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), result)
 		assert.Equal(suite.T(), int64(3), result)
 
 		sortedValues, err := client.LRange(context.Background(), sortedKey, 0, -1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"20", "30", "40"}, sortedValues)
 	})
 }
@@ -4415,7 +4370,7 @@ func (suite *GlideTestSuite) TestSortReadOnly_SuccessfulSort() {
 
 		sortResult, err := client.SortReadOnly(context.Background(), key)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("1"),
@@ -4440,7 +4395,7 @@ func (suite *GlideTestSuite) TestSortReadyOnlyWithOptions_DescendingOrder() {
 
 		sortResult, err := client.SortReadOnlyWithOptions(context.Background(), key, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("c"),
@@ -4463,10 +4418,10 @@ func (suite *GlideTestSuite) TestBLMove() {
 
 		res1, err := client.BLMove(context.Background(), key1, key2, constants.Left, constants.Right, 100*time.Millisecond)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res2, err := client.LPush(context.Background(), key1, []string{"four", "three", "two", "one"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		// only source exists, only source elements gets popped, creates a list at nonExistingKey
@@ -4479,66 +4434,60 @@ func (suite *GlideTestSuite) TestBLMove() {
 			100*time.Millisecond,
 		)
 		assert.Equal(suite.T(), "four", res3.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res4, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"one", "two", "three"}, res4)
 
 		// source and destination are the same, performing list rotation, "one" gets popped and added back
 		res5, err := client.BLMove(context.Background(), key1, key1, constants.Left, constants.Left, 100*time.Millisecond)
 		assert.Equal(suite.T(), "one", res5.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res6, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"one", "two", "three"}, res6)
 		// normal use case, "three" gets popped and added to the left of destination
 		res7, err := client.LPush(context.Background(), key2, []string{"six", "five", "four"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res7)
 
 		res8, err := client.BLMove(context.Background(), key1, key2, constants.Right, constants.Left, 100*time.Millisecond)
 		assert.Equal(suite.T(), "three", res8.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		res9, err := client.LRange(context.Background(), key1, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"one", "two"}, res9)
 
 		res10, err := client.LRange(context.Background(), key2, int64(0), int64(-1))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"three", "four", "five", "six"}, res10)
 
 		// source exists but is not a list type key
 		suite.verifyOK(client.Set(context.Background(), nonListKey, "value"))
 
 		res11, err := client.BLMove(
-			context.Background(),
 			nonListKey,
 			key1,
 			constants.Left,
 			constants.Left,
 			100*time.Millisecond,
 		)
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res11)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(models.CreateNilStringResult(), res11)
 
 		// destination exists but is not a list type key
 		suite.verifyOK(client.Set(context.Background(), nonListKey, "value"))
 
 		res12, err := client.BLMove(
-			context.Background(),
 			key1,
 			nonListKey,
 			constants.Left,
 			constants.Left,
 			100*time.Millisecond,
 		)
-		assert.Equal(suite.T(), models.CreateNilStringResult(), res12)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Equal(models.CreateNilStringResult(), res12)
 	})
 }
 
@@ -4554,7 +4503,7 @@ func (suite *GlideTestSuite) TestDel_MultipleKeys() {
 
 		deletedCount, err := client.Del(context.Background(), []string{key1, key2, key3})
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), deletedCount)
 
 		result1, err1 := client.Get(context.Background(), key1)
@@ -4578,16 +4527,16 @@ func (suite *GlideTestSuite) TestType() {
 		keyName := "{keyName}" + uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), keyName, initialValue))
 		result, err := client.Type(context.Background(), keyName)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.IsType(suite.T(), result, "string", "Value is string")
 
 		// Test 2: Check if the value is list
 		key1 := "{keylist}-1" + uuid.NewString()
 		resultLPush, err := client.LPush(context.Background(), key1, []string{"one", "two", "three"})
 		assert.Equal(suite.T(), int64(3), resultLPush)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		resultType, err := client.Type(context.Background(), key1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.IsType(suite.T(), resultType, "list", "Value is list")
 	})
 }
@@ -4600,12 +4549,12 @@ func (suite *GlideTestSuite) TestTouch() {
 		suite.verifyOK(client.Set(context.Background(), keyName, initialValue))
 		suite.verifyOK(client.Set(context.Background(), keyName1, "anotherValue"))
 		result, err := client.Touch(context.Background(), []string{keyName, keyName1})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), result, "The touch should be 2")
 
 		// Test 2: Check if an touch invalid key
 		resultInvalidKey, err := client.Touch(context.Background(), []string{"invalidKey", "invalidKey1"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultInvalidKey, "The touch should be 0")
 	})
 }
@@ -4618,12 +4567,12 @@ func (suite *GlideTestSuite) TestUnlink() {
 		suite.verifyOK(client.Set(context.Background(), keyName, initialValue))
 		suite.verifyOK(client.Set(context.Background(), keyName1, "anotherValue"))
 		resultValidKey, err := client.Unlink(context.Background(), []string{keyName, keyName1})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), resultValidKey, "The unlink should be 2")
 
 		// Test 2: Check if an unlink for invalid key
 		resultInvalidKey, err := client.Unlink(context.Background(), []string{"invalidKey2", "invalidKey3"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), resultInvalidKey, "The unlink should be 0")
 	})
 }
@@ -4640,9 +4589,8 @@ func (suite *GlideTestSuite) TestRename() {
 		// Test 2 Check if the rename command return false if the key/newkey is invalid.
 		key1 := "{keyName}" + uuid.NewString()
 		res1, err := client.Rename(context.Background(), key1, "invalidKey")
-		assert.Equal(suite.T(), "", res1)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Equal("", res1)
 	})
 }
 
@@ -4653,7 +4601,7 @@ func (suite *GlideTestSuite) TestRenameNX() {
 		key2 := "{keyName}" + uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, initialValue))
 		res1, err := client.RenameNX(context.Background(), key, key2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1)
 
 		// Test 2 Check if the RenameNX command return false if newKey already exists.
@@ -4662,7 +4610,7 @@ func (suite *GlideTestSuite) TestRenameNX() {
 		suite.verifyOK(client.Set(context.Background(), key3, initialValue))
 		suite.verifyOK(client.Set(context.Background(), key4, initialValue))
 		res2, err := client.RenameNX(context.Background(), key3, key4)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res2)
 	})
 }
@@ -4672,26 +4620,26 @@ func (suite *GlideTestSuite) TestXAdd() {
 		key := uuid.NewString()
 		// stream does not exist
 		res, err := client.XAdd(context.Background(), key, [][]string{{"field1", "value1"}, {"field1", "value2"}})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res.IsNil())
 		// don't check the value, because it contains server's timestamp
 
 		// adding data to existing stream
 		res, err = client.XAdd(context.Background(), key, [][]string{{"field3", "value3"}})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res.IsNil())
 
 		// incorrect input
 		_, err = client.XAdd(context.Background(), key, [][]string{})
-		assert.NotNil(suite.T(), err)
+		suite.Error(err)
 		_, err = client.XAdd(context.Background(), key, [][]string{{"1", "2", "3"}})
-		assert.NotNil(suite.T(), err)
+		suite.Error(err)
 
 		// key is not a string
 		key = uuid.NewString()
 		client.Set(context.Background(), key, "abc")
 		_, err = client.XAdd(context.Background(), key, [][]string{{"f", "v"}})
-		assert.NotNil(suite.T(), err)
+		suite.Error(err)
 	})
 }
 
@@ -4704,7 +4652,7 @@ func (suite *GlideTestSuite) TestXAddWithOptions() {
 			[][]string{{"field1", "value1"}},
 			*options.NewXAddOptions().SetDontMakeNewStream(),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res.IsNil())
 
 		// adding data to with given ID
@@ -4714,7 +4662,7 @@ func (suite *GlideTestSuite) TestXAddWithOptions() {
 			[][]string{{"field1", "value1"}},
 			*options.NewXAddOptions().SetId("0-1"),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "0-1", res.Value())
 
 		client.XAdd(context.Background(), key, [][]string{{"field2", "value2"}})
@@ -4725,7 +4673,7 @@ func (suite *GlideTestSuite) TestXAddWithOptions() {
 			[][]string{{"field3", "value3"}},
 			*options.NewXAddOptions().SetTrimOptions(options.NewXTrimOptionsWithMaxLen(2).SetExactTrimming()),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res.IsNil())
 		// TODO run XLen there
 	})
@@ -4879,7 +4827,7 @@ func (suite *GlideTestSuite) TestXAutoClaim() {
 		key2 := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key2, key2))
 		_, err = client.XAutoClaim(context.Background(), key2, "_", "_", 0, "_")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5035,11 +4983,11 @@ func (suite *GlideTestSuite) TestXReadGroup() {
 		// error cases:
 		// key does not exist
 		_, err = client.XReadGroup(context.Background(), "_", "_", map[string]string{key3: "0"})
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		// key is not a stream
 		suite.verifyOK(client.Set(context.Background(), key3, uuid.New().String()))
 		_, err = client.XReadGroup(context.Background(), "_", "_", map[string]string{key3: "0"})
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		del, err := client.Del(context.Background(), []string{key3})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(1), del)
@@ -5048,7 +4996,7 @@ func (suite *GlideTestSuite) TestXReadGroup() {
 		assert.NoError(suite.T(), err)
 		assert.NotNil(suite.T(), xadd)
 		_, err = client.XReadGroup(context.Background(), "_", "_", map[string]string{key3: "0"})
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		// consumer don't exist
 		sendWithCustomCommand(
 			suite,
@@ -5077,7 +5025,7 @@ func (suite *GlideTestSuite) TestXRead() {
 
 		// key does not exist
 		read, err := client.XRead(context.Background(), map[string]string{key1: "0-0"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), read)
 
 		res, err := client.XAddWithOptions(context.Background(),
@@ -5085,7 +5033,7 @@ func (suite *GlideTestSuite) TestXRead() {
 			[][]string{{"k1_field1", "k1_value1"}, {"k1_field1", "k1_value2"}},
 			*options.NewXAddOptions().SetId("0-1"),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res.IsNil())
 
 		res, err = client.XAddWithOptions(context.Background(),
@@ -5093,16 +5041,16 @@ func (suite *GlideTestSuite) TestXRead() {
 			[][]string{{"k2_field1", "k2_value1"}},
 			*options.NewXAddOptions().SetId("2-0"),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.False(suite.T(), res.IsNil())
 
 		// reading ID which does not exist yet
 		read, err = client.XRead(context.Background(), map[string]string{key1: "100-500"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), read)
 
 		read, err = client.XRead(context.Background(), map[string]string{key1: "0-0", key2: "0-0"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		// Check that we have two streams
 		assert.Equal(suite.T(), 2, len(read))
@@ -5124,8 +5072,7 @@ func (suite *GlideTestSuite) TestXRead() {
 		// Key exists, but it is not a stream
 		client.Set(context.Background(), key3, "xread")
 		_, err = client.XRead(context.Background(), map[string]string{key1: "0-0", key3: "0-0"})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// ensure that commands doesn't time out even if timeout > request timeout
 		var testClient interfaces.BaseClientCommands
@@ -5144,7 +5091,7 @@ func (suite *GlideTestSuite) TestXRead() {
 			map[string]string{key1: "0-1"},
 			*options.NewXReadOptions().SetBlock(1000 * time.Millisecond),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Empty(suite.T(), read)
 
 		// with 0 timeout (no timeout) should never time out,
@@ -5156,12 +5103,12 @@ func (suite *GlideTestSuite) TestXRead() {
 				map[string]string{key1: "0-1"},
 				*options.NewXReadOptions().SetBlock(0 * time.Millisecond),
 			)
-			assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+			suite.Error(err)
 			finished <- true
 		}()
 		select {
 		case <-finished:
-			assert.Fail(suite.T(), "Infinite block finished")
+			suite.Fail("Infinite block finished")
 		case <-time.After(3 * time.Second):
 		}
 		testClient.Close()
@@ -5259,11 +5206,11 @@ func (suite *GlideTestSuite) TestXGroupSetId() {
 
 		// An error is raised if XGROUP SETID is called with a non-existing key
 		_, err = client.XGroupSetId(context.Background(), uuid.NewString(), group, "1-1")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// An error is raised if XGROUP SETID is called with a non-existing group
 		_, err = client.XGroupSetId(context.Background(), key, uuid.NewString(), "1-1")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Setting the ID to a non-existing ID is allowed
 		suite.verifyOK(client.XGroupSetId(context.Background(), key, group, "99-99"))
@@ -5272,7 +5219,7 @@ func (suite *GlideTestSuite) TestXGroupSetId() {
 		key = uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, "xgroup setid"))
 		_, err = client.XGroupSetId(context.Background(), key, group, "1-1")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5303,32 +5250,30 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		assert.NoError(t, err)
 
 		_, err = client.ZAdd(context.Background(), key2, membersScoreMap)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// wrong key type for zaddincr
 		_, err = client.ZAddIncr(context.Background(), key2, "one", float64(2))
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// with NX & XX
 		onlyIfExistsOpts := options.NewZAddOptions().SetConditionalChange(constants.OnlyIfExists)
 		onlyIfDoesNotExistOpts := options.NewZAddOptions().SetConditionalChange(constants.OnlyIfDoesNotExist)
 
 		res, err = client.ZAddWithOptions(context.Background(), key3, membersScoreMap, *onlyIfExistsOpts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 
 		res, err = client.ZAddWithOptions(context.Background(), key3, membersScoreMap, *onlyIfDoesNotExistOpts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key3, "one", 5, *onlyIfDoesNotExistOpts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resIncr.IsNil())
 
 		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key3, "one", 5, *onlyIfExistsOpts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), float64(6), resIncr.Value())
 
 		// with GT or LT
@@ -5339,7 +5284,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		}
 
 		res, err = client.ZAdd(context.Background(), key4, membersScoreMap2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		membersScoreMap2["one"] = 10.0
@@ -5350,19 +5295,19 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		ltOptsChanged, _ := options.NewZAddOptions().SetUpdateOptions(options.ScoreLessThanCurrent).SetChanged(true)
 
 		res, err = client.ZAddWithOptions(context.Background(), key4, membersScoreMap2, *gtOptsChanged)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res)
 
 		res, err = client.ZAddWithOptions(context.Background(), key4, membersScoreMap2, *ltOptsChanged)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 
 		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key4, "one", -3, *ltOpts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), float64(7), resIncr.Value())
 
 		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key4, "one", -3, *gtOpts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), resIncr.IsNil())
 	})
 }
@@ -5374,27 +5319,26 @@ func (suite *GlideTestSuite) TestZincrBy() {
 
 		// key does not exist
 		res1, err := client.ZIncrBy(context.Background(), key1, 2.5, "value1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), 2.5, res1)
 
 		// key exists, but value doesn't
 		res2, err := client.ZIncrBy(context.Background(), key1, -3.3, "value2")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), -3.3, res2)
 
 		// updating existing value in existing key
 		res3, err := client.ZIncrBy(context.Background(), key1, 1.0, "value1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), 3.5, res3)
 
 		// Key exists, but it is not a sorted set
 		res4, err := client.SAdd(context.Background(), key2, []string{"one", "two"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res4)
 
 		_, err = client.ZIncrBy(context.Background(), key2, 0.5, "_")
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5406,27 +5350,27 @@ func (suite *GlideTestSuite) TestBZPopMin() {
 
 		// Add elements to key1
 		zaddResult1, err := client.ZAdd(context.Background(), key1, map[string]float64{"a": 1.0, "b": 1.5})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), zaddResult1)
 
 		// Add elements to key2
 		zaddResult2, err := client.ZAdd(context.Background(), key2, map[string]float64{"c": 2.0})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), zaddResult2)
 
 		// Pop minimum element from key1 and key2
 		bzpopminResult1, err := client.BZPopMin(context.Background(), []string{key1, key2}, 500*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.KeyWithMemberAndScore{Key: key1, Member: "a", Score: 1.0}, bzpopminResult1.Value())
 
 		// Attempt to pop from non-existent key3
 		bzpopminResult2, err := client.BZPopMin(context.Background(), []string{key3}, 1*time.Second)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), bzpopminResult2.IsNil())
 
 		// Pop minimum element from key2
 		bzpopminResult3, err := client.BZPopMin(context.Background(), []string{key3, key2}, 500*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.KeyWithMemberAndScore{Key: key2, Member: "c", Score: 2.0}, bzpopminResult3.Value())
 
 		// Set key3 to a non-sorted set value
@@ -5434,9 +5378,7 @@ func (suite *GlideTestSuite) TestBZPopMin() {
 
 		// Attempt to pop from key3 which is not a sorted set
 		_, err = client.BZPopMin(context.Background(), []string{key3}, 500*time.Millisecond)
-		if assert.Error(suite.T(), err) {
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-		}
+		suite.Error(err)
 	})
 }
 
@@ -5451,24 +5393,23 @@ func (suite *GlideTestSuite) TestZPopMin() {
 		}
 
 		res, err := client.ZAdd(context.Background(), key1, memberScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		res2, err := client.ZPopMin(context.Background(), key1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]float64{"one": float64(1)}, res2)
 
 		res3, err := client.ZPopMinWithOptions(context.Background(), key1, *options.NewZPopOptions().SetCount(2))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]float64{"two": float64(2), "three": float64(3)}, res3)
 
 		// non sorted set key
 		_, err = client.Set(context.Background(), key2, "test")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZPopMin(context.Background(), key2)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5482,24 +5423,23 @@ func (suite *GlideTestSuite) TestZPopMax() {
 			"three": 3.0,
 		}
 		res, err := client.ZAdd(context.Background(), key1, memberScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		res2, err := client.ZPopMax(context.Background(), key1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]float64{"three": float64(3)}, res2)
 
 		res3, err := client.ZPopMaxWithOptions(context.Background(), key1, *options.NewZPopOptions().SetCount(2))
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), map[string]float64{"two": float64(2), "one": float64(1)}, res3)
 
 		// non sorted set key
 		_, err = client.Set(context.Background(), key2, "test")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZPopMax(context.Background(), key2)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5512,30 +5452,28 @@ func (suite *GlideTestSuite) TestZRem() {
 			"three": 3.0,
 		}
 		res, err := client.ZAdd(context.Background(), key, memberScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
 		// no members to remove
 		_, err = client.ZRem(context.Background(), key, []string{})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		res, err = client.ZRem(context.Background(), key, []string{"one"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res)
 
 		// TODO: run ZCard there
 		res, err = client.ZRem(context.Background(), key, []string{"one", "two", "three"})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res)
 
 		// non sorted set key
 		_, err = client.Set(context.Background(), key, "test")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZRem(context.Background(), key, []string{"value"})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5958,30 +5896,29 @@ func (suite *GlideTestSuite) TestZRank() {
 		stringKey := uuid.New().String()
 		client.ZAdd(context.Background(), key, map[string]float64{"one": 1.5, "two": 2.0, "three": 3.0})
 		res, err := client.ZRank(context.Background(), key, "two")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res.Value())
 
 		if suite.serverVersion >= "7.2.0" {
 			res2Rank, res2Score, err := client.ZRankWithScore(context.Background(), key, "one")
-			assert.Nil(suite.T(), err)
+			suite.NoError(err)
 			assert.Equal(suite.T(), int64(0), res2Rank.Value())
 			assert.Equal(suite.T(), float64(1.5), res2Score.Value())
 			res4Rank, res4Score, err := client.ZRankWithScore(context.Background(), key, "non-existing-member")
-			assert.Nil(suite.T(), err)
+			suite.NoError(err)
 			assert.True(suite.T(), res4Rank.IsNil())
 			assert.True(suite.T(), res4Score.IsNil())
 		}
 
 		res3, err := client.ZRank(context.Background(), key, "non-existing-member")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res3.IsNil())
 
 		// key exists, but it is not a set
 		suite.verifyOK(client.Set(context.Background(), stringKey, "value"))
 
 		_, err = client.ZRank(context.Background(), stringKey, "value")
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -5991,30 +5928,29 @@ func (suite *GlideTestSuite) TestZRevRank() {
 		stringKey := uuid.New().String()
 		client.ZAdd(context.Background(), key, map[string]float64{"one": 1.5, "two": 2.0, "three": 3.0})
 		res, err := client.ZRevRank(context.Background(), key, "two")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res.Value())
 
 		if suite.serverVersion >= "7.2.0" {
 			res2Rank, res2Score, err := client.ZRevRankWithScore(context.Background(), key, "one")
-			assert.Nil(suite.T(), err)
+			suite.NoError(err)
 			assert.Equal(suite.T(), int64(2), res2Rank.Value())
 			assert.Equal(suite.T(), float64(1.5), res2Score.Value())
 			res4Rank, res4Score, err := client.ZRevRankWithScore(context.Background(), key, "non-existing-member")
-			assert.Nil(suite.T(), err)
+			suite.NoError(err)
 			assert.True(suite.T(), res4Rank.IsNil())
 			assert.True(suite.T(), res4Score.IsNil())
 		}
 
 		res3, err := client.ZRevRank(context.Background(), key, "non-existing-member")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res3.IsNil())
 
 		// key exists, but it is not a set
 		suite.verifyOK(client.Set(context.Background(), stringKey, "value"))
 
 		_, err = client.ZRevRank(context.Background(), stringKey, "value")
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -6106,11 +6042,9 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 		// Throw Exception: Key exists - but it is not a stream
 		suite.verifyOK(client.Set(context.Background(), key2, "xtrimtest"))
 		_, err = client.XTrim(context.Background(), key2, *options.NewXTrimOptionsWithMinId("0-1"))
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		_, err = client.XLen(context.Background(), key2)
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -6148,8 +6082,7 @@ func (suite *GlideTestSuite) Test_ZScore() {
 		assert.Equal(t, setResult, "OK")
 
 		_, err = client.ZScore(context.Background(), key2, "one")
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -6227,8 +6160,7 @@ func (suite *GlideTestSuite) TestZCount() {
 			options.NewInfiniteScoreBoundary(constants.PositiveInfinity),
 		)
 		_, err = client.ZCount(context.Background(), key2, *zCountRange)
-		assert.NotNil(t, err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -6276,8 +6208,7 @@ func (suite *GlideTestSuite) Test_XDel() {
 		assert.Equal(t, "OK", setResult)
 
 		_, err = client.XDel(context.Background(), key2, []string{streamId3})
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -6311,24 +6242,23 @@ func (suite *GlideTestSuite) TestZScan() {
 		// Negative cursor
 		if suite.serverVersion >= "8.0.0" {
 			_, _, err = client.ZScan(context.Background(), key1, "-1")
-			assert.NotNil(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 		} else {
 			resCursor, resCollection, err = client.ZScan(context.Background(), key1, "-1")
-			assert.NoError(suite.T(), err)
-			assert.Equal(suite.T(), initialCursor, resCursor)
-			assert.Empty(suite.T(), resCollection)
+			suite.NoError(err)
+			suite.Equal(initialCursor, resCursor)
+			suite.Empty(resCollection)
 		}
 
 		// Result contains the whole set
 		res, err := client.ZAdd(context.Background(), key1, charMap)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(5), res)
+		suite.NoError(err)
+		suite.Equal(int64(5), res)
 
 		resCursor, resCollection, err = client.ZScan(context.Background(), key1, initialCursor)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), initialCursor, resCursor)
-		assert.Equal(suite.T(), len(charMap)*2, len(resCollection))
+		suite.NoError(err)
+		suite.Equal(initialCursor, resCursor)
+		suite.Equal(len(charMap)*2, len(resCollection))
 
 		resultKeySet := make([]string, 0, len(charMap))
 		resultValueSet := make([]string, 0, len(charMap))
@@ -6423,19 +6353,16 @@ func (suite *GlideTestSuite) TestZScan() {
 		assert.Equal(suite.T(), "OK", setRes)
 
 		_, _, err = client.ZScan(context.Background(), stringKey, initialCursor)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		opts = options.NewZScanOptions().SetMatch("test").SetCount(1)
 		_, _, err = client.ZScanWithOptions(context.Background(), stringKey, initialCursor, *opts)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Negative count
 		opts = options.NewZScanOptions().SetCount(-1)
 		_, _, err = client.ZScanWithOptions(context.Background(), key1, "-1", *opts)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -6716,16 +6643,14 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				groupName,
 				*options.NewXPendingOptions("invalid-id", "+", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				key,
 				groupName,
 				*options.NewXPendingOptions("-", "invalid-id", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 
 			// invalid count should return no results
 			detailResult, err = client.XPendingWithOptions(context.Background(),
@@ -6741,27 +6666,24 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				key,
 				"invalid-group",
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 			// non-existent key throws a RequestError (NOGROUP)
 			_, err = client.XPending(context.Background(),
 				missingKey,
 				groupName,
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				missingKey,
 				groupName,
 				*options.NewXPendingOptions("-", "+", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 			// Key exists, but it is not a stream
 			_, _ = client.Set(context.Background(), nonStreamKey, "bar")
@@ -6769,18 +6691,16 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				nonStreamKey,
 				groupName,
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "WRONGTYPE"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				nonStreamKey,
 				groupName,
 				*options.NewXPendingOptions("-", "+", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "WRONGTYPE"))
 		}
 
 		execCluster := func(client interfaces.GlideClusterClientCommands) {
@@ -6876,16 +6796,14 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				groupName,
 				*options.NewXPendingOptions("invalid-id", "+", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				key,
 				groupName,
 				*options.NewXPendingOptions("-", "invalid-id", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 
 			// invalid count should return no results
 			detailResult, err = client.XPendingWithOptions(context.Background(),
@@ -6901,27 +6819,24 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				key,
 				"invalid-group",
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 			// non-existent key throws a RequestError (NOGROUP)
 			_, err = client.XPending(context.Background(),
 				missingKey,
 				groupName,
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				missingKey,
 				groupName,
 				*options.NewXPendingOptions("-", "+", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 			// Key exists, but it is not a stream
 			_, _ = client.Set(context.Background(), nonStreamKey, "bar")
@@ -6929,18 +6844,16 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				nonStreamKey,
 				groupName,
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "WRONGTYPE"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				nonStreamKey,
 				groupName,
 				*options.NewXPendingOptions("-", "+", 10),
 			)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
+			suite.Error(err)
+			suite.True(strings.Contains(err.Error(), "WRONGTYPE"))
 		}
 
 		assert.Equal(suite.T(), "OK", "OK")
@@ -6965,8 +6878,7 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 
 		// Stream not created results in error
 		_, err := client.XGroupCreate(context.Background(), key, group, id)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Stream with option to create creates stream & Group
 		opts := options.NewXGroupCreateOptions().SetMakeStream()
@@ -6974,18 +6886,18 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 
 		// ...and again results in BUSYGROUP error, because group names must be unique
 		_, err = client.XGroupCreate(context.Background(), key, group, id)
-		assert.ErrorContains(suite.T(), err, "BUSYGROUP")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.True(strings.Contains(err.Error(), "BUSYGROUP"))
 
 		// Stream Group can be destroyed returns: true
 		destroyed, err := client.XGroupDestroy(context.Background(), key, group)
-		assert.NoError(suite.T(), err)
-		assert.True(suite.T(), destroyed)
+		suite.NoError(err)
+		suite.True(destroyed)
 
 		// ...and again results in: false
 		destroyed, err = client.XGroupDestroy(context.Background(), key, group)
-		assert.NoError(suite.T(), err)
-		assert.False(suite.T(), destroyed)
+		suite.NoError(err)
+		suite.False(destroyed)
 
 		// ENTRIESREAD option was added in valkey 7.0.0
 		opts = options.NewXGroupCreateOptions().SetEntriesRead(100)
@@ -6993,16 +6905,14 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 			suite.verifyOK(client.XGroupCreateWithOptions(context.Background(), key, group, id, *opts))
 		} else {
 			_, err = client.XGroupCreateWithOptions(context.Background(), key, group, id, *opts)
-			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+			suite.Error(err)
 		}
 
 		// key is not a stream
 		key = uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, id))
 		_, err = client.XGroupCreate(context.Background(), key, group, id)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7043,7 +6953,7 @@ func (suite *GlideTestSuite) TestDumpRestore() {
 		assert.Nil(t, err)
 		assert.Equal(t, int64(1), deletedCount)
 		result_test1, err := client.Restore(context.Background(), key, int64(0), resultDump.Value())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result_test1)
 		resultGetRestoreKey, err := client.Get(context.Background(), key)
 		assert.Nil(t, err)
@@ -7074,7 +6984,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Equal(t, int64(1), deletedCount)
 		optsReplace := options.NewRestoreOptions().SetReplace()
 		result_test1, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *optsReplace)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result_test1)
 		resultGetRestoreKey, err := client.Get(context.Background(), key)
 		assert.Nil(t, err)
@@ -7086,7 +6996,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Equal(t, int64(1), delete_test2)
 		opts_test2 := options.NewRestoreOptions().SetABSTTL()
 		result_test2, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *opts_test2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result_test2)
 		resultGet_test2, err := client.Get(context.Background(), key)
 		assert.Nil(t, err)
@@ -7098,7 +7008,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Equal(t, int64(1), delete_test3)
 		opts_test3 := options.NewRestoreOptions().SetEviction(constants.FREQ, 10)
 		result_test3, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *opts_test3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result_test3)
 		resultGet_test3, err := client.Get(context.Background(), key)
 		assert.Nil(t, err)
@@ -7110,7 +7020,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Equal(t, int64(1), delete_test4)
 		opts_test4 := options.NewRestoreOptions().SetEviction(constants.IDLETIME, 10)
 		result_test4, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *opts_test4)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", result_test4)
 		resultGet_test4, err := client.Get(context.Background(), key)
 		assert.Nil(t, err)
@@ -7161,8 +7071,7 @@ func (suite *GlideTestSuite) TestZRemRangeByRank() {
 		assert.Equal(suite.T(), "OK", setResult)
 
 		_, err = client.ZRemRangeByRank(context.Background(), stringKey, 0, 10)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7217,8 +7126,7 @@ func (suite *GlideTestSuite) TestZRemRangeByLex() {
 			stringKey,
 			*options.NewRangeByLexQuery(options.NewLexBoundary("a", false), options.NewLexBoundary("c", false)),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7277,8 +7185,7 @@ func (suite *GlideTestSuite) TestZRemRangeByScore() {
 			stringKey,
 			*options.NewRangeByScoreQuery(options.NewScoreBoundary(1.0, false), options.NewScoreBoundary(10.0, true)),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7322,13 +7229,13 @@ func (suite *GlideTestSuite) TestZMScore() {
 
 		// invalid arg - member list must not be empty
 		_, err = client.ZMScore(context.Background(), key, []string{})
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// key exists, but it is not a sorted set
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "ZMScore"))
 		_, err = client.ZMScore(context.Background(), key2, []string{"one"})
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7386,11 +7293,11 @@ func (suite *GlideTestSuite) TestZRandMember() {
 		// Key exists, but is not a set
 		suite.verifyOK(client.Set(context.Background(), key2, "ZRandMember"))
 		_, err = client.ZRandMember(context.Background(), key2)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		_, err = client.ZRandMemberWithCount(context.Background(), key2, 2)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 		_, err = client.ZRandMemberWithCountWithScores(context.Background(), key2, 2)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7479,7 +7386,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_ExternalWeights() {
 
 		sortResult, err := client.SortWithOptions(context.Background(), key, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		resultList := []models.Result[string]{
 			models.CreateStringResult("item2"),
 			models.CreateStringResult("item3"),
@@ -7508,7 +7415,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_GetPatterns() {
 
 		sortResult, err := client.SortWithOptions(context.Background(), key, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("Object_1"),
@@ -7543,7 +7450,7 @@ func (suite *GlideTestSuite) TestSortWithOptions_SuccessfulSortByWeightAndGet() 
 
 		sortResult, err := client.SortWithOptions(context.Background(), key, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		resultList := []models.Result[string]{
 			models.CreateStringResult("Object 2"),
@@ -7557,15 +7464,15 @@ func (suite *GlideTestSuite) TestSortWithOptions_SuccessfulSortByWeightAndGet() 
 		assert.Equal(suite.T(), resultList, sortResult)
 
 		objectItem2, err := client.Get(context.Background(), "{key}object_item2")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Object 2", objectItem2.Value())
 
 		objectItem1, err := client.Get(context.Background(), "{key}object_item1")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Object 1", objectItem1.Value())
 
 		objectItem3, err := client.Get(context.Background(), "{key}object_item3")
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Object 3", objectItem3.Value())
 
 		assert.Equal(suite.T(), "item2", sortResult[1].Value())
@@ -7590,12 +7497,12 @@ func (suite *GlideTestSuite) TestSortStoreWithOptions_ByPattern() {
 
 		result, err := client.SortStoreWithOptions(context.Background(), key, sortedKey, *options)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.NotNil(suite.T(), result)
 		assert.Equal(suite.T(), int64(5), result)
 
 		sortedValues, err := client.LRange(context.Background(), sortedKey, 0, -1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []string{"d", "b", "c", "e", "a"}, sortedValues)
 	})
 }
@@ -7620,32 +7527,31 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 
 		// create a consumer for a group that doesn't exist should result in a NOGROUP error
 		_, err = client.XGroupCreateConsumer(context.Background(), key, "non-existent-group", consumerName)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-		assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
+		suite.Error(err)
+		suite.True(strings.Contains(err.Error(), "NOGROUP"))
 
 		// create consumer that already exists should return false
 		respBool, err = client.XGroupCreateConsumer(context.Background(), key, groupName, consumerName)
-		assert.NoError(suite.T(), err)
-		assert.False(suite.T(), respBool)
+		suite.NoError(err)
+		suite.False(respBool)
 
 		// Delete a consumer that hasn't been created should return 0
 		respInt64, err := client.XGroupDelConsumer(context.Background(), key, groupName, "non-existent-consumer")
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), respInt64)
+		suite.NoError(err)
+		suite.Equal(int64(0), respInt64)
 
 		// Add two stream entries
 		streamId1, err := client.XAdd(context.Background(), key, [][]string{{"field1", "value1"}})
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		streamId2, err := client.XAdd(context.Background(), key, [][]string{{"field2", "value2"}})
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		// read the stream for the consumer and mark messages as pending
 		actualGroup, err := client.XReadGroup(context.Background(), groupName, consumerName, map[string]string{key: ">"})
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		// Check that we have the stream with the correct name in the map
-		assert.Equal(suite.T(), 1, len(actualGroup))
+		assert.True(suite.T(), reflect.DeepEqual(expectedGroup, actualGroup),
 		streamResponse, exists := actualGroup[key]
 		assert.True(suite.T(), exists)
 
@@ -7667,12 +7573,12 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 
 		// delete one of the streams using XDel
 		respInt64, err = client.XDel(context.Background(), key, []string{streamId1.Value()})
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), respInt64)
+		suite.NoError(err)
+		suite.Equal(int64(1), respInt64)
 
 		// xreadgroup should return one empty stream and one non-empty stream
 		resp, err := client.XReadGroup(context.Background(), groupName, consumerName, map[string]string{key: zeroStreamId})
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		// Check that we have one stream
 		assert.Equal(suite.T(), 1, len(resp))
@@ -7680,7 +7586,7 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 		assert.True(suite.T(), exists)
 
 		// Check entries
-		entryMap = make(map[string]map[string]string)
+		assert.Equal(suite.T(), map[string]map[string][][]string{
 		for _, entry := range streamResponse.Entries {
 			entryMap[entry.ID] = entry.Fields
 		}
@@ -7694,30 +7600,30 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 
 		// add a new stream entry
 		streamId3, err := client.XAdd(context.Background(), key, [][]string{{"field3", "value3"}})
-		assert.NoError(suite.T(), err)
-		assert.NotNil(suite.T(), streamId3)
+		suite.NoError(err)
+		suite.NotNil(streamId3)
 
 		// xack that streamid1 and streamid2 have been processed
 		xackResult, err := client.XAck(context.Background(), key, groupName, []string{streamId1.Value(), streamId2.Value()})
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), xackResult)
+		suite.NoError(err)
+		suite.Equal(int64(2), xackResult)
 
 		// Delete the consumer group and expect 0 pending messages
 		respInt64, err = client.XGroupDelConsumer(context.Background(), key, groupName, consumerName)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), respInt64)
+		suite.NoError(err)
+		suite.Equal(int64(0), respInt64)
 
 		// xack streamid_1, and streamid_2 already received returns 0L
 		xackResult, err = client.XAck(context.Background(), key, groupName, []string{streamId1.Value(), streamId2.Value()})
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), xackResult)
+		suite.NoError(err)
+		suite.Equal(int64(0), xackResult)
 
 		// Consume the last message with the previously deleted consumer (creates the consumer anew)
 		resp, err = client.XReadGroup(context.Background(), groupName, consumerName, map[string]string{key: ">"})
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		// Check that we have one stream with entries
-		assert.Equal(suite.T(), 1, len(resp))
+		assert.Equal(suite.T(), 1, len(resp[key]))
 		streamResponse, exists = resp[key]
 		assert.True(suite.T(), exists)
 		assert.Equal(suite.T(), 1, len(streamResponse.Entries))
@@ -7726,24 +7632,22 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 
 		// Use non existent group, so xack streamid_3 returns 0
 		xackResult, err = client.XAck(context.Background(), key, "non-existent-group", []string{streamId3.Value()})
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), xackResult)
+		suite.NoError(err)
+		suite.Equal(int64(0), xackResult)
 
 		// Delete the consumer group and expect 1 pending message
 		respInt64, err = client.XGroupDelConsumer(context.Background(), key, groupName, consumerName)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(1), respInt64)
+		suite.NoError(err)
+		suite.Equal(int64(1), respInt64)
 
 		// Set a string key, and expect an error when you try to create or delete a consumer group
 		_, err = client.Set(context.Background(), stringKey, "test")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		_, err = client.XGroupCreateConsumer(context.Background(), stringKey, groupName, consumerName)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.XGroupDelConsumer(context.Background(), stringKey, groupName, consumerName)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -7759,7 +7663,7 @@ func (suite *GlideTestSuite) TestXInfoStream() {
 			[][]string{{"a", "b"}, {"c", "d"}},
 			*options.NewXAddOptions().SetId("1-0"),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "1-0", xadd.Value())
 
 		suite.verifyOK(client.XGroupCreate(context.Background(), key, group, "0-0"))
@@ -7781,7 +7685,7 @@ func (suite *GlideTestSuite) TestXInfoStream() {
 			[][]string{{"e", "f"}},
 			*options.NewXAddOptions().SetId("1-1"),
 		)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "1-1", xadd.Value())
 
 		infoFull, err := client.XInfoStreamFullWithOptions(
@@ -7913,25 +7817,25 @@ func (suite *GlideTestSuite) TestXInfoConsumers() {
 		// Passing a non-existing key raises an error
 		key = uuid.NewString()
 		_, err = client.XInfoConsumers(context.Background(), key, "_")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// key exists, but it is not a stream
 		suite.verifyOK(client.Set(context.Background(), key, key))
 		_, err = client.XInfoConsumers(context.Background(), key, "_")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Passing a non-existing group raises an error
 		key = uuid.NewString()
 		_, err = client.XAdd(context.Background(), key, [][]string{{"a", "b"}})
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		_, err = client.XInfoConsumers(context.Background(), key, "_")
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// no consumers yet
 		suite.verifyOK(client.XGroupCreate(context.Background(), key, group, "0-0"))
 		info, err = client.XInfoConsumers(context.Background(), key, group)
-		assert.NoError(suite.T(), err)
-		assert.Empty(suite.T(), info)
+		suite.NoError(err)
+		suite.Empty(info)
 	})
 }
 
@@ -7953,9 +7857,9 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 
 		// one empty group exists
 		xinfo, err := client.XInfoGroups(context.Background(), key)
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		if suite.serverVersion < "7.0.0" {
-			assert.Equal(suite.T(), []models.XInfoGroupInfo{
+			suite.Equal([]models.XInfoGroupInfo{
 				{
 					Name:            group,
 					Consumers:       0,
@@ -8003,9 +7907,9 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 
 		// same as previous check, bug lag = 3, there are 3 messages unread
 		xinfo, err = client.XInfoGroups(context.Background(), key)
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		if suite.serverVersion < "7.0.0" {
-			assert.Equal(suite.T(), []models.XInfoGroupInfo{
+			suite.Equal([]models.XInfoGroupInfo{
 				{
 					Name:            group,
 					Consumers:       0,
@@ -8116,12 +8020,12 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 		// Passing a non-existing key raises an error
 		key = uuid.NewString()
 		_, err = client.XInfoGroups(context.Background(), key)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// key exists, but it is not a stream
 		suite.verifyOK(client.Set(context.Background(), key, key))
 		_, err = client.XInfoGroups(context.Background(), key)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// create a second stream
 		key = uuid.NewString()
@@ -8689,20 +8593,18 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 
 		// claim with invalid stream entry IDs
 		_, err = client.XClaimJustId(context.Background(), key, groupName, consumer1, int64(1), []string{"invalid-stream-id"})
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// claim with empty stream entry IDs returns empty map
 		claimResult, err := client.XClaimJustId(context.Background(), key, groupName, consumer1, int64(1), []string{})
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), []string{}, claimResult)
+		suite.NoError(err)
+		suite.Equal([]string{}, claimResult)
 
 		// non existent key causes a RequestError
 		claimOptions := options.NewXClaimOptions().SetIdleTime(1)
 		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-		assert.Contains(suite.T(), err.Error(), "NOGROUP")
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimWithOptions(context.Background(),
 			stringKey,
@@ -8712,9 +8614,8 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-		assert.Contains(suite.T(), err.Error(), "NOGROUP")
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustId(
 			context.Background(),
@@ -8724,9 +8625,8 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			int64(1),
 			[]string{streamid_1.Value()},
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-		assert.Contains(suite.T(), err.Error(), "NOGROUP")
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustIdWithOptions(context.Background(),
 			stringKey,
@@ -8736,16 +8636,15 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
-		assert.Contains(suite.T(), err.Error(), "NOGROUP")
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		// key exists, but is not a stream
 		_, err = client.Set(context.Background(), stringKey, "test")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimWithOptions(context.Background(),
 			stringKey,
@@ -8755,8 +8654,8 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustId(
 			context.Background(),
@@ -8766,8 +8665,8 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			int64(1),
 			[]string{streamid_1.Value()},
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustIdWithOptions(context.Background(),
 			stringKey,
@@ -8777,8 +8676,8 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
+		suite.Contains(err.Error(), "NOGROUP")
 	})
 }
 
@@ -8787,18 +8686,17 @@ func (suite *GlideTestSuite) TestCopy() {
 		key := "{key}" + uuid.New().String()
 		key2 := "{key}" + uuid.New().String()
 		value := "hello"
-		t := suite.T()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
 		// Test 1: Check the copy command
 		resultCopy, err := client.Copy(context.Background(), key, key2)
-		assert.Nil(t, err)
-		assert.True(t, resultCopy)
+		suite.NoError(err)
+		suite.True(resultCopy)
 
 		// Test 2: Check if the value stored at the source is same with destination key.
 		resultGet, err := client.Get(context.Background(), key2)
-		assert.Nil(t, err)
-		assert.Equal(t, value, resultGet.Value())
+		suite.NoError(err)
+		suite.Equal(value, resultGet.Value())
 	})
 }
 
@@ -9025,16 +8923,14 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 			negativeInfinity,
 			positiveInfinity,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.XRevRange(context.Background(),
 			stringKey,
 			positiveInfinity,
 			negativeInfinity,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// xrange and xrevrange when range bound is not a valid id
 		_, err = client.XRange(context.Background(),
@@ -9042,16 +8938,14 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 			options.NewStreamBoundary("invalid-id", true),
 			positiveInfinity,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.XRevRange(context.Background(),
 			key,
 			options.NewStreamBoundary("invalid-id", true),
 			negativeInfinity,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -9064,12 +8958,12 @@ func (suite *GlideTestSuite) TestBitField_GetAndIncrBy() {
 		}
 
 		result1, err := client.BitField(context.Background(), key, commands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), result1, 1)
 		firstValue := result1[0].Value()
 
 		result2, err := client.BitField(context.Background(), key, commands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), result2, 1)
 		assert.Equal(suite.T(), firstValue+1, result2[0].Value())
 
@@ -9078,7 +8972,7 @@ func (suite *GlideTestSuite) TestBitField_GetAndIncrBy() {
 		}
 
 		getResult, err := client.BitField(context.Background(), key, getCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), getResult, 1)
 		assert.Equal(suite.T(), result2[0].Value(), getResult[0].Value())
 	})
@@ -9095,7 +8989,7 @@ func (suite *GlideTestSuite) TestBitField_Overflow() {
 		}
 
 		satResult, err := client.BitField(context.Background(), key1, satCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), satResult, 2)
 
 		assert.Equal(suite.T(), int64(2), satResult[0].Value())
@@ -9110,7 +9004,7 @@ func (suite *GlideTestSuite) TestBitField_Overflow() {
 		}
 
 		wrapResult, err := client.BitField(context.Background(), key2, wrapCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), wrapResult, 2)
 
 		assert.Equal(suite.T(), int64(3), wrapResult[0].Value())
@@ -9125,7 +9019,7 @@ func (suite *GlideTestSuite) TestBitField_Overflow() {
 		}
 
 		failResult, err := client.BitField(context.Background(), key3, failCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), failResult, 2)
 
 		assert.Equal(suite.T(), int64(3), failResult[0].Value())
@@ -9145,7 +9039,7 @@ func (suite *GlideTestSuite) TestBitField_MultipleOperations() {
 
 		result, err := client.BitField(context.Background(), key, commands)
 
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Len(suite.T(), result, 3)
 
 		assert.LessOrEqual(suite.T(), result[0].Value(), int64(10))
@@ -9279,19 +9173,19 @@ func (suite *GlideTestSuite) TestBitFieldRO_BasicOperation() {
 			options.NewBitFieldSet(options.SignedInt, 8, 16, value),
 		}
 		_, err := client.BitField(context.Background(), key, setCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		getNormalCommands := []options.BitFieldSubCommands{
 			options.NewBitFieldGet(options.SignedInt, 8, 16),
 		}
 		getNormal, err := client.BitField(context.Background(), key, getNormalCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		getROCommands := []options.BitFieldROCommands{
 			options.NewBitFieldGet(options.SignedInt, 8, 16),
 		}
 		getRO, err := client.BitFieldRO(context.Background(), key, getROCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.Equal(suite.T(), getNormal[0].Value(), getRO[0].Value())
 		assert.Equal(suite.T(), value, getRO[0].Value())
@@ -9310,7 +9204,7 @@ func (suite *GlideTestSuite) TestBitFieldRO_MultipleGets() {
 		}
 
 		_, err := client.BitField(context.Background(), key, setCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		getNormalCommands := []options.BitFieldSubCommands{
 			options.NewBitFieldGet(options.SignedInt, 8, 0),
@@ -9318,7 +9212,7 @@ func (suite *GlideTestSuite) TestBitFieldRO_MultipleGets() {
 		}
 
 		getNormal, err := client.BitField(context.Background(), key, getNormalCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		getROCommands := []options.BitFieldROCommands{
 			options.NewBitFieldGet(options.SignedInt, 8, 0),
@@ -9326,7 +9220,7 @@ func (suite *GlideTestSuite) TestBitFieldRO_MultipleGets() {
 		}
 
 		getRO, err := client.BitFieldRO(context.Background(), key, getROCommands)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		assert.Equal(suite.T(),
 			[]int64{getNormal[0].Value(), getNormal[1].Value()},
@@ -9423,23 +9317,20 @@ func (suite *GlideTestSuite) TestZInter() {
 		_, err = client.ZInterWithScores(context.Background(), options.KeyArray{Keys: []string{}},
 			*options.NewZInterOptions().SetAggregate(options.AggregateSum),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// key exists but not a set
 		_, err = client.Set(context.Background(), key3, "value")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZInter(context.Background(), options.KeyArray{Keys: []string{key1, key3}})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.ZInterWithScores(context.Background(),
 			options.KeyArray{Keys: []string{key1, key3}},
 			*options.NewZInterOptions().SetAggregate(options.AggregateSum),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -9574,11 +9465,10 @@ func (suite *GlideTestSuite) TestZInterStore() {
 
 		// key exists but not a set
 		_, err = client.Set(context.Background(), key4, "value")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZInterStore(context.Background(), key3, options.KeyArray{Keys: []string{key1, key4}})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -9644,15 +9534,13 @@ func (suite *GlideTestSuite) TestZDiff() {
 
 		// Key exists, but it is not a set
 		setResult, _ := client.Set(context.Background(), nonExistentKey, "bar")
-		assert.Equal(t, setResult, "OK")
+		suite.Equal(setResult, "OK")
 
 		_, err = client.ZDiff(context.Background(), []string{nonExistentKey, key2})
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.ZDiffWithScores(context.Background(), []string{nonExistentKey, key2})
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -9728,11 +9616,10 @@ func (suite *GlideTestSuite) TestZDiffStore() {
 
 		// Key exists, but it is not a set
 		setResult, err := client.Set(context.Background(), key5, "bar")
-		assert.NoError(t, err)
-		assert.Equal(t, setResult, "OK")
+		suite.NoError(err)
+		suite.Equal(setResult, "OK")
 		_, err = client.ZDiffStore(context.Background(), key4, []string{key5, key1})
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -9851,18 +9738,16 @@ func (suite *GlideTestSuite) TestZUnionAndZUnionWithScores() {
 
 		// key exists but not a set
 		_, err = client.Set(context.Background(), key3, "value")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZUnion(context.Background(), options.KeyArray{Keys: []string{key1, key3}})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.ZUnionWithScores(context.Background(),
 			options.KeyArray{Keys: []string{key1, key3}},
 			options.NewZUnionOptionsBuilder().SetAggregate(options.AggregateSum),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10012,19 +9897,17 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 
 		// key exists but not a set
 		_, err = client.Set(context.Background(), key3, "value")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 
 		_, err = client.ZUnionStore(context.Background(), dest, options.KeyArray{Keys: []string{key1, key3}})
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		_, err = client.ZUnionStoreWithOptions(context.Background(),
 			dest,
 			options.KeyArray{Keys: []string{key1, key3}},
 			options.NewZUnionOptionsBuilder().SetAggregate(options.AggregateSum),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10095,8 +9978,7 @@ func (suite *GlideTestSuite) TestZInterCard() {
 			[]string{key1, key3},
 			options.NewZInterCardOptions().SetLimit(3),
 		)
-		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10165,8 +10047,7 @@ func (suite *GlideTestSuite) TestZLexCount() {
 				options.NewLexBoundary("c", true),
 			),
 		)
-		assert.NotNil(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10229,8 +10110,7 @@ func (suite *GlideTestSuite) TestGeoAdd() {
 			membersToCoordinates,
 			*options.NewGeoAddOptions().SetChanged(true),
 		)
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10271,57 +10151,49 @@ func (suite *GlideTestSuite) TestGeoDist() {
 
 		// key exists but holds a non-ZSET value
 		_, err = client.Set(context.Background(), key2, "bar")
-		assert.NoError(t, err)
+		suite.NoError(err)
 		_, err = client.GeoDist(context.Background(), key2, member1, member2)
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
 func (suite *GlideTestSuite) TestGeoAdd_InvalidArgs() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
-		t := suite.T()
 		key := "{testKey}:3-" + uuid.New().String()
 
 		// Test empty members
 		_, err := client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{})
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Test invalid longitude (-181)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: -181, Latitude: 0},
 		})
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Test invalid longitude (181)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: 181, Latitude: 0},
 		})
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Test invalid latitude (86)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: 0, Latitude: 86},
 		})
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Test invalid latitude (-86)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: 0, Latitude: -86},
 		})
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
 func (suite *GlideTestSuite) TestGeoHash() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := uuid.New().String()
-		t := suite.T()
 
 		// Add some locations to the geo index
 		membersToCoordinates := map[string]options.GeospatialData{
@@ -10331,15 +10203,15 @@ func (suite *GlideTestSuite) TestGeoHash() {
 
 		// Add the coordinates
 		result, err := client.GeoAdd(context.Background(), key1, membersToCoordinates)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(2), result)
+		suite.NoError(err)
+		suite.Equal(int64(2), result)
 
 		// Test getting geohash for multiple members
 		geoHashResults, err := client.GeoHash(context.Background(), key1, []string{"Palermo", "Catania"})
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(geoHashResults))
-		assert.Equal(t, "sqc8b49rny0", geoHashResults[0].Value())
-		assert.Equal(t, "sqdtr74hyu0", geoHashResults[1].Value())
+		suite.NoError(err)
+		suite.Equal(2, len(geoHashResults))
+		assert.Equal(t, geoHashResults[0], "sqc8b49rny0")
+		assert.Equal(t, geoHashResults[1], "sqdtr74hyu0")
 
 		// Test getting geohash for non-existent members
 		geoHashResults, err = client.GeoHash(context.Background(), key1, []string{"Gotham City"})
@@ -10349,16 +10221,15 @@ func (suite *GlideTestSuite) TestGeoHash() {
 
 		// Test getting geohash for empty members
 		geoHashResults, err = client.GeoHash(context.Background(), key1, []string{})
-		assert.NoError(t, err)
-		assert.Equal(t, 0, len(geoHashResults))
+		suite.NoError(err)
+		suite.Equal(0, len(geoHashResults))
 
 		// Test with wrong key type
 		wrongKey := "{testKey}:3-" + uuid.New().String()
 		_, err = client.Set(context.Background(), wrongKey, "value")
-		assert.NoError(t, err)
+		suite.NoError(err)
 		_, err = client.GeoHash(context.Background(), wrongKey, []string{"Palermo"})
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10370,7 +10241,7 @@ func (suite *GlideTestSuite) TestGetSet_SendLargeValues() {
 			value := suite.GenerateLargeUuid()
 			suite.verifyOK(client.Set(ctx, key, value))
 			result, err := client.Get(ctx, key)
-			assert.Nil(suite.T(), err)
+			suite.NoError(err)
 			assert.Equal(suite.T(), value, result.Value())
 		})
 	})
@@ -10378,7 +10249,6 @@ func (suite *GlideTestSuite) TestGetSet_SendLargeValues() {
 
 func (suite *GlideTestSuite) TestGeoPos() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
-		t := suite.T()
 		key1 := "{testKey}:1-" + uuid.New().String()
 		key2 := "{testKey}:2-" + uuid.New().String()
 
@@ -10395,28 +10265,27 @@ func (suite *GlideTestSuite) TestGeoPos() {
 		}
 
 		result, err := client.GeoAdd(context.Background(), key1, membersCoordinates)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(2), result)
+		suite.NoError(err)
+		suite.Equal(int64(2), result)
 
 		// Get positions and verify
 		actual, err := client.GeoPos(context.Background(), key1, members)
-		assert.NoError(t, err)
+		suite.NoError(err)
 
 		// Verify each coordinate with high precision
 		for i, coords := range actual {
-			assert.NotNil(t, coords)
-			assert.Equal(t, 2, len(coords))
+			suite.NotNil(coords)
+			suite.Equal(2, len(coords))
 
-			assert.InDeltaSlice(t, expected[i], coords, 1e-6)
+			suite.InDeltaSlice(expected[i], coords, 1e-6)
 		}
 
 		// Test error case with wrong key type
 		_, err = client.Set(context.Background(), key2, "geopos")
-		assert.NoError(t, err)
+		suite.NoError(err)
 
 		_, err = client.GeoPos(context.Background(), key2, members)
-		assert.Error(t, err)
-		assert.IsType(t, &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10706,12 +10575,11 @@ func (suite *GlideTestSuite) TestGeoSearch() {
 			*options.NewCircleSearchShape(100, constants.GeoUnitMeters),
 			*resultOpts,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// Test wrong key type error
 		_, err = client.Set(context.Background(), key2, "nonZSETvalue")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		_, err = client.GeoSearchWithResultOptions(context.Background(),
 			key2,
 			&options.GeoCoordOrigin{
@@ -10720,8 +10588,7 @@ func (suite *GlideTestSuite) TestGeoSearch() {
 			*options.NewCircleSearchShape(100, constants.GeoUnitMeters),
 			*resultOpts,
 		)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10756,8 +10623,8 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		}
 		// Add geospatial data
 		result, err := client.GeoAdd(context.Background(), sourceKey, membersToCoordinates)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), result)
+		suite.NoError(err)
+		suite.Equal(int64(4), result)
 
 		// Test storing results of a box search, from a geospatial data point
 		searchOrigin := &options.GeoCoordOrigin{
@@ -10766,13 +10633,13 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		boxShape := options.NewBoxSearchShape(400, 400, constants.GeoUnitKilometers)
 
 		count, err := client.GeoSearchStore(context.Background(), destinationKey, sourceKey, searchOrigin, *boxShape)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), count)
+		suite.NoError(err)
+		suite.Equal(int64(4), count)
 
 		// Verify stored results
 		zRangeResult, err := client.ZRangeWithScores(context.Background(), destinationKey, options.NewRangeByIndexQuery(0, -1))
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), expectedArray, zRangeResult)
+		suite.NoError(err)
+		suite.Equal(expectedArray, zRangeResult)
 
 		// Test storing results of a box search, unit: kilometers, from a geospatial data point, with distance
 		count, err = client.GeoSearchStoreWithInfoOptions(context.Background(),
@@ -10782,8 +10649,8 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			*boxShape,
 			*options.NewGeoSearchStoreInfoOptions().SetStoreDist(true),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), count)
+		suite.NoError(err)
+		suite.Equal(int64(4), count)
 
 		// Verify stored results with distance
 		zRangeResultWithDist, err := client.ZRangeWithScores(
@@ -10791,9 +10658,9 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			destinationKey,
 			options.NewRangeByIndexQuery(0, -1),
 		)
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		for i := range expectedArray2 {
-			assert.InDelta(suite.T(), expectedArray2[i].Score, zRangeResultWithDist[i].Score, 1e-6)
+			suite.InDelta(expectedArray2[i].Score, zRangeResultWithDist[i].Score, 1e-6)
 		}
 
 		// Test storing results of a box search, unit: kilometers, from a geospatial data point, with count
@@ -10804,8 +10671,8 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			*boxShape,
 			*options.NewGeoSearchResultOptions().SetCount(2),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), count)
+		suite.NoError(err)
+		suite.Equal(int64(2), count)
 
 		// Verify stored results with count
 		zRangeResultWithCount, err := client.ZRangeWithScores(
@@ -10813,9 +10680,8 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			destinationKey,
 			options.NewRangeByIndexQuery(0, -1),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(
-			suite.T(),
+		suite.NoError(err)
+		suite.Equal(
 			[]models.MemberAndScore{
 				{Member: "Palermo", Score: 3479099956230698},
 				{Member: "Catania", Score: 3479447370796909},
@@ -10832,8 +10698,8 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			*options.NewCircleSearchShape(feetValue, constants.GeoUnitFeet),
 			*options.NewGeoSearchResultOptions().SetCount(2),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(2), count)
+		suite.NoError(err)
+		suite.Equal(int64(2), count)
 
 		// Verify stored results with count
 		zRangeResultWithCount, err = client.ZRangeWithScores(
@@ -10841,8 +10707,8 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			destinationKey,
 			options.NewRangeByIndexQuery(0, -1),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), expectedArray3, zRangeResultWithCount)
+		suite.NoError(err)
+		suite.Equal(expectedArray3, zRangeResultWithCount)
 
 		// Test storing results of a search that returns 0 results
 		count, err = client.GeoSearchStore(context.Background(),
@@ -10851,15 +10717,15 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			searchOrigin,
 			*options.NewCircleSearchShape(1, constants.GeoUnitMeters),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(0), count)
+		suite.NoError(err)
+		suite.Equal(int64(0), count)
 		zRangeResultZero, err := client.ZRangeWithScores(
 			context.Background(),
 			destinationKey,
 			options.NewRangeByIndexQuery(0, -1),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), []models.MemberAndScore{}, zRangeResultZero)
+		suite.NoError(err)
+		suite.Equal([]models.MemberAndScore{}, zRangeResultZero)
 
 		// Test storing results of a search with ANY option
 		count, err = client.GeoSearchStoreWithResultOptions(context.Background(),
@@ -10869,34 +10735,32 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 			*boxShape,
 			*options.NewGeoSearchResultOptions().SetIsAny(true),
 		)
-		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), int64(4), count)
+		suite.NoError(err)
+		suite.Equal(int64(4), count)
 		zRangeResultANY, err := client.ZRangeWithScores(
 			context.Background(),
 			destinationKey,
 			options.NewRangeByIndexQuery(0, -1),
 		)
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		expectedANYResults := []models.MemberAndScore{
 			{Member: "Palermo", Score: 3479099956230698.0},
 			{Member: "edge1", Score: 3479273021651468.0},
 			{Member: "Catania", Score: 3479447370796909.0},
 			{Member: "edge2", Score: 3481342659049484.0},
 		}
-		assert.Equal(suite.T(), expectedANYResults, zRangeResultANY)
+		suite.Equal(expectedANYResults, zRangeResultANY)
 
 		// member does not exist
 		nonExistingMemberOrigin := &options.GeoMemberOrigin{Member: "non-existing-member"}
 		_, err = client.GeoSearchStore(context.Background(), destinationKey, sourceKey, nonExistingMemberOrigin, *boxShape)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 
 		// key exists but holds a non-ZSET value
 		_, err = client.Set(context.Background(), key3, "nonZSETvalue")
-		assert.NoError(suite.T(), err)
+		suite.NoError(err)
 		_, err = client.GeoSearchStore(context.Background(), destinationKey, key3, searchOrigin, *boxShape)
-		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+		suite.Error(err)
 	})
 }
 
@@ -10907,7 +10771,7 @@ func (suite *GlideTestSuite) TestBZPopMax() {
 		key1 := "{key}-1" + uuid.NewString()
 
 		res1, err := client.BZPopMax(context.Background(), []string{key1}, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1.IsNil())
 
 		membersScoreMap := map[string]float64{
@@ -10917,11 +10781,11 @@ func (suite *GlideTestSuite) TestBZPopMax() {
 		}
 
 		res2, err := client.ZAdd(context.Background(), key1, membersScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res2)
 
 		res3, err := client.BZPopMax(context.Background(), []string{key1}, 100*time.Millisecond)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), models.KeyWithMemberAndScore{Key: key1, Member: "three", Score: 3.0}, res3.Value())
 	})
 }
@@ -10935,7 +10799,7 @@ func (suite *GlideTestSuite) TestZMPop() {
 		key3 := "{key}-3" + uuid.NewString()
 
 		res1, err := client.ZMPop(context.Background(), []string{key1}, constants.MIN)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1.IsNil())
 
 		membersScoreMap := map[string]float64{
@@ -10944,19 +10808,19 @@ func (suite *GlideTestSuite) TestZMPop() {
 			"three": 3.0,
 		}
 		res2, err := client.ZAdd(context.Background(), key1, membersScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res2)
 
 		res3, err := client.ZAdd(context.Background(), key2, map[string]float64{
 			"four": 4.0,
 			"five": 5.0,
 		})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res3)
 
 		// Pop minimum value from key1
 		res4, err := client.ZMPop(context.Background(), []string{key1}, constants.MIN)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), key1, res4.Value().Key)
 		assert.ElementsMatch(
 			suite.T(),
@@ -10968,7 +10832,7 @@ func (suite *GlideTestSuite) TestZMPop() {
 
 		// Pop maximum value from key2
 		res5, err := client.ZMPop(context.Background(), []string{key2}, constants.MAX)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), key2, res5.Value().Key)
 		assert.ElementsMatch(
 			suite.T(),
@@ -10980,7 +10844,7 @@ func (suite *GlideTestSuite) TestZMPop() {
 
 		// pop from an empty key3
 		res6, err := client.ZMPop(context.Background(), []string{key3}, constants.MIN)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res6.IsNil())
 	})
 }
@@ -10996,7 +10860,7 @@ func (suite *GlideTestSuite) TestZMPopWithOptions() {
 		opts := *options.NewZMPopOptions().SetCount(2)
 
 		res1, err := client.ZMPopWithOptions(context.Background(), []string{key1}, constants.MIN, opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res1.IsNil())
 
 		membersScoreMap := map[string]float64{
@@ -11006,18 +10870,18 @@ func (suite *GlideTestSuite) TestZMPopWithOptions() {
 			"four":  4.0,
 		}
 		res2, err := client.ZAdd(context.Background(), key1, membersScoreMap)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(4), res2)
 
 		res3, err := client.ZAdd(context.Background(), key2, map[string]float64{
 			"a": 10.0,
 			"b": 20.0,
 		})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), int64(2), res3)
 
 		res4, err := client.ZMPopWithOptions(context.Background(), []string{key1}, constants.MIN, opts)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), key1, res4.Value().Key)
 		assert.ElementsMatch(
 			suite.T(),
@@ -11030,7 +10894,7 @@ func (suite *GlideTestSuite) TestZMPopWithOptions() {
 
 		opts10 := *options.NewZMPopOptions().SetCount(10)
 		res5, err := client.ZMPopWithOptions(context.Background(), []string{key1}, constants.MIN, opts10)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), key1, res5.Value().Key)
 		assert.ElementsMatch(
 			suite.T(),
@@ -11043,7 +10907,7 @@ func (suite *GlideTestSuite) TestZMPopWithOptions() {
 
 		opts1 := *options.NewZMPopOptions().SetCount(1)
 		res6, err := client.ZMPopWithOptions(context.Background(), []string{key2}, constants.MAX, opts1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), key2, res6.Value().Key)
 		assert.ElementsMatch(
 			suite.T(),
@@ -11054,7 +10918,7 @@ func (suite *GlideTestSuite) TestZMPopWithOptions() {
 		)
 
 		res7, err := client.ZMPopWithOptions(context.Background(), []string{key3}, constants.MIN, opts1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.True(suite.T(), res7.IsNil())
 	})
 }
@@ -11067,7 +10931,7 @@ func (suite *GlideTestSuite) TestInvokeScriptWithoutRoute() {
 		// Test a script that returns a string without keys and args.
 		script1 := options.NewScript("return 'Hello'")
 		response1, err := client.InvokeScript(context.Background(), *script1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "Hello", response1)
 
 		// Test script that sets a key with value.
@@ -11077,14 +10941,14 @@ func (suite *GlideTestSuite) TestInvokeScriptWithoutRoute() {
 		scriptOptions := options.NewScriptOptions()
 		scriptOptions.WithKeys([]string{key1}).WithArgs([]string{"value1"})
 		setResponse, err := client.InvokeScriptWithOptions(context.Background(), *script2, *scriptOptions)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", setResponse)
 
 		// Set another key, key2 with the same script
 		scriptOptions2 := options.NewScriptOptions()
 		scriptOptions2.WithKeys([]string{key2}).WithArgs([]string{"value2"})
 		setResponse2, err := client.InvokeScriptWithOptions(context.Background(), *script2, *scriptOptions2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", setResponse2)
 		script2.Close()
 
@@ -11095,7 +10959,7 @@ func (suite *GlideTestSuite) TestInvokeScriptWithoutRoute() {
 		scriptOptions3 := options.NewScriptOptions()
 		scriptOptions3.WithKeys([]string{key1})
 		getResponse1, err := client.InvokeScriptWithOptions(context.Background(), *script3, *scriptOptions3)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "value1", getResponse1)
 
 		// Get another key's value
@@ -11103,7 +10967,7 @@ func (suite *GlideTestSuite) TestInvokeScriptWithoutRoute() {
 		scriptOptions4.WithKeys([]string{key2})
 		getResponse2, err := client.InvokeScriptWithOptions(context.Background(), *script3, *scriptOptions4)
 		assert.Equal(suite.T(), "value2", getResponse2)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		script3.Close()
 	})
 }
@@ -11115,35 +10979,35 @@ func (suite *GlideTestSuite) TestScriptFlush() {
 
 		// Load script
 		_, err := client.InvokeScript(context.Background(), *script)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		// Check existence of script
 		scriptHash := script.GetHash()
 		result, err := client.ScriptExists(context.Background(), []string{scriptHash})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []bool{true}, result)
 
 		// Flush the script cache
 		flushResult, err := client.ScriptFlush(context.Background())
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", flushResult)
 
 		// Check that the script no longer exists
 		result, err = client.ScriptExists(context.Background(), []string{scriptHash})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []bool{false}, result)
 
 		// Test with ASYNC mode
 		_, err = client.InvokeScript(context.Background(), *script)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		asyncMode := options.FlushMode(options.ASYNC)
 		flushResult, err = client.ScriptFlushWithMode(context.Background(), asyncMode)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), "OK", flushResult)
 
 		result, err = client.ScriptExists(context.Background(), []string{scriptHash})
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), []bool{false}, result)
 
 		script.Close()
@@ -11161,14 +11025,14 @@ func (suite *GlideTestSuite) TestScriptShow() {
 
 		// Load the script
 		_, err := client.InvokeScript(context.Background(), *script)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 
 		// Get the SHA1 digest of the script
 		sha1 := script.GetHash()
 
 		// Test with String
 		scriptSource, err := client.ScriptShow(context.Background(), sha1)
-		assert.Nil(suite.T(), err)
+		suite.NoError(err)
 		assert.Equal(suite.T(), code, scriptSource)
 
 		// Test with non-existing SHA1

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
@@ -403,17 +403,17 @@ func (suite *GlideTestSuite) TestIncrCommands_TypeError() {
 		res1, err := client.Incr(context.Background(), key)
 		assert.Equal(suite.T(), int64(0), res1)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res2, err := client.IncrBy(context.Background(), key, 10)
 		assert.Equal(suite.T(), int64(0), res2)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res3, err := client.IncrByFloat(context.Background(), key, float64(10.1))
 		assert.Equal(suite.T(), float64(0), res3)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -491,7 +491,7 @@ func (suite *GlideTestSuite) TestSetRange_existingAndNonExistingKeys() {
 		res, err = client.SetRange(context.Background(), key, math.MaxInt32, "test")
 		assert.Equal(suite.T(), int64(0), res)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -1469,11 +1469,11 @@ func (suite *GlideTestSuite) TestHRandField() {
 		key = uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, "HRandField"))
 		_, err = client.HRandField(context.Background(), key)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		_, err = client.HRandFieldWithCount(context.Background(), key, 42)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		_, err = client.HRandFieldWithCountWithValues(context.Background(), key, 42)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -1518,12 +1518,12 @@ func (suite *GlideTestSuite) TestLPushLPop_typeError() {
 		res1, err := client.LPush(context.Background(), key, []string{"value1"})
 		assert.Equal(suite.T(), int64(0), res1)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res2, err := client.LPopCount(context.Background(), key, 2)
 		assert.Nil(suite.T(), res2)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -1574,13 +1574,13 @@ func (suite *GlideTestSuite) TestLPos_withAndWithoutOptions() {
 		res8, err := client.LPosWithOptions(context.Background(), key, "a", *options.NewLPosOptions().SetRank(0))
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res8)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// invalid maxlen value
 		res9, err := client.LPosWithOptions(context.Background(), key, "a", *options.NewLPosOptions().SetMaxLen(-1))
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res9)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// non-existent key
 		res10, err := client.LPos(context.Background(), "non_existent_key", "a")
@@ -1593,7 +1593,7 @@ func (suite *GlideTestSuite) TestLPos_withAndWithoutOptions() {
 		res11, err := client.LPos(context.Background(), keyString, "a")
 		assert.Equal(suite.T(), models.CreateNilInt64Result(), res11)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -1617,7 +1617,7 @@ func (suite *GlideTestSuite) TestLPosCount() {
 		res4, err := client.LPosCount(context.Background(), key, "a", int64(-1))
 		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// non-existent key
 		res5, err := client.LPosCount(context.Background(), "non_existent_key", "a", int64(1))
@@ -1630,7 +1630,7 @@ func (suite *GlideTestSuite) TestLPosCount() {
 		res6, err := client.LPosCount(context.Background(), keyString, "a", int64(1))
 		assert.Nil(suite.T(), res6)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -1690,7 +1690,7 @@ func (suite *GlideTestSuite) TestRPush() {
 		res2, err := client.RPush(context.Background(), key2, []string{"value1"})
 		assert.Equal(suite.T(), int64(0), res2)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -1861,7 +1861,7 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		res11, err := client.SUnionStore(context.Background(), key4, []string{})
 		assert.Equal(suite.T(), int64(0), res11)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// non-set key
 		_, err = client.Set(context.Background(), stringKey, "value")
@@ -1870,7 +1870,7 @@ func (suite *GlideTestSuite) TestSUnionStore() {
 		res12, err := client.SUnionStore(context.Background(), key4, []string{stringKey, key1})
 		assert.Equal(suite.T(), int64(0), res12)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// overwrite destination when destination is not a set
 		res13, err := client.SUnionStore(context.Background(), stringKey, []string{key1, key3})
@@ -2150,7 +2150,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		res10, err := client.SInterStore(context.Background(), key3, []string{})
 		assert.Equal(suite.T(), int64(0), res10)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// non-set key
 		_, err = client.Set(context.Background(), stringKey, "value")
@@ -2159,7 +2159,7 @@ func (suite *GlideTestSuite) TestSinterStore() {
 		res11, err := client.SInterStore(context.Background(), key3, []string{stringKey})
 		assert.Equal(suite.T(), int64(0), res11)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// overwrite the non-set key
 		res12, err := client.SInterStore(context.Background(), stringKey, []string{key2})
@@ -2479,13 +2479,13 @@ func (suite *GlideTestSuite) TestSMIsMember() {
 		// invalid argument - member list must not be empty
 		_, err4 := client.SMIsMember(context.Background(), key1, []string{})
 		assert.NotNil(suite.T(), err4)
-		assert.IsType(suite.T(), &errors.RequestError{}, err4)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err4)
 
 		// source key exists, but it is not a set
 		suite.verifyOK(client.Set(context.Background(), stringKey, "value"))
 		_, err5 := client.SMIsMember(context.Background(), stringKey, []string{"two"})
 		assert.NotNil(suite.T(), err5)
-		assert.IsType(suite.T(), &errors.RequestError{}, err5)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err5)
 	})
 }
 
@@ -2533,13 +2533,13 @@ func (suite *GlideTestSuite) TestSUnion() {
 		// Exceptions with empty keys
 		res6, err := client.SUnion(context.Background(), []string{})
 		assert.Nil(suite.T(), res6)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Exception with a non-set key
 		suite.verifyOK(client.Set(context.Background(), nonSetKey, "value"))
 		res7, err := client.SUnion(context.Background(), []string{nonSetKey, key1})
 		assert.Nil(suite.T(), res7)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2638,7 +2638,7 @@ func (suite *GlideTestSuite) TestSMove() {
 
 		_, err = client.SMove(context.Background(), stringKey, key1, "_")
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2675,7 +2675,7 @@ func (suite *GlideTestSuite) TestSScan() {
 		} else {
 			_, _, err = client.SScan(context.Background(), key1, "-1")
 			assert.NotNil(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		}
 
 		// result contains the whole set
@@ -2743,7 +2743,7 @@ func (suite *GlideTestSuite) TestSScan() {
 
 		_, _, err = client.SScan(context.Background(), key2, initialCursor)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2770,7 +2770,7 @@ func (suite *GlideTestSuite) TestLRange() {
 		res4, err := client.LRange(context.Background(), key2, int64(0), int64(1))
 		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2803,7 +2803,7 @@ func (suite *GlideTestSuite) TestLIndex() {
 		res5, err := client.LIndex(context.Background(), key2, int64(0))
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res5)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2834,7 +2834,7 @@ func (suite *GlideTestSuite) TestLTrim() {
 		res4, err := client.LIndex(context.Background(), key2, int64(0))
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res4)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2861,7 +2861,7 @@ func (suite *GlideTestSuite) TestLLen() {
 		res4, err := client.LLen(context.Background(), key2)
 		assert.Equal(suite.T(), int64(0), res4)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2933,12 +2933,12 @@ func (suite *GlideTestSuite) TestRPopAndRPopCount() {
 		res6, err := client.RPop(context.Background(), key2)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res6)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res7, err := client.RPopCount(context.Background(), key2, int64(2))
 		assert.Nil(suite.T(), res7)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -2977,7 +2977,7 @@ func (suite *GlideTestSuite) TestLInsert() {
 		res7, err := client.LInsert(context.Background(), key2, constants.Before, "value5", "value6")
 		assert.Equal(suite.T(), int64(0), res7)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3004,7 +3004,7 @@ func (suite *GlideTestSuite) TestBLPop() {
 		res4, err := client.BLPop(context.Background(), []string{key}, 1*time.Second)
 		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3031,7 +3031,7 @@ func (suite *GlideTestSuite) TestBRPop() {
 		res4, err := client.BRPop(context.Background(), []string{key}, 1*time.Second)
 		assert.Nil(suite.T(), res4)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3066,12 +3066,12 @@ func (suite *GlideTestSuite) TestRPushX() {
 		res6, err := client.RPushX(context.Background(), key3, []string{"value1"})
 		assert.Equal(suite.T(), int64(0), res6)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res7, err := client.RPushX(context.Background(), key2, []string{})
 		assert.Equal(suite.T(), int64(0), res7)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3106,12 +3106,12 @@ func (suite *GlideTestSuite) TestLPushX() {
 		res6, err := client.LPushX(context.Background(), key3, []string{"value1"})
 		assert.Equal(suite.T(), int64(0), res6)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res7, err := client.LPushX(context.Background(), key2, []string{})
 		assert.Equal(suite.T(), int64(0), res7)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3162,12 +3162,12 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		res7, err := client.LMPop(context.Background(), []string{key3}, constants.Left)
 		assert.Nil(suite.T(), res7)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res8, err := client.LMPop(context.Background(), []string{key3}, "Invalid")
 		assert.Nil(suite.T(), res8)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3224,7 +3224,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		res7, err := client.BLMPop(context.Background(), []string{key3}, constants.Left, 100*time.Millisecond)
 		assert.Nil(suite.T(), res7)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3310,7 +3310,7 @@ func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
 		res8, err := client.BZMPop(context.Background(), []string{key3}, constants.MIN, 100*time.Millisecond)
 		assert.True(suite.T(), res8.IsNil())
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -3321,7 +3321,7 @@ func (suite *GlideTestSuite) TestLSet() {
 
 		_, err := client.LSet(context.Background(), nonExistentKey, int64(0), "zero")
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res2, err := client.LPush(context.Background(), key, []string{"four", "three", "two", "one"})
 		assert.Nil(suite.T(), err)
@@ -3329,7 +3329,7 @@ func (suite *GlideTestSuite) TestLSet() {
 
 		_, err = client.LSet(context.Background(), key, int64(10), "zero")
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		suite.verifyOK(client.LSet(context.Background(), key, int64(0), "zero"))
 
@@ -3402,7 +3402,7 @@ func (suite *GlideTestSuite) TestLMove() {
 		res11, err := client.LMove(context.Background(), nonListKey, key1, constants.Left, constants.Left)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res11)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// destination exists but is not a list type key
 		suite.verifyOK(client.Set(context.Background(), nonListKey, "value"))
@@ -3410,7 +3410,7 @@ func (suite *GlideTestSuite) TestLMove() {
 		res12, err := client.LMove(context.Background(), key1, nonListKey, constants.Left, constants.Left)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res12)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -4523,7 +4523,7 @@ func (suite *GlideTestSuite) TestBLMove() {
 		)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res11)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// destination exists but is not a list type key
 		suite.verifyOK(client.Set(context.Background(), nonListKey, "value"))
@@ -4538,7 +4538,7 @@ func (suite *GlideTestSuite) TestBLMove() {
 		)
 		assert.Equal(suite.T(), models.CreateNilStringResult(), res12)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -4642,7 +4642,7 @@ func (suite *GlideTestSuite) TestRename() {
 		res1, err := client.Rename(context.Background(), key1, "invalidKey")
 		assert.Equal(suite.T(), "", res1)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -4879,7 +4879,7 @@ func (suite *GlideTestSuite) TestXAutoClaim() {
 		key2 := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key2, key2))
 		_, err = client.XAutoClaim(context.Background(), key2, "_", "_", 0, "_")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -5035,11 +5035,11 @@ func (suite *GlideTestSuite) TestXReadGroup() {
 		// error cases:
 		// key does not exist
 		_, err = client.XReadGroup(context.Background(), "_", "_", map[string]string{key3: "0"})
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		// key is not a stream
 		suite.verifyOK(client.Set(context.Background(), key3, uuid.New().String()))
 		_, err = client.XReadGroup(context.Background(), "_", "_", map[string]string{key3: "0"})
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		del, err := client.Del(context.Background(), []string{key3})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(1), del)
@@ -5048,7 +5048,7 @@ func (suite *GlideTestSuite) TestXReadGroup() {
 		assert.NoError(suite.T(), err)
 		assert.NotNil(suite.T(), xadd)
 		_, err = client.XReadGroup(context.Background(), "_", "_", map[string]string{key3: "0"})
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		// consumer don't exist
 		sendWithCustomCommand(
 			suite,
@@ -5125,7 +5125,7 @@ func (suite *GlideTestSuite) TestXRead() {
 		client.Set(context.Background(), key3, "xread")
 		_, err = client.XRead(context.Background(), map[string]string{key1: "0-0", key3: "0-0"})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// ensure that commands doesn't time out even if timeout > request timeout
 		var testClient interfaces.BaseClientCommands
@@ -5156,7 +5156,7 @@ func (suite *GlideTestSuite) TestXRead() {
 				map[string]string{key1: "0-1"},
 				*options.NewXReadOptions().SetBlock(0 * time.Millisecond),
 			)
-			assert.IsType(suite.T(), &errors.ClosingError{}, err)
+			assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 			finished <- true
 		}()
 		select {
@@ -5259,11 +5259,11 @@ func (suite *GlideTestSuite) TestXGroupSetId() {
 
 		// An error is raised if XGROUP SETID is called with a non-existing key
 		_, err = client.XGroupSetId(context.Background(), uuid.NewString(), group, "1-1")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// An error is raised if XGROUP SETID is called with a non-existing group
 		_, err = client.XGroupSetId(context.Background(), key, uuid.NewString(), "1-1")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Setting the ID to a non-existing ID is allowed
 		suite.verifyOK(client.XGroupSetId(context.Background(), key, group, "99-99"))
@@ -5272,7 +5272,7 @@ func (suite *GlideTestSuite) TestXGroupSetId() {
 		key = uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key, "xgroup setid"))
 		_, err = client.XGroupSetId(context.Background(), key, group, "1-1")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -5304,12 +5304,12 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 
 		_, err = client.ZAdd(context.Background(), key2, membersScoreMap)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// wrong key type for zaddincr
 		_, err = client.ZAddIncr(context.Background(), key2, "one", float64(2))
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// with NX & XX
 		onlyIfExistsOpts := options.NewZAddOptions().SetConditionalChange(constants.OnlyIfExists)
@@ -5394,7 +5394,7 @@ func (suite *GlideTestSuite) TestZincrBy() {
 
 		_, err = client.ZIncrBy(context.Background(), key2, 0.5, "_")
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -5435,7 +5435,7 @@ func (suite *GlideTestSuite) TestBZPopMin() {
 		// Attempt to pop from key3 which is not a sorted set
 		_, err = client.BZPopMin(context.Background(), []string{key3}, 500*time.Millisecond)
 		if assert.Error(suite.T(), err) {
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		}
 	})
 }
@@ -5468,7 +5468,7 @@ func (suite *GlideTestSuite) TestZPopMin() {
 
 		_, err = client.ZPopMin(context.Background(), key2)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -5499,7 +5499,7 @@ func (suite *GlideTestSuite) TestZPopMax() {
 
 		_, err = client.ZPopMax(context.Background(), key2)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -5518,7 +5518,7 @@ func (suite *GlideTestSuite) TestZRem() {
 		// no members to remove
 		_, err = client.ZRem(context.Background(), key, []string{})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		res, err = client.ZRem(context.Background(), key, []string{"one"})
 		assert.Nil(suite.T(), err)
@@ -5535,7 +5535,7 @@ func (suite *GlideTestSuite) TestZRem() {
 
 		_, err = client.ZRem(context.Background(), key, []string{"value"})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -5981,7 +5981,7 @@ func (suite *GlideTestSuite) TestZRank() {
 
 		_, err = client.ZRank(context.Background(), stringKey, "value")
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6014,7 +6014,7 @@ func (suite *GlideTestSuite) TestZRevRank() {
 
 		_, err = client.ZRevRank(context.Background(), stringKey, "value")
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6107,10 +6107,10 @@ func (suite *GlideTestSuite) Test_XAdd_XLen_XTrim() {
 		suite.verifyOK(client.Set(context.Background(), key2, "xtrimtest"))
 		_, err = client.XTrim(context.Background(), key2, *options.NewXTrimOptionsWithMinId("0-1"))
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 		_, err = client.XLen(context.Background(), key2)
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6149,7 +6149,7 @@ func (suite *GlideTestSuite) Test_ZScore() {
 
 		_, err = client.ZScore(context.Background(), key2, "one")
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6228,7 +6228,7 @@ func (suite *GlideTestSuite) TestZCount() {
 		)
 		_, err = client.ZCount(context.Background(), key2, *zCountRange)
 		assert.NotNil(t, err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6277,7 +6277,7 @@ func (suite *GlideTestSuite) Test_XDel() {
 
 		_, err = client.XDel(context.Background(), key2, []string{streamId3})
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6312,7 +6312,7 @@ func (suite *GlideTestSuite) TestZScan() {
 		if suite.serverVersion >= "8.0.0" {
 			_, _, err = client.ZScan(context.Background(), key1, "-1")
 			assert.NotNil(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		} else {
 			resCursor, resCollection, err = client.ZScan(context.Background(), key1, "-1")
 			assert.NoError(suite.T(), err)
@@ -6424,18 +6424,18 @@ func (suite *GlideTestSuite) TestZScan() {
 
 		_, _, err = client.ZScan(context.Background(), stringKey, initialCursor)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		opts = options.NewZScanOptions().SetMatch("test").SetCount(1)
 		_, _, err = client.ZScanWithOptions(context.Background(), stringKey, initialCursor, *opts)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Negative count
 		opts = options.NewZScanOptions().SetCount(-1)
 		_, _, err = client.ZScanWithOptions(context.Background(), key1, "-1", *opts)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -6717,7 +6717,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("invalid-id", "+", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				key,
@@ -6725,7 +6725,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("-", "invalid-id", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 			// invalid count should return no results
 			detailResult, err = client.XPendingWithOptions(context.Background(),
@@ -6742,7 +6742,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				"invalid-group",
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 			// non-existent key throws a RequestError (NOGROUP)
@@ -6751,7 +6751,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				groupName,
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
@@ -6760,7 +6760,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("-", "+", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 			// Key exists, but it is not a stream
@@ -6770,7 +6770,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				groupName,
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
@@ -6779,7 +6779,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("-", "+", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
 		}
 
@@ -6877,7 +6877,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("invalid-id", "+", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 			_, err = client.XPendingWithOptions(context.Background(),
 				key,
@@ -6885,7 +6885,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("-", "invalid-id", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 			// invalid count should return no results
 			detailResult, err = client.XPendingWithOptions(context.Background(),
@@ -6902,7 +6902,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				"invalid-group",
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 			// non-existent key throws a RequestError (NOGROUP)
@@ -6911,7 +6911,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				groupName,
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
@@ -6920,7 +6920,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("-", "+", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 			// Key exists, but it is not a stream
@@ -6930,7 +6930,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				groupName,
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
 
 			_, err = client.XPendingWithOptions(context.Background(),
@@ -6939,7 +6939,7 @@ func (suite *GlideTestSuite) TestXPendingFailures() {
 				*options.NewXPendingOptions("-", "+", 10),
 			)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 			assert.True(suite.T(), strings.Contains(err.Error(), "WRONGTYPE"))
 		}
 
@@ -6966,7 +6966,7 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 		// Stream not created results in error
 		_, err := client.XGroupCreate(context.Background(), key, group, id)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Stream with option to create creates stream & Group
 		opts := options.NewXGroupCreateOptions().SetMakeStream()
@@ -6975,7 +6975,7 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 		// ...and again results in BUSYGROUP error, because group names must be unique
 		_, err = client.XGroupCreate(context.Background(), key, group, id)
 		assert.ErrorContains(suite.T(), err, "BUSYGROUP")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Stream Group can be destroyed returns: true
 		destroyed, err := client.XGroupDestroy(context.Background(), key, group)
@@ -6994,7 +6994,7 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 		} else {
 			_, err = client.XGroupCreateWithOptions(context.Background(), key, group, id, *opts)
 			assert.Error(suite.T(), err)
-			assert.IsType(suite.T(), &errors.RequestError{}, err)
+			assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		}
 
 		// key is not a stream
@@ -7002,7 +7002,7 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 		suite.verifyOK(client.Set(context.Background(), key, id))
 		_, err = client.XGroupCreate(context.Background(), key, group, id)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7162,7 +7162,7 @@ func (suite *GlideTestSuite) TestZRemRangeByRank() {
 
 		_, err = client.ZRemRangeByRank(context.Background(), stringKey, 0, 10)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7218,7 +7218,7 @@ func (suite *GlideTestSuite) TestZRemRangeByLex() {
 			*options.NewRangeByLexQuery(options.NewLexBoundary("a", false), options.NewLexBoundary("c", false)),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7278,7 +7278,7 @@ func (suite *GlideTestSuite) TestZRemRangeByScore() {
 			*options.NewRangeByScoreQuery(options.NewScoreBoundary(1.0, false), options.NewScoreBoundary(10.0, true)),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7322,13 +7322,13 @@ func (suite *GlideTestSuite) TestZMScore() {
 
 		// invalid arg - member list must not be empty
 		_, err = client.ZMScore(context.Background(), key, []string{})
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// key exists, but it is not a sorted set
 		key2 := uuid.NewString()
 		suite.verifyOK(client.Set(context.Background(), key2, "ZMScore"))
 		_, err = client.ZMScore(context.Background(), key2, []string{"one"})
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7386,11 +7386,11 @@ func (suite *GlideTestSuite) TestZRandMember() {
 		// Key exists, but is not a set
 		suite.verifyOK(client.Set(context.Background(), key2, "ZRandMember"))
 		_, err = client.ZRandMember(context.Background(), key2)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		_, err = client.ZRandMemberWithCount(context.Background(), key2, 2)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		_, err = client.ZRandMemberWithCountWithScores(context.Background(), key2, 2)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7621,7 +7621,7 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 		// create a consumer for a group that doesn't exist should result in a NOGROUP error
 		_, err = client.XGroupCreateConsumer(context.Background(), key, "non-existent-group", consumerName)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		assert.True(suite.T(), strings.Contains(err.Error(), "NOGROUP"))
 
 		// create consumer that already exists should return false
@@ -7739,11 +7739,11 @@ func (suite *GlideTestSuite) TestXGroupStreamCommands() {
 		assert.NoError(suite.T(), err)
 		_, err = client.XGroupCreateConsumer(context.Background(), stringKey, groupName, consumerName)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.XGroupDelConsumer(context.Background(), stringKey, groupName, consumerName)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -7913,19 +7913,19 @@ func (suite *GlideTestSuite) TestXInfoConsumers() {
 		// Passing a non-existing key raises an error
 		key = uuid.NewString()
 		_, err = client.XInfoConsumers(context.Background(), key, "_")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// key exists, but it is not a stream
 		suite.verifyOK(client.Set(context.Background(), key, key))
 		_, err = client.XInfoConsumers(context.Background(), key, "_")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Passing a non-existing group raises an error
 		key = uuid.NewString()
 		_, err = client.XAdd(context.Background(), key, [][]string{{"a", "b"}})
 		assert.NoError(suite.T(), err)
 		_, err = client.XInfoConsumers(context.Background(), key, "_")
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// no consumers yet
 		suite.verifyOK(client.XGroupCreate(context.Background(), key, group, "0-0"))
@@ -8116,12 +8116,12 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 		// Passing a non-existing key raises an error
 		key = uuid.NewString()
 		_, err = client.XInfoGroups(context.Background(), key)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// key exists, but it is not a stream
 		suite.verifyOK(client.Set(context.Background(), key, key))
 		_, err = client.XInfoGroups(context.Background(), key)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// create a second stream
 		key = uuid.NewString()
@@ -8690,7 +8690,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		// claim with invalid stream entry IDs
 		_, err = client.XClaimJustId(context.Background(), key, groupName, consumer1, int64(1), []string{"invalid-stream-id"})
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// claim with empty stream entry IDs returns empty map
 		claimResult, err := client.XClaimJustId(context.Background(), key, groupName, consumer1, int64(1), []string{})
@@ -8701,7 +8701,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		claimOptions := options.NewXClaimOptions().SetIdleTime(1)
 		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		assert.Contains(suite.T(), err.Error(), "NOGROUP")
 
 		_, err = client.XClaimWithOptions(context.Background(),
@@ -8713,7 +8713,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			*claimOptions,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		assert.Contains(suite.T(), err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustId(
@@ -8725,7 +8725,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		assert.Contains(suite.T(), err.Error(), "NOGROUP")
 
 		_, err = client.XClaimJustIdWithOptions(context.Background(),
@@ -8737,7 +8737,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			*claimOptions,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 		assert.Contains(suite.T(), err.Error(), "NOGROUP")
 
 		// key exists, but is not a stream
@@ -8745,7 +8745,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		assert.NoError(suite.T(), err)
 		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.XClaimWithOptions(context.Background(),
 			stringKey,
@@ -8756,7 +8756,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			*claimOptions,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.XClaimJustId(
 			context.Background(),
@@ -8767,7 +8767,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.XClaimJustIdWithOptions(context.Background(),
 			stringKey,
@@ -8778,7 +8778,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			*claimOptions,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -9026,7 +9026,7 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 			positiveInfinity,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.XRevRange(context.Background(),
 			stringKey,
@@ -9034,7 +9034,7 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 			negativeInfinity,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// xrange and xrevrange when range bound is not a valid id
 		_, err = client.XRange(context.Background(),
@@ -9043,7 +9043,7 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 			positiveInfinity,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.XRevRange(context.Background(),
 			key,
@@ -9051,7 +9051,7 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 			negativeInfinity,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -9424,7 +9424,7 @@ func (suite *GlideTestSuite) TestZInter() {
 			*options.NewZInterOptions().SetAggregate(options.AggregateSum),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// key exists but not a set
 		_, err = client.Set(context.Background(), key3, "value")
@@ -9432,14 +9432,14 @@ func (suite *GlideTestSuite) TestZInter() {
 
 		_, err = client.ZInter(context.Background(), options.KeyArray{Keys: []string{key1, key3}})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.ZInterWithScores(context.Background(),
 			options.KeyArray{Keys: []string{key1, key3}},
 			*options.NewZInterOptions().SetAggregate(options.AggregateSum),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -9578,7 +9578,7 @@ func (suite *GlideTestSuite) TestZInterStore() {
 
 		_, err = client.ZInterStore(context.Background(), key3, options.KeyArray{Keys: []string{key1, key4}})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -9648,11 +9648,11 @@ func (suite *GlideTestSuite) TestZDiff() {
 
 		_, err = client.ZDiff(context.Background(), []string{nonExistentKey, key2})
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 
 		_, err = client.ZDiffWithScores(context.Background(), []string{nonExistentKey, key2})
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -9732,7 +9732,7 @@ func (suite *GlideTestSuite) TestZDiffStore() {
 		assert.Equal(t, setResult, "OK")
 		_, err = client.ZDiffStore(context.Background(), key4, []string{key5, key1})
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -9855,14 +9855,14 @@ func (suite *GlideTestSuite) TestZUnionAndZUnionWithScores() {
 
 		_, err = client.ZUnion(context.Background(), options.KeyArray{Keys: []string{key1, key3}})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.ZUnionWithScores(context.Background(),
 			options.KeyArray{Keys: []string{key1, key3}},
 			options.NewZUnionOptionsBuilder().SetAggregate(options.AggregateSum),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10016,7 +10016,7 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 
 		_, err = client.ZUnionStore(context.Background(), dest, options.KeyArray{Keys: []string{key1, key3}})
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		_, err = client.ZUnionStoreWithOptions(context.Background(),
 			dest,
@@ -10024,7 +10024,7 @@ func (suite *GlideTestSuite) TestZUnionStoreAndZUnionStoreWithOptions() {
 			options.NewZUnionOptionsBuilder().SetAggregate(options.AggregateSum),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10096,7 +10096,7 @@ func (suite *GlideTestSuite) TestZInterCard() {
 			options.NewZInterCardOptions().SetLimit(3),
 		)
 		assert.NotNil(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10166,7 +10166,7 @@ func (suite *GlideTestSuite) TestZLexCount() {
 			),
 		)
 		assert.NotNil(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10230,7 +10230,7 @@ func (suite *GlideTestSuite) TestGeoAdd() {
 			*options.NewGeoAddOptions().SetChanged(true),
 		)
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10274,7 +10274,7 @@ func (suite *GlideTestSuite) TestGeoDist() {
 		assert.NoError(t, err)
 		_, err = client.GeoDist(context.Background(), key2, member1, member2)
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10286,35 +10286,35 @@ func (suite *GlideTestSuite) TestGeoAdd_InvalidArgs() {
 		// Test empty members
 		_, err := client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{})
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 
 		// Test invalid longitude (-181)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: -181, Latitude: 0},
 		})
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 
 		// Test invalid longitude (181)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: 181, Latitude: 0},
 		})
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 
 		// Test invalid latitude (86)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: 0, Latitude: 86},
 		})
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 
 		// Test invalid latitude (-86)
 		_, err = client.GeoAdd(context.Background(), key, map[string]options.GeospatialData{
 			"Place": {Longitude: 0, Latitude: -86},
 		})
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10358,7 +10358,7 @@ func (suite *GlideTestSuite) TestGeoHash() {
 		assert.NoError(t, err)
 		_, err = client.GeoHash(context.Background(), wrongKey, []string{"Palermo"})
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10416,7 +10416,7 @@ func (suite *GlideTestSuite) TestGeoPos() {
 
 		_, err = client.GeoPos(context.Background(), key2, members)
 		assert.Error(t, err)
-		assert.IsType(t, &errors.RequestError{}, err)
+		assert.IsType(t, &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10707,7 +10707,7 @@ func (suite *GlideTestSuite) TestGeoSearch() {
 			*resultOpts,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// Test wrong key type error
 		_, err = client.Set(context.Background(), key2, "nonZSETvalue")
@@ -10721,7 +10721,7 @@ func (suite *GlideTestSuite) TestGeoSearch() {
 			*resultOpts,
 		)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 
@@ -10889,14 +10889,14 @@ func (suite *GlideTestSuite) TestGeoSearchStore() {
 		nonExistingMemberOrigin := &options.GeoMemberOrigin{Member: "non-existing-member"}
 		_, err = client.GeoSearchStore(context.Background(), destinationKey, sourceKey, nonExistingMemberOrigin, *boxShape)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 		// key exists but holds a non-ZSET value
 		_, err = client.Set(context.Background(), key3, "nonZSETvalue")
 		assert.NoError(suite.T(), err)
 		_, err = client.GeoSearchStore(context.Background(), destinationKey, key3, searchOrigin, *boxShape)
 		assert.Error(suite.T(), err)
-		assert.IsType(suite.T(), &errors.RequestError{}, err)
+		assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 	})
 }
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -2435,8 +2435,7 @@ func (suite *GlideTestSuite) TestSPopCount_WrongType() {
 
 		// Try to pop from a key that's not a set
 		_, err := client.SPopCount(context.Background(), key, 3)
-		suite.Error(err)
-		suite.Contains(err.Error(), "WRONGTYPE")
+		suite.ErrorContains(err, "WRONGTYPE")
 	})
 }
 
@@ -8603,8 +8602,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		// non existent key causes a RequestError
 		claimOptions := options.NewXClaimOptions().SetIdleTime(1)
 		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
-		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
+		suite.ErrorContains(err, "NOGROUP")
 
 		_, err = client.XClaimWithOptions(context.Background(),
 			stringKey,
@@ -8614,8 +8612,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
-		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
+		suite.ErrorContains(err, "NOGROUP")
 
 		_, err = client.XClaimJustId(
 			context.Background(),
@@ -8625,8 +8622,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			int64(1),
 			[]string{streamid_1.Value()},
 		)
-		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
+		suite.ErrorContains(err, "NOGROUP")
 
 		_, err = client.XClaimJustIdWithOptions(context.Background(),
 			stringKey,
@@ -8636,8 +8632,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
-		suite.Error(err)
-		suite.Contains(err.Error(), "NOGROUP")
+		suite.ErrorContains(err, "NOGROUP")
 
 		// key exists, but is not a stream
 		_, err = client.Set(context.Background(), stringKey, "test")

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
 	"github.com/google/uuid"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
 	"github.com/google/uuid"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 
@@ -451,7 +451,7 @@ func (suite *GlideTestSuite) TestPing_ClosedClient() {
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestPingWithOptions_WithMessage() {
@@ -476,7 +476,7 @@ func (suite *GlideTestSuite) TestPingWithOptions_ClosedClient() {
 	result, err := client.PingWithOptions(context.Background(), options)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestTime_Success() {
@@ -507,7 +507,7 @@ func (suite *GlideTestSuite) TestTime_Error() {
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), results)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAll() {
@@ -582,7 +582,7 @@ func (suite *GlideTestSuite) TestFlushAll_ClosedClient() {
 	response, err := client.FlushAllWithOptions(context.Background(), options.SYNC)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", response)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAll_MultipleFlush() {
@@ -692,7 +692,7 @@ func (suite *GlideTestSuite) TestFlushDBWithOptions_ClosedClient() {
 	result, err := client.FlushDBWithOptions(context.Background(), options.SYNC)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glide.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordAuthNonValidPass() {

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
 	"github.com/google/uuid"
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 
@@ -160,7 +160,7 @@ func (suite *GlideTestSuite) TestCustomCommand_invalidCommand() {
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestCustomCommand_invalidArgs() {
@@ -169,7 +169,7 @@ func (suite *GlideTestSuite) TestCustomCommand_invalidArgs() {
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestCustomCommand_closedClient() {
@@ -180,7 +180,7 @@ func (suite *GlideTestSuite) TestCustomCommand_closedClient() {
 
 	assert.Nil(suite.T(), result)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestConfigSetAndGet_multipleArgs() {
@@ -204,12 +204,12 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_noArgs() {
 
 	_, err := client.ConfigSet(context.Background(), configMap)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 	result2, err := client.ConfigGet(context.Background(), []string{})
 	assert.Nil(suite.T(), result2)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
@@ -219,7 +219,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
 
 	_, err := client.ConfigSet(context.Background(), configMap)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 	result2, err := client.ConfigGet(context.Background(), []string{"time"})
 	assert.Equal(suite.T(), map[string]string{}, result2)
@@ -461,7 +461,7 @@ func (suite *GlideTestSuite) TestPing_ClosedClient() {
 
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestPingWithOptions_WithMessage() {
@@ -486,7 +486,7 @@ func (suite *GlideTestSuite) TestPingWithOptions_ClosedClient() {
 	result, err := client.PingWithOptions(context.Background(), options)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestTime_Success() {
@@ -517,7 +517,7 @@ func (suite *GlideTestSuite) TestTime_Error() {
 
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), results)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAll() {
@@ -592,7 +592,7 @@ func (suite *GlideTestSuite) TestFlushAll_ClosedClient() {
 	response, err := client.FlushAllWithOptions(context.Background(), options.SYNC)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", response)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFlushAll_MultipleFlush() {
@@ -702,7 +702,7 @@ func (suite *GlideTestSuite) TestFlushDBWithOptions_ClosedClient() {
 	result, err := client.FlushDBWithOptions(context.Background(), options.SYNC)
 	assert.NotNil(suite.T(), err)
 	assert.Equal(suite.T(), "", result)
-	assert.IsType(suite.T(), &errors.ClosingError{}, err)
+	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPasswordAuthNonValidPass() {
@@ -713,12 +713,12 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordAuthNonValidPass() {
 	// Test empty password
 	_, err := testClient.UpdateConnectionPassword(context.Background(), "", true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 	// Test with no password parameter
 	_, err = testClient.UpdateConnectionPassword(context.Background(), "", true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPassword_NoServerAuth() {
@@ -734,7 +734,7 @@ func (suite *GlideTestSuite) TestUpdateConnectionPassword_NoServerAuth() {
 	pwd := uuid.NewString()
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPassword_LongPassword() {
@@ -781,7 +781,7 @@ func (suite *GlideTestSuite) TestUpdateConnectionPassword_ImmediateAuthWrongPass
 	// Test that re-authentication fails when using wrong password
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
 	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 
 	// But using correct password returns OK
 	_, err = testClient.UpdateConnectionPassword(context.Background(), notThePwd, true)
@@ -1008,7 +1008,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsStandalone() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDelete(context.Background(), "anotherLib")
-	assert.IsType(suite.T(), &errors.RequestError{}, err)
+	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
 }
 
 func (suite *GlideTestSuite) TestFunctionStats() {

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -26,7 +26,7 @@ func (suite *GlideTestSuite) TestCustomCommandInfo() {
 	client := suite.defaultClient()
 	result, err := client.CustomCommand(context.Background(), []string{"INFO"})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.IsType(suite.T(), "", result)
 	strResult := result.(string)
 	assert.True(suite.T(), strings.Contains(strResult, "# Stats"))
@@ -36,7 +36,7 @@ func (suite *GlideTestSuite) TestCustomCommandPing_StringResponse() {
 	client := suite.defaultClient()
 	result, err := client.CustomCommand(context.Background(), []string{"PING"})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "PONG", result.(string))
 }
 
@@ -50,7 +50,7 @@ func (suite *GlideTestSuite) TestCustomCommandClientInfo() {
 
 	result, err := client.CustomCommand(context.Background(), []string{"CLIENT", "INFO"})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.IsType(suite.T(), "", result)
 	strResult := result.(string)
 	assert.True(suite.T(), strings.Contains(strResult, fmt.Sprintf("name=%s", clientName)))
@@ -61,7 +61,7 @@ func (suite *GlideTestSuite) TestCustomCommandGet_NullResponse() {
 	key := uuid.New().String()
 	result, err := client.CustomCommand(context.Background(), []string{"GET", key})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), nil, result)
 }
 
@@ -71,7 +71,7 @@ func (suite *GlideTestSuite) TestCustomCommandDel_LongResponse() {
 	suite.verifyOK(client.Set(context.Background(), key, "value"))
 	result, err := client.CustomCommand(context.Background(), []string{"DEL", key})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), int64(1), result.(int64))
 }
 
@@ -81,12 +81,12 @@ func (suite *GlideTestSuite) TestCustomCommandHExists_BoolResponse() {
 	key := uuid.New().String()
 
 	res1, err := client.HSet(context.Background(), key, fields)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), int64(1), res1)
 
 	result, err := client.CustomCommand(context.Background(), []string{"HEXISTS", key, "field1"})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), true, result.(bool))
 }
 
@@ -96,7 +96,7 @@ func (suite *GlideTestSuite) TestCustomCommandIncrByFloat_FloatResponse() {
 
 	result, err := client.CustomCommand(context.Background(), []string{"INCRBYFLOAT", key, fmt.Sprintf("%f", 0.1)})
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), float64(0.1), result.(float64))
 }
 
@@ -123,7 +123,7 @@ func (suite *GlideTestSuite) TestCustomCommandMGet_ArrayResponse() {
 	values := []any{value, value, nil}
 	result, err := client.CustomCommand(context.Background(), append([]string{"MGET"}, keys...))
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), values, result.([]any))
 }
 
@@ -136,7 +136,7 @@ func (suite *GlideTestSuite) TestCustomCommandConfigGet_MapResponse() {
 	suite.verifyOK(client.ConfigSet(context.Background(), configMap))
 
 	result2, err := client.CustomCommand(context.Background(), []string{"CONFIG", "GET", "timeout", "maxmemory"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), map[string]any{"timeout": "1000", "maxmemory": "1073741824"}, result2)
 }
 
@@ -146,41 +146,35 @@ func (suite *GlideTestSuite) TestCustomCommandConfigSMembers_SetResponse() {
 	members := []string{"member1", "member2", "member3"}
 
 	res1, err := client.SAdd(context.Background(), key, members)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), int64(3), res1)
 
 	result2, err := client.CustomCommand(context.Background(), []string{"SMEMBERS", key})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), map[string]struct{}{"member1": {}, "member2": {}, "member3": {}}, result2)
 }
 
 func (suite *GlideTestSuite) TestCustomCommand_invalidCommand() {
 	client := suite.defaultClient()
-	result, err := client.CustomCommand(context.Background(), []string{"pewpew"})
+	_, err := client.CustomCommand(context.Background(), []string{"pewpew"})
 
-	assert.Nil(suite.T(), result)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestCustomCommand_invalidArgs() {
 	client := suite.defaultClient()
-	result, err := client.CustomCommand(context.Background(), []string{"ping", "pang", "pong"})
+	_, err := client.CustomCommand(context.Background(), []string{"ping", "pang", "pong"})
 
-	assert.Nil(suite.T(), result)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestCustomCommand_closedClient() {
 	client := suite.defaultClient()
 	client.Close()
 
-	result, err := client.CustomCommand(context.Background(), []string{"ping"})
+	_, err := client.CustomCommand(context.Background(), []string{"ping"})
 
-	assert.Nil(suite.T(), result)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.ClosingError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestConfigSetAndGet_multipleArgs() {
@@ -193,7 +187,7 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_multipleArgs() {
 	suite.verifyOK(client.ConfigSet(context.Background(), configMap))
 
 	result2, err := client.ConfigGet(context.Background(), []string{"timeout", "maxmemory"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), resultConfigMap, result2)
 }
 
@@ -203,13 +197,10 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_noArgs() {
 	configMap := map[string]string{}
 
 	_, err := client.ConfigSet(context.Background(), configMap)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 
-	result2, err := client.ConfigGet(context.Background(), []string{})
-	assert.Nil(suite.T(), result2)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	_, err = client.ConfigGet(context.Background(), []string{})
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
@@ -218,12 +209,11 @@ func (suite *GlideTestSuite) TestConfigSetAndGet_invalidArgs() {
 	configMap := map[string]string{"time": "1000"}
 
 	_, err := client.ConfigSet(context.Background(), configMap)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 
 	result2, err := client.ConfigGet(context.Background(), []string{"time"})
-	assert.Equal(suite.T(), map[string]string{}, result2)
-	assert.Nil(suite.T(), err)
+	suite.Equal(map[string]string{}, result2)
+	suite.NoError(err)
 }
 
 func (suite *GlideTestSuite) TestSelect_WithValidIndex() {
@@ -236,7 +226,7 @@ func (suite *GlideTestSuite) TestSelect_WithValidIndex() {
 	suite.verifyOK(client.Set(context.Background(), key, value))
 
 	res, err := client.Get(context.Background(), key)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), value, res.Value())
 }
 
@@ -266,17 +256,17 @@ func (suite *GlideTestSuite) TestSelect_SwitchBetweenDatabases() {
 	suite.verifyOK(client.Set(context.Background(), key2, value2))
 
 	result, err := client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "", result.Value())
 
 	suite.verifyOK(client.Select(context.Background(), 0))
 	result, err = client.Get(context.Background(), key2)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "", result.Value())
 
 	suite.verifyOK(client.Select(context.Background(), 1))
 	result, err = client.Get(context.Background(), key2)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), value2, result.Value())
 }
 
@@ -298,7 +288,7 @@ func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_ExternalWeights() {
 
 	sortResult, err := client.SortReadOnlyWithOptions(context.Background(), key, *options)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	resultList := []models.Result[string]{
 		models.CreateStringResult("item2"),
 		models.CreateStringResult("item3"),
@@ -326,7 +316,7 @@ func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_GetPatterns() {
 
 	sortResult, err := client.SortReadOnlyWithOptions(context.Background(), key, *options)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	resultList := []models.Result[string]{
 		models.CreateStringResult("Object_1"),
@@ -361,7 +351,7 @@ func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_SuccessfulSortByWeightA
 
 	sortResult, err := client.SortReadOnlyWithOptions(context.Background(), key, *options)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	resultList := []models.Result[string]{
 		models.CreateStringResult("Object 2"),
@@ -375,15 +365,15 @@ func (suite *GlideTestSuite) TestSortReadOnlyWithOptions_SuccessfulSortByWeightA
 	assert.Equal(suite.T(), resultList, sortResult)
 
 	objectItem2, err := client.Get(context.Background(), "object_item2")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "Object 2", objectItem2.Value())
 
 	objectItem1, err := client.Get(context.Background(), "object_item1")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "Object 1", objectItem1.Value())
 
 	objectItem3, err := client.Get(context.Background(), "object_item3")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "Object 3", objectItem3.Value())
 
 	assert.Equal(suite.T(), "item2", sortResult[1].Value())
@@ -431,7 +421,7 @@ func (suite *GlideTestSuite) TestInfoStandalone() {
 func (suite *GlideTestSuite) TestDBSize() {
 	client := suite.defaultClient()
 	result, err := client.DBSize(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.GreaterOrEqual(suite.T(), result, int64(0))
 }
 
@@ -439,7 +429,7 @@ func (suite *GlideTestSuite) TestPing_NoArgument() {
 	client := suite.defaultClient()
 
 	result, err := client.Ping(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "PONG", result)
 }
 
@@ -471,7 +461,7 @@ func (suite *GlideTestSuite) TestPingWithOptions_WithMessage() {
 	}
 
 	result, err := client.PingWithOptions(context.Background(), options)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "hello", result)
 }
 
@@ -493,17 +483,17 @@ func (suite *GlideTestSuite) TestTime_Success() {
 	client := suite.defaultClient()
 	results, err := client.Time(context.Background())
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Len(suite.T(), results, 2)
 
 	now := time.Now().Unix() - 1
 
 	timestamp, err := strconv.ParseInt(results[0], 10, 64)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Greater(suite.T(), timestamp, now)
 
 	microseconds, err := strconv.ParseInt(results[1], 10, 64)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Less(suite.T(), microseconds, int64(1000000))
 }
 
@@ -526,20 +516,20 @@ func (suite *GlideTestSuite) TestFlushAll() {
 	key2 := uuid.New().String()
 
 	_, err := client.Set(context.Background(), key1, "value1")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	_, err = client.Set(context.Background(), key2, "value2")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	result, err := client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "value1", result.Value())
 
 	response, err := client.FlushAll(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", response)
 
 	result, err = client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Empty(suite.T(), result.Value())
 }
 
@@ -549,20 +539,20 @@ func (suite *GlideTestSuite) TestFlushAll_Sync() {
 	key2 := uuid.New().String()
 
 	_, err := client.Set(context.Background(), key1, "value1")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	_, err = client.Set(context.Background(), key2, "value2")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	result, err := client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "value1", result.Value())
 
 	response, err := client.FlushAllWithOptions(context.Background(), options.SYNC)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", response)
 
 	result, err = client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Empty(suite.T(), result.Value())
 }
 
@@ -572,16 +562,16 @@ func (suite *GlideTestSuite) TestFlushAll_Async() {
 	key2 := uuid.New().String()
 
 	_, err := client.Set(context.Background(), key1, "value1")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	_, err = client.Set(context.Background(), key2, "value2")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	response, err := client.FlushAllWithOptions(context.Background(), options.ASYNC)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", response)
 
 	result, err := client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Empty(suite.T(), result.Value())
 }
 
@@ -600,18 +590,18 @@ func (suite *GlideTestSuite) TestFlushAll_MultipleFlush() {
 	key1 := uuid.New().String()
 
 	response, err := client.FlushAllWithOptions(context.Background(), options.SYNC)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", response)
 
 	_, err = client.Set(context.Background(), key1, "value1")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	response, err = client.FlushAllWithOptions(context.Background(), options.ASYNC)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", response)
 
 	result, err := client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Empty(suite.T(), result.Value())
 }
 
@@ -621,20 +611,20 @@ func (suite *GlideTestSuite) TestFlushDB() {
 	key2 := uuid.New().String()
 
 	_, err := client.Set(context.Background(), key1, "value1")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	_, err = client.Set(context.Background(), key2, "value2")
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	result, err := client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "value1", result.Value())
 
 	response, err := client.FlushDB(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "OK", response)
 
 	result, err = client.Get(context.Background(), key1)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Empty(suite.T(), result.Value())
 }
 
@@ -712,13 +702,11 @@ func (suite *GlideTestSuite) TestUpdateConnectionPasswordAuthNonValidPass() {
 
 	// Test empty password
 	_, err := testClient.UpdateConnectionPassword(context.Background(), "", true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 
 	// Test with no password parameter
 	_, err = testClient.UpdateConnectionPassword(context.Background(), "", true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPassword_NoServerAuth() {
@@ -728,13 +716,12 @@ func (suite *GlideTestSuite) TestUpdateConnectionPassword_NoServerAuth() {
 
 	// Validate that we can use the client
 	_, err := testClient.Info(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Test immediate re-authentication fails when no server password is set
 	pwd := uuid.NewString()
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestUpdateConnectionPassword_LongPassword() {
@@ -772,24 +759,23 @@ func (suite *GlideTestSuite) TestUpdateConnectionPassword_ImmediateAuthWrongPass
 
 	// Validate that we can use the client
 	_, err := testClient.Info(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Set the password to something else
 	_, err = adminClient.ConfigSet(context.Background(), map[string]string{"requirepass": notThePwd})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Test that re-authentication fails when using wrong password
 	_, err = testClient.UpdateConnectionPassword(context.Background(), pwd, true)
-	assert.NotNil(suite.T(), err)
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 
 	// But using correct password returns OK
 	_, err = testClient.UpdateConnectionPassword(context.Background(), notThePwd, true)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	// Cleanup: Reset password
 	_, err = adminClient.ConfigSet(context.Background(), map[string]string{"requirepass": ""})
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersion() {
@@ -819,7 +805,7 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_EmptyArgs() {
 func (suite *GlideTestSuite) TestClientId() {
 	client := suite.defaultClient()
 	result, err := client.ClientId(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Greater(suite.T(), result, int64(0))
 }
 
@@ -1008,7 +994,7 @@ func (suite *GlideTestSuite) TestFunctionCommandsStandalone() {
 
 	// delete missing lib returns a error
 	_, err = client.FunctionDelete(context.Background(), "anotherLib")
-	assert.IsType(suite.T(), &glideErrors.RequestError{}, err)
+	suite.Error(err)
 }
 
 func (suite *GlideTestSuite) TestFunctionStats() {
@@ -1193,7 +1179,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestore() {
 
 	// Dumping an empty lib
 	emptyDump, err := client.FunctionDump(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.NotNil(suite.T(), emptyDump)
 	assert.Greater(suite.T(), len(emptyDump), 0)
 
@@ -1209,21 +1195,21 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestore() {
 
 	// Load the functions
 	loadResult, err := client.FunctionLoad(context.Background(), code, true)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), name1, loadResult)
 
 	// Verify functions work
 	result1, err := client.FCallWithKeysAndArgs(context.Background(), name1, []string{}, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "meow", result1)
 
 	result2, err := client.FCallWithKeysAndArgs(context.Background(), name2, []string{}, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), int64(2), result2)
 
 	// Dump the library
 	dump, err := client.FunctionDump(context.Background())
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 
 	// Restore without cleaning the lib and/or overwrite option causes an error
 	_, err = client.FunctionRestore(context.Background(), dump)
@@ -1240,11 +1226,11 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestore() {
 
 	// Functions still work the same after replace
 	result1, err = client.FCallWithKeysAndArgs(context.Background(), name1, []string{}, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "meow", result1)
 
 	result2, err = client.FCallWithKeysAndArgs(context.Background(), name2, []string{}, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), int64(2), result2)
 
 	// create lib with another name, but with the same function names
@@ -1254,7 +1240,7 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestore() {
 		name2: "return #args",
 	}, false)
 	loadResult, err = client.FunctionLoad(context.Background(), code, true)
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), name2, loadResult)
 
 	// REPLACE policy now fails due to a name collision
@@ -1271,11 +1257,11 @@ func (suite *GlideTestSuite) TestFunctionDumpAndRestore() {
 
 	// Original functions work again
 	result1, err = client.FCallWithKeysAndArgs(context.Background(), name1, []string{}, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), "meow", result1)
 
 	result2, err = client.FCallWithKeysAndArgs(context.Background(), name2, []string{}, []string{"meow", "woem"})
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	assert.Equal(suite.T(), int64(2), result2)
 }
 

--- a/go/integTest/vss_module_test.go
+++ b/go/integTest/vss_module_test.go
@@ -21,7 +21,7 @@ func (suite *GlideTestSuite) TestModuleVerifyVssLoaded() {
 		},
 	)
 
-	assert.Nil(suite.T(), err)
+	suite.NoError(err)
 	for _, value := range result.MultiValue() {
 		assert.True(suite.T(), strings.Contains(value, "# search_index_stats"))
 	}

--- a/go/internal/utils/transform_utils.go
+++ b/go/internal/utils/transform_utils.go
@@ -3,8 +3,8 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"math"
 	"strconv"
 	"time"
@@ -109,7 +109,7 @@ func ToString(v any) (string, bool) {
 func DurationToMilliseconds(d time.Duration) (uint32, error) {
 	milliseconds := d.Milliseconds()
 	if milliseconds < 0 || milliseconds > math.MaxUint32 {
-		return 0, glideErrors.NewConfigurationError("invalid duration was specified")
+		return 0, errors.New("invalid duration was specified")
 	}
 	return uint32(milliseconds), nil
 }

--- a/go/internal/utils/transform_utils.go
+++ b/go/internal/utils/transform_utils.go
@@ -4,12 +4,11 @@ package utils
 
 import (
 	"fmt"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"math"
 	"strconv"
 	"time"
 	"unsafe"
-
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
 )
 
 // Convert `s` of type `string` into `[]byte`
@@ -110,7 +109,7 @@ func ToString(v any) (string, bool) {
 func DurationToMilliseconds(d time.Duration) (uint32, error) {
 	milliseconds := d.Milliseconds()
 	if milliseconds < 0 || milliseconds > math.MaxUint32 {
-		return 0, &errors.ConfigurationError{Msg: "invalid duration was specified"}
+		return 0, glideErrors.NewConfigurationError("invalid duration was specified")
 	}
 	return uint32(milliseconds), nil
 }

--- a/go/opentelemetry.go
+++ b/go/opentelemetry.go
@@ -26,7 +26,6 @@
 package glide
 
 /*
-#cgo LDFLAGS: -lglide_ffi
 #include "lib.h"
 #include <stdlib.h>
 */

--- a/go/opentelemetry.go
+++ b/go/opentelemetry.go
@@ -27,7 +27,6 @@ package glide
 
 /*
 #include "lib.h"
-#include <stdlib.h>
 */
 import "C"
 

--- a/go/options/bitop_options.go
+++ b/go/options/bitop_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 )
 
 type BitOpType string

--- a/go/options/bitop_options.go
+++ b/go/options/bitop_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
+	"errors"
 )
 
 type BitOpType string
@@ -26,11 +26,11 @@ type BitOp struct {
 func NewBitOp(operation BitOpType, destKey string, srcKeys []string) (*BitOp, error) {
 	if operation == NOT {
 		if len(srcKeys) != 1 {
-			return nil, glideErrors.NewRequestError("BITOP NOT requires exactly 1 source key")
+			return nil, errors.New("BITOP NOT requires exactly 1 source key")
 		}
 	} else {
 		if len(srcKeys) < 2 {
-			return nil, glideErrors.NewRequestError("BITOP requires at least 2 source keys")
+			return nil, errors.New("BITOP requires at least 2 source keys")
 		}
 	}
 

--- a/go/options/bitop_options.go
+++ b/go/options/bitop_options.go
@@ -3,7 +3,7 @@
 package options
 
 import (
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 )
 
 type BitOpType string
@@ -26,11 +26,11 @@ type BitOp struct {
 func NewBitOp(operation BitOpType, destKey string, srcKeys []string) (*BitOp, error) {
 	if operation == NOT {
 		if len(srcKeys) != 1 {
-			return nil, &errors.RequestError{Msg: "BITOP NOT requires exactly 1 source key"}
+			return nil, glideErrors.NewRequestError("BITOP NOT requires exactly 1 source key")
 		}
 	} else {
 		if len(srcKeys) < 2 {
-			return nil, &errors.RequestError{Msg: "BITOP requires at least 2 source keys"}
+			return nil, glideErrors.NewRequestError("BITOP requires at least 2 source keys")
 		}
 	}
 

--- a/go/options/command_options.go
+++ b/go/options/command_options.go
@@ -110,7 +110,7 @@ func (opts *SetOptions) ToArgs() ([]string, error) {
 		case constants.KeepExisting:
 			args = append(args, string(opts.Expiry.Type))
 		default:
-			err = errors.New("Invalid expiry type")
+			err = errors.New("invalid expiry type")
 		}
 	}
 
@@ -148,7 +148,7 @@ func (opts *GetExOptions) ToArgs() ([]string, error) {
 		case constants.Persist:
 			args = append(args, string(opts.Expiry.Type))
 		default:
-			err = errors.New("Invalid expiry type")
+			err = errors.New("invalid expiry type")
 		}
 	}
 

--- a/go/options/command_options.go
+++ b/go/options/command_options.go
@@ -3,12 +3,12 @@
 package options
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
-	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 )
 
@@ -110,7 +110,7 @@ func (opts *SetOptions) ToArgs() ([]string, error) {
 		case constants.KeepExisting:
 			args = append(args, string(opts.Expiry.Type))
 		default:
-			err = glideErrors.NewRequestError("Invalid expiry type")
+			err = errors.New("Invalid expiry type")
 		}
 	}
 
@@ -148,7 +148,7 @@ func (opts *GetExOptions) ToArgs() ([]string, error) {
 		case constants.Persist:
 			args = append(args, string(opts.Expiry.Type))
 		default:
-			err = glideErrors.NewRequestError("Invalid expiry type")
+			err = errors.New("Invalid expiry type")
 		}
 	}
 

--- a/go/options/command_options.go
+++ b/go/options/command_options.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
-	"github.com/valkey-io/valkey-glide/go/v2/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/glideErrors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 )
 
@@ -110,7 +110,7 @@ func (opts *SetOptions) ToArgs() ([]string, error) {
 		case constants.KeepExisting:
 			args = append(args, string(opts.Expiry.Type))
 		default:
-			err = &errors.RequestError{Msg: "Invalid expiry type"}
+			err = glideErrors.NewRequestError("Invalid expiry type")
 		}
 	}
 
@@ -148,7 +148,7 @@ func (opts *GetExOptions) ToArgs() ([]string, error) {
 		case constants.Persist:
 			args = append(args, string(opts.Expiry.Type))
 		default:
-			err = &errors.RequestError{Msg: "Invalid expiry type"}
+			err = glideErrors.NewRequestError("Invalid expiry type")
 		}
 	}
 

--- a/go/options/command_options.go
+++ b/go/options/command_options.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 )
 

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -1745,7 +1745,7 @@ func (b *BaseBatch[T]) LMPop(keys []string, listDirection constants.ListDirectio
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-2 {
-		return b.addError("LMPop", errors.New("Length overflow for the provided keys"))
+		return b.addError("LMPop", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 2 more arguments with the keys provided.
@@ -1784,7 +1784,7 @@ func (b *BaseBatch[T]) LMPopCount(keys []string, listDirection constants.ListDir
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-4 {
-		return b.addError("LMPopCount", errors.New("Length overflow for the provided keys"))
+		return b.addError("LMPopCount", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 4 more arguments with the keys provided.
@@ -1829,7 +1829,7 @@ func (b *BaseBatch[T]) BLMPop(keys []string, listDirection constants.ListDirecti
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
-		return b.addError("BLMPop", errors.New("Length overflow for the provided keys"))
+		return b.addError("BLMPop", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 3 more arguments with the keys provided.
@@ -1880,7 +1880,7 @@ func (b *BaseBatch[T]) BLMPopCount(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
-		return b.addError("BLMPopCount", errors.New("Length overflow for the provided keys"))
+		return b.addError("BLMPopCount", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 5 more arguments with the keys provided.
@@ -2969,7 +2969,7 @@ func (b *BaseBatch[T]) BZMPop(keys []string, scoreFilter constants.ScoreFilter, 
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
-		return b.addError("BZMPop", errors.New("Length overflow for the provided keys"))
+		return b.addError("BZMPop", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 3 more arguments with the keys provided.
@@ -3024,7 +3024,7 @@ func (b *BaseBatch[T]) BZMPopWithOptions(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
-		return b.addError("BZMPopWithOptions", errors.New("Length overflow for the provided keys"))
+		return b.addError("BZMPopWithOptions", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 5 more arguments with the keys provided.
@@ -5216,7 +5216,7 @@ func (b *BaseBatch[T]) ZMPop(keys []string, scoreFilter constants.ScoreFilter) *
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-2 {
-		return b.addError("ZMPop", errors.New("Length overflow for the provided keys"))
+		return b.addError("ZMPop", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 2 more arguments with the keys provided.
@@ -5254,7 +5254,7 @@ func (b *BaseBatch[T]) ZMPopWithOptions(keys []string, scoreFilter constants.Sco
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-4 {
-		return b.addError("ZMPopWithOptions", errors.New("Length overflow for the provided keys"))
+		return b.addError("ZMPopWithOptions", errors.New("length overflow for the provided keys"))
 	}
 
 	// args slice will have 4 more arguments with the keys provided.

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -6,6 +6,7 @@ package pipeline
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -17,7 +18,6 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 
 	"github.com/valkey-io/valkey-glide/go/v2/internal"
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/internal/utils"
 )
 
@@ -1745,7 +1745,7 @@ func (b *BaseBatch[T]) LMPop(keys []string, listDirection constants.ListDirectio
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-2 {
-		return b.addError("LMPop", &errors.RequestError{Msg: "Length overflow for the provided keys"})
+		return b.addError("LMPop", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 2 more arguments with the keys provided.
@@ -1784,7 +1784,7 @@ func (b *BaseBatch[T]) LMPopCount(keys []string, listDirection constants.ListDir
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-4 {
-		return b.addError("LMPopCount", &errors.RequestError{Msg: "Length overflow for the provided keys"})
+		return b.addError("LMPopCount", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 4 more arguments with the keys provided.
@@ -1829,7 +1829,7 @@ func (b *BaseBatch[T]) BLMPop(keys []string, listDirection constants.ListDirecti
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
-		return b.addError("BLMPop", &errors.RequestError{Msg: "Length overflow for the provided keys"})
+		return b.addError("BLMPop", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 3 more arguments with the keys provided.
@@ -1880,7 +1880,7 @@ func (b *BaseBatch[T]) BLMPopCount(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
-		return b.addError("BLMPopCount", &errors.RequestError{Msg: "Length overflow for the provided keys"})
+		return b.addError("BLMPopCount", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 5 more arguments with the keys provided.
@@ -2969,9 +2969,7 @@ func (b *BaseBatch[T]) BZMPop(keys []string, scoreFilter constants.ScoreFilter, 
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-3 {
-		return b.addError("BZMPop", &errors.RequestError{
-			Msg: "Length overflow for the provided keys",
-		})
+		return b.addError("BZMPop", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 3 more arguments with the keys provided.
@@ -3026,9 +3024,7 @@ func (b *BaseBatch[T]) BZMPopWithOptions(
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-5 {
-		return b.addError("BZMPopWithOptions", &errors.RequestError{
-			Msg: "Length overflow for the provided keys",
-		})
+		return b.addError("BZMPopWithOptions", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 5 more arguments with the keys provided.
@@ -5220,9 +5216,7 @@ func (b *BaseBatch[T]) ZMPop(keys []string, scoreFilter constants.ScoreFilter) *
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-2 {
-		return b.addError("ZMPop", &errors.RequestError{
-			Msg: "Length overflow for the provided keys",
-		})
+		return b.addError("ZMPop", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 2 more arguments with the keys provided.
@@ -5260,9 +5254,7 @@ func (b *BaseBatch[T]) ZMPopWithOptions(keys []string, scoreFilter constants.Sco
 
 	// Check for potential length overflow.
 	if len(keys) > math.MaxInt-4 {
-		return b.addError("ZMPopWithOptions", &errors.RequestError{
-			Msg: "Length overflow for the provided keys",
-		})
+		return b.addError("ZMPopWithOptions", errors.New("Length overflow for the provided keys"))
 	}
 
 	// args slice will have 4 more arguments with the keys provided.

--- a/go/pipeline/batch.go
+++ b/go/pipeline/batch.go
@@ -317,7 +317,9 @@ func (b *BaseBatch[T]) addCmdAndConverter(
 		}
 		// data lost even though it was incorrect
 		// TODO maybe still return the data?
-		return errors.New(fmt.Sprintf("Unexpected return type from Glide: got %v, expected %v", reflect.TypeOf(res), expectedType))
+		return errors.New(
+			fmt.Sprintf("Unexpected return type from Glide: got %v, expected %v", reflect.TypeOf(res), expectedType),
+		)
 	}
 	b.Commands = append(b.Commands, Cmd{RequestType: request, Args: args, Converter: converterAndTypeChecker})
 	return b.self

--- a/go/pipeline/batch.go
+++ b/go/pipeline/batch.go
@@ -6,7 +6,6 @@ package pipeline
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -310,15 +309,15 @@ func (b *BaseBatch[T]) addCmdAndConverter(
 			if isNilable {
 				return nil
 			}
-			return errors.New(fmt.Sprintf("Unexpected return type from Glide: got nil, expected %v", expectedType))
+			return fmt.Errorf("Unexpected return type from Glide: got nil, expected %v", expectedType)
 		}
 		if reflect.TypeOf(res).Kind() == expectedType {
 			return converter(res)
 		}
 		// data lost even though it was incorrect
 		// TODO maybe still return the data?
-		return errors.New(
-			fmt.Sprintf("Unexpected return type from Glide: got %v, expected %v", reflect.TypeOf(res), expectedType),
+		return fmt.Errorf(
+			"Unexpected return type from Glide: got %v, expected %v", reflect.TypeOf(res), expectedType,
 		)
 	}
 	b.Commands = append(b.Commands, Cmd{RequestType: request, Args: args, Converter: converterAndTypeChecker})

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -26,7 +26,7 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 		return fmt.Errorf(
 			"unexpected return type from Valkey: got nil, expected %s",
 			C.GoString(expectedTypeStr),
-		}
+		)
 	}
 
 	if isNilable && (response == nil || response.response_type == uint32(C.Null)) {
@@ -42,7 +42,7 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 		"unexpected return type from Valkey: got %s, expected %s",
 		C.GoString(actualTypeStr),
 		C.GoString(expectedTypeStr),
-	}
+	)
 }
 
 func convertCharArrayToString(response *C.struct_CommandResponse, isNilable bool) (models.Result[string], error) {
@@ -950,7 +950,7 @@ func handleXClaimResponse(response *C.struct_CommandResponse) (map[string]models
 	// Process the map data directly
 	claimMap, ok := data.(map[string]any)
 	if !ok {
-		return nil, &errors.RequestError{Msg: fmt.Sprintf("unexpected type received: %T", data)}
+		return nil, fmt.Errorf("unexpected type received: %T", data)
 	}
 
 	for id, entriesArray := range claimMap {
@@ -1233,7 +1233,7 @@ func handleStreamResponse(response *C.struct_CommandResponse) (map[string]models
 	// Process the map data directly
 	streamMap, ok := data.(map[string]any)
 	if !ok {
-		return nil, &errors.RequestError{Msg: fmt.Sprintf("unexpected type received: %T", data)}
+		return nil, fmt.Errorf("unexpected type received: %T", data)
 	}
 	for streamName, streamData := range streamMap {
 		streamResponse := models.StreamResponse{

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -23,11 +23,9 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 	expectedTypeStr := C.get_response_type_string(expectedTypeInt)
 
 	if !isNilable && response == nil {
-		return errors.New(
-			fmt.Sprintf(
-				"Unexpected return type from Valkey: got nil, expected %s",
-				C.GoString(expectedTypeStr),
-			),
+		return fmt.Errorf(
+			"Unexpected return type from Valkey: got nil, expected %s",
+			C.GoString(expectedTypeStr),
 		}
 	}
 
@@ -40,12 +38,10 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 	}
 
 	actualTypeStr := C.get_response_type_string(response.response_type)
-	return errors.New(
-		fmt.Sprintf(
-			"Unexpected return type from Valkey: got %s, expected %s",
-			C.GoString(actualTypeStr),
-			C.GoString(expectedTypeStr),
-		),
+	return fmt.Errorf(
+		"Unexpected return type from Valkey: got %s, expected %s",
+		C.GoString(actualTypeStr),
+		C.GoString(expectedTypeStr),
 	}
 }
 
@@ -242,7 +238,7 @@ func (node mapConverter[T]) convert(data any) (any, error) {
 		if node.canBeNil {
 			return nil, nil
 		} else {
-			return nil, errors.New(fmt.Sprintf("Unexpected type received: nil, expected: map[string]%v", getType[T]()))
+			return nil, fmt.Errorf("Unexpected type received: nil, expected: map[string]%v", getType[T]())
 		}
 	}
 	result := make(map[string]T)
@@ -253,9 +249,7 @@ func (node mapConverter[T]) convert(data any) (any, error) {
 			// try direct conversion to T when there is no next converter
 			valueT, ok := value.(T)
 			if !ok {
-				return nil, errors.New(
-					fmt.Sprintf("Unexpected type of map element: %T, expected: %v", value, getType[T]()),
-				)
+				return nil, fmt.Errorf("Unexpected type of map element: %T, expected: %v", value, getType[T]())
 			}
 			result[key] = valueT
 		} else {
@@ -272,7 +266,7 @@ func (node mapConverter[T]) convert(data any) (any, error) {
 			// convert to T
 			valueT, ok := val.(T)
 			if !ok {
-				return nil, errors.New(fmt.Sprintf("Unexpected type of map element: %T, expected: %v", val, getType[T]()))
+				return nil, fmt.Errorf("Unexpected type of map element: %T, expected: %v", val, getType[T]())
 			}
 			result[key] = valueT
 		}
@@ -292,7 +286,7 @@ func (node arrayConverter[T]) convert(data any) (any, error) {
 		if node.canBeNil {
 			return nil, nil
 		} else {
-			return nil, errors.New(fmt.Sprintf("Unexpected type received: nil, expected: []%v", getType[T]()))
+			return nil, fmt.Errorf("Unexpected type received: nil, expected: []%v", getType[T]())
 		}
 	}
 	arrData := data.([]any)
@@ -301,9 +295,7 @@ func (node arrayConverter[T]) convert(data any) (any, error) {
 		if node.next == nil {
 			valueT, ok := value.(T)
 			if !ok {
-				return nil, errors.New(
-					fmt.Sprintf("Unexpected type of array element: %T, expected: %v", value, getType[T]()),
-				)
+				return nil, fmt.Errorf("Unexpected type of array element: %T, expected: %v", value, getType[T]())
 			}
 			result = append(result, valueT)
 		} else {
@@ -318,7 +310,7 @@ func (node arrayConverter[T]) convert(data any) (any, error) {
 			}
 			valueT, ok := val.(T)
 			if !ok {
-				return nil, errors.New(fmt.Sprintf("Unexpected type of array element: %T, expected: %v", val, getType[T]()))
+				return nil, fmt.Errorf("Unexpected type of array element: %T, expected: %v", val, getType[T]())
 			}
 			result = append(result, valueT)
 		}
@@ -413,7 +405,7 @@ func handle2DStringArrayResponse(response *C.struct_CommandResponse) ([][]string
 	}
 	res, ok := converted.([][]string)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type: %T", converted))
+		return nil, fmt.Errorf("unexpected type: %T", converted)
 	}
 	return res, nil
 }
@@ -440,7 +432,7 @@ func handle2DFloat64OrNullArrayResponse(response *C.struct_CommandResponse) ([][
 	}
 	res, ok := converted.([][]float64)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type: %T", converted))
+		return nil, fmt.Errorf("unexpected type: %T", converted)
 	}
 	return res, nil
 }
@@ -710,7 +702,7 @@ func handleStringDoubleMapResponse(response *C.struct_CommandResponse) (map[stri
 	}
 	result, ok := converted.(map[string]float64)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type of map: %T", converted))
+		return nil, fmt.Errorf("unexpected type of map: %T", converted)
 	}
 	return result, nil
 }
@@ -737,7 +729,7 @@ func handleStringToStringMapResponse(response *C.struct_CommandResponse) (map[st
 	}
 	result, ok := converted.(map[string]string)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type of map: %T", converted))
+		return nil, fmt.Errorf("unexpected type of map: %T", converted)
 	}
 	return result, nil
 }
@@ -801,7 +793,7 @@ func handleStringToStringArrayMapOrNilResponse(
 		return result, nil
 	}
 
-	return nil, errors.New(fmt.Sprintf("unexpected type received: %T", res))
+	return nil, fmt.Errorf("unexpected type received: %T", res)
 }
 
 func handleStringSetResponse(response *C.struct_CommandResponse) (map[string]struct{}, error) {
@@ -881,8 +873,8 @@ func handleKeyWithArrayOfMembersAndScoresResponse(
 	res, ok := converted.(map[string]float64)
 
 	if !ok {
-		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), errors.New(
-			fmt.Sprintf("unexpected type of second element: %T", converted),
+		return models.CreateNilKeyWithArrayOfMembersAndScoresResult(), fmt.Errorf(
+			"unexpected type of second element: %T", converted,
 		)
 	}
 	MemberAndScoreArray := make([]models.MemberAndScore, 0, len(res))
@@ -1027,7 +1019,7 @@ func handleXRangeResponse(response *C.struct_CommandResponse) ([]models.XRangeRe
 	}
 	claimedEntries, ok := converted.(map[string][][]string)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type of second element: %T", converted))
+		return nil, fmt.Errorf("unexpected type of second element: %T", converted)
 	}
 
 	XRangeResponseArray := make([]models.XRangeResponse, 0, len(claimedEntries))
@@ -1072,7 +1064,7 @@ func handleXRevRangeResponse(response *C.struct_CommandResponse) ([]models.XRang
 	}
 	claimedEntries, ok := converted.(map[string][][]string)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type of second element: %T", converted))
+		return nil, fmt.Errorf("unexpected type of second element: %T", converted)
 	}
 
 	XRangeResponseArray := make([]models.XRangeResponse, 0, len(claimedEntries))
@@ -1101,7 +1093,7 @@ func handleXAutoClaimResponse(response *C.struct_CommandResponse) (models.XAutoC
 	arr := slice.([]any)
 	len := len(arr)
 	if len < 2 || len > 3 {
-		return null, errors.New(fmt.Sprintf("Unexpected response array length: %d", len))
+		return null, fmt.Errorf("Unexpected response array length: %d", len)
 	}
 	converted, err := mapConverter[[][]string]{
 		arrayConverter[[]string]{
@@ -1118,7 +1110,7 @@ func handleXAutoClaimResponse(response *C.struct_CommandResponse) (models.XAutoC
 	}
 	claimedEntries, ok := converted.(map[string][][]string)
 	if !ok {
-		return null, errors.New(fmt.Sprintf("unexpected type of second element: %T", converted))
+		return null, fmt.Errorf("unexpected type of second element: %T", converted)
 	}
 	var deletedMessages []string
 	deletedMessages = nil
@@ -1132,7 +1124,7 @@ func handleXAutoClaimResponse(response *C.struct_CommandResponse) (models.XAutoC
 		}
 		deletedMessages, ok = converted.([]string)
 		if !ok {
-			return null, errors.New(fmt.Sprintf("unexpected type of third element: %T", converted))
+			return null, fmt.Errorf("unexpected type of third element: %T", converted)
 		}
 	}
 	return models.XAutoClaimResponse{
@@ -1156,7 +1148,7 @@ func handleXAutoClaimJustIdResponse(response *C.struct_CommandResponse) (models.
 	arr := slice.([]any)
 	len := len(arr)
 	if len < 2 || len > 3 {
-		return null, errors.New(fmt.Sprintf("Unexpected response array length: %d", len))
+		return null, fmt.Errorf("Unexpected response array length: %d", len)
 	}
 	converted, err := arrayConverter[string]{
 		nil,
@@ -1167,7 +1159,7 @@ func handleXAutoClaimJustIdResponse(response *C.struct_CommandResponse) (models.
 	}
 	claimedEntries, ok := converted.([]string)
 	if !ok {
-		return null, errors.New(fmt.Sprintf("unexpected type of second element: %T", converted))
+		return null, fmt.Errorf("unexpected type of second element: %T", converted)
 	}
 	var deletedMessages []string
 	deletedMessages = nil
@@ -1181,7 +1173,7 @@ func handleXAutoClaimJustIdResponse(response *C.struct_CommandResponse) (models.
 		}
 		deletedMessages, ok = converted.([]string)
 		if !ok {
-			return null, errors.New(fmt.Sprintf("unexpected type of third element: %T", converted))
+			return null, fmt.Errorf("unexpected type of third element: %T", converted)
 		}
 	}
 	return models.XAutoClaimJustIdResponse{
@@ -1222,7 +1214,7 @@ func handleXReadResponse(response *C.struct_CommandResponse) (map[string]map[str
 	if result, ok := res.(map[string]map[string][][]string); ok {
 		return result, nil
 	}
-	return nil, errors.New(fmt.Sprintf("unexpected type received: %T", res))
+	return nil, fmt.Errorf("unexpected type received: %T", res)
 }
 
 func handleStreamResponse(response *C.struct_CommandResponse) (map[string]models.StreamResponse, error) {
@@ -1400,7 +1392,7 @@ func handleXInfoConsumersResponse(response *C.struct_CommandResponse) ([]models.
 	}
 	arr, ok := converted.([]map[string]any)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type: %T", converted))
+		return nil, fmt.Errorf("unexpected type: %T", converted)
 	}
 
 	result := make([]models.XInfoConsumerInfo, 0, len(arr))
@@ -1443,7 +1435,7 @@ func handleXInfoGroupsResponse(response *C.struct_CommandResponse) ([]models.XIn
 	}
 	arr, ok := converted.([]map[string]any)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type: %T", converted))
+		return nil, fmt.Errorf("unexpected type: %T", converted)
 	}
 
 	result := make([]models.XInfoGroupInfo, 0, len(arr))
@@ -1508,7 +1500,7 @@ func handleRawStringArrayMapResponse(response *C.struct_CommandResponse) (map[st
 	}
 	mapResult, ok := result.(map[string][]string)
 	if !ok {
-		return nil, errors.New("Unexpected conversion result type")
+		return nil, fmt.Errorf("Unexpected conversion result type: %T", result)
 	}
 
 	return mapResult, nil
@@ -1535,7 +1527,7 @@ func handleMapOfStringMapResponse(response *C.struct_CommandResponse) (map[strin
 	}
 	mapResult, ok := result.(map[string]map[string]string)
 	if !ok {
-		return nil, glideErrors.NewRequestError("Unexpected conversion result type")
+		return nil, fmt.Errorf("Unexpected conversion result type: %T", result)
 	}
 
 	return mapResult, nil
@@ -1585,7 +1577,7 @@ func handleStringIntMapResponse(response *C.struct_CommandResponse) (map[string]
 	}
 	result, ok := converted.(map[string]int64)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type of map: %T", converted))
+		return nil, fmt.Errorf("unexpected type of map: %T", converted)
 	}
 	return result, nil
 }
@@ -1749,7 +1741,7 @@ func handleSortedSetWithScoresResponse(response *C.struct_CommandResponse, rever
 	}
 	result, ok := converted.(map[string]float64)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("unexpected type of map: %T", converted))
+		return nil, fmt.Errorf("unexpected type of map: %T", converted)
 	}
 
 	zRangeResponseArray := make([]models.MemberAndScore, 0, len(result))

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -238,7 +238,7 @@ func (node mapConverter[T]) convert(data any) (any, error) {
 		if node.canBeNil {
 			return nil, nil
 		} else {
-			return nil, fmt.Errorf("Unexpected type received: nil, expected: map[string]%v", getType[T]())
+			return nil, fmt.Errorf("unexpected type received: nil, expected: map[string]%v", getType[T]())
 		}
 	}
 	result := make(map[string]T)
@@ -249,7 +249,7 @@ func (node mapConverter[T]) convert(data any) (any, error) {
 			// try direct conversion to T when there is no next converter
 			valueT, ok := value.(T)
 			if !ok {
-				return nil, fmt.Errorf("Unexpected type of map element: %T, expected: %v", value, getType[T]())
+				return nil, fmt.Errorf("unexpected type of map element: %T, expected: %v", value, getType[T]())
 			}
 			result[key] = valueT
 		} else {
@@ -266,7 +266,7 @@ func (node mapConverter[T]) convert(data any) (any, error) {
 			// convert to T
 			valueT, ok := val.(T)
 			if !ok {
-				return nil, fmt.Errorf("Unexpected type of map element: %T, expected: %v", val, getType[T]())
+				return nil, fmt.Errorf("unexpected type of map element: %T, expected: %v", val, getType[T]())
 			}
 			result[key] = valueT
 		}
@@ -286,7 +286,7 @@ func (node arrayConverter[T]) convert(data any) (any, error) {
 		if node.canBeNil {
 			return nil, nil
 		} else {
-			return nil, fmt.Errorf("Unexpected type received: nil, expected: []%v", getType[T]())
+			return nil, fmt.Errorf("unexpected type received: nil, expected: []%v", getType[T]())
 		}
 	}
 	arrData := data.([]any)
@@ -295,7 +295,7 @@ func (node arrayConverter[T]) convert(data any) (any, error) {
 		if node.next == nil {
 			valueT, ok := value.(T)
 			if !ok {
-				return nil, fmt.Errorf("Unexpected type of array element: %T, expected: %v", value, getType[T]())
+				return nil, fmt.Errorf("unexpected type of array element: %T, expected: %v", value, getType[T]())
 			}
 			result = append(result, valueT)
 		} else {
@@ -310,7 +310,7 @@ func (node arrayConverter[T]) convert(data any) (any, error) {
 			}
 			valueT, ok := val.(T)
 			if !ok {
-				return nil, fmt.Errorf("Unexpected type of array element: %T, expected: %v", val, getType[T]())
+				return nil, fmt.Errorf("unexpected type of array element: %T, expected: %v", val, getType[T]())
 			}
 			result = append(result, valueT)
 		}
@@ -1093,7 +1093,7 @@ func handleXAutoClaimResponse(response *C.struct_CommandResponse) (models.XAutoC
 	arr := slice.([]any)
 	len := len(arr)
 	if len < 2 || len > 3 {
-		return null, fmt.Errorf("Unexpected response array length: %d", len)
+		return null, fmt.Errorf("unexpected response array length: %d", len)
 	}
 	converted, err := mapConverter[[][]string]{
 		arrayConverter[[]string]{
@@ -1148,7 +1148,7 @@ func handleXAutoClaimJustIdResponse(response *C.struct_CommandResponse) (models.
 	arr := slice.([]any)
 	len := len(arr)
 	if len < 2 || len > 3 {
-		return null, fmt.Errorf("Unexpected response array length: %d", len)
+		return null, fmt.Errorf("unexpected response array length: %d", len)
 	}
 	converted, err := arrayConverter[string]{
 		nil,
@@ -1500,7 +1500,7 @@ func handleRawStringArrayMapResponse(response *C.struct_CommandResponse) (map[st
 	}
 	mapResult, ok := result.(map[string][]string)
 	if !ok {
-		return nil, fmt.Errorf("Unexpected conversion result type: %T", result)
+		return nil, fmt.Errorf("unexpected conversion result type: %T", result)
 	}
 
 	return mapResult, nil
@@ -1527,7 +1527,7 @@ func handleMapOfStringMapResponse(response *C.struct_CommandResponse) (map[strin
 	}
 	mapResult, ok := result.(map[string]map[string]string)
 	if !ok {
-		return nil, fmt.Errorf("Unexpected conversion result type: %T", result)
+		return nil, fmt.Errorf("unexpected conversion result type: %T", result)
 	}
 
 	return mapResult, nil

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -13,7 +13,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/valkey-io/valkey-glide/go/v2/internal/errors"
+	"github.com/valkey-io/valkey-glide/go/v2/errors"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 )

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -149,7 +149,7 @@ func parseInterface(response *C.struct_CommandResponse) (any, error) {
 		if !ok {
 			return nil, errors.New("Error message isn't a string")
 		}
-		return nil, errors.New(errStrString)
+		return errors.New(errStrString), nil
 	}
 
 	return nil, errors.New("Unexpected return type from Valkey")

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -24,7 +24,7 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 
 	if !isNilable && response == nil {
 		return fmt.Errorf(
-			"Unexpected return type from Valkey: got nil, expected %s",
+			"unexpected return type from Valkey: got nil, expected %s",
 			C.GoString(expectedTypeStr),
 		}
 	}
@@ -39,7 +39,7 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 
 	actualTypeStr := C.get_response_type_string(response.response_type)
 	return fmt.Errorf(
-		"Unexpected return type from Valkey: got %s, expected %s",
+		"unexpected return type from Valkey: got %s, expected %s",
 		C.GoString(actualTypeStr),
 		C.GoString(expectedTypeStr),
 	}
@@ -139,16 +139,16 @@ func parseInterface(response *C.struct_CommandResponse) (any, error) {
 	case C.Error:
 		errStr, err := parseString(response)
 		if err != nil {
-			return nil, errors.New("Cannot read error message")
+			return nil, errors.New("cannot read error message")
 		}
 		errStrString, ok := errStr.(string)
 		if !ok {
-			return nil, errors.New("Error message isn't a string")
+			return nil, errors.New("error message isn't a string")
 		}
 		return errors.New(errStrString), nil
 	}
 
-	return nil, errors.New("Unexpected return type from Valkey")
+	return nil, errors.New("unexpected return type from Valkey")
 }
 
 func parseString(response *C.struct_CommandResponse) (any, error) {


### PR DESCRIPTION
Supersedes #4090

* Convert Batch errors to `[]error`
* Implement custom `BatchError` to defer formatting batch error message until needed.
* Fix error messages to follow idiomatic Go guideline: start with lowercase letters and don't end with punctuation.

This PR is dependent on #3989 

### Issue link

This Pull Request is linked to issue #4031

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
