### PR TITLE
Go: Modifying Commands to use `time.Duration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 * Go: XClaim and XClaimWithOptions update response type ([#4091](https://github.com/valkey-io/valkey-glide/pull/4091))
 * Modify `PFADD` to return a boolean rather than an integer ([#4094](https://github.com/valkey-io/valkey-glide/pull/4094))
 * Go: Modify blocking commands to use type `time.Duration` for timeouts ([#4086](https://github.com/valkey-io/valkey-glide/pull/4086))
+* Go: Modify most commands to use type `time.Duration` (check PR for list of commands modified) ([#4105](https://github.com/valkey-io/valkey-glide/pull/4105))
 
 #### Fixes
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -3553,7 +3553,7 @@ func (client *baseClient) ExpireAtWithOptions(
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to set timeout on it.
-//	expireTime - Duration for the key to expire
+//	expireTime - Duration for the key to expire.
 //
 // Return value:
 //

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -3402,7 +3402,7 @@ func (client *baseClient) Exists(ctx context.Context, keys []string) (int64, err
 // Expire sets a timeout on key. After the timeout has expired, the key will automatically be deleted.
 //
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -3411,7 +3411,7 @@ func (client *baseClient) Exists(ctx context.Context, keys []string) (int64, err
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to expire.
-//	seconds - Time in seconds for the key to expire
+//	expireTime - Duration for the key to expire
 //
 // Return value:
 //
@@ -3419,8 +3419,8 @@ func (client *baseClient) Exists(ctx context.Context, keys []string) (int64, err
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/expire/
-func (client *baseClient) Expire(ctx context.Context, key string, seconds int64) (bool, error) {
-	result, err := client.executeCommand(ctx, C.Expire, []string{key, utils.IntToString(seconds)})
+func (client *baseClient) Expire(ctx context.Context, key string, expireTime time.Duration) (bool, error) {
+	result, err := client.executeCommand(ctx, C.Expire, []string{key, utils.FloatToString(expireTime.Seconds())})
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
@@ -3431,7 +3431,7 @@ func (client *baseClient) Expire(ctx context.Context, key string, seconds int64)
 // Expire sets a timeout on key. After the timeout has expired, the key will automatically be deleted.
 //
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -3440,7 +3440,7 @@ func (client *baseClient) Expire(ctx context.Context, key string, seconds int64)
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to expire.
-//	seconds - Time in seconds for the key to expire.
+//	expireTime - Duration for the key to expire
 //	expireCondition - The option to set expiry, see [options.ExpireCondition].
 //
 // Return value:
@@ -3452,14 +3452,14 @@ func (client *baseClient) Expire(ctx context.Context, key string, seconds int64)
 func (client *baseClient) ExpireWithOptions(
 	ctx context.Context,
 	key string,
-	seconds int64,
+	expireTime time.Duration,
 	expireCondition constants.ExpireCondition,
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.ToString()
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
-	result, err := client.executeCommand(ctx, C.Expire, []string{key, utils.IntToString(seconds), expireConditionStr})
+	result, err := client.executeCommand(ctx, C.Expire, []string{key, utils.FloatToString(expireTime.Seconds()), expireConditionStr})
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
@@ -3472,7 +3472,7 @@ func (client *baseClient) ExpireWithOptions(
 // If key already has an existing expire set, the time to live is updated to the new value.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -3481,7 +3481,7 @@ func (client *baseClient) ExpireWithOptions(
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to expire.
-//	unixTimestampInSeconds - Absolute Unix timestamp
+//	expireTime - The timestamp for expiry.
 //
 // Return value:
 //
@@ -3489,8 +3489,8 @@ func (client *baseClient) ExpireWithOptions(
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/expireat/
-func (client *baseClient) ExpireAt(ctx context.Context, key string, unixTimestampInSeconds int64) (bool, error) {
-	result, err := client.executeCommand(ctx, C.ExpireAt, []string{key, utils.IntToString(unixTimestampInSeconds)})
+func (client *baseClient) ExpireAt(ctx context.Context, key string, expireTime time.Time) (bool, error) {
+	result, err := client.executeCommand(ctx, C.ExpireAt, []string{key, utils.IntToString(expireTime.Unix())})
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
@@ -3504,7 +3504,7 @@ func (client *baseClient) ExpireAt(ctx context.Context, key string, unixTimestam
 // If key already has an existing expire set, the time to live is updated to the new value.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -3513,7 +3513,7 @@ func (client *baseClient) ExpireAt(ctx context.Context, key string, unixTimestam
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to expire.
-//	unixTimestampInSeconds - Absolute Unix timestamp.
+//	expireTime - The timestamp for expiry.
 //	expireCondition - The option to set expiry - see [options.ExpireCondition].
 //
 // Return value:
@@ -3525,7 +3525,7 @@ func (client *baseClient) ExpireAt(ctx context.Context, key string, unixTimestam
 func (client *baseClient) ExpireAtWithOptions(
 	ctx context.Context,
 	key string,
-	unixTimestampInSeconds int64,
+	expireTime time.Time,
 	expireCondition constants.ExpireCondition,
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.ToString()
@@ -3534,7 +3534,7 @@ func (client *baseClient) ExpireAtWithOptions(
 	}
 	result, err := client.executeCommand(ctx,
 		C.ExpireAt,
-		[]string{key, utils.IntToString(unixTimestampInSeconds), expireConditionStr},
+		[]string{key, utils.IntToString(expireTime.Unix()), expireConditionStr},
 	)
 	if err != nil {
 		return models.DefaultBoolResponse, err
@@ -3544,7 +3544,7 @@ func (client *baseClient) ExpireAtWithOptions(
 
 // Sets a timeout on key in milliseconds. After the timeout has expired, the key will automatically be deleted.
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If milliseconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -3553,7 +3553,7 @@ func (client *baseClient) ExpireAtWithOptions(
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to set timeout on it.
-//	milliseconds - The timeout in milliseconds.
+//	expireTime - Duration for the key to expire
 //
 // Return value:
 //
@@ -3561,8 +3561,8 @@ func (client *baseClient) ExpireAtWithOptions(
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/pexpire/
-func (client *baseClient) PExpire(ctx context.Context, key string, milliseconds int64) (bool, error) {
-	result, err := client.executeCommand(ctx, C.PExpire, []string{key, utils.IntToString(milliseconds)})
+func (client *baseClient) PExpire(ctx context.Context, key string, expireTime time.Duration) (bool, error) {
+	result, err := client.executeCommand(ctx, C.PExpire, []string{key, utils.IntToString(expireTime.Milliseconds())})
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
@@ -3571,7 +3571,7 @@ func (client *baseClient) PExpire(ctx context.Context, key string, milliseconds 
 
 // Sets a timeout on key in milliseconds. After the timeout has expired, the key will automatically be deleted.
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If milliseconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -3580,7 +3580,7 @@ func (client *baseClient) PExpire(ctx context.Context, key string, milliseconds 
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to set timeout on it.
-//	milliseconds - The timeout in milliseconds.
+//	expireTime - Duration for the key to expire
 //	option - The option to set expiry, see [options.ExpireCondition].
 //
 // Return value:
@@ -3592,14 +3592,14 @@ func (client *baseClient) PExpire(ctx context.Context, key string, milliseconds 
 func (client *baseClient) PExpireWithOptions(
 	ctx context.Context,
 	key string,
-	milliseconds int64,
+	expireTime time.Duration,
 	expireCondition constants.ExpireCondition,
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.ToString()
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
-	result, err := client.executeCommand(ctx, C.PExpire, []string{key, utils.IntToString(milliseconds), expireConditionStr})
+	result, err := client.executeCommand(ctx, C.PExpire, []string{key, utils.IntToString(expireTime.Milliseconds()), expireConditionStr})
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
@@ -3618,7 +3618,7 @@ func (client *baseClient) PExpireWithOptions(
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to set timeout on it.
-//	unixMilliseconds - The timeout in an absolute Unix timestamp.
+//	expireTime - The timestamp for expiry.
 //
 // Return value:
 //
@@ -3626,8 +3626,8 @@ func (client *baseClient) PExpireWithOptions(
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/pexpireat/
-func (client *baseClient) PExpireAt(ctx context.Context, key string, unixTimestampInMilliSeconds int64) (bool, error) {
-	result, err := client.executeCommand(ctx, C.PExpireAt, []string{key, utils.IntToString(unixTimestampInMilliSeconds)})
+func (client *baseClient) PExpireAt(ctx context.Context, key string, expireTime time.Time) (bool, error) {
+	result, err := client.executeCommand(ctx, C.PExpireAt, []string{key, utils.IntToString(expireTime.UnixMilli())})
 	if err != nil {
 		return models.DefaultBoolResponse, err
 	}
@@ -3646,7 +3646,7 @@ func (client *baseClient) PExpireAt(ctx context.Context, key string, unixTimesta
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to set timeout on it.
-//	unixMilliseconds - The timeout in an absolute Unix timestamp.
+//	expireTime - The timestamp for expiry.
 //	expireCondition - The option to set expiry, see [options.ExpireCondition].
 //
 // Return value:
@@ -3658,7 +3658,7 @@ func (client *baseClient) PExpireAt(ctx context.Context, key string, unixTimesta
 func (client *baseClient) PExpireAtWithOptions(
 	ctx context.Context,
 	key string,
-	unixTimestampInMilliSeconds int64,
+	expireTime time.Time,
 	expireCondition constants.ExpireCondition,
 ) (bool, error) {
 	expireConditionStr, err := expireCondition.ToString()
@@ -3667,7 +3667,7 @@ func (client *baseClient) PExpireAtWithOptions(
 	}
 	result, err := client.executeCommand(ctx,
 		C.PExpireAt,
-		[]string{key, utils.IntToString(unixTimestampInMilliSeconds), expireConditionStr},
+		[]string{key, utils.IntToString(expireTime.UnixMilli()), expireConditionStr},
 	)
 	if err != nil {
 		return models.DefaultBoolResponse, err
@@ -4679,7 +4679,7 @@ func (client *baseClient) BZMPop(
 //	scoreFilter   - The element pop criteria - either [options.MIN] or [options.MAX] to pop members with the lowest/highest
 //					scores accordingly.
 //	count         - The maximum number of popped elements.
-//	timeout   - The number of seconds to wait for a blocking operation to complete. A value of `0` will block indefinitely.
+//	timeout       - The duration to wait for a blocking operation to complete. A value of `0` will block indefinitely.
 //	opts          - Pop options, see [options.ZMPopOptions].
 //
 // Return value:
@@ -5110,7 +5110,7 @@ func (client *baseClient) XAutoClaim(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	start string,
 ) (models.XAutoClaimResponse, error) {
 	return client.XAutoClaimWithOptions(ctx, key, group, consumer, minIdleTime, start, *options.NewXAutoClaimOptions())
@@ -5151,11 +5151,11 @@ func (client *baseClient) XAutoClaimWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	start string,
 	options options.XAutoClaimOptions,
 ) (models.XAutoClaimResponse, error) {
-	args := []string{key, group, consumer, utils.IntToString(minIdleTime), start}
+	args := []string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds()), start}
 	optArgs, err := options.ToArgs()
 	if err != nil {
 		return models.XAutoClaimResponse{}, err
@@ -5202,7 +5202,7 @@ func (client *baseClient) XAutoClaimJustId(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	start string,
 ) (models.XAutoClaimJustIdResponse, error) {
 	return client.XAutoClaimJustIdWithOptions(ctx, key, group, consumer, minIdleTime, start, *options.NewXAutoClaimOptions())
@@ -5243,11 +5243,11 @@ func (client *baseClient) XAutoClaimJustIdWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	start string,
 	opts options.XAutoClaimOptions,
 ) (models.XAutoClaimJustIdResponse, error) {
-	args := []string{key, group, consumer, utils.IntToString(minIdleTime), start}
+	args := []string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds()), start}
 	optArgs, err := opts.ToArgs()
 	if err != nil {
 		return models.XAutoClaimJustIdResponse{}, err
@@ -5507,7 +5507,7 @@ func (client *baseClient) XGroupCreateWithOptions(
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to create.
-//	ttl - The expiry time (in milliseconds). If 0, the key will persist.
+//	ttl - The expiry time. If 0, the key will persist.
 //	value - The serialized value to deserialize and assign to key.
 //
 // Return value:
@@ -5515,7 +5515,7 @@ func (client *baseClient) XGroupCreateWithOptions(
 //	Return OK if successfully create a key with a value.
 //
 // [valkey.io]: https://valkey.io/commands/restore/
-func (client *baseClient) Restore(ctx context.Context, key string, ttl int64, value string) (string, error) {
+func (client *baseClient) Restore(ctx context.Context, key string, ttl time.Duration, value string) (string, error) {
 	return client.RestoreWithOptions(ctx, key, ttl, value, *options.NewRestoreOptions())
 }
 
@@ -5526,7 +5526,7 @@ func (client *baseClient) Restore(ctx context.Context, key string, ttl int64, va
 //
 //	ctx - The context for controlling the command execution.
 //	key - The key to create.
-//	ttl - The expiry time (in milliseconds). If 0, the key will persist.
+//	ttl - The expiry time. If 0, the key will persist.
 //	value - The serialized value to deserialize and assign to key.
 //	restoreOptions - Set restore options with replace and absolute TTL modifiers, object idletime and frequency.
 //
@@ -5535,7 +5535,7 @@ func (client *baseClient) Restore(ctx context.Context, key string, ttl int64, va
 //	Return OK if successfully create a key with a value.
 //
 // [valkey.io]: https://valkey.io/commands/restore/
-func (client *baseClient) RestoreWithOptions(ctx context.Context, key string, ttl int64,
+func (client *baseClient) RestoreWithOptions(ctx context.Context, key string, ttl time.Duration,
 	value string, options options.RestoreOptions,
 ) (string, error) {
 	optionArgs, err := options.ToArgs()
@@ -5544,7 +5544,7 @@ func (client *baseClient) RestoreWithOptions(ctx context.Context, key string, tt
 	}
 	result, err := client.executeCommand(ctx, C.Restore, append([]string{
 		key,
-		utils.IntToString(ttl), value,
+		utils.IntToString(ttl.Milliseconds()), value,
 	}, optionArgs...))
 	if err != nil {
 		return models.DefaultStringResponse, err
@@ -6325,19 +6325,18 @@ func (client *baseClient) GetBit(ctx context.Context, key string, offset int64) 
 //
 //	ctx - The context for controlling the command execution.
 //	numberOfReplicas - The number of replicas to reach.
-//	timeout - The timeout value specified in milliseconds. A value of `0` will
-//	block indefinitely.
+//	timeout - The timeout value. A value of `0` will block indefinitely.
 //
 // Return value:
 //
 //	The number of replicas reached by all the writes performed in the context of the current connection.
 //
 // [valkey.io]: https://valkey.io/commands/wait/
-func (client *baseClient) Wait(ctx context.Context, numberOfReplicas int64, timeout int64) (int64, error) {
+func (client *baseClient) Wait(ctx context.Context, numberOfReplicas int64, timeout time.Duration) (int64, error) {
 	result, err := client.executeCommand(
 		ctx,
 		C.Wait,
-		[]string{utils.IntToString(numberOfReplicas), utils.IntToString(timeout)},
+		[]string{utils.IntToString(numberOfReplicas), utils.IntToString(timeout.Milliseconds())},
 	)
 	if err != nil {
 		return models.DefaultIntResponse, err
@@ -6452,7 +6451,7 @@ func (client *baseClient) BitCountWithOptions(ctx context.Context, key string, o
 //	key         - The key of the stream.
 //	group       - The name of the consumer group.
 //	consumer    - The name of the consumer.
-//	minIdleTime - The minimum idle time in milliseconds.
+//	minIdleTime - The minimum idle time.
 //	ids         - The ids of the entries to claim.
 //
 // Return value:
@@ -6468,7 +6467,7 @@ func (client *baseClient) XClaim(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	ids []string,
 ) (map[string]models.XClaimResponse, error) {
 	return client.XClaimWithOptions(ctx, key, group, consumer, minIdleTime, ids, *options.NewXClaimOptions())
@@ -6484,7 +6483,7 @@ func (client *baseClient) XClaim(
 //	key         - The key of the stream.
 //	group       - The name of the consumer group.
 //	consumer    - The name of the consumer.
-//	minIdleTime - The minimum idle time in milliseconds.
+//	minIdleTime - The minimum idle time.
 //	ids         - The ids of the entries to claim.
 //	options     - Stream claim options.
 //
@@ -6501,11 +6500,11 @@ func (client *baseClient) XClaimWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	ids []string,
 	opts options.XClaimOptions,
 ) (map[string]models.XClaimResponse, error) {
-	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime)}, ids...)
+	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds())}, ids...)
 	optionArgs, err := opts.ToArgs()
 	if err != nil {
 		return nil, err
@@ -6529,7 +6528,7 @@ func (client *baseClient) XClaimWithOptions(
 //	key         - The key of the stream.
 //	group       - The name of the consumer group.
 //	consumer    - The name of the consumer.
-//	minIdleTime - The minimum idle time in milliseconds.
+//	minIdleTime - The minimum idle time.
 //	ids         - The ids of the entries to claim.
 //	options     - Stream claim options.
 //
@@ -6543,7 +6542,7 @@ func (client *baseClient) XClaimJustId(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	ids []string,
 ) ([]string, error) {
 	return client.XClaimJustIdWithOptions(ctx, key, group, consumer, minIdleTime, ids, *options.NewXClaimOptions())
@@ -6560,7 +6559,7 @@ func (client *baseClient) XClaimJustId(
 //	key         - The key of the stream.
 //	group       - The name of the consumer group.
 //	consumer    - The name of the consumer.
-//	minIdleTime - The minimum idle time in milliseconds.
+//	minIdleTime - The minimum idle time.
 //	ids         - The ids of the entries to claim.
 //	options     - Stream claim options.
 //
@@ -6574,11 +6573,11 @@ func (client *baseClient) XClaimJustIdWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	ids []string,
 	opts options.XClaimOptions,
 ) ([]string, error) {
-	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime)}, ids...)
+	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds())}, ids...)
 	optionArgs, err := opts.ToArgs()
 	if err != nil {
 		return nil, err

--- a/go/generic_base_commands_test.go
+++ b/go/generic_base_commands_test.go
@@ -86,8 +86,8 @@ func ExampleClusterClient_Exists() {
 func ExampleClient_Expire() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Unix()+1)
-	result2, err := client.Expire(context.Background(), "key", 1)
+	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Add(1*time.Second))
+	result2, err := client.Expire(context.Background(), "key", 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -104,8 +104,8 @@ func ExampleClient_Expire() {
 func ExampleClusterClient_Expire() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Unix()+1)
-	result2, err := client.Expire(context.Background(), "key", 1)
+	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Add(1*time.Second))
+	result2, err := client.Expire(context.Background(), "key", 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -122,7 +122,7 @@ func ExampleClusterClient_Expire() {
 func ExampleClient_ExpireWithOptions() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireWithOptions(context.Background(), "key", 1, constants.HasNoExpiry)
+	result1, err := client.ExpireWithOptions(context.Background(), "key", 1*time.Second, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -137,7 +137,7 @@ func ExampleClient_ExpireWithOptions() {
 func ExampleClusterClient_ExpireWithOptions() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireWithOptions(context.Background(), "key", 1, constants.HasNoExpiry)
+	result1, err := client.ExpireWithOptions(context.Background(), "key", 1*time.Second, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -152,7 +152,7 @@ func ExampleClusterClient_ExpireWithOptions() {
 func ExampleClient_ExpireAt() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Unix()+1)
+	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Add(1*time.Second))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -167,7 +167,7 @@ func ExampleClient_ExpireAt() {
 func ExampleClusterClient_ExpireAt() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Unix()+1)
+	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Add(1*time.Second))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -182,7 +182,7 @@ func ExampleClusterClient_ExpireAt() {
 func ExampleClient_ExpireAtWithOptions() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireAtWithOptions(context.Background(), "key", time.Now().Unix()+1, constants.HasNoExpiry)
+	result1, err := client.ExpireAtWithOptions(context.Background(), "key", time.Now().Add(1*time.Second), constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -197,7 +197,7 @@ func ExampleClient_ExpireAtWithOptions() {
 func ExampleClusterClient_ExpireAtWithOptions() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.ExpireAtWithOptions(context.Background(), "key", time.Now().Unix()+1, constants.HasNoExpiry)
+	result1, err := client.ExpireAtWithOptions(context.Background(), "key", time.Now().Add(1*time.Second), constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -212,7 +212,7 @@ func ExampleClusterClient_ExpireAtWithOptions() {
 func ExampleClient_PExpire() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpire(context.Background(), "key", int64(5*1000))
+	result1, err := client.PExpire(context.Background(), "key", 5000*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -227,7 +227,7 @@ func ExampleClient_PExpire() {
 func ExampleClusterClient_PExpire() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpire(context.Background(), "key", int64(5*1000))
+	result1, err := client.PExpire(context.Background(), "key", 5000*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -242,7 +242,7 @@ func ExampleClusterClient_PExpire() {
 func ExampleClient_PExpireWithOptions() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpireWithOptions(context.Background(), "key", int64(5*1000), constants.HasNoExpiry)
+	result1, err := client.PExpireWithOptions(context.Background(), "key", 5000*time.Millisecond, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -257,7 +257,7 @@ func ExampleClient_PExpireWithOptions() {
 func ExampleClusterClient_PExpireWithOptions() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpireWithOptions(context.Background(), "key", int64(5*1000), constants.HasNoExpiry)
+	result1, err := client.PExpireWithOptions(context.Background(), "key", 5000*time.Millisecond, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -272,7 +272,7 @@ func ExampleClusterClient_PExpireWithOptions() {
 func ExampleClient_PExpireAt() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpireAt(context.Background(), "key", time.Now().Unix()*1000)
+	result1, err := client.PExpireAt(context.Background(), "key", time.Now().Add(10000*time.Millisecond))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -287,7 +287,7 @@ func ExampleClient_PExpireAt() {
 func ExampleClusterClient_PExpireAt() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpireAt(context.Background(), "key", time.Now().Unix()*1000)
+	result1, err := client.PExpireAt(context.Background(), "key", time.Now().Add(10000*time.Millisecond))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -302,7 +302,7 @@ func ExampleClusterClient_PExpireAt() {
 func ExampleClient_PExpireAtWithOptions() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpireAtWithOptions(context.Background(), "key", time.Now().Unix()*1000, constants.HasNoExpiry)
+	result1, err := client.PExpireAtWithOptions(context.Background(), "key", time.Now().Add(10000*time.Millisecond), constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -317,7 +317,7 @@ func ExampleClient_PExpireAtWithOptions() {
 func ExampleClusterClient_PExpireAtWithOptions() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
-	result1, err := client.PExpireAtWithOptions(context.Background(), "key", time.Now().Unix()*1000, constants.HasNoExpiry)
+	result1, err := client.PExpireAtWithOptions(context.Background(), "key", time.Now().Add(10000*time.Millisecond), constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -336,7 +336,7 @@ func ExampleClient_ExpireTime() {
 	_, err = client.ExpireAt(
 		context.Background(),
 		"key",
-		time.Now().Unix()*1000,
+		time.Now().Add(10*time.Second),
 	) // ExpireTime("key") returns proper unix timestamp in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -356,7 +356,7 @@ func ExampleClusterClient_ExpireTime() {
 	_, err = client.ExpireAt(
 		context.Background(),
 		"key",
-		time.Now().Unix()*1000,
+		time.Now().Add(10*time.Second),
 	) // ExpireTime("key") returns proper unix timestamp in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -376,7 +376,7 @@ func ExampleClient_PExpireTime() {
 	_, err = client.PExpireAt(
 		context.Background(),
 		"key",
-		time.Now().Unix()*1000,
+		time.Now().Add(10000*time.Millisecond),
 	) // PExpireTime("key") returns proper unix time in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -396,7 +396,7 @@ func ExampleClusterClient_PExpireTime() {
 	_, err = client.PExpireAt(
 		context.Background(),
 		"key",
-		time.Now().Unix()*1000,
+		time.Now().Add(10000*time.Millisecond),
 	) // PExpireTime("key") returns proper unix time in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -413,7 +413,7 @@ func ExampleClient_TTL() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
 	result1, err := client.TTL(context.Background(), "key")
-	_, err = client.ExpireAt(context.Background(), "key", time.Now().Unix()*1000) // TTL("key") returns proper TTL in seconds
+	_, err = client.ExpireAt(context.Background(), "key", time.Now().Add(10*time.Second)) // TTL("key") returns proper TTL in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -429,7 +429,7 @@ func ExampleClusterClient_TTL() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key", "someValue")
 	result1, err := client.TTL(context.Background(), "key")
-	_, err = client.ExpireAt(context.Background(), "key", time.Now().Unix()*1000) // TTL("key") returns proper TTL in seconds
+	_, err = client.ExpireAt(context.Background(), "key", time.Now().Add(10*time.Second)) // TTL("key") returns proper TTL in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -448,7 +448,7 @@ func ExampleClient_PTTL() {
 	_, err = client.PExpireAt(
 		context.Background(),
 		"key",
-		time.Now().Unix()*100000,
+		time.Now().Add(10000*time.Millisecond),
 	) // PTTL("key") returns proper TTL in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -468,7 +468,7 @@ func ExampleClusterClient_PTTL() {
 	_, err = client.PExpireAt(
 		context.Background(),
 		"key",
-		time.Now().Unix()*100000,
+		time.Now().Add(10000*time.Millisecond),
 	) // PTTL("key") returns proper TTL in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -646,7 +646,7 @@ func ExampleClusterClient_RenameNX() {
 func ExampleClient_Persist() {
 	var client *Client = getExampleClient() // example helper function
 	result, err := client.Set(context.Background(), "key1", "someValue")
-	result1, err := client.ExpireAt(context.Background(), "key1", time.Now().Unix()*1000)
+	result1, err := client.ExpireAt(context.Background(), "key1", time.Now().Add(10*time.Second))
 	result2, err := client.Persist(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -664,7 +664,7 @@ func ExampleClient_Persist() {
 func ExampleClusterClient_Persist() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	result, err := client.Set(context.Background(), "key1", "someValue")
-	result1, err := client.ExpireAt(context.Background(), "key1", time.Now().Unix()*1000)
+	result1, err := client.ExpireAt(context.Background(), "key1", time.Now().Add(10*time.Second))
 	result2, err := client.Persist(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -1119,7 +1119,7 @@ func ExampleClusterClient_SortReadOnlyWithOptions() {
 func ExampleClient_Wait() {
 	var client *Client = getExampleClient() // example helper function
 	client.Set(context.Background(), "key1", "someValue")
-	result, err := client.Wait(context.Background(), 2, 1)
+	result, err := client.Wait(context.Background(), 2, 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -1134,7 +1134,7 @@ func ExampleClient_Wait() {
 func ExampleClusterClient_Wait() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	client.Set(context.Background(), "key1", "someValue")
-	result, err := client.Wait(context.Background(), 2, 1)
+	result, err := client.Wait(context.Background(), 2, 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -715,30 +715,30 @@ func CreateGenericCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serv
 	batch.Exists([]string{slotHashedKey1})
 	testData = append(testData, CommandTestData{ExpectedResponse: int64(0), TestName: "Exists([slotHashedKey1])"})
 
-	batch.Expire(slotHashedKey1, 1)
+	batch.Expire(slotHashedKey1, 1*time.Second)
 	testData = append(testData, CommandTestData{ExpectedResponse: false, TestName: "Expire(slotHashedKey1, 1)"})
-	batch.Expire(singleNodeKey1, 1)
+	batch.Expire(singleNodeKey1, 1*time.Second)
 	testData = append(testData, CommandTestData{ExpectedResponse: true, TestName: "Expire(singleNodeKey1, 1)"})
 
 	batch.Set(slotHashedKey1, "value")
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value)"})
-	batch.ExpireAt(slotHashedKey1, 0)
+	batch.ExpireAt(slotHashedKey1, time.Now())
 	testData = append(testData, CommandTestData{ExpectedResponse: true, TestName: "ExpireAt(slotHashedKey1, 0)"})
 
 	batch.Set(slotHashedKey1, "value")
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value)"})
-	batch.PExpire(slotHashedKey1, int64(5*1000))
+	batch.PExpire(slotHashedKey1, 5000*time.Millisecond)
 	testData = append(testData, CommandTestData{ExpectedResponse: true, TestName: "PExpire(slotHashedKey1, 5000)"})
-	batch.PExpire(prefix+"nonExistentKey", int64(5*1000))
+	batch.PExpire(prefix+"nonExistentKey", 5000*time.Millisecond)
 	testData = append(testData, CommandTestData{ExpectedResponse: false, TestName: "PExpire(badkey, 5000)"})
 
 	batch.Set(slotHashedKey1, "value")
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value)"})
-	batch.PExpireAt(slotHashedKey1, 0)
+	batch.PExpireAt(slotHashedKey1, time.Now())
 	testData = append(testData, CommandTestData{ExpectedResponse: true, TestName: "PExpireAt(slotHashedKey1, 0)"})
 
 	if serverVer >= "7.0.0" {
-		batch.ExpireWithOptions(singleNodeKey1, 1, constants.HasExistingExpiry)
+		batch.ExpireWithOptions(singleNodeKey1, 1*time.Second, constants.HasExistingExpiry)
 		testData = append(
 			testData,
 			CommandTestData{ExpectedResponse: true, TestName: "ExpireWithOptions(singleNodeKey1, 1, HasExistingExpiry)"},
@@ -746,7 +746,7 @@ func CreateGenericCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serv
 
 		batch.Set(slotHashedKey1, "value")
 		testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value)"})
-		batch.ExpireAtWithOptions(slotHashedKey1, 0, constants.HasNoExpiry)
+		batch.ExpireAtWithOptions(slotHashedKey1, time.Now(), constants.HasNoExpiry)
 		testData = append(
 			testData,
 			CommandTestData{ExpectedResponse: true, TestName: "ExpireAtWithOptions(slotHashedKey1, 0, HasNoExpiry)"},
@@ -754,7 +754,7 @@ func CreateGenericCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serv
 
 		batch.Set(slotHashedKey1, "value")
 		testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value)"})
-		batch.PExpireWithOptions(slotHashedKey1, int64(5*1000), constants.HasNoExpiry)
+		batch.PExpireWithOptions(slotHashedKey1, 5000*time.Millisecond, constants.HasNoExpiry)
 		testData = append(
 			testData,
 			CommandTestData{ExpectedResponse: true, TestName: "PExpireWithOptions(slotHashedKey1, 5000, HasNoExpiry)"},
@@ -762,7 +762,7 @@ func CreateGenericCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serv
 
 		batch.Set(slotHashedKey1, "value")
 		testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value)"})
-		batch.PExpireAtWithOptions(slotHashedKey1, 0, constants.HasNoExpiry)
+		batch.PExpireAtWithOptions(slotHashedKey1, time.Now(), constants.HasNoExpiry)
 		testData = append(
 			testData,
 			CommandTestData{ExpectedResponse: true, TestName: "PExpireAtWithOptions(slotHashedKey1, 0, HasNoExpiry)"},
@@ -823,7 +823,7 @@ func CreateGenericCommandTests(batch *pipeline.ClusterBatch, isAtomic bool, serv
 
 	batch.Set(slotHashedKey1, "value1")
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "Set(slotHashedKey1, value1)"})
-	batch.Expire(slotHashedKey1, 100)
+	batch.Expire(slotHashedKey1, 100*time.Second)
 	testData = append(testData, CommandTestData{ExpectedResponse: true, TestName: "Expire(slotHashedKey1, 100)"})
 	batch.Persist(slotHashedKey1)
 	testData = append(testData, CommandTestData{ExpectedResponse: true, TestName: "Persist(slotHashedKey1)"})

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3447,7 +3447,7 @@ func (suite *GlideTestSuite) TestExpire() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		result, err := client.Expire(context.Background(), key, 1)
+		result, err := client.Expire(context.Background(), key, 1*time.Second)
 		assert.Nil(suite.T(), err, "Expected no error from Expire command")
 		assert.True(suite.T(), result, "Expire command should return true when expiry is set")
 
@@ -3463,7 +3463,7 @@ func (suite *GlideTestSuite) TestExpire_KeyDoesNotExist() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()
 		// Trying to set an expiry on a non-existent key
-		result, err := client.Expire(context.Background(), key, 1)
+		result, err := client.Expire(context.Background(), key, 1*time.Second)
 		assert.Nil(suite.T(), err)
 		assert.False(suite.T(), result)
 	})
@@ -3477,7 +3477,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		result, err := client.ExpireWithOptions(context.Background(), key, 2, constants.HasNoExpiry)
+		result, err := client.ExpireWithOptions(context.Background(), key, 2*time.Second, constants.HasNoExpiry)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), result)
 
@@ -3487,7 +3487,7 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasNoExpiry() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "", resultGet.Value())
 
-		result, err = client.ExpireWithOptions(context.Background(), key, 1, constants.HasNoExpiry)
+		result, err = client.ExpireWithOptions(context.Background(), key, 1*time.Second, constants.HasNoExpiry)
 		assert.Nil(suite.T(), err)
 		assert.False(suite.T(), result)
 	})
@@ -3501,11 +3501,11 @@ func (suite *GlideTestSuite) TestExpireWithOptions_HasExistingExpiry() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resexp, err := client.ExpireWithOptions(context.Background(), key, 20, constants.HasNoExpiry)
+		resexp, err := client.ExpireWithOptions(context.Background(), key, 20*time.Second, constants.HasNoExpiry)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resexp)
 
-		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 1, constants.HasExistingExpiry)
+		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 1*time.Second, constants.HasExistingExpiry)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
@@ -3525,11 +3525,11 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryGreaterThanCurrent()
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 2, constants.HasNoExpiry)
+		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 2*time.Second, constants.HasNoExpiry)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 5, constants.NewExpiryGreaterThanCurrent)
+		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 5*time.Second, constants.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 		time.Sleep(6 * time.Second)
@@ -3547,16 +3547,16 @@ func (suite *GlideTestSuite) TestExpireWithOptions_NewExpiryLessThanCurrent() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 10, constants.HasNoExpiry)
+		resultExpire, err := client.ExpireWithOptions(context.Background(), key, 10*time.Second, constants.HasNoExpiry)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 5, constants.NewExpiryLessThanCurrent)
+		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 5*time.Second, constants.NewExpiryLessThanCurrent)
 		assert.Nil(suite.T(), err)
 
 		assert.True(suite.T(), resultExpire)
 
-		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 15, constants.NewExpiryGreaterThanCurrent)
+		resultExpire, err = client.ExpireWithOptions(context.Background(), key, 15*time.Second, constants.NewExpiryGreaterThanCurrent)
 		assert.Nil(suite.T(), err)
 
 		assert.True(suite.T(), resultExpire)
@@ -3575,7 +3575,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
+		futureTimestamp := time.Now().Add(10 * time.Second)
 
 		resultExpire, err := client.ExpireAtWithOptions(context.Background(), key, futureTimestamp, constants.HasNoExpiry)
 		assert.Nil(suite.T(), err)
@@ -3586,7 +3586,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasNoExpiry() {
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(
 			context.Background(),
 			key,
-			futureTimestamp+10,
+			futureTimestamp.Add(10),
 			constants.HasNoExpiry,
 		)
 		assert.Nil(suite.T(), err)
@@ -3601,7 +3601,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
+		futureTimestamp := time.Now().Add(10 * time.Second)
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpireAt)
@@ -3609,7 +3609,7 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_HasExistingExpiry() {
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(
 			context.Background(),
 			key,
-			futureTimestamp+10,
+			futureTimestamp.Add(10),
 			constants.HasExistingExpiry,
 		)
 		assert.Nil(suite.T(), err)
@@ -3625,12 +3625,12 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryGreaterThanCurrent
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
+		futureTimestamp := time.Now().Add(10 * time.Second)
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpireAt)
 
-		newFutureTimestamp := time.Now().Add(20 * time.Second).Unix()
+		newFutureTimestamp := time.Now().Add(20 * time.Second)
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(context.Background(),
 			key,
 			newFutureTimestamp,
@@ -3649,12 +3649,12 @@ func (suite *GlideTestSuite) TestExpireAtWithOptions_NewExpiryLessThanCurrent() 
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		futureTimestamp := time.Now().Add(10 * time.Second).Unix()
+		futureTimestamp := time.Now().Add(10 * time.Second)
 		resultExpireAt, err := client.ExpireAt(context.Background(), key, futureTimestamp)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpireAt)
 
-		newFutureTimestamp := time.Now().Add(5 * time.Second).Unix()
+		newFutureTimestamp := time.Now().Add(5 * time.Second)
 		resultExpireWithOptions, err := client.ExpireAtWithOptions(
 			context.Background(),
 			key,
@@ -3698,17 +3698,16 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasExistingExpiry() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		initialExpire := 500
-		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
+		resultExpire, err := client.PExpire(context.Background(), key, 500*time.Millisecond)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		newExpire := 1000
+		newExpire := 1000 * time.Millisecond
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(
 			context.Background(),
 			key,
-			int64(newExpire),
+			newExpire,
 			constants.HasExistingExpiry,
 		)
 		assert.Nil(suite.T(), err)
@@ -3729,12 +3728,12 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_HasNoExpiry() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		newExpire := 500
+		newExpire := 500 * time.Millisecond
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(
 			context.Background(),
 			key,
-			int64(newExpire),
+			newExpire,
 			constants.HasNoExpiry,
 		)
 		assert.Nil(suite.T(), err)
@@ -3755,17 +3754,16 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryGreaterThanCurrent(
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		initialExpire := 500
-		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
+		resultExpire, err := client.PExpire(context.Background(), key, 500*time.Millisecond)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		newExpire := 1000
+		newExpire := 1000 * time.Millisecond
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(
 			context.Background(),
 			key,
-			int64(newExpire),
+			newExpire,
 			constants.NewExpiryGreaterThanCurrent,
 		)
 		assert.Nil(suite.T(), err)
@@ -3786,17 +3784,16 @@ func (suite *GlideTestSuite) TestPExpireWithOptions_NewExpiryLessThanCurrent() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		initialExpire := 500
-		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
+		resultExpire, err := client.PExpire(context.Background(), key, 500*time.Millisecond)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		newExpire := 200
+		newExpire := 200 * time.Millisecond
 
 		resultExpireWithOptions, err := client.PExpireWithOptions(
 			context.Background(),
 			key,
-			int64(newExpire),
+			newExpire,
 			constants.NewExpiryLessThanCurrent,
 		)
 		assert.Nil(suite.T(), err)
@@ -3815,7 +3812,7 @@ func (suite *GlideTestSuite) TestPExpireAt() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		expireAfterMilliseconds := time.Now().Unix() * 1000
+		expireAfterMilliseconds := time.Now().Add(1000 * time.Millisecond)
 		resultPExpireAt, err := client.PExpireAt(context.Background(), key, expireAfterMilliseconds)
 		assert.Nil(suite.T(), err)
 
@@ -3837,7 +3834,7 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasNoExpiry() {
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		timestamp := time.Now().Unix() * 1000
+		timestamp := time.Now().Add(1000 * time.Millisecond)
 		result, err := client.PExpireAtWithOptions(context.Background(), key, timestamp, constants.HasNoExpiry)
 
 		assert.Nil(suite.T(), err)
@@ -3857,11 +3854,10 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_HasExistingExpiry() {
 		value := uuid.New().String()
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
-		initialExpire := 500
-		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
+		resultExpire, err := client.PExpire(context.Background(), key, 500*time.Millisecond)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
-		newExpire := time.Now().Unix()*1000 + 1000
+		newExpire := time.Now().Add(1000 * time.Millisecond)
 
 		resultExpireWithOptions, err := client.PExpireAtWithOptions(
 			context.Background(),
@@ -3887,12 +3883,12 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryGreaterThanCurren
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		initialExpire := time.Now().UnixMilli() + 1000
+		initialExpire := time.Now().Add(1000 * time.Millisecond)
 		resultExpire, err := client.PExpireAt(context.Background(), key, initialExpire)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		newExpire := time.Now().UnixMilli() + 2000
+		newExpire := time.Now().Add(2000 * time.Millisecond)
 
 		resultExpireWithOptions, err := client.PExpireAtWithOptions(
 			context.Background(),
@@ -3918,12 +3914,11 @@ func (suite *GlideTestSuite) TestPExpireAtWithOptions_NewExpiryLessThanCurrent()
 
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		initialExpire := 1000
-		resultExpire, err := client.PExpire(context.Background(), key, int64(initialExpire))
+		resultExpire, err := client.PExpire(context.Background(), key, 1000*time.Millisecond)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpire)
 
-		newExpire := time.Now().Unix()*1000 + 500
+		newExpire := time.Now().Add(500 * time.Millisecond)
 
 		resultExpireWithOptions, err := client.PExpireAtWithOptions(
 			context.Background(),
@@ -3954,14 +3949,14 @@ func (suite *GlideTestSuite) TestExpireTime() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), value, result.Value())
 
-		expireTime := time.Now().Unix() + 3
+		expireTime := time.Now().Add(3 * time.Second)
 		resultExpAt, err := client.ExpireAt(context.Background(), key, expireTime)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpAt)
 
 		resexptime, err := client.ExpireTime(context.Background(), key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), expireTime, resexptime)
+		assert.Equal(suite.T(), expireTime.Unix(), resexptime)
 
 		time.Sleep(4 * time.Second)
 
@@ -3995,14 +3990,14 @@ func (suite *GlideTestSuite) TestPExpireTime() {
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), value, result.Value())
 
-		pexpireTime := time.Now().UnixMilli() + 3000
+		pexpireTime := time.Now().Add(3000 * time.Millisecond)
 		resultExpAt, err := client.PExpireAt(context.Background(), key, pexpireTime)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resultExpAt)
 
 		respexptime, err := client.PExpireTime(context.Background(), key)
 		assert.Nil(suite.T(), err)
-		assert.Equal(suite.T(), pexpireTime, respexptime)
+		assert.Equal(suite.T(), pexpireTime.UnixMilli(), respexptime)
 
 		time.Sleep(4 * time.Second)
 
@@ -4057,7 +4052,7 @@ func (suite *GlideTestSuite) TestTTL_WithValidKey() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resExpire, err := client.Expire(context.Background(), key, 1)
+		resExpire, err := client.Expire(context.Background(), key, 1*time.Second)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resExpire)
 		resTTL, err := client.TTL(context.Background(), key)
@@ -4072,7 +4067,7 @@ func (suite *GlideTestSuite) TestTTL_WithExpiredKey() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resExpire, err := client.Expire(context.Background(), key, 1)
+		resExpire, err := client.Expire(context.Background(), key, 1*time.Second)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resExpire)
 
@@ -4090,7 +4085,7 @@ func (suite *GlideTestSuite) TestPTTL_WithValidKey() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resExpire, err := client.Expire(context.Background(), key, 1)
+		resExpire, err := client.Expire(context.Background(), key, 1*time.Second)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resExpire)
 
@@ -4106,7 +4101,7 @@ func (suite *GlideTestSuite) TestPTTL_WithExpiredKey() {
 		value := uuid.New().String()
 		suite.verifyOK(client.Set(context.Background(), key, value))
 
-		resExpire, err := client.Expire(context.Background(), key, 1)
+		resExpire, err := client.Expire(context.Background(), key, 1*time.Second)
 		assert.Nil(suite.T(), err)
 		assert.True(suite.T(), resExpire)
 
@@ -5930,7 +5925,7 @@ func (suite *GlideTestSuite) TestPersist() {
 		keyName := "{keyName}" + uuid.NewString()
 		t := suite.T()
 		suite.verifyOK(client.Set(context.Background(), keyName, initialValue))
-		resultExpire, err := client.Expire(context.Background(), keyName, 300)
+		resultExpire, err := client.Expire(context.Background(), keyName, 300*time.Second)
 		assert.Nil(t, err)
 		assert.True(t, resultExpire)
 		resultPersist, err := client.Persist(context.Background(), keyName)
@@ -7042,7 +7037,7 @@ func (suite *GlideTestSuite) TestDumpRestore() {
 		deletedCount, err := client.Del(context.Background(), []string{key})
 		assert.Nil(t, err)
 		assert.Equal(t, int64(1), deletedCount)
-		result_test1, err := client.Restore(context.Background(), key, int64(0), resultDump.Value())
+		result_test1, err := client.Restore(context.Background(), key, 0, resultDump.Value())
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "OK", result_test1)
 		resultGetRestoreKey, err := client.Get(context.Background(), key)
@@ -7073,7 +7068,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Nil(t, err)
 		assert.Equal(t, int64(1), deletedCount)
 		optsReplace := options.NewRestoreOptions().SetReplace()
-		result_test1, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *optsReplace)
+		result_test1, err := client.RestoreWithOptions(context.Background(), key, 0, resultDump.Value(), *optsReplace)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "OK", result_test1)
 		resultGetRestoreKey, err := client.Get(context.Background(), key)
@@ -7085,7 +7080,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Nil(t, err)
 		assert.Equal(t, int64(1), delete_test2)
 		opts_test2 := options.NewRestoreOptions().SetABSTTL()
-		result_test2, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *opts_test2)
+		result_test2, err := client.RestoreWithOptions(context.Background(), key, 0, resultDump.Value(), *opts_test2)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "OK", result_test2)
 		resultGet_test2, err := client.Get(context.Background(), key)
@@ -7097,7 +7092,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Nil(t, err)
 		assert.Equal(t, int64(1), delete_test3)
 		opts_test3 := options.NewRestoreOptions().SetEviction(constants.FREQ, 10)
-		result_test3, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *opts_test3)
+		result_test3, err := client.RestoreWithOptions(context.Background(), key, 0, resultDump.Value(), *opts_test3)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "OK", result_test3)
 		resultGet_test3, err := client.Get(context.Background(), key)
@@ -7109,7 +7104,7 @@ func (suite *GlideTestSuite) TestRestoreWithOptions() {
 		assert.Nil(t, err)
 		assert.Equal(t, int64(1), delete_test4)
 		opts_test4 := options.NewRestoreOptions().SetEviction(constants.IDLETIME, 10)
-		result_test4, err := client.RestoreWithOptions(context.Background(), key, int64(0), resultDump.Value(), *opts_test4)
+		result_test4, err := client.RestoreWithOptions(context.Background(), key, 0, resultDump.Value(), *opts_test4)
 		assert.Nil(suite.T(), err)
 		assert.Equal(suite.T(), "OK", result_test4)
 		resultGet_test4, err := client.Get(context.Background(), key)
@@ -8190,12 +8185,12 @@ func (suite *GlideTestSuite) TestWait() {
 		key := uuid.New().String()
 		client.Set(context.Background(), key, "test")
 		// Test 1:  numberOfReplicas (2)
-		resultInt64, err := client.Wait(context.Background(), 2, 2000)
+		resultInt64, err := client.Wait(context.Background(), 2, 2000*time.Millisecond)
 		assert.NoError(suite.T(), err)
 		assert.True(suite.T(), resultInt64 >= 2)
 
 		// Test 2: Invalid timeout (negative)
-		_, err = client.Wait(context.Background(), 2, -1)
+		_, err = client.Wait(context.Background(), 2, -1*time.Millisecond)
 
 		// Assert error and message for invalid timeout
 		assert.NotNil(suite.T(), err)
@@ -8572,7 +8567,7 @@ func (suite *GlideTestSuite) TestXPendingAndXClaim() {
 			key,
 			groupName,
 			consumer1,
-			int64(0),
+			0,
 			[]string{streamid_3.Value(), streamid_5.Value()},
 		)
 		assert.NoError(suite.T(), err)
@@ -8586,7 +8581,7 @@ func (suite *GlideTestSuite) TestXPendingAndXClaim() {
 			key,
 			groupName,
 			consumer1,
-			int64(0),
+			0,
 			[]string{streamid_3.Value(), streamid_5.Value()},
 		)
 		assert.NoError(suite.T(), err)
@@ -8601,7 +8596,7 @@ func (suite *GlideTestSuite) TestXPendingAndXClaim() {
 			key,
 			groupName,
 			consumer1,
-			int64(0),
+			0,
 			[]string{streamid_6.Value()},
 			*options.NewXClaimOptions().SetForce().SetRetryCount(99),
 		)
@@ -8688,18 +8683,18 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		assert.NotNil(suite.T(), readGroupResult)
 
 		// claim with invalid stream entry IDs
-		_, err = client.XClaimJustId(context.Background(), key, groupName, consumer1, int64(1), []string{"invalid-stream-id"})
+		_, err = client.XClaimJustId(context.Background(), key, groupName, consumer1, 1*time.Millisecond, []string{"invalid-stream-id"})
 		assert.Error(suite.T(), err)
 		assert.IsType(suite.T(), &errors.RequestError{}, err)
 
 		// claim with empty stream entry IDs returns empty map
-		claimResult, err := client.XClaimJustId(context.Background(), key, groupName, consumer1, int64(1), []string{})
+		claimResult, err := client.XClaimJustId(context.Background(), key, groupName, consumer1, 1*time.Millisecond, []string{})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), []string{}, claimResult)
 
 		// non existent key causes a RequestError
 		claimOptions := options.NewXClaimOptions().SetIdleTime(1)
-		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
+		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, 1*time.Millisecond, []string{streamid_1.Value()})
 		assert.Error(suite.T(), err)
 		assert.IsType(suite.T(), &errors.RequestError{}, err)
 		assert.Contains(suite.T(), err.Error(), "NOGROUP")
@@ -8708,7 +8703,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			stringKey,
 			groupName,
 			consumer1,
-			int64(1),
+			1*time.Millisecond,
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
@@ -8721,7 +8716,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			stringKey,
 			groupName,
 			consumer1,
-			int64(1),
+			1*time.Millisecond,
 			[]string{streamid_1.Value()},
 		)
 		assert.Error(suite.T(), err)
@@ -8732,7 +8727,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			stringKey,
 			groupName,
 			consumer1,
-			int64(1),
+			1*time.Millisecond,
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
@@ -8743,7 +8738,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 		// key exists, but is not a stream
 		_, err = client.Set(context.Background(), stringKey, "test")
 		assert.NoError(suite.T(), err)
-		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, int64(1), []string{streamid_1.Value()})
+		_, err = client.XClaim(context.Background(), stringKey, groupName, consumer1, 1*time.Millisecond, []string{streamid_1.Value()})
 		assert.Error(suite.T(), err)
 		assert.IsType(suite.T(), &errors.RequestError{}, err)
 
@@ -8751,7 +8746,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			stringKey,
 			groupName,
 			consumer1,
-			int64(1),
+			1*time.Millisecond,
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)
@@ -8763,7 +8758,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			stringKey,
 			groupName,
 			consumer1,
-			int64(1),
+			1*time.Millisecond,
 			[]string{streamid_1.Value()},
 		)
 		assert.Error(suite.T(), err)
@@ -8773,7 +8768,7 @@ func (suite *GlideTestSuite) TestXClaimFailure() {
 			stringKey,
 			groupName,
 			consumer1,
-			int64(1),
+			1*time.Millisecond,
 			[]string{streamid_1.Value()},
 			*claimOptions,
 		)

--- a/go/internal/interfaces/generic_base_commands.go
+++ b/go/internal/interfaces/generic_base_commands.go
@@ -4,6 +4,7 @@ package interfaces
 
 import (
 	"context"
+	"time"
 
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
@@ -20,34 +21,34 @@ type GenericBaseCommands interface {
 
 	Exists(ctx context.Context, keys []string) (int64, error)
 
-	Expire(ctx context.Context, key string, seconds int64) (bool, error)
+	Expire(ctx context.Context, key string, expireTime time.Duration) (bool, error)
 
-	ExpireWithOptions(ctx context.Context, key string, seconds int64, expireCondition constants.ExpireCondition) (bool, error)
+	ExpireWithOptions(ctx context.Context, key string, expireTime time.Duration, expireCondition constants.ExpireCondition) (bool, error)
 
-	ExpireAt(ctx context.Context, key string, unixTimestampInSeconds int64) (bool, error)
+	ExpireAt(ctx context.Context, key string, expireTime time.Time) (bool, error)
 
 	ExpireAtWithOptions(
 		ctx context.Context,
 		key string,
-		unixTimestampInSeconds int64,
+		expireTime time.Time,
 		expireCondition constants.ExpireCondition,
 	) (bool, error)
 
-	PExpire(ctx context.Context, key string, milliseconds int64) (bool, error)
+	PExpire(ctx context.Context, key string, expireTime time.Duration) (bool, error)
 
 	PExpireWithOptions(
 		ctx context.Context,
 		key string,
-		milliseconds int64,
+		expireTime time.Duration,
 		expireCondition constants.ExpireCondition,
 	) (bool, error)
 
-	PExpireAt(ctx context.Context, key string, unixTimestampInMilliSeconds int64) (bool, error)
+	PExpireAt(ctx context.Context, key string, expireTime time.Time) (bool, error)
 
 	PExpireAtWithOptions(
 		ctx context.Context,
 		key string,
-		unixTimestampInMilliSeconds int64,
+		expireTime time.Time,
 		expireCondition constants.ExpireCondition,
 	) (bool, error)
 
@@ -71,9 +72,9 @@ type GenericBaseCommands interface {
 
 	Persist(ctx context.Context, key string) (bool, error)
 
-	Restore(ctx context.Context, key string, ttl int64, value string) (string, error)
+	Restore(ctx context.Context, key string, ttl time.Duration, value string) (string, error)
 
-	RestoreWithOptions(ctx context.Context, key string, ttl int64, value string, option options.RestoreOptions) (string, error)
+	RestoreWithOptions(ctx context.Context, key string, ttl time.Duration, value string, option options.RestoreOptions) (string, error)
 
 	ObjectEncoding(ctx context.Context, key string) (models.Result[string], error)
 
@@ -97,7 +98,7 @@ type GenericBaseCommands interface {
 
 	SortReadOnlyWithOptions(ctx context.Context, key string, sortOptions options.SortOptions) ([]models.Result[string], error)
 
-	Wait(ctx context.Context, numberOfReplicas int64, timeout int64) (int64, error)
+	Wait(ctx context.Context, numberOfReplicas int64, timeout time.Duration) (int64, error)
 
 	Copy(ctx context.Context, source string, destination string) (bool, error)
 

--- a/go/internal/interfaces/stream_commands.go
+++ b/go/internal/interfaces/stream_commands.go
@@ -4,6 +4,7 @@ package interfaces
 
 import (
 	"context"
+	"time"
 
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
@@ -33,7 +34,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		start string,
 	) (models.XAutoClaimResponse, error)
 
@@ -42,7 +43,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		start string,
 		options options.XAutoClaimOptions,
 	) (models.XAutoClaimResponse, error)
@@ -52,7 +53,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		start string,
 	) (models.XAutoClaimJustIdResponse, error)
 
@@ -61,7 +62,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		start string,
 		options options.XAutoClaimOptions,
 	) (models.XAutoClaimJustIdResponse, error)
@@ -133,7 +134,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		ids []string,
 	) (map[string]models.XClaimResponse, error)
 
@@ -142,7 +143,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		ids []string,
 		options options.XClaimOptions,
 	) (map[string]models.XClaimResponse, error)
@@ -152,7 +153,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		ids []string,
 	) ([]string, error)
 
@@ -161,7 +162,7 @@ type StreamCommands interface {
 		key string,
 		group string,
 		consumer string,
-		minIdleTime int64,
+		minIdleTime time.Duration,
 		ids []string,
 		options options.XClaimOptions,
 	) ([]string, error)

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -2036,7 +2036,7 @@ func (b *BaseBatch[T]) Exists(keys []string) *T {
 // Sets a timeout on key. After the timeout has expired, the key will automatically be deleted.
 //
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -2044,7 +2044,7 @@ func (b *BaseBatch[T]) Exists(keys []string) *T {
 // Parameters:
 //
 //	key - The key to expire.
-//	seconds - Time in seconds for the key to expire
+//	expireTime - Duration for the key to expire
 //
 // Command Response:
 //
@@ -2052,14 +2052,14 @@ func (b *BaseBatch[T]) Exists(keys []string) *T {
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/expire/
-func (b *BaseBatch[T]) Expire(key string, seconds int64) *T {
-	return b.addCmdAndTypeChecker(C.Expire, []string{key, utils.IntToString(seconds)}, reflect.Bool, false)
+func (b *BaseBatch[T]) Expire(key string, expireTime time.Duration) *T {
+	return b.addCmdAndTypeChecker(C.Expire, []string{key, utils.FloatToString(expireTime.Seconds())}, reflect.Bool, false)
 }
 
 // Sets a timeout on key. After the timeout has expired, the key will automatically be deleted.
 //
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -2067,7 +2067,7 @@ func (b *BaseBatch[T]) Expire(key string, seconds int64) *T {
 // Parameters:
 //
 //	key - The key to expire.
-//	seconds - Time in seconds for the key to expire.
+//	expireTime - Duration for the key to expire.
 //	expireCondition - The option to set expiry, see [constants.ExpireCondition].
 //
 // Command Response:
@@ -2076,12 +2076,12 @@ func (b *BaseBatch[T]) Expire(key string, seconds int64) *T {
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/expire/
-func (b *BaseBatch[T]) ExpireWithOptions(key string, seconds int64, expireCondition constants.ExpireCondition) *T {
+func (b *BaseBatch[T]) ExpireWithOptions(key string, expireTime time.Duration, expireCondition constants.ExpireCondition) *T {
 	expireConditionStr, err := expireCondition.ToString()
 	if err != nil {
 		return b.addError("ExpireWithOptions", err)
 	}
-	return b.addCmdAndTypeChecker(C.Expire, []string{key, utils.IntToString(seconds), expireConditionStr}, reflect.Bool, false)
+	return b.addCmdAndTypeChecker(C.Expire, []string{key, utils.FloatToString(expireTime.Seconds()), expireConditionStr}, reflect.Bool, false)
 }
 
 // Sets a timeout on key using an absolute Unix timestamp. It takes an absolute Unix timestamp (seconds since January 1, 1970)
@@ -2090,7 +2090,7 @@ func (b *BaseBatch[T]) ExpireWithOptions(key string, seconds int64, expireCondit
 // If key already has an existing expire set, the time to live is updated to the new value.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -2098,7 +2098,7 @@ func (b *BaseBatch[T]) ExpireWithOptions(key string, seconds int64, expireCondit
 // Parameters:
 //
 //	key - The key to expire.
-//	unixTimestampInSeconds - Absolute Unix timestamp
+//	expireTime - The timestamp for expiry.
 //
 // Command Response:
 //
@@ -2106,8 +2106,8 @@ func (b *BaseBatch[T]) ExpireWithOptions(key string, seconds int64, expireCondit
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/expireat/
-func (b *BaseBatch[T]) ExpireAt(key string, unixTimestampInSeconds int64) *T {
-	return b.addCmdAndTypeChecker(C.ExpireAt, []string{key, utils.IntToString(unixTimestampInSeconds)}, reflect.Bool, false)
+func (b *BaseBatch[T]) ExpireAt(key string, expireTime time.Time) *T {
+	return b.addCmdAndTypeChecker(C.ExpireAt, []string{key, utils.IntToString(expireTime.Unix())}, reflect.Bool, false)
 }
 
 // Sets a timeout on key using an absolute Unix timestamp. It takes an absolute Unix timestamp (seconds since January 1, 1970)
@@ -2116,7 +2116,7 @@ func (b *BaseBatch[T]) ExpireAt(key string, unixTimestampInSeconds int64) *T {
 // If key already has an existing expire set, the time to live is updated to the new value.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If seconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -2124,7 +2124,7 @@ func (b *BaseBatch[T]) ExpireAt(key string, unixTimestampInSeconds int64) *T {
 // Parameters:
 //
 //	key - The key to expire.
-//	unixTimestampInSeconds - Absolute Unix timestamp.
+//	expireTime - The timestamp for expiry.
 //	expireCondition - The option to set expiry - see [constants.ExpireCondition].
 //
 // Command Response:
@@ -2135,7 +2135,7 @@ func (b *BaseBatch[T]) ExpireAt(key string, unixTimestampInSeconds int64) *T {
 // [valkey.io]: https://valkey.io/commands/expireat/
 func (b *BaseBatch[T]) ExpireAtWithOptions(
 	key string,
-	unixTimestampInSeconds int64,
+	expireTime time.Time,
 	expireCondition constants.ExpireCondition,
 ) *T {
 	expireConditionStr, err := expireCondition.ToString()
@@ -2144,7 +2144,7 @@ func (b *BaseBatch[T]) ExpireAtWithOptions(
 	}
 	return b.addCmdAndTypeChecker(
 		C.ExpireAt,
-		[]string{key, utils.IntToString(unixTimestampInSeconds), expireConditionStr},
+		[]string{key, utils.IntToString(expireTime.Unix()), expireConditionStr},
 		reflect.Bool,
 		false,
 	)
@@ -2152,7 +2152,7 @@ func (b *BaseBatch[T]) ExpireAtWithOptions(
 
 // Sets a timeout on key in milliseconds. After the timeout has expired, the key will automatically be deleted.
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If milliseconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -2160,7 +2160,7 @@ func (b *BaseBatch[T]) ExpireAtWithOptions(
 // Parameters:
 //
 //	key - The key to set timeout on it.
-//	milliseconds - The timeout in milliseconds.
+//	expireTime - Duration for the key to expire.
 //
 // Command Response:
 //
@@ -2168,13 +2168,13 @@ func (b *BaseBatch[T]) ExpireAtWithOptions(
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/pexpire/
-func (b *BaseBatch[T]) PExpire(key string, milliseconds int64) *T {
-	return b.addCmdAndTypeChecker(C.PExpire, []string{key, utils.IntToString(milliseconds)}, reflect.Bool, false)
+func (b *BaseBatch[T]) PExpire(key string, expireTime time.Duration) *T {
+	return b.addCmdAndTypeChecker(C.PExpire, []string{key, utils.IntToString(expireTime.Milliseconds())}, reflect.Bool, false)
 }
 
 // Sets a timeout on key in milliseconds. After the timeout has expired, the key will automatically be deleted.
 // If key already has an existing expire set, the time to live is updated to the new value.
-// If milliseconds is a non-positive number, the key will be deleted rather than expired.
+// If expireTime is a non-positive number, the key will be deleted rather than expired.
 // The timeout will only be cleared by commands that delete or overwrite the contents of key.
 //
 // See [valkey.io] for details.
@@ -2182,7 +2182,7 @@ func (b *BaseBatch[T]) PExpire(key string, milliseconds int64) *T {
 // Parameters:
 //
 //	key - The key to set timeout on it.
-//	milliseconds - The timeout in milliseconds.
+//	expireTime - Duration for the key to expire.
 //	expireCondition - The option to set expiry, see [constants.ExpireCondition].
 //
 // Command Response:
@@ -2191,14 +2191,14 @@ func (b *BaseBatch[T]) PExpire(key string, milliseconds int64) *T {
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/pexpire/
-func (b *BaseBatch[T]) PExpireWithOptions(key string, milliseconds int64, expireCondition constants.ExpireCondition) *T {
+func (b *BaseBatch[T]) PExpireWithOptions(key string, expireTime time.Duration, expireCondition constants.ExpireCondition) *T {
 	expireConditionStr, err := expireCondition.ToString()
 	if err != nil {
 		return b.addError("PExpireWithOptions", err)
 	}
 	return b.addCmdAndTypeChecker(
 		C.PExpire,
-		[]string{key, utils.IntToString(milliseconds), expireConditionStr},
+		[]string{key, utils.IntToString(expireTime.Milliseconds()), expireConditionStr},
 		reflect.Bool,
 		false,
 	)
@@ -2215,7 +2215,7 @@ func (b *BaseBatch[T]) PExpireWithOptions(key string, milliseconds int64, expire
 // Parameters:
 //
 //	key - The key to set timeout on it.
-//	unixTimestampInMilliSeconds - The timeout in an absolute Unix timestamp.
+//	expireTime - The timestamp for expiry.
 //
 // Command Response:
 //
@@ -2223,10 +2223,10 @@ func (b *BaseBatch[T]) PExpireWithOptions(key string, milliseconds int64, expire
 //	or operation skipped due to the provided arguments.
 //
 // [valkey.io]: https://valkey.io/commands/pexpireat/
-func (b *BaseBatch[T]) PExpireAt(key string, unixTimestampInMilliSeconds int64) *T {
+func (b *BaseBatch[T]) PExpireAt(key string, expireTime time.Time) *T {
 	return b.addCmdAndTypeChecker(
 		C.PExpireAt,
-		[]string{key, utils.IntToString(unixTimestampInMilliSeconds)},
+		[]string{key, utils.IntToString(expireTime.UnixMilli())},
 		reflect.Bool,
 		false,
 	)
@@ -2243,7 +2243,7 @@ func (b *BaseBatch[T]) PExpireAt(key string, unixTimestampInMilliSeconds int64) 
 // Parameters:
 //
 //	key - The key to set timeout on it.
-//	unixTimestampInMilliSeconds - The timeout in an absolute Unix timestamp.
+//	expireTime - The timestamp for expiry.
 //	expireCondition - The option to set expiry, see [constants.ExpireCondition].
 //
 // Command Response:
@@ -2254,7 +2254,7 @@ func (b *BaseBatch[T]) PExpireAt(key string, unixTimestampInMilliSeconds int64) 
 // [valkey.io]: https://valkey.io/commands/pexpireat/
 func (b *BaseBatch[T]) PExpireAtWithOptions(
 	key string,
-	unixTimestampInMilliSeconds int64,
+	expireTime time.Time,
 	expireCondition constants.ExpireCondition,
 ) *T {
 	expireConditionStr, err := expireCondition.ToString()
@@ -2263,7 +2263,7 @@ func (b *BaseBatch[T]) PExpireAtWithOptions(
 	}
 	return b.addCmdAndTypeChecker(
 		C.PExpireAt,
-		[]string{key, utils.IntToString(unixTimestampInMilliSeconds), expireConditionStr},
+		[]string{key, utils.IntToString(expireTime.UnixMilli()), expireConditionStr},
 		reflect.Bool,
 		false,
 	)
@@ -3330,7 +3330,7 @@ func (b *BaseBatch[T]) XLen(key string) *T {
 //	    These IDs are deleted from the Pending Entries List.
 //
 // [valkey.io]: https://valkey.io/commands/xautoclaim/
-func (b *BaseBatch[T]) XAutoClaim(key string, group string, consumer string, minIdleTime int64, start string) *T {
+func (b *BaseBatch[T]) XAutoClaim(key string, group string, consumer string, minIdleTime time.Duration, start string) *T {
 	return b.XAutoClaimWithOptions(key, group, consumer, minIdleTime, start, *options.NewXAutoClaimOptions())
 }
 
@@ -3367,11 +3367,11 @@ func (b *BaseBatch[T]) XAutoClaimWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	start string,
 	options options.XAutoClaimOptions,
 ) *T {
-	args := []string{key, group, consumer, utils.IntToString(minIdleTime), start}
+	args := []string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds()), start}
 	optArgs, err := options.ToArgs()
 	if err != nil {
 		return b.addError("XAutoClaimWithOptions", err)
@@ -3408,7 +3408,7 @@ func (b *BaseBatch[T]) XAutoClaimWithOptions(
 //	    These IDs are deleted from the Pending Entries List.
 //
 // [valkey.io]: https://valkey.io/commands/xautoclaim/
-func (b *BaseBatch[T]) XAutoClaimJustId(key string, group string, consumer string, minIdleTime int64, start string) *T {
+func (b *BaseBatch[T]) XAutoClaimJustId(key string, group string, consumer string, minIdleTime time.Duration, start string) *T {
 	return b.XAutoClaimJustIdWithOptions(key, group, consumer, minIdleTime, start, *options.NewXAutoClaimOptions())
 }
 
@@ -3445,11 +3445,11 @@ func (b *BaseBatch[T]) XAutoClaimJustIdWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	start string,
 	options options.XAutoClaimOptions,
 ) *T {
-	args := []string{key, group, consumer, utils.IntToString(minIdleTime), start}
+	args := []string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds()), start}
 	optArgs, err := options.ToArgs()
 	if err != nil {
 		return b.addError("XAutoClaimJustIdWithOptions", err)
@@ -3640,7 +3640,7 @@ func (b *BaseBatch[T]) XGroupCreateWithOptions(key string, group string, id stri
 // Parameters:
 //
 //	key - The key to create.
-//	ttl - The expiry time (in milliseconds). If `0`, the key will persist.
+//	ttl - The expiry time. If `0`, the key will persist.
 //	value - The serialized value to deserialize and assign to key.
 //
 // Command Response:
@@ -3648,7 +3648,7 @@ func (b *BaseBatch[T]) XGroupCreateWithOptions(key string, group string, id stri
 //	Return OK if successfully create a key with a value.
 //
 // [valkey.io]: https://valkey.io/commands/restore/
-func (b *BaseBatch[T]) Restore(key string, ttl int64, value string) *T {
+func (b *BaseBatch[T]) Restore(key string, ttl time.Duration, value string) *T {
 	return b.RestoreWithOptions(key, ttl, value, *options.NewRestoreOptions())
 }
 
@@ -3660,7 +3660,7 @@ func (b *BaseBatch[T]) Restore(key string, ttl int64, value string) *T {
 // Parameters:
 //
 //	key - The key to create.
-//	ttl - The expiry time (in milliseconds). If `0`, the key will persist.
+//	ttl - The expiry time. If `0`, the key will persist.
 //	value - The serialized value to deserialize and assign to key.
 //	restoreOptions - Set restore options with replace and absolute TTL modifiers, object idletime and frequency.
 //
@@ -3669,14 +3669,14 @@ func (b *BaseBatch[T]) Restore(key string, ttl int64, value string) *T {
 //	Return OK if successfully create a key with a value.
 //
 // [valkey.io]: https://valkey.io/commands/restore/
-func (b *BaseBatch[T]) RestoreWithOptions(key string, ttl int64, value string, restoreOptions options.RestoreOptions) *T {
+func (b *BaseBatch[T]) RestoreWithOptions(key string, ttl time.Duration, value string, restoreOptions options.RestoreOptions) *T {
 	optionArgs, err := restoreOptions.ToArgs()
 	if err != nil {
 		return b.addError("RestoreWithOptions", err)
 	}
 	return b.addCmdAndTypeChecker(C.Restore, append([]string{
 		key,
-		utils.IntToString(ttl), value,
+		utils.IntToString(ttl.Milliseconds()), value,
 	}, optionArgs...), reflect.String, false)
 }
 
@@ -4262,17 +4262,17 @@ func (b *BaseBatch[T]) GetBit(key string, offset int64) *T {
 // Parameters:
 //
 //	numberOfReplicas - The number of replicas to reach.
-//	timeout - The timeout value specified in milliseconds. A value of `0` will block indefinitely.
+//	timeout - The timeout value. A value of `0` will block indefinitely.
 //
 // Command Response:
 //
 //	The number of replicas reached by all the writes performed in the context of the current connection.
 //
 // [valkey.io]: https://valkey.io/commands/wait/
-func (b *BaseBatch[T]) Wait(numberOfReplicas int64, timeout int64) *T {
+func (b *BaseBatch[T]) Wait(numberOfReplicas int64, timeout time.Duration) *T {
 	return b.addCmdAndTypeChecker(
 		C.Wait,
-		[]string{utils.IntToString(numberOfReplicas), utils.IntToString(timeout)},
+		[]string{utils.IntToString(numberOfReplicas), utils.IntToString(timeout.Milliseconds())},
 		reflect.Int64,
 		false,
 	)
@@ -4369,7 +4369,7 @@ func (b *BaseBatch[T]) BitCountWithOptions(key string, opts options.BitCountOpti
 //	the consumer.
 //
 // [valkey.io]: https://valkey.io/commands/xclaim/
-func (b *BaseBatch[T]) XClaim(key string, group string, consumer string, minIdleTime int64, ids []string) *T {
+func (b *BaseBatch[T]) XClaim(key string, group string, consumer string, minIdleTime time.Duration, ids []string) *T {
 	return b.XClaimWithOptions(key, group, consumer, minIdleTime, ids, *options.NewXClaimOptions())
 }
 
@@ -4395,11 +4395,11 @@ func (b *BaseBatch[T]) XClaimWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	ids []string,
 	opts options.XClaimOptions,
 ) *T {
-	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime)}, ids...)
+	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds())}, ids...)
 	optionArgs, err := opts.ToArgs()
 	if err != nil {
 		return b.addError("XClaimWithOptions", err)
@@ -4427,7 +4427,7 @@ func (b *BaseBatch[T]) XClaimWithOptions(
 //	the consumer.
 //
 // [valkey.io]: https://valkey.io/commands/xclaim/
-func (b *BaseBatch[T]) XClaimJustId(key string, group string, consumer string, minIdleTime int64, ids []string) *T {
+func (b *BaseBatch[T]) XClaimJustId(key string, group string, consumer string, minIdleTime time.Duration, ids []string) *T {
 	return b.XClaimJustIdWithOptions(key, group, consumer, minIdleTime, ids, *options.NewXClaimOptions())
 }
 
@@ -4454,11 +4454,11 @@ func (b *BaseBatch[T]) XClaimJustIdWithOptions(
 	key string,
 	group string,
 	consumer string,
-	minIdleTime int64,
+	minIdleTime time.Duration,
 	ids []string,
 	opts options.XClaimOptions,
 ) *T {
-	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime)}, ids...)
+	args := append([]string{key, group, consumer, utils.IntToString(minIdleTime.Milliseconds())}, ids...)
 	optionArgs, err := opts.ToArgs()
 	if err != nil {
 		return b.addError("XClaimJustIdWithOptions", err)

--- a/go/stream_commands_test.go
+++ b/go/stream_commands_test.go
@@ -1353,7 +1353,7 @@ func ExampleClient_XClaim() {
 		return
 	}
 
-	response, err := client.XClaim(context.Background(), key, group, consumer2, result[0].IdleTime, []string{result[0].Id})
+	response, err := client.XClaim(context.Background(), key, group, consumer2, time.Duration(result[0].IdleTime)*time.Millisecond, []string{result[0].Id})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -1398,7 +1398,7 @@ func ExampleClusterClient_XClaim() {
 		return
 	}
 
-	response, err := client.XClaim(context.Background(), key, group, consumer2, result[0].IdleTime, []string{result[0].Id})
+	response, err := client.XClaim(context.Background(), key, group, consumer2, time.Duration(result[0].IdleTime)*time.Millisecond, []string{result[0].Id})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -1449,7 +1449,7 @@ func ExampleClient_XClaimWithOptions() {
 		key,
 		group,
 		consumer2,
-		result[0].IdleTime,
+		time.Duration(result[0].IdleTime)*time.Millisecond,
 		[]string{result[0].Id},
 		*opts,
 	)
@@ -1511,7 +1511,7 @@ func ExampleClusterClient_XClaimWithOptions() {
 		key,
 		group,
 		consumer2,
-		result[0].IdleTime,
+		time.Duration(result[0].IdleTime)*time.Millisecond,
 		[]string{result[0].Id},
 		*opts,
 	)
@@ -1558,7 +1558,7 @@ func ExampleClient_XClaimJustId() {
 		key,
 		group,
 		consumer2,
-		result[0].IdleTime,
+		time.Duration(result[0].IdleTime)*time.Millisecond,
 		[]string{result[0].Id},
 	)
 	if err != nil {
@@ -1604,7 +1604,7 @@ func ExampleClusterClient_XClaimJustId() {
 		key,
 		group,
 		consumer2,
-		result[0].IdleTime,
+		time.Duration(result[0].IdleTime)*time.Millisecond,
 		[]string{result[0].Id},
 	)
 	if err != nil {
@@ -1651,7 +1651,7 @@ func ExampleClient_XClaimJustIdWithOptions() {
 		key,
 		group,
 		consumer2,
-		result[0].IdleTime,
+		time.Duration(result[0].IdleTime)*time.Millisecond,
 		[]string{result[0].Id},
 		*opts,
 	)
@@ -1699,7 +1699,7 @@ func ExampleClusterClient_XClaimJustIdWithOptions() {
 		key,
 		group,
 		consumer2,
-		result[0].IdleTime,
+		time.Duration(result[0].IdleTime)*time.Millisecond,
 		[]string{result[0].Id},
 		*opts,
 	)


### PR DESCRIPTION
It makes more sense to keep it consistent for all the commands. By using `time.Duration` we make the commands more readable and easier for the user.

Modified Commands:
- Expire
- ExpireWithOptions
- ExpireAt
- ExpireAtWithOptions
- PExpire
- PExpireWithOptions
- PExpireAt
- PExpireAtWithOptions
- Restore
- RestoreWithOptions
- Wait
- XAutoClaim
- XAutoClaimWithOptions
- XAutoClaimJustId
- XAutoClaimJustIdWithOptions
- XClaim
- XClaimWithOptions
- XClaimJustId
- XClaimJustIdWithOptions

### Issue link

This Pull Request is linked to issue (URL): #4070, closes #4006

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
