### PR TITLE
Add explicit run-modules-tests parameter to workflow_dispatch trigger of CI tests

### DIFF
--- a/.github/workflows/full-matrix-tests-sweeper.yml
+++ b/.github/workflows/full-matrix-tests-sweeper.yml
@@ -38,7 +38,10 @@ jobs:
                             owner: context.repo.owner,
                             repo: context.repo.repo,
                             workflow_id: workflowFile,
-                            ref: branch // The branch where workflow_dispatch is triggered
+                            ref: branch, // The branch where workflow_dispatch is triggered
+                            inputs: {
+                              'run-modules-tests': 'false' // Dont run modules tests
+                            }
                           });
                           console.log(`Successfully triggered workflow for branch: ${branch}`);
                         } catch (error) {

--- a/.github/workflows/full-matrix-tests.yml
+++ b/.github/workflows/full-matrix-tests.yml
@@ -7,6 +7,10 @@ on:
                 description: "Run the full engine and host matrix"
                 type: boolean
                 default: true
+            run-modules-tests:
+                description: "Run modules tests"
+                type: boolean
+                default: true
             # GHA supports up to 10 inputs, there is no option for multi-choice
             core:
                 description: "Test GLIDE core"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,10 @@ on:
                 required: false
                 type: string
                 description: "(Optional) Test run name"
+            run-modules-tests:
+                description: "Run modules tests"
+                type: boolean
+                default: false
 
     workflow_call:
 
@@ -269,7 +273,7 @@ jobs:
                       go/reports/**
 
     test-modules:
-        if: (github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch') || github.event.pull_request.head.repo.owner.login == 'valkey-io'
+        if: ((github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch' && github.event.inputs.run-modules-tests == 'true') || github.event.pull_request.head.repo.owner.login == 'valkey-io')
         environment: AWS_ACTIONS
         name: Modules Tests
         runs-on: [self-hosted, linux, ARM64, persistent]

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -43,6 +43,10 @@ on:
                 required: false
                 type: string
                 description: "(Optional) Test run name"
+            run-modules-tests:
+                description: "Run modules tests"
+                type: boolean
+                default: false
 
     workflow_call:
 
@@ -303,7 +307,7 @@ jobs:
               name: lint java rust
 
     test-modules:
-        if: (github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch') || github.event.pull_request.head.repo.owner.login == 'valkey-io'
+        if: ((github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch' && github.event.inputs.run-modules-tests == 'true') || github.event.pull_request.head.repo.owner.login == 'valkey-io')
         environment: AWS_ACTIONS
         name: Modules Tests
         runs-on: [self-hosted, linux, ARM64, persistent]

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -41,6 +41,10 @@ on:
                 required: false
                 type: string
                 description: "(Optional) Test run name"
+            run-modules-tests:
+                description: "Run modules tests"
+                type: boolean
+                default: false
 
     workflow_call:
 
@@ -385,7 +389,7 @@ jobs:
                       benchmarks/results/**
 
     test-modules:
-        if: (github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch') || github.event.pull_request.head.repo.owner.login == 'valkey-io'
+        if: ((github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch' && github.event.inputs.run-modules-tests == 'true') || github.event.pull_request.head.repo.owner.login == 'valkey-io')
         environment: AWS_ACTIONS
         name: Running Module Tests
         runs-on: [self-hosted, linux, ARM64, persistent]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,6 +47,10 @@ on:
                 required: false
                 type: string
                 description: "(Optional) Test run name"
+            run-modules-tests:
+                description: "Run modules tests"
+                type: boolean
+                default: false
 
     workflow_call:
 
@@ -347,7 +351,7 @@ jobs:
                       benchmarks/results/**
 
     test-modules:
-        if: (github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch') || github.event.pull_request.head.repo.owner.login == 'valkey-io'
+        if: ((github.repository_owner == 'valkey-io' && github.event_name == 'workflow_dispatch' && github.event.inputs.run-modules-tests == 'true') || github.event.pull_request.head.repo.owner.login == 'valkey-io')
         environment: AWS_ACTIONS
         name: Running Module Tests
         runs-on: [self-hosted, linux, ARM64, persistent]


### PR DESCRIPTION
Currently modules tests will run unconditionally on workflow_dispatch trigger.
The introduction of full-matrix-tests-sweeper.yml requires explicit parameter for running the modules tests, since the sweeper being triggered by cron, triggers the CI tests via workflow_dispatch event.


### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[] Tests are added or updated.~
-   ~[] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
