### PR TITLE
Add cross-compilation documentation to Go README

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -133,3 +133,122 @@ For more code examples please refer to [examples.md](examples/examples.md).
 ### Building & Testing
 
 Development instructions for local building & testing the package are in the [DEVELOPER.md](DEVELOPER.md) file.
+
+## Cross-Compilation Guide
+
+### Cross-Compiling with Docker
+
+Valkey GLIDE uses CGO to interface with its Rust-based core, which can make cross-compilation challenging. Docker provides a convenient solution for cross-compiling applications that use Valkey GLIDE.
+
+#### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed on your system
+- Your Go application using Valkey GLIDE
+
+#### Cross-Compiling for Linux (AMD64/ARM64)
+
+The official Golang Docker image includes the necessary tools for cross-compiling to Linux targets:
+
+```bash
+# Build for Linux AMD64
+docker run --rm -v "$PWD":/app -w /app golang:1.22 \
+  bash -c "CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o myapp-linux-amd64 ./..."
+
+# Build for Linux ARM64
+docker run --rm -v "$PWD":/app -w /app golang:1.22 \
+  bash -c "CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -o myapp-linux-arm64 ./..."
+```
+
+#### Cross-Compiling for macOS
+
+Due to Apple's platform restrictions, cross-compiling CGO code for macOS requires building on a macOS system:
+
+```bash
+# On a macOS system
+CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -o myapp-darwin-amd64 ./...
+CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -o myapp-darwin-arm64 ./...
+```
+
+### Setting Up GitHub Actions for Multi-Platform Builds
+
+You can use GitHub Actions to automatically build your application for all supported platforms. Here's a sample workflow file:
+
+```yaml
+name: Multi-Platform Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            runner: ubuntu-latest
+          - os: linux
+            arch: arm64
+            runner: ubuntu-latest
+          - os: darwin
+            arch: amd64
+            runner: macos-latest
+          - os: darwin
+            arch: arm64
+            runner: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: Build Linux
+      if: matrix.os == 'linux'
+      run: |
+        if [ "${{ matrix.arch }}" = "amd64" ]; then
+          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o myapp-linux-amd64 ./...
+        else
+          CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -o myapp-linux-arm64 ./...
+        fi
+
+    - name: Build macOS
+      if: matrix.os == 'darwin'
+      run: |
+        CGO_ENABLED=1 GOOS=darwin GOARCH=${{ matrix.arch }} go build -o myapp-darwin-${{ matrix.arch }} ./...
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: myapp-${{ matrix.os }}-${{ matrix.arch }}
+        path: myapp-${{ matrix.os }}-${{ matrix.arch }}
+```
+
+This workflow:
+
+1. Runs on both push to main and pull requests
+2. Creates a build matrix for all four supported platforms
+3. Uses the appropriate runner for each OS
+4. Sets the correct build flags for each platform
+5. Uploads the compiled binaries as artifacts
+
+You can customize this workflow to fit your specific application needs, such as adding tests, packaging steps, or deployment actions.
+
+### Troubleshooting Cross-Compilation
+
+If you encounter issues during cross-compilation:
+
+1. **Missing Libraries**: Ensure Valkey GLIDE is properly installed and its pre-compiled libraries are available
+2. **Linker Errors**: Check that CGO is enabled and the correct cross-compiler is being used
+3. **Architecture Mismatch**: Verify that you're using the correct GOARCH value for your target platform
+4. **Docker Issues**: Make sure your Docker container has sufficient resources and access to the source code
+
+For more complex cross-compilation scenarios or if you encounter specific issues, please open a GitHub issue for assistance.


### PR DESCRIPTION
This PR adds a new section to the Go README.md that documents how to cross-compile applications that use valkey-glide.

The new documentation includes:

1. Instructions for using Docker to cross-compile for Linux platforms (AMD64 and ARM64)
2. Instructions for compiling for macOS platforms on macOS systems
3. A complete GitHub Actions workflow example that builds for all four supported platforms
4. Troubleshooting tips for common cross-compilation issues

This documentation will help users understand how to properly cross-compile applications that use valkey-glide and set up automated builds for all supported platforms.