### PR TITLE
Documentation update for protobuf installation

### DIFF
--- a/go/DEVELOPER.md
+++ b/go/DEVELOPER.md
@@ -47,6 +47,9 @@ source "$HOME/.cargo/env"
 rustc --version
 ```
 
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
+
 Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 **Dependencies installation for CentOS**
@@ -66,13 +69,16 @@ source "$HOME/.cargo/env"
 rustc --version
 ```
 
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
+
 Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuild`** below.
 
 **Dependencies installation for MacOS**
 
 ```bash
 brew update
-brew install go make git gcc pkgconfig protobuf@3 openssl cmake
+brew install go make git gcc pkgconfig openssl cmake
 export PATH="$PATH:$HOME/go/bin"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
@@ -80,22 +86,16 @@ source "$HOME/.cargo/env"
 rustc --version
 ```
 
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
+
+Continue with **Install protobuf compiler** below.
+It is not necessary to **Install `ziglang` and `zigbuild`** for MacOS.
+
 **Install protobuf compiler**
 
-To install protobuf for MacOS, run:
-
-```bash
-brew install protobuf@3
-# Verify the Protobuf compiler installation
-protoc --version
-
-# If protoc is not found or does not work correctly, update the PATH
-echo 'export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"' >> /Users/$USER/.bash_profile
-source /Users/$USER/.bash_profile
-protoc --version
-```
-
-For the remaining systems, do the following:
+Various platform-specific zips can be found [here](https://github.com/protocolbuffers/protobuf/releases/v3.20.3).
+Choose the appropriate zip for your system and run the commands below, adjusting for the zip you chose:
 
 ```bash
 PB_REL="https://github.com/protocolbuffers/protobuf/releases"
@@ -105,6 +105,9 @@ export PATH="$PATH:$HOME/.local/bin"
 # Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
 protoc --version
 ```
+
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
 
 **Install `ziglang` and `zigbuild`**
 

--- a/java/DEVELOPER.md
+++ b/java/DEVELOPER.md
@@ -18,7 +18,7 @@ The Valkey GLIDE Java wrapper consists of both Java and Rust code. Rust bindings
 - GCC
 - pkg-config
 - cmake
-- protoc (protobuf compiler) >= 29.1
+- protoc (protobuf compiler) >= v29.1
 - openssl
 - openssl-dev
 - rustup
@@ -59,24 +59,20 @@ Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuil
 
 ```bash
 brew update
-brew install openjdk@11 git gcc pkgconfig protobuf openssl cmake
+brew install openjdk@11 git gcc pkgconfig openssl cmake
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```
 
 Continue with **Install protobuf compiler** below.
+It is not necessary to **Install `ziglang` and `zigbuild`** for MacOS.
 
 **Install protobuf compiler**
 
-To install protobuf for MacOS, run:
+Only protobuf v29.1 is supported. Other versions are not supported and may cause build issues.
 
-```bash
-brew install protobuf
-# Check that the protobuf compiler version 29.1 or higher is installed
-protoc --version
-```
-
-For the remaining systems, do the following:
+Various platform-specific zips can be found [here](https://github.com/protocolbuffers/protobuf/releases/tag/v29.1).
+Choose the appropriate zip for your system and run the commands below, adjusting for the zip you chose:
 
 ```bash
 PB_REL="https://github.com/protocolbuffers/protobuf/releases"
@@ -86,6 +82,9 @@ export PATH="$PATH:$HOME/.local/bin"
 # Check that the protobuf compiler version 29.1 or higher is installed
 protoc --version
 ```
+
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
 
 **Install `ziglang` and `zigbuild`**
 
@@ -174,7 +173,6 @@ Some troubleshooting issues:
   you may need to restart your machine. In particular, this may solve the following problems:
   - Failed to find `cargo` after `rustup`.
   - No Protobuf compiler (protoc) found.
-- If protobuf 29.0 or earlier is detected, upgrade to the latest protobuf release.
 
 ## Running Examples App
 

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -21,7 +21,7 @@ If your Nodejs version is below the supported version specified in the client's 
 - GCC
 - pkg-config
 - cmake
-- protoc (protobuf compiler)
+- protoc (protobuf compiler) >= v3.20.0
 - openssl
 - openssl-dev
 - rustup
@@ -30,32 +30,56 @@ If your Nodejs version is below the supported version specified in the client's 
 
 ```bash
 sudo apt update -y
-sudo apt install -y nodejs npm git gcc pkg-config protobuf-compiler openssl libssl-dev cmake
+sudo apt install -y nodejs npm git gcc pkg-config openssl libssl-dev cmake
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check the installed node version
 node -v
 ```
 
-> **Note:** Ensure that you installed a supported Node.js version. For Ubuntu 22.04 or earlier, please refer to the instructions [here](#note-nodejs-supported-version) to upgrade your Node.js version.
+Continue with **Install protobuf compiler** below.
+
+> [!NOTE]
+> Ensure that you installed a supported Node.js version. For Ubuntu 22.04 or earlier, please refer to the instructions [here](#note-nodejs-supported-version) to upgrade your Node.js version.
 
 **Dependencies installation for CentOS**
 
 ```bash
 sudo yum update -y
