### PR TITLE
Go: Fix `LRange` Docs Return Type

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1482,7 +1482,7 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(
                 LRange,
                 new GlideString[] {key, gs(Long.toString(start)), gs(Long.toString(end))},
-                response -> castArray(handleArrayOrNullResponseBinary(response), GlideString.class));
+                response -> castArray(handleArrayResponseBinary(response), GlideString.class));
     }
 
     @Override


### PR DESCRIPTION
Go:

```go
// Return value:
//
//	Array of elements as models.Result[string] in the specified range
```

but return value is 

```go
([]string, error)
```

Node: returns `GlideString[]`, python too

Java: `handleArrayOrNullResponse` (e.g. array or null, not array of nullables).

It shouldn't be possible to have a null inside the return value, so we need to fix the docs for the Go client.

### Issue link

This Pull Request is linked to issue (URL): #4070 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
