### PR TITLE
Go: Fix Linking to Other Commands in Docs

### DIFF
--- a/go/base_client.go
+++ b/go/base_client.go
@@ -3266,14 +3266,14 @@ func (client *baseClient) LMove(
 	return handleStringOrNilResponse(result)
 }
 
-// Blocks the connection until it pops atomically and removes the left/right-most element to the list stored at source
-// depending on whereFrom, and pushes the element at the first/last element of the list stored at <destination depending on
-// wherefrom.
-// BLMove is the blocking variant of [LMove].
+// Blocks the connection until it pops atomically and removes the left/right-most element to the list stored at `source`
+// depending on `whereFrom`, and pushes the element at the first/last element of the list stored at `destination` depending on
+// `whereFrom`.
+// `BLMove` is the blocking variant of [Client.LMove] and [ClusterClient.LMove].
 //
 // Note:
-//   - When in cluster mode, all source and destination must map to the same hash slot.
-//   - BLMove is a client blocking command, see [Blocking Commands] for more details and best practices.
+//   - When in cluster mode, `source` and `destination` must map to the same hash slot.
+//   - `BLMove` is a client blocking command, see [Blocking Commands] for more details and best practices.
 //
 // Since:
 //
@@ -3286,13 +3286,13 @@ func (client *baseClient) LMove(
 //	ctx         - The context for controlling the command execution.
 //	source      - The key to the source list.
 //	destination - The key to the destination list.
-//	wherefrom   - The ListDirection the element should be removed from.
-//	whereto     - The ListDirection the element should be added to.
+//	whereFrom   - The ListDirection the element should be removed from.
+//	whereTo     - The ListDirection the element should be added to.
 //	timeout     - The duration to wait for a blocking operation to complete. A value of `0` will block indefinitely.
 //
 // Return value:
 //
-//	A models.Result[string] containing the popped element or models.CreateNilStringResult() if source does not exist or if the
+//	A models.Result[string] containing the popped element or models.CreateNilStringResult() if `source` does not exist or if the
 //	operation timed-out.
 //
 // [valkey.io]: https://valkey.io/commands/blmove/
@@ -4562,11 +4562,11 @@ func (client *baseClient) ZCard(ctx context.Context, key string) (int64, error) 
 // Blocks the connection until it removes and returns a member-score pair
 // with the lowest score from the first non-empty sorted set.
 // The given `keys` being checked in the order they are provided.
-// BZPOPMIN is the blocking variant of [ZPOPMIN].
+// `BZPopMin` is the blocking variant of [Client.BZPopMin] and [ClusterClient.BZPopMin].
 //
 // Note:
 //   - When in cluster mode, all `keys` must map to the same hash slot.
-//   - `BZPOPMIN` is a client blocking command, see [Blocking Commands] for more details and best practices.
+//   - `BZPopMin` is a client blocking command, see [Blocking Commands] for more details and best practices.
 //
 // See [valkey.io] for more details.
 //
@@ -7640,11 +7640,11 @@ func (client *baseClient) ZLexCount(ctx context.Context, key string, rangeQuery 
 // Blocks the connection until it pops and returns a member-score pair
 // with the highest score from the first non-empty sorted set.
 // The given `keys` being checked in the order they are provided.
-// BZPOPMIN is the blocking variant of [ZPOPMIN].
+// `BZPopMax` is the blocking variant of [Client.ZPopMax] and [ClusterClient.ZPopMax].
 //
 // Note:
 //   - When in cluster mode, all keys must map to the same hash slot.
-//   - BZPopMax is a client blocking command, see [Blocking Commands] for more details and best practices.
+//   - `BZPopMax` is a client blocking command, see [Blocking Commands] for more details and best practices.
 //
 // See [valkey.io] for details.
 //

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -742,8 +742,8 @@ func (client *baseClient) Set(ctx context.Context, key string, value string) (st
 }
 
 // SetWithOptions sets the given key with the given value using the given options. The return value is dependent on the
-// passed options. If the value is successfully set, "OK" is returned. If value isn't set because of [OnlyIfExists] or
-// [OnlyIfDoesNotExist] conditions, models.CreateNilStringResult() is returned. If [SetOptions#ReturnOldValue] is
+// passed options. If the value is successfully set, "OK" is returned. If value isn't set because of [constants.OnlyIfExists]
+// or [constants.OnlyIfDoesNotExist] conditions, models.CreateNilStringResult() is returned. If [constants.ReturnOldValue] is
 // set, the old value is returned.
 //
 // See [valkey.io] for details.
@@ -3081,7 +3081,7 @@ func (client *baseClient) LMPopCount(
 }
 
 // Blocks the connection until it pops one element from the first non-empty list from the provided keys.
-// BLMPop is the blocking variant of [LMPop].
+// BLMPop is the blocking variant of [Client.LMPop] and [ClusterClient.LMPop].
 //
 // Note:
 //   - When in cluster mode, all keys must map to the same hash slot.
@@ -3137,7 +3137,7 @@ func (client *baseClient) BLMPop(
 }
 
 // Blocks the connection until it pops one or more elements from the first non-empty list from the provided keys.
-// BLMPopCount is the blocking variant of [LMPopCount].
+// BLMPopCount is the blocking variant of [Client.LMPopCount] [ClusterClient.LMPopCount].
 //
 // Note:
 //   - When in cluster mode, all keys must map to the same hash slot.
@@ -3292,8 +3292,8 @@ func (client *baseClient) LMove(
 //
 // Return value:
 //
-//	A models.Result[string] containing the popped element or models.CreateNilStringResult() if `source` does not exist or if the
-//	operation timed-out.
+//	A models.Result[string] containing the popped element or models.CreateNilStringResult() if `source` does not exist or if
+//	the operation timed-out.
 //
 // [valkey.io]: https://valkey.io/commands/blmove/
 // [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
@@ -3852,7 +3852,7 @@ func (client *baseClient) PfMerge(ctx context.Context, destination string, sourc
 }
 
 // Unlink (delete) multiple keys from the database. A key is ignored if it does not exist.
-// This command, similar to [Del], however, this command does not block the server.
+// This command, similar to [Client.Del] and [ClusterClient.Del], however, this command does not block the server.
 //
 // Note:
 //
@@ -4243,7 +4243,7 @@ func (client *baseClient) ZAdd(
 //	ctx - The context for controlling the command execution.
 //	key - The key of the set.
 //	membersScoreMap - A map of members to their scores.
-//	opts - The options for the command. See [ZAddOptions] for details.
+//	opts - The options for the command. See [Client.ZAddOptions] [ClusterClient.ZAddOptions] for details.
 //
 // Return value:
 //
@@ -4600,7 +4600,7 @@ func (client *baseClient) BZPopMin(
 
 // Blocks the connection until it pops and returns a member-score pair from the first non-empty sorted set, with the
 // given keys being checked in the order they are provided.
-// BZMPop is the blocking variant of [ZMPop].
+// BZMPop is the blocking variant of [Client.ZMPop] and [ClusterClient.ZMPop].
 //
 // Note:
 //   - When in cluster mode, all keys must map to the same hash slot.
@@ -4662,7 +4662,7 @@ func (client *baseClient) BZMPop(
 
 // Blocks the connection until it pops and returns a member-score pair from the first non-empty sorted set, with the
 // given keys being checked in the order they are provided.
-// BZMPop is the blocking variant of [ZMPop].
+// BZMPop is the blocking variant of [Client.ZMPop] and [ClusterClient.ZMPop].
 //
 // Note:
 //   - When in cluster mode, all keys must map to the same hash slot.
@@ -4733,7 +4733,7 @@ func (client *baseClient) BZMPopWithOptions(
 // Returns the specified range of elements in the sorted set stored at `key`.
 // `ZRANGE` can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
 //
-// To get the elements with their scores, see [ZRangeWithScores].
+// To get the elements with their scores, see [Client.ZRangeWithScores] and [ClusterClient.ZRangeWithScores].
 //
 // See [valkey.io] for more details.
 //
@@ -4915,7 +4915,7 @@ func (client *baseClient) ZCount(ctx context.Context, key string, rangeOptions o
 
 // Returns the rank of `member` in the sorted set stored at `key`, with
 // scores ordered from low to high, starting from `0`.
-// To get the rank of `member` with its score, see [ZRankWithScore].
+// To get the rank of `member` with its score, see [Client.ZRankWithScore] and [ClusterClient.ZRankWithScore].
 //
 // See [valkey.io] for details.
 //
@@ -4976,7 +4976,7 @@ func (client *baseClient) ZRankWithScore(
 
 // Returns the rank of `member` in the sorted set stored at `key`, where
 // scores are ordered from the highest to lowest, starting from `0`.
-// To get the rank of `member` with its score, see [ZRevRankWithScore].
+// To get the rank of `member` with its score, see [Client.ZRevRankWithScore] and [ClusterClient.ZRevRankWithScore].
 //
 // See [valkey.io] for details.
 //
@@ -5004,7 +5004,6 @@ func (client *baseClient) ZRevRank(ctx context.Context, key string, member strin
 
 // Returns the rank of `member` in the sorted set stored at `key`, where
 // scores are ordered from the highest to lowest, starting from `0`.
-// To get the rank of `member` with its score, see [ZRevRankWithScore].
 //
 // Since:
 //
@@ -5022,7 +5021,7 @@ func (client *baseClient) ZRevRank(ctx context.Context, key string, member strin
 //
 //	A tuple containing the rank of `member` and its score.
 //	If `key` doesn't exist, or if `member` is not present in the set,
-//	`nil` will be returned.s
+//	`nil` will be returned.
 //
 // [valkey.io]: https://valkey.io/commands/zrevrank/
 func (client *baseClient) ZRevRankWithScore(
@@ -5511,7 +5510,7 @@ func (client *baseClient) XGroupCreateWithOptions(
 }
 
 // Creates a key associated with a value that is obtained by
-// deserializing the provided serialized value (obtained via [Dump]).
+// deserializing the provided serialized value (obtained via [Client.Dump] or [ClusterClient.Dump]).
 //
 // Parameters:
 //
@@ -5530,7 +5529,7 @@ func (client *baseClient) Restore(ctx context.Context, key string, ttl time.Dura
 }
 
 // Creates a key associated with a value that is obtained by
-// deserializing the provided serialized value (obtained via [Dump]).
+// deserializing the provided serialized value (obtained via [Client.Dump] or [ClusterClient.Dump]).
 //
 // Parameters:
 //
@@ -5959,7 +5958,7 @@ func (client *baseClient) ObjectRefCount(ctx context.Context, key string) (model
 // Sorts the elements in the list, set, or sorted set at key and returns the result.
 // The sort command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To store the result into a new key, see the [SortStore] function.
+// To store the result into a new key, see the [Client.SortStore] or [ClusterClient.SortStore] function.
 //
 // See [valkey.io] for details.
 //
@@ -5984,7 +5983,8 @@ func (client *baseClient) Sort(ctx context.Context, key string) ([]models.Result
 // Sorts the elements in the list, set, or sorted set at key and returns the result.
 // The sort command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To store the result into a new key, see the [SortStore] function.
+// To store the result into a new key, see the [Client.SortStoreWithOptions] or
+// [ClusterClient.SortStoreWithOptions] function.
 //
 // Note:
 //
@@ -6101,7 +6101,8 @@ func (client *baseClient) SortReadOnlyWithOptions(
 // different criteria, apply transformations on sorted elements, and store the result in a new key.
 // The SortStore command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To get the sort result without storing it into a key, see the [Sort] or [SortReadOnly] function.
+// To get the sort result without storing it into a key, see the [Client.Sort] and [ClusterClient.Sort]
+// or [Client.SortReadOnly] and [ClusterClient.SortReadOnly] function.
 //
 // Note:
 //
@@ -6138,7 +6139,8 @@ func (client *baseClient) SortStore(ctx context.Context, key string, destination
 // different criteria, apply transformations on sorted elements, and store the result in a new key.
 // The SortStore command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To get the sort result without storing it into a key, see the [Sort] or [SortReadOnly] function.
+// To get the sort result without storing it into a key, see the [Client.SortWithOptions] and [ClusterClient.SortWithOptions]
+// or [Client.SortReadOnlyWithOptions] and [ClusterClient.SortReadOnlyWithOptions] function.
 //
 // Note:
 //
@@ -7117,7 +7119,7 @@ func (client *baseClient) Time(ctx context.Context) ([]string, error) {
 }
 
 // Returns the intersection of members from sorted sets specified by the given `keys`.
-// To get the elements with their scores, see [ZInterWithScores].
+// To get the elements with their scores, see [Client.ZInterWithScores] or [ClusterClient.ZInterWithScores].
 //
 // Note:
 //
@@ -7275,7 +7277,7 @@ func (client *baseClient) ZInterStoreWithOptions(
 }
 
 // Returns the difference between the first sorted set and all the successive sorted sets.
-// To get the elements with their scores, see [ZDiffWithScores].
+// To get the elements with their scores, see [Client.ZDiffWithScores] or [ClusterClient.ZDiffWithScores].
 //
 // Note:
 //
@@ -7379,7 +7381,7 @@ func (client *baseClient) ZDiffStore(ctx context.Context, destination string, ke
 }
 
 // Returns the union of members from sorted sets specified by the given `keys`.
-// To get the elements with their scores, see [ZUnionWithScores].
+// To get the elements with their scores, see [Client.ZUnionWithScores] or [ClusterClient.ZUnionWithScores].
 //
 // Since:
 //
@@ -7969,7 +7971,7 @@ func (client *baseClient) GeoDistWithUnit(
 	return handleFloatOrNilResponse(result)
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [Client.GeoAdd] or [ClusterClient.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -8036,7 +8038,7 @@ func (client *baseClient) GeoSearchWithFullOptions(
 	return handleLocationArrayResponse(result)
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [Client.GeoAdd] or [ClusterClient.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -8093,7 +8095,7 @@ func (client *baseClient) GeoSearchWithResultOptions(
 	return handleStringArrayResponse(result)
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [Client.GeoAdd] or [ClusterClient.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -8141,7 +8143,7 @@ func (client *baseClient) GeoSearchWithInfoOptions(
 	)
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [Client.GeoAdd] or [ClusterClient.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -8184,7 +8186,7 @@ func (client *baseClient) GeoSearch(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [Client.GeoSearchWithFullOptions] or [ClusterClient.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -8256,7 +8258,7 @@ func (client *baseClient) GeoSearchStoreWithFullOptions(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [Client.GeoSearchWithFullOptions] or [ClusterClient.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -8307,7 +8309,7 @@ func (client *baseClient) GeoSearchStore(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [Client.GeoSearchWithFullOptions] or [ClusterClient.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -8360,7 +8362,7 @@ func (client *baseClient) GeoSearchStoreWithResultOptions(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [Client.GeoSearchWithFullOptions] or [ClusterClient.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -8519,7 +8521,7 @@ func (client *baseClient) FunctionFlushAsync(ctx context.Context) (string, error
 
 // Invokes a previously loaded function.
 // The command will be routed to a primary random node.
-// To route to a replica please refer to [FCallReadOnly].
+// To route to a replica please refer to [Client.FCallReadOnly] or [ClusterClient.FCallReadOnly].
 //
 // Since:
 //
@@ -8574,7 +8576,7 @@ func (client *baseClient) FCallReadOnly(ctx context.Context, function string) (a
 
 // Invokes a previously loaded function.
 // This command is routed to primary nodes only.
-// To route to a replica please refer to [FCallReadOnly].
+// To route to a replica please refer to [Client.FCallReadOnly] or [ClusterClient.FCallReadOnly].
 //
 // Since:
 //

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -486,7 +486,7 @@ func (config *ClusterClientConfiguration) GetSubscription() *ClusterSubscription
 	return nil
 }
 
-// Represents advanced configuration settings for a Standalone [Client] used in [ClientConfiguration].
+// Represents advanced configuration settings for a Standalone client used in [ClientConfiguration].
 type AdvancedClientConfiguration struct {
 	connectionTimeout time.Duration
 }
@@ -511,7 +511,7 @@ func (config *AdvancedClientConfiguration) WithConnectionTimeout(
 	return config
 }
 
-// Represents advanced configuration settings for a Standalone [ClusterClient] used in
+// Represents advanced configuration settings for a Cluster client used in
 // [ClusterClientConfiguration].
 type AdvancedClusterClientConfiguration struct {
 	connectionTimeout time.Duration

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -775,7 +775,7 @@ func (client *Client) FunctionKill(ctx context.Context) (string, error) {
 // Return value:
 //
 //	A map of node addresses to their function statistics represented by
-//	[FunctionStatsResult] object containing the following information:
+//	[models.FunctionStatsResult] object containing the following information:
 //	running_script - Information about the running script.
 //	engines - Information about available engines and their stats.
 //
@@ -865,7 +865,7 @@ func (client *Client) FunctionDump(ctx context.Context) (string, error) {
 	return handleStringResponse(result)
 }
 
-// Restores libraries from the serialized payload returned by [FunctionDump].
+// Restores libraries from the serialized payload returned by [Client.FunctionDump].
 //
 // Since:
 //
@@ -891,7 +891,7 @@ func (client *Client) FunctionRestore(ctx context.Context, payload string) (stri
 	return handleOkResponse(result)
 }
 
-// Restores libraries from the serialized payload returned by [FunctionDump].
+// Restores libraries from the serialized payload returned by [Client.FunctionDump].
 //
 // Since:
 //

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -240,7 +240,7 @@ func (client *ClusterClient) Info(ctx context.Context) (map[string]string, error
 }
 
 // Gets information and statistics about the server.
-// The command will be routed to all primary nodes, unless `route` in [ClusterInfoOptions] is provided.
+// The command will be routed to all primary nodes, unless `route` in [options.ClusterInfoOptions] is provided.
 //
 // Note:
 //
@@ -1469,7 +1469,7 @@ func (client *ClusterClient) FunctionFlushAsyncWithRoute(ctx context.Context, ro
 }
 
 // Invokes a previously loaded function.
-// To route to a replica please refer to [FCallReadOnly].
+// To route to a replica please refer to [ClusterClient.FCallReadOnly].
 //
 // Since:
 //
@@ -2159,7 +2159,7 @@ func (client *ClusterClient) FunctionDump(ctx context.Context) (string, error) {
 //
 // Return value:
 //
-//	A [ClusterValue] containing the serialized payload of all loaded libraries.
+//	A [models.ClusterValue] containing the serialized payload of all loaded libraries.
 //
 // [valkey.io]: https://valkey.io/commands/function-dump/
 func (client *ClusterClient) FunctionDumpWithRoute(

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -1899,7 +1899,7 @@ func (b *BaseBatch[T]) BLMPop(keys []string, listDirection constants.ListDirecti
 }
 
 // Blocks the connection until it pops one or more elements from the first non-empty list.
-// BLMPopCount is the blocking variant of [LMPopCount].
+// BLMPopCount is the blocking variant of [BaseBatch.LMPopCount].
 //
 // Note:
 //
@@ -2008,7 +2008,7 @@ func (b *BaseBatch[T]) LMove(
 // Blocks the connection until it pops atomically and removes the left/right-most element to the list stored at source
 // depending on whereFrom, and pushes the element at the first/last element of the list stored at <destination depending on
 // wherefrom.
-// BLMove is the blocking variant of [LMove].
+// BLMove is the blocking variant of [BaseBatch.LMove].
 //
 // Note:
 //
@@ -2466,7 +2466,7 @@ func (b *BaseBatch[T]) PfMerge(destination string, sourceKeys []string) *T {
 }
 
 // Unlinks (deletes) multiple keys from the database. A key is ignored if it does not exist.
-// This command, similar to [Del], however, this command does not block the server.
+// This command, similar to [BaseBatch.Del], however, this command does not block the server.
 //
 // See [valkey.io] for details.
 //
@@ -2979,7 +2979,7 @@ func (b *BaseBatch[T]) ZCard(key string) *T {
 // Blocks the connection until it pops and returns a member-score pair
 // with the lowest score from the first non-empty sorted set.
 // The given `keys` being checked in the order they are provided.
-// BZPOPMIN is the blocking variant of [ZPOPMIN].
+// BZPopMin is the blocking variant of [BaseBatch.ZPopMin].
 //
 // Note:
 //
@@ -3013,7 +3013,7 @@ func (b *BaseBatch[T]) BZPopMin(keys []string, timeout time.Duration) *T {
 
 // Blocks the connection until it pops and returns a member-score pair from the first non-empty sorted set, with the
 // given keys being checked in the order they are provided.
-// BZMPop is the blocking variant of [ZMPop].
+// BZMPop is the blocking variant of [BaseBatch.ZMPop].
 //
 // Note:
 //
@@ -3063,7 +3063,7 @@ func (b *BaseBatch[T]) BZMPop(keys []string, scoreFilter constants.ScoreFilter, 
 
 // Blocks the connection until it pops and returns a member-score pair from the first non-empty sorted set, with the
 // given keys being checked in the order they are provided.
-// BZMPop is the blocking variant of [ZMPop].
+// BZMPop is the blocking variant of [BaseBatch.ZMPop].
 //
 // Note:
 //
@@ -3124,7 +3124,7 @@ func (b *BaseBatch[T]) BZMPopWithOptions(
 // Returns the specified range of elements in the sorted set stored at `key`.
 // `ZRANGE` can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
 //
-// To get the elements with their scores, see [ZRangeWithScores].
+// To get the elements with their scores, see [BaseBatch.ZRangeWithScores].
 //
 // See [valkey.io] for details.
 //
@@ -3267,7 +3267,7 @@ func (b *BaseBatch[T]) ZCount(key string, rangeOptions options.ZCountRange) *T {
 
 // Returns the rank of `member` in the sorted set stored at `key`, with
 // scores ordered from low to high, starting from `0`.
-// To get the rank of `member` with its score, see [ZRankWithScore].
+// To get the rank of `member` with its score, see [BaseBatch.ZRankWithScore].
 //
 // See [valkey.io] for details.
 //
@@ -3312,7 +3312,7 @@ func (b *BaseBatch[T]) ZRankWithScore(key string, member string) *T {
 
 // Returns the rank of `member` in the sorted set stored at `key`, where
 // scores are ordered from the highest to lowest, starting from `0`.
-// To get the rank of `member` with its score, see [ZRevRankWithScore].
+// To get the rank of `member` with its score, see [BaseBatch.ZRevRankWithScore].
 //
 // See [valkey.io] for details.
 //
@@ -3333,7 +3333,6 @@ func (b *BaseBatch[T]) ZRevRank(key string, member string) *T {
 
 // Returns the rank of `member` in the sorted set stored at `key`, where
 // scores are ordered from the highest to lowest, starting from `0`.
-// To get the rank of `member` with its score, see [ZRevRankWithScore].
 //
 // Since:
 //
@@ -3743,7 +3742,7 @@ func (b *BaseBatch[T]) XGroupCreateWithOptions(key string, group string, id stri
 }
 
 // Creates a key associated with a value that is obtained by
-// deserializing the provided serialized value (obtained via [Dump]).
+// deserializing the provided serialized value (obtained via [BaseBatch.Dump]).
 //
 // See [valkey.io] for details.
 //
@@ -3763,7 +3762,7 @@ func (b *BaseBatch[T]) Restore(key string, ttl time.Duration, value string) *T {
 }
 
 // Creates a key associated with a value that is obtained by
-// deserializing the provided serialized value (obtained via [Dump]).
+// deserializing the provided serialized value (obtained via [BaseBatch.Dump]).
 //
 // See [valkey.io] for details.
 //
@@ -4141,7 +4140,7 @@ func (b *BaseBatch[T]) Sort(key string) *T {
 // Sorts the elements in the list, set, or sorted set at key and returns the result.
 // The sort command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To store the result into a new key, see the [SortStore] function.
+// To store the result into a new key, see the [BaseBatch.SortStoreWithOptions] function.
 //
 // Note:
 //
@@ -4233,7 +4232,7 @@ func (b *BaseBatch[T]) SortReadOnlyWithOptions(key string, options options.SortO
 // different criteria, apply transformations on sorted elements, and store the result in a new key.
 // The SortStore command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To get the sort result without storing it into a key, see the [Sort] or [SortReadOnly] function.
+// To get the sort result without storing it into a key, see the [BaseBatch.Sort] or [BaseBatch.SortReadOnly] function.
 //
 // See [valkey.io] for details.
 //
@@ -4256,7 +4255,7 @@ func (b *BaseBatch[T]) SortStore(key string, destination string) *T {
 // different criteria, apply transformations on sorted elements, and store the result in a new key.
 // The SortStore command can be used to sort elements based on different criteria and apply
 // transformations on sorted elements.
-// To get the sort result without storing it into a key, see the [Sort] or [SortReadOnly] function.
+// To get the sort result without storing it into a key, see the [BaseBatch.Sort] or [BaseBatch.SortReadOnly] function.
 //
 // See [valkey.io] for details.
 //
@@ -5008,7 +5007,7 @@ func (b *BaseBatch[T]) Time() *T {
 }
 
 // Returns the intersection of members from sorted sets specified by the given `keys`.
-// To get the elements with their scores, see [ZInterWithScores].
+// To get the elements with their scores, see [BaseBatch.ZInterWithScores].
 //
 // See [valkey.io] for details.
 //
@@ -5139,7 +5138,7 @@ func (b *BaseBatch[T]) ZInterStoreWithOptions(
 }
 
 // Returns the difference between the first sorted set and all the successive sorted sets.
-// To get the elements with their scores, see [ZDiffWithScores].
+// To get the elements with their scores, see [BaseBatch.ZDiffWithScores].
 //
 // See [valkey.io] for details.
 //
@@ -5219,7 +5218,7 @@ func (b *BaseBatch[T]) ZDiffStore(destination string, keys []string) *T {
 }
 
 // Returns the union of members from sorted sets specified by the given `keys`.
-// To get the elements with their scores, see [ZUnionWithScores].
+// To get the elements with their scores, see [BaseBatch.ZUnionWithScores].
 //
 // See [valkey.io] for details.
 //
@@ -5505,7 +5504,7 @@ func (b *BaseBatch[T]) ZLexCount(key string, rangeQuery options.RangeByLex) *T {
 // Blocks the connection until it pops and returns a member-score pair
 // with the highest score from the first non-empty sorted set.
 // The given `keys` being checked in the order they are provided.
-// BZPOPMAX is the blocking variant of [ZPOPMAX].
+// BZPopMax is the blocking variant of [BaseBatch.ZPopMax].
 //
 // Note:
 //
@@ -5685,7 +5684,7 @@ func (b *BaseBatch[T]) GeoDistWithUnit(key string, member1 string, member2 strin
 	)
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [BaseBatch.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -5746,7 +5745,7 @@ func (b *BaseBatch[T]) GeoSearchWithFullOptions(
 	return b.addCmdAndConverter(C.GeoSearch, args, reflect.Slice, false, internal.ConvertLocationArrayResponse)
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [BaseBatch.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -5779,7 +5778,7 @@ func (b *BaseBatch[T]) GeoSearch(
 	return b.GeoSearchWithResultOptions(key, searchFrom, searchByShape, *options.NewGeoSearchResultOptions())
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [BaseBatch.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -5830,7 +5829,7 @@ func (b *BaseBatch[T]) GeoSearchWithResultOptions(
 	return b.addCmdAndConverter(C.GeoSearch, args, reflect.Slice, false, internal.ConvertArrayOf[string])
 }
 
-// Returns the members of a sorted set populated with geospatial information using [GeoAdd],
+// Returns the members of a sorted set populated with geospatial information using [BaseBatch.GeoAdd],
 // which are within the borders of the area specified by a given shape.
 //
 // Since:
@@ -5877,7 +5876,7 @@ func (b *BaseBatch[T]) GeoSearchWithInfoOptions(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [BaseBatch.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -5938,7 +5937,7 @@ func (b *BaseBatch[T]) GeoSearchStoreWithFullOptions(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [BaseBatch.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -5981,7 +5980,7 @@ func (b *BaseBatch[T]) GeoSearchStore(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [BaseBatch.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -6026,7 +6025,7 @@ func (b *BaseBatch[T]) GeoSearchStoreWithResultOptions(
 // Searches for members in a sorted set stored at `sourceKey` representing geospatial data
 // within a circular or rectangular area and stores the result in `destinationKey`. If
 // `destinationKey` already exists, it is overwritten. Otherwise, a new sorted set will be
-// created. To get the result directly, see [GeoSearchWithFullOptions].
+// created. To get the result directly, see [BaseBatch.GeoSearchWithFullOptions].
 //
 // Since:
 //
@@ -6307,7 +6306,7 @@ func (b *BaseBatch[T]) FunctionDump() *T {
 	return b.addCmdAndTypeChecker(C.FunctionDump, []string{}, reflect.String, false)
 }
 
-// Restores libraries from the serialized payload returned by [FunctionDump].
+// Restores libraries from the serialized payload returned by [BaseBatch.FunctionDump].
 //
 // Since:
 //
@@ -6328,7 +6327,7 @@ func (b *BaseBatch[T]) FunctionRestore(payload string) *T {
 	return b.addCmdAndTypeChecker(C.FunctionRestore, []string{payload}, reflect.String, false)
 }
 
-// Restores libraries from the serialized payload returned by [FunctionDump].
+// Restores libraries from the serialized payload returned by [BaseBatch.FunctionDump].
 //
 // Since:
 //


### PR DESCRIPTION
## Issue Description:

Need to fix links to other classes in docs.

For example, [BLMOVE](https://pkg.go.dev/github.com/valkey-io/valkey-glide/go@v1.3.0-rc4/api#GlideClient.BLMove): ListDirection should be clickable. Description also has a mistake.

[BZPOPMIN](https://pkg.go.dev/github.com/valkey-io/valkey-glide/go@v1.3.0-rc4/api#GlideClient.BZPopMin) - link to ZMPopMindoesn’t work, link to wiki too.

[BitField](https://pkg.go.dev/github.com/valkey-io/valkey-glide/go@v1.3.0-rc4/api#GlideClient.BitField) - no links in args.

## PR Description:

We are able to link to other functions in the comments. This allows users to click on the related function directly allowing for a seamless experience.

### Issue link

This Pull Request is linked to issue (URL): #4070

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
