### PR TITLE
JAVA: HSETEX hash field expiration command

### DIFF
--- a/glide-core/src/protobuf/command_request.proto
+++ b/glide-core/src/protobuf/command_request.proto
@@ -179,6 +179,7 @@ enum RequestType {
     HSetNX                         = 614;
     HStrlen                        = 615;
     HVals                          = 616;
+    HSetex                         = 617;
 
     //// HyperLogLog commands
 

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -144,6 +144,7 @@ pub enum RequestType {
     HSetNX = 614,
     HStrlen = 615,
     HVals = 616,
+    HSetex = 617,
 
     //// HyperLogLog commands
     PfAdd = 701,
@@ -520,6 +521,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::HSetNX => RequestType::HSetNX,
             ProtobufRequestType::SIsMember => RequestType::SIsMember,
             ProtobufRequestType::HVals => RequestType::HVals,
+            ProtobufRequestType::HSetex => RequestType::HSetex,
             ProtobufRequestType::PTTL => RequestType::PTTL,
             ProtobufRequestType::ZRemRangeByRank => RequestType::ZRemRangeByRank,
             ProtobufRequestType::Persist => RequestType::Persist,
@@ -782,6 +784,7 @@ impl RequestType {
             RequestType::HSetNX => Some(cmd("HSETNX")),
             RequestType::SIsMember => Some(cmd("SISMEMBER")),
             RequestType::HVals => Some(cmd("HVALS")),
+            RequestType::HSetex => Some(cmd("HSETEX")),
             RequestType::PTTL => Some(cmd("PTTL")),
             RequestType::ZRemRangeByRank => Some(cmd("ZREMRANGEBYRANK")),
             RequestType::Persist => Some(cmd("PERSIST")),

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -49,6 +49,7 @@ import static command_request.CommandRequestOuterClass.RequestType.HRandField;
 import static command_request.CommandRequestOuterClass.RequestType.HScan;
 import static command_request.CommandRequestOuterClass.RequestType.HSet;
 import static command_request.CommandRequestOuterClass.RequestType.HSetNX;
+import static command_request.CommandRequestOuterClass.RequestType.HSetex;
 import static command_request.CommandRequestOuterClass.RequestType.HStrlen;
 import static command_request.CommandRequestOuterClass.RequestType.HVals;
 import static command_request.CommandRequestOuterClass.RequestType.Incr;
@@ -217,6 +218,7 @@ import glide.api.models.PubSubMessage;
 import glide.api.models.Script;
 import glide.api.models.commands.ExpireOptions;
 import glide.api.models.commands.GetExOptions;
+import glide.api.models.commands.HashFieldExpirationOptions;
 import glide.api.models.commands.LInsertOptions.InsertPosition;
 import glide.api.models.commands.LPosOptions;
 import glide.api.models.commands.ListDirection;
@@ -1166,6 +1168,36 @@ public abstract class BaseClient
             @NonNull GlideString key, @NonNull GlideString field, @NonNull GlideString value) {
         return commandManager.submitNewCommand(
                 HSetNX, new GlideString[] {key, field, value}, this::handleBooleanResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> hsetex(
+            @NonNull String key,
+            @NonNull Map<String, String> fieldValueMap,
+            @NonNull HashFieldExpirationOptions options) {
+        String[] arguments =
+                concatenateArrays(
+                        new String[] {key},
+                        options.toArgs(),
+                        new String[] {"FIELDS", String.valueOf(fieldValueMap.size())},
+                        convertMapToKeyValueStringArray(fieldValueMap));
+        return commandManager.submitNewCommand(HSetex, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> hsetex(
+            @NonNull GlideString key,
+            @NonNull Map<GlideString, GlideString> fieldValueMap,
+            @NonNull HashFieldExpirationOptions options) {
+        GlideString[] arguments =
+                new ArgsBuilder()
+                        .add(key)
+                        .add(options.toArgs())
+                        .add("FIELDS")
+                        .add(fieldValueMap.size())
+                        .add(convertMapToKeyValueGlideStringArray(fieldValueMap))
+                        .toArray();
+        return commandManager.submitNewCommand(HSetex, arguments, this::handleLongResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/HashBaseCommands.java
@@ -2,6 +2,7 @@
 package glide.api.commands;
 
 import glide.api.models.GlideString;
+import glide.api.models.commands.HashFieldExpirationOptions;
 import glide.api.models.commands.scan.HScanOptions;
 import glide.api.models.commands.scan.HScanOptions.HScanOptionsBuilder;
 import glide.api.models.commands.scan.HScanOptionsBinary;
@@ -760,4 +761,74 @@ public interface HashBaseCommands {
      */
     CompletableFuture<Object[]> hscan(
             GlideString key, GlideString cursor, HScanOptionsBinary hScanOptions);
+
+    /**
+     * Sets the specified fields to their respective values in the hash stored at <code>key</code>
+     * with optional expiration and conditional options.
+     *
+     * @since Valkey 9.0 and above.
+     * @see <a href="https://valkey.io/commands/hsetex/">valkey.io</a> for details.
+     * @param key The key of the hash.
+     * @param fieldValueMap A field-value map consisting of fields and their corresponding values to
+     *     be set in the hash stored at the specified key.
+     * @param options Optional parameters for the command including conditional changes and expiry
+     *     settings.
+     * @return The number of fields that were added to the hash.
+     * @example
+     *     <pre>{@code
+     * // Set fields with 60 second expiration
+     * HashFieldExpirationOptions options = HashFieldExpirationOptions.builder()
+     *     .expiry(HashFieldExpirationOptions.ExpirySet.Seconds(60L))
+     *     .build();
+     * Long num = client.hsetex("my_hash", Map.of("field1", "value1", "field2", "value2"), options).get();
+     * assert num == 2L;
+     *
+     * // Set fields only if hash doesn't exist with field conditional
+     * HashFieldExpirationOptions conditionalOptions = HashFieldExpirationOptions.builder()
+     *     .conditionalSetOnlyIfNotExist()
+     *     .fieldConditionalSetOnlyIfNoneExist()
+     *     .expiry(HashFieldExpirationOptions.ExpirySet.Milliseconds(30000L))
+     *     .build();
+     * Long result = client.hsetex("new_hash", Map.of("field", "value"), conditionalOptions).get();
+     * assert result == 1L;
+     * }</pre>
+     */
+    CompletableFuture<Long> hsetex(
+            String key, Map<String, String> fieldValueMap, HashFieldExpirationOptions options);
+
+    /**
+     * Sets the specified fields to their respective values in the hash stored at <code>key</code>
+     * with optional expiration and conditional options.
+     *
+     * @since Valkey 9.0 and above.
+     * @see <a href="https://valkey.io/commands/hsetex/">valkey.io</a> for details.
+     * @param key The key of the hash.
+     * @param fieldValueMap A field-value map consisting of fields and their corresponding values to
+     *     be set in the hash stored at the specified key.
+     * @param options Optional parameters for the command including conditional changes and expiry
+     *     settings.
+     * @return The number of fields that were added to the hash.
+     * @example
+     *     <pre>{@code
+     * // Set fields with 60 second expiration
+     * HashFieldExpirationOptions options = HashFieldExpirationOptions.builder()
+     *     .expiry(HashFieldExpirationOptions.ExpirySet.Seconds(60L))
+     *     .build();
+     * Long num = client.hsetex(gs("my_hash"), Map.of(gs("field1"), gs("value1"), gs("field2"), gs("value2")), options).get();
+     * assert num == 2L;
+     *
+     * // Set fields only if hash doesn't exist with field conditional
+     * HashFieldExpirationOptions conditionalOptions = HashFieldExpirationOptions.builder()
+     *     .conditionalSetOnlyIfNotExist()
+     *     .fieldConditionalSetOnlyIfNoneExist()
+     *     .expiry(HashFieldExpirationOptions.ExpirySet.Milliseconds(30000L))
+     *     .build();
+     * Long result = client.hsetex(gs("new_hash"), Map.of(gs("field"), gs("value")), conditionalOptions).get();
+     * assert result == 1L;
+     * }</pre>
+     */
+    CompletableFuture<Long> hsetex(
+            GlideString key,
+            Map<GlideString, GlideString> fieldValueMap,
+            HashFieldExpirationOptions options);
 }

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -67,6 +67,7 @@ import static command_request.CommandRequestOuterClass.RequestType.HRandField;
 import static command_request.CommandRequestOuterClass.RequestType.HScan;
 import static command_request.CommandRequestOuterClass.RequestType.HSet;
 import static command_request.CommandRequestOuterClass.RequestType.HSetNX;
+import static command_request.CommandRequestOuterClass.RequestType.HSetex;
 import static command_request.CommandRequestOuterClass.RequestType.HStrlen;
 import static command_request.CommandRequestOuterClass.RequestType.HVals;
 import static command_request.CommandRequestOuterClass.RequestType.Incr;
@@ -231,6 +232,7 @@ import glide.api.commands.StringBaseCommands;
 import glide.api.models.commands.ExpireOptions;
 import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.GetExOptions;
+import glide.api.models.commands.HashFieldExpirationOptions;
 import glide.api.models.commands.InfoOptions.Section;
 import glide.api.models.commands.LInsertOptions.InsertPosition;
 import glide.api.models.commands.LPosOptions;
@@ -797,6 +799,38 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
         protobufBatch.addCommands(
                 buildCommand(
                         HSet, newArgsBuilder().add(key).add(flattenMapToGlideStringArray(fieldValueMap))));
+        return getThis();
+    }
+
+    /**
+     * Sets the specified fields to their respective values in the hash stored at <code>key</code>
+     * with optional expiration. If <code>key</code> does not exist, a new key holding a hash is
+     * created.
+     *
+     * @since Valkey 9.0.0.
+     * @implNote {@link ArgType} is limited to {@link String} or {@link GlideString}, any other type
+     *     will throw {@link IllegalArgumentException}.
+     * @see <a href="https://valkey.io/commands/hsetex/">valkey.io</a> for details.
+     * @param key The key of the hash.
+     * @param fieldValueMap A field-value map consisting of fields and their corresponding values to
+     *     be set in the hash stored at the specified key.
+     * @param options The {@link HashFieldExpirationOptions} for the command.
+     * @return Command Response - The number of fields that were added to the hash.
+     */
+    public <ArgType> T hsetex(
+            @NonNull ArgType key,
+            @NonNull Map<ArgType, ArgType> fieldValueMap,
+            @NonNull HashFieldExpirationOptions options) {
+        checkTypeOrThrow(key);
+        protobufBatch.addCommands(
+                buildCommand(
+                        HSetex,
+                        newArgsBuilder()
+                                .add(key)
+                                .add(options.toArgs())
+                                .add("FIELDS")
+                                .add(fieldValueMap.size())
+                                .add(flattenMapToGlideStringArray(fieldValueMap))));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/commands/HashFieldExpirationOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/HashFieldExpirationOptions.java
@@ -1,0 +1,345 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.commands;
+
+import static glide.api.models.commands.HashFieldExpirationOptions.ExpiryType.KEEP_EXISTING;
+import static glide.api.models.commands.HashFieldExpirationOptions.ExpiryType.MILLISECONDS;
+import static glide.api.models.commands.HashFieldExpirationOptions.ExpiryType.SECONDS;
+import static glide.api.models.commands.HashFieldExpirationOptions.ExpiryType.UNIX_MILLISECONDS;
+import static glide.api.models.commands.HashFieldExpirationOptions.ExpiryType.UNIX_SECONDS;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Optional arguments for hash field expiration commands like HSETEX, HGETEX, HEXPIRE, etc.
+ *
+ * @see <a href="https://valkey.io/commands/hsetex/">valkey.io</a>
+ */
+@Builder
+public final class HashFieldExpirationOptions {
+
+    /** Conditional change option for hash operations (NX/XX). */
+    private final ConditionalChange conditionalChange;
+
+    /** Field-specific conditional change option for HSETEX (FNX/FXX). */
+    private final FieldConditionalChange fieldConditionalChange;
+
+    /** Expiration condition for HEXPIRE-like commands (NX/XX/GT/LT). */
+    private final ExpirationCondition expirationCondition;
+
+    /** Expiry configuration for the hash fields. */
+    private final ExpirySet expiry;
+
+    /**
+     * Conditions which define whether hash operations should be performed based on hash existence.
+     */
+    @RequiredArgsConstructor
+    @Getter
+    public enum ConditionalChange {
+        /**
+         * Only perform operation if the hash already exists. Equivalent to <code>XX</code> in the
+         * Valkey API.
+         */
+        ONLY_IF_EXISTS("XX"),
+        /**
+         * Only perform operation if the hash does not exist. Equivalent to <code>NX</code> in the
+         * Valkey API.
+         */
+        ONLY_IF_DOES_NOT_EXIST("NX");
+
+        private final String valkeyApi;
+    }
+
+    /** Field-specific conditions for HSETEX command. */
+    @RequiredArgsConstructor
+    @Getter
+    public enum FieldConditionalChange {
+        /**
+         * Only set fields if all of them already exist. Equivalent to <code>FXX</code> in the Valkey
+         * API.
+         */
+        ONLY_IF_ALL_EXIST("FXX"),
+        /**
+         * Only set fields if none of them already exist. Equivalent to <code>FNX</code> in the Valkey
+         * API.
+         */
+        ONLY_IF_NONE_EXIST("FNX");
+
+        private final String valkeyApi;
+    }
+
+    /** Expiration conditions for HEXPIRE-like commands. */
+    @RequiredArgsConstructor
+    @Getter
+    public enum ExpirationCondition {
+        /**
+         * Only set expiration when field has no expiration. Equivalent to <code>NX</code> in the Valkey
+         * API.
+         */
+        ONLY_IF_NO_EXPIRY("NX"),
+        /**
+         * Only set expiration when field has existing expiration. Equivalent to <code>XX</code> in the
+         * Valkey API.
+         */
+        ONLY_IF_HAS_EXPIRY("XX"),
+        /**
+         * Only set expiration when new expiration is greater than current. Equivalent to <code>GT
+         * </code> in the Valkey API.
+         */
+        ONLY_IF_GREATER_THAN_CURRENT("GT"),
+        /**
+         * Only set expiration when new expiration is less than current. Equivalent to <code>LT</code>
+         * in the Valkey API.
+         */
+        ONLY_IF_LESS_THAN_CURRENT("LT");
+
+        private final String valkeyApi;
+    }
+
+    /** Configuration of field expiration lifetime. */
+    public static final class ExpirySet {
+
+        /** Expiry type for the time to live */
+        private final ExpiryType type;
+
+        /**
+         * The amount of time to live before the field expires. Ignored when {@link
+         * ExpiryType#KEEP_EXISTING} type is set.
+         */
+        private Long count;
+
+        private ExpirySet(ExpiryType type) {
+            this.type = type;
+        }
+
+        private ExpirySet(ExpiryType type, Long count) {
+            this.type = type;
+            this.count = count;
+        }
+
+        /**
+         * Retain the time to live associated with the field. Equivalent to <code>KEEPTTL</code> in the
+         * Valkey API.
+         */
+        public static ExpirySet KeepExisting() {
+            return new ExpirySet(KEEP_EXISTING);
+        }
+
+        /**
+         * Set the specified expire time, in seconds. Equivalent to <code>EX</code> in the Valkey API.
+         *
+         * @param seconds time to expire, in seconds
+         * @return ExpirySet
+         */
+        public static ExpirySet Seconds(Long seconds) {
+            return new ExpirySet(SECONDS, seconds);
+        }
+
+        /**
+         * Set the specified expire time, in milliseconds. Equivalent to <code>PX</code> in the Valkey
+         * API.
+         *
+         * @param milliseconds time to expire, in milliseconds
+         * @return ExpirySet
+         */
+        public static ExpirySet Milliseconds(Long milliseconds) {
+            return new ExpirySet(MILLISECONDS, milliseconds);
+        }
+
+        /**
+         * Set the specified Unix time at which the field will expire, in seconds. Equivalent to <code>
+         * EXAT</code> in the Valkey API.
+         *
+         * @param unixSeconds <code>UNIX TIME</code> to expire, in seconds.
+         * @return ExpirySet
+         */
+        public static ExpirySet UnixSeconds(Long unixSeconds) {
+            return new ExpirySet(UNIX_SECONDS, unixSeconds);
+        }
+
+        /**
+         * Set the specified Unix time at which the field will expire, in milliseconds. Equivalent to
+         * <code>PXAT</code> in the Valkey API.
+         *
+         * @param unixMilliseconds <code>UNIX TIME</code> to expire, in milliseconds.
+         * @return ExpirySet
+         */
+        public static ExpirySet UnixMilliseconds(Long unixMilliseconds) {
+            return new ExpirySet(UNIX_MILLISECONDS, unixMilliseconds);
+        }
+
+        /**
+         * Converts ExpirySet into a String[] to add to command arguments.
+         *
+         * @return String[]
+         */
+        public String[] toArgs() {
+            List<String> args = new ArrayList<>();
+            args.add(type.valkeyApi);
+            if (type != KEEP_EXISTING) {
+                assert count != null
+                        : "Hash field expiration command received expiry type "
+                                + type
+                                + ", but count was not set.";
+                args.add(count.toString());
+            }
+            return args.toArray(new String[0]);
+        }
+    }
+
+    /** Types of field expiration configuration. */
+    @RequiredArgsConstructor
+    protected enum ExpiryType {
+        KEEP_EXISTING("KEEPTTL"),
+        SECONDS("EX"),
+        MILLISECONDS("PX"),
+        UNIX_SECONDS("EXAT"),
+        UNIX_MILLISECONDS("PXAT");
+
+        private final String valkeyApi;
+    }
+
+    /**
+     * Validates that mutually exclusive options are not set together.
+     *
+     * @throws IllegalArgumentException if mutually exclusive options are set
+     */
+    private void validateOptions() {
+        // Validate that conditionalChange and fieldConditionalChange are not both set to conflicting
+        // values
+        if (conditionalChange != null && fieldConditionalChange != null) {
+            // Both NX-type options or both XX-type options would be redundant but not conflicting
+            // The validation here is more about logical consistency
+            if ((conditionalChange == ConditionalChange.ONLY_IF_DOES_NOT_EXIST
+                            && fieldConditionalChange == FieldConditionalChange.ONLY_IF_ALL_EXIST)
+                    || (conditionalChange == ConditionalChange.ONLY_IF_EXISTS
+                            && fieldConditionalChange == FieldConditionalChange.ONLY_IF_NONE_EXIST)) {
+                throw new IllegalArgumentException(
+                        "Conflicting conditional options: "
+                                + conditionalChange
+                                + " and "
+                                + fieldConditionalChange);
+            }
+        }
+    }
+
+    /**
+     * Converts HashFieldExpirationOptions into a String[] to add to command arguments. This method
+     * validates options before conversion.
+     *
+     * @return String[]
+     * @throws IllegalArgumentException if mutually exclusive options are set
+     */
+    public String[] toArgs() {
+        validateOptions();
+
+        List<String> optionArgs = new ArrayList<>();
+
+        if (conditionalChange != null) {
+            optionArgs.add(conditionalChange.valkeyApi);
+        }
+
+        if (fieldConditionalChange != null) {
+            optionArgs.add(fieldConditionalChange.valkeyApi);
+        }
+
+        if (expirationCondition != null) {
+            optionArgs.add(expirationCondition.valkeyApi);
+        }
+
+        if (expiry != null) {
+            String[] expiryArgs = expiry.toArgs();
+            for (String arg : expiryArgs) {
+                optionArgs.add(arg);
+            }
+        }
+
+        return optionArgs.toArray(new String[0]);
+    }
+
+    /** Builder class for {@link HashFieldExpirationOptions}. */
+    public static class HashFieldExpirationOptionsBuilder {
+        /**
+         * Sets the condition to {@link ConditionalChange#ONLY_IF_EXISTS} for the operation.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder conditionalSetOnlyIfExists() {
+            this.conditionalChange = ConditionalChange.ONLY_IF_EXISTS;
+            return this;
+        }
+
+        /**
+         * Sets the condition to {@link ConditionalChange#ONLY_IF_DOES_NOT_EXIST} for the operation.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder conditionalSetOnlyIfNotExist() {
+            this.conditionalChange = ConditionalChange.ONLY_IF_DOES_NOT_EXIST;
+            return this;
+        }
+
+        /**
+         * Sets the field condition to {@link FieldConditionalChange#ONLY_IF_ALL_EXIST}.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder fieldConditionalSetOnlyIfAllExist() {
+            this.fieldConditionalChange = FieldConditionalChange.ONLY_IF_ALL_EXIST;
+            return this;
+        }
+
+        /**
+         * Sets the field condition to {@link FieldConditionalChange#ONLY_IF_NONE_EXIST}.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder fieldConditionalSetOnlyIfNoneExist() {
+            this.fieldConditionalChange = FieldConditionalChange.ONLY_IF_NONE_EXIST;
+            return this;
+        }
+
+        /**
+         * Sets the expiration condition to {@link ExpirationCondition#ONLY_IF_NO_EXPIRY}.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder expirationConditionOnlyIfNoExpiry() {
+            this.expirationCondition = ExpirationCondition.ONLY_IF_NO_EXPIRY;
+            return this;
+        }
+
+        /**
+         * Sets the expiration condition to {@link ExpirationCondition#ONLY_IF_HAS_EXPIRY}.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder expirationConditionOnlyIfHasExpiry() {
+            this.expirationCondition = ExpirationCondition.ONLY_IF_HAS_EXPIRY;
+            return this;
+        }
+
+        /**
+         * Sets the expiration condition to {@link ExpirationCondition#ONLY_IF_GREATER_THAN_CURRENT}.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder expirationConditionOnlyIfGreaterThanCurrent() {
+            this.expirationCondition = ExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT;
+            return this;
+        }
+
+        /**
+         * Sets the expiration condition to {@link ExpirationCondition#ONLY_IF_LESS_THAN_CURRENT}.
+         *
+         * @return This builder instance
+         */
+        public HashFieldExpirationOptionsBuilder expirationConditionOnlyIfLessThanCurrent() {
+            this.expirationCondition = ExpirationCondition.ONLY_IF_LESS_THAN_CURRENT;
+            return this;
+        }
+    }
+}

--- a/java/client/src/test/java/glide/api/commands/HashFieldExpirationCommandsTest.java
+++ b/java/client/src/test/java/glide/api/commands/HashFieldExpirationCommandsTest.java
@@ -1,0 +1,168 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import glide.api.models.commands.HashFieldExpirationOptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for hash field expiration commands options and validation. Integration tests are in
+ * the integTest module.
+ */
+public class HashFieldExpirationCommandsTest {
+
+    // Unit tests for HashFieldExpirationOptions validation
+    @Test
+    public void hashFieldExpirationOptions_validation_success() {
+        // Test valid option combinations
+        HashFieldExpirationOptions options1 =
+                HashFieldExpirationOptions.builder()
+                        .expiry(HashFieldExpirationOptions.ExpirySet.Seconds(60L))
+                        .build();
+        assertNotNull(options1.toArgs());
+
+        HashFieldExpirationOptions options2 =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfExists()
+                        .fieldConditionalSetOnlyIfAllExist()
+                        .expiry(HashFieldExpirationOptions.ExpirySet.Milliseconds(30000L))
+                        .build();
+        assertNotNull(options2.toArgs());
+
+        HashFieldExpirationOptions options3 =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfNotExist()
+                        .fieldConditionalSetOnlyIfNoneExist()
+                        .expiry(
+                                HashFieldExpirationOptions.ExpirySet.UnixSeconds(
+                                        System.currentTimeMillis() / 1000 + 3600))
+                        .build();
+        assertNotNull(options3.toArgs());
+
+        HashFieldExpirationOptions options4 =
+                HashFieldExpirationOptions.builder()
+                        .expiry(
+                                HashFieldExpirationOptions.ExpirySet.UnixMilliseconds(
+                                        System.currentTimeMillis() + 3600000))
+                        .build();
+        assertNotNull(options4.toArgs());
+
+        HashFieldExpirationOptions options5 =
+                HashFieldExpirationOptions.builder()
+                        .expiry(HashFieldExpirationOptions.ExpirySet.KeepExisting())
+                        .build();
+        assertNotNull(options5.toArgs());
+    }
+
+    @Test
+    public void hashFieldExpirationOptions_validation_conflicting_options() {
+        // Test conflicting conditional options
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    HashFieldExpirationOptions.builder()
+                            .conditionalSetOnlyIfNotExist() // NX
+                            .fieldConditionalSetOnlyIfAllExist() // FXX
+                            .build()
+                            .toArgs();
+                });
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    HashFieldExpirationOptions.builder()
+                            .conditionalSetOnlyIfExists() // XX
+                            .fieldConditionalSetOnlyIfNoneExist() // FNX
+                            .build()
+                            .toArgs();
+                });
+    }
+
+    @Test
+    public void hashFieldExpirationOptions_toArgs_correctFormat() {
+        // Test that options are converted to correct argument format
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfExists()
+                        .fieldConditionalSetOnlyIfAllExist()
+                        .expiry(HashFieldExpirationOptions.ExpirySet.Seconds(60L))
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals("XX", args[0]);
+        assertEquals("FXX", args[1]);
+        assertEquals("EX", args[2]);
+        assertEquals("60", args[3]);
+    }
+
+    @Test
+    public void hashFieldExpirationOptions_builder_methods() {
+        // Test all builder methods work correctly
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfExists()
+                        .fieldConditionalSetOnlyIfAllExist()
+                        .expirationConditionOnlyIfGreaterThanCurrent()
+                        .expiry(HashFieldExpirationOptions.ExpirySet.Seconds(60L))
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals(5, args.length);
+        assertEquals("XX", args[0]);
+        assertEquals("FXX", args[1]);
+        assertEquals("GT", args[2]);
+        assertEquals("EX", args[3]);
+        assertEquals("60", args[4]);
+    }
+
+    @Test
+    public void hashFieldExpirationOptions_expiration_conditions() {
+        // Test all expiration conditions
+        HashFieldExpirationOptions nxOptions =
+                HashFieldExpirationOptions.builder().expirationConditionOnlyIfNoExpiry().build();
+        assertEquals("NX", nxOptions.toArgs()[0]);
+
+        HashFieldExpirationOptions xxOptions =
+                HashFieldExpirationOptions.builder().expirationConditionOnlyIfHasExpiry().build();
+        assertEquals("XX", xxOptions.toArgs()[0]);
+
+        HashFieldExpirationOptions gtOptions =
+                HashFieldExpirationOptions.builder().expirationConditionOnlyIfGreaterThanCurrent().build();
+        assertEquals("GT", gtOptions.toArgs()[0]);
+
+        HashFieldExpirationOptions ltOptions =
+                HashFieldExpirationOptions.builder().expirationConditionOnlyIfLessThanCurrent().build();
+        assertEquals("LT", ltOptions.toArgs()[0]);
+    }
+
+    @Test
+    public void hashFieldExpirationOptions_empty_options() {
+        // Test empty options
+        HashFieldExpirationOptions options = HashFieldExpirationOptions.builder().build();
+        String[] args = options.toArgs();
+        assertEquals(0, args.length);
+    }
+
+    @Test
+    public void hashFieldExpirationOptions_complex_combination() {
+        // Test complex combination of options
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfNotExist()
+                        .fieldConditionalSetOnlyIfNoneExist()
+                        .expirationConditionOnlyIfLessThanCurrent()
+                        .expiry(HashFieldExpirationOptions.ExpirySet.UnixMilliseconds(1640995200000L))
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals(5, args.length);
+        assertEquals("NX", args[0]);
+        assertEquals("FNX", args[1]);
+        assertEquals("LT", args[2]);
+        assertEquals("PXAT", args[3]);
+        assertEquals("1640995200000", args[4]);
+    }
+}

--- a/java/client/src/test/java/glide/api/models/commands/HashFieldExpirationOptionsTest.java
+++ b/java/client/src/test/java/glide/api/models/commands/HashFieldExpirationOptionsTest.java
@@ -1,0 +1,186 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.commands;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class HashFieldExpirationOptionsTest {
+
+    @Test
+    public void testConditionalChangeEnums() {
+        assertEquals("XX", HashFieldExpirationOptions.ConditionalChange.ONLY_IF_EXISTS.getValkeyApi());
+        assertEquals(
+                "NX", HashFieldExpirationOptions.ConditionalChange.ONLY_IF_DOES_NOT_EXIST.getValkeyApi());
+    }
+
+    @Test
+    public void testFieldConditionalChangeEnums() {
+        assertEquals(
+                "FXX", HashFieldExpirationOptions.FieldConditionalChange.ONLY_IF_ALL_EXIST.getValkeyApi());
+        assertEquals(
+                "FNX", HashFieldExpirationOptions.FieldConditionalChange.ONLY_IF_NONE_EXIST.getValkeyApi());
+    }
+
+    @Test
+    public void testExpirationConditionEnums() {
+        assertEquals(
+                "NX", HashFieldExpirationOptions.ExpirationCondition.ONLY_IF_NO_EXPIRY.getValkeyApi());
+        assertEquals(
+                "XX", HashFieldExpirationOptions.ExpirationCondition.ONLY_IF_HAS_EXPIRY.getValkeyApi());
+        assertEquals(
+                "GT",
+                HashFieldExpirationOptions.ExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT.getValkeyApi());
+        assertEquals(
+                "LT",
+                HashFieldExpirationOptions.ExpirationCondition.ONLY_IF_LESS_THAN_CURRENT.getValkeyApi());
+    }
+
+    @Test
+    public void testExpirySetSeconds() {
+        HashFieldExpirationOptions.ExpirySet expiry = HashFieldExpirationOptions.ExpirySet.Seconds(60L);
+        String[] args = expiry.toArgs();
+        assertEquals(2, args.length);
+        assertEquals("EX", args[0]);
+        assertEquals("60", args[1]);
+    }
+
+    @Test
+    public void testExpirySetMilliseconds() {
+        HashFieldExpirationOptions.ExpirySet expiry =
+                HashFieldExpirationOptions.ExpirySet.Milliseconds(5000L);
+        String[] args = expiry.toArgs();
+        assertEquals(2, args.length);
+        assertEquals("PX", args[0]);
+        assertEquals("5000", args[1]);
+    }
+
+    @Test
+    public void testExpirySetUnixSeconds() {
+        HashFieldExpirationOptions.ExpirySet expiry =
+                HashFieldExpirationOptions.ExpirySet.UnixSeconds(1640995200L);
+        String[] args = expiry.toArgs();
+        assertEquals(2, args.length);
+        assertEquals("EXAT", args[0]);
+        assertEquals("1640995200", args[1]);
+    }
+
+    @Test
+    public void testExpirySetUnixMilliseconds() {
+        HashFieldExpirationOptions.ExpirySet expiry =
+                HashFieldExpirationOptions.ExpirySet.UnixMilliseconds(1640995200000L);
+        String[] args = expiry.toArgs();
+        assertEquals(2, args.length);
+        assertEquals("PXAT", args[0]);
+        assertEquals("1640995200000", args[1]);
+    }
+
+    @Test
+    public void testExpirySetKeepExisting() {
+        HashFieldExpirationOptions.ExpirySet expiry =
+                HashFieldExpirationOptions.ExpirySet.KeepExisting();
+        String[] args = expiry.toArgs();
+        assertEquals(1, args.length);
+        assertEquals("KEEPTTL", args[0]);
+    }
+
+    @Test
+    public void testBasicOptionsToArgs() {
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalChange(HashFieldExpirationOptions.ConditionalChange.ONLY_IF_EXISTS)
+                        .fieldConditionalChange(
+                                HashFieldExpirationOptions.FieldConditionalChange.ONLY_IF_ALL_EXIST)
+                        .expiry(HashFieldExpirationOptions.ExpirySet.Seconds(60L))
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals(4, args.length);
+        assertEquals("XX", args[0]);
+        assertEquals("FXX", args[1]);
+        assertEquals("EX", args[2]);
+        assertEquals("60", args[3]);
+    }
+
+    @Test
+    public void testExpirationConditionToArgs() {
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .expirationCondition(
+                                HashFieldExpirationOptions.ExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT)
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals(1, args.length);
+        assertEquals("GT", args[0]);
+    }
+
+    @Test
+    public void testEmptyOptionsToArgs() {
+        HashFieldExpirationOptions options = HashFieldExpirationOptions.builder().build();
+        String[] args = options.toArgs();
+        assertEquals(0, args.length);
+    }
+
+    @Test
+    public void testValidationConflictingConditionalOptions() {
+        // Test conflicting conditional options: hash doesn't exist (NX) but all fields must exist (FXX)
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalChange(HashFieldExpirationOptions.ConditionalChange.ONLY_IF_DOES_NOT_EXIST)
+                        .fieldConditionalChange(
+                                HashFieldExpirationOptions.FieldConditionalChange.ONLY_IF_ALL_EXIST)
+                        .build();
+
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, options::toArgs);
+        assertTrue(exception.getMessage().contains("Conflicting conditional options"));
+    }
+
+    @Test
+    public void testValidationConflictingConditionalOptions2() {
+        // Test conflicting conditional options: hash must exist (XX) but no fields should exist (FNX)
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalChange(HashFieldExpirationOptions.ConditionalChange.ONLY_IF_EXISTS)
+                        .fieldConditionalChange(
+                                HashFieldExpirationOptions.FieldConditionalChange.ONLY_IF_NONE_EXIST)
+                        .build();
+
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, options::toArgs);
+        assertTrue(exception.getMessage().contains("Conflicting conditional options"));
+    }
+
+    @Test
+    public void testBuilderMethods() {
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfExists()
+                        .fieldConditionalSetOnlyIfAllExist()
+                        .expirationConditionOnlyIfGreaterThanCurrent()
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals(3, args.length);
+        assertEquals("XX", args[0]);
+        assertEquals("FXX", args[1]);
+        assertEquals("GT", args[2]);
+    }
+
+    @Test
+    public void testBuilderMethodsAlternative() {
+        HashFieldExpirationOptions options =
+                HashFieldExpirationOptions.builder()
+                        .conditionalSetOnlyIfNotExist()
+                        .fieldConditionalSetOnlyIfNoneExist()
+                        .expirationConditionOnlyIfNoExpiry()
+                        .build();
+
+        String[] args = options.toArgs();
+        assertEquals(3, args.length);
+        assertEquals("NX", args[0]);
+        assertEquals("FNX", args[1]);
+        assertEquals("NX", args[2]); // expiration condition NX
+    }
+}


### PR DESCRIPTION
### Overview
This PR implements support for hash field expiration commands in the Java client, specifically adding the `HSETEX` command functionality. This feature allows setting hash fields with expiration times and various conditional options.

### Changes Made

### Core Protocol Updates
- **Protobuf Definition**: Added `HSetex = 617` to the command request protocol
- **Rust Request Types**: Updated `request_type.rs` to include the new `HSetex` command type with proper mapping and command generation

#### Java Client Implementation

##### New Classes
- **`HashFieldExpirationOptions`**: options class with builder pattern supporting:
  - Conditional changes (NX/XX for hash existence)
  - Field conditional changes (FNX/FXX for field existence)
  - Expiration conditions (NX/XX/GT/LT for expiry management)
  - Multiple expiry types (seconds, milliseconds, Unix timestamps, keep existing)

##### Interface Updates
- **`HashBaseCommands`**: Added `hsetex()` methods for both String and GlideString variants
- **`BaseClient`**: Implemented the actual command execution logic
- **`BaseBatch`**: Added batch operation support for `hsetex`

#### Testing Coverage

##### Unit Tests
- **`HashFieldExpirationOptionsTest`**: testing of the options class
- **`HashFieldExpirationCommandsTest`**: Dedicated test class for command functionality
- **`GlideClientTest`**: Integration of hsetex tests into main client test suite
- **`BatchTests`**: Batch operation testing

##### Integration Tests
- **`SharedCommandTests`**: End-to-end testing to verify command functionality

### Issue link

This Pull Request is linked to issue (URL): #4496 

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [X] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
