### PR TITLE
ORT: fix workflow permissions

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,7 +1,7 @@
 name: The OSS Review Toolkit (ORT)
 
 permissions:
-    contents: read
+    contents: write
     pull-requests: write
     actions: read
 
@@ -268,7 +268,7 @@ jobs:
                   git checkout -b ${ORT_DIFF_BRANCH_NAME}
                   git add $PYTHON_ATTRIBUTIONS $NODE_ATTRIBUTIONS $RUST_ATTRIBUTIONS $JAVA_ATTRIBUTIONS $GO_ATTRIBUTIONS
                   git commit -m "Updated attribution files" -s
-                  git push --set-upstream origin ${ORT_DIFF_BRANCH_NAME} -f
+                  git push --set-upstream origin ${ORT_DIFF_BRANCH_NAME} -f || { echo "Failed to push branch."; exit 1; }
 
                   # Check if PR already exists
                   existing_pr=$(gh pr list --base ${TARGET_BRANCH} --head ${ORT_DIFF_BRANCH_NAME} --json number --jq '.[0].number')
@@ -276,12 +276,12 @@ jobs:
                   if [ -z "$existing_pr" ]; then
                     # Create a new PR if none exists
                     title="Updated attribution files for commit ${TARGET_COMMIT}"
-                    gh pr create -B ${TARGET_BRANCH} -H ${ORT_DIFF_BRANCH_NAME} --title "${title}" --body "Created by Github action. ${{ env.LICENSES_LIST }}"
+                    gh pr create -B ${TARGET_BRANCH} -H ${ORT_DIFF_BRANCH_NAME} --title "${title}" --body "Created by Github action. ${{ env.LICENSES_LIST }}" || { echo "Failed to create PR."; exit 1; }
                     echo "Pull request created successfully."
                   else
                     # Update the existing PR
                     echo "Pull request #$existing_pr already exists. Updating branch."
-                    gh pr edit $existing_pr --title "Updated attribution files for commit ${TARGET_COMMIT}" --body "Created by Github action. ${{ env.LICENSES_LIST }}"
+                    gh pr edit $existing_pr --title "Updated attribution files for commit ${TARGET_COMMIT}" --body "Created by Github action. ${{ env.LICENSES_LIST }}" || { echo "Failed to update PR."; exit 1; }
                     echo "Pull request updated successfully."
                   fi
               env:


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

Currently ORT workflow doesn't have permissions to push a branch or create a PR, because of this change in permissions -https://github.com/valkey-io/valkey-glide/pull/4274

This PR fixed the permissions and adds `exit` statements to fail the workflow if something fails.
### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
