### PR TITLE
Core: Set RESP3 as default

### DIFF
--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -2373,8 +2373,8 @@ pub fn from_owned_redis_value<T: FromRedisValue>(v: Value) -> RedisResult<T> {
 #[repr(C)]
 pub enum ProtocolVersion {
     /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP2.md>
-    #[default]
     RESP2,
     /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md>
+    #[default]
     RESP3,
 }


### PR DESCRIPTION
Change default protocol version. There is no change for clients which use protobuf for connection request (as of now: java, python, node, go).
This change reflects for python sync, C# and C++ clients.


Protobuf usess enum value with ordinal 0 if value is unset.
https://github.com/valkey-io/valkey-glide/blob/682fc30da8c4f2aa2adfe0d4d3a70647a344236e/glide-core/src/protobuf/connection_request.proto#L29

Actually, it is a misuse of protobuf. Enums there shouldn't have 0 ordinal to distuingish default value vs no value.