### PR TITLE
feat: Respect OTLP protocol environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Changes
 
+* Core: Respect OTLP protocol environment variables (`OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`) ([#4334](https://github.com/valkey-io/valkey-glide/issues/4334))
 * Java: fix addReturnField method in FT module ([#4084]https://github.com/valkey-io/valkey-glide/pull/4084)
 * Python: Create openTelemetry span to measure command latency ([#3985](https://github.com/valkey-io/valkey-glide/pull/3985))
 * Go: Add client name and version identifiers ([#3903](https://github.com/valkey-io/valkey-glide/pull/3903))


### PR DESCRIPTION
This change updates the OpenTelemetry initialization logic to respect the `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`, and `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` environment variables for selecting the OTLP protocol.

The priority is as follows:
1. Specific environment variable (e.g., `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`)
2. Generic environment variable (`OTEL_EXPORTER_OTLP_PROTOCOL`)
3. URL scheme from the endpoint configuration

If an environment variable is set but invalid, the system falls back to the next priority level.

New tests have been added to verify this behavior, and existing tests have been updated to ensure they don't interfere with each other due to the global nature of OpenTelemetry initialization.

Also updates CHANGELOG.md.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
