### PR TITLE
Fix test report artifact name

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -134,7 +134,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       csharp/TestReport.html
                       benchmarks/results/*
@@ -212,7 +212,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.IMAGE }}-${{ matrix.host.ARCH }}
+                  name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ env.IMAGE }}-${{ matrix.host.ARCH }}
                   path: |
                       csharp/TestReport.html
                       benchmarks/results/*

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -134,7 +134,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       csharp/TestReport.html
                       benchmarks/results/*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -167,7 +167,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-report-go-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: test-report-go-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       utils/clusters/**
                       benchmarks/results/**
@@ -440,7 +440,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-report-go-long-timeout-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: test-report-go-long-timeout-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       utils/clusters/**
                       benchmarks/results/**

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -167,7 +167,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-report-go-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: test-report-go-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       utils/clusters/**
                       benchmarks/results/**
@@ -440,7 +440,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-report-go-long-timeout-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: test-report-go-long-timeout-${{ matrix.go }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       utils/clusters/**
                       benchmarks/results/**

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -234,7 +234,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-pubsub-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: test-reports-pubsub-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       java/integTest/build/reports/**
                       utils/clusters/**

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -234,7 +234,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-pubsub-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: test-reports-pubsub-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       java/integTest/build/reports/**
                       utils/clusters/**

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -143,7 +143,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: node-test-reports-${{ matrix.node }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: node-test-reports-${{ matrix.node }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       node/test-report*.html
 

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -143,7 +143,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: node-test-reports-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}-${{ matrix.node }}-${{ github.run_id }}
+                  name: node-test-reports-${{ matrix.host.OS }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       node/test-report*.html
 
@@ -377,7 +377,6 @@ jobs:
                   npm run test
 
             - name: Sanitize IMAGE variable
-              if: ${{ matrix.host.TARGET == 'x86_64-unknown-linux-musl' }}
               # Replace `:` in the variable otherwise it can't be used in `upload-artifact`
               run: echo "SANITIZED_IMAGE=${{ matrix.host.IMAGE }}" | sed -r 's/:/-/g' >> $GITHUB_ENV
 

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -143,7 +143,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: node-test-reports-${{ matrix.host.OS }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: node-test-reports-${{ matrix.node }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       node/test-report*.html
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -155,7 +155,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       python/tests/pytest_report.html
                       utils/clusters/**
@@ -221,7 +221,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: pubsub-test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
+                  name: pubsub-test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       python/tests/pytest_report.html
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -155,7 +155,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       python/tests/pytest_report.html
                       utils/clusters/**
@@ -221,7 +221,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: pubsub-test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: pubsub-test-report-python-${{ matrix.python }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ toJson(matrix.host.RUNNER) }}
                   path: |
                       python/tests/pytest_report.html
 


### PR DESCRIPTION
Fix artifact (test reports) naming errors spotted in [full matrix tests](https://github.com/valkey-io/valkey-glide/actions/runs/16612782839), such as:
1. using unsanitized image name
```
The artifact name is not valid: test-reports-dotnet-8.0-valkey-8.0-amazonlinux:latest-x64. Contains the following character:  Colon :
```
2. using unset variables (`test-report-node-16.x-redis-6.2--x64`)
3. using `RUNNER` as a name (`test-reports-dotnet-6.0-redis-6.2-Array`)

See test run with fixes: https://github.com/valkey-io/valkey-glide/actions/runs/16631192125