### PR TITLE
Go: fix go benchmark parameter format

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -80,7 +80,7 @@ function runJavaBenchmark(){
 function runGoBenchmark(){
     cd ${BENCH_FOLDER}/../go/benchmarks
     export LD_LIBRARY_PATH=${BENCH_FOLDER}/../go/target/release:$LD_LIBRARY_PATH
-    go run . -resultsFile ${BENCH_FOLDER}/$1 -dataSize $2 -concurrentTasks $concurrentTasks -clients $chosenClients -host $host $portFlag -clientCount $clientCount $tlsFlag $clusterFlag $minimalFlag
+    go run . -resultsFile "${BENCH_FOLDER}/$1" -dataSize "$2" -concurrentTasks "$concurrentTasks" -clients "$chosenClients" -host "$host" $portFlag -clientCount "$clientCount" $tlsFlag $clusterFlag $minimalFlag
 }
 
 function runRustBenchmark(){


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->


The problem was caused by improper bash parameter quoting in the install_and_test.sh script. The $concurrentTasks variable contains space-separated values ("1 10 100 1000"), and without proper quoting, bash was splitting the command line incorrectly, causing parameter misalignment.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
