### PR TITLE
Fix `SCRIPT SHOW` in batch test.

### DIFF
--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -2326,11 +2326,13 @@ func CreateScriptTest(batch *pipeline.ClusterBatch, isAtomic bool, serverVer str
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "ScriptFlush()"})
 	batch.ScriptFlushWithMode(options.SYNC)
 	testData = append(testData, CommandTestData{ExpectedResponse: "OK", TestName: "ScriptFlushWithMode()"})
-	batch.ScriptShow("abc")
-	testData = append(
-		testData,
-		CommandTestData{ExpectedResponse: errors.New(""), CheckTypeOnly: true, TestName: "ScriptShow()"},
-	)
+	if serverVer >= "8.0.0" {
+		batch.ScriptShow("abc")
+		testData = append(
+			testData,
+			CommandTestData{ExpectedResponse: errors.New(""), CheckTypeOnly: true, TestName: "ScriptShow()"},
+		)
+	}
 	batch.ScriptKill()
 	testData = append(
 		testData,


### PR DESCRIPTION
Add version check for [`SCRIPT SHOW`](https://valkey.io/commands/script-show/) command in batch tests. It was [failing](https://github.com/valkey-io/valkey-glide/actions/runs/15598722134/job/43934630822#step:7:748) on servers < 8

### Issue link

This Pull Request is linked to issue (URL): #4070

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.