### PR TITLE
C#: Sorted Set Public Preview Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ cpp/src/connection_request.pb.cc
 **/.claude/settings.local.json
 copilot-instructions.md
 **/.yarn
+
+# AI agent related files
+.kiro/

--- a/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
@@ -31,8 +31,20 @@ public abstract partial class BaseClient : ISortedSetCommands
     public async Task<long> SortedSetRemoveAsync(ValkeyKey key, ValkeyValue[] members, CommandFlags flags = CommandFlags.None)
         => await Command(Request.SortedSetRemoveAsync(key, members, flags));
 
-    public async Task<long> SortedSetLengthAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)
-        => await Command(Request.SortedSetLengthAsync(key, flags));
+    public async Task<long> SortedSetLengthAsync(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+    {
+        // If both min and max are infinity (default values), use ZCARD
+        if (double.IsNegativeInfinity(min) && double.IsPositiveInfinity(max))
+        {
+            return await Command(Request.SortedSetCardAsync(key, flags));
+        }
+        
+        // Otherwise use ZCOUNT with the specified range
+        return await Command(Request.SortedSetCountAsync(key, min, max, exclude, flags));
+    }
+
+    public async Task<long> SortedSetCardAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetCardAsync(key, flags));
 
     public async Task<long> SortedSetCountAsync(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
         => await Command(Request.SortedSetCountAsync(key, min, max, exclude, flags));

--- a/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
@@ -30,4 +30,36 @@ public abstract partial class BaseClient : ISortedSetCommands
 
     public async Task<long> SortedSetRemoveAsync(ValkeyKey key, ValkeyValue[] members, CommandFlags flags = CommandFlags.None)
         => await Command(Request.SortedSetRemoveAsync(key, members, flags));
+
+    public async Task<long> SortedSetLengthAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetLengthAsync(key, flags));
+
+    public async Task<long> SortedSetCountAsync(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetCountAsync(key, min, max, exclude, flags));
+
+    public async Task<ValkeyValue[]> SortedSetRangeByRankAsync(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetRangeByRankAsync(key, start, stop, order, flags));
+
+    public async Task<SortedSetEntry[]> SortedSetRangeByRankWithScoresAsync(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetRangeByRankWithScoresAsync(key, start, stop, order, flags));
+
+    public async Task<ValkeyValue[]> SortedSetRangeByScoreAsync(ValkeyKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetRangeByScoreAsync(key, start, stop, exclude, order, skip, take, flags));
+
+    public async Task<SortedSetEntry[]> SortedSetRangeByScoreWithScoresAsync(ValkeyKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1, CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetRangeByScoreWithScoresAsync(key, start, stop, exclude, order, skip, take, flags));
+
+    public async Task<ValkeyValue[]> SortedSetRangeByValueAsync(ValkeyKey key, ValkeyValue min, ValkeyValue max, Exclude exclude, long skip, long take, CommandFlags flags = CommandFlags.None)
+        => await SortedSetRangeByValueAsync(key, min, max, exclude, Order.Ascending, skip, take, flags);
+
+    public async Task<ValkeyValue[]> SortedSetRangeByValueAsync(
+        ValkeyKey key,
+        ValkeyValue min = default,
+        ValkeyValue max = default,
+        Exclude exclude = Exclude.None,
+        Order order = Order.Ascending,
+        long skip = 0,
+        long take = -1,
+        CommandFlags flags = CommandFlags.None)
+        => await Command(Request.SortedSetRangeByValueAsync(key, min, max, exclude, order, skip, take, flags));
 }

--- a/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
@@ -38,7 +38,7 @@ public abstract partial class BaseClient : ISortedSetCommands
         {
             return await SortedSetCardAsync(key, flags);
         }
-        
+
         // Otherwise use ZCOUNT with the specified range
         return await SortedSetCountAsync(key, min, max, exclude, flags);
     }

--- a/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/BaseClient.SortedSetCommands.cs
@@ -36,11 +36,11 @@ public abstract partial class BaseClient : ISortedSetCommands
         // If both min and max are infinity (default values), use ZCARD
         if (double.IsNegativeInfinity(min) && double.IsPositiveInfinity(max))
         {
-            return await Command(Request.SortedSetCardAsync(key, flags));
+            return await SortedSetCardAsync(key, flags);
         }
         
         // Otherwise use ZCOUNT with the specified range
-        return await Command(Request.SortedSetCountAsync(key, min, max, exclude, flags));
+        return await SortedSetCountAsync(key, min, max, exclude, flags);
     }
 
     public async Task<long> SortedSetCardAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)

--- a/csharp/sources/Valkey.Glide/Commands/Constants/Constants.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Constants/Constants.cs
@@ -13,4 +13,29 @@ public static class Constants
     public const string AbsttlKeyword = "ABSTTL";
     public const string IdletimeKeyword = "IDLETIME";
     public const string FreqKeyword = "FREQ";
+    public const string WithScoresKeyword = "WITHSCORES";
+    public const string ReverseKeyword = "REV";
+    public const string ByLexKeyword = "BYLEX";
+    public const string ByScoreKeyword = "BYSCORE";
+
+    /// <summary>
+    /// The highest bound in the sorted set for lexicographical operations.
+    /// </summary>
+    public const string PositiveInfinity = "+";
+
+    /// <summary>
+    /// The lowest bound in the sorted set for lexicographical operations.
+    /// </summary>
+    public const string NegativeInfinity = "-";
+
+    /// <summary>
+    /// The highest bound in the sorted set for score operations.
+    /// </summary>
+    public const string PositiveInfinityScore = "+inf";
+
+    /// <summary>
+    /// The lowest bound in the sorted set for score operations.
+    /// </summary>
+    public const string NegativeInfinityScore = "-inf";
+
 }

--- a/csharp/sources/Valkey.Glide/Commands/ISortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Commands/ISortedSetCommands.cs
@@ -108,6 +108,30 @@ public interface ISortedSetCommands
     Task<long> SortedSetRemoveAsync(ValkeyKey key, ValkeyValue[] members, CommandFlags flags = CommandFlags.None);
 
     /// <summary>
+    /// Returns the sorted set cardinality (number of elements) of the sorted set stored at key.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zcard"/>
+    /// <seealso href="https://valkey.io/commands/zcount"/>
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="min">The min score to filter by (defaults to negative infinity).</param>
+    /// <param name="max">The max score to filter by (defaults to positive infinity).</param>
+    /// <param name="exclude">Whether to exclude <paramref name="min"/> and <paramref name="max"/> from the range check (defaults to both inclusive).</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>The cardinality (number of elements) of the sorted set, or 0 if key does not exist.</returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// // Get total cardinality
+    /// long totalCount = await client.SortedSetLengthAsync(key);
+    /// 
+    /// // Count elements in score range
+    /// long rangeCount = await client.SortedSetLengthAsync(key, 1.0, 10.0);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<long> SortedSetLengthAsync(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
     /// Returns the cardinality (number of elements) of the sorted set stored at key.
     /// </summary>
     /// <seealso href="https://valkey.io/commands/zcard"/>
@@ -121,11 +145,11 @@ public interface ISortedSetCommands
     /// <remarks>
     /// <example>
     /// <code>
-    /// long result = await client.SortedSetLengthAsync(key);
+    /// long result = await client.SortedSetCardAsync(key);
     /// </code>
     /// </example>
     /// </remarks>
-    Task<long> SortedSetLengthAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None);
+    Task<long> SortedSetCardAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None);
 
     /// <summary>
     /// Returns the number of members in the sorted set stored at key with scores between min and max score.

--- a/csharp/sources/Valkey.Glide/Commands/ISortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Commands/ISortedSetCommands.cs
@@ -106,4 +106,236 @@ public interface ISortedSetCommands
     /// </example>
     /// </remarks>
     Task<long> SortedSetRemoveAsync(ValkeyKey key, ValkeyValue[] members, CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the cardinality (number of elements) of the sorted set stored at key.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zcard"/>
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	The number of elements in the sorted set.
+    ///	If key does not exist, it is treated as an empty sorted set, and this command returns 0.
+    ///	If key holds a value that is not a sorted set, an error is returned.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// long result = await client.SortedSetLengthAsync(key);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<long> SortedSetLengthAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the number of members in the sorted set stored at key with scores between min and max score.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zcount"/>
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="min">The minimum score to count from (defaults to negative infinity).</param>
+    /// <param name="max">The maximum score to count up to (defaults to positive infinity).</param>
+    /// <param name="exclude">Whether to exclude min and max from the range check (defaults to both inclusive).</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>The number of members in the specified score range.</returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// long result = await client.SortedSetCountAsync(key, 1.0, 10.0);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<long> SortedSetCountAsync(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None, CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the specified range of elements in the sorted set stored at key by their index (rank).
+    /// By default the elements are considered to be ordered from the lowest to the highest score.
+    /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.<br/>
+    /// To get the elements with their scores, <see cref="SortedSetRangeByRankWithScoresAsync" />.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zrange"/>
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="start">The start index to get.</param>
+    /// <param name="stop">The stop index to get.</param>
+    /// <param name="order">The order to sort by (defaults to ascending).</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	An array of elements within the specified range.
+    ///	If key does not exist, it is treated as an empty sorted set, and the command returns an empty array.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// ValkeyValue[] result = await client.SortedSetRangeByRankAsync(key, 0, 10);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<ValkeyValue[]> SortedSetRangeByRankAsync(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the specified range of elements with their scores in the sorted set stored at key by their index (rank).
+    /// By default the elements are considered to be ordered from the lowest to the highest score.
+    /// Both start and stop are zero-based indexes, where 0 is the first element, 1 is the next element and so on.<br/>
+    /// To get the elements without their scores, <see cref="SortedSetRangeByRankAsync" />.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zrange"/>
+    /// <seealso href="https://redis.io/commands/zrevrange"/>.
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="start">The start index to get.</param>
+    /// <param name="stop">The stop index to get.</param>
+    /// <param name="order">The order to sort by (defaults to ascending).</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	An array of elements and their scores within the specified range.
+    ///	If key does not exist, it is treated as an empty sorted set, and the command returns an empty array.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// SortedSetEntry[] result = await client.SortedSetRangeByRankWithScoresAsync(key, 0, 10);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<SortedSetEntry[]> SortedSetRangeByRankWithScoresAsync(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending, CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the specified range of elements in the sorted set stored at key by their score.
+    /// By default the elements are considered to be ordered from the lowest to the highest score.
+    /// Start and stop are used to specify the min and max range for score values.
+    /// To get the elements with their scores, <see cref="SortedSetRangeByScoreWithScoresAsync" />.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zrange"/>
+    /// <seealso href="https://redis.io/commands/zrevrange"/>.
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="start">The minimum score to filter by.</param>
+    /// <param name="stop">The maximum score to filter by.</param>
+    /// <param name="exclude">Which of start and stop to exclude (defaults to both inclusive).</param>
+    /// <param name="order">The order to sort by (defaults to ascending).</param>
+    /// <param name="skip">How many items to skip.</param>
+    /// <param name="take">How many items to take.</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	An array of elements within the specified range.
+    ///	If key does not exist, it is treated as an empty sorted set, and the command returns an empty array.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// ValkeyValue[] result = await client.SortedSetRangeByScoreAsync(key, 1.0, 10.0);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<ValkeyValue[]> SortedSetRangeByScoreAsync(
+        ValkeyKey key,
+        double start = double.NegativeInfinity,
+        double stop = double.PositiveInfinity,
+        Exclude exclude = Exclude.None,
+        Order order = Order.Ascending,
+        long skip = 0,
+        long take = -1,
+        CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the specified range of elements in the sorted set stored at key with their scores by their score.
+    /// By default the elements are considered to be ordered from the lowest to the highest score.
+    /// Start and stop are used to specify the min and max range for score values 
+    /// To get the elements without their scores, <see cref="SortedSetRangeByScoreAsync" />.
+    /// </summary>.
+    /// <seealso href="https://valkey.io/commands/zrange"/>
+    /// <seealso href="https://redis.io/commands/zrevrange"/>.
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="start">The minimum score to filter by.</param>
+    /// <param name="stop">The maximum score to filter by.</param>
+    /// <param name="exclude">Which of start and stop to exclude (defaults to both inclusive).</param>
+    /// <param name="order">The order to sort by (defaults to ascending).</param>
+    /// <param name="skip">How many items to skip.</param>
+    /// <param name="take">How many items to take.</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	An array of elements and their scores within the specified range.
+    ///	If key does not exist, it is treated as an empty sorted set, and the command returns an empty array.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// SortedSetEntry[] result = await client.SortedSetRangeByScoreWithScoresAsync(key, 1.0, 10.0);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<SortedSetEntry[]> SortedSetRangeByScoreWithScoresAsync(
+        ValkeyKey key,
+        double start = double.NegativeInfinity,
+        double stop = double.PositiveInfinity,
+        Exclude exclude = Exclude.None,
+        Order order = Order.Ascending,
+        long skip = 0,
+        long take = -1,
+        CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the specified range of elements in the sorted set stored at key by their lexicographical order.
+    /// This command returns all the elements in the sorted set at key with a value between min and max.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zrange"/>
+    /// <seealso href="https://redis.io/commands/zrevrange"/>.
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="min">The min value to filter by.</param>
+    /// <param name="max">The max value to filter by.</param>
+    /// <param name="exclude">Which of min and max to exclude.</param>
+    /// <param name="skip">How many items to skip.</param>
+    /// <param name="take">How many items to take.</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	An array of elements within the specified range.
+    ///	If key does not exist, it is treated as an empty sorted set, and the command returns an empty array.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// ValkeyValue[] result = await client.SortedSetRangeByValueAsync(key, "a", "z", Exclude.None, 0, -1);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<ValkeyValue[]> SortedSetRangeByValueAsync(
+        ValkeyKey key,
+        ValkeyValue min,
+        ValkeyValue max,
+        Exclude exclude,
+        long skip,
+        long take = -1,
+        CommandFlags flags = CommandFlags.None);
+
+    /// <summary>
+    /// Returns the specified range of elements in the sorted set stored at key by their lexicographical order.
+    /// This command returns all the elements in the sorted set at key with a value between min and max.
+    /// </summary>
+    /// <seealso href="https://valkey.io/commands/zrange"/>
+    /// <seealso href="https://redis.io/commands/zrevrange"/>.
+    /// <param name="key">The key of the sorted set.</param>
+    /// <param name="min">The min value to filter by.</param>
+    /// <param name="max">The max value to filter by.</param>
+    /// <param name="exclude">Which of min and max to exclude (defaults to both inclusive).</param>
+    /// <param name="order">The order to sort by (defaults to ascending).</param>
+    /// <param name="skip">How many items to skip.</param>
+    /// <param name="take">How many items to take.</param>
+    /// <param name="flags">The flags to use for this operation. Currently flags are ignored.</param>
+    /// <returns>
+    ///	An array of elements within the specified range.
+    ///	If key does not exist, it is treated as an empty sorted set, and the command returns an empty array.
+    /// </returns>
+    /// <remarks>
+    /// <example>
+    /// <code>
+    /// ValkeyValue[] result = await client.SortedSetRangeByValueAsync(key, "a", "z", order: Order.Descending);
+    /// </code>
+    /// </example>
+    /// </remarks>
+    Task<ValkeyValue[]> SortedSetRangeByValueAsync(
+        ValkeyKey key,
+        ValkeyValue min = default,
+        ValkeyValue max = default,
+        Exclude exclude = Exclude.None,
+        Order order = Order.Ascending,
+        long skip = 0,
+        long take = -1,
+        CommandFlags flags = CommandFlags.None);
 }

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZCountOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZCountOptions.cs
@@ -23,5 +23,5 @@ public readonly struct ZCountRange(ScoreBoundary min, ScoreBoundary max)
     /// Converts the range to command arguments.
     /// </summary>
     /// <returns>An array of string arguments for the command.</returns>
