### PR TITLE
Fix Go CD workflow for v2 module path

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -174,7 +174,7 @@ jobs:
                   git commit -m "Automated commit from GitHub Actions"
                   git tag go/$RELEASE_VERSION
                   git push origin go/$RELEASE_VERSION
-                  GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go@$RELEASE_VERSION
+                  GOPROXY=proxy.golang.org go list -m github.com/valkey-io/valkey-glide/go/v2@$RELEASE_VERSION
 
     extra-post-commit-test:
         needs:


### PR DESCRIPTION
## Description

This PR fixes the Go CD workflow failure related to the module path mismatch in v2.0.0-rc6 as reported in issue #4156.

The error was occurring because the workflow was trying to publish the Go module with a path that didn't match the module declaration in go.mod:

```
go: github.com/valkey-io/valkey-glide/go@v2.0.0-rc6: reading https://proxy.golang.org/github.com/valkey-io/valkey-glide/go/@v/v2.0.0-rc6.info: 404 Not Found
server response: not found: github.com/valkey-io/valkey-glide/go@v2.0.0-rc6: invalid version: go/go.mod has post-v2 module path "github.com/valkey-io/valkey-glide/go/v2" at revision go/v2.0.0-rc6
```

## Changes

- Updated the `go list` command to correctly use the v2 module path that matches the declaration in go.mod

## Related Issues

Fixes #4156

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.