### PR TITLE
Update C# Benchmark Driver stopwatch use

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -123,7 +123,7 @@ public static class MainClass
             int index = (int)(s_started_tasks_counter % clients.Length);
             ClientWrapper client = clients[index];
             ChosenAction action = ChooseAction();
-            stopwatch.Start();
+            stopwatch.Restart();
             switch (action)
             {
                 case ChosenAction.GET_EXISTING:
@@ -140,7 +140,7 @@ public static class MainClass
             }
             stopwatch.Stop();
             ConcurrentBag<double> latency_list = action_latencies[action];
-            latency_list.Add(((double)stopwatch.ElapsedMilliseconds) / 1000);
+            latency_list.Add(stopwatch.Elapsed.TotalMilliseconds);
         } while (s_started_tasks_counter < total_commands);
     }
 


### PR DESCRIPTION
Fix for: https://github.com/valkey-io/valkey-glide/issues/4453 

Fix the use of Stopwatch in benchmarks/csharp/Program.cs to use .Restart() instead of .Start().

The prior code kept a running total of the time used by all runs. .Restart() will zero the stopwatch instance for each action taken.

Used the finer-grained millisecond timer available via stopwatch.Elapsed.TotalMilliseconds, which is already of type double.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
