### PR TITLE
Fix XAdd return type with no optional args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 * Modify `PFADD` to return a boolean rather than an integer ([#4094](https://github.com/valkey-io/valkey-glide/pull/4094))
 * Go: Modify blocking commands to use type `time.Duration` for timeouts ([#4086](https://github.com/valkey-io/valkey-glide/pull/4086))
 * Go: Modify most commands to use type `time.Duration` (check PR for list of commands modified) ([#4105](https://github.com/valkey-io/valkey-glide/pull/4105))
-* Go: Update return type for `XAdd` without optional arguments ([#4129](https://github.com/valkey-io/valkey-glide/pull/4129))
+* Go: Update return type for `XAdd` without optional arguments ([#4141](https://github.com/valkey-io/valkey-glide/pull/4141))
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 * Modify `PFADD` to return a boolean rather than an integer ([#4094](https://github.com/valkey-io/valkey-glide/pull/4094))
 * Go: Modify blocking commands to use type `time.Duration` for timeouts ([#4086](https://github.com/valkey-io/valkey-glide/pull/4086))
 * Go: Modify most commands to use type `time.Duration` (check PR for list of commands modified) ([#4105](https://github.com/valkey-io/valkey-glide/pull/4105))
+* Go: Update return type for `XAdd` without optional arguments ([#4129](https://github.com/valkey-io/valkey-glide/pull/4129))
 
 #### Fixes
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -4005,8 +4005,12 @@ func (client *baseClient) RenameNX(ctx context.Context, key string, newKey strin
 //	The id of the added entry.
 //
 // [valkey.io]: https://valkey.io/commands/xadd/
-func (client *baseClient) XAdd(ctx context.Context, key string, values [][]string) (models.Result[string], error) {
-	return client.XAddWithOptions(ctx, key, values, *options.NewXAddOptions())
+func (client *baseClient) XAdd(ctx context.Context, key string, values [][]string) (string, error) {
+	result, err := client.XAddWithOptions(ctx, key, values, *options.NewXAddOptions())
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return result.Value(), nil
 }
 
 // Adds an entry to the specified stream stored at `key`. If the `key` doesn't exist, the stream is created.

--- a/go/internal/interfaces/stream_commands.go
+++ b/go/internal/interfaces/stream_commands.go
@@ -16,7 +16,7 @@ import (
 //
 // [valkey.io]: https://valkey.io/commands/#stream
 type StreamCommands interface {
-	XAdd(ctx context.Context, key string, values [][]string) (models.Result[string], error)
+	XAdd(ctx context.Context, key string, values [][]string) (string, error)
 
 	XAddWithOptions(
 		ctx context.Context,

--- a/go/stream_commands_test.go
+++ b/go/stream_commands_test.go
@@ -29,7 +29,7 @@ func ExampleClient_XAdd() {
 	}
 	matches, _ := regexp.Match(
 		`^\d{13}-0$`,
-		[]byte(result.Value()),
+		[]byte(result),
 	) // matches a number that is 13 digits long followed by "-0"
 	fmt.Println(matches)
 
@@ -48,7 +48,7 @@ func ExampleClusterClient_XAdd() {
 	}
 	matches, _ := regexp.Match(
 		`^\d{13}-0$`,
-		[]byte(result.Value()),
+		[]byte(result),
 	) // matches a number that is 13 digits long followed by "-0"
 	fmt.Println(matches)
 
@@ -1285,7 +1285,7 @@ func ExampleClient_XAck() {
 		context.Background(),
 		key,
 		group,
-		[]string{streamId.Value()},
+		[]string{streamId},
 	) // ack the message and remove it from the pending list
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -1313,7 +1313,7 @@ func ExampleClusterClient_XAck() {
 		context.Background(),
 		key,
 		group,
-		[]string{streamId.Value()},
+		[]string{streamId},
 	) // ack the message and remove it from the pending list
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -1769,8 +1769,8 @@ func ExampleClient_XRangeWithOptions() {
 	streamId2, _ := client.XAdd(context.Background(), key, [][]string{{"field2", "value2"}})
 
 	response, err := client.XRangeWithOptions(context.Background(), key,
-		options.NewStreamBoundary(streamId1.Value(), true),
-		options.NewStreamBoundary(streamId2.Value(), true),
+		options.NewStreamBoundary(streamId1, true),
+		options.NewStreamBoundary(streamId2, true),
 		*options.NewXRangeOptions().SetCount(1))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
@@ -1788,8 +1788,8 @@ func ExampleClusterClient_XRangeWithOptions() {
 	streamId2, _ := client.XAdd(context.Background(), key, [][]string{{"field2", "value2"}})
 
 	response, err := client.XRangeWithOptions(context.Background(), key,
-		options.NewStreamBoundary(streamId1.Value(), true),
-		options.NewStreamBoundary(streamId2.Value(), true),
+		options.NewStreamBoundary(streamId1, true),
+		options.NewStreamBoundary(streamId2, true),
 		*options.NewXRangeOptions().SetCount(1))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)


### PR DESCRIPTION
`XAdd` can never return null/nil when there is no optional arguments provided, updating the return type accordingly

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4070

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
