### PR TITLE
Python: fix flaky Open Telemetry memory checks

### DIFF
--- a/python/tests/test_opentelemetry.py
+++ b/python/tests/test_opentelemetry.py
@@ -267,14 +267,13 @@ class TestOpenTelemetryGlide:
         # Get final memory usage
         final_memory = process.memory_info().rss
 
-        # Check that memory usage hasn't grown significantly (indicating span leaks)
-        # Allow for some reasonable growth, but not excessive
-        memory_growth = final_memory - initial_memory
-        max_allowed_growth = 10 * 1024 * 1024  # 10MB threshold
+        # Calculate memory increase percentage
+        memory_increase = ((final_memory - initial_memory) / initial_memory) * 100
 
+        # Assert memory increase is not more than 10%
         assert (
-            memory_growth < max_allowed_growth
-        ), f"Memory grew by {memory_growth} bytes, which exceeds the {max_allowed_growth} byte threshold"
+            memory_increase < 10
+        ), f"Memory usage increased by {memory_increase: .2f}%, which is more than the allowed 10%"
 
         await client.close()
 
@@ -334,14 +333,13 @@ class TestOpenTelemetryGlide:
         # Get final memory usage
         final_memory = process.memory_info().rss
 
-        # Check that memory usage hasn't grown significantly (indicating span leaks)
-        # Allow for some reasonable growth, but not excessive
-        memory_growth = final_memory - initial_memory
-        max_allowed_growth = 10 * 1024 * 1024  # 10MB threshold
+        # Calculate memory increase percentage
+        memory_increase = ((final_memory - initial_memory) / initial_memory) * 100
 
+        # Assert memory increase is not more than 10%
         assert (
-            memory_growth < max_allowed_growth
-        ), f"Memory grew by {memory_growth} bytes, which exceeds the {max_allowed_growth} byte threshold"
+            memory_increase < 10
+        ), f"Memory usage increased by {memory_increase: .2f}%, which is more than the allowed 10%"
 
         await client.close()
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This PR fixes OTel tests memory checks in python, which were flaky (see - https://github.com/valkey-io/valkey-glide/actions/runs/15573227804/job/43858277697). It changes it from testing that a threshold of 10 Mb increase in memory is not crossed, to testing that there's no more than 10% increase, which is aligned with the other tests and with the equivalent tests in the other wrappers.


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
