### PR TITLE
C#: fix endpoint string conversion

### DIFF
--- a/csharp/sources/Valkey.Glide/Abstract/ConnectionMultiplexer.cs
+++ b/csharp/sources/Valkey.Glide/Abstract/ConnectionMultiplexer.cs
@@ -68,10 +68,10 @@ public sealed class ConnectionMultiplexer : IConnectionMultiplexer, IDisposable,
             : [.. GetServers().Select(s => s.EndPoint)];
 
     public IServer GetServer(string host, int port, object? asyncState = null)
-        => GetServer(Utils.ParseEndPoint(host, port), asyncState);
+        => GetServer(Format.ParseEndPoint(host, port), asyncState);
 
     public IServer GetServer(string hostAndPort, object? asyncState = null)
-        => Utils.TryParseEndPoint(hostAndPort, out IPEndPoint? ep)
+        => Format.TryParseEndPoint(hostAndPort, out EndPoint? ep)
             ? GetServer(ep, asyncState)
             : throw new ArgumentException($"The specified host and port could not be parsed: {hostAndPort}", nameof(hostAndPort));
 
@@ -165,8 +165,7 @@ public sealed class ConnectionMultiplexer : IConnectionMultiplexer, IDisposable,
         T config = new();
         foreach (EndPoint ep in configuration.EndPoints)
         {
-            string[] parts = ep.ToString()!.Split(':');
-            config.Addresses += (parts[0], ushort.Parse(parts[1]));
+            config.Addresses += Utils.SplitEndpoint(ep);
         }
         config.UseTls = configuration.Ssl;
         _ = configuration.ConnectTimeout.HasValue ? config.ConnectionTimeout = TimeSpan.FromMilliseconds(configuration.ConnectTimeout.Value) : new();

--- a/csharp/sources/Valkey.Glide/Abstract/ValkeyServer.cs
+++ b/csharp/sources/Valkey.Glide/Abstract/ValkeyServer.cs
@@ -21,6 +21,12 @@ internal class ValkeyServer(DatabaseImpl conn, EndPoint endpoint) : IServer
     private Dictionary<GlideString, object> Hello()
         => (Dictionary<GlideString, object>)_conn.CustomCommand(["hello"]).GetAwaiter().GetResult()!;
 
+    private Route MakeRoute()
+    {
+        (string host, ushort port) = Utils.SplitEndpoint(EndPoint);
+        return new ByAddressRoute(host, port);
+    }
+
     public EndPoint EndPoint { get; } = endpoint;
 
     public bool IsConnected => true;
@@ -38,7 +44,7 @@ internal class ValkeyServer(DatabaseImpl conn, EndPoint endpoint) : IServer
             [Enum.Parse<InfoOptions.Section>(section.ToString(), true)];
 
         return _conn
-            .Command(Request.Info(sections), new ByAddressRoute(EndPoint.ToString()!))
+            .Command(Request.Info(sections), MakeRoute())
             .ContinueWith(task => (string?)task.Result);
     }
 
@@ -53,11 +59,11 @@ internal class ValkeyServer(DatabaseImpl conn, EndPoint endpoint) : IServer
         => InfoAsync(section, flags).GetAwaiter().GetResult();
 
     public async Task<TimeSpan> PingAsync(CommandFlags flags = CommandFlags.None)
-        => await _conn.Command(Request.Ping(flags), new ByAddressRoute(EndPoint.ToString()!));
+        => await _conn.Command(Request.Ping(flags), MakeRoute());
 
     public async Task<TimeSpan> PingAsync(ValkeyValue message, CommandFlags flags = CommandFlags.None)
-        => await _conn.Command(Request.Ping(message, flags), new ByAddressRoute(EndPoint.ToString()!));
+        => await _conn.Command(Request.Ping(message, flags), MakeRoute());
 
     public async Task<ValkeyValue> EchoAsync(ValkeyValue message, CommandFlags flags = CommandFlags.None)
-        => await _conn.Command(Request.Echo(message, flags), new ByAddressRoute(EndPoint.ToString()!));
+        => await _conn.Command(Request.Echo(message, flags), MakeRoute());
 }

