### PR TITLE
CI: Fix GHA

### DIFF
--- a/.github/workflows/full-matrix-tests.yml
+++ b/.github/workflows/full-matrix-tests.yml
@@ -2,6 +2,8 @@ name: Full Matrix tests
 
 permissions:
     contents: read
+    actions: write
+    id-token: write
 
 on:
     workflow_dispatch: # note: if started manually, it won't run all matrix


### PR DESCRIPTION
Fix full matrix pipeline. It wasn't able to start if manually triggered.
Fixing following errors:
[one](https://github.com/valkey-io/valkey-glide/actions/runs/16060472310)
> [Invalid workflow file: .github/workflows/full-matrix-tests.yml#L66](https://github.com/valkey-io/valkey-glide/actions/runs/16060472310/workflow)
> The workflow is not valid. .github/workflows/full-matrix-tests.yml (Line: 66, Col: 5): Error calling workflow 'valkey-io/valkey-glide/.github/workflows/redis-rs.yml@1a7701ce0d752df6e3db36afbc66ad4c2dc10611'. The workflow is requesting 'actions: write', but is only allowed 'actions: none'.

[two](https://github.com/valkey-io/valkey-glide/actions/runs/16060552793)
> [Invalid workflow file: .github/workflows/full-matrix-tests.yml#L79](https://github.com/valkey-io/valkey-glide/actions/runs/16060552793/workflow)
> The workflow is not valid. .github/workflows/full-matrix-tests.yml (Line: 79, Col: 5): Error calling workflow 'valkey-io/valkey-glide/.github/workflows/python.yml@9169c50b7bf01b3cc99ecb5c2820b32a6b327802'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.

I don't know what caused that behaviour? A new secutiry rules? Changes from GH?
