### PR TITLE
Fix tls

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,7 @@ allow = [
     "ISC",
     "OpenSSL",
     "MPL-2.0",
-    "Unicode-3.0"
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -70,9 +70,7 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+    { allow = ["CDLA-Permissive-2.0"], name = "webpki-root-certs", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -62,7 +62,7 @@ tempfile = "3.3.0"
 rstest = "^0.25"
 serial_test = "3"
 criterion = { version = "^0.6", features = ["html_reports", "async_tokio"] }
-which = "7"
+which = "8"
 ctor = "0.4"
 redis = { path = "./redis-rs/redis", features = ["tls-rustls-insecure"] }
 rustls = { version = "0.23", features = ["ring"], default-features = false}

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/redis-rs/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.70"
 readme = "../README.md"
 
 [package.metadata.docs.rs]
@@ -67,7 +67,7 @@ tokio-retry2 = { version = "0.5", features = ["jitter"], optional = true }
 
 # Only needed for rustls (default TLS implementation)
 rustls = { version = "0.23", features = ["ring"], default-features = false }
-rustls-native-certs = { version = "0.8" }
+webpki-roots = "1"
 tokio-rustls = { version = "0.26", default-features = false }
 rustls-pemfile = { version = "2" }
 rustls-pki-types = { version = "1" }

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -67,7 +67,7 @@ tokio-retry2 = { version = "0.5", features = ["jitter"], optional = true }
 
 # Only needed for rustls (default TLS implementation)
 rustls = { version = "0.23", features = ["ring"], default-features = false }
-webpki-roots = "1"
+rustls-platform-verifier = { version = "0.6", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }
 rustls-pemfile = { version = "2" }
 rustls-pki-types = { version = "1" }

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -65,17 +65,12 @@ async-trait = { version = "0.1", optional = true }
 # Only needed for tokio support
 tokio-retry2 = { version = "0.5", features = ["jitter"], optional = true }
 
-# Only needed for native tls
-native-tls = { version = "0.2", optional = true }
-tokio-native-tls = { version = "0.3", optional = true }
-
-# Only needed for rustls
-rustls = { version = "0.23", features = ["ring"], default-features = false, optional = true }
-
-rustls-native-certs = { version = "0.8", optional = true }
-tokio-rustls = { version = "0.26", default-features = false, optional = true }
-rustls-pemfile = { version = "2", optional = true }
-rustls-pki-types = { version = "1", optional = true }
+# Only needed for rustls (default TLS implementation)
+rustls = { version = "0.23", features = ["ring"], default-features = false }
+rustls-native-certs = { version = "0.8" }
+tokio-rustls = { version = "0.26", default-features = false }
+rustls-pemfile = { version = "2" }
+rustls-pki-types = { version = "1" }
 
 # Only needed for RedisJSON Support
 serde = { version = "1", optional = true }
@@ -126,18 +121,10 @@ aio = [
 ]
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]
-tls-native-tls = ["native-tls"]
-tls-rustls = [
-    "rustls",
-    "rustls-native-certs",
-    "rustls-pemfile",
-    "rustls-pki-types",
-]
-tls-rustls-insecure = ["tls-rustls"]
+tls-rustls-insecure = []
 
 tokio-comp = ["aio", "tokio/net", "tokio-retry2"]
-tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
-tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
+tokio-rustls-comp = ["tokio-comp"]
 connection-manager = ["futures", "aio", "tokio-retry2"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "dashmap"]
@@ -150,13 +137,9 @@ num-bigint = []
 uuid = ["dep:uuid"]
 disable-client-setinfo = []
 
-# Deprecated features
-tls = ["tls-native-tls"] # use "tls-native-tls" instead
-
 [dev-dependencies]
 rand = "0.9"
 socket2 = "0.5"
-assert_approx_eq = "1"
 fnv = "1"
 futures = "0.3"
 futures-time = "3"
@@ -172,10 +155,9 @@ tokio = { version = "1", features = [
 tempfile = "3"
 once_cell = "1"
 anyhow = "1"
-sscanf = "0.4"
 serial_test = "3"
 versions = "7"
-which = "7"
+which = "8"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [[test]]

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -442,7 +442,6 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             .0
         }
 
-        #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
         ConnectionAddr::TcpTls {
             ref host,
             port,
@@ -471,14 +470,6 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             }))
             .await?
             .0