-    public string[] ToArgs() => [Min.ToString(), Max.ToString()];
+    internal string[] ToArgs() => [Min.ToString(), Max.ToString()];
 }

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZCountOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZCountOptions.cs
@@ -1,0 +1,30 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide.Commands.Options;
+
+/// <summary>
+/// Represents the range options for the ZCOUNT command.
+/// </summary>
+/// <param name="min">The minimum score boundary.</param>
+/// <param name="max">The maximum score boundary.</param>
+public readonly struct ZCountRange(ScoreBoundary min, ScoreBoundary max)
+{
+    /// <summary>
+    /// The minimum score boundary.
+    /// </summary>
+    public ScoreBoundary Min { get; } = min;
+
+    /// <summary>
+    /// The maximum score boundary.
+    /// </summary>
+    public ScoreBoundary Max { get; } = max;
+
+    /// <summary>
+    /// Converts the range to command arguments.
+    /// </summary>
+    /// <returns>An array of string arguments for the command.</returns>
+    public string[] ToArgs()
+    {
+        return [Min.ToString(), Max.ToString()];
+    }
+}

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZCountOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZCountOptions.cs
@@ -23,8 +23,5 @@ public readonly struct ZCountRange(ScoreBoundary min, ScoreBoundary max)
     /// Converts the range to command arguments.
     /// </summary>
     /// <returns>An array of string arguments for the command.</returns>
