### PR TITLE
Fix Cross Slot Docs for RO Commands

### DIFF
--- a/go/base_client.go
+++ b/go/base_client.go
@@ -3321,12 +3321,7 @@ func (client *baseClient) BLMove(
 //
 // Note:
 //
-//	In cluster mode, if keys in `keyValueMap` map to different hash slots, the command
-//	will be split across these slots and executed separately for each. This means the command
-//	is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-//	call will return the first encountered error, even though some requests may have succeeded
-//	while others did not. If this behavior impacts your application logic, consider splitting
-//	the request into sub-requests per slot to ensure atomicity.
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
 //
 // See [valkey.io] for details.
 //
@@ -3843,12 +3838,7 @@ func (client *baseClient) PfMerge(ctx context.Context, destination string, sourc
 //
 // Note:
 //
-//	In cluster mode, if keys in keys map to different hash slots, the command
-//	will be split across these slots and executed separately for each. This means the command
-//	is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-//	call will return the first encountered error, even though some requests may have succeeded
-//	while others did not. If this behavior impacts your application logic, consider splitting
-//	the request into sub-requests per slot to ensure atomicity.
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
 //
 // Parameters:
 //

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -932,12 +932,9 @@ func (client *baseClient) MSetNX(ctx context.Context, keyValueMap map[string]str
 //
 // Note:
 //
-//	In cluster mode, if keys in `keys` map to different hash slots, the command
-//	will be split across these slots and executed separately for each. This means the command
-//	is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-//	call will return the first encountered error, even though some requests may have succeeded
-//	while others did not. If this behavior impacts your application logic, consider splitting
-//	the request into sub-requests per slot to ensure atomicity.
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
+//
+// See [valkey.io] for details.
 //
 // Parameters:
 //
@@ -3356,12 +3353,7 @@ func (client *baseClient) Del(ctx context.Context, keys []string) (int64, error)
 //
 // Note:
 //
-//	In cluster mode, if keys in `keyValueMap` map to different hash slots, the command
-//	will be split across these slots and executed separately for each. This means the command
-//	is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-//	call will return the first encountered error, even though some requests may have succeeded
-//	while others did not. If this behavior impacts your application logic, consider splitting
-//	the request into sub-requests per slot to ensure atomicity.
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
 //
 // See [valkey.io] for details.
 //
@@ -9082,13 +9074,7 @@ func (client *baseClient) ScriptKill(ctx context.Context) (string, error) {
 //
 // Note:
 //
-//	In cluster mode, if keys in `keys` map to different hash slots,
-//	the command will be split across these slots and executed separately for each.
-//	This means the command is atomic only at the slot level. If one or more slot-specific
-//	requests fail, the entire call will return the first encountered error, even
-//	though some requests may have succeeded while others did not.
-//	If this behavior impacts your application logic, consider splitting the
-//	request into sub-requests per slot to ensure atomicity.
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
 //
 // Parameters:
 //

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -187,10 +187,6 @@ func (b *BaseBatch[T]) MSetNX(keyValueMap map[string]string) *T {
 
 // Retrieves the values of multiple keys.
 //
-// Note:
-//
-//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
-//
 // See [valkey.io] for details.
 //
 // Parameters:
@@ -2088,10 +2084,6 @@ func (b *BaseBatch[T]) Del(keys []string) *T {
 }
 
 // Returns the number of keys that exist in the database.
-//
-// Note:
-//
-//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
 //
 // See [valkey.io] for details.
 //

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -187,6 +187,10 @@ func (b *BaseBatch[T]) MSetNX(keyValueMap map[string]string) *T {
 
 // Retrieves the values of multiple keys.
 //
+// Note:
+//
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
+//
 // See [valkey.io] for details.
 //
 // Parameters:
@@ -2084,6 +2088,10 @@ func (b *BaseBatch[T]) Del(keys []string) *T {
 }
 
 // Returns the number of keys that exist in the database.
+//
+// Note:
+//
+//	When in cluster mode, the command may route to multiple nodes when keys in `keys` map to different hash slots.
 //
 // See [valkey.io] for details.
 //

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -63,12 +63,8 @@ public interface GenericBaseCommands {
     /**
      * Returns the number of keys in <code>keys</code> that exist in the database.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
+     *     map to different hash slots.
      * @see <a href="https://valkey.io/commands/exists/">valkey.io</a> for details.
      * @param keys The keys list to check.
      * @return The number of keys that exist. If the same existing key is mentioned in <code>keys
@@ -84,12 +80,8 @@ public interface GenericBaseCommands {
     /**
      * Returns the number of keys in <code>keys</code> that exist in the database.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
+     *     map to different hash slots.
      * @see <a href="https://valkey.io/commands/exists/">valkey.io</a> for details.
      * @param keys The keys list to check.
      * @return The number of keys that exist. If the same existing key is mentioned in <code>keys

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -22,12 +22,8 @@ public interface GenericBaseCommands {
      * Removes the specified <code>keys</code> from the database. A key is ignored if it does not
      * exist.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/del/">valkey.io</a> for details.
      * @param keys The keys we wanted to remove.
      * @return The number of keys that were removed.
@@ -43,12 +39,8 @@ public interface GenericBaseCommands {
      * Removes the specified <code>keys</code> from the database. A key is ignored if it does not
      * exist.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/del/">valkey.io</a> for details.
      * @param keys The keys we wanted to remove.
      * @return The number of keys that were removed.
@@ -100,12 +92,8 @@ public interface GenericBaseCommands {
      * specified keys and ignores non-existent ones. However, this command does not block the server,
      * while <a href="https://valkey.io/commands/del/">DEL</a> does.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/unlink/">valkey.io</a> for details.
      * @param keys The list of keys to unlink.
      * @return The number of <code>keys</code> that were unlinked.
@@ -123,12 +111,8 @@ public interface GenericBaseCommands {
      * specified keys and ignores non-existent ones. However, this command does not block the server,
      * while <a href="https://valkey.io/commands/del/">DEL</a> does.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/unlink/">valkey.io</a> for details.
      * @param keys The list of keys to unlink.
      * @return The number of <code>keys</code> that were unlinked.

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -63,8 +63,8 @@ public interface GenericBaseCommands {
     /**
      * Returns the number of keys in <code>keys</code> that exist in the database.
      *
-     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
-     *     map to different hash slots.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/exists/">valkey.io</a> for details.
      * @param keys The keys list to check.
      * @return The number of keys that exist. If the same existing key is mentioned in <code>keys
@@ -80,8 +80,8 @@ public interface GenericBaseCommands {
     /**
      * Returns the number of keys in <code>keys</code> that exist in the database.
      *
-     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
-     *     map to different hash slots.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/exists/">valkey.io</a> for details.
      * @param keys The keys list to check.
      * @return The number of keys that exist. If the same existing key is mentioned in <code>keys

--- a/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
@@ -256,8 +256,8 @@ public interface StringBaseCommands {
     /**
      * Retrieves the values of multiple <code>keys</code>.
      *
-     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
-     *     map to different hash slots.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/mget/">valkey.io</a> for details.
      * @param keys A list of keys to retrieve values for.
      * @return An array of values corresponding to the provided <code>keys</code>.<br>
@@ -274,8 +274,8 @@ public interface StringBaseCommands {
     /**
      * Retrieves the values of multiple <code>keys</code>.
      *
-     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
-     *     map to different hash slots.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/mget/">valkey.io</a> for details.
      * @param keys A list of keys to retrieve values for.
      * @return An array of values corresponding to the provided <code>keys</code>.<br>

--- a/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
@@ -256,12 +256,8 @@ public interface StringBaseCommands {
     /**
      * Retrieves the values of multiple <code>keys</code>.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
+     *     map to different hash slots.
      * @see <a href="https://valkey.io/commands/mget/">valkey.io</a> for details.
      * @param keys A list of keys to retrieve values for.
      * @return An array of values corresponding to the provided <code>keys</code>.<br>
@@ -278,12 +274,8 @@ public interface StringBaseCommands {
     /**
      * Retrieves the values of multiple <code>keys</code>.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
+     *     map to different hash slots.
      * @see <a href="https://valkey.io/commands/mget/">valkey.io</a> for details.
      * @param keys A list of keys to retrieve values for.
      * @return An array of values corresponding to the provided <code>keys</code>.<br>

--- a/java/client/src/main/java/glide/api/commands/TransactionsBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/TransactionsBaseCommands.java
@@ -15,12 +15,8 @@ public interface TransactionsBaseCommands {
      * will only execute commands if the watched keys are not modified before execution of the
      * transaction.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
+     *     map to different hash slots.
      * @see <a href="https://valkey.io/commands/watch/">valkey.io</a> for details.
      * @param keys The keys to watch.
      * @return <code>OK</code>.
@@ -45,12 +41,8 @@ public interface TransactionsBaseCommands {
      * will only execute commands if the watched keys are not modified before execution of the
      * transaction.
      *
-     * @apiNote In cluster mode, if keys in <code>keys</code> map to different hash slots, the command
-     *     will be split across these slots and executed separately for each. This means the command
-     *     is atomic only at the slot level. If one or more slot-specific requests fail, the entire
-     *     call will return the first encountered error, even though some requests may have succeeded
-     *     while others did not. If this behavior impacts your application logic, consider splitting
-     *     the request into sub-requests per slot to ensure atomicity.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
+     *     map to different hash slots.
      * @see <a href="https://valkey.io/commands/watch/">valkey.io</a> for details.
      * @param keys The keys to watch.
      * @return <code>OK</code>.

--- a/java/client/src/main/java/glide/api/commands/TransactionsBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/TransactionsBaseCommands.java
@@ -15,8 +15,8 @@ public interface TransactionsBaseCommands {
      * will only execute commands if the watched keys are not modified before execution of the
      * transaction.
      *
-     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
-     *     map to different hash slots.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/watch/">valkey.io</a> for details.
      * @param keys The keys to watch.
      * @return <code>OK</code>.
@@ -41,8 +41,8 @@ public interface TransactionsBaseCommands {
      * will only execute commands if the watched keys are not modified before execution of the
      * transaction.
      *
-     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code> 
-     *     map to different hash slots.
+     * @apiNote When in cluster mode, the command may route to multiple nodes when keys in <code>keys
+     *     </code> map to different hash slots.
      * @see <a href="https://valkey.io/commands/watch/">valkey.io</a> for details.
      * @param keys The keys to watch.
      * @return <code>OK</code>.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1922,7 +1922,7 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/mget/|valkey.io} for details.
      *
-     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to 
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to
      * different hash slots.
      *
      * @param keys - A list of keys to retrieve values for.
@@ -3998,7 +3998,7 @@ export class BaseClient {
     /**
      * Returns the number of keys in `keys` that exist in the database.
      *
-     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to 
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to
      * different hash slots.
      *
      * @see {@link https://valkey.io/commands/exists/|valkey.io} for details.
@@ -7952,7 +7952,7 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/watch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
      *
-     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to 
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to
      * different hash slots.
      *
      * @param keys - The keys to watch.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1811,13 +1811,8 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/del/|valkey.io} for details.
      *
-     * @remarks In cluster mode, if keys in `keys` map to different hash slots,
-     * the command will be split across these slots and executed separately for each.
-     * This means the command is atomic only at the slot level. If one or more slot-specific
-     * requests fail, the entire call will return the first encountered error, even
-     * though some requests may have succeeded while others did not.
-     * If this behavior impacts your application logic, consider splitting the
-     * request into sub-requests per slot to ensure atomicity.
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to
+     * different hash slots.
      *
      * @param keys - The keys we wanted to remove.
      * @returns The number of keys that were removed.
@@ -4025,13 +4020,8 @@ export class BaseClient {
      * This command, similar to {@link del}, removes specified keys and ignores non-existent ones.
      * However, this command does not block the server, while {@link https://valkey.io/commands/del|`DEL`} does.
      *
-     * @remarks In cluster mode, if keys in `keys` map to different hash slots,
-     * the command will be split across these slots and executed separately for each.
-     * This means the command is atomic only at the slot level. If one or more slot-specific
-     * requests fail, the entire call will return the first encountered error, even
-     * though some requests may have succeeded while others did not.
-     * If this behavior impacts your application logic, consider splitting the
-     * request into sub-requests per slot to ensure atomicity.
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to
+     * different hash slots.
      *
      * @see {@link https://valkey.io/commands/unlink/|valkey.io} for details.
      *

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1922,13 +1922,8 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/mget/|valkey.io} for details.
      *
-     * @remarks In cluster mode, if keys in `keys` map to different hash slots,
-     * the command will be split across these slots and executed separately for each.
-     * This means the command is atomic only at the slot level. If one or more slot-specific
-     * requests fail, the entire call will return the first encountered error, even
-     * though some requests may have succeeded while others did not.
-     * If this behavior impacts your application logic, consider splitting the
-     * request into sub-requests per slot to ensure atomicity.
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to 
+     * different hash slots.
      *
      * @param keys - A list of keys to retrieve values for.
      * @param options - (Optional) See {@link DecoderOption}.
@@ -4003,13 +3998,8 @@ export class BaseClient {
     /**
      * Returns the number of keys in `keys` that exist in the database.
      *
-     * @remarks In cluster mode, if keys in `keys` map to different hash slots,
-     * the command will be split across these slots and executed separately for each.
-     * This means the command is atomic only at the slot level. If one or more slot-specific
-     * requests fail, the entire call will return the first encountered error, even
-     * though some requests may have succeeded while others did not.
-     * If this behavior impacts your application logic, consider splitting the
-     * request into sub-requests per slot to ensure atomicity.
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to 
+     * different hash slots.
      *
      * @see {@link https://valkey.io/commands/exists/|valkey.io} for details.
      *
@@ -7962,13 +7952,8 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/watch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
      *
-     * @remarks In cluster mode, if keys in `keys` map to different hash slots,
-     * the command will be split across these slots and executed separately for each.
-     * This means the command is atomic only at the slot level. If one or more slot-specific
-     * requests fail, the entire call will return the first encountered error, even
-     * though some requests may have succeeded while others did not.
-     * If this behavior impacts your application logic, consider splitting the
-     * request into sub-requests per slot to ensure atomicity.
+     * @remarks When in cluster mode, the command may route to multiple nodes when keys in `keys` map to 
+     * different hash slots.
      *
      * @param keys - The keys to watch.
      * @returns A simple `"OK"` response.

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -971,7 +971,7 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/mget/) for more details.
 
         Note:
-            When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code>
+            When in cluster mode, the command may route to multiple nodes when keys in `keys`
             map to different hash slots.
 
         Args:
@@ -2605,7 +2605,7 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/exists/) for more details.
 
         Note:
-            When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code>
+            When in cluster mode, the command may route to multiple nodes when keys in `keys`
             map to different hash slots.
 
         Args:
@@ -6984,13 +6984,8 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/watch) for more details.
 
         Note:
-            In cluster mode, if keys in `keys` map to different hash slots,
-            the command will be split across these slots and executed separately for each.
-            This means the command is atomic only at the slot level. If one or more slot-specific
-            requests fail, the entire call will return the first encountered error, even
-            though some requests may have succeeded while others did not.
-            If this behavior impacts your application logic, consider splitting the
-            request into sub-requests per slot to ensure atomicity.
+            When in cluster mode, the command may route to multiple nodes when keys in `keys`
+            map to different hash slots.
 
         Args:
             keys (List[TEncodable]): The keys to watch.

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -971,13 +971,8 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/mget/) for more details.
 
         Note:
-            In cluster mode, if keys in `keys` map to different hash slots,
-            the command will be split across these slots and executed separately for each.
-            This means the command is atomic only at the slot level. If one or more slot-specific
-            requests fail, the entire call will return the first encountered error, even
-            though some requests may have succeeded while others did not.
-            If this behavior impacts your application logic, consider splitting the
-            request into sub-requests per slot to ensure atomicity.
+            When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code>
+            map to different hash slots.
 
         Args:
             keys (List[TEncodable]): A list of keys to retrieve values for.
@@ -2610,13 +2605,8 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/exists/) for more details.
 
         Note:
-            In cluster mode, if keys in `keys` map to different hash slots,
-            the command will be split across these slots and executed separately for each.
-            This means the command is atomic only at the slot level. If one or more slot-specific
-            requests fail, the entire call will return the first encountered error, even
-            though some requests may have succeeded while others did not.
-            If this behavior impacts your application logic, consider splitting the
-            request into sub-requests per slot to ensure atomicity.
+            When in cluster mode, the command may route to multiple nodes when keys in <code>keys</code>
+            map to different hash slots.
 
         Args:
             keys (List[TEncodable]): The list of keys to check.

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -782,13 +782,8 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/del/) for details.
 
         Note:
-            In cluster mode, if keys in `keys` map to different hash slots,
-            the command will be split across these slots and executed separately for each.
-            This means the command is atomic only at the slot level. If one or more slot-specific
-            requests fail, the entire call will return the first encountered error, even
-            though some requests may have succeeded while others did not.
-            If this behavior impacts your application logic, consider splitting the
-            request into sub-requests per slot to ensure atomicity.
+            When in cluster mode, the command may route to multiple nodes when keys in `keys`
+            map to different hash slots.
 
         Args:
             keys (List[TEncodable]): A list of keys to be deleted from the database.
@@ -2631,13 +2626,8 @@ class CoreCommands(Protocol):
         See [valkey.io](https://valkey.io/commands/unlink/) for more details.
 
         Note:
-            In cluster mode, if keys in `key_value_map` map to different hash slots,
-            the command will be split across these slots and executed separately for each.
-            This means the command is atomic only at the slot level. If one or more slot-specific
-            requests fail, the entire call will return the first encountered error, even
-            though some requests may have succeeded while others did not.
-            If this behavior impacts your application logic, consider splitting the
-            request into sub-requests per slot to ensure atomicity.
+            When in cluster mode, the command may route to multiple nodes when keys in `keys`
+            map to different hash slots.
 
         Args:
             keys (List[TEncodable]): The list of keys to unlink.


### PR DESCRIPTION
It has big cross slot notice, because core is able to split it and route to multiple nodes and assemble a total result.

```
//	In cluster mode, if keys in `keyValueMap` map to different hash slots, the command
//	will be split across these slots and executed separately for each. This means the command
//	is atomic only at the slot level. If one or more slot-specific requests fail, the entire
//	call will return the first encountered error, even though some requests may have succeeded
//	while others did not. If this behavior impacts your application logic, consider splitting
//	the request into sub-requests per slot to ensure atomicity.
```

But the command is RO, it probably never fails. Even if it is, there is no inconsistensy in such case, because it is RO.
I propose to put here a simple notice that was there before (something like “command may route to multiple nodes”)

Applicable to all clients.

### Issue link

This Pull Request is linked to issue (URL): #4239 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
