### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust tests
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/valkey-io/valkey-glide/security/code-scanning/52](https://github.com/valkey-io/valkey-glide/security/code-scanning/52)

To fix the issue, we will add an explicit `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the workflow's actions, it appears that the `contents: read` permission is sufficient for most jobs, with additional permissions (e.g., `pull-requests: write`) added only if necessary. The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific `permissions` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
