### PR TITLE
Go: Update return type for LMPop and related commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 * Go: Update return type for `XAdd` without optional arguments ([#4141](https://github.com/valkey-io/valkey-glide/pull/4141))
 * Go: Change options arguments to not be pointers ([#4106](https://github.com/valkey-io/valkey-glide/pull/4106))
 * Go: Change `ZAddIncr` Return Type to be `float64` ([#4190](https://github.com/valkey-io/valkey-glide/pull/4190))
+* Go: Update return type for `LMPop` and related commands ([#4164](https://github.com/valkey-io/valkey-glide/pull/4164))
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@
 * Go: Update return type for `XAdd` without optional arguments ([#4141](https://github.com/valkey-io/valkey-glide/pull/4141))
 * Go: Change options arguments to not be pointers ([#4106](https://github.com/valkey-io/valkey-glide/pull/4106))
 * Go: Change `ZAddIncr` Return Type to be `float64` ([#4190](https://github.com/valkey-io/valkey-glide/pull/4190))
-* Go: Update return type for `LMPop` and related commands ([#4164](https://github.com/valkey-io/valkey-glide/pull/4164))
+* Go: Update return type for `LMPop` and related commands ([#4166](https://github.com/valkey-io/valkey-glide/pull/4166))
 
 #### Fixes
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -2984,7 +2984,7 @@ func (client *baseClient) LPushX(ctx context.Context, key string, elements []str
 //
 // Return value:
 //
-//	A map of key name mapped array of popped element.
+//	A slice of [models.KeyValues], each containing a key name and an array of popped elements.
 //	If no elements could be popped, returns 'nil'.
 //
 // [valkey.io]: https://valkey.io/commands/lmpop/
@@ -2992,7 +2992,7 @@ func (client *baseClient) LMPop(
 	ctx context.Context,
 	keys []string,
 	listDirection constants.ListDirection,
-) (map[string][]string, error) {
+) ([]models.KeyValues, error) {
 	listDirectionStr, err := listDirection.ToString()
 	if err != nil {
 		return nil, err
@@ -3013,7 +3013,7 @@ func (client *baseClient) LMPop(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNilResponse(result)
+	return handleKeyValuesArrayOrNilResponse(result)
 }
 
 // Pops one or more elements from the first non-empty list from the provided keys.
@@ -3037,7 +3037,7 @@ func (client *baseClient) LMPop(
 //
 // Return value:
 //
-//	A map of key name mapped array of popped elements.
+//	A slice of [models.KeyValues], each containing a key name and an array of popped elements.
 //	If no elements could be popped, returns 'nil'.
 //
 // [valkey.io]: https://valkey.io/commands/lmpop/
@@ -3046,7 +3046,7 @@ func (client *baseClient) LMPopCount(
 	keys []string,
 	listDirection constants.ListDirection,
 	count int64,
-) (map[string][]string, error) {
+) ([]models.KeyValues, error) {
 	listDirectionStr, err := listDirection.ToString()
 	if err != nil {
 		return nil, err
@@ -3067,7 +3067,7 @@ func (client *baseClient) LMPopCount(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNilResponse(result)
+	return handleKeyValuesArrayOrNilResponse(result)
 }
 
 // Blocks the connection until it pops one element from the first non-empty list from the provided keys.
@@ -3092,7 +3092,7 @@ func (client *baseClient) LMPopCount(
 //
 // Return value:
 //
-//	A map of key name mapped array of popped element.
+//	A slice of [models.KeyValues], each containing a key name and an array of popped elements.
 //	If no member could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blmpop/
@@ -3102,7 +3102,7 @@ func (client *baseClient) BLMPop(
 	keys []string,
 	listDirection constants.ListDirection,
 	timeout time.Duration,
-) (map[string][]string, error) {
+) ([]models.KeyValues, error) {
 	listDirectionStr, err := listDirection.ToString()
 	if err != nil {
 		return nil, err
@@ -3123,7 +3123,7 @@ func (client *baseClient) BLMPop(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNilResponse(result)
+	return handleKeyValuesArrayOrNilResponse(result)
 }
 
 // Blocks the connection until it pops one or more elements from the first non-empty list from the provided keys.
@@ -3151,7 +3151,7 @@ func (client *baseClient) BLMPop(
 //
 // Return value:
 //
-//	A map of key name mapped array of popped element.
+//	A slice of [models.KeyValues], each containing a key name and an array of popped elements.
 //	If no member could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blmpop/
@@ -3162,7 +3162,7 @@ func (client *baseClient) BLMPopCount(
 	listDirection constants.ListDirection,
 	count int64,
 	timeout time.Duration,
-) (map[string][]string, error) {
+) ([]models.KeyValues, error) {
 	listDirectionStr, err := listDirection.ToString()
 	if err != nil {
 		return nil, err
@@ -3183,7 +3183,7 @@ func (client *baseClient) BLMPopCount(
 		return nil, err
 	}
 
-	return handleStringToStringArrayMapOrNilResponse(result)
+	return handleKeyValuesArrayOrNilResponse(result)
 }
 
 // Sets the list element at index to element.

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -3107,7 +3107,7 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
-			map[string][]string{key1: {"five"}},
+			[]models.KeyValues{{Key: key1, Values: []string{"five"}}},
 			res5,
 		)
 
@@ -3115,9 +3115,7 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
-			map[string][]string{
-				key2: {"one", "two"},
-			},
+			[]models.KeyValues{{Key: key2, Values: []string{"one", "two"}}},
 			res6,
 		)
 
@@ -3161,7 +3159,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
-			map[string][]string{key1: {"five"}},
+			[]models.KeyValues{{Key: key1, Values: []string{"five"}}},
 			res5,
 		)
 
@@ -3175,9 +3173,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 		suite.NoError(err)
 		assert.Equal(
 			suite.T(),
-			map[string][]string{
-				key2: {"one", "two"},
-			},
+			[]models.KeyValues{{Key: key2, Values: []string{"one", "two"}}},
 			res6,
 		)
 

--- a/go/internal/converter_helpers.go
+++ b/go/internal/converter_helpers.go
@@ -36,7 +36,6 @@ type arrayConverter[T any] struct {
 }
 
 type keyValuesConverter struct {
-	next     responseConverter
 	canBeNil bool
 }
 

--- a/go/internal/converters.go
+++ b/go/internal/converters.go
@@ -581,3 +581,7 @@ func ConverterAndTypeChecker(
 	// TODO maybe still return the data?
 	return nil, fmt.Errorf("unexpected return type from Glide: got %v, expected %v", reflect.TypeOf(data), expectedType)
 }
+
+func ConvertKeyValuesArrayOrNil(data any) ([]models.KeyValues, error) {
+	return keyValuesConverter{canBeNil: true}.convert(data)
+}

--- a/go/internal/interfaces/list_commands.go
+++ b/go/internal/interfaces/list_commands.go
@@ -69,21 +69,21 @@ type ListCommands interface {
 
 	LPushX(ctx context.Context, key string, elements []string) (int64, error)
 
-	LMPop(ctx context.Context, keys []string, listDirection constants.ListDirection) (map[string][]string, error)
+	LMPop(ctx context.Context, keys []string, listDirection constants.ListDirection) ([]models.KeyValues, error)
 
 	LMPopCount(
 		ctx context.Context,
 		keys []string,
 		listDirection constants.ListDirection,
 		count int64,
-	) (map[string][]string, error)
+	) ([]models.KeyValues, error)
 
 	BLMPop(
 		ctx context.Context,
 		keys []string,
 		listDirection constants.ListDirection,
 		timeout time.Duration,
-	) (map[string][]string, error)
+	) ([]models.KeyValues, error)
 
 	BLMPopCount(
 		ctx context.Context,
@@ -91,7 +91,7 @@ type ListCommands interface {
 		listDirection constants.ListDirection,
 		count int64,
 		timeout time.Duration,
-	) (map[string][]string, error)
+	) ([]models.KeyValues, error)
 
 	LSet(ctx context.Context, key string, index int64, element string) (string, error)
 

--- a/go/list_commands_test.go
+++ b/go/list_commands_test.go
@@ -4,6 +4,7 @@ package glide
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -680,11 +681,13 @@ func ExampleClient_LMPop() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three]]
+	// [{"Key":"my_list","Values":["three"]}]
 }
 
 func ExampleClusterClient_LMPop() {
@@ -695,11 +698,13 @@ func ExampleClusterClient_LMPop() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three]]
+	// [{"Key":"my_list","Values":["three"]}]
 }
 
 func ExampleClient_LMPopCount() {
@@ -710,11 +715,13 @@ func ExampleClient_LMPopCount() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three two]]
+	// [{"Key":"my_list","Values":["three","two"]}]
 }
 
 func ExampleClusterClient_LMPopCount() {
@@ -725,11 +732,13 @@ func ExampleClusterClient_LMPopCount() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three two]]
+	// [{"Key":"my_list","Values":["three","two"]}]
 }
 
 func ExampleClient_BLMPop() {
@@ -740,11 +749,13 @@ func ExampleClient_BLMPop() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three]]
+	// [{"Key":"my_list","Values":["three"]}]
 }
 
 func ExampleClusterClient_BLMPop() {
@@ -755,11 +766,13 @@ func ExampleClusterClient_BLMPop() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three]]
+	// [{"Key":"my_list","Values":["three"]}]
 }
 
 func ExampleClient_BLMPopCount() {
@@ -770,11 +783,13 @@ func ExampleClient_BLMPopCount() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three two]]
+	// [{"Key":"my_list","Values":["three","two"]}]
 }
 
 func ExampleClusterClient_BLMPopCount() {
@@ -785,11 +800,13 @@ func ExampleClusterClient_BLMPopCount() {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
-	fmt.Println(result1)
+
+	jsonResult1, err := json.Marshal(result1)
+	fmt.Println(string(jsonResult1))
 
 	// Output:
 	// 3
-	// map[my_list:[three two]]
+	// [{"Key":"my_list","Values":["three","two"]}]
 }
 
 func ExampleClient_LSet() {

--- a/go/models/key_values.go
+++ b/go/models/key_values.go
@@ -1,0 +1,8 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package models
+
+type KeyValues struct {
+	Key    string
+	Values []string
+}

--- a/go/models/key_values.go
+++ b/go/models/key_values.go
@@ -1,8 +1,0 @@
-// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-
-package models
-
-type KeyValues struct {
-	Key    string
-	Values []string
-}

--- a/go/models/response_types.go
+++ b/go/models/response_types.go
@@ -341,3 +341,11 @@ type XInfoStreamResponse struct {
 	// The ID and field-value tuples of the last entry in the stream
 	LastEntry StreamEntry
 }
+
+// KeyValues represents a key and a list of associated values
+type KeyValues struct {
+	// The key associated with the values
+	Key string
+	// The slice of string values associated with the key
+	Values []string
+}

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -808,24 +808,7 @@ func handleKeyValuesArrayOrNilResponse(
 		return nil, err
 	}
 
-	converters := mapConverter[[]string]{
-		arrayConverter[string]{},
-		false,
-	}
-
-	res, err := converters.convert(data)
-	if err != nil {
-		return nil, err
-	}
-	if result, ok := res.(map[string][]string); ok {
-		resultArray := make([]models.KeyValues, 0, len(result))
-		for key, values := range result {
-			resultArray = append(resultArray, models.KeyValues{Key: key, Values: values})
-		}
-		return resultArray, nil
-	}
-
-	return nil, fmt.Errorf("unexpected type received: %T", res)
+	return internal.ConvertKeyValuesArrayOrNil(data)
 }
 
 func handleStringSetResponse(response *C.struct_CommandResponse) (map[string]struct{}, error) {


### PR DESCRIPTION
### Description

This PR updates the return type for List commands (`LMPop`, `LMPopCount`, `BLMPop`, `BLMPopCount`) to provide a more user-friendly response structure. This change is part of the initiative to return smart objects for commands with complex return types.

### Issue link

This Pull Request is linked to issue https://github.com/valkey-io/valkey-glide/issues/4144

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.