### PR TITLE
C#: fix client performance

### DIFF
--- a/csharp/rust/src/lib.rs
+++ b/csharp/rust/src/lib.rs
@@ -136,6 +136,7 @@ pub unsafe extern "C-unwind" fn create_client(
     let request = unsafe { create_connection_request(config) };
     let runtime = Builder::new_multi_thread()
         .enable_all()
+        .worker_threads(10)
         .thread_name("GLIDE C# thread")
         .build()
         .unwrap();

--- a/csharp/tests/Valkey.Glide.IntegrationTests/TestConfiguration.cs
+++ b/csharp/tests/Valkey.Glide.IntegrationTests/TestConfiguration.cs
@@ -29,22 +29,6 @@ public class TestConfiguration : IDisposable
             .WithProtocolVersion(ConnectionConfiguration.Protocol.RESP3)
             .WithTls(TLS);
 
-    public static GlideClient DefaultStandaloneClientWithExtraTimeout()
-        => GlideClient.CreateClient(
-                DefaultClientConfig()
-                .WithRequestTimeout(TimeSpan.FromSeconds(1))
-                .Build())
-            .GetAwaiter()
-            .GetResult();
-
-    public static GlideClusterClient DefaultClusterClientWithExtraTimeout()
-        => GlideClusterClient.CreateClient(
-                DefaultClusterClientConfig()
-                .WithRequestTimeout(TimeSpan.FromSeconds(1))
-                .Build())
-            .GetAwaiter()
-            .GetResult();
-
     public static GlideClient DefaultStandaloneClient()
         => GlideClient.CreateClient(DefaultClientConfig().Build()).GetAwaiter().GetResult();
 
@@ -73,14 +57,12 @@ public class TestConfiguration : IDisposable
             {
                 GlideClient resp2client = GlideClient.CreateClient(
                     DefaultClientConfig()
-                    .WithRequestTimeout(TimeSpan.FromSeconds(1))
                     .WithProtocolVersion(ConnectionConfiguration.Protocol.RESP2)
                     .Build()
                 ).GetAwaiter().GetResult();
                 resp2client.SetInfo("RESP2");
                 GlideClient resp3client = GlideClient.CreateClient(
                     DefaultClientConfig()
-                    .WithRequestTimeout(TimeSpan.FromSeconds(1))
                     .WithProtocolVersion(ConnectionConfiguration.Protocol.RESP3)
                     .Build()
                 ).GetAwaiter().GetResult();
@@ -101,14 +83,12 @@ public class TestConfiguration : IDisposable
             {
                 GlideClusterClient resp2client = GlideClusterClient.CreateClient(
                     DefaultClusterClientConfig()
-                    .WithRequestTimeout(TimeSpan.FromSeconds(1))
                     .WithProtocolVersion(ConnectionConfiguration.Protocol.RESP2)
                     .Build()
                 ).GetAwaiter().GetResult();
                 resp2client.SetInfo("RESP2");
                 GlideClusterClient resp3client = GlideClusterClient.CreateClient(
                     DefaultClusterClientConfig()
-                    .WithRequestTimeout(TimeSpan.FromSeconds(1))
                     .WithProtocolVersion(ConnectionConfiguration.Protocol.RESP3)
                     .Build()
                 ).GetAwaiter().GetResult();
@@ -138,7 +118,6 @@ public class TestConfiguration : IDisposable
         ConfigurationOptions config = new();
         config.EndPoints.Add(STANDALONE_HOSTS[0].host, STANDALONE_HOSTS[0].port);
         config.Ssl = TLS;
-        config.ResponseTimeout = 1000;
         return config;
     }
 
@@ -147,7 +126,6 @@ public class TestConfiguration : IDisposable
         ConfigurationOptions config = new();
         config.EndPoints.Add(CLUSTER_HOSTS[0].host, CLUSTER_HOSTS[0].port);
         config.Ssl = TLS;
-        config.ResponseTimeout = 1000;
         return config;
     }
 


### PR DESCRIPTION
See discussion in https://github.com/valkey-io/valkey-glide/issues/3563#issuecomment-2788053881

Cluster client was failing `ConcurrentOperationsWork` test having only 1 thread in tokio thread pool (request timeouts). After increasing them to 1 sec (default = 250ms) timeouts disappeared, but it is not a fix.
With bigger thread pool no tests fail with default timeout. See full matrix CI run: https://github.com/valkey-io/valkey-glide/actions/runs/16629098022

### Issue link

This Pull Request is linked to issue (URL): ~#216~ #4369

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Commits will be squashed upon merging.