-    public string[] ToArgs()
-    {
-        return [Min.ToString(), Max.ToString()];
-    }
+    public string[] ToArgs() => [Min.ToString(), Max.ToString()];
 }

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
@@ -26,10 +26,14 @@ public readonly struct ScoreBoundary
     public static ScoreBoundary Inclusive(double score)
     {
         if (double.IsPositiveInfinity(score))
-            return new ScoreBoundary(PositiveInfinityScore);
+        {
+            return new(PositiveInfinityScore);
+        }
         if (double.IsNegativeInfinity(score))
-            return new ScoreBoundary(NegativeInfinityScore);
-        return new ScoreBoundary(score.ToString(CultureInfo.InvariantCulture));
+        {
+            return new(NegativeInfinityScore);
+        }
+        return new(score.ToString(CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -40,23 +44,27 @@ public readonly struct ScoreBoundary
     public static ScoreBoundary Exclusive(double score)
     {
         if (double.IsPositiveInfinity(score))
-            return new ScoreBoundary(PositiveInfinityScore);
+        {
+            return new(PositiveInfinityScore);
+        }
         if (double.IsNegativeInfinity(score))
-            return new ScoreBoundary(NegativeInfinityScore);
-        return new ScoreBoundary("(" + score.ToString(CultureInfo.InvariantCulture));
+        {
+            return new(NegativeInfinityScore);
+        }
+        return new("(" + score.ToString(CultureInfo.InvariantCulture));
     }
 
     /// <summary>
     /// Creates a positive infinity boundary.
     /// </summary>
     /// <returns>A positive infinity boundary.</returns>
-    public static ScoreBoundary PositiveInfinity() => new ScoreBoundary(PositiveInfinityScore);
+    public static ScoreBoundary PositiveInfinity() => new(PositiveInfinityScore);
 
     /// <summary>
     /// Creates a negative infinity boundary.
     /// </summary>
     /// <returns>A negative infinity boundary.</returns>
-    public static ScoreBoundary NegativeInfinity() => new ScoreBoundary(NegativeInfinityScore);
+    public static ScoreBoundary NegativeInfinity() => new(NegativeInfinityScore);
 
     /// <summary>
     /// Converts the score boundary to its string representation.
@@ -316,32 +324,26 @@ public readonly struct LexBoundary
     /// </summary>
     /// <param name="value">The lexicographical value.</param>
     /// <returns>An inclusive lexicographical boundary.</returns>
-    public static LexBoundary Inclusive(ValkeyValue value)
-    {
-        return new LexBoundary("[" + value.ToString());
-    }
+    public static LexBoundary Inclusive(ValkeyValue value) => new("[" + value.ToString());
 
     /// <summary>
     /// Creates an exclusive lexicographical boundary.
     /// </summary>
     /// <param name="value">The lexicographical value.</param>
     /// <returns>An exclusive lexicographical boundary.</returns>
-    public static LexBoundary Exclusive(ValkeyValue value)
-    {
-        return new LexBoundary("(" + value.ToString());
-    }
+    public static LexBoundary Exclusive(ValkeyValue value) => new("(" + value.ToString());
 
     /// <summary>
     /// Creates a negative infinity boundary.
     /// </summary>
     /// <returns>A negative infinity boundary.</returns>
-    public static LexBoundary NegativeInfinity() => new LexBoundary(Commands.Constants.Constants.NegativeInfinity);
+    public static LexBoundary NegativeInfinity() => new(Commands.Constants.Constants.NegativeInfinity);
 
     /// <summary>
     /// Creates a positive infinity boundary.
     /// </summary>
     /// <returns>A positive infinity boundary.</returns>
-    public static LexBoundary PositiveInfinity() => new LexBoundary(Commands.Constants.Constants.PositiveInfinity);
+    public static LexBoundary PositiveInfinity() => new(Commands.Constants.Constants.PositiveInfinity);
 
     /// <summary>
     /// Converts the lexicographical boundary to its string representation.

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
@@ -99,7 +99,7 @@ public class RangeByIndex(long start, long stop)
     /// Converts the query to command arguments.
     /// </summary>
     /// <returns>An array of string arguments for the command.</returns>
-    public string[] ToArgs()
+    internal string[] ToArgs()
     {
         List<string> args = [
             Start.ToString(CultureInfo.InvariantCulture),
@@ -168,7 +168,7 @@ public class RangeByScore(ScoreBoundary start, ScoreBoundary end)
     /// Converts the query to command arguments.
     /// </summary>
     /// <returns>An array of string arguments for the command.</returns>
-    public string[] ToArgs()
+    internal string[] ToArgs()
     {
         List<string> args = [];
 
@@ -256,7 +256,7 @@ public class RangeByLex(LexBoundary start, LexBoundary end)
     /// Converts the query to command arguments.
     /// </summary>
     /// <returns>An array of string arguments for the command.</returns>
-    public string[] ToArgs()
+    internal string[] ToArgs()
     {
         List<string> args = [];
 

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
@@ -1,0 +1,357 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+using System.Globalization;
+
+using static Valkey.Glide.Commands.Constants.Constants;
+
+namespace Valkey.Glide.Commands.Options;
+
+/// <summary>
+/// Represents a score boundary for sorted set range operations.
+/// </summary>
+public readonly struct ScoreBoundary
+{
+    private readonly string _value;
+
+    private ScoreBoundary(string value)
+    {
+        _value = value;
+    }
+
+    /// <summary>
+    /// Creates an inclusive score boundary.
+    /// </summary>
+    /// <param name="score">The score value.</param>
+    /// <returns>An inclusive score boundary.</returns>
+    public static ScoreBoundary Inclusive(double score)
+    {
+        if (double.IsPositiveInfinity(score))
+            return new ScoreBoundary(PositiveInfinityScore);
+        if (double.IsNegativeInfinity(score))
+            return new ScoreBoundary(NegativeInfinityScore);
+        return new ScoreBoundary(score.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Creates an exclusive score boundary.
+    /// </summary>
+    /// <param name="score">The score value.</param>
+    /// <returns>An exclusive score boundary.</returns>
+    public static ScoreBoundary Exclusive(double score)
+    {
+        if (double.IsPositiveInfinity(score))
+            return new ScoreBoundary(PositiveInfinityScore);
+        if (double.IsNegativeInfinity(score))
+            return new ScoreBoundary(NegativeInfinityScore);
+        return new ScoreBoundary("(" + score.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Creates a positive infinity boundary.
+    /// </summary>
+    /// <returns>A positive infinity boundary.</returns>
+    public static ScoreBoundary PositiveInfinity() => new ScoreBoundary(PositiveInfinityScore);
+
+    /// <summary>
+    /// Creates a negative infinity boundary.
+    /// </summary>
+    /// <returns>A negative infinity boundary.</returns>
+    public static ScoreBoundary NegativeInfinity() => new ScoreBoundary(NegativeInfinityScore);
+
+    /// <summary>
+    /// Converts the score boundary to its string representation.
+    /// </summary>
+    /// <returns>The string representation of the score boundary.</returns>
+    public override string ToString() => _value;
+
+    /// <summary>
+    /// Implicit conversion to string.
+    /// </summary>
+    /// <param name="boundary">The score boundary.</param>
+    public static implicit operator string(ScoreBoundary boundary) => boundary._value;
+}
+
+/// <summary>
+/// Represents a range query by index (rank) for the ZRANGE command.
+/// </summary>
+/// <param name="start">The start index.</param>
+/// <param name="stop">The stop index.</param>
+public class RangeByIndex(long start, long stop)
+{
+    /// <summary>
+    /// The start index.
+    /// </summary>
+    public long Start { get; } = start;
+
+    /// <summary>
+    /// The stop index.
+    /// </summary>
+    public long Stop { get; } = stop;
+
+    /// <summary>
+    /// Whether to reverse the order.
+    /// </summary>
+    public bool Reverse { get; private set; }
+
+    /// <summary>
+    /// Sets the query to return results in reverse order.
+    /// </summary>
+    /// <returns>This instance for method chaining.</returns>
+    public RangeByIndex SetReverse()
+    {
+        Reverse = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Converts the query to command arguments.
+    /// </summary>
+    /// <returns>An array of string arguments for the command.</returns>
+    public string[] ToArgs()
+    {
+        List<string> args = [
+            Start.ToString(CultureInfo.InvariantCulture),
+            Stop.ToString(CultureInfo.InvariantCulture)
+        ];
+
+        if (Reverse)
+        {
+            args.Add(ReverseKeyword);
+        }
+
+        return [.. args];
+    }
+}
+
+/// <summary>
+/// Represents a range query by score for the ZRANGE command.
+/// </summary>
+/// <param name="start">The start score boundary.</param>
+/// <param name="end">The end score boundary.</param>
+public class RangeByScore(ScoreBoundary start, ScoreBoundary end)
+{
+    /// <summary>
+    /// The start score boundary.
+    /// </summary>
+    public ScoreBoundary Start { get; } = start;
+
+    /// <summary>
+    /// The end score boundary.
+    /// </summary>
+    public ScoreBoundary End { get; } = end;
+
+    /// <summary>
+    /// Whether to reverse the order.
+    /// </summary>
+    public bool Reverse { get; private set; }
+
+    /// <summary>
+    /// The limit offset and count.
+    /// </summary>
+    public (long Offset, long Count)? Limit { get; private set; }
+
+    /// <summary>
+    /// Sets the query to return results in reverse order.
+    /// </summary>
+    /// <returns>This instance for method chaining.</returns>
+    public RangeByScore SetReverse()
+    {
+        Reverse = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a limit on the number of results returned.
+    /// </summary>
+    /// <param name="offset">The offset to start from.</param>
+    /// <param name="count">The maximum number of results to return.</param>
+    /// <returns>This instance for method chaining.</returns>
+    public RangeByScore SetLimit(long offset, long count)
+    {
+        Limit = (offset, count);
+        return this;
+    }
+
+    /// <summary>
+    /// Converts the query to command arguments.
+    /// </summary>
+    /// <returns>An array of string arguments for the command.</returns>
+    public string[] ToArgs()
+    {
+        List<string> args = [];
+
+        // When using REV with BYSCORE, the start should be the highest score and end should be the lowest score
+        // So we need to swap the order of arguments when Reverse is true
+        if (Reverse)
+        {
+            args.Add(End.ToString());
+            args.Add(Start.ToString());
+        }
+        else
+        {
+            args.Add(Start.ToString());
+            args.Add(End.ToString());
+        }
+
+        args.Add(ByScoreKeyword);
+
+        if (Reverse)
+        {
+            args.Add(ReverseKeyword);
+        }
+
+        if (Limit.HasValue)
+        {
+            args.Add(LimitKeyword);
+            args.Add(Limit.Value.Offset.ToString(CultureInfo.InvariantCulture));
+            args.Add(Limit.Value.Count.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return [.. args];
+    }
+}
+
+/// <summary>
+/// Represents a range query by lexicographical value for the ZRANGE command.
+/// </summary>
+/// <param name="start">The start lexicographical boundary.</param>
+/// <param name="end">The end lexicographical boundary.</param>
+public class RangeByLex(LexBoundary start, LexBoundary end)
+{
+    /// <summary>
+    /// The start lexicographical boundary.
+    /// </summary>
+    public LexBoundary Start { get; } = start;
+
+    /// <summary>
+    /// The end lexicographical boundary.
+    /// </summary>
+    public LexBoundary End { get; } = end;
+
+    /// <summary>
+    /// Whether to reverse the order.
+    /// </summary>
+    public bool Reverse { get; private set; }
+
+    /// <summary>
+    /// The limit offset and count.
+    /// </summary>
+    public (long Offset, long Count)? Limit { get; private set; }
+
+    /// <summary>
+    /// Sets the query to return results in reverse order.
+    /// </summary>
+    /// <returns>This instance for method chaining.</returns>
+    public RangeByLex SetReverse()
+    {
+        Reverse = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a limit on the number of results returned.
+    /// </summary>
+    /// <param name="offset">The offset to start from.</param>
+    /// <param name="count">The maximum number of results to return.</param>
+    /// <returns>This instance for method chaining.</returns>
+    public RangeByLex SetLimit(long offset, long count)
+    {
+        Limit = (offset, count);
+        return this;
+    }
+
+    /// <summary>
+    /// Converts the query to command arguments.
+    /// </summary>
+    /// <returns>An array of string arguments for the command.</returns>
+    public string[] ToArgs()
+    {
+        List<string> args = [];
+
+        // When using REV with BYLEX, the start should be the highest lex value and end should be the lowest lex value
+        // So we need to swap the order of arguments when Reverse is true
+        if (Reverse)
+        {
+            args.Add(End.ToString());
+            args.Add(Start.ToString());
+        }
+        else
+        {
+            args.Add(Start.ToString());
+            args.Add(End.ToString());
+        }
+
+        args.Add(ByLexKeyword);
+
+        if (Reverse)
+        {
+            args.Add(ReverseKeyword);
+        }
+
+        if (Limit.HasValue)
+        {
+            args.Add(LimitKeyword);
+            args.Add(Limit.Value.Offset.ToString(CultureInfo.InvariantCulture));
+            args.Add(Limit.Value.Count.ToString(CultureInfo.InvariantCulture));
+        }
+
+        return [.. args];
+    }
+}
+
+/// <summary>
+/// Represents a lexicographical boundary for sorted set range operations.
+/// </summary>
+public readonly struct LexBoundary
+{
+    private readonly string _value;
+
+    private LexBoundary(string value)
+    {
+        _value = value;
+    }
+
+    /// <summary>
+    /// Creates an inclusive lexicographical boundary.
+    /// </summary>
+    /// <param name="value">The lexicographical value.</param>
+    /// <returns>An inclusive lexicographical boundary.</returns>
+    public static LexBoundary Inclusive(ValkeyValue value)
+    {
+        return new LexBoundary("[" + value.ToString());
+    }
+
+    /// <summary>
+    /// Creates an exclusive lexicographical boundary.
+    /// </summary>
+    /// <param name="value">The lexicographical value.</param>
+    /// <returns>An exclusive lexicographical boundary.</returns>
+    public static LexBoundary Exclusive(ValkeyValue value)
+    {
+        return new LexBoundary("(" + value.ToString());
+    }
+
+    /// <summary>
+    /// Creates a negative infinity boundary.
+    /// </summary>
+    /// <returns>A negative infinity boundary.</returns>
+    public static LexBoundary NegativeInfinity() => new LexBoundary(Commands.Constants.Constants.NegativeInfinity);
+
+    /// <summary>
+    /// Creates a positive infinity boundary.
+    /// </summary>
+    /// <returns>A positive infinity boundary.</returns>
+    public static LexBoundary PositiveInfinity() => new LexBoundary(Commands.Constants.Constants.PositiveInfinity);
+
+    /// <summary>
+    /// Converts the lexicographical boundary to its string representation.
+    /// </summary>
+    /// <returns>The string representation of the lexicographical boundary.</returns>
+    public override string ToString() => _value;
+
+    /// <summary>
+    /// Implicit conversion to string.
+    /// </summary>
+    /// <param name="boundary">The lexicographical boundary.</param>
+    public static implicit operator string(LexBoundary boundary) => boundary._value;
+}

--- a/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
+++ b/csharp/sources/Valkey.Glide/Commands/Options/ZRangeOptions.cs
@@ -23,36 +23,20 @@ public readonly struct ScoreBoundary
     /// </summary>
     /// <param name="score">The score value.</param>
     /// <returns>An inclusive score boundary.</returns>
-    public static ScoreBoundary Inclusive(double score)
-    {
-        if (double.IsPositiveInfinity(score))
-        {
-            return new(PositiveInfinityScore);
-        }
-        if (double.IsNegativeInfinity(score))
-        {
-            return new(NegativeInfinityScore);
-        }
-        return new(score.ToString(CultureInfo.InvariantCulture));
-    }
+    public static ScoreBoundary Inclusive(double score) =>
+        double.IsPositiveInfinity(score) ? new(PositiveInfinityScore) :
+        double.IsNegativeInfinity(score) ? new(NegativeInfinityScore) :
+        new(score.ToString(CultureInfo.InvariantCulture));
 
     /// <summary>
     /// Creates an exclusive score boundary.
     /// </summary>
     /// <param name="score">The score value.</param>
     /// <returns>An exclusive score boundary.</returns>
-    public static ScoreBoundary Exclusive(double score)
-    {
-        if (double.IsPositiveInfinity(score))
-        {
-            return new(PositiveInfinityScore);
-        }
-        if (double.IsNegativeInfinity(score))
-        {
-            return new(NegativeInfinityScore);
-        }
-        return new("(" + score.ToString(CultureInfo.InvariantCulture));
-    }
+    public static ScoreBoundary Exclusive(double score) =>
+        double.IsPositiveInfinity(score) ? new(PositiveInfinityScore) :
+        double.IsNegativeInfinity(score) ? new(NegativeInfinityScore) :
+        new("(" + score.ToString(CultureInfo.InvariantCulture));
 
     /// <summary>
     /// Creates a positive infinity boundary.

--- a/csharp/sources/Valkey.Glide/Internals/Request.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Internals/Request.SortedSetCommands.cs
@@ -107,7 +107,7 @@ internal partial class Request
             ? ScoreBoundary.Exclusive(max)
             : ScoreBoundary.Inclusive(max);
 
-        ZCountRange range = new ZCountRange(minBoundary, maxBoundary);
+        ZCountRange range = new(minBoundary, maxBoundary);
         string[] rangeArgs = range.ToArgs();
 
         List<GlideString> args = [key.ToGlideString()];
@@ -120,10 +120,10 @@ internal partial class Request
     {
         Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
 
-        RangeByIndex query = new RangeByIndex(start, stop);
+        RangeByIndex query = new(start, stop);
         if (order == Order.Descending)
         {
-            query.SetReverse();
+            _ = query.SetReverse();
         }
 
         string[] queryArgs = query.ToArgs();
@@ -137,10 +137,10 @@ internal partial class Request
     {
         Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
 
-        RangeByIndex query = new RangeByIndex(start, stop);
+        RangeByIndex query = new(start, stop);
         if (order == Order.Descending)
         {
-            query.SetReverse();
+            _ = query.SetReverse();
         }
 
         string[] queryArgs = query.ToArgs();
@@ -179,15 +179,15 @@ internal partial class Request
             ? ScoreBoundary.Exclusive(stop)
             : ScoreBoundary.Inclusive(stop);
 
-        RangeByScore query = new RangeByScore(startBoundary, stopBoundary);
+        RangeByScore query = new(startBoundary, stopBoundary);
         if (order == Order.Descending)
         {
-            query.SetReverse();
+            _ = query.SetReverse();
         }
 
         if (take != -1)
         {
-            query.SetLimit(skip, take);
+            _ = query.SetLimit(skip, take);
         }
 
         string[] queryArgs = query.ToArgs();
@@ -210,15 +210,15 @@ internal partial class Request
             ? ScoreBoundary.Exclusive(stop)
             : ScoreBoundary.Inclusive(stop);
 
-        RangeByScore query = new RangeByScore(startBoundary, stopBoundary);
+        RangeByScore query = new(startBoundary, stopBoundary);
         if (order == Order.Descending)
         {
-            query.SetReverse();
+            _ = query.SetReverse();
         }
 
         if (take != -1)
         {
-            query.SetLimit(skip, take);
+            _ = query.SetLimit(skip, take);
         }
 
         string[] queryArgs = query.ToArgs();
@@ -257,11 +257,11 @@ internal partial class Request
             ? LexBoundary.Exclusive(max)
             : LexBoundary.Inclusive(max);
 
-        RangeByLex query = new RangeByLex(minBoundary, maxBoundary);
+        RangeByLex query = new(minBoundary, maxBoundary);
 
         if (take != -1)
         {
-            query.SetLimit(skip, take);
+            _ = query.SetLimit(skip, take);
         }
 
         string[] queryArgs = query.ToArgs();
@@ -281,49 +281,31 @@ internal partial class Request
 
         // Create lexicographical boundaries based on exclude flags
         // Handle double infinity values and default infinity symbols by converting them to lexicographical infinity symbols
-        LexBoundary minBoundary;
         string minStr = actualMin.ToString();
-        if (minStr == NegativeInfinityScore || minStr == NegativeInfinity)
+        LexBoundary minBoundary = minStr switch
         {
-            minBoundary = LexBoundary.NegativeInfinity();
-        }
-        else if (minStr == PositiveInfinityScore || minStr == PositiveInfinity)
-        {
-            minBoundary = LexBoundary.PositiveInfinity();
-        }
-        else
-        {
-            minBoundary = exclude.HasFlag(Exclude.Start)
-                ? LexBoundary.Exclusive(actualMin)
-                : LexBoundary.Inclusive(actualMin);
-        }
+            string s when s == NegativeInfinityScore || s == NegativeInfinity => LexBoundary.NegativeInfinity(),
+            string s when s == PositiveInfinityScore || s == PositiveInfinity => LexBoundary.PositiveInfinity(),
+            _ => exclude.HasFlag(Exclude.Start) ? LexBoundary.Exclusive(actualMin) : LexBoundary.Inclusive(actualMin)
+        };
 
-        LexBoundary maxBoundary;
         string maxStr = actualMax.ToString();
-        if (maxStr == NegativeInfinityScore || maxStr == NegativeInfinity)
+        LexBoundary maxBoundary = maxStr switch
         {
-            maxBoundary = LexBoundary.NegativeInfinity();
-        }
-        else if (maxStr == PositiveInfinityScore || maxStr == PositiveInfinity)
-        {
-            maxBoundary = LexBoundary.PositiveInfinity();
-        }
-        else
-        {
-            maxBoundary = exclude.HasFlag(Exclude.Stop)
-                ? LexBoundary.Exclusive(actualMax)
-                : LexBoundary.Inclusive(actualMax);
-        }
+            string s when s == NegativeInfinityScore || s == NegativeInfinity => LexBoundary.NegativeInfinity(),
+            string s when s == PositiveInfinityScore || s == PositiveInfinity => LexBoundary.PositiveInfinity(),
+            _ => exclude.HasFlag(Exclude.Stop) ? LexBoundary.Exclusive(actualMax) : LexBoundary.Inclusive(actualMax)
+        };
 
-        RangeByLex query = new RangeByLex(minBoundary, maxBoundary);
+        RangeByLex query = new(minBoundary, maxBoundary);
         if (order == Order.Descending)
         {
-            query.SetReverse();
+            _ = query.SetReverse();
         }
 
         if (take != -1)
         {
-            query.SetLimit(skip, take);
+            _ = query.SetLimit(skip, take);
         }
 
         string[] queryArgs = query.ToArgs();

--- a/csharp/sources/Valkey.Glide/Internals/Request.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Internals/Request.SortedSetCommands.cs
@@ -86,7 +86,7 @@ internal partial class Request
         return Simple<long>(RequestType.ZRem, [.. args]);
     }
 
-    public static Cmd<long, long> SortedSetLengthAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)
+    public static Cmd<long, long> SortedSetCardAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)
     {
         Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
 

--- a/csharp/sources/Valkey.Glide/Internals/Request.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Internals/Request.SortedSetCommands.cs
@@ -284,16 +284,16 @@ internal partial class Request
         string minStr = actualMin.ToString();
         LexBoundary minBoundary = minStr switch
         {
-            string s when s == NegativeInfinityScore || s == NegativeInfinity => LexBoundary.NegativeInfinity(),
-            string s when s == PositiveInfinityScore || s == PositiveInfinity => LexBoundary.PositiveInfinity(),
+            NegativeInfinityScore or NegativeInfinity => LexBoundary.NegativeInfinity(),
+            PositiveInfinityScore or PositiveInfinity => LexBoundary.PositiveInfinity(),
             _ => exclude.HasFlag(Exclude.Start) ? LexBoundary.Exclusive(actualMin) : LexBoundary.Inclusive(actualMin)
         };
 
         string maxStr = actualMax.ToString();
         LexBoundary maxBoundary = maxStr switch
         {
-            string s when s == NegativeInfinityScore || s == NegativeInfinity => LexBoundary.NegativeInfinity(),
-            string s when s == PositiveInfinityScore || s == PositiveInfinity => LexBoundary.PositiveInfinity(),
+            NegativeInfinityScore or NegativeInfinity => LexBoundary.NegativeInfinity(),
+            PositiveInfinityScore or PositiveInfinity => LexBoundary.PositiveInfinity(),
             _ => exclude.HasFlag(Exclude.Stop) ? LexBoundary.Exclusive(actualMax) : LexBoundary.Inclusive(actualMax)
         };
 

--- a/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
@@ -27,11 +27,11 @@ public abstract partial class BaseBatch<T>
         // If both min and max are infinity (default values), use ZCARD
         if (double.IsNegativeInfinity(min) && double.IsPositiveInfinity(max))
         {
-            return AddCmd(SortedSetCardAsync(key));
+            return SortedSetCard(key);
         }
         
         // Otherwise use ZCOUNT with the specified range
-        return AddCmd(SortedSetCountAsync(key, min, max, exclude));
+        return SortedSetCount(key, min, max, exclude);
     }
 
     /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetCard(ValkeyKey)" />

--- a/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
@@ -29,7 +29,7 @@ public abstract partial class BaseBatch<T>
         {
             return SortedSetCard(key);
         }
-        
+
         // Otherwise use ZCOUNT with the specified range
         return SortedSetCount(key, min, max, exclude);
     }

--- a/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
@@ -21,8 +21,21 @@ public abstract partial class BaseBatch<T>
     /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRemove(ValkeyKey, ValkeyValue[])" />
     public T SortedSetRemove(ValkeyKey key, ValkeyValue[] members) => AddCmd(SortedSetRemoveAsync(key, members));
 
-    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetLength(ValkeyKey)" />
-    public T SortedSetLength(ValkeyKey key) => AddCmd(SortedSetLengthAsync(key));
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetLength(ValkeyKey, double, double, Exclude)" />
+    public T SortedSetLength(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None)
+    {
+        // If both min and max are infinity (default values), use ZCARD
+        if (double.IsNegativeInfinity(min) && double.IsPositiveInfinity(max))
+        {
+            return AddCmd(SortedSetCardAsync(key));
+        }
+        
+        // Otherwise use ZCOUNT with the specified range
+        return AddCmd(SortedSetCountAsync(key, min, max, exclude));
+    }
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetCard(ValkeyKey)" />
+    public T SortedSetCard(ValkeyKey key) => AddCmd(SortedSetCardAsync(key));
 
     /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetCount(ValkeyKey, double, double, Exclude)" />
     public T SortedSetCount(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None) => AddCmd(SortedSetCountAsync(key, min, max, exclude));
@@ -50,7 +63,8 @@ public abstract partial class BaseBatch<T>
     IBatch IBatchSortedSetCommands.SortedSetAdd(ValkeyKey key, SortedSetEntry[] values, SortedSetWhen when) => SortedSetAdd(key, values, when);
     IBatch IBatchSortedSetCommands.SortedSetRemove(ValkeyKey key, ValkeyValue member) => SortedSetRemove(key, member);
     IBatch IBatchSortedSetCommands.SortedSetRemove(ValkeyKey key, ValkeyValue[] members) => SortedSetRemove(key, members);
-    IBatch IBatchSortedSetCommands.SortedSetLength(ValkeyKey key) => SortedSetLength(key);
+    IBatch IBatchSortedSetCommands.SortedSetLength(ValkeyKey key, double min, double max, Exclude exclude) => SortedSetLength(key, min, max, exclude);
+    IBatch IBatchSortedSetCommands.SortedSetCard(ValkeyKey key) => SortedSetCard(key);
     IBatch IBatchSortedSetCommands.SortedSetCount(ValkeyKey key, double min, double max, Exclude exclude) => SortedSetCount(key, min, max, exclude);
     IBatch IBatchSortedSetCommands.SortedSetRangeByRank(ValkeyKey key, long start, long stop, Order order) => SortedSetRangeByRank(key, start, stop, order);
     IBatch IBatchSortedSetCommands.SortedSetRangeByRankWithScores(ValkeyKey key, long start, long stop, Order order) => SortedSetRangeByRankWithScores(key, start, stop, order);

--- a/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Pipeline/BaseBatch.SortedSetCommands.cs
@@ -21,9 +21,41 @@ public abstract partial class BaseBatch<T>
     /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRemove(ValkeyKey, ValkeyValue[])" />
     public T SortedSetRemove(ValkeyKey key, ValkeyValue[] members) => AddCmd(SortedSetRemoveAsync(key, members));
 
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetLength(ValkeyKey)" />
+    public T SortedSetLength(ValkeyKey key) => AddCmd(SortedSetLengthAsync(key));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetCount(ValkeyKey, double, double, Exclude)" />
+    public T SortedSetCount(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None) => AddCmd(SortedSetCountAsync(key, min, max, exclude));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRangeByRank(ValkeyKey, long, long, Order)" />
+    public T SortedSetRangeByRank(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending) => AddCmd(SortedSetRangeByRankAsync(key, start, stop, order));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRangeByRankWithScores(ValkeyKey, long, long, Order)" />
+    public T SortedSetRangeByRankWithScores(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending) => AddCmd(SortedSetRangeByRankWithScoresAsync(key, start, stop, order));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRangeByScore(ValkeyKey, double, double, Exclude, Order, long, long)" />
+    public T SortedSetRangeByScore(ValkeyKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1) => AddCmd(SortedSetRangeByScoreAsync(key, start, stop, exclude, order, skip, take));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRangeByScoreWithScores(ValkeyKey, double, double, Exclude, Order, long, long)" />
+    public T SortedSetRangeByScoreWithScores(ValkeyKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1) => AddCmd(SortedSetRangeByScoreWithScoresAsync(key, start, stop, exclude, order, skip, take));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRangeByValue(ValkeyKey, ValkeyValue, ValkeyValue, Exclude, long, long)" />
+    public T SortedSetRangeByValue(ValkeyKey key, ValkeyValue min, ValkeyValue max, Exclude exclude = Exclude.None, long skip = 0, long take = -1) => AddCmd(SortedSetRangeByValueAsync(key, min, max, exclude, skip, take));
+
+    /// <inheritdoc cref="IBatchSortedSetCommands.SortedSetRangeByValue(ValkeyKey, ValkeyValue, ValkeyValue, Exclude, Order, long, long)" />
+    public T SortedSetRangeByValue(ValkeyKey key, ValkeyValue min = default, ValkeyValue max = default, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1) => AddCmd(SortedSetRangeByValueAsync(key, min, max, exclude, order, skip, take));
+
     // Explicit interface implementations for IBatchSortedSetCommands
     IBatch IBatchSortedSetCommands.SortedSetAdd(ValkeyKey key, ValkeyValue member, double score, SortedSetWhen when) => SortedSetAdd(key, member, score, when);
     IBatch IBatchSortedSetCommands.SortedSetAdd(ValkeyKey key, SortedSetEntry[] values, SortedSetWhen when) => SortedSetAdd(key, values, when);
     IBatch IBatchSortedSetCommands.SortedSetRemove(ValkeyKey key, ValkeyValue member) => SortedSetRemove(key, member);
     IBatch IBatchSortedSetCommands.SortedSetRemove(ValkeyKey key, ValkeyValue[] members) => SortedSetRemove(key, members);
+    IBatch IBatchSortedSetCommands.SortedSetLength(ValkeyKey key) => SortedSetLength(key);
+    IBatch IBatchSortedSetCommands.SortedSetCount(ValkeyKey key, double min, double max, Exclude exclude) => SortedSetCount(key, min, max, exclude);
+    IBatch IBatchSortedSetCommands.SortedSetRangeByRank(ValkeyKey key, long start, long stop, Order order) => SortedSetRangeByRank(key, start, stop, order);
+    IBatch IBatchSortedSetCommands.SortedSetRangeByRankWithScores(ValkeyKey key, long start, long stop, Order order) => SortedSetRangeByRankWithScores(key, start, stop, order);
+    IBatch IBatchSortedSetCommands.SortedSetRangeByScore(ValkeyKey key, double start, double stop, Exclude exclude, Order order, long skip, long take) => SortedSetRangeByScore(key, start, stop, exclude, order, skip, take);
+    IBatch IBatchSortedSetCommands.SortedSetRangeByScoreWithScores(ValkeyKey key, double start, double stop, Exclude exclude, Order order, long skip, long take) => SortedSetRangeByScoreWithScores(key, start, stop, exclude, order, skip, take);
+    IBatch IBatchSortedSetCommands.SortedSetRangeByValue(ValkeyKey key, ValkeyValue min, ValkeyValue max, Exclude exclude, long skip, long take) => SortedSetRangeByValue(key, min, max, exclude, skip, take);
+    IBatch IBatchSortedSetCommands.SortedSetRangeByValue(ValkeyKey key, ValkeyValue min, ValkeyValue max, Exclude exclude, Order order, long skip, long take) => SortedSetRangeByValue(key, min, max, exclude, order, skip, take);
 }

--- a/csharp/sources/Valkey.Glide/Pipeline/IBatchSortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Pipeline/IBatchSortedSetCommands.cs
@@ -25,9 +25,13 @@ internal interface IBatchSortedSetCommands
     /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRemoveAsync(ValkeyKey, ValkeyValue[], CommandFlags)" /></returns>
     IBatch SortedSetRemove(ValkeyKey key, ValkeyValue[] members);
 
-    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetLengthAsync(ValkeyKey, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
-    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetLengthAsync(ValkeyKey, CommandFlags)" /></returns>
-    IBatch SortedSetLength(ValkeyKey key);
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetLengthAsync(ValkeyKey, double, double, Exclude, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetLengthAsync(ValkeyKey, double, double, Exclude, CommandFlags)" /></returns>
+    IBatch SortedSetLength(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetCardAsync(ValkeyKey, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetCardAsync(ValkeyKey, CommandFlags)" /></returns>
+    IBatch SortedSetCard(ValkeyKey key);
 
     /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetCountAsync(ValkeyKey, double, double, Exclude, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
     /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetCountAsync(ValkeyKey, double, double, Exclude, CommandFlags)" /></returns>

--- a/csharp/sources/Valkey.Glide/Pipeline/IBatchSortedSetCommands.cs
+++ b/csharp/sources/Valkey.Glide/Pipeline/IBatchSortedSetCommands.cs
@@ -24,4 +24,36 @@ internal interface IBatchSortedSetCommands
     /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRemoveAsync(ValkeyKey, ValkeyValue[], CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
     /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRemoveAsync(ValkeyKey, ValkeyValue[], CommandFlags)" /></returns>
     IBatch SortedSetRemove(ValkeyKey key, ValkeyValue[] members);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetLengthAsync(ValkeyKey, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetLengthAsync(ValkeyKey, CommandFlags)" /></returns>
+    IBatch SortedSetLength(ValkeyKey key);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetCountAsync(ValkeyKey, double, double, Exclude, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetCountAsync(ValkeyKey, double, double, Exclude, CommandFlags)" /></returns>
+    IBatch SortedSetCount(ValkeyKey key, double min = double.NegativeInfinity, double max = double.PositiveInfinity, Exclude exclude = Exclude.None);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByRankAsync(ValkeyKey, long, long, Order, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByRankAsync(ValkeyKey, long, long, Order, CommandFlags)" /></returns>
+    IBatch SortedSetRangeByRank(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByRankWithScoresAsync(ValkeyKey, long, long, Order, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByRankWithScoresAsync(ValkeyKey, long, long, Order, CommandFlags)" /></returns>
+    IBatch SortedSetRangeByRankWithScores(ValkeyKey key, long start = 0, long stop = -1, Order order = Order.Ascending);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByScoreAsync(ValkeyKey, double, double, Exclude, Order, long, long, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByScoreAsync(ValkeyKey, double, double, Exclude, Order, long, long, CommandFlags)" /></returns>
+    IBatch SortedSetRangeByScore(ValkeyKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByScoreWithScoresAsync(ValkeyKey, double, double, Exclude, Order, long, long, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByScoreWithScoresAsync(ValkeyKey, double, double, Exclude, Order, long, long, CommandFlags)" /></returns>
+    IBatch SortedSetRangeByScoreWithScores(ValkeyKey key, double start = double.NegativeInfinity, double stop = double.PositiveInfinity, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByValueAsync(ValkeyKey, ValkeyValue, ValkeyValue, Exclude, long, long, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByValueAsync(ValkeyKey, ValkeyValue, ValkeyValue, Exclude, long, long, CommandFlags)" /></returns>
+    IBatch SortedSetRangeByValue(ValkeyKey key, ValkeyValue min, ValkeyValue max, Exclude exclude = Exclude.None, long skip = 0, long take = -1);
+
+    /// <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByValueAsync(ValkeyKey, ValkeyValue, ValkeyValue, Exclude, Order, long, long, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
+    /// <returns>Command Response - <inheritdoc cref="Commands.ISortedSetCommands.SortedSetRangeByValueAsync(ValkeyKey, ValkeyValue, ValkeyValue, Exclude, Order, long, long, CommandFlags)" /></returns>
+    IBatch SortedSetRangeByValue(ValkeyKey key, ValkeyValue min = default, ValkeyValue max = default, Exclude exclude = Exclude.None, Order order = Order.Ascending, long skip = 0, long take = -1);
 }

--- a/csharp/tests/Valkey.Glide.IntegrationTests/BatchTestUtils.cs
+++ b/csharp/tests/Valkey.Glide.IntegrationTests/BatchTestUtils.cs
@@ -397,6 +397,88 @@ internal class BatchTestUtils
         _ = batch.SortedSetRemove(key1, "nonexistent");
         testData.Add(new(false, "SortedSetRemove(key1, nonexistent)"));
 
+        // Add some test data for length, count, and range operations
+        _ = batch.SortedSetAdd(key1, "testMember1", 1.0);
+        testData.Add(new(true, "SortedSetAdd(key1, testMember1, 1.0)"));
+
+        _ = batch.SortedSetAdd(key1, "testMember2", 2.0);
+        testData.Add(new(true, "SortedSetAdd(key1, testMember2, 2.0)"));
+
+        _ = batch.SortedSetAdd(key1, "testMember3", 3.0);
+        testData.Add(new(true, "SortedSetAdd(key1, testMember3, 3.0)"));
+
+        // Test SortedSetLength
+        _ = batch.SortedSetLength(key1);
+        testData.Add(new(3L, "SortedSetLength(key1)"));
+
+        _ = batch.SortedSetLength(key2);
+        testData.Add(new(1L, "SortedSetLength(key2)"));
+
+        // Test SortedSetCount
+        _ = batch.SortedSetCount(key1);
+        testData.Add(new(3L, "SortedSetCount(key1) - all elements"));
+
+        _ = batch.SortedSetCount(key1, 1.5, 2.5);
+        testData.Add(new(1L, "SortedSetCount(key1, 1.5, 2.5)"));
+
+        _ = batch.SortedSetCount(key1, 1.0, 3.0, Exclude.Start);
+        testData.Add(new(2L, "SortedSetCount(key1, 1.0, 3.0, Exclude.Start)"));
+
+        // Test SortedSetRangeByRank
+        _ = batch.SortedSetRangeByRank(key1);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByRank(key1) - all elements", true));
+
+        _ = batch.SortedSetRangeByRank(key1, 0, 1);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByRank(key1, 0, 1)", true));
+
+        _ = batch.SortedSetRangeByRank(key1, 0, 1, Order.Descending);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByRank(key1, 0, 1, Descending)", true));
+
+        // Test SortedSetRangeByRankWithScores
+        _ = batch.SortedSetRangeByRankWithScores(key1);
+        testData.Add(new(Array.Empty<SortedSetEntry>(), "SortedSetRangeByRankWithScores(key1) - all elements", true));
+
+        _ = batch.SortedSetRangeByRankWithScores(key1, 0, 1);
+        testData.Add(new(Array.Empty<SortedSetEntry>(), "SortedSetRangeByRankWithScores(key1, 0, 1)", true));
+
+        // Test SortedSetRangeByScore
+        _ = batch.SortedSetRangeByScore(key1, 1.0, 3.0);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByScore(key1, 1.0, 3.0)", true));
+
+        _ = batch.SortedSetRangeByScore(key1, 1.0, 3.0, Exclude.None, Order.Descending);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByScore(key1, 1.0, 3.0, Descending)", true));
+
+        // Test SortedSetRangeByScoreWithScores
+        _ = batch.SortedSetRangeByScoreWithScores(key1, 1.0, 3.0);
+        testData.Add(new(Array.Empty<SortedSetEntry>(), "SortedSetRangeByScoreWithScores(key1, 1.0, 3.0)", true));
+
+        _ = batch.SortedSetRangeByScoreWithScores(key1, 1.0, 3.0, skip: 1, take: 1);
+        testData.Add(new(Array.Empty<SortedSetEntry>(), "SortedSetRangeByScoreWithScores(key1, 1.0, 3.0, skip: 1, take: 1)", true));
+
+        // Add members with same score for lexicographical ordering tests
+        _ = batch.SortedSetAdd(key2, "apple", 0.0);
+        testData.Add(new(false, "SortedSetAdd(key2, apple, 0.0)"));
+
+        _ = batch.SortedSetAdd(key2, "banana", 0.0);
+        testData.Add(new(true, "SortedSetAdd(key2, banana, 0.0)"));
+
+        _ = batch.SortedSetAdd(key2, "cherry", 0.0);
+        testData.Add(new(true, "SortedSetAdd(key2, cherry, 0.0)"));
+
+        // Test SortedSetRangeByValue
+        _ = batch.SortedSetRangeByValue(key2, "a", "c", Exclude.None, 0, -1);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByValue(key2, 'a', 'c', Exclude.None, 0, -1)", true));
+
+        _ = batch.SortedSetRangeByValue(key2, "b", "d", Exclude.None, skip: 1, take: 1);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByValue(key2, 'b', 'd', Exclude.None, skip: 1, take: 1)", true));
+
+        // Test SortedSetRangeByValue
+        _ = batch.SortedSetRangeByValue(key2, order: Order.Descending);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByValue(key2, order: Descending)", true));
+
+        _ = batch.SortedSetRangeByValue(key2, "a", "c", order: Order.Ascending);
+        testData.Add(new(Array.Empty<ValkeyValue>(), "SortedSetRangeByValue(key2, 'a', 'c', order: Ascending)", true));
+
         return testData;
     }
 

--- a/csharp/tests/Valkey.Glide.IntegrationTests/BatchTestUtils.cs
+++ b/csharp/tests/Valkey.Glide.IntegrationTests/BatchTestUtils.cs
@@ -407,12 +407,23 @@ internal class BatchTestUtils
         _ = batch.SortedSetAdd(key1, "testMember3", 3.0);
         testData.Add(new(true, "SortedSetAdd(key1, testMember3, 3.0)"));
 
-        // Test SortedSetLength
+        // Test SortedSetLength (uses ZCARD)
         _ = batch.SortedSetLength(key1);
         testData.Add(new(3L, "SortedSetLength(key1)"));
 
         _ = batch.SortedSetLength(key2);
         testData.Add(new(1L, "SortedSetLength(key2)"));
+
+        // Test SortedSetLength with range (uses ZCOUNT)
+        _ = batch.SortedSetLength(key1, 1.5, 2.5);
+        testData.Add(new(1L, "SortedSetLength(key1, 1.5, 2.5)"));
+
+        // Test SortedSetCard (ZCARD)
+        _ = batch.SortedSetCard(key1);
+        testData.Add(new(3L, "SortedSetCard(key1)"));
+
+        _ = batch.SortedSetCard(key2);
+        testData.Add(new(1L, "SortedSetCard(key2)"));
 
         // Test SortedSetCount
         _ = batch.SortedSetCount(key1);

--- a/csharp/tests/Valkey.Glide.IntegrationTests/SortedSetCommandTests.cs
+++ b/csharp/tests/Valkey.Glide.IntegrationTests/SortedSetCommandTests.cs
@@ -308,4 +308,333 @@ public class SortedSetCommandTests(TestConfiguration config)
         Assert.True(await client.SortedSetRemoveAsync(key, "-1"));
         Assert.True(await client.SortedSetRemoveAsync(key, "true"));
     }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetLengthAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        Assert.Equal(0, await client.SortedSetLengthAsync(key));
+
+        // Add members and test length
+        Assert.True(await client.SortedSetAddAsync(key, "member1", 1.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member2", 2.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member3", 3.0));
+
+        Assert.Equal(3, await client.SortedSetLengthAsync(key));
+
+        // Remove a member and test length
+        Assert.True(await client.SortedSetRemoveAsync(key, "member2"));
+        Assert.Equal(2, await client.SortedSetLengthAsync(key));
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetCountAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        Assert.Equal(0, await client.SortedSetCountAsync(key));
+
+        // Add members with different scores
+        Assert.True(await client.SortedSetAddAsync(key, "member1", 1.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member2", 2.5));
+        Assert.True(await client.SortedSetAddAsync(key, "member3", 5.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member4", 10.0));
+
+        // Test count with default range (all elements)
+        Assert.Equal(4, await client.SortedSetCountAsync(key));
+
+        // Test count with specific range
+        Assert.Equal(2, await client.SortedSetCountAsync(key, 2.0, 6.0));
+
+        // Test count with exclusive bounds
+        Assert.Equal(1, await client.SortedSetCountAsync(key, 2.5, 5.0, Exclude.Start));  // Exclude member2 (2.5), include member3 (5.0)
+        Assert.Equal(1, await client.SortedSetCountAsync(key, 2.5, 5.0, Exclude.Stop));   // Include member2 (2.5), exclude member3 (5.0)
+        Assert.Equal(0, await client.SortedSetCountAsync(key, 2.5, 5.0, Exclude.Both));   // Exclude both member2 and member3
+
+        // Test count with infinity bounds
+        Assert.Equal(4, await client.SortedSetCountAsync(key, double.NegativeInfinity, double.PositiveInfinity));
+
+        // Test count with no matches
+        Assert.Equal(0, await client.SortedSetCountAsync(key, 15.0, 20.0));
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetRangeByRankAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        ValkeyValue[] result = await client.SortedSetRangeByRankAsync(key);
+        Assert.Empty(result);
+
+        // Add members with scores
+        Assert.True(await client.SortedSetAddAsync(key, "member1", 1.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member2", 2.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member3", 3.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member4", 4.0));
+
+        // Test default range (all elements, ascending)
+        result = await client.SortedSetRangeByRankAsync(key);
+        Assert.Equal(4, result.Length);
+        Assert.Equal("member1", result[0]);
+        Assert.Equal("member2", result[1]);
+        Assert.Equal("member3", result[2]);
+        Assert.Equal("member4", result[3]);
+
+        // Test specific range
+        result = await client.SortedSetRangeByRankAsync(key, 1, 2);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member2", result[0]);
+        Assert.Equal("member3", result[1]);
+
+        // Test descending order
+        result = await client.SortedSetRangeByRankAsync(key, 0, 1, Order.Descending);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member4", result[0]);
+        Assert.Equal("member3", result[1]);
+
+        // Test negative indices
+        result = await client.SortedSetRangeByRankAsync(key, -2, -1);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member3", result[0]);
+        Assert.Equal("member4", result[1]);
+
+        // Test single element range
+        result = await client.SortedSetRangeByRankAsync(key, 0, 0);
+        Assert.Single(result);
+        Assert.Equal("member1", result[0]);
+
+        // Test out of range
+        result = await client.SortedSetRangeByRankAsync(key, 10, 20);
+        Assert.Empty(result);
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetRangeByRankWithScoresAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        SortedSetEntry[] result = await client.SortedSetRangeByRankWithScoresAsync(key);
+        Assert.Empty(result);
+
+        // Add members with scores
+        Assert.True(await client.SortedSetAddAsync(key, "member1", 1.5));
+        Assert.True(await client.SortedSetAddAsync(key, "member2", 2.5));
+        Assert.True(await client.SortedSetAddAsync(key, "member3", 3.5));
+
+        // Test default range (all elements, ascending)
+        result = await client.SortedSetRangeByRankWithScoresAsync(key);
+        Assert.Equal(3, result.Length);
+        Assert.Equal("member1", result[0].Element);
+        Assert.Equal(1.5, result[0].Score);
+        Assert.Equal("member2", result[1].Element);
+        Assert.Equal(2.5, result[1].Score);
+        Assert.Equal("member3", result[2].Element);
+        Assert.Equal(3.5, result[2].Score);
+
+        // Test specific range
+        result = await client.SortedSetRangeByRankWithScoresAsync(key, 0, 1);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member1", result[0].Element);
+        Assert.Equal(1.5, result[0].Score);
+        Assert.Equal("member2", result[1].Element);
+        Assert.Equal(2.5, result[1].Score);
+
+        // Test descending order
+        result = await client.SortedSetRangeByRankWithScoresAsync(key, 0, 1, Order.Descending);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member3", result[0].Element);
+        Assert.Equal(3.5, result[0].Score);
+        Assert.Equal("member2", result[1].Element);
+        Assert.Equal(2.5, result[1].Score);
+
+        // Test single element
+        result = await client.SortedSetRangeByRankWithScoresAsync(key, 1, 1);
+        Assert.Single(result);
+        Assert.Equal("member2", result[0].Element);
+        Assert.Equal(2.5, result[0].Score);
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetRangeByRank_SpecialScores(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Add members with special scores
+        Assert.True(await client.SortedSetAddAsync(key, "neginf", double.NegativeInfinity));
+        Assert.True(await client.SortedSetAddAsync(key, "zero", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "posinf", double.PositiveInfinity));
+
+        // Test range with special scores
+        ValkeyValue[] result = await client.SortedSetRangeByRankAsync(key);
+        Assert.Equal(3, result.Length);
+        Assert.Equal("neginf", result[0]);
+        Assert.Equal("zero", result[1]);
+        Assert.Equal("posinf", result[2]);
+
+        // Test with scores
+        SortedSetEntry[] resultWithScores = await client.SortedSetRangeByRankWithScoresAsync(key);
+        Assert.Equal(3, resultWithScores.Length);
+        Assert.Equal("neginf", resultWithScores[0].Element);
+        Assert.True(double.IsNegativeInfinity(resultWithScores[0].Score));
+        Assert.Equal("zero", resultWithScores[1].Element);
+        Assert.Equal(0.0, resultWithScores[1].Score);
+        Assert.Equal("posinf", resultWithScores[2].Element);
+        Assert.True(double.IsPositiveInfinity(resultWithScores[2].Score));
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetRangeByScoreWithScoresAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        SortedSetEntry[] result = await client.SortedSetRangeByScoreWithScoresAsync(key);
+        Assert.Empty(result);
+
+        // Add members with scores
+        Assert.True(await client.SortedSetAddAsync(key, "member1", 1.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member2", 2.5));
+        Assert.True(await client.SortedSetAddAsync(key, "member3", 5.0));
+        Assert.True(await client.SortedSetAddAsync(key, "member4", 10.0));
+
+        // Test default range (all elements, ascending)
+        result = await client.SortedSetRangeByScoreWithScoresAsync(key);
+        Assert.Equal(4, result.Length);
+        Assert.Equal("member1", result[0].Element);
+        Assert.Equal(1.0, result[0].Score);
+        Assert.Equal("member2", result[1].Element);
+        Assert.Equal(2.5, result[1].Score);
+        Assert.Equal("member3", result[2].Element);
+        Assert.Equal(5.0, result[2].Score);
+        Assert.Equal("member4", result[3].Element);
+        Assert.Equal(10.0, result[3].Score);
+
+        // Test specific score range
+        result = await client.SortedSetRangeByScoreWithScoresAsync(key, 2.0, 6.0);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member2", result[0].Element);
+        Assert.Equal(2.5, result[0].Score);
+        Assert.Equal("member3", result[1].Element);
+        Assert.Equal(5.0, result[1].Score);
+
+        // Test descending order
+        result = await client.SortedSetRangeByScoreWithScoresAsync(key, 2.0, 6.0, order: Order.Descending);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member3", result[0].Element);
+        Assert.Equal(5.0, result[0].Score);
+        Assert.Equal("member2", result[1].Element);
+        Assert.Equal(2.5, result[1].Score);
+
+        // Test with exclusions
+        result = await client.SortedSetRangeByScoreWithScoresAsync(key, 2.5, 5.0, Exclude.Start);
+        Assert.Single(result);
+        Assert.Equal("member3", result[0].Element);
+        Assert.Equal(5.0, result[0].Score);
+
+        // Test with limit
+        result = await client.SortedSetRangeByScoreWithScoresAsync(key, double.NegativeInfinity, double.PositiveInfinity, skip: 1, take: 2);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("member2", result[0].Element);
+        Assert.Equal(2.5, result[0].Score);
+        Assert.Equal("member3", result[1].Element);
+        Assert.Equal(5.0, result[1].Score);
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetRangeByValueAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        ValkeyValue[] result = await client.SortedSetRangeByValueAsync(key, "a", "z", Exclude.None, Order.Ascending, 0, -1);
+        Assert.Empty(result);
+
+        // Add members with same score for lexicographical ordering
+        Assert.True(await client.SortedSetAddAsync(key, "apple", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "banana", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "cherry", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "date", 0.0));
+
+        // Test specific range
+        result = await client.SortedSetRangeByValueAsync(key, "b", "d", Exclude.None, Order.Ascending, 0, -1);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("banana", result[0]);
+        Assert.Equal("cherry", result[1]);
+
+        // Test with exclusions
+        result = await client.SortedSetRangeByValueAsync(key, "banana", "cherry", Exclude.Start, Order.Ascending, 0, -1);
+        Assert.Single(result);
+        Assert.Equal("cherry", result[0]);
+
+        // Test with limit
+        result = await client.SortedSetRangeByValueAsync(key, "a", "z", Exclude.None, Order.Ascending, 1, 2);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("banana", result[0]);
+        Assert.Equal("cherry", result[1]);
+
+        // Test full range
+        result = await client.SortedSetRangeByValueAsync(key, double.NegativeInfinity, double.PositiveInfinity, Exclude.None, Order.Ascending, 0, -1);
+        Assert.Equal(4, result.Length);
+        Assert.Equal("apple", result[0]);
+        Assert.Equal("banana", result[1]);
+        Assert.Equal("cherry", result[2]);
+        Assert.Equal("date", result[3]);
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestSortedSetRangeByValueWithOrderAsync(BaseClient client)
+    {
+        string key = Guid.NewGuid().ToString();
+
+        // Test on non-existent key
+        ValkeyValue[] result = await client.SortedSetRangeByValueAsync(key, order: Order.Descending);
+        Assert.Empty(result);
+
+        // Add members with same score for lexicographical ordering
+        Assert.True(await client.SortedSetAddAsync(key, "apple", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "banana", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "cherry", 0.0));
+        Assert.True(await client.SortedSetAddAsync(key, "date", 0.0));
+
+        // Test ascending order (default)
+        result = await client.SortedSetRangeByValueAsync(key, order: Order.Ascending);
+        Assert.Equal(4, result.Length);
+        Assert.Equal("apple", result[0]);
+        Assert.Equal("banana", result[1]);
+        Assert.Equal("cherry", result[2]);
+        Assert.Equal("date", result[3]);
+
+        // Test descending order
+        result = await client.SortedSetRangeByValueAsync(key, order: Order.Descending);
+        Assert.Equal(4, result.Length);
+        Assert.Equal("date", result[0]);
+        Assert.Equal("cherry", result[1]);
+        Assert.Equal("banana", result[2]);
+        Assert.Equal("apple", result[3]);
+
+        // Test specific range with descending order
+        result = await client.SortedSetRangeByValueAsync(key, "b", "d", order: Order.Descending);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("cherry", result[0]);
+        Assert.Equal("banana", result[1]);
+
+        // Test with limit and descending order
+        result = await client.SortedSetRangeByValueAsync(key, order: Order.Descending, skip: 1, take: 2);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("cherry", result[0]);
+        Assert.Equal("banana", result[1]);
+    }
 }

--- a/csharp/tests/Valkey.Glide.UnitTests/BoundaryTests.cs
+++ b/csharp/tests/Valkey.Glide.UnitTests/BoundaryTests.cs
@@ -1,0 +1,96 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+using Valkey.Glide.Commands.Options;
+
+using Xunit;
+
+namespace Valkey.Glide.UnitTests;
+
+public class BoundaryTests
+{
+    [Fact]
+    public void LexBoundary_Inclusive_CreatesCorrectBoundary()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("[abc", LexBoundary.Inclusive("abc").ToString()),
+            () => Assert.Equal("[123", LexBoundary.Inclusive("123").ToString()),
+            () => Assert.Equal("[", LexBoundary.Inclusive("").ToString()),
+            () => Assert.Equal("[", LexBoundary.Inclusive(ValkeyValue.Null).ToString())
+        );
+    }
+
+    [Fact]
+    public void LexBoundary_Exclusive_CreatesCorrectBoundary()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("(abc", LexBoundary.Exclusive("abc").ToString()),
+            () => Assert.Equal("(123", LexBoundary.Exclusive("123").ToString()),
+            () => Assert.Equal("(", LexBoundary.Exclusive("").ToString()),
+            () => Assert.Equal("(", LexBoundary.Exclusive(ValkeyValue.Null).ToString())
+        );
+    }
+
+    [Fact]
+    public void LexBoundary_Infinity_CreatesCorrectBoundaries()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("-", LexBoundary.NegativeInfinity().ToString()),
+            () => Assert.Equal("+", LexBoundary.PositiveInfinity().ToString())
+        );
+    }
+
+    [Fact]
+    public void LexBoundary_ImplicitStringConversion_Works()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("[test", (string)LexBoundary.Inclusive("test")),
+            () => Assert.Equal("(test", (string)LexBoundary.Exclusive("test")),
+            () => Assert.Equal("-", (string)LexBoundary.NegativeInfinity()),
+            () => Assert.Equal("+", (string)LexBoundary.PositiveInfinity())
+        );
+    }
+
+    [Fact]
+    public void ScoreBoundary_Inclusive_CreatesCorrectBoundary()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("10.5", ScoreBoundary.Inclusive(10.5).ToString()),
+            () => Assert.Equal("0", ScoreBoundary.Inclusive(0).ToString()),
+            () => Assert.Equal("-5.25", ScoreBoundary.Inclusive(-5.25).ToString()),
+            () => Assert.Equal("+inf", ScoreBoundary.Inclusive(double.PositiveInfinity).ToString()),
+            () => Assert.Equal("-inf", ScoreBoundary.Inclusive(double.NegativeInfinity).ToString())
+        );
+    }
+
+    [Fact]
+    public void ScoreBoundary_Exclusive_CreatesCorrectBoundary()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("(10.5", ScoreBoundary.Exclusive(10.5).ToString()),
+            () => Assert.Equal("(0", ScoreBoundary.Exclusive(0).ToString()),
+            () => Assert.Equal("(-5.25", ScoreBoundary.Exclusive(-5.25).ToString()),
+            () => Assert.Equal("+inf", ScoreBoundary.Exclusive(double.PositiveInfinity).ToString()),
+            () => Assert.Equal("-inf", ScoreBoundary.Exclusive(double.NegativeInfinity).ToString())
+        );
+    }
+
+    [Fact]
+    public void ScoreBoundary_Infinity_CreatesCorrectBoundaries()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("-inf", ScoreBoundary.NegativeInfinity().ToString()),
+            () => Assert.Equal("+inf", ScoreBoundary.PositiveInfinity().ToString())
+        );
+    }
+
+    [Fact]
+    public void ScoreBoundary_ImplicitStringConversion_Works()
+    {
+        Assert.Multiple(
+            () => Assert.Equal("10.5", (string)ScoreBoundary.Inclusive(10.5)),
+            () => Assert.Equal("(10.5", (string)ScoreBoundary.Exclusive(10.5)),
+            () => Assert.Equal("-inf", (string)ScoreBoundary.NegativeInfinity()),
+            () => Assert.Equal("+inf", (string)ScoreBoundary.PositiveInfinity())
+        );
+    }
+}

--- a/csharp/tests/Valkey.Glide.UnitTests/CommandTests.cs
+++ b/csharp/tests/Valkey.Glide.UnitTests/CommandTests.cs
@@ -238,7 +238,7 @@ public class CommandTests
             () => Assert.True(Request.SortedSetRemoveAsync("key", "member").Converter(1L)),
             () => Assert.False(Request.SortedSetRemoveAsync("key", "member").Converter(0L)),
             () => Assert.Equal(2L, Request.SortedSetRemoveAsync("key", ["member1", "member2"]).Converter(2L)),
-            () => Assert.Equal(5L, Request.SortedSetLengthAsync("key").Converter(5L)),
+            () => Assert.Equal(5L, Request.SortedSetCardAsync("key").Converter(5L)),
             () => Assert.Equal(3L, Request.SortedSetCountAsync("key", 1.0, 10.0).Converter(3L)),
             () => Assert.Equal(0L, Request.SortedSetCountAsync("key").Converter(0L))
         );

--- a/csharp/tests/Valkey.Glide.UnitTests/SortedSetCommandTests.cs
+++ b/csharp/tests/Valkey.Glide.UnitTests/SortedSetCommandTests.cs
@@ -1,5 +1,6 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+using Valkey.Glide.Commands.Options;
 using Valkey.Glide.Internals;
 
 using Xunit;
@@ -56,7 +57,10 @@ public class SortedSetCommandTests
             () => Assert.Equal("-inf", double.NegativeInfinity.ToGlideString().ToString()),
             () => Assert.Equal("nan", double.NaN.ToGlideString().ToString()),
             () => Assert.Equal("0", 0.0.ToGlideString().ToString()),
-            () => Assert.Equal("10.5", 10.5.ToGlideString().ToString())
+            () => Assert.Equal("10.5", 10.5.ToGlideString().ToString()),
+
+            () => Assert.Equal(["ZRANGE", "key", "-", "+", "BYLEX"], Request.SortedSetRangeByValueAsync("key", double.NegativeInfinity, double.PositiveInfinity, Exclude.None, Order.Ascending, 0, -1).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "6", "2", "BYSCORE", "REV", "WITHSCORES"], Request.SortedSetRangeByScoreWithScoresAsync("key", 2.0, 6.0, order: Order.Descending).GetArgs())
         );
     }
 
@@ -71,6 +75,194 @@ public class SortedSetCommandTests
             // SortedSetRemove exceptions
             () => Assert.Throws<NotImplementedException>(() => Request.SortedSetRemoveAsync("key", "member", CommandFlags.DemandReplica)),
             () => Assert.Throws<NotImplementedException>(() => Request.SortedSetRemoveAsync("key", ["member1", "member2"], CommandFlags.DemandReplica))
+        );
+    }
+
+    [Fact]
+    public void RangeByLex_ToArgs_GeneratesCorrectArguments()
+    {
+        Assert.Multiple(
+            // Basic range
+            () => Assert.Equal(["[a", "[z", "BYLEX"], new RangeByLex(LexBoundary.Inclusive("a"), LexBoundary.Inclusive("z")).ToArgs()),
+
+            // Exclusive boundaries
+            () => Assert.Equal(["(a", "(z", "BYLEX"], new RangeByLex(LexBoundary.Exclusive("a"), LexBoundary.Exclusive("z")).ToArgs()),
+
+            // Mixed boundaries
+            () => Assert.Equal(["[a", "(z", "BYLEX"], new RangeByLex(LexBoundary.Inclusive("a"), LexBoundary.Exclusive("z")).ToArgs()),
+
+            // Infinity boundaries
+            () => Assert.Equal(["-", "+", "BYLEX"], new RangeByLex(LexBoundary.NegativeInfinity(), LexBoundary.PositiveInfinity()).ToArgs()),
+
+            // With reverse
+            () => Assert.Equal(["[z", "[a", "BYLEX", "REV"], new RangeByLex(LexBoundary.Inclusive("a"), LexBoundary.Inclusive("z")).SetReverse().ToArgs()),
+
+            // With limit
+            () => Assert.Equal(["[a", "[z", "BYLEX", "LIMIT", "10", "20"], new RangeByLex(LexBoundary.Inclusive("a"), LexBoundary.Inclusive("z")).SetLimit(10, 20).ToArgs()),
+
+            // With reverse and limit
+            () => Assert.Equal(["[z", "[a", "BYLEX", "REV", "LIMIT", "5", "15"], new RangeByLex(LexBoundary.Inclusive("a"), LexBoundary.Inclusive("z")).SetReverse().SetLimit(5, 15).ToArgs())
+        );
+    }
+
+    [Fact]
+    public void RangeByScore_ToArgs_GeneratesCorrectArguments()
+    {
+        Assert.Multiple(
+            // Basic range
+            () => Assert.Equal(["10", "20", "BYSCORE"], new RangeByScore(ScoreBoundary.Inclusive(10), ScoreBoundary.Inclusive(20)).ToArgs()),
+
+            // Exclusive boundaries
+            () => Assert.Equal(["(10", "(20", "BYSCORE"], new RangeByScore(ScoreBoundary.Exclusive(10), ScoreBoundary.Exclusive(20)).ToArgs()),
+
+            // Mixed boundaries
+            () => Assert.Equal(["10", "(20", "BYSCORE"], new RangeByScore(ScoreBoundary.Inclusive(10), ScoreBoundary.Exclusive(20)).ToArgs()),
+
+            // Infinity boundaries
+            () => Assert.Equal(["-inf", "+inf", "BYSCORE"], new RangeByScore(ScoreBoundary.NegativeInfinity(), ScoreBoundary.PositiveInfinity()).ToArgs()),
+
+            // With reverse
+            () => Assert.Equal(["20", "10", "BYSCORE", "REV"], new RangeByScore(ScoreBoundary.Inclusive(10), ScoreBoundary.Inclusive(20)).SetReverse().ToArgs()),
+
+            // With limit
+            () => Assert.Equal(["10", "20", "BYSCORE", "LIMIT", "10", "20"], new RangeByScore(ScoreBoundary.Inclusive(10), ScoreBoundary.Inclusive(20)).SetLimit(10, 20).ToArgs()),
+
+            // With reverse and limit
+            () => Assert.Equal(["20", "10", "BYSCORE", "REV", "LIMIT", "5", "15"], new RangeByScore(ScoreBoundary.Inclusive(10), ScoreBoundary.Inclusive(20)).SetReverse().SetLimit(5, 15).ToArgs())
+        );
+    }
+
+    [Fact]
+    public void SortedSetLengthAsync_ValidatesArguments()
+    {
+        Assert.Multiple(
+            // Basic ZCARD command
+            () => Assert.Equal(["ZCARD", "key"], Request.SortedSetLengthAsync("key").GetArgs()),
+            () => Assert.Equal(["ZCARD", "mykey"], Request.SortedSetLengthAsync("mykey").GetArgs()),
+            () => Assert.Equal(["ZCARD", "test:sorted:set"], Request.SortedSetLengthAsync("test:sorted:set").GetArgs()),
+
+            // Empty key should work
+            () => Assert.Equal(["ZCARD", ""], Request.SortedSetLengthAsync("").GetArgs())
+        );
+    }
+
+    [Fact]
+    public void SortedSetCountAsync_ValidatesArguments()
+    {
+        Assert.Multiple(
+            // Default parameters (negative infinity to positive infinity)
+            () => Assert.Equal(["ZCOUNT", "key", "-inf", "+inf"], Request.SortedSetCountAsync("key").GetArgs()),
+
+            // Specific score ranges
+            () => Assert.Equal(["ZCOUNT", "key", "1", "10"], Request.SortedSetCountAsync("key", 1.0, 10.0).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "0", "100"], Request.SortedSetCountAsync("key", 0.0, 100.0).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "-5", "5"], Request.SortedSetCountAsync("key", -5.0, 5.0).GetArgs()),
+
+            // Decimal scores
+            () => Assert.Equal(["ZCOUNT", "key", "1.5", "9.75"], Request.SortedSetCountAsync("key", 1.5, 9.75).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "0.1", "0.9"], Request.SortedSetCountAsync("key", 0.1, 0.9).GetArgs()),
+
+            // Infinity values
+            () => Assert.Equal(["ZCOUNT", "key", "-inf", "10"], Request.SortedSetCountAsync("key", double.NegativeInfinity, 10.0).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "0", "+inf"], Request.SortedSetCountAsync("key", 0.0, double.PositiveInfinity).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "-inf", "+inf"], Request.SortedSetCountAsync("key", double.NegativeInfinity, double.PositiveInfinity).GetArgs()),
+
+            // Exclude options
+            () => Assert.Equal(["ZCOUNT", "key", "1", "10"], Request.SortedSetCountAsync("key", 1.0, 10.0, Exclude.None).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "(1", "10"], Request.SortedSetCountAsync("key", 1.0, 10.0, Exclude.Start).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "1", "(10"], Request.SortedSetCountAsync("key", 1.0, 10.0, Exclude.Stop).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "(1", "(10"], Request.SortedSetCountAsync("key", 1.0, 10.0, Exclude.Both).GetArgs()),
+
+            // Edge cases
+            () => Assert.Equal(["ZCOUNT", "key", "0", "0"], Request.SortedSetCountAsync("key", 0.0, 0.0).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "key", "(0", "(0"], Request.SortedSetCountAsync("key", 0.0, 0.0, Exclude.Both).GetArgs()),
+
+            // Different key names
+            () => Assert.Equal(["ZCOUNT", "mykey", "1", "10"], Request.SortedSetCountAsync("mykey", 1.0, 10.0).GetArgs()),
+            () => Assert.Equal(["ZCOUNT", "test:sorted:set", "1", "10"], Request.SortedSetCountAsync("test:sorted:set", 1.0, 10.0).GetArgs())
+        );
+    }
+
+    [Fact]
+    public void SortedSetRangeByRank_ValidatesArguments()
+    {
+        Assert.Multiple(
+            // Basic functionality
+            () => Assert.Equal(["ZRANGE", "key", "0", "-1"], Request.SortedSetRangeByRankAsync("key").GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "5"], Request.SortedSetRangeByRankAsync("key", 1, 5).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "-5", "-1"], Request.SortedSetRangeByRankAsync("key", -5, -1).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "0", "-1", "REV"], Request.SortedSetRangeByRankAsync("key", 0, -1, Order.Descending).GetArgs()),
+
+            // With scores
+            () => Assert.Equal(["ZRANGE", "key", "0", "-1", "WITHSCORES"], Request.SortedSetRangeByRankWithScoresAsync("key").GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "5", "WITHSCORES"], Request.SortedSetRangeByRankWithScoresAsync("key", 1, 5).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "0", "-1", "REV", "WITHSCORES"], Request.SortedSetRangeByRankWithScoresAsync("key", 0, -1, Order.Descending).GetArgs()),
+
+            // Edge cases
+            () => Assert.Equal(["ZRANGE", "key", "0", "0"], Request.SortedSetRangeByRankAsync("key", 0, 0).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "mykey", "0", "10"], Request.SortedSetRangeByRankAsync("mykey", 0, 10).GetArgs())
+        );
+    }
+
+    [Fact]
+    public void SortedSetRangeByScore_ValidatesArguments()
+    {
+        Assert.Multiple(
+            // Basic functionality
+            () => Assert.Equal(["ZRANGE", "key", "-inf", "+inf", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key").GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "10", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1.5", "9.75", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 1.5, 9.75).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "-inf", "10", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", double.NegativeInfinity, 10.0).GetArgs()),
+
+            // Exclude options
+            () => Assert.Equal(["ZRANGE", "key", "(1", "10", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0, Exclude.Start).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "(10", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0, Exclude.Stop).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "(1", "(10", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0, Exclude.Both).GetArgs()),
+
+            // Order and limit
+            () => Assert.Equal(["ZRANGE", "key", "10", "1", "BYSCORE", "REV"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0, Exclude.None, Order.Descending).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "10", "BYSCORE", "LIMIT", "2", "3"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0, Exclude.None, Order.Ascending, 2, 3).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "(10", "(1", "BYSCORE", "REV", "LIMIT", "1", "5"], Request.SortedSetRangeByScoreAsync("key", 1.0, 10.0, Exclude.Both, Order.Descending, 1, 5).GetArgs()),
+
+            // With scores
+            () => Assert.Equal(["ZRANGE", "key", "-inf", "+inf", "BYSCORE", "WITHSCORES"], Request.SortedSetRangeByScoreWithScoresAsync("key").GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "10", "BYSCORE", "WITHSCORES"], Request.SortedSetRangeByScoreWithScoresAsync("key", 1.0, 10.0).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "10", "1", "BYSCORE", "REV", "WITHSCORES"], Request.SortedSetRangeByScoreWithScoresAsync("key", 1.0, 10.0, Exclude.None, Order.Descending).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "1", "10", "BYSCORE", "LIMIT", "2", "3", "WITHSCORES"], Request.SortedSetRangeByScoreWithScoresAsync("key", 1.0, 10.0, Exclude.None, Order.Ascending, 2, 3).GetArgs()),
+
+            // Edge cases
+            () => Assert.Equal(["ZRANGE", "key", "0", "0", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 0.0, 0.0).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "(0", "(0", "BYSCORE"], Request.SortedSetRangeByScoreAsync("key", 0.0, 0.0, Exclude.Both).GetArgs())
+        );
+    }
+
+    [Fact]
+    public void SortedSetRangeByValue_ValidatesArguments()
+    {
+        Assert.Multiple(
+            // Basic lexicographical ranges with explicit min/max
+            () => Assert.Equal(["ZRANGE", "key", "[a", "[z", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "a", "z", Exclude.None, 0, -1, CommandFlags.None).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "[apple", "[zebra", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "apple", "zebra", Exclude.None, 0, -1, CommandFlags.None).GetArgs()),
+
+            // Exclude options with explicit min/max
+            () => Assert.Equal(["ZRANGE", "key", "(a", "[z", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "a", "z", Exclude.Start, 0, -1, CommandFlags.None).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "[a", "(z", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "a", "z", Exclude.Stop, 0, -1, CommandFlags.None).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "(a", "(z", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "a", "z", Exclude.Both, 0, -1, CommandFlags.None).GetArgs()),
+
+            // Skip and take parameters with explicit min/max
+            () => Assert.Equal(["ZRANGE", "key", "[a", "[z", "BYLEX", "LIMIT", "2", "3"], Request.SortedSetRangeByValueAsync("key", "a", "z", Exclude.None, 2, 3, CommandFlags.None).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "(a", "(z", "BYLEX", "LIMIT", "1", "5"], Request.SortedSetRangeByValueAsync("key", "a", "z", Exclude.Both, 1, 5, CommandFlags.None).GetArgs()),
+
+            // Default parameters (should use lexicographical infinity symbols)
+            () => Assert.Equal(["ZRANGE", "key", "-", "+", "BYLEX"], Request.SortedSetRangeByValueAsync("key").GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "-", "+", "BYLEX"], Request.SortedSetRangeByValueAsync("key", default, default, Exclude.None, Order.Ascending, 0, -1).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "+", "-", "BYLEX", "REV"], Request.SortedSetRangeByValueAsync("key", default, default, Exclude.None, Order.Descending, 0, -1).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "-", "+", "BYLEX", "LIMIT", "2", "3"], Request.SortedSetRangeByValueAsync("key", default, default, Exclude.None, Order.Ascending, 2, 3).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "-", "+", "BYLEX"], Request.SortedSetRangeByValueAsync("key", double.NegativeInfinity, double.PositiveInfinity, Exclude.None, Order.Ascending, 0, -1).GetArgs()),
+
+            // Edge cases
+            () => Assert.Equal(["ZRANGE", "key", "[a", "[a", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "a", "a", Exclude.None, 0, -1, CommandFlags.None).GetArgs()),
+            () => Assert.Equal(["ZRANGE", "key", "[", "[z", "BYLEX"], Request.SortedSetRangeByValueAsync("key", "", "z", Exclude.None, 0, -1, CommandFlags.None).GetArgs())
         );
     }
 }

