### PR TITLE
fix: resolve broken protobuf path

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -44,9 +44,9 @@ jobs:
                   export PLATFORM_MATRIX=$(jq 'map(
                       select(.PACKAGE_MANAGERS != null and (.PACKAGE_MANAGERS | contains(["pkg_go_dev"])))
                       | .RUNNER = (
-                          if (.RUNNER | type == "array") 
-                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
+                          if (.RUNNER | type == "array")
+                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end))
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end)
                           end
                       )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)
@@ -133,7 +133,7 @@ jobs:
                   path: |
                       ffi/target/release/libglide_ffi.a
                       go/lib.h
-                      go/protobuf/
+                      go/internal/protobuf/
 
     commit-auto-gen-files-with-tag:
         if: ${{ github.event_name == 'push' || inputs.pkg_go_dev_publish == true }}
@@ -157,8 +157,8 @@ jobs:
                   # TODO: move generation of protobuf and header file to a non-matrix step
                   cd x86_64-unknown-linux-gnu
                   cp lib.h $GITHUB_WORKSPACE/go/
-                  mkdir -p $GITHUB_WORKSPACE/go/protobuf
-                  cp protobuf/* $GITHUB_WORKSPACE/go/protobuf/
+                  mkdir -p $GITHUB_WORKSPACE/go/internal/protobuf
+                  cp internal/protobuf/* $GITHUB_WORKSPACE/go/internal/protobuf/
             - name: Commit and push tag
               run: |
                   RELEASE_VERSION=${{ needs.validate-release-version.outputs.RELEASE_VERSION }}


### PR DESCRIPTION
When the recent restructuring was done, the protobuf path in the CD pipeline was not updated to match the new location.

### Issue link

This Pull Request is linked to issue (#4148)

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
