### PR TITLE
Fix `LTRIM` Docs

### DIFF
--- a/go/base_client.go
+++ b/go/base_client.go
@@ -2686,10 +2686,10 @@ func (client *baseClient) LIndex(ctx context.Context, key string, index int64) (
 //
 // Return value:
 //
-//	Always `"OK"`.
-//	If start exceeds the end of the list, or if start is greater than end, the result will be an empty list (which causes
-//	key to be removed).
-//	If end exceeds the actual end of the list, it will be treated like the last element of the list.
+//	Always "OK".
+//	If `start` exceeds the end of the list, or if `start` is greater than `end`, the list is emptied
+//	and the key is removed.
+//	If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
 //	If key does not exist, `"OK"` will be returned without changes to the database.
 //
 // [valkey.io]: https://valkey.io/commands/ltrim/

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -1545,8 +1545,8 @@ func (b *BaseBatch[T]) LIndex(key string, index int64) *T {
 // Command Response:
 //
 //	Always "OK".
-//	If `start` exceeds the end of the list, or if `start` is greater than `end`, the result will be an empty list
-//	(which causes key to be removed).
+//	If `start` exceeds the end of the list, or if `start` is greater than `end`, the list is emptied
+//	and the key is removed.
 //	If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
 //	If key does not exist, `"OK"` will be returned without changes to the database.
 //

--- a/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
@@ -458,7 +458,7 @@ public interface ListBaseCommands {
      * @param end The end of the range.
      * @return Always <code>OK</code>.<br>
      *     If <code>start</code> exceeds the end of the list, or if <code>start</code> is greater than
-     *     <code>end</code>, the result will be an empty list (which causes key to be removed).<br>
+     *     <code>end</code>, the list is emptied and the key is removed.<br>
      *     If <code>end</code> exceeds the actual end of the list, it will be treated like the last
      *     element of the list.<br>
      *     If <code>key</code> does not exist, OK will be returned without changes to the database.

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -1288,7 +1288,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @param end The end of the range.
      * @return Command Response - Always <code>OK</code>.<br>
      *     If <code>start</code> exceeds the end of the list, or if <code>start</code> is greater than
-     *     <code>end</code>, the result will be an empty list (which causes key to be removed).<br>
+     *     <code>end</code>, the list is emptied and the key is removed.<br>
      *     If <code>end</code> exceeds the actual end of the list, it will be treated like the last
      *     element of the list.<br>
      *     If <code>key</code> does not exist, OK will be returned without changes to the database.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3100,7 +3100,7 @@ export class BaseClient {
      * @param start - The starting point of the range.
      * @param end - The end of the range.
      * @returns always "OK".
-     * If `start` exceeds the end of the list, or if `start` is greater than `end`, the result will be an empty list (which causes key to be removed).
+     * If `start` exceeds the end of the list, or if `start` is greater than `end`, the list is emptied and the key is removed.
      * If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
      * If `key` does not exist the command will be ignored.
      *

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -1204,7 +1204,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * @param end - The end of the range.
      *
      * Command Response - always "OK".
-     * If `start` exceeds the end of the list, or if `start` is greater than `end`, the result will be an empty list (which causes key to be removed).
+     * If `start` exceeds the end of the list, or if `start` is greater than `end`, the list is emptied and the key is removed.
      * If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
      * If `key` does not exist the command will be ignored.
      */

--- a/python/python/glide/async_commands/batch.py
+++ b/python/python/glide/async_commands/batch.py
@@ -1695,8 +1695,8 @@ class BaseBatch:
         Commands response:
             TOK: A simple "OK" response.
 
-            If `start` exceeds the end of the list, or if `start` is greater than `end`, the result will be an empty list
-            (which causes `key` to be removed).
+            If `start` exceeds the end of the list, or if `start` is greater than `end`, the list is emptied
+            and the key is removed.
 
             If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
 

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2536,8 +2536,8 @@ class CoreCommands(Protocol):
         Returns:
             TOK: A simple "OK" response.
 
-            If `start` exceeds the end of the list, or if `start` is greater than `end`, the result will be an empty list
-            (which causes `key` to be removed).
+            If `start` exceeds the end of the list, or if `start` is greater than `end`, the list is emptied
+            and the key is removed.
 
             If `end` exceeds the actual end of the list, it will be treated like the last element of the list.
 


### PR DESCRIPTION
Doc says

```
Always `"OK"`.

If start exceeds the end of the list, or if start is greater than end, the result will be an empty list (which causes key to be removed).
```

Need to reword this. In all clients.

### Issue link

This Pull Request is linked to issue (URL): #4070 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
