### PR TITLE
Allow scheduling of full matrix tests for different branches

### DIFF
--- a/.github/workflows/full-matrix-tests-sweeper.yml
+++ b/.github/workflows/full-matrix-tests-sweeper.yml
@@ -1,0 +1,56 @@
+name: CI - Trigger periodic full matrix tests for relevant branches
+
+on:
+    workflow_dispatch:
+
+    schedule:
+        - cron: "0 0 * * *" # Runs daily at 00:00 UTC
+
+jobs:
+    trigger-full-matrix-tests:
+        runs-on: ubuntu-latest
+        if: github.repository_owner == 'valkey-io'
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Fetch relevant branches
+              id: get-branches
+              run: |
+                  # Currently run only for release-2.0 branch
+                  branches="release-2.0"
+                  echo "::set-output name=branches::$branches"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Trigger full-matrix-tests workflow
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const branches = "${{ steps.get-branches.outputs.branches }}".split(" ");
+                      const workflowFile = "full-matrix-tests.yml";
+
+                      const triggerWorkflow = async (branch) => {
+                        try {
+                          console.log(`Triggering workflow for branch: ${branch}`);
+                          await github.rest.actions.createWorkflowDispatch({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            workflow_id: workflowFile,
+                            ref: branch // The branch where workflow_dispatch is triggered
+                          });
+                          console.log(`Successfully triggered workflow for branch: ${branch}`);
+                        } catch (error) {
+                          core.setFailed(error.message);
+                        }
+                      };
+
+                      // Fire all workflow dispatch requests concurrently
+                      const promises = branches
+                        .filter(branch => branch) // Skip empty branches
+                        .map(branch => triggerWorkflow(branch));
+
+                      await Promise.allSettled(promises);
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/full-matrix-tests.yml
+++ b/.github/workflows/full-matrix-tests.yml
@@ -37,9 +37,6 @@ on:
                 type: boolean
                 default: true
 
-    schedule:
-        - cron: "0 3 * * *"
-
 concurrency:
     group: nightly-${{ github.head_ref || github.ref }}-${{ toJson(inputs) }}
     cancel-in-progress: true


### PR DESCRIPTION
Currently the full matrix tests can be scheduled only for main branch.
This PR utilizes the ORT sweeper technique to allow scheduling for different branches. 

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[] Tests are added or updated.~
-   ~[] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
