### PR TITLE
Fix `LREM` Count Parameter Docs

### DIFF
--- a/go/base_client.go
+++ b/go/base_client.go
@@ -2743,10 +2743,6 @@ func (client *baseClient) LLen(ctx context.Context, key string) (int64, error) {
 }
 
 // Removes the first count occurrences of elements equal to element from the list stored at key.
-// If count is positive: Removes elements equal to element moving from head to tail.
-// If count is negative: Removes elements equal to element moving from tail to head.
-// If count is 0 or count is greater than the occurrences of elements equal to element, it removes all elements equal to
-// element.
 //
 // See [valkey.io] for details.
 //
@@ -2755,6 +2751,10 @@ func (client *baseClient) LLen(ctx context.Context, key string) (int64, error) {
 //	ctx     - The context for controlling the command execution.
 //	key     - The key of the list.
 //	count   - The count of the occurrences of elements equal to element to remove.
+//			  If count is positive: Removes elements equal to element moving from head to tail.
+//			  If count is negative: Removes elements equal to element moving from tail to head.
+//			  If count is 0 or count is greater than the occurrences of elements equal to element,
+//			  it removes all elements equal to element.
 //	element - The element to remove from the list.
 //
 // Return value:

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -1539,10 +1539,6 @@ func (b *BaseBatch[T]) LLen(key string) *T {
 }
 
 // Removes the first `count` occurrences of elements equal to `element` from the list stored at key.
-// If `count` is positive: Removes elements equal to `element` moving from head to tail.
-// If `count` is negative: Removes elements equal to `element` moving from tail to head.
-// If `count` is `0` or `count` is greater than the occurrences of elements equal to element, it removes all elements equal to
-// `element`.
 //
 // See [valkey.io] for details.
 //
@@ -1550,6 +1546,10 @@ func (b *BaseBatch[T]) LLen(key string) *T {
 //
 //	key     - The key of the list.
 //	count   - The count of the occurrences of elements equal to element to remove.
+//			  If count is positive: Removes elements equal to element moving from head to tail.
+//			  If count is negative: Removes elements equal to element moving from tail to head.
+//			  If count is 0 or count is greater than the occurrences of elements equal to element,
+//			  it removes all elements equal to element.
 //	element - The element to remove from the list.
 //
 // Command Response:

--- a/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
@@ -531,16 +531,17 @@ public interface ListBaseCommands {
     /**
      * Removes the first <code>count</code> occurrences of elements equal to <code>element</code> from
      * the list stored at <code>key</code>.<br>
-     * If <code>count</code> is positive: Removes elements equal to <code>element</code> moving from
-     * head to tail.<br>
-     * If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
-     * tail to head.<br>
-     * If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
-     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.
      *
      * @see <a href="https://valkey.io/commands/lrem/">valkey.io</a> for details.
      * @param key The key of the list.
      * @param count The count of the occurrences of elements equal to <code>element</code> to remove.
+     *     If <code>count</code> is positive: Removes elements equal to <code>element</code> moving
+     *     from head to tail.<br>
+     *     If <code>count</code> is negative: Removes elements equal to <code>element</code> moving
+     *     from tail to head.<br>
+     *     If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of
+     *     elements equal to <code>element</code>, it removes all elements equal to <code>element
+     *     </code>.`
      * @param element The element to remove from the list.
      * @return The number of the removed elements.<br>
      *     If <code>key</code> does not exist, <code>0</code> is returned.
@@ -555,16 +556,17 @@ public interface ListBaseCommands {
     /**
      * Removes the first <code>count</code> occurrences of elements equal to <code>element</code> from
      * the list stored at <code>key</code>.<br>
-     * If <code>count</code> is positive: Removes elements equal to <code>element</code> moving from
-     * head to tail.<br>
-     * If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
-     * tail to head.<br>
-     * If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
-     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.
      *
      * @see <a href="https://valkey.io/commands/lrem/">valkey.io</a> for details.
      * @param key The key of the list.
      * @param count The count of the occurrences of elements equal to <code>element</code> to remove.
+     *     If <code>count</code> is positive: Removes elements equal to <code>element</code> moving
+     *     from head to tail.<br>
+     *     If <code>count</code> is negative: Removes elements equal to <code>element</code> moving
+     *     from tail to head.<br>
+     *     If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of
+     *     elements equal to <code>element</code>, it removes all elements equal to <code>element
+     *     </code>.`
      * @param element The element to remove from the list.
      * @return The number of the removed elements.<br>
      *     If <code>key</code> does not exist, <code>0</code> is returned.

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -1319,18 +1319,18 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     /**
      * Removes the first <code>count</code> occurrences of elements equal to <code>element</code> from
      * the list stored at <code>key</code>.<br>
-     * If <code>count</code> is positive: Removes elements equal to <code>element</code> moving from
-     * head to tail.<br>
-     * If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
-     * tail to head.<br>
-     * If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
-     * equal to <code>element</code>, it removes all elements equal to <code>element</code>.
      *
      * @implNote {@link ArgType} is limited to {@link String} or {@link GlideString}, any other type
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/lrem/">valkey.io</a> for details.
      * @param key The key of the list.
      * @param count The count of the occurrences of elements equal to <code>element</code> to remove.
+     *     If <code>count</code> is positive: Removes elements equal to <code>element</code> moving from
+     *     head to tail.<br>
+     *     If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
+     *     tail to head.<br>
+     *     If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
+     *     equal to <code>element</code>, it removes all elements equal to <code>element</code>.
      * @param element The element to remove from the list.
      * @return Command Response - The number of the removed elements.<br>
      *     If <code>key</code> does not exist, <code>0</code> is returned.

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -1325,12 +1325,13 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @see <a href="https://valkey.io/commands/lrem/">valkey.io</a> for details.
      * @param key The key of the list.
      * @param count The count of the occurrences of elements equal to <code>element</code> to remove.
-     *     If <code>count</code> is positive: Removes elements equal to <code>element</code> moving from
-     *     head to tail.<br>
-     *     If <code>count</code> is negative: Removes elements equal to <code>element</code> moving from
-     *     tail to head.<br>
-     *     If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of elements
-     *     equal to <code>element</code>, it removes all elements equal to <code>element</code>.
+     *     If <code>count</code> is positive: Removes elements equal to <code>element</code> moving
+     *     from head to tail.<br>
+     *     If <code>count</code> is negative: Removes elements equal to <code>element</code> moving
+     *     from tail to head.<br>
+     *     If <code>count</code> is 0 or <code>count</code> is greater than the occurrences of
+     *     elements equal to <code>element</code>, it removes all elements equal to <code>element
+     *     </code>.
      * @param element The element to remove from the list.
      * @return Command Response - The number of the removed elements.<br>
      *     If <code>key</code> does not exist, <code>0</code> is returned.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3086,12 +3086,12 @@ export class BaseClient {
     }
 
     /** Removes the first `count` occurrences of elements equal to `element` from the list stored at `key`.
-     * If `count` is positive : Removes elements equal to `element` moving from head to tail.
-     * If `count` is negative : Removes elements equal to `element` moving from tail to head.
-     * If `count` is 0 or `count` is greater than the occurrences of elements equal to `element`: Removes all elements equal to `element`.
      *
      * @param key - The key of the list.
      * @param count - The count of the occurrences of elements equal to `element` to remove.
+     * If `count` is positive : Removes elements equal to `element` moving from head to tail.
+     * If `count` is negative : Removes elements equal to `element` moving from tail to head.
+     * If `count` is 0 or `count` is greater than the occurrences of elements equal to `element`: Removes all elements equal to `element`.
      * @param element - The element to remove from the list.
      * @returns the number of the removed elements.
      * If `key` does not exist, 0 is returned.

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -1213,12 +1213,12 @@ export class BaseBatch<T extends BaseBatch<T>> {
     }
 
     /** Removes the first `count` occurrences of elements equal to `element` from the list stored at `key`.
-     * If `count` is positive : Removes elements equal to `element` moving from head to tail.
-     * If `count` is negative : Removes elements equal to `element` moving from tail to head.
-     * If `count` is 0 or `count` is greater than the occurrences of elements equal to `element`: Removes all elements equal to `element`.
      *
      * @param key - The key of the list.
      * @param count - The count of the occurrences of elements equal to `element` to remove.
+     * If `count` is positive : Removes elements equal to `element` moving from head to tail.
+     * If `count` is negative : Removes elements equal to `element` moving from tail to head.
+     * If `count` is 0 or `count` is greater than the occurrences of elements equal to `element`: Removes all elements equal to `element`.
      * @param element - The element to remove from the list.
      *
      * Command Response - the number of the removed elements.

--- a/python/python/glide/async_commands/batch.py
+++ b/python/python/glide/async_commands/batch.py
@@ -1712,16 +1712,18 @@ class BaseBatch:
     ) -> TBatch:
         """
         Removes the first `count` occurrences of elements equal to `element` from the list stored at `key`.
-        If `count` is positive, it removes elements equal to `element` moving from head to tail.
-        If `count` is negative, it removes elements equal to `element` moving from tail to head.
-        If `count` is 0 or greater than the occurrences of elements equal to `element`, it removes all elements
-        equal to `element`.
 
         See [valkey.io](https://valkey.io/commands/lrem/) for more details.
 
         Args:
             key (TEncodable): The key of the list.
             count (int): The count of occurrences of elements equal to `element` to remove.
+
+                - If `count` is positive, it removes elements equal to `element` moving from head to tail.
+                - If `count` is negative, it removes elements equal to `element` moving from tail to head.
+                - If `count` is 0 or greater than the occurrences of elements equal to `element`, it removes all elements
+                  equal to `element`.
+
             element (TEncodable): The element to remove from the list.
 
         Commands response:

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2555,9 +2555,6 @@ class CoreCommands(Protocol):
     async def lrem(self, key: TEncodable, count: int, element: TEncodable) -> int:
         """
         Removes the first `count` occurrences of elements equal to `element` from the list stored at `key`.
-        If `count` is positive, it removes elements equal to `element` moving from head to tail.
-        If `count` is negative, it removes elements equal to `element` moving from tail to head.
-        If `count` is 0 or greater than the occurrences of elements equal to `element`, it removes all elements
         equal to `element`.
 
         See [valkey.io](https://valkey.io/commands/lrem/) for more details.
@@ -2565,6 +2562,11 @@ class CoreCommands(Protocol):
         Args:
             key (TEncodable): The key of the list.
             count (int): The count of occurrences of elements equal to `element` to remove.
+
+                - If `count` is positive, it removes elements equal to `element` moving from head to tail.
+                - If `count` is negative, it removes elements equal to `element` moving from tail to head.
+                - If `count` is 0 or greater than the occurrences of elements equal to `element`, it removes all elements
+
             element (TEncodable): The element to remove from the list.
 
         Returns:


### PR DESCRIPTION
Description of count param should be in params section. This applies to all the clients

```go
// Removes the first count occurrences of elements equal to element from the list stored at key.
// If count is positive: Removes elements equal to element moving from head to tail.
// If count is negative: Removes elements equal to element moving from tail to head.
// If count is 0 or count is greater than the occurrences of elements equal to element, it removes all elements equal to
// element.
//
// See [valkey.io] for details.
//
// Parameters:
//
//	ctx     - The context for controlling the command execution.
//	key     - The key of the list.
//	count   - The count of the occurrences of elements equal to element to remove.
//	element - The element to remove from the list.
```

### Issue link

This Pull Request is linked to issue (URL): #4070 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