--- a/csharp/tests/Valkey.Glide.UnitTests/SortedSetCommandTests.cs
+++ b/csharp/tests/Valkey.Glide.UnitTests/SortedSetCommandTests.cs
@@ -74,7 +74,13 @@ public class SortedSetCommandTests
 
             // SortedSetRemove exceptions
             () => Assert.Throws<NotImplementedException>(() => Request.SortedSetRemoveAsync("key", "member", CommandFlags.DemandReplica)),
-            () => Assert.Throws<NotImplementedException>(() => Request.SortedSetRemoveAsync("key", ["member1", "member2"], CommandFlags.DemandReplica))
+            () => Assert.Throws<NotImplementedException>(() => Request.SortedSetRemoveAsync("key", ["member1", "member2"], CommandFlags.DemandReplica)),
+
+            // SortedSetCard exceptions
+            () => Assert.Throws<NotImplementedException>(() => Request.SortedSetCardAsync("key", CommandFlags.DemandReplica)),
+
+            // SortedSetCount exceptions
+            () => Assert.Throws<NotImplementedException>(() => Request.SortedSetCountAsync("key", 1.0, 10.0, Exclude.None, CommandFlags.DemandReplica))
         );
     }
 
@@ -133,16 +139,16 @@ public class SortedSetCommandTests
     }
 
     [Fact]