--- a/csharp/sources/Valkey.Glide/Internals/Utils.cs
+++ b/csharp/sources/Valkey.Glide/Internals/Utils.cs
@@ -5,24 +5,13 @@ using System.Net;
 
 internal class Utils
 {
-    public static EndPoint ParseEndPoint(string host, int port)
-        => IPAddress.TryParse(host, out IPAddress? ip)
-            ? new IPEndPoint(ip, port)
-            : new DnsEndPoint(host, port);
-
-    public static bool TryParseEndPoint(string hostAndPort, out IPEndPoint result)
-    {
-        if (!Uri.TryCreate($"tcp://{hostAndPort}", UriKind.Absolute, out Uri? uri) ||
-            !IPAddress.TryParse(uri.Host, out IPAddress? ipAddress) ||
-            uri.Port < 0 || uri.Port > 65535)
+    public static (string host, ushort port) SplitEndpoint(EndPoint ep)
+        => ep switch
         {
-            result = new(0, 0);
-            return false;
-        }
-
-        result = new IPEndPoint(ipAddress, uri.Port);
-        return true;
-    }
+            DnsEndPoint dns => (dns.Host, (ushort)dns.Port),
+            IPEndPoint ip => (ip.Address.ToString(), (ushort)ip.Port),
+            _ => throw new ArgumentException($"Unsupported endpoint type: {ep.GetType()}"),
+        };
 
     public static void Requires<TException>(bool predicate, string message)
         where TException : Exception, new()

--- a/csharp/tests/Valkey.Glide.IntegrationTests/ServerTests.cs
+++ b/csharp/tests/Valkey.Glide.IntegrationTests/ServerTests.cs
@@ -19,10 +19,10 @@ public class ServerTests(TestConfiguration config)
             ? TestConfiguration.CLUSTER_HOSTS[0]
             : TestConfiguration.STANDALONE_HOSTS[0];
 
-        Assert.Equal($"{host}:{port}", conn.GetServer(host, port).EndPoint.ToString());
-        Assert.Equal($"{host}:{port}", conn.GetServer($"{host}:{port}").EndPoint.ToString());
-        Assert.Equal($"{host}:{port}", conn.GetServer(IPAddress.Parse(host), port).EndPoint.ToString());
-        Assert.Equal($"{host}:{port}", conn.GetServer(new IPEndPoint(IPAddress.Parse(host), port)).EndPoint.ToString());
+        Assert.Equal($"{host}:{port}", Format.ToString(conn.GetServer(host, port).EndPoint));
+        Assert.Equal($"{host}:{port}", Format.ToString(conn.GetServer($"{host}:{port}").EndPoint));
+        Assert.Equal($"{host}:{port}", Format.ToString(conn.GetServer(IPAddress.Parse(host), port).EndPoint));
+        Assert.Equal($"{host}:{port}", Format.ToString(conn.GetServer(new IPEndPoint(IPAddress.Parse(host), port)).EndPoint));
 
         // TODO currently this returns only primary node on standalone
         // https://github.com/valkey-io/valkey-glide/issues/4293
@@ -45,7 +45,7 @@ public class ServerTests(TestConfiguration config)
             {
                 if (line.Contains("tcp_port:"))
                 {
-                    Assert.Contains(server.EndPoint.ToString()!.Split(':')[1], line);
+                    Assert.Contains(Format.ToString(server.EndPoint).Split(':')[1], line);
                     break;
                 }
             }
@@ -60,7 +60,7 @@ public class ServerTests(TestConfiguration config)
                     {
                         if (pair.Key == "tcp_port")
                         {
-                            Assert.Equal(pair.Value, server.EndPoint.ToString()!.Split(':')[1]);
+                            Assert.Equal(pair.Value, Format.ToString(server.EndPoint).Split(':')[1]);
                             portFound = true;
                             break;
                         }

--- a/csharp/tests/Valkey.Glide.IntegrationTests/TestConfiguration.cs
+++ b/csharp/tests/Valkey.Glide.IntegrationTests/TestConfiguration.cs
@@ -212,7 +212,8 @@ public class TestConfiguration : IDisposable
 #pragma warning disable xUnit1046 // Avoid using TheoryDataRow arguments that are not serializable
                 field = [
                     .. TestStandaloneConnections.Select(d => new TheoryDataRow<ConnectionMultiplexer, bool>(d.Data, false)),
-                    .. TestClusterConnections.Select(d => new TheoryDataRow<ConnectionMultiplexer, bool>(d.Data, true))];
+                    .. TestClusterConnections.Select(d => new TheoryDataRow<ConnectionMultiplexer, bool>(d.Data, true))
+                ];
 #pragma warning restore xUnit1046 // Avoid using TheoryDataRow arguments that are not serializable
             }
             return field;


### PR DESCRIPTION
The issue caused by calling `ToString()` method on an `DnsEndPoint` instance, which prints address familty, so resulting string were "Unspecified/localhost:6379".

### Issue link

This Pull Request is linked to issue (URL): fixes #4391

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.