### PR TITLE
Go: Fix collision in option types.

### DIFF
--- a/go/config/request_routing_config.go
+++ b/go/config/request_routing_config.go
@@ -19,7 +19,7 @@ type Route interface {
 
 type SingleNodeRoute interface {
 	IsMultiNode() bool
-	dummy()
+	dummySingleNodeRoute()
 }
 
 type (
@@ -41,9 +41,9 @@ const (
 
 func (route SimpleNodeRoute) IsMultiNode() bool { return route != SimpleNodeRoute(RandomRoute) }
 
-func (route SimpleSingleNodeRoute) IsMultiNode() bool { return false }
-func (route SimpleMultiNodeRoute) IsMultiNode() bool  { return true }
-func (route SimpleSingleNodeRoute) dummy()            {}
+func (route SimpleSingleNodeRoute) IsMultiNode() bool     { return false }
+func (route SimpleMultiNodeRoute) IsMultiNode() bool      { return true }
+func (route SimpleSingleNodeRoute) dummySingleNodeRoute() {}
 
 func (snr SimpleSingleNodeRoute) ToPtr() *Route {
 	a := Route(snr)
@@ -79,8 +79,8 @@ func NewSlotIdRoute(slotType SlotType, slotId int32) *SlotIdRoute {
 	return &SlotIdRoute{SlotType: slotType, SlotID: slotId}
 }
 
-func (route SlotIdRoute) dummy()            {}
-func (route SlotIdRoute) IsMultiNode() bool { return false }
+func (route SlotIdRoute) dummySingleNodeRoute() {}
+func (route SlotIdRoute) IsMultiNode() bool     { return false }
 
 // Request routing configuration overrides the [api.ReadFrom] connection configuration.
 // If SlotTypeReplica is used, the request will be routed to a replica, even if the strategy is ReadFrom [api.PreferReplica].
@@ -95,8 +95,8 @@ func NewSlotKeyRoute(slotType SlotType, slotKey string) *SlotKeyRoute {
 	return &SlotKeyRoute{SlotType: slotType, SlotKey: slotKey}
 }
 
-func (route SlotKeyRoute) dummy()            {}
-func (route SlotKeyRoute) IsMultiNode() bool { return false }
+func (route SlotKeyRoute) dummySingleNodeRoute() {}
+func (route SlotKeyRoute) IsMultiNode() bool     { return false }
 
 // Routes a request to a node by its address.
 type ByAddressRoute struct {
@@ -127,5 +127,5 @@ func NewByAddressRouteWithHost(host string) (*ByAddressRoute, error) {
 	return &ByAddressRoute{Host: split[0], Port: int32(port)}, nil
 }
 
-func (route ByAddressRoute) dummy()            {}
-func (route ByAddressRoute) IsMultiNode() bool { return false }
+func (route ByAddressRoute) dummySingleNodeRoute() {}
+func (route ByAddressRoute) IsMultiNode() bool     { return false }

--- a/go/options/bitfield_options.go
+++ b/go/options/bitfield_options.go
@@ -9,12 +9,14 @@ import (
 // Subcommands for bitfield operations.
 type BitFieldSubCommands interface {
 	ToArgs() ([]string, error)
+	dummyBitFieldSubCommands()
 }
 
 // Subcommands for bitfieldReadOnly.
 type BitFieldROCommands interface {
-	dummy()
 	ToArgs() ([]string, error)
+	dummyBitFieldSubCommands()
+	dummyBitFieldROCommands()
 }
 
 type EncType string
@@ -69,7 +71,8 @@ func (cmd *BitFieldGet) ToArgs() ([]string, error) {
 	return args, nil
 }
 
-func (cmd *BitFieldGet) dummy() {}
+func (cmd *BitFieldGet) dummyBitFieldROCommands()  {}
+func (cmd *BitFieldGet) dummyBitFieldSubCommands() {}
 
 // BitFieldSet represents a SET operation to set the bits in the binary
 // representation of the string stored in key based on EncType and Offset.
@@ -104,6 +107,8 @@ func (cmd *BitFieldSet) ToArgs() ([]string, error) {
 	return args, nil
 }
 
+func (cmd *BitFieldSet) dummyBitFieldSubCommands() {}
+
 // BitFieldIncrBy represents a INCRBY subcommand for increasing or decreasing the bits in the binary
 // representation of the string stored in key based on EncType and Offset.
 type BitFieldIncrBy struct {
@@ -137,6 +142,8 @@ func (cmd *BitFieldIncrBy) ToArgs() ([]string, error) {
 	return args, nil
 }
 
+func (cmd *BitFieldIncrBy) dummyBitFieldSubCommands() {}
+
 // BitFieldOverflow represents a OVERFLOW subcommand that determines the result of the SET
 // or INCRBY commands when an under or overflow occurs.
 type BitFieldOverflow struct {
@@ -154,3 +161,5 @@ func NewBitFieldOverflow(overflow OverflowType) *BitFieldOverflow {
 func (cmd *BitFieldOverflow) ToArgs() ([]string, error) {
 	return []string{overFlow, string(cmd.Overflow)}, nil
 }
+
+func (cmd *BitFieldOverflow) dummyBitFieldSubCommands() {}

--- a/go/options/geosearch_options.go
+++ b/go/options/geosearch_options.go
@@ -21,6 +21,7 @@ type Location struct {
 // The interface representing origin of the search for the `GeoSearch` command
 type GeoSearchOrigin interface {
 	ToArgs() ([]string, error)
+	dummyGeoSearchOrigin()
 }
 
 // The search origin represented by a [GeospatialData] position
@@ -37,6 +38,8 @@ func (o *GeoCoordOrigin) ToArgs() ([]string, error) {
 	}, nil
 }
 
+func (o *GeoCoordOrigin) dummyGeoSearchOrigin() {}
+
 // The search origin represented by an existing member in the sorted set
 type GeoMemberOrigin struct {
 	Member string
@@ -49,6 +52,8 @@ func (o *GeoMemberOrigin) ToArgs() ([]string, error) {
 		o.Member,
 	}, nil
 }
+
+func (o *GeoMemberOrigin) dummyGeoSearchOrigin() {}
 
 // The search options for the `GeoSearch` command
 type GeoSearchShape struct {

--- a/go/options/zrange_options.go
+++ b/go/options/zrange_options.go
@@ -13,6 +13,7 @@ import (
 //   - For range queries by score, use `RangeByScore`.
 type ZRangeQuery interface {
 	ToArgs() ([]string, error)
+	dummyZRangeQuery()
 }
 
 type ZRemRangeQuery interface {
@@ -115,6 +116,8 @@ func (rbi *RangeByIndex) ToArgs() ([]string, error) {
 	return args, nil
 }
 
+func (rbi *RangeByIndex) dummyZRangeQuery() {}
+
 // Queries a range of elements from a sorted set by theirs score.
 //
 // Parameters:
@@ -156,6 +159,8 @@ func (rbs *RangeByScore) ToArgs() ([]string, error) {
 func (rbs *RangeByScore) ToArgsRemRange() ([]string, error) {
 	return []string{string(rbs.start), string(rbs.end)}, nil
 }
+
+func (rbi *RangeByScore) dummyZRangeQuery() {}
 
 // Queries a range of elements from a sorted set by theirs lexicographical order.
 //
@@ -203,15 +208,18 @@ func (rbl *RangeByLex) ToArgsLexCount() []string {
 	return []string{string(rbl.start), string(rbl.end)}
 }
 
+func (rbi *RangeByLex) dummyZRangeQuery() {}
+
 // Query for `ZRangeWithScores` in [SortedSetCommands]
 //   - For range queries by index (rank), use `RangeByIndex`.
 //   - For range queries by score, use `RangeByScore`.
 type ZRangeQueryWithScores interface {
-	// A dummy interface to distinguish queries for `ZRange` and `ZRangeWithScores`
+	// A dummyZRangeQueryWithScores interface to distinguish queries for `ZRange` and `ZRangeWithScores`
 	// `ZRangeWithScores` does not support BYLEX
-	dummy()
+	dummyZRangeQueryWithScores()
+	dummyZRangeQuery()
 	ToArgs() ([]string, error)
 }
 
-func (q *RangeByIndex) dummy() {}
-func (q *RangeByScore) dummy() {}
+func (q *RangeByIndex) dummyZRangeQueryWithScores() {}
+func (q *RangeByScore) dummyZRangeQueryWithScores() {}


### PR DESCRIPTION
Fix interface collision for option types. Added few private dummy methods which protects versus misuse option types.

### Issue link

This Pull Request is linked to issue (URL): fixes #4142

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.