### PR TITLE
Go: Fix `ZAddIncr` Return Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 * Go: XInfoStream update response ([#4136](https://github.com/valkey-io/valkey-glide/pull/4136))
 * Go: Update return type for `XAdd` without optional arguments ([#4141](https://github.com/valkey-io/valkey-glide/pull/4141))
 * Go: Change options arguments to not be pointers ([#4106](https://github.com/valkey-io/valkey-glide/pull/4106))
+* Go: Change `ZAddIncr` Return Type to be `float64` ([#4190](https://github.com/valkey-io/valkey-glide/pull/4190))
 
 #### Fixes
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -4308,7 +4308,7 @@ func (client *baseClient) zAddIncrBase(
 //
 // Return value:
 //
-//	models.Result[float64] - The new score of the member.
+//	The new score of the member.
 //
 // [valkey.io]: https://valkey.io/commands/zadd/
 func (client *baseClient) ZAddIncr(
@@ -4316,13 +4316,18 @@ func (client *baseClient) ZAddIncr(
 	key string,
 	member string,
 	increment float64,
-) (models.Result[float64], error) {
+) (float64, error) {
 	options, err := options.NewZAddOptions().SetIncr(true, increment, member)
 	if err != nil {
-		return models.CreateNilFloat64Result(), err
+		return models.DefaultFloatResponse, err
 	}
 
-	return client.zAddIncrBase(ctx, key, options)
+	res, err := client.zAddIncrBase(ctx, key, options)
+	if err != nil {
+		return models.DefaultFloatResponse, err
+	}
+
+	return res.Value(), nil
 }
 
 // Increments the score of member in the sorted set stored at `key` by `increment`.

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -5269,7 +5269,7 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 
 		resIncr, err := client.ZAddIncr(context.Background(), key, "one", float64(2))
 		assert.Nil(t, err)
-		assert.Equal(t, float64(3), resIncr.Value())
+		assert.Equal(t, float64(3), resIncr)
 
 		// error cases
 		// non-sortedset key
@@ -5295,13 +5295,13 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		suite.NoError(err)
 		assert.Equal(suite.T(), int64(3), res)
 
-		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key3, "one", 5, *onlyIfDoesNotExistOpts)
+		resIncr2, err := client.ZAddIncrWithOptions(context.Background(), key3, "one", 5, *onlyIfDoesNotExistOpts)
 		suite.NoError(err)
-		assert.True(suite.T(), resIncr.IsNil())
+		assert.True(suite.T(), resIncr2.IsNil())
 
-		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key3, "one", 5, *onlyIfExistsOpts)
+		resIncr2, err = client.ZAddIncrWithOptions(context.Background(), key3, "one", 5, *onlyIfExistsOpts)
 		suite.NoError(err)
-		assert.Equal(suite.T(), float64(6), resIncr.Value())
+		assert.Equal(suite.T(), float64(6), resIncr2.Value())
 
 		// with GT or LT
 		membersScoreMap2 := map[string]float64{
@@ -5329,13 +5329,13 @@ func (suite *GlideTestSuite) TestZAddAndZAddIncr() {
 		suite.NoError(err)
 		assert.Equal(suite.T(), int64(0), res)
 
-		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key4, "one", -3, *ltOpts)
+		resIncr2, err = client.ZAddIncrWithOptions(context.Background(), key4, "one", -3, *ltOpts)
 		suite.NoError(err)
-		assert.Equal(suite.T(), float64(7), resIncr.Value())
+		assert.Equal(suite.T(), float64(7), resIncr2.Value())
 
-		resIncr, err = client.ZAddIncrWithOptions(context.Background(), key4, "one", -3, *gtOpts)
+		resIncr2, err = client.ZAddIncrWithOptions(context.Background(), key4, "one", -3, *gtOpts)
 		suite.NoError(err)
-		assert.True(suite.T(), resIncr.IsNil())
+		assert.True(suite.T(), resIncr2.IsNil())
 	})
 }
 

--- a/go/internal/interfaces/sorted_set_commands.go
+++ b/go/internal/interfaces/sorted_set_commands.go
@@ -26,7 +26,7 @@ type SortedSetCommands interface {
 		opts options.ZAddOptions,
 	) (int64, error)
 
-	ZAddIncr(ctx context.Context, key string, member string, increment float64) (models.Result[float64], error)
+	ZAddIncr(ctx context.Context, key string, member string, increment float64) (float64, error)
 
 	ZAddIncrWithOptions(
 		ctx context.Context,

--- a/go/sorted_set_commands_test.go
+++ b/go/sorted_set_commands_test.go
@@ -83,7 +83,7 @@ func ExampleClient_ZAddIncr() {
 	fmt.Println(result)
 
 	// Output:
-	// {1 false}
+	// 1
 }
 
 func ExampleClusterClient_ZAddIncr() {
@@ -96,7 +96,7 @@ func ExampleClusterClient_ZAddIncr() {
 	fmt.Println(result)
 
 	// Output:
-	// {1 false}
+	// 1
 }
 
 func ExampleClient_ZAddIncrWithOptions() {


### PR DESCRIPTION
## Issue

Command returns a nil or int, but doc doesnt say when null is returned.

## PR Description

In reality, `ZAddIncr` without options will **never** return `nil`. This aligns with the Java client's implementation. We should update it to reflect this fact.

https://github.com/valkey-io/valkey-glide/blob/184772bdf65d2eae723d8f2dba8e224a1b21069d/java/client/src/main/java/glide/api/BaseClient.java#L2059-L2067

### Issue link

This Pull Request is linked to issue (URL): #4070 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