-    public void SortedSetLengthAsync_ValidatesArguments()
+    public void SortedSetCardAsync_ValidatesArguments()
     {
         Assert.Multiple(
             // Basic ZCARD command
-            () => Assert.Equal(["ZCARD", "key"], Request.SortedSetLengthAsync("key").GetArgs()),
-            () => Assert.Equal(["ZCARD", "mykey"], Request.SortedSetLengthAsync("mykey").GetArgs()),
-            () => Assert.Equal(["ZCARD", "test:sorted:set"], Request.SortedSetLengthAsync("test:sorted:set").GetArgs()),
+            () => Assert.Equal(["ZCARD", "key"], Request.SortedSetCardAsync("key").GetArgs()),
+            () => Assert.Equal(["ZCARD", "mykey"], Request.SortedSetCardAsync("mykey").GetArgs()),
+            () => Assert.Equal(["ZCARD", "test:sorted:set"], Request.SortedSetCardAsync("test:sorted:set").GetArgs()),
 
             // Empty key should work
-            () => Assert.Equal(["ZCARD", ""], Request.SortedSetLengthAsync("").GetArgs())
+            () => Assert.Equal(["ZCARD", ""], Request.SortedSetCardAsync("").GetArgs())
         );
     }
 


### PR DESCRIPTION
This PR adds the rest of the Sorted Set Public Preview Commands

**Note**:

`SortedSetLengthAsync` is split into `SortedSetLengthAsync` (`ZCard`) and `SortedSetCountAsync` (`ZCount`)

For `SortedSetRangeByValueAsync` (ZRange BYLEX), it doesn't have a `WithScores` method in SER.

### Issue link

This Pull Request is linked to issue (URL): #4222 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
