### PR TITLE
Removed `Transaction` from docs website, re-added docs script

### DIFF
--- a/docs/markdown/python/base_batch.md
+++ b/docs/markdown/python/base_batch.md
@@ -1,2 +1,1 @@
-Note - Starting version `2.0.0`, the `Batch` class will be available and replace the `Transaction` class.
 ::: glide.async_commands.batch.BaseBatch

--- a/docs/markdown/python/cluster_batch.md
+++ b/docs/markdown/python/cluster_batch.md
@@ -1,2 +1,1 @@
-Note - Starting version `2.0.0`, the `Batch` class will be available and replace the `Transaction` class.
 ::: glide.async_commands.batch.ClusterBatch

--- a/docs/markdown/python/cluster_transaction.md
+++ b/docs/markdown/python/cluster_transaction.md
@@ -1,2 +1,0 @@
-Note - The `Transaction` class will be dperecated starting version `2.0.0`, and will be replaced with the `Batch` class.
-::: glide.async_commands.batch.ClusterTransaction

--- a/docs/markdown/python/standalone_batch.md
+++ b/docs/markdown/python/standalone_batch.md
@@ -1,2 +1,1 @@
-Note - Starting version `2.0.0`, the `Batch` class will be available and replace the `Transaction` class.
 ::: glide.async_commands.batch.Batch

--- a/docs/markdown/python/standalone_transaction.md
+++ b/docs/markdown/python/standalone_transaction.md
@@ -1,2 +1,0 @@
-Note - The `Transaction` class will be dperecated starting version `2.0.0`, and will be replaced with the `Batch` class.
-::: glide.async_commands.batch.Transaction

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,11 +14,9 @@ nav:
           - Core Commands: python/core.md
           - Cluster Commands: python/cluster_commands.md
           - Standalone Commands: python/standalone_commands.md
-          - Base Batch (from version 2.0.0): python/base_batch.md
-          - Standalone Batch (from version 2.0.0): python/standalone_batch.md
-          - Cluster Batch (from version 2.0.0): python/cluster_batch.md
-          - Standalone Transaction (deprecated): python/standalone_transaction.md
-          - Cluster Transaction (deprecated): python/cluster_transaction.md
+          - Base Batch: python/base_batch.md
+          - Standalone Batch: python/standalone_batch.md
+          - Cluster Batch: python/cluster_batch.md
       - Exceptions: python/exceptions.md
       - Logger: python/logger.md
   - TypeScript:
@@ -26,11 +24,9 @@ nav:
           - Standalone: node/GlideClient/classes/GlideClient.md
           - Cluster: node/GlideClusterClient/classes/GlideClusterClient.md
           - Base: node/BaseClient/classes/BaseClient.md
-          - Base Batch (from version 2.0.0): node/Batch/classes/BaseBatch.md
-          - Standalone Batch (from version 2.0.0): node/Batch/classes/Batch.md
-          - Cluster Batch (from version 2.0.0): node/Batch/classes/ClusterBatch.md
-          - Transaction (deprecated): node/Batch/classes/Transaction.md
-          - Cluster Transaction (deprecated): node/Batch/classes/ClusterTransaction.md
+          - Base Batch: node/Batch/classes/BaseBatch.md
+          - Standalone Batch: node/Batch/classes/Batch.md
+          - Cluster Batch: node/Batch/classes/ClusterBatch.md
       - config: node/BaseClient/interfaces/BaseClientConfiguration.md
       - Modules:
           - JSON: node/server-modules/GlideJson/classes/GlideJson.md

--- a/node/package.json
+++ b/node/package.json
@@ -81,7 +81,8 @@
         "staged": "lint-staged",
         "prereq": "npm install",
         "artifacts": "napi artifacts",
-        "prepublishOnly": "cd ../.. && napi prepublish --config npm/glide/package.json -t npm --skip-gh-release"
+        "prepublishOnly": "cd ../.. && napi prepublish --config npm/glide/package.json -t npm --skip-gh-release",
+        "docs": "npm run build && ./docs/build-docs"
     },
     "devDependencies": {
         "@jest/globals": "29",


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue: #3882 

This PR removes the transaction pages from the docs website, now that version 2.0 is out. 
It also re-adds the `docs` script to node's `package.json` that was mistakenly removed in #3930.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
