### PR TITLE
Fix rust code lints

### DIFF
--- a/csharp/rust/src/ffi.rs
+++ b/csharp/rust/src/ffi.rs
@@ -557,7 +557,7 @@ pub(crate) unsafe fn create_pipeline(ptr: *const BatchInfo) -> Result<Pipeline, 
     for (i, cmd_ptr) in cmd_pointers.iter().enumerate() {
         match unsafe { create_cmd(*cmd_ptr) } {
             Ok(cmd) => pipeline.add_command(cmd),
-            Err(err) => return Err(format!("Coudln't create {:?}'th command: {:?}", i, err)),
+            Err(err) => return Err(format!("Coudln't create {i:?}'th command: {err:?}")),
         };
     }
     if info.is_atomic {


### PR DESCRIPTION
Rust update caused new linter errors on main
https://github.com/valkey-io/valkey-glide/actions/runs/15913131318/job/44885085679#step:3:748
