### PR TITLE
Go: Return strongly typed object for LCS commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 * Go: Change `ZAddIncr` Return Type to be `float64` ([#4190](https://github.com/valkey-io/valkey-glide/pull/4190))
 * Go: Update return type for `LMPop` and related commands ([#4166](https://github.com/valkey-io/valkey-glide/pull/4166))
 * Go: `ZRankWithScore` and `ZRevRankWithScore` update response type ([#4196](https://github.com/valkey-io/valkey-glide/pull/4196))
+* Go: Update return type for LCS commands ([#4187](https://github.com/valkey-io/valkey-glide/pull/4187))
 
 #### Fixes
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1286,7 +1286,7 @@ func (client *baseClient) LCSWithOptions(
 	ctx context.Context,
 	key1, key2 string,
 	opts options.LCSIdxOptions,
-) (map[string]any, error) {
+) (*models.LCSMatch, error) {
 	optArgs, err := opts.ToArgs()
 	if err != nil {
 		return nil, err
@@ -1295,7 +1295,17 @@ func (client *baseClient) LCSWithOptions(
 	if err != nil {
 		return nil, err
 	}
-	return handleStringToAnyMapResponse(response)
+	lcsResp, err := handleStringToAnyMapResponse(response)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("LCS Response: %+v\n", lcsResp)
+
+	return &models.LCSMatch{
+		MatchString: lcsResp["match_string"].(string),
+		Matches:     lcsResp["matches"].([]models.LCSMatchedPosition),
+		Len:         lcsResp["len"].(int64),
+	}, nil
 }
 
 // GetDel gets the value associated with the given key and deletes the key.

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1211,13 +1211,13 @@ func (client *baseClient) Append(ctx context.Context, key string, value string) 
 //	An empty string is returned if the keys do not exist or have no common subsequences.
 //
 // [valkey.io]: https://valkey.io/commands/lcs/
-func (client *baseClient) LCS(ctx context.Context, key1 string, key2 string) (string, error) {
+func (client *baseClient) LCS(ctx context.Context, key1 string, key2 string) (*models.LCSMatch, error) {
 	result, err := client.executeCommand(ctx, C.LCS, []string{key1, key2})
 	if err != nil {
-		return models.DefaultStringResponse, err
+		return nil, err
 	}
 
-	return handleStringResponse(result)
+	return handleLCSMatchResponse(result, models.SimpleLCSString)
 }
 
 // Returns the total length of all the longest common subsequences between strings stored at `key1` and `key2`.
@@ -1243,13 +1243,13 @@ func (client *baseClient) LCS(ctx context.Context, key1 string, key2 string) (st
 //	The total length of all the longest common subsequences the 2 strings.
 //
 // [valkey.io]: https://valkey.io/commands/lcs/
-func (client *baseClient) LCSLen(ctx context.Context, key1, key2 string) (int64, error) {
+func (client *baseClient) LCSLen(ctx context.Context, key1, key2 string) (*models.LCSMatch, error) {
 	result, err := client.executeCommand(ctx, C.LCS, []string{key1, key2, options.LCSLenCommand})
 	if err != nil {
-		return models.DefaultIntResponse, err
+		return nil, err
 	}
 
-	return handleIntResponse(result)
+	return handleLCSMatchResponse(result, models.SimpleLCSLength)
 }
 
 // Returns the longest common subsequence between strings stored at `key1` and `key2`.
@@ -1295,17 +1295,8 @@ func (client *baseClient) LCSWithOptions(
 	if err != nil {
 		return nil, err
 	}
-	lcsResp, err := handleStringToAnyMapResponse(response)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Printf("LCS Response: %+v\n", lcsResp)
 
-	return &models.LCSMatch{
-		MatchString: lcsResp["match_string"].(string),
-		Matches:     lcsResp["matches"].([]models.LCSMatchedPosition),
-		Len:         lcsResp["len"].(int64),
-	}, nil
+	return handleLCSMatchResponse(response, models.ComplexLCSMatch)
 }
 
 // GetDel gets the value associated with the given key and deletes the key.

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1279,7 +1279,8 @@ func (client *baseClient) LCSLen(ctx context.Context, key1, key2 string) (*model
 //	  - "len" is mapped to the total length of the all longest common subsequences between
 //	     the 2 strings.
 //	  - "matches" is mapped to a array that stores pairs of indices that represent the location
-//	     of the common subsequences in the strings held by key1 and key2.
+//	     of the common subsequences in the strings held by key1 and key2. If WithMatchLen is
+//	     specified, the array also contains the length of each match, otherwise the length is 0.
 //
 // [valkey.io]: https://valkey.io/commands/lcs/
 func (client *baseClient) LCSWithOptions(

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1207,8 +1207,11 @@ func (client *baseClient) Append(ctx context.Context, key string, value string) 
 //
 // Return value:
 //
-//	A string containing all the longest common subsequences combined between the 2 strings.
-//	An empty string is returned if the keys do not exist or have no common subsequences.
+//	A [models.LCSMatch] object containing:
+//	- `MatchString`: A string containing all the longest common subsequences combined between the 2 strings. An empty string is
+//		returned if the keys do not exist or have no common subsequences.
+//	- `Matches`: Empty array.
+//	- `Len`: 0
 //
 // [valkey.io]: https://valkey.io/commands/lcs/
 func (client *baseClient) LCS(ctx context.Context, key1 string, key2 string) (*models.LCSMatch, error) {
@@ -1240,7 +1243,10 @@ func (client *baseClient) LCS(ctx context.Context, key1 string, key2 string) (*m
 //
 // Return value:
 //
-//	The total length of all the longest common subsequences the 2 strings.
+//	A [models.LCSMatch] object containing:
+//	- `MatchString`: Empty string.
+//	- `Matches`: Empty array.
+//	- `Len`: The total length of all the longest common subsequences the 2 strings.
 //
 // [valkey.io]: https://valkey.io/commands/lcs/
 func (client *baseClient) LCSLen(ctx context.Context, key1, key2 string) (*models.LCSMatch, error) {
@@ -1273,14 +1279,11 @@ func (client *baseClient) LCSLen(ctx context.Context, key1, key2 string) (*model
 //
 // Return value:
 //
-//	A Map containing the indices of the longest common subsequence between the 2 strings
-//	and the total length of all the longest common subsequences. The resulting map contains
-//	two keys, "matches" and "len":
-//	  - "len" is mapped to the total length of the all longest common subsequences between
-//	     the 2 strings.
-//	  - "matches" is mapped to a array that stores pairs of indices that represent the location
-//	     of the common subsequences in the strings held by key1 and key2. If WithMatchLen is
-//	     specified, the array also contains the length of each match, otherwise the length is 0.
+//	A [models.LCSMatch] object containing:
+//	- `MatchString`: Empty string.
+//	- `Matches`: Array of [models.LCSMatchedPosition] objects with the common subsequences in the strings held by key1 and
+//		key2. If WithMatchLen is specified, the array also contains the length of each match, otherwise the length is 0.
+//	- `Len`: The total length of all the longest common subsequences the 2 strings.
 //
 // [valkey.io]: https://valkey.io/commands/lcs/
 func (client *baseClient) LCSWithOptions(

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -1217,7 +1217,7 @@ func (client *baseClient) LCS(ctx context.Context, key1 string, key2 string) (*m
 		return nil, err
 	}
 
-	return handleLCSMatchResponse(result, models.SimpleLCSString)
+	return handleLCSMatchResponse(result, internal.SimpleLCSString)
 }
 
 // Returns the total length of all the longest common subsequences between strings stored at `key1` and `key2`.
@@ -1249,7 +1249,7 @@ func (client *baseClient) LCSLen(ctx context.Context, key1, key2 string) (*model
 		return nil, err
 	}
 
-	return handleLCSMatchResponse(result, models.SimpleLCSLength)
+	return handleLCSMatchResponse(result, internal.SimpleLCSLength)
 }
 
 // Returns the longest common subsequence between strings stored at `key1` and `key2`.
@@ -1296,7 +1296,7 @@ func (client *baseClient) LCSWithOptions(
 		return nil, err
 	}
 
-	return handleLCSMatchResponse(response, models.ComplexLCSMatch)
+	return handleLCSMatchResponse(response, internal.ComplexLCSMatch)
 }
 
 // GetDel gets the value associated with the given key and deletes the key.

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -586,18 +586,18 @@ func (suite *GlideTestSuite) TestLCS_existingAndNonExistingKeys() {
 
 		res, err := client.LCS(context.Background(), key1, key2)
 		suite.NoError(err)
-		assert.Equal(suite.T(), "", res)
+		assert.Equal(suite.T(), "", res.MatchString)
 
 		suite.verifyOK(client.Set(context.Background(), key1, "Dummy string"))
 		suite.verifyOK(client.Set(context.Background(), key2, "Dummy value"))
 
 		res, err = client.LCS(context.Background(), key1, key2)
 		suite.NoError(err)
-		assert.Equal(suite.T(), "Dummy ", res)
+		assert.Equal(suite.T(), "Dummy ", res.MatchString)
 	})
 }
 
-func (suite *GlideTestSuite) TestLCSLen_existingAndNonExistingKeys() {
+func (suite *GlideTestSuite) TestLCS_len_existingAndNonExistingKeys() {
 	suite.SkipIfServerVersionLowerThan("7.0.0", suite.T())
 
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
@@ -606,14 +606,14 @@ func (suite *GlideTestSuite) TestLCSLen_existingAndNonExistingKeys() {
 
 		res, err := client.LCSLen(context.Background(), key1, key2)
 		suite.NoError(err)
-		assert.Equal(suite.T(), int64(0), res)
+		assert.Equal(suite.T(), int64(0), res.Len)
 
 		suite.verifyOK(client.Set(context.Background(), key1, "ohmytext"))
 		suite.verifyOK(client.Set(context.Background(), key2, "mynewtext"))
 
 		res, err = client.LCSLen(context.Background(), key1, key2)
 		suite.NoError(err)
-		assert.Equal(suite.T(), int64(6), res)
+		assert.Equal(suite.T(), int64(6), res.Len)
 	})
 }
 
@@ -633,19 +633,21 @@ func (suite *GlideTestSuite) TestLCS_BasicIDXOption() {
 		suite.NoError(err)
 		assert.NotNil(suite.T(), lcsIdxResult)
 
-		assert.Equal(suite.T(), int64(6), lcsIdxResult["len"])
+		assert.Equal(suite.T(), int64(6), lcsIdxResult.Len)
 
-		matches := lcsIdxResult["matches"].([]any)
+		matches := lcsIdxResult.Matches
 		assert.Len(suite.T(), matches, 2)
 
-		expectedMatches := []any{
-			[]any{
-				[]any{int64(4), int64(7)},
-				[]any{int64(5), int64(8)},
+		expectedMatches := []models.LCSMatchedPosition{
+			{
+				Key1:     models.LCSPosition{Start: 4, End: 7},
+				Key2:     models.LCSPosition{Start: 5, End: 8},
+				MatchLen: 4,
 			},
-			[]any{
-				[]any{int64(2), int64(3)},
-				[]any{int64(0), int64(1)},
+			{
+				Key1:     models.LCSPosition{Start: 2, End: 3},
+				Key2:     models.LCSPosition{Start: 0, End: 1},
+				MatchLen: 2,
 			},
 		}
 		assert.Equal(suite.T(), expectedMatches, matches)
@@ -671,14 +673,15 @@ func (suite *GlideTestSuite) TestLCS_MinMatchLengthOption() {
 		suite.NoError(err)
 		assert.NotNil(suite.T(), lcsIdxMinMatchResult)
 
-		assert.Equal(suite.T(), int64(6), lcsIdxMinMatchResult["len"])
+		assert.Equal(suite.T(), int64(6), lcsIdxMinMatchResult.Len)
 
-		matches := lcsIdxMinMatchResult["matches"].([]any)
+		matches := lcsIdxMinMatchResult.Matches
 		assert.Len(suite.T(), matches, 1)
 
-		expectedMatch := []any{
-			[]any{int64(4), int64(7)},
-			[]any{int64(5), int64(8)},
+		expectedMatch := models.LCSMatchedPosition{
+			Key1:     models.LCSPosition{Start: 4, End: 7},
+			Key2:     models.LCSPosition{Start: 5, End: 8},
+			MatchLen: 4,
 		}
 		assert.Equal(suite.T(), expectedMatch, matches[0])
 	})
@@ -702,17 +705,17 @@ func (suite *GlideTestSuite) TestLCS_WithMatchLengthOption() {
 		lcsIdxFullOptionsResult, err := client.LCSWithOptions(context.Background(), "{lcs}key1", "{lcs}key2", *opts)
 
 		suite.NoError(err)
-		assert.NotNil(suite.T(), lcsIdxFullOptionsResult)
+		require.NotNil(suite.T(), lcsIdxFullOptionsResult)
 
-		assert.Equal(suite.T(), int64(6), lcsIdxFullOptionsResult["len"])
+		assert.Equal(suite.T(), int64(6), lcsIdxFullOptionsResult.Len)
 
-		matches := lcsIdxFullOptionsResult["matches"].([]any)
+		matches := lcsIdxFullOptionsResult.Matches
 		assert.Len(suite.T(), matches, 1)
 
-		expectedMatch := []any{
-			[]any{int64(4), int64(7)},
-			[]any{int64(5), int64(8)},
-			int64(4),
+		expectedMatch := models.LCSMatchedPosition{
+			Key1:     models.LCSPosition{Start: 4, End: 7},
+			Key2:     models.LCSPosition{Start: 5, End: 8},
+			MatchLen: 4,
 		}
 		assert.Equal(suite.T(), expectedMatch, matches[0])
 	})

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -642,12 +642,12 @@ func (suite *GlideTestSuite) TestLCS_BasicIDXOption() {
 			{
 				Key1:     models.LCSPosition{Start: 4, End: 7},
 				Key2:     models.LCSPosition{Start: 5, End: 8},
-				MatchLen: 4,
+				MatchLen: 0,
 			},
 			{
 				Key1:     models.LCSPosition{Start: 2, End: 3},
 				Key2:     models.LCSPosition{Start: 0, End: 1},
-				MatchLen: 2,
+				MatchLen: 0,
 			},
 		}
 		assert.Equal(suite.T(), expectedMatches, matches)
@@ -681,7 +681,7 @@ func (suite *GlideTestSuite) TestLCS_MinMatchLengthOption() {
 		expectedMatch := models.LCSMatchedPosition{
 			Key1:     models.LCSPosition{Start: 4, End: 7},
 			Key2:     models.LCSPosition{Start: 5, End: 8},
-			MatchLen: 4,
+			MatchLen: 0,
 		}
 		assert.Equal(suite.T(), expectedMatch, matches[0])
 	})

--- a/go/internal/cmd.go
+++ b/go/internal/cmd.go
@@ -47,3 +47,11 @@ type BatchOptions struct {
 	RetryServerError     *bool
 	RetryConnectionError *bool
 }
+
+type LCSResponseType int
+
+const (
+	SimpleLCSString LCSResponseType = iota
+	SimpleLCSLength
+	ComplexLCSMatch
+)

--- a/go/internal/interfaces/string_commands.go
+++ b/go/internal/interfaces/string_commands.go
@@ -53,7 +53,7 @@ type StringCommands interface {
 
 	LCSLen(ctx context.Context, key1 string, key2 string) (int64, error)
 
-	LCSWithOptions(ctx context.Context, key1, key2 string, opts options.LCSIdxOptions) (map[string]any, error)
+	LCSWithOptions(ctx context.Context, key1, key2 string, opts options.LCSIdxOptions) (*models.LCSMatch, error)
 
 	GetDel(ctx context.Context, key string) (models.Result[string], error)
 }

--- a/go/internal/interfaces/string_commands.go
+++ b/go/internal/interfaces/string_commands.go
@@ -49,9 +49,9 @@ type StringCommands interface {
 
 	Append(ctx context.Context, key string, value string) (int64, error)
 
-	LCS(ctx context.Context, key1 string, key2 string) (string, error)
+	LCS(ctx context.Context, key1 string, key2 string) (*models.LCSMatch, error)
 
-	LCSLen(ctx context.Context, key1 string, key2 string) (int64, error)
+	LCSLen(ctx context.Context, key1 string, key2 string) (*models.LCSMatch, error)
 
 	LCSWithOptions(ctx context.Context, key1, key2 string, opts options.LCSIdxOptions) (*models.LCSMatch, error)
 

--- a/go/models/response_types.go
+++ b/go/models/response_types.go
@@ -456,6 +456,15 @@ type RankAndScore struct {
 	Score float64
 }
 
+type LCSResponseType int
+
+const (
+	SimpleLCSString LCSResponseType = iota
+	SimpleLCSLength
+	ComplexLCSMatch
+)
+
+
 type LCSMatch struct {
 	MatchString string
 	Matches     []LCSMatchedPosition

--- a/go/models/response_types.go
+++ b/go/models/response_types.go
@@ -455,3 +455,20 @@ type RankAndScore struct {
 	// The score of the member
 	Score float64
 }
+
+type LCSMatch struct {
+	MatchString string
+	Matches     []LCSMatchedPosition
+	Len         int64
+}
+
+type LCSMatchedPosition struct {
+	Key1     LCSPosition
+	Key2     LCSPosition
+	MatchLen int64
+}
+
+type LCSPosition struct {
+	Start int64
+	End   int64
+}

--- a/go/models/response_types.go
+++ b/go/models/response_types.go
@@ -456,19 +456,31 @@ type RankAndScore struct {
 	Score float64
 }
 
+// LCSMatch represents a longest common subsequence match.
 type LCSMatch struct {
+	// MatchString is the actual longest common subsequence string.
 	MatchString string
-	Matches     []LCSMatchedPosition
-	Len         int64
+	// Matches is a slice of LCSMatchedPosition objects.
+	Matches []LCSMatchedPosition
+	// Len is the total length of all the longest common subsequences.
+	Len int64
 }
 
+// LCSMatchedPosition represents the position of a longest common subsequence match.
 type LCSMatchedPosition struct {
-	Key1     LCSPosition
-	Key2     LCSPosition
+	// Key1 is the position in the first string.
+	Key1 LCSPosition
+	// Key2 is the position in the second string.
+	Key2 LCSPosition
+
+	// if WithMatchLen is specified, the array also contains the length of each match, otherwise the length is 0.
 	MatchLen int64
 }
 
+// LCSPosition represents a position in a longest common subsequence match.
 type LCSPosition struct {
+	// Start is the starting index of the match.
 	Start int64
-	End   int64
+	// End is the ending index of the match.
+	End int64
 }

--- a/go/models/response_types.go
+++ b/go/models/response_types.go
@@ -456,15 +456,6 @@ type RankAndScore struct {
 	Score float64
 }
 
-type LCSResponseType int
-
-const (
-	SimpleLCSString LCSResponseType = iota
-	SimpleLCSLength
-	ComplexLCSMatch
-)
-
-
 type LCSMatch struct {
 	MatchString string
 	Matches     []LCSMatchedPosition

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -113,6 +113,26 @@ func convertToStringArray(input []any) ([]string, error) {
 	return result, nil
 }
 
+// toInt64 converts any numeric value to int64
+func convertToInt64(value any) (int64, error) {
+	switch v := value.(type) {
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	case float64:
+		return int64(v), nil
+	case string:
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot convert string %q to int64: %w", v, err)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int64", value)
+	}
+}
+
 func parseInterface(response *C.struct_CommandResponse) (any, error) {
 	if response == nil {
 		return nil, nil
@@ -213,6 +233,100 @@ func parseSet(response *C.struct_CommandResponse) (any, error) {
 	}
 
 	return slice, nil
+}
+
+// parseLCSMatchedPositions converts the nested array structure from LCSWithOptions into a slice of LCSMatchedPosition structs
+// The input structure has the shape of:
+// ```
+// 1) 1) 1) (integer) 4
+//  2. (integer) 7
+//  2. 1) (integer) 5
+//  2. (integer) 8
+//  2. 1) 1) (integer) 2
+//  2. (integer) 3
+//  2. 1) (integer) 0
+//  2. (integer) 1
+//
+// ```
+// which represents matched positions between two strings
+func parseLCSMatchedPositions(matches any) ([]models.LCSMatchedPosition, error) {
+	if matches == nil {
+		return []models.LCSMatchedPosition{}, nil
+	}
+
+	matchesArray, ok := matches.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected matches to be an array, got %T", matches)
+	}
+
+	result := make([]models.LCSMatchedPosition, len(matchesArray))
+	for i, match := range matchesArray {
+		matchArray, ok := match.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expected match to be an array, got %T ", match)
+		}
+
+		if len(matchArray) != 2 && len(matchArray) != 3 {
+			return nil, fmt.Errorf("expected match to be an array of length 2 or 3, got %T with length %d", matchArray, len(matchArray))
+		}
+
+		// Parse Key1 position
+		key1Array, ok := matchArray[0].([]any)
+		if !ok || len(key1Array) != 2 {
+			return nil, fmt.Errorf("expected key1 to be an array of length 2, got %T with length %d", matchArray[0], len(key1Array))
+		}
+
+		key1Start, err := convertToInt64(key1Array[0])
+		if err != nil {
+			return nil, fmt.Errorf("expected key1 start to be a number, got %T", key1Array[0])
+		}
+
+		key1End, err := convertToInt64(key1Array[1])
+		if err != nil {
+			return nil, fmt.Errorf("expected key1 end to be a number, got %T", key1Array[1])
+		}
+
+		// Parse Key2 position
+		key2Array, ok := matchArray[1].([]any)
+		if !ok || len(key2Array) != 2 {
+			return nil, fmt.Errorf("expected key2 to be an array of length 2, got %T with length %d", matchArray[1], len(key2Array))
+		}
+
+		key2Start, err := convertToInt64(key2Array[0])
+		if err != nil {
+			return nil, fmt.Errorf("expected key2 start to be a number, got %T", key2Array[0])
+		}
+
+		key2End, err := convertToInt64(key2Array[1])
+		if err != nil {
+			return nil, fmt.Errorf("expected key2 end to be a number, got %T", key2Array[1])
+		}
+
+		var matchLen int64
+		if len(matchArray) == 2 {
+			// Calculate match length (end - start + 1)
+			matchLen = key1End - key1Start + 1
+		} else if len(matchArray) == 3 {
+			matchLen, err = convertToInt64(matchArray[2])
+			if err != nil {
+				return nil, fmt.Errorf("expected match length to be a number, got %T", matchArray[2])
+			}
+		}
+
+		result[i] = models.LCSMatchedPosition{
+			Key1: models.LCSPosition{
+				Start: key1Start,
+				End:   key1End,
+			},
+			Key2: models.LCSPosition{
+				Start: key2Start,
+				End:   key2End,
+			},
+			MatchLen: matchLen,
+		}
+	}
+
+	return result, nil
 }
 
 // convert (typecast) untyped response into a typed value
@@ -1400,11 +1514,63 @@ func handleStringToAnyMapResponse(response *C.struct_CommandResponse) (map[strin
 	if typeErr != nil {
 		return nil, typeErr
 	}
+
 	result, err := parseMap(response)
 	if err != nil {
 		return nil, err
 	}
 	return result.(map[string]any), nil
+}
+
+func handleLCSMatchResponse(response *C.struct_CommandResponse, lcsResponseType models.LCSResponseType) (*models.LCSMatch, error) {
+
+	switch lcsResponseType {
+	case models.SimpleLCSString:
+		lcsResp, err := handleStringResponse(response)
+		if err != nil {
+			return nil, err
+		}
+		return &models.LCSMatch{
+			MatchString: lcsResp,
+			Matches:     make([]models.LCSMatchedPosition, 0),
+			Len:         0,
+		}, nil
+	case models.SimpleLCSLength:
+		lcsResp, err := handleIntResponse(response)
+		if err != nil {
+			return nil, err
+		}
+		return &models.LCSMatch{
+			MatchString: models.DefaultStringResponse,
+			Matches:     make([]models.LCSMatchedPosition, 0),
+			Len:         lcsResp,
+		}, nil
+	case models.ComplexLCSMatch:
+		lcsResp, err := handleStringToAnyMapResponse(response)
+		if err != nil {
+			return nil, err
+		}
+
+		lenVal, err := convertToInt64(lcsResp["len"])
+		if err != nil {
+			return nil, fmt.Errorf("expected len to be a number, got %T", lcsResp["len"])
+		}
+
+		// Parse the matches array using the helper function
+		matches, err := parseLCSMatchedPositions(lcsResp["matches"])
+		if err != nil {
+			return nil, err
+		}
+
+		return &models.LCSMatch{
+			MatchString: models.DefaultStringResponse,
+			Matches:     matches,
+			Len:         lenVal,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown LCS response type: %d", lcsResponseType)
+	}
+
 }
 
 func handleRawStringArrayMapResponse(response *C.struct_CommandResponse) (map[string][]string, error) {

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -113,26 +113,6 @@ func convertToStringArray(input []any) ([]string, error) {
 	return result, nil
 }
 
-// toInt64 converts any numeric value to int64
-func convertToInt64(value any) (int64, error) {
-	switch v := value.(type) {
-	case int64:
-		return v, nil
-	case int:
-		return int64(v), nil
-	case float64:
-		return int64(v), nil
-	case string:
-		parsed, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("cannot convert string %q to int64: %w", v, err)
-		}
-		return parsed, nil
-	default:
-		return 0, fmt.Errorf("cannot convert %T to int64", value)
-	}
-}
-
 func parseInterface(response *C.struct_CommandResponse) (any, error) {
 	if response == nil {
 		return nil, nil
@@ -233,109 +213,6 @@ func parseSet(response *C.struct_CommandResponse) (any, error) {
 	}
 
 	return slice, nil
-}
-
-// parseLCSMatchedPositions converts the nested array structure from LCSWithOptions into a slice of LCSMatchedPosition structs
-// The input structure has the shape of:
-// ```
-// 1) 1) 1) (integer) 4
-//  2. (integer) 7
-//  2. 1) (integer) 5
-//  2. (integer) 8
-//  2. 1) 1) (integer) 2
-//  2. (integer) 3
-//  2. 1) (integer) 0
-//  2. (integer) 1
-//
-// ```
-// which represents matched positions between two strings
-func parseLCSMatchedPositions(matches any) ([]models.LCSMatchedPosition, error) {
-	if matches == nil {
-		return []models.LCSMatchedPosition{}, nil
-	}
-
-	matchesArray, ok := matches.([]any)
-	if !ok {
-		return nil, fmt.Errorf("expected matches to be an array, got %T", matches)
-	}
-
-	result := make([]models.LCSMatchedPosition, len(matchesArray))
-	for i, match := range matchesArray {
-		matchArray, ok := match.([]any)
-		if !ok {
-			return nil, fmt.Errorf("expected match to be an array, got %T ", match)
-		}
-
-		if len(matchArray) != 2 && len(matchArray) != 3 {
-			return nil, fmt.Errorf(
-				"expected match to be an array of length 2 or 3, got %T with length %d",
-				matchArray,
-				len(matchArray),
-			)
-		}
-
-		// Parse Key1 position
-		key1Array, ok := matchArray[0].([]any)
-		if !ok || len(key1Array) != 2 {
-			return nil, fmt.Errorf(
-				"expected key1 to be an array of length 2, got %T with length %d",
-				matchArray[0],
-				len(key1Array),
-			)
-		}
-
-		key1Start, err := convertToInt64(key1Array[0])
-		if err != nil {
-			return nil, fmt.Errorf("expected key1 start to be a number, got %T", key1Array[0])
-		}
-
-		key1End, err := convertToInt64(key1Array[1])
-		if err != nil {
-			return nil, fmt.Errorf("expected key1 end to be a number, got %T", key1Array[1])
-		}
-
-		// Parse Key2 position
-		key2Array, ok := matchArray[1].([]any)
-		if !ok || len(key2Array) != 2 {
-			return nil, fmt.Errorf(
-				"expected key2 to be an array of length 2, got %T with length %d",
-				matchArray[1],
-				len(key2Array),
-			)
-		}
-
-		key2Start, err := convertToInt64(key2Array[0])
-		if err != nil {
-			return nil, fmt.Errorf("expected key2 start to be a number, got %T", key2Array[0])
-		}
-
-		key2End, err := convertToInt64(key2Array[1])
-		if err != nil {
-			return nil, fmt.Errorf("expected key2 end to be a number, got %T", key2Array[1])
-		}
-
-		var matchLen int64
-		if len(matchArray) == 3 {
-			matchLen, err = convertToInt64(matchArray[2])
-			if err != nil {
-				return nil, fmt.Errorf("expected match length to be a number, got %T", matchArray[2])
-			}
-		}
-
-		result[i] = models.LCSMatchedPosition{
-			Key1: models.LCSPosition{
-				Start: key1Start,
-				End:   key1End,
-			},
-			Key2: models.LCSPosition{
-				Start: key2Start,
-				End:   key2End,
-			},
-			MatchLen: matchLen,
-		}
-	}
-
-	return result, nil
 }
 
 // convert (typecast) untyped response into a typed value
@@ -1562,13 +1439,13 @@ func handleLCSMatchResponse(
 			return nil, err
 		}
 
-		lenVal, err := convertToInt64(lcsResp["len"])
+		lenVal, err := internal.ConvertToInt64(lcsResp["len"])
 		if err != nil {
 			return nil, fmt.Errorf("expected len to be a number, got %T", lcsResp["len"])
 		}
 
 		// Parse the matches array using the helper function
-		matches, err := parseLCSMatchedPositions(lcsResp["matches"])
+		matches, err := internal.ParseLCSMatchedPositions(lcsResp["matches"])
 		if err != nil {
 			return nil, err
 		}

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -315,10 +315,7 @@ func parseLCSMatchedPositions(matches any) ([]models.LCSMatchedPosition, error) 
 		}
 
 		var matchLen int64
-		if len(matchArray) == 2 {
-			// Calculate match length (end - start + 1)
-			matchLen = key1End - key1Start + 1
-		} else if len(matchArray) == 3 {
+		if len(matchArray) == 3 {
 			matchLen, err = convertToInt64(matchArray[2])
 			if err != nil {
 				return nil, fmt.Errorf("expected match length to be a number, got %T", matchArray[2])

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -267,13 +267,21 @@ func parseLCSMatchedPositions(matches any) ([]models.LCSMatchedPosition, error) 
 		}
 
 		if len(matchArray) != 2 && len(matchArray) != 3 {
-			return nil, fmt.Errorf("expected match to be an array of length 2 or 3, got %T with length %d", matchArray, len(matchArray))
+			return nil, fmt.Errorf(
+				"expected match to be an array of length 2 or 3, got %T with length %d",
+				matchArray,
+				len(matchArray),
+			)
 		}
 
 		// Parse Key1 position
 		key1Array, ok := matchArray[0].([]any)
 		if !ok || len(key1Array) != 2 {
-			return nil, fmt.Errorf("expected key1 to be an array of length 2, got %T with length %d", matchArray[0], len(key1Array))
+			return nil, fmt.Errorf(
+				"expected key1 to be an array of length 2, got %T with length %d",
+				matchArray[0],
+				len(key1Array),
+			)
 		}
 
 		key1Start, err := convertToInt64(key1Array[0])
@@ -289,7 +297,11 @@ func parseLCSMatchedPositions(matches any) ([]models.LCSMatchedPosition, error) 
 		// Parse Key2 position
 		key2Array, ok := matchArray[1].([]any)
 		if !ok || len(key2Array) != 2 {
-			return nil, fmt.Errorf("expected key2 to be an array of length 2, got %T with length %d", matchArray[1], len(key2Array))
+			return nil, fmt.Errorf(
+				"expected key2 to be an array of length 2, got %T with length %d",
+				matchArray[1],
+				len(key2Array),
+			)
 		}
 
 		key2Start, err := convertToInt64(key2Array[0])
@@ -1522,10 +1534,12 @@ func handleStringToAnyMapResponse(response *C.struct_CommandResponse) (map[strin
 	return result.(map[string]any), nil
 }
 
-func handleLCSMatchResponse(response *C.struct_CommandResponse, lcsResponseType models.LCSResponseType) (*models.LCSMatch, error) {
-
+func handleLCSMatchResponse(
+	response *C.struct_CommandResponse,
+	lcsResponseType internal.LCSResponseType,
+) (*models.LCSMatch, error) {
 	switch lcsResponseType {
-	case models.SimpleLCSString:
+	case internal.SimpleLCSString:
 		lcsResp, err := handleStringResponse(response)
 		if err != nil {
 			return nil, err
@@ -1535,7 +1549,7 @@ func handleLCSMatchResponse(response *C.struct_CommandResponse, lcsResponseType 
 			Matches:     make([]models.LCSMatchedPosition, 0),
 			Len:         0,
 		}, nil
-	case models.SimpleLCSLength:
+	case internal.SimpleLCSLength:
 		lcsResp, err := handleIntResponse(response)
 		if err != nil {
 			return nil, err
@@ -1545,7 +1559,7 @@ func handleLCSMatchResponse(response *C.struct_CommandResponse, lcsResponseType 
 			Matches:     make([]models.LCSMatchedPosition, 0),
 			Len:         lcsResp,
 		}, nil
-	case models.ComplexLCSMatch:
+	case internal.ComplexLCSMatch:
 		lcsResp, err := handleStringToAnyMapResponse(response)
 		if err != nil {
 			return nil, err
@@ -1570,7 +1584,6 @@ func handleLCSMatchResponse(response *C.struct_CommandResponse, lcsResponseType 
 	default:
 		return nil, fmt.Errorf("unknown LCS response type: %d", lcsResponseType)
 	}
-
 }
 
 func handleRawStringArrayMapResponse(response *C.struct_CommandResponse) (map[string][]string, error) {

--- a/go/string_commands_test.go
+++ b/go/string_commands_test.go
@@ -4,6 +4,7 @@ package glide
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -610,7 +611,7 @@ func ExampleClient_LCS() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	fmt.Println(result)
+	fmt.Println(result.MatchString)
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
@@ -625,7 +626,7 @@ func ExampleClusterClient_LCS() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	fmt.Println(result)
+	fmt.Println(result.MatchString)
 
 	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
 
@@ -676,7 +677,7 @@ func ExampleClient_LCSLen() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	fmt.Println(result)
+	fmt.Println(result.Len)
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
@@ -693,7 +694,7 @@ func ExampleClusterClient_LCSLen() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	fmt.Println(result)
+	fmt.Println(result.Len)
 
 	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
 
@@ -712,7 +713,8 @@ func ExampleClient_LCSWithOptions() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	fmt.Println("Basic LCS result:", result1)
+	jsonRes1, _ := json.Marshal(result1)
+	fmt.Println("Basic LCS result:", string(jsonRes1))
 
 	// LCS IDX with MINMATCHLEN = 4
 	optsWithMin := options.NewLCSIdxOptions()
@@ -721,34 +723,44 @@ func ExampleClient_LCSWithOptions() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	fmt.Println("With MinMatchLen 4:", result2)
+	jsonRes2, _ := json.Marshal(result2)
+	fmt.Println("With MinMatchLen 4:", string(jsonRes2))
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
 	// Output:
-	// Basic LCS result: map[len:3 matches:[[0 1 0 1] [6 7 4 5]]]
-	// With MinMatchLen 4: map[len:0 matches:[]]
+	// Basic LCS result: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
+	// With MinMatchLen 4: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
 }
 
 func ExampleClusterClient_LCSWithOptions() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 
-	client.Set(context.Background(), "{my_key}1", "ohmytext")
-	client.Set(context.Background(), "{my_key}2", "mynewtext")
+	client.Set(context.Background(), "{key}1", "ohmytext")
+	client.Set(context.Background(), "{key}2", "mynewtext")
 
-	// LCS IDX with MINMATCHLEN and WITHMATCHLEN
+	// Basic LCS IDX without additional options
 	opts := options.NewLCSIdxOptions()
-	opts.SetMinMatchLen(2)
-	opts.SetWithMatchLen(true)
-	result, err := client.LCSWithOptions(context.Background(), "{my_key}1", "{my_key}2", *opts)
+	result1, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
+	jsonRes1, _ := json.Marshal(result1)
+	fmt.Println("Basic LCS result:", string(jsonRes1))
 
-	fmt.Println("Full result with both options:", result)
+	// LCS IDX with MINMATCHLEN = 4
+	optsWithMin := options.NewLCSIdxOptions()
+	optsWithMin.SetMinMatchLen(4)
+	result2, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *optsWithMin)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	jsonRes2, _ := json.Marshal(result2)
+	fmt.Println("With MinMatchLen 4:", string(jsonRes2))
 
-	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
+	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
 	// Output:
-	// Full result with both options: map[len:3 matches:[[0 1 0 1 2] [6 7 4 5 2]]]
+	// Basic LCS result: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
+	// With MinMatchLen 4: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
 }

--- a/go/string_commands_test.go
+++ b/go/string_commands_test.go
@@ -613,6 +613,7 @@ func ExampleClient_LCS() {
 	fmt.Println(result)
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
+
 	// Output: h o
 }
 
@@ -627,6 +628,7 @@ func ExampleClusterClient_LCS() {
 	fmt.Println(result)
 
 	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
+
 	// Output: h o
 }
 
@@ -677,7 +679,8 @@ func ExampleClient_LCSLen() {
 	fmt.Println(result)
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
-	// Output: 3
+
+	// Output: 6
 }
 
 func ExampleClusterClient_LCSLen() {
@@ -693,7 +696,8 @@ func ExampleClusterClient_LCSLen() {
 	fmt.Println(result)
 
 	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
-	// Output: 3
+
+	// Output: 6
 }
 
 func ExampleClient_LCSWithOptions() {
@@ -720,6 +724,7 @@ func ExampleClient_LCSWithOptions() {
 	fmt.Println("With MinMatchLen 4:", result2)
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
+
 	// Output:
 	// Basic LCS result: map[len:3 matches:[[0 1 0 1] [6 7 4 5]]]
 	// With MinMatchLen 4: map[len:0 matches:[]]
@@ -743,6 +748,7 @@ func ExampleClusterClient_LCSWithOptions() {
 	fmt.Println("Full result with both options:", result)
 
 	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
+
 	// Output:
 	// Full result with both options: map[len:3 matches:[[0 1 0 1 2] [6 7 4 5 2]]]
 }

--- a/go/string_commands_test.go
+++ b/go/string_commands_test.go
@@ -603,36 +603,6 @@ func ExampleClusterClient_Append() {
 	// my_value
 }
 
-func ExampleClient_LCS() {
-	var client *Client = getExampleClient() // example helper function
-
-	client.MSet(context.Background(), map[string]string{"my_key1": "oh my gosh", "my_key2": "hello world"})
-	result, err := client.LCS(context.Background(), "my_key1", "my_key2")
-	if err != nil {
-		fmt.Println("Glide example failed with an error: ", err)
-	}
-	fmt.Println(result.MatchString)
-
-	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
-
-	// Output: h o
-}
-
-func ExampleClusterClient_LCS() {
-	var client *ClusterClient = getExampleClusterClient() // example helper function
-
-	client.MSet(context.Background(), map[string]string{"{my_key}1": "oh my gosh", "{my_key}2": "hello world"})
-	result, err := client.LCS(context.Background(), "{my_key}1", "{my_key}2")
-	if err != nil {
-		fmt.Println("Glide example failed with an error: ", err)
-	}
-	fmt.Println(result.MatchString)
-
-	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
-
-	// Output: h o
-}
-
 func ExampleClient_GetDel() {
 	var client *Client = getExampleClient() // example helper function
 
@@ -665,6 +635,36 @@ func ExampleClusterClient_GetDel() {
 	// Output:
 	// my_value
 	// true
+}
+
+func ExampleClient_LCS() {
+	var client *Client = getExampleClient() // example helper function
+
+	client.MSet(context.Background(), map[string]string{"my_key1": "oh my gosh", "my_key2": "hello world"})
+	result, err := client.LCS(context.Background(), "my_key1", "my_key2")
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	fmt.Println(result.MatchString)
+
+	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
+
+	// Output: h o
+}
+
+func ExampleClusterClient_LCS() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+
+	client.MSet(context.Background(), map[string]string{"{my_key}1": "oh my gosh", "{my_key}2": "hello world"})
+	result, err := client.LCS(context.Background(), "{my_key}1", "{my_key}2")
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	fmt.Println(result.MatchString)
+
+	// LCS is only available in 7.0 and above. It will fail in any release < 7.0
+
+	// Output: h o
 }
 
 func ExampleClient_LCSLen() {
@@ -701,7 +701,7 @@ func ExampleClusterClient_LCSLen() {
 	// Output: 6
 }
 
-func ExampleClient_LCSWithOptions() {
+func ExampleClient_LCSWithOptions_basic() {
 	var client *Client = getExampleClient() // example helper function
 
 	client.Set(context.Background(), "my_key1", "ohmytext")
@@ -709,12 +709,101 @@ func ExampleClient_LCSWithOptions() {
 
 	// Basic LCS IDX without additional options
 	opts := options.NewLCSIdxOptions()
-	result1, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *opts)
+	result, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	jsonRes1, _ := json.Marshal(result1)
-	fmt.Println("Basic LCS result:", string(jsonRes1))
+	jsonRes, _ := json.MarshalIndent(result, "", "  ")
+	fmt.Println("Basic LCS result:\n", string(jsonRes))
+
+	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
+
+	// Output:
+	// Basic LCS result:
+	//  {
+	//   "MatchString": "",
+	//   "Matches": [
+	//     {
+	//       "Key1": {
+	//         "Start": 4,
+	//         "End": 7
+	//       },
+	//       "Key2": {
+	//         "Start": 5,
+	//         "End": 8
+	//       },
+	//       "MatchLen": 0
+	//     },
+	//     {
+	//       "Key1": {
+	//         "Start": 2,
+	//         "End": 3
+	//       },
+	//       "Key2": {
+	//         "Start": 0,
+	//         "End": 1
+	//       },
+	//       "MatchLen": 0
+	//     }
+	//   ],
+	//   "Len": 6
+	// }
+}
+
+func ExampleClusterClient_LCSWithOptions_basic() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+
+	client.Set(context.Background(), "{key}1", "ohmytext")
+	client.Set(context.Background(), "{key}2", "mynewtext")
+
+	// Basic LCS IDX without additional options
+	opts := options.NewLCSIdxOptions()
+	result, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *opts)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	jsonRes, _ := json.MarshalIndent(result, "", "  ")
+	fmt.Println("Basic LCS result:\n", string(jsonRes))
+
+	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
+
+	// Output:
+	// Basic LCS result:
+	//  {
+	//   "MatchString": "",
+	//   "Matches": [
+	//     {
+	//       "Key1": {
+	//         "Start": 4,
+	//         "End": 7
+	//       },
+	//       "Key2": {
+	//         "Start": 5,
+	//         "End": 8
+	//       },
+	//       "MatchLen": 0
+	//     },
+	//     {
+	//       "Key1": {
+	//         "Start": 2,
+	//         "End": 3
+	//       },
+	//       "Key2": {
+	//         "Start": 0,
+	//         "End": 1
+	//       },
+	//       "MatchLen": 0
+	//     }
+	//   ],
+	//   "Len": 6
+	// }
+}
+
+func ExampleClient_LCSWithOptions_minmatchlen() {
+	var client *Client = getExampleClient() // example helper function
+
+	client.Set(context.Background(), "my_key1", "ohmytext")
+	client.Set(context.Background(), "my_key2", "mynewtext")
 
 	// LCS IDX with MINMATCHLEN = 4
 	optsWithMin := options.NewLCSIdxOptions()
@@ -723,48 +812,67 @@ func ExampleClient_LCSWithOptions() {
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	jsonRes2, _ := json.Marshal(result2)
-	fmt.Println("With MinMatchLen 4:", string(jsonRes2))
+	jsonRes2, _ := json.MarshalIndent(result2, "", "  ")
+	fmt.Println("With MinMatchLen 4:\n", string(jsonRes2))
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
 	// Output:
-	// Basic LCS result:
-	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
 	// With MinMatchLen 4:
-	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
+	//  {
+	//   "MatchString": "",
+	//   "Matches": [
+	//     {
+	//       "Key1": {
+	//         "Start": 4,
+	//         "End": 7
+	//       },
+	//       "Key2": {
+	//         "Start": 5,
+	//         "End": 8
+	//       },
+	//       "MatchLen": 0
+	//     }
+	//   ],
+	//   "Len": 6
+	// }
 }
 
-func ExampleClusterClient_LCSWithOptions() {
+func ExampleClusterClient_LCSWithOptions_minmatchlen() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 
 	client.Set(context.Background(), "{key}1", "ohmytext")
 	client.Set(context.Background(), "{key}2", "mynewtext")
 
-	// Basic LCS IDX without additional options
-	opts := options.NewLCSIdxOptions()
-	result1, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *opts)
-	if err != nil {
-		fmt.Println("Glide example failed with an error: ", err)
-	}
-	jsonRes1, _ := json.Marshal(result1)
-	fmt.Println("Basic LCS result:", string(jsonRes1))
-
 	// LCS IDX with MINMATCHLEN = 4
 	optsWithMin := options.NewLCSIdxOptions()
 	optsWithMin.SetMinMatchLen(4)
-	result2, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *optsWithMin)
+	result2, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *optsWithMin)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
-	jsonRes2, _ := json.Marshal(result2)
-	fmt.Println("With MinMatchLen 4:", string(jsonRes2))
+	jsonRes2, _ := json.MarshalIndent(result2, "", "  ")
+	fmt.Println("With MinMatchLen 4:\n", string(jsonRes2))
 
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
 	// Output:
-	// Basic LCS result:
-	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
 	// With MinMatchLen 4:
-	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
+	//  {
+	//   "MatchString": "",
+	//   "Matches": [
+	//     {
+	//       "Key1": {
+	//         "Start": 4,
+	//         "End": 7
+	//       },
+	//       "Key2": {
+	//         "Start": 5,
+	//         "End": 8
+	//       },
+	//       "MatchLen": 0
+	//     }
+	//   ],
+	//   "Len": 6
+	// }
 }

--- a/go/string_commands_test.go
+++ b/go/string_commands_test.go
@@ -729,8 +729,10 @@ func ExampleClient_LCSWithOptions() {
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
 	// Output:
-	// Basic LCS result: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
-	// With MinMatchLen 4: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
+	// Basic LCS result:
+	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
+	// With MinMatchLen 4:
+	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
 }
 
 func ExampleClusterClient_LCSWithOptions() {
@@ -761,6 +763,8 @@ func ExampleClusterClient_LCSWithOptions() {
 	// LCS is only available in 7.0 and above. It will fail in any server < 7.0
 
 	// Output:
-	// Basic LCS result: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
-	// With MinMatchLen 4: {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
+	// Basic LCS result:
+	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4},{"Key1":{"Start":2,"End":3},"Key2":{"Start":0,"End":1},"MatchLen":2}],"Len":6}
+	// With MinMatchLen 4:
+	// {"MatchString":"","Matches":[{"Key1":{"Start":4,"End":7},"Key2":{"Start":5,"End":8},"MatchLen":4}],"Len":6}
 }

--- a/go/string_commands_test.go
+++ b/go/string_commands_test.go
@@ -758,7 +758,7 @@ func ExampleClusterClient_LCSWithOptions_basic() {
 
 	// Basic LCS IDX without additional options
 	opts := options.NewLCSIdxOptions()
-	result, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *opts)
+	result, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}
@@ -847,7 +847,7 @@ func ExampleClusterClient_LCSWithOptions_minmatchlen() {
 	// LCS IDX with MINMATCHLEN = 4
 	optsWithMin := options.NewLCSIdxOptions()
 	optsWithMin.SetMinMatchLen(4)
-	result2, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *optsWithMin)
+	result2, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *optsWithMin)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
 	}


### PR DESCRIPTION
### Description

This PR updates the return type for LCS commands to return strongly typed objects instead of raw responses, making the API more user-friendly and consistent with other commands. This addresses part of issue #4144, which aims to return smart and user-friendly objects/structs for commands with complex return types.

### Issue link

This Pull Request is linked to issue (#4144)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.