### PR TITLE
C#: Fix `dotnet` Docs

### DIFF
--- a/csharp/DEVELOPER.md
+++ b/csharp/DEVELOPER.md
@@ -101,6 +101,7 @@ cd valkey-glide
 2. Build the C# wrapper
 
 ```bash
+cd csharp
 dotnet build
 ```
 

--- a/csharp/DEVELOPER.md
+++ b/csharp/DEVELOPER.md
@@ -110,14 +110,10 @@ dotnet build
 Run test suite from `csharp` directory:
 
 ```bash
-dotnet test --framework net8.0
-
-# AND/OR
-
-dotnet test --framework net6.0
+dotnet test -m:1
 ```
 
-You can also run both in parallel with `dotnet test` but it could lead to some unexpected errors.
+You can also specify which framework version to use for testing (by defaults it runs on net6.0 and net8.0) by adding `--framework net8.0` or `--framework net6.0` accordingly.
 
 By default, `dotnet test` produces no reporting and does not display the test results.  To log the test results to the console and/or produce a test report, you can use the `--logger` attribute with the test command.  For example:
 

--- a/csharp/DEVELOPER.md
+++ b/csharp/DEVELOPER.md
@@ -110,10 +110,16 @@ dotnet build
 Run test suite from `csharp` directory:
 
 ```bash
+# Run tests on supported dotnet versions sequentially
 dotnet test -m:1
-```
 
-You can also specify which framework version to use for testing (by defaults it runs on net6.0 and net8.0) by adding `--framework net8.0` or `--framework net6.0` accordingly.
+# Run tests on supported dotnet versions in parallel (may conflict and fail)
+dotnet test
+
+# Run tests with a specific dotnet version
+dotnet test --framework net8.0
+dotnet test --framework net6.0
+```
 
 By default, `dotnet test` produces no reporting and does not display the test results.  To log the test results to the console and/or produce a test report, you can use the `--logger` attribute with the test command.  For example:
 

--- a/csharp/DEVELOPER.md
+++ b/csharp/DEVELOPER.md
@@ -110,6 +110,9 @@ Run test suite from `csharp` directory:
 
 ```bash
 dotnet test
+
+# If the above fails, try running
+sudo dotnet test
 ```
 
 You can also specify which framework version to use for testing (by defaults it runs on net6.0 and net8.0) by adding `--framework net8.0` or `--framework net6.0` accordingly.

--- a/csharp/DEVELOPER.md
+++ b/csharp/DEVELOPER.md
@@ -109,13 +109,14 @@ dotnet build
 Run test suite from `csharp` directory:
 
 ```bash
-dotnet test
+dotnet test --framework net8.0
 
-# If the above fails, try running
-sudo dotnet test
+# AND/OR
+
+dotnet test --framework net6.0
 ```
 
-You can also specify which framework version to use for testing (by defaults it runs on net6.0 and net8.0) by adding `--framework net8.0` or `--framework net6.0` accordingly.
+You can also run both in parallel with `dotnet test` but it could lead to some unexpected errors.
 
 By default, `dotnet test` produces no reporting and does not display the test results.  To log the test results to the console and/or produce a test report, you can use the `--logger` attribute with the test command.  For example:
 


### PR DESCRIPTION
One small step is missing in the docs, and `dotnet test` would cause cluster manager to fail sometimes

### Issue link

This Pull Request is linked to issue (URL): closes #4228 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
