### PR TITLE
Node: Validate clientAZ when using AZ affinity strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,6 @@
 * Go: XInfoStream example fix ([#4185](https://github.com/valkey-io/valkey-glide/pull/4185))
 * Node: Validate clientAZ when using AZ affinity strategies ([#4267](https://github.com/valkey-io/valkey-glide/pull/4267))
 
-
 #### Breaking Changes
 
 * Go: Drop support for Go 1.20 ([#3513](https://github.com/valkey-io/valkey-glide/pull/3513))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@
 * Go: Add Opentelemetry support of creating spans ([#3932](https://github.com/valkey-io/valkey-glide/pull/3932))
 * Go: Fix API to use errors idiomatically ([#4090](https://github.com/valkey-io/valkey-glide/pull/4090))
 * Go: XInfoStream example fix ([#4185](https://github.com/valkey-io/valkey-glide/pull/4185))
+* Node: Validate clientAZ when using AZ affinity strategies ([#4267](https://github.com/valkey-io/valkey-glide/pull/4267))
+
 
 #### Breaking Changes
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -8403,14 +8403,13 @@ export class BaseClient {
 
         // Validate that clientAz is set when using AZ affinity strategies
         if (
-            options.readFrom === "AZAffinity" ||
-            options.readFrom === "AZAffinityReplicasAndPrimary"
+            (options.readFrom === "AZAffinity" ||
+                options.readFrom === "AZAffinityReplicasAndPrimary") &&
+            !options.clientAz
         ) {
-            if (!options.clientAz) {
-                throw new ConfigurationError(
-                    `clientAz must be set when readFrom is set to ${options.readFrom}`,
-                );
-            }
+            throw new ConfigurationError(
+                `clientAz must be set when readFrom is set to ${options.readFrom}`,
+            );
         }
 
         return {

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -8401,6 +8401,15 @@ export class BaseClient {
             | connection_request.ProtocolVersion
             | undefined;
 
+        // Validate that clientAz is set when using AZ affinity strategies
+        if (options.readFrom === "AZAffinity" || options.readFrom === "AZAffinityReplicasAndPrimary") {
+            if (!options.clientAz) {
+                throw new ConfigurationError(
+                    `clientAz must be set when readFrom is set to ${options.readFrom}`,
+                );
+            }
+        }
+
         return {
             protocol,
             clientName: options.clientName,

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -8402,7 +8402,10 @@ export class BaseClient {
             | undefined;
 
         // Validate that clientAz is set when using AZ affinity strategies
-        if (options.readFrom === "AZAffinity" || options.readFrom === "AZAffinityReplicasAndPrimary") {
+        if (
+            options.readFrom === "AZAffinity" ||
+            options.readFrom === "AZAffinityReplicasAndPrimary"
+        ) {
             if (!options.clientAz) {
                 throw new ConfigurationError(
                     `clientAz must be set when readFrom is set to ${options.readFrom}`,


### PR DESCRIPTION
Adding the check in baseclient config so that an error is thrown when the readfrom strategy is specified to be AZAffinity, but a clientAZ is not present.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4233

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