-        }
-
-        #[cfg(not(any(feature = "tls-native-tls", feature = "tls-rustls")))]
-        ConnectionAddr::TcpTls { .. } => {
-            fail!((
-                ErrorKind::InvalidClientConfig,
-                "Cannot connect to TCP with TLS without the tls feature"
-            ));
         }
 
         #[cfg(unix)]

--- a/glide-core/redis-rs/redis/src/aio/mod.rs
+++ b/glide-core/redis-rs/redis/src/aio/mod.rs
@@ -18,11 +18,7 @@ use std::path::Path;
 use std::pin::Pin;
 use std::time::Duration;
 
-#[cfg(feature = "tls-rustls")]
 use crate::tls::TlsConnParams;
-
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
-use crate::connection::TlsConnParams;
 
 /// Enables the tokio compatibility
 #[cfg(feature = "tokio-comp")]
@@ -36,7 +32,6 @@ pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {
     async fn connect_tcp(socket_addr: SocketAddr) -> RedisResult<Self>;
 
     // Performs a TCP TLS connection
-    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,

--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -15,24 +15,11 @@ use tokio::{
     net::TcpStream as TcpStreamTokio,
 };
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
-use native_tls::TlsConnector;
-
-#[cfg(feature = "tls-rustls")]
 use crate::connection::create_rustls_config;
-#[cfg(feature = "tls-rustls")]
 use std::sync::Arc;
-#[cfg(feature = "tls-rustls")]
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
-#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-comp")))]
-use tokio_native_tls::TlsStream;
-
-#[cfg(feature = "tokio-rustls-comp")]
 use crate::tls::TlsConnParams;
-
-#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tls-rustls")))]
-use crate::connection::TlsConnParams;
 
 #[cfg(unix)]
 use super::Path;
@@ -70,7 +57,6 @@ pub(crate) enum Tokio {
     /// Represents a Tokio TCP connection.
     Tcp(TcpStreamTokio),
     /// Represents a Tokio TLS encrypted TCP connection
-    #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
     TcpTls(Box<TlsStream<TcpStreamTokio>>),
     /// Represents a Tokio Unix connection.
     #[cfg(unix)]
@@ -85,7 +71,6 @@ impl AsyncWrite for Tokio {
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_write(cx, buf),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_write(cx, buf),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_write(cx, buf),
@@ -95,7 +80,6 @@ impl AsyncWrite for Tokio {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_flush(cx),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_flush(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_flush(cx),
@@ -105,7 +89,6 @@ impl AsyncWrite for Tokio {
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_shutdown(cx),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_shutdown(cx),
@@ -121,7 +104,6 @@ impl AsyncRead for Tokio {
     ) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_read(cx, buf),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_read(cx, buf),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_read(cx, buf),
@@ -135,30 +117,6 @@ impl RedisRuntime for Tokio {
         Ok(connect_tcp(&socket_addr).await.map(Tokio::Tcp)?)
     }
 
-    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
-    async fn connect_tcp_tls(
-        hostname: &str,
-        socket_addr: SocketAddr,
-        insecure: bool,
-        _: &Option<TlsConnParams>,
-    ) -> RedisResult<Self> {
-        let tls_connector: tokio_native_tls::TlsConnector = if insecure {
-            TlsConnector::builder()
-                .danger_accept_invalid_certs(true)
-                .danger_accept_invalid_hostnames(true)
-                .use_sni(false)
-                .build()?
-        } else {
-            TlsConnector::new()?
-        }
-        .into();
-        Ok(tls_connector
-            .connect(hostname, connect_tcp(&socket_addr).await?)
-            .await
-            .map(|con| Tokio::TcpTls(Box::new(con)))?)
-    }
-
-    #[cfg(feature = "tls-rustls")]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -195,7 +153,6 @@ impl RedisRuntime for Tokio {
     fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {
         match self {
             Tokio::Tcp(x) => Box::pin(x),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
             Tokio::TcpTls(x) => Box::pin(x),
             #[cfg(unix)]
             Tokio::Unix(x) => Box::pin(x),

--- a/glide-core/redis-rs/redis/src/client.rs
+++ b/glide-core/redis-rs/redis/src/client.rs
@@ -17,7 +17,6 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use tokio::sync::mpsc;
 
-#[cfg(feature = "tls-rustls")]
 use crate::tls::{inner_build_with_tls, TlsCertificates};
 
 /// The client type.
@@ -537,7 +536,6 @@ impl Client {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(feature = "tls-rustls")]
     pub fn build_with_tls<C: IntoConnectionInfo>(
         conn_info: C,
         tls_certs: TlsCertificates,

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -65,11 +65,7 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 
-#[cfg(feature = "tls-rustls")]
 use crate::tls::TlsConnParams;
-
-#[cfg(not(feature = "tls-rustls"))]
-use crate::connection::TlsConnParams;
 
 #[derive(Clone)]
 enum Input<'a> {

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -908,9 +908,8 @@ impl<C> Future for Request<C> {
                 }
                 if let Some(request) = self.project().request.take() {
                     return Next::Retry { request }.into();
-                } else {
-                    return Next::Done.into();
                 }
+                return Next::Done.into();
             }
             _ => panic!("Request future must be Some"),
         };

--- a/glide-core/redis-rs/redis/src/cluster_client.rs
+++ b/glide-core/redis-rs/redis/src/cluster_client.rs
@@ -12,16 +12,11 @@ use rand::Rng;
 use std::ops::Add;
 use std::time::Duration;
 
-#[cfg(feature = "tls-rustls")]
 use crate::tls::TlsConnParams;
-
-#[cfg(not(feature = "tls-rustls"))]
-use crate::connection::TlsConnParams;
 
 #[cfg(feature = "cluster-async")]
 use crate::cluster_async;
 
-#[cfg(feature = "tls-rustls")]
 use crate::tls::{retrieve_tls_certificates, TlsCertificates};
 
 use tokio::sync::mpsc;
@@ -35,7 +30,6 @@ struct BuilderParams {
     username: Option<String>,
     read_from_replicas: ReadFromReplicaStrategy,
     tls: Option<TlsMode>,
-    #[cfg(feature = "tls-rustls")]
     certs: Option<TlsCertificates>,
     retries_configuration: RetryParams,
     connection_timeout: Option<Duration>,
@@ -154,10 +148,6 @@ pub struct ClusterParams {
 
 impl ClusterParams {
     fn from(value: BuilderParams) -> RedisResult<Self> {
-        #[cfg(not(feature = "tls-rustls"))]
-        let tls_params = None;
-
-        #[cfg(feature = "tls-rustls")]
         let tls_params = {
             let retrieved_tls_params = value.certs.clone().map(retrieve_tls_certificates);
 
@@ -353,7 +343,6 @@ impl ClusterClientBuilder {
     /// Sets TLS mode for the new ClusterClient.
     ///
     /// It is extracted from the first node of initial_nodes if not set.
-    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
     pub fn tls(mut self, tls: TlsMode) -> ClusterClientBuilder {
         self.builder_params.tls = Some(tls);
         self
@@ -374,7 +363,6 @@ impl ClusterClientBuilder {
     ///
     /// If `ClientTlsConfig` ( cert+key pair ) is not provided, then client-side authentication is not enabled.
     /// If `root_cert` is not provided, then system root certificates are used instead.
-    #[cfg(feature = "tls-rustls")]
     pub fn certs(mut self, certificates: TlsCertificates) -> ClusterClientBuilder {
         self.builder_params.tls = Some(TlsMode::Secure);
         self.builder_params.certs = Some(certificates);

--- a/glide-core/redis-rs/redis/src/cluster_slotmap.rs
+++ b/glide-core/redis-rs/redis/src/cluster_slotmap.rs
@@ -122,7 +122,7 @@ impl SlotMap {
     pub fn is_primary(&self, address: &String) -> bool {
         self.nodes_map
             .get(address)
-            .map_or(false, |shard_addrs| *shard_addrs.primary() == *address)
+            .is_some_and(|shard_addrs| *shard_addrs.primary() == *address)
     }
 
     pub fn slot_value_for_route(&self, route: &Route) -> Option<&SlotMapValue> {

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -456,10 +456,8 @@ pub mod cluster_async;
 #[cfg(feature = "sentinel")]
 pub mod sentinel;
 
-#[cfg(feature = "tls-rustls")]
 mod tls;
 
-#[cfg(feature = "tls-rustls")]
 pub use crate::tls::{ClientTlsConfig, TlsCertificates};
 
 mod client;

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -764,20 +764,6 @@ impl From<NulError> for RedisError {
     }
 }
 
-#[cfg(feature = "tls-native-tls")]
-impl From<native_tls::Error> for RedisError {
-    fn from(err: native_tls::Error) -> RedisError {
-        RedisError {
-            repr: ErrorRepr::WithDescriptionAndDetail(
-                ErrorKind::IoError,
-                "TLS error",
-                err.to_string(),
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "tls-rustls")]
 impl From<rustls::Error> for RedisError {
     fn from(err: rustls::Error) -> RedisError {
         RedisError {
@@ -790,7 +776,6 @@ impl From<rustls::Error> for RedisError {
     }
 }
 
-#[cfg(feature = "tls-rustls")]
 impl From<rustls_pki_types::InvalidDnsNameError> for RedisError {
     fn from(err: rustls_pki_types::InvalidDnsNameError) -> RedisError {
         RedisError {

--- a/glide-core/redis-rs/redis/tests/support/cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/cluster.rs
@@ -26,7 +26,6 @@ use tempfile::TempDir;
 
 use crate::support::{build_keys_and_certs_for_tls, Module};
 
-#[cfg(feature = "tls-rustls")]
 use super::{build_single_client, load_certs_from_file};
 
 use super::use_protocol;
@@ -105,7 +104,6 @@ impl RedisCluster {
         RedisCluster::with_modules(nodes, replicas, &[], false)
     }
 
-    #[cfg(feature = "tls-rustls")]
     pub fn new_with_mtls(nodes: u16, replicas: u16) -> RedisCluster {
         RedisCluster::with_modules(nodes, replicas, &[], true)
     }
@@ -295,12 +293,9 @@ impl RedisCluster {
                 conn_info.addr
             );
 
-            #[cfg(feature = "tls-rustls")]
             let client =
                 build_single_client(server.connection_info(), &self.tls_paths, _mtls_enabled)
                     .unwrap();
-            #[cfg(not(feature = "tls-rustls"))]
-            let client = redis::Client::open(server.connection_info()).unwrap();
 
             let mut con = client.get_connection(None).unwrap();
 
@@ -369,7 +364,6 @@ impl TestClusterContext {
         Self::new_with_cluster_client_builder(nodes, replicas, identity, false)
     }
 
-    #[cfg(feature = "tls-rustls")]
     pub fn new_with_mtls(nodes: u16, replicas: u16) -> TestClusterContext {
         Self::new_with_cluster_client_builder(nodes, replicas, identity, true)
     }
@@ -391,7 +385,6 @@ impl TestClusterContext {
         let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes.clone())
             .use_protocol(use_protocol());
 
-        #[cfg(feature = "tls-rustls")]
         if mtls_enabled {
             if let Some(tls_file_paths) = &cluster.tls_paths {
                 builder = builder.certs(load_certs_from_file(tls_file_paths));
@@ -454,15 +447,12 @@ impl TestClusterContext {
 
     pub fn disable_default_user(&self) {
         for server in &self.cluster.servers {
-            #[cfg(feature = "tls-rustls")]
             let client = build_single_client(
                 server.connection_info(),
                 &self.cluster.tls_paths,
                 self.mtls_enabled,
             )
             .unwrap();
-            #[cfg(not(feature = "tls-rustls"))]
-            let client = redis::Client::open(server.connection_info()).unwrap();
 
             let mut con = client.get_connection(None).unwrap();
             let _: () = redis::cmd("ACL")

--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -5,7 +5,6 @@ use std::{
     env, fs, io, net::SocketAddr, net::TcpListener, path::PathBuf, process, thread::sleep,
     time::Duration,
 };
-#[cfg(feature = "tls-rustls")]
 use std::{
     fs::File,
     io::{BufReader, Read},
@@ -15,7 +14,6 @@ use std::{
 use futures::Future;
 use redis::{ConnectionAddr, InfoDict, Pipeline, ProtocolVersion, RedisConnectionInfo, Value};
 
-#[cfg(feature = "tls-rustls")]
 use redis::{ClientTlsConfig, TlsCertificates};
 
 use socket2::{Domain, Socket, Type};
@@ -150,7 +148,6 @@ impl RedisServer {
         RedisServer::with_modules(&[], false)
     }
 
-    #[cfg(feature = "tls-rustls")]
     pub fn new_with_mtls() -> RedisServer {
         RedisServer::with_modules(&[], true)
     }
@@ -386,7 +383,7 @@ pub struct TestContext {
 }
 
 pub(crate) fn is_tls_enabled() -> bool {
-    cfg!(all(feature = "tls-rustls", not(feature = "tls-native-tls")))
+    true
 }
 
 impl TestContext {
@@ -394,7 +391,6 @@ impl TestContext {
         TestContext::with_modules(&[], false)
     }
 
-    #[cfg(feature = "tls-rustls")]
     pub fn new_with_mtls() -> TestContext {
         Self::with_modules(&[], true)
     }
@@ -442,11 +438,8 @@ impl TestContext {
             },
         );
 
-        #[cfg(feature = "tls-rustls")]
         let client =
             build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled).unwrap();
-        #[cfg(not(feature = "tls-rustls"))]
-        let client = redis::Client::open(server.connection_info()).unwrap();
 
         Self::connect_with_retries(&client);
 
@@ -460,11 +453,8 @@ impl TestContext {
     pub fn with_modules(modules: &[Module], mtls_enabled: bool) -> TestContext {
         let server = RedisServer::with_modules(modules, mtls_enabled);
 
-        #[cfg(feature = "tls-rustls")]
         let client =
             build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled).unwrap();
-        #[cfg(not(feature = "tls-rustls"))]
-        let client = redis::Client::open(server.connection_info()).unwrap();
 
         Self::connect_with_retries(&client);
 
@@ -485,10 +475,7 @@ impl TestContext {
             },
         };
 
-        #[cfg(feature = "tls-rustls")]
         let client = build_single_client(con_info, &server.tls_paths, false).unwrap();
-        #[cfg(not(feature = "tls-rustls"))]
-        let client = redis::Client::open(con_info).unwrap();
 
         Self::connect_with_retries(&client);
 
@@ -758,7 +745,6 @@ pub fn is_version(expected_major_minor: (u16, u16), version: Version) -> bool {
         || (expected_major_minor.0 == version.0 && expected_major_minor.1 <= version.1)
 }
 
-#[cfg(feature = "tls-rustls")]
 fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     let ca_file = File::open(&tls_file_paths.ca_crt).expect("Cannot open CA cert file");
     let mut root_cert_vec = Vec::new();
@@ -787,7 +773,6 @@ fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     }
 }
 
-#[cfg(feature = "tls-rustls")]
 pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
     connection_info: T,
     tls_file_params: &Option<TlsFilePaths>,
@@ -807,7 +792,6 @@ pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
     }
 }
 
-#[cfg(feature = "tls-rustls")]
 pub(crate) mod mtls_test {
     use super::*;
     use redis::{cluster::ClusterClient, ConnectionInfo, RedisError};

--- a/glide-core/redis-rs/redis/tests/test_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_async.rs
@@ -906,7 +906,6 @@ mod basic_async {
         .unwrap();
     }
 
-    #[cfg(feature = "tls-rustls")]
     mod mtls_test {
         use super::*;
 

--- a/glide-core/redis-rs/redis/tests/test_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster.rs
@@ -1053,7 +1053,6 @@ mod cluster {
         assert!(res.is_ok());
     }
 
-    #[cfg(feature = "tls-rustls")]
     mod mtls_test {
         use super::*;
         use crate::support::mtls_test::create_cluster_client_from_cluster;

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -1370,17 +1370,12 @@ mod cluster_async {
                 for server in env.cluster.iter_servers() {
                     let addr = server.client_addr();
 
-                    #[cfg(feature = "tls-rustls")]
                     let client = build_single_client(
                         server.connection_info(),
                         &server.tls_paths,
                         _mtls_enabled,
                     )
                     .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
-
-                    #[cfg(not(feature = "tls-rustls"))]
-                    let client = redis::Client::open(server.connection_info())
-                        .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
 
                     let mut conn = client
                         .get_multiplexed_async_connection(GlideConnectionOptions::default())
@@ -6150,7 +6145,6 @@ mod cluster_async {
         assert_eq!(request_counter.load(Ordering::Relaxed), 1);
     }
 
-    #[cfg(feature = "tls-rustls")]
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;
         use redis::ConnectionInfo;

--- a/utils/get_licenses_from_ort.py
+++ b/utils/get_licenses_from_ort.py
@@ -53,6 +53,7 @@ APPROVED_PACKAGES = [
     "PyPI::certifi:2023.11.17",
     "Crate::ring:0.17.8",
     "Maven:org.json:json:20231013",
+    "Crate::webpki-root-certs:1.0.0"
 ]
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link
This Pull Request is linked to issue #4164 
This PR is built from 3 commits which related to the same issue - 
1. **Backport from main** — TLS dual features and variety of libs available but not in use **cleanup**. 
The commit was **approved and merged** to main, but not to release-2.0 as it was out of scope, and merged after 2.0 became the target for release related content.

This commit is mainly removal of feature-gates and shadowed unused code, along with the related dependencies and contains most of this PR content (+100, -300) but contains **no logic changes**, and as mentioned, already part of main.

This commit is needed since both the fix (commit 2) and the cleanups are **based on the same piece of code** and both **performing similar changes** from feature gated native TLS shaded code to solely `rustls`. 
To avoid **conflicts and logic diffs** between main and release, the commit becomes relevant to the fix and to the release.

2. **The actual fix** — while cleaning the core code, and removing dead pieces of code, instead of removing the `native-tls pki` certs data source, and using only the `rustls webpki-roots`, I did the opposite. Since we don't use `native-tls`, but `rustls`, it broke the ability to use TLS as now the lib cannot check the validity of the certs. The fix simply put back the `pki` of `rustls`, and remove the `native-tls` one.

3. The updated back `pki` lib has a new license in the updated version, which is not approved yet.
While using the old version is possible, I wanted to check if it is needed or if those licenses are fine.
While checking the issue in the lib repo, [the docs pointing that we should not use the cert validation](https://github.com/rustls/webpki-roots?tab=readme-ov-file#warning) as we do, and this way is for live app only, and not for deliverable software.

It appears that we [are using a problematic method](https://github.com/rustls/webpki-roots/issues/100#issuecomment-2963277203) for cert's validation which can lead to sudden breakage in user code in case of addition or removal of data from the data source from which the validation of the certs is pulled, hence needing to use `rustls-platform-verifier`  as recommended, which solves the issue, and in the right cases use `webpki-roots` as well.

The bug was reproduced and been solved.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
