### PR TITLE
FFI & Sync Python: add sync logger

### DIFF
--- a/ffi/miri-tests/README.md
+++ b/ffi/miri-tests/README.md
@@ -2,7 +2,7 @@
 
 These tests are for running MIRI over the FFI layer.
 
-The `mock-redis`, `mock-glide-core`, `mock-telemetry`, and `mock-tokio` crates
+The `mock-redis`, `mock-glide-core`, `mock-telemetry`, `mock-tokio` and `mock-logger-core` crates
 found here are used to mock out components that prevented MIRI tests from
 running. This is because MIRI does not support calling foreign code, which
 happens in a few places in `tokio` and Rust's `std` library.

--- a/ffi/miri-tests/mock-logger-core/src/lib.rs
+++ b/ffi/miri-tests/mock-logger-core/src/lib.rs
@@ -3,6 +3,16 @@
 // Mock logger_core implementation for miri tests
 // These functions are no-ops to avoid any complex logging infrastructure
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Level {
+    Error = 0,
+    Warn = 1,
+    Info = 2,
+    Debug = 3,
+    Trace = 4,
+    Off = 5,
+}
+
 pub fn log_error(_module: &str, _message: impl std::fmt::Display) {
     // No-op for miri tests
 }
@@ -17,4 +27,16 @@ pub fn log_debug(_module: &str, _message: impl std::fmt::Display) {
 
 pub fn log_info(_module: &str, _message: impl std::fmt::Display) {
     // No-op for miri tests
+}
+
+pub fn init(_minimal_level: Option<Level>, _file_name: Option<&str>) -> Level {
+    Level::Warn
+}
+
+pub fn log<Message: AsRef<str>, Identifier: AsRef<str>>(
+    _log_level: Level,
+    _log_identifier: Identifier,
+    _message: Message,
+) {
+    // No-op for Miri tests
 }

--- a/ffi/miri-tests/tests/ffi_miri_tests.rs
+++ b/ffi/miri-tests/tests/ffi_miri_tests.rs
@@ -165,8 +165,7 @@ fn test_create_otel_span_with_parent_miri() {
     );
 
     // Test with invalid parent pointer (should fallback to independent span)
-    let child_invalid_parent =
-        unsafe { create_otel_span_with_parent(RequestType::Exists, 0xDEADBEEF) };
+    let child_invalid_parent = unsafe { create_otel_span_with_parent(RequestType::Exists, 0xDEADBEEF) };
     assert_ne!(
         child_invalid_parent, 0,
         "Child span with invalid parent should fallback"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2778,10 +2778,8 @@ pub unsafe extern "C" fn init(level: *const Level, file_name: *const c_char) -> 
         }
     };
 
-    // Initialize the logger and get the actual level that was set
     let logger_level = logger_core::init(level_option, file_name_option);
 
