### PR TITLE
Go: Fix batch examples.

### DIFF
--- a/go/batch_test.go
+++ b/go/batch_test.go
@@ -5,6 +5,7 @@ package glide
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
@@ -49,7 +50,7 @@ func ExampleClient_ExecWithOptions_transaction() {
 	batch := pipeline.NewStandaloneBatch(true)
 	batch.Set("key", "1").CustomCommand([]string{"incr", "key"}).Get("key")
 	// Set a timeout of 1000 milliseconds
-	options := pipeline.NewStandaloneBatchOptions().WithTimeout(1000)
+	options := pipeline.NewStandaloneBatchOptions().WithTimeout(1000 * time.Millisecond)
 
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {
@@ -66,7 +67,7 @@ func ExampleClient_ExecWithOptions_pipeline() {
 	batch := pipeline.NewStandaloneBatch(false)
 	batch.Set("key1", "value1").Set("key2", "value2").Get("key1").Get("key2")
 	// Set a timeout of 1000 milliseconds
-	options := pipeline.NewStandaloneBatchOptions().WithTimeout(1000)
+	options := pipeline.NewStandaloneBatchOptions().WithTimeout(1000 * time.Millisecond)
 
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {
@@ -113,7 +114,7 @@ func ExampleClusterClient_ExecWithOptions_transaction() {
 	batch := pipeline.NewClusterBatch(true)
 	batch.Set("key", "1").CustomCommand([]string{"incr", "key"}).Get("key")
 	// Set a timeout of 1000 milliseconds
-	options := pipeline.NewClusterBatchOptions().WithTimeout(1000)
+	options := pipeline.NewClusterBatchOptions().WithTimeout(1000 * time.Millisecond)
 
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {


### PR DESCRIPTION
Fix batch example tests https://github.com/valkey-io/valkey-glide/actions/runs/15640000268/job/44064842032#step:8:47
Initially, timeout was in ms, but later it was changed to `time.Duration` where units are ns.

### Issue link

This Pull Request is linked to issue (URL): #4070

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.