### PR TITLE
CI: Add actions:write permission to full-matrix-tests-sweeper

### DIFF
--- a/.github/workflows/full-matrix-tests-sweeper.yml
+++ b/.github/workflows/full-matrix-tests-sweeper.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
     contents: read
+    actions: write
 
 jobs:
     trigger-full-matrix-tests:


### PR DESCRIPTION
Fix "Resource not accessible by integration" error in CI by adding the necessary actions:write permission to the workflow. This permission is required for the workflow to trigger the full-matrix-tests workflow using the GitHub API via github.rest.actions.createWorkflowDispatch().

Without this permission, the workflow was unable to trigger other workflows, causing the CI process to fail.

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   ~[] Tests are added or updated.~
-   ~[] CHANGELOG.md and documentation files are updated.~
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
