### PR TITLE
Java: Change Response Handler for `xpending`

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -3105,14 +3105,14 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Object[]> xpending(@NonNull String key, @NonNull String group) {
         return commandManager.submitNewCommand(
-                XPending, new String[] {key, group}, this::handleArrayOrNullResponse);
+                XPending, new String[] {key, group}, this::handleArrayResponse);
     }
 
     @Override
     public CompletableFuture<Object[]> xpending(
             @NonNull GlideString key, @NonNull GlideString group) {
         return commandManager.submitNewCommand(
-                XPending, new GlideString[] {key, group}, this::handleArrayOrNullResponseBinary);
+                XPending, new GlideString[] {key, group}, this::handleArrayResponseBinary);
     }
 
     @Override


### PR DESCRIPTION
Command `xpendingWithOptions` returns an array of few items, but code has `handleArrayOrNullResponse`

Even in the case where there's nothing pending, we will still get an array of some sort (NOT `null`). Thus, this handler partially makes sense here and should be changed

### Issue link

This Pull Request is linked to issue (URL): #4070 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