-    // Return success with the actual level
     Box::into_raw(Box::new(LogResult {
         log_error: std::ptr::null_mut(),
         level: logger_level.into(),

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -301,6 +301,54 @@ pub struct CommandError {
     pub command_error_type: RequestErrorType,
 }
 
+/// Represents the result of a logging operation.
+///
+/// This struct is used to communicate both success/failure status and relevant data
+/// across the FFI boundary. For initialization operations, it contains the log level
+/// that was set. For other operations, it primarily indicates success or failure.
+///
+/// # Fields
+///
+/// - `log_error`: A pointer to a null-terminated C string containing an error message.
+///   This field is `null` if the operation succeeded, or points to an error description
+///   if the operation failed.
+/// - `level`: The log level value. For initialization operations, this contains the
+///   actual level that was set by the logger. For other operations, this field may
+///   be ignored when there's an error.
+///
+/// # Memory Management
+///
+/// The returned `LogResult` must be freed using [`free_log_result`] to avoid memory leaks.
+/// This will properly deallocate both the struct itself and any error message it contains.
+///
+/// # Safety
+///
+/// - The `log_error` field must either be null or point to a valid, null-terminated C string
+/// - The struct must be freed exactly once using [`free_log_result`]
+/// - The error string must not be accessed after the struct has been freed
+/// - The `level` field is only meaningful when `log_error` is null (success case)
+///
+/// # Example Usage Pattern
+///
+/// ```c
+/// LogResult* result = init(level_ptr, file_name);
+/// if (result != NULL) {
+///     if (result->log_error != NULL) {
+///         // Handle error case
+///         printf("Operation failed: %s\n", result->log_error);
+///     } else {
+///         // Success case - use the level
+///         printf("Logger initialized with level: %d\n", result->level);
+///     }
+///     free_log_result(result);
+/// }
+/// ```
+#[repr(C)]
+pub struct LogResult {
+    pub log_error: *mut c_char,
+    pub level: Level,
+}
+
 /// Represents the result of executing a command, either a successful response or an error.
 ///
 /// This is the  return type for FFI functions that execute commands synchronously (e.g. with a SyncClient).
@@ -2657,22 +2705,50 @@ impl From<Level> for logger_core::Level {
 /// The caller (Python, etc.) is responsible for filtering log messages according to the logger's current log level.
 /// This function will log any message it receives.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn log(level: Level, identifier: *const c_char, message: *const c_char) {
-    let id_str = unsafe {
-        CStr::from_ptr(identifier)
-            .to_str()
-            .expect("Log identifier should be valid UTF-8")
+pub unsafe extern "C" fn log(
+    level: Level,
+    identifier: *const c_char,
+    message: *const c_char,
+) -> *mut LogResult {
+    let id_str = match unsafe { CStr::from_ptr(identifier).to_str() } {
+        Ok(s) => s,
+        Err(err) => {
+            let c_err = CString::new(format!("Log identifier error: {err}"))
+                .unwrap_or_default()
+                .into_raw();
+            return Box::into_raw(Box::new(LogResult {
+                log_error: c_err,
+                level: Level::OFF, // Default value, should be ignored when there's an error
+            }));
+        }
     };
-    let msg_str = unsafe {
-        CStr::from_ptr(message)
-            .to_str()
-            .expect("Log message should be valid UTF-8")
+
+    let msg_str = match unsafe { CStr::from_ptr(message).to_str() } {
+        Ok(s) => s,
+        Err(err) => {
+            let c_err = CString::new(format!("Log message error: {err}"))
+                .unwrap_or_default()
+                .into_raw();
+            return Box::into_raw(Box::new(LogResult {
+                log_error: c_err,
+                level: Level::OFF, // Default value, should be ignored when there's an error
+            }));
+        }
     };
 
     logger_core::log(level.into(), id_str, msg_str);
+
+    Box::into_raw(Box::new(LogResult {
+        log_error: std::ptr::null_mut(),
+        level: Level::OFF, // Level is not meaningful for log operations, but set a default
+    }))
 }
 
 /// Initializes the logger with the provided log level and optional log file path.
+///
+/// This function provides proper error handling instead of panicking on invalid input.
+/// Success is indicated by a `LogResult` with a null `log_error` field and the actual
+/// log level set in the `level` field.
 ///
 /// # Parameters
 ///
@@ -2681,14 +2757,19 @@ pub unsafe extern "C" fn log(level: Level, identifier: *const c_char, message: *
 ///
 /// # Returns
 ///
-/// The actual log level set by the logger.
+/// A pointer to a `LogResult` struct containing either:
+/// - Success: `log_error` is null, `level` contains the actual log level that was set
+/// - Error: `log_error` contains the error message, `level` should be ignored
+///
+/// The returned pointer must be freed using [`free_log_result`].
 ///
 /// # Safety
 ///
 /// * `level` may be null. If not null, it must point to a valid instance of the `Level` enum.
-/// * `file_name` may be null. If not null, it must point to a valid, null-terminated UTF-8 encoded C string.
+/// * `file_name` may be null. If not null, it must point to a valid, null-terminated C string.
+///   If the string contains invalid UTF-8, an error will be returned instead of panicking.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn init(level: *const Level, file_name: *const c_char) -> Level {
+pub unsafe extern "C" fn init(level: *const Level, file_name: *const c_char) -> *mut LogResult {
     let level_option = if level.is_null() {
         None
     } else {
@@ -2698,13 +2779,51 @@ pub unsafe extern "C" fn init(level: *const Level, file_name: *const c_char) -> 
     let file_name_option = if file_name.is_null() {
         None
     } else {
-        Some(unsafe {
-            CStr::from_ptr(file_name)
-                .to_str()
-                .expect("File name should be valid UTF-8")
-        })
+        match unsafe { CStr::from_ptr(file_name).to_str() } {
+            Ok(file_str) => Some(file_str),
+            Err(err) => {
+                let c_err = CString::new(format!("File name contains invalid UTF-8: {err}"))
+                    .unwrap_or_else(|_| CString::new("File name contains invalid UTF-8").unwrap())
+                    .into_raw();
+                return Box::into_raw(Box::new(LogResult {
+                    log_error: c_err,
+                    level: Level::OFF, // Default value, should be ignored when there's an error
+                }));
+            }
+        }
     };
 
+    // Initialize the logger and get the actual level that was set
     let logger_level = logger_core::init(level_option, file_name_option);
-    logger_level.into()
+
+    // Return success with the actual level
+    Box::into_raw(Box::new(LogResult {
+        log_error: std::ptr::null_mut(),
+        level: logger_level.into(),
+    }))
+}
+
+/// Frees a log result.
+///
+/// This function deallocates a `LogResult` struct and any error message it contains.
+///
+/// # Parameters
+///
+/// * `result_ptr` - A pointer to the `LogResult` to free, or null.
+///
+/// # Safety
+///
+/// * `result_ptr` must be a valid pointer to a `LogResult` returned by [`log`] or [`init`], or null.
+/// * This function must be called exactly once for each `LogResult`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn free_log_result(result_ptr: *mut LogResult) {
+    if result_ptr.is_null() {
+        return;
+    }
+    unsafe {
+        let result = Box::from_raw(result_ptr);
+        if !result.log_error.is_null() {
+            free_c_string(result.log_error);
+        }
+    }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2724,7 +2724,7 @@ pub unsafe extern "C" fn log(
 
     Box::into_raw(Box::new(LogResult {
         log_error: std::ptr::null_mut(),
-        level: Level::OFF, // Level is not meaningful for log operations, but set a default
+        level, // Level is not meaningful for log operations, but set a default
     }))
 }
 

--- a/python/glide-async/python/glide/logger.py
+++ b/python/glide-async/python/glide/logger.py
@@ -40,7 +40,7 @@ class Logger:
     def init(cls, level: Optional[Level] = None, file_name: Optional[str] = None):
         """
         Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
-        replace an existing logger.
+        replace an existing logger. Otherwise, use `set_logger_config` for overriding the existing logger configs.
         The logger will filter all logs with a level lower than the given level.
         If given a file_name argument, will write the logs to files postfixed with file_name. If file_name isn't provided,
         the logs will be written to the console.

--- a/python/glide-shared/glide_shared/__init__.py
+++ b/python/glide-shared/glide_shared/__init__.py
@@ -151,6 +151,7 @@ from .exceptions import (
     ConnectionError,
     ExecAbortError,
     GlideError,
+    LoggerError,
     RequestError,
     TimeoutError,
 )
@@ -290,6 +291,7 @@ __all__ = [
     "GlideError",
     "RequestError",
     "TimeoutError",
+    "LoggerError",
     # Ft
     "DataType",
     "DistanceMetricType",

--- a/python/glide-shared/glide_shared/exceptions.py
+++ b/python/glide-shared/glide_shared/exceptions.py
@@ -63,6 +63,8 @@ class ConfigurationError(RequestError):
     Errors that are thrown when a request cannot be completed in current configuration settings.
     """
 
+    pass
+
 
 class LoggerError(GlideError):
     """

--- a/python/glide-shared/glide_shared/exceptions.py
+++ b/python/glide-shared/glide_shared/exceptions.py
@@ -64,6 +64,14 @@ class ConfigurationError(RequestError):
     """
 
 
+class LoggerError(GlideError):
+    """
+    Errors that are thrown when the logger has an error initializing.
+    """
+
+    pass
+
+
 def get_request_error_class(
     error_type: Optional[RequestErrorType.ValueType],
 ) -> Type[RequestError]:

--- a/python/glide-sync/glide_sync/__init__.py
+++ b/python/glide-sync/glide_sync/__init__.py
@@ -78,6 +78,7 @@ from glide_shared import (
     LexBoundary,
     Limit,
     ListDirection,
+    LoggerError,
     MaxId,
     MinId,
     NodeAddress,
@@ -275,10 +276,12 @@ __all__ = [
     "ConnectionError",
     "ExecAbortError",
     "GlideError",
-    "Logger",
-    "LogLevel",
     "RequestError",
     "TimeoutError",
+    "LoggerError",
+    # Logger
+    "Logger",
+    "LogLevel",
     # Ft
     "DataType",
     "DistanceMetricType",

--- a/python/glide-sync/glide_sync/__init__.py
+++ b/python/glide-sync/glide_sync/__init__.py
@@ -146,6 +146,8 @@ from glide_shared import (
 
 from .config import GlideClientConfiguration, GlideClusterClientConfiguration
 from .glide_client import GlideClient, GlideClusterClient, TGlideClient
+from .logger import Level as LogLevel
+from .logger import Logger
 
 __all__ = [
     # Client
@@ -273,6 +275,8 @@ __all__ = [
     "ConnectionError",
     "ExecAbortError",
     "GlideError",
+    "Logger",
+    "LogLevel",
     "RequestError",
     "TimeoutError",
     # Ft

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -22,6 +22,7 @@ from .config import (
     GlideClientConfiguration,
     GlideClusterClientConfiguration,
 )
+from .logger import Level, Logger
 from .sync_commands.cluster_commands import ClusterCommands
 from .sync_commands.core import CoreCommands
 from .sync_commands.standalone_commands import StandaloneCommands
@@ -108,6 +109,9 @@ class BaseClient(CoreCommands):
         client_response_ptr = self._lib.create_client(
             conn_req_bytes, len(conn_req_bytes), client_type
         )
+
+        Logger.log(Level.INFO, "connection info", "new connection established")
+
         # Handle the connection response
         if client_response_ptr != self._ffi.NULL:
             client_response = self._try_ffi_cast(

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -18,10 +18,7 @@ from glide_shared.exceptions import (
 from glide_shared.protobuf.command_request_pb2 import RequestType
 from glide_shared.routes import Route, build_protobuf_route
 
-from .config import (
-    GlideClientConfiguration,
-    GlideClusterClientConfiguration,
-)
+from .config import GlideClientConfiguration, GlideClusterClientConfiguration
 from .logger import Level, Logger
 from .sync_commands.cluster_commands import ClusterCommands
 from .sync_commands.core import CoreCommands

--- a/python/glide-sync/glide_sync/logger.py
+++ b/python/glide-sync/glide_sync/logger.py
@@ -1,0 +1,143 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import traceback
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from cffi import FFI
+
+ENCODING = "utf-8"
+CURR_DIR = Path(__file__).resolve().parent
+LIB_FILE = CURR_DIR / "libglide_ffi.so"
+
+
+class Level(Enum):
+    ERROR = 0
+    WARN = 1
+    INFO = 2
+    DEBUG = 3
+    TRACE = 4
+    OFF = 5
+
+
+class Logger:
+    """
+    A singleton class that allows logging which is consistent with logs from the internal GLIDE core.
+    The logger can be set up in 2 ways -
+    1. By calling Logger.init, which configures the logger only if it wasn't previously configured.
+    2. By calling Logger.set_logger_config, which replaces the existing configuration, and means that new logs will not be
+    saved with the logs that were sent before the call.
+    If none of these functions are called, the first log attempt will initialize a new logger with default configuration.
+    """
+
+    logger_level: Optional[Level] = None
+    _instance = None
+
+    def __init__(self, level: Optional[Level] = None, file_name: Optional[str] = None):
+
+        Logger.logger_level = level
+
+        self._init_ffi()
+
+        c_level = (
+            self._ffi.new("Level*", level.value)
+            if level is not None
+            else self._ffi.NULL
+        )
+        c_file_name = (
+            self._ffi.new("char[]", file_name.encode(ENCODING))
+            if file_name
+            else self._ffi.NULL
+        )
+
+        if file_name is not None:
+            c_file_name = self._ffi.new("char[]", file_name.encode(ENCODING))
+        else:
+            c_file_name = self._ffi.NULL
+
+        self._lib.init(c_level, c_file_name)
+
+    @classmethod
+    def init(cls, level: Optional[Level] = None, file_name: Optional[str] = None):
+        """
+        Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
+        replace an existing logger.
+        The logger will filter all logs with a level lower than the given level.
+        If given a file_name argument, will write the logs to files postfixed with file_name. If file_name isn't provided,
+        the logs will be written to the console.
+
+        Args:
+            level (Optional[Level]): Set the logger level to one of [ERROR, WARN, INFO, DEBUG, TRACE, OFF].
+                If log level isn't provided, the logger will be configured with default configuration.
+                To turn off logging completely, set the level to Level.OFF.
+            file_name (Optional[str]): If provided the target of the logs will be the file mentioned.
+                Otherwise, logs will be printed to the console.
+        """
+        if cls._instance is None:
+            cls._instance = cls(level, file_name)
+
+    @classmethod
+    def log(
+        cls,
+        log_level: Level,
+        log_identifier: str,
+        message: str,
+        err: Optional[Exception] = None,
+    ):
+        """
+        Logs the provided message if the provided log level is lower then the logger level.
+
+        Args:
+            log_level (Level): The log level of the provided message.
+            log_identifier (str): The log identifier should give the log a context.
+            message (str): The message to log.
+            err (Optional[Exception]): The exception or error to log.
+        """
+        if not cls._instance:
+            cls._instance = cls(None)
+        if err:
+            message = f"{message}: {traceback.format_exception(err)}"
+
+        c_identifier = cls._ffi.new("char[]", log_identifier.encode(ENCODING))
+        c_message = cls._ffi.new("char[]", message.encode(ENCODING))
+
+        cls._lib.log(log_level.value, cls.logger_level.value, c_identifier, c_message)
+
+    @classmethod
+    def _init_ffi(cls):
+        cls._ffi = FFI()
+        cls._ffi.cdef(
+            """
+            typedef enum {
+                Error = 0,
+                Warn = 1,
+                Info = 2,
+                Debug = 3,
+                Trace = 4,
+                Off = 5
+            } Level;
+
+            Level init(const Level* level, const char* file_name);
+            void log(Level level, Level logger_level, const char* identifier, const char* message);
+        """
+        )
+        cls._lib = cls._ffi.dlopen(str(LIB_FILE.resolve()))
+
+    @classmethod
+    def set_logger_config(
+        cls, level: Optional[Level] = None, file_name: Optional[str] = None
+    ):
+        """
+        Creates a new logger instance and configure it with the provided log level and file name.
+
+        Args:
+            level (Optional[Level]): Set the logger level to one of [ERROR, WARN, INFO, DEBUG, TRACE, OFF].
+                If log level isn't provided, the logger will be configured with default configuration.
+                To turn off logging completely, set the level to OFF.
+            file_name (Optional[str]): If provided the target of the logs will be the file mentioned.
+                Otherwise, logs will be printed to the console.
+        """
+        Logger._instance = Logger(level, file_name)

--- a/python/glide-sync/glide_sync/logger.py
+++ b/python/glide-sync/glide_sync/logger.py
@@ -73,7 +73,7 @@ class Logger:
     def init(cls, level: Optional[Level] = None, file_name: Optional[str] = None):
         """
         Initialize a logger if it wasn't initialized before - this method is meant to be used when there is no intention to
-        replace an existing logger.
+        replace an existing logger. Otherwise, use `set_logger_config` for overriding the existing logger configs.
         The logger will filter all logs with a level lower than the given level.
         If given a file_name argument, will write the logs to files postfixed with file_name. If file_name isn't provided,
         the logs will be written to the console.
@@ -125,10 +125,10 @@ class Logger:
                     # If the log failed due to invalid provided identifier or message,
                     # Log the FFI log error using logger_core directly
                     error_identifier = Logger._ffi.new(
-                        "char[]", "Logger.log".encode(ENCODING)
+                        "char[]", "Logger".encode(ENCODING)
                     )
                     error_message = Logger._ffi.new(
-                        "char[]", f"FFI log error: {error_str}".encode(ENCODING)
+                        "char[]", f"log error: {error_str}".encode(ENCODING)
                     )
                     error_result_ptr = Logger._lib.log(
                         Level.ERROR.value, error_identifier, error_message
@@ -141,9 +141,9 @@ class Logger:
 
         else:
             # Log the null pointer error using logger_core directly
-            error_identifier = Logger._ffi.new("char[]", "Logger.log".encode(ENCODING))
+            error_identifier = Logger._ffi.new("char[]", "Logger".encode(ENCODING))
             error_message = Logger._ffi.new(
-                "char[]", "FFI Log function returned a null pointer".encode(ENCODING)
+                "char[]", "Log function returned a null pointer".encode(ENCODING)
             )
             error_result_ptr = Logger._lib.log(
                 Level.ERROR.value, error_identifier, error_message

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -14,9 +14,11 @@ from glide_shared.exceptions import ClosingError
 from glide_sync import GlideClient as SyncGlideClient
 from glide_sync import GlideClusterClient as SyncGlideClusterClient
 from glide_sync import TGlideClient as TSyncGlideClient
+from glide_sync.logger import Logger
 
 from tests.utils.cluster import ValkeyCluster
 from tests.utils.utils import (
+    DEFAULT_SYNC_TEST_LOG_LEVEL,
     INITIAL_PASSWORD,
     NEW_PASSWORD,
     USERNAME,
@@ -25,6 +27,8 @@ from tests.utils.utils import (
     create_sync_client_config,
     set_new_acl_username_with_password,
 )
+
+Logger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -12,6 +12,7 @@ from tests.utils.utils import (
     DEFAULT_SYNC_TEST_LOG_LEVEL,
     DEFAULT_TEST_LOG_LEVEL,
     compare_maps,
+    get_random_string,
 )
 
 CURR_DIR = Path(__file__).resolve().parent
@@ -37,22 +38,28 @@ class TestLogger:
         Logger.set_logger_config(DEFAULT_TEST_LOG_LEVEL)
         assert Logger.logger_level == DEFAULT_TEST_LOG_LEVEL.value
 
-    def test_init_does_not_override_existing_logger(self):
-        # Initialize first with set_logger_config to change the existing logger config
-        Logger.set_logger_config(level=Level.INFO)
-        logger1 = Logger._instance
-        level1 = Logger.logger_level
+    def test_log_writes_to_file(self):
+        filename = get_random_string(10) + ".log"
+        Logger.set_logger_config(Level.INFO, filename)
+        Logger.log(Level.INFO, "test", "test log message")
 
-        # Initialize the logger with init (should not change the existing logger)
-        Logger.init(level=Level.DEBUG)
-        logger2 = Logger._instance
-        level2 = Logger.logger_level
+        matched_files = find_log_files(filename)
+        assert (
+            len(matched_files) == 1
+        ), f"Expected exactly one log file with prefix '{filename}', found {len(matched_files)}"
 
-        # Assert singleton and level didn't change
-        assert logger1 is logger2
-        assert level1 == level2
+        log_file = matched_files[0]
 
-        # Revert the logger back to the default test log level
+        with open(log_file, "r", encoding="utf-8") as f:
+            contents = f.read()
+            assert (
+                "test log message" in contents
+            ), "Log message not found in the log file"
+
+        # Clean up the file
+        os.remove(log_file)
+
+        # Reset logger config to default
         Logger.set_logger_config(DEFAULT_TEST_LOG_LEVEL)
 
     def test_init_sync_logger(self):
@@ -67,22 +74,28 @@ class TestLogger:
         SyncLogger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
         assert SyncLogger.logger_level == DEFAULT_SYNC_TEST_LOG_LEVEL
 
-    def test_sync_init_does_not_override_existing_logger(self):
-        # Initialize first with set_logger_config to change the existing logger config
-        SyncLogger.set_logger_config(level=SyncLogLevel.INFO)
-        logger1 = SyncLogger._instance
-        level1 = SyncLogger.logger_level
+    def test_sync_log_writes_to_file(self):
+        filename = get_random_string(10) + ".log"
+        SyncLogger.set_logger_config(SyncLogLevel.INFO, filename)
+        SyncLogger.log(SyncLogLevel.INFO, "test", "test log message")
 
-        # Initialize the logger with init (should not change the existing logger)
-        SyncLogger.init(level=SyncLogLevel.DEBUG)
-        logger2 = SyncLogger._instance
-        level2 = SyncLogger.logger_level
+        matched_files = find_log_files(filename)
+        assert (
+            len(matched_files) == 1
+        ), f"Expected exactly one log file with prefix '{filename}', found {len(matched_files)}"
 
-        # Assert singleton and level didn't change
-        assert logger1 is logger2
-        assert level1 == level2
+        log_file = matched_files[0]
 
-        # Revert the logger back to the default test log level
+        with open(log_file, "r", encoding="utf-8") as f:
+            contents = f.read()
+            assert (
+                "test log message" in contents
+            ), "Log message not found in the log file"
+
+        # Clean up the file
+        os.remove(log_file)
+
+        # Reset logger config to default
         SyncLogger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
 
 

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -37,6 +37,24 @@ class TestLogger:
         Logger.set_logger_config(DEFAULT_TEST_LOG_LEVEL)
         assert Logger.logger_level == DEFAULT_TEST_LOG_LEVEL.value
 
+    def test_init_does_not_override_existing_logger(self):
+        # Initialize first with set_logger_config to change the existing logger config
+        Logger.set_logger_config(level=Level.INFO)
+        logger1 = Logger._instance
+        level1 = Logger.logger_level
+
+        # Initialize the logger with init (should not change the existing logger)
+        Logger.init(level=Level.DEBUG)
+        logger2 = Logger._instance
+        level2 = Logger.logger_level
+
+        # Assert singleton and level didn't change
+        assert logger1 is logger2
+        assert level1 == level2
+
+        # Revert the logger back to the default test log level
+        Logger.set_logger_config(DEFAULT_TEST_LOG_LEVEL)
+
     def test_init_sync_logger(self):
         # The logger is already configured in the conftest file, so calling init again shouldn't modify the log level
         SyncLogger.init(SyncLogLevel.ERROR)
@@ -49,27 +67,23 @@ class TestLogger:
         SyncLogger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
         assert SyncLogger.logger_level == DEFAULT_SYNC_TEST_LOG_LEVEL
 
-    def test_sync_logger_init_is_idempotent(self):
-        # Clean up any existing files before test
-        for prefix in ("first.log", "second.log"):
-            for f in find_log_files(prefix):
-                os.remove(f)
-
-        # Initialize once with first.log
-        SyncLogger.init(level=SyncLogLevel.INFO, file_name="first.log")
-        SyncLogger.log(SyncLogLevel.INFO, "test", "Message after first init")
+    def test_sync_init_does_not_override_existing_logger(self):
+        # Initialize first with set_logger_config to change the existing logger config
+        SyncLogger.set_logger_config(level=SyncLogLevel.INFO)
         logger1 = SyncLogger._instance
         level1 = SyncLogger.logger_level
 
-        # Re-run init with second.log (should NOT reconfigure)
-        SyncLogger.init(level=SyncLogLevel.DEBUG, file_name="second.log")
-        SyncLogger.log(SyncLogLevel.INFO, "test", "Message after second init")
+        # Initialize the logger with init (should not change the existing logger)
+        SyncLogger.init(level=SyncLogLevel.DEBUG)
         logger2 = SyncLogger._instance
         level2 = SyncLogger.logger_level
 
         # Assert singleton and level didn't change
         assert logger1 is logger2
         assert level1 == level2
+
+        # Revert the logger back to the default test log level
+        SyncLogger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
 
 
 class TestCompareMaps:

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,8 +1,14 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 from glide.logger import Level, Logger
+from glide_sync import LogLevel as SyncLogLevel
+from glide_sync.logger import Logger as SyncLogger
 
-from tests.utils.utils import DEFAULT_TEST_LOG_LEVEL, compare_maps
+from tests.utils.utils import (
+    DEFAULT_SYNC_TEST_LOG_LEVEL,
+    DEFAULT_TEST_LOG_LEVEL,
+    compare_maps,
+)
 
 
 class TestLogger:
@@ -17,6 +23,18 @@ class TestLogger:
         # Revert to the tests default log level
         Logger.set_logger_config(DEFAULT_TEST_LOG_LEVEL)
         assert Logger.logger_level == DEFAULT_TEST_LOG_LEVEL.value
+
+    def test_init_sync_logger(self):
+        # The logger is already configured in the conftest file, so calling init again shouldn't modify the log level
+        SyncLogger.init(SyncLogLevel.ERROR)
+        assert SyncLogger.logger_level == DEFAULT_SYNC_TEST_LOG_LEVEL
+
+    def test_sync_set_logger_config(self):
+        SyncLogger.set_logger_config(SyncLogLevel.INFO)
+        assert SyncLogger.logger_level == SyncLogLevel.INFO
+        # Revert to the tests default log level
+        SyncLogger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
+        assert SyncLogger.logger_level == DEFAULT_SYNC_TEST_LOG_LEVEL
 
 
 class TestCompareMaps:

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -54,7 +54,7 @@ TAnyGlideClient = Union[TGlideClient, TSyncGlideClient]
 
 T = TypeVar("T")
 DEFAULT_TEST_LOG_LEVEL = logLevel.OFF
-DEFAULT_SYNC_TEST_LOG_LEVEL = SyncLogLevel.OFF
+DEFAULT_SYNC_TEST_LOG_LEVEL = SyncLogLevel.DEBUG
 USERNAME = "username"
 INITIAL_PASSWORD = "initial_password"
 NEW_PASSWORD = "new_secure_password"

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -54,7 +54,7 @@ TAnyGlideClient = Union[TGlideClient, TSyncGlideClient]
 
 T = TypeVar("T")
 DEFAULT_TEST_LOG_LEVEL = logLevel.OFF
-DEFAULT_SYNC_TEST_LOG_LEVEL = SyncLogLevel.DEBUG
+DEFAULT_SYNC_TEST_LOG_LEVEL = SyncLogLevel.OFF
 USERNAME = "username"
 INITIAL_PASSWORD = "initial_password"
 NEW_PASSWORD = "new_secure_password"

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -45,6 +45,7 @@ from glide_sync.config import GlideClientConfiguration as SyncGlideClientConfigu
 from glide_sync.config import (
     GlideClusterClientConfiguration as SyncGlideClusterClientConfiguration,
 )
+from glide_sync.logger import Level as SyncLogLevel
 from packaging import version
 
 from tests.utils.cluster import ValkeyCluster
@@ -53,6 +54,7 @@ TAnyGlideClient = Union[TGlideClient, TSyncGlideClient]
 
 T = TypeVar("T")
 DEFAULT_TEST_LOG_LEVEL = logLevel.OFF
+DEFAULT_SYNC_TEST_LOG_LEVEL = SyncLogLevel.OFF
 USERNAME = "username"
 INITIAL_PASSWORD = "initial_password"
 NEW_PASSWORD = "new_secure_password"


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This PR adds FFI logger functions and implements the logger for the sync python client.

The FFI log function puts the responsibility of checking whether a log is below or above the set logger level **on the calling wrappper**, in order to avoid redundant FFI calls. 


### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/3999
### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