-sudo yum install -y nodejs git gcc pkgconfig protobuf-compiler openssl openssl-devel gettext cmake
+sudo yum install -y nodejs git gcc pkgconfig openssl openssl-devel gettext cmake
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```
+
+Continue with **Install protobuf compiler** below.
 
 **Dependencies installation for MacOS**
 
 ```bash
 brew update
-brew install nodejs git gcc pkgconfig protobuf openssl cmake
+brew install nodejs git gcc pkgconfig openssl cmake
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 ```
+
+Continue with **Install protobuf compiler** below.
+
+**Install protobuf compiler**
+
+Various platform-specific zips can be found [here](https://github.com/protocolbuffers/protobuf/releases/v3.20.3).
+Choose the appropriate zip for your system and run the commands below, adjusting for the zip you chose:
+
+```bash
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
+unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
+export PATH="$PATH:$HOME/.local/bin"
+# Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
+protoc --version
+```
+
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
 
 **Valkey Server and CLI**
 See the [Valkey installation guide](https://valkey.io/topics/installation/) to install the Valkey server and CLI.

--- a/python/DEVELOPER.md
+++ b/python/DEVELOPER.md
@@ -122,33 +122,23 @@ Continue with **Install protobuf compiler** and **Install `ziglang` and `zigbuil
 
 ```bash
 brew update
-brew install python3 git gcc pkgconfig protobuf@3 openssl virtualenv cmake
+brew install python3 git gcc pkgconfig openssl virtualenv cmake
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 # Check that the Rust compiler is installed
 rustc --version
 ```
+
 Continue with **Install protobuf compiler** below.
+It is not necessary to **Install `ziglang` and `zigbuild`** for MacOS.
 
 </details>
 
 <details>
 <summary>Install protobuf compiler</summary>
 
-To install protobuf for MacOS, run:
-
-```bash
-brew install protobuf@3
-# Verify the Protobuf compiler installation
-protoc --version
-
-# If protoc is not found or does not work correctly, update the PATH
-echo 'export PATH="/opt/homebrew/opt/protobuf@3/bin:$PATH"' >> /Users/$USER/.bash_profile
-source /Users/$USER/.bash_profile
-protoc --version
-```
-
-For the remaining systems, do the following:
+Various platform-specific zips can be found [here](https://github.com/protocolbuffers/protobuf/releases/v3.20.3).
+Choose the appropriate zip for your system and run the commands below, adjusting for the zip you chose:
 
 ```bash
 PB_REL="https://github.com/protocolbuffers/protobuf/releases"
@@ -158,6 +148,9 @@ export PATH="$PATH:$HOME/.local/bin"
 # Check that the protobuf compiler is installed. A minimum version of 3.20.0 is required.
 protoc --version
 ```
+
+> [!NOTE]
+> You may wish to add the entire `export PATH` line to your shell configuration file to persist this path addition, either `.bashrc` or `.zshrc` depending on which shell you are using.
 
 </details>
 
@@ -358,7 +351,7 @@ This section explains how the `valkey-glide` (async client) and `valkey-glide-sy
 
 > By default, `mkdocs` should still be using Google's Python Docstring Style so the "Documentation Style" section below will still be valid.
 
-We follow the [Google Style Python Docstrings format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) in our documentation. For our documentation tool, we use `sphinx`. 
+We follow the [Google Style Python Docstrings format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) in our documentation. For our documentation tool, we use `sphinx`.
 
 **Note:** `docs/index.rst` has manual modifications to it and should NOT be deleted. Modify this file with caution.
 
@@ -424,7 +417,7 @@ Examples:
 """
 ```
 
-### Example of Properly Formatted Documentation for a Class 
+### Example of Properly Formatted Documentation for a Class
 
 ```python
 class BitOffsetMultiplier(BitFieldOffset):
@@ -495,7 +488,7 @@ Attributes:
 
 #### Return value(s)
 
-Return values are a little special for sphinx. If we wanted to provide more context or multiple possible return values, the convention we will go for is that we should add a space between every different return value. 
+Return values are a little special for sphinx. If we wanted to provide more context or multiple possible return values, the convention we will go for is that we should add a space between every different return value.
 
 We start by adding the return type on the first line, followed by a description of the return value.
 
@@ -504,10 +497,10 @@ We start by adding the return type on the first line, followed by a description 
 ```python
 Returns:
     List[int]: Some description here regarding the purpose of the list of ints being
-    returned. Notice how this new line is not indented but it is still apart of the same 
+    returned. Notice how this new line is not indented but it is still apart of the same
     description.
 
-    If we ever want to provide more context or another description of another return value 
+    If we ever want to provide more context or another description of another return value
     (ex. None, -1, True/False, etc.) we add a space between this description and the
     previous description.
 ```
@@ -551,7 +544,7 @@ Examples:
         }
         # Indicates the stream entries for "my_stream" with IDs greater than "0-0". The operation blocks up to
         # 1000ms if there is no stream data.
-    
+
     ... # More examples here
 ```
 


### PR DESCRIPTION
### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4375

### Description

As of 2025-07-01, brew no longer allows installation of `protobuf@3`. In this PR documentation for all of the GA clients have been updated to manually install protobuf.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
