### PR TITLE
Java: Fix Incorrect `XRANGE` `XREVRANGE` Return Docs

### DIFF
--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -434,8 +434,7 @@ public interface StreamBaseCommands {
      *     </ul>
      *
      * @return A <code>Map</code> of key to stream entry data, where entry data is an array of
-     *     pairings with format <code>[[field, entry], [field, entry], ...]</code>. Returns or <code>
-     *     null</code> if <code>count</code> is non-positive.
+     *     pairings with format <code>[[field, entry], [field, entry], ...]</code>.
      * @example
      *     <pre>{@code
      * // Retrieve all stream entries
@@ -475,8 +474,7 @@ public interface StreamBaseCommands {
      *     </ul>
      *
      * @return A <code>Map</code> of key to stream entry data, where entry data is an array of
-     *     pairings with format <code>[[field, entry], [field, entry], ...]</code>. Returns or <code>
-     *     null</code> if <code>count</code> is non-positive.
+     *     pairings with format <code>[[field, entry], [field, entry], ...]</code>.
      * @example
      *     <pre>{@code
      * // Retrieve all stream entries
@@ -599,8 +597,7 @@ public interface StreamBaseCommands {
      *     </ul>
      *
      * @return A <code>Map</code> of key to stream entry data, where entry data is an array of
-     *     pairings with format <code>[[field, entry], [field, entry], ...]</code>. Returns or <code>
-     *     null</code> if <code>count</code> is non-positive.
+     *     pairings with format <code>[[field, entry], [field, entry], ...]</code>.
      * @example
      *     <pre>{@code
      * // Retrieve all stream entries

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -3563,7 +3563,6 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *
      * @return Command Response - A <code>Map</code> of key to stream entry data, where entry data is
      *     an array of pairings with format <code>[[field, entry], [field, entry], ...]</code>.
-     *     Returns or <code>null</code> if <code>count</code> is non-positive.
      */
     public <ArgType> T xrange(
             @NonNull ArgType key, @NonNull StreamRange start, @NonNull StreamRange end) {
@@ -3636,7 +3635,6 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *
      * @return Command Response - A <code>Map</code> of key to stream entry data, where entry data is
      *     an array of pairings with format <code>[[field, entry], [field, entry], ...]</code>.
-     *     Returns or <code>null</code> if <code>count</code> is non-positive.
      */
     public <ArgType> T xrevrange(
             @NonNull ArgType key, @NonNull StreamRange end, @NonNull StreamRange start) {


### PR DESCRIPTION
In these two commands, it shouldn't be possible to return `null` since they don't have access to `count` so they won't be able to set it to a negative number.

### Issue link

This Pull Request is linked to issue (URL): #4239 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
