### PR TITLE
Python sync: add update_connection_password

### DIFF
--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -90,7 +90,7 @@ async def acl_glide_client(
     """
     Client fot tests that use a server pre-configured with an ACL user.
     This function first uses the management client to register the USERNAME with INITIAL_PASSWORD,so that
-    the client would be ablt to connect.
+    the client would be able to connect.
     It then returns a client with this USERNAME and INITIAL_PASSWORD already set as its ServerCredentials.
     """
 

--- a/python/tests/sync_tests/test_sync_auth.py
+++ b/python/tests/sync_tests/test_sync_auth.py
@@ -1,0 +1,332 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+
+import time
+
+import pytest
+from glide_shared.config import ProtocolVersion
+from glide_shared.constants import OK
+from glide_shared.exceptions import RequestError
+from glide_sync.glide_client import TGlideClient
+
+from tests.utils.utils import (
+    NEW_PASSWORD,
+    USERNAME,
+    WRONG_PASSWORD,
+    auth_client,
+    config_set_new_password,
+    delete_acl_username_and_password,
+    kill_connections,
+    set_new_acl_username_with_password,
+)
+
+
+class TestSyncAuthCommands:
+    """Test cases for password authentication and management"""
+
+    @pytest.fixture(autouse=True, scope="function")
+    def cleanup(self, request, management_sync_client: TGlideClient):
+        """
+        Ensure password is reset for default user and USERNAME user is deleted after each test, regardless of test outcome.
+        This fixture runs after each test.
+        """
+        yield
+        try:
+            # reset password for default user
+            auth_client(management_sync_client, NEW_PASSWORD)
+            config_set_new_password(management_sync_client, "")
+            management_sync_client.update_connection_password(None)
+
+            # delete USERNAME user
+            delete_acl_username_and_password(management_sync_client, USERNAME)
+        except RequestError:
+            pass
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing the connection password without immediate re-authentication.
+        Verifies that:
+        1. The client can update its internal password
+        2. The client remains connected with current auth
+        3. The client can reconnect using the new password after server password change
+        This test is only for cluster mode, as standalone mode does not have a connection available handler
+        """
+        result = glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=False
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert glide_sync_client.set("test_key", "test_value") == OK
+        value = glide_sync_client.get("test_key")
+        assert value == b"test_value"
+        config_set_new_password(glide_sync_client, NEW_PASSWORD)
+        kill_connections(management_sync_client)
+        # Add a short delay to allow the server to apply the new password
+        # without this delay, command may or may not time out while the client reconnect
+        # ending up with a flaky test
+        time.sleep(2)
+        # Verify that the client is able to reconnect with the new password,
+        value = glide_sync_client.get("test_key")
+        assert value == b"test_value"
+        kill_connections(management_sync_client)
+        time.sleep(2)
+        # Verify that the client is able to immediateAuth with the new password after client is killed
+        result = glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert glide_sync_client.set("test_key", "test_value") == OK
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_connection_lost_before_password_update(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test changing server password when connection is lost before password update.
+        Verifies that the client will not be able to reach the inner core and return an error
+        on immediate re-authentication, but will succeed with non-immediate re-auth
+        """
+        glide_sync_client.set("test_key", "test_value")
+        config_set_new_password(glide_sync_client, NEW_PASSWORD)
+        kill_connections(management_sync_client)
+        time.sleep(2)
+        result = glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=False
+        )
+        assert result == OK
+        with pytest.raises(RequestError):
+            glide_sync_client.update_connection_password(
+                NEW_PASSWORD, immediate_auth=True
+            )
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_no_server_auth(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test that immediate re-authentication fails when no server password is set.
+        This verifies proper error handling when trying to re-authenticate with a
+        password when the server has no password set.
+        """
+        with pytest.raises(RequestError):
+            glide_sync_client.update_connection_password(
+                WRONG_PASSWORD, immediate_auth=True
+            )
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_long(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with a long password string.
+        Verifies that the client can handle long passwords (1000 characters).
+        """
+        long_password = "p" * 1000
+        result = glide_sync_client.update_connection_password(
+            long_password, immediate_auth=False
+        )
+        assert result == OK
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_replace_password_immediate_auth_wrong_password(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test that re-authentication fails when using wrong password.
+        Verifies proper error handling when immediate re-authentication is attempted
+        with a password that doesn't match the server's password.
+        """
+        config_set_new_password(glide_sync_client, NEW_PASSWORD)
+        with pytest.raises(RequestError):
+            glide_sync_client.update_connection_password(
+                WRONG_PASSWORD, immediate_auth=True
+            )
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_with_immediate_auth(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication.
+        Verifies that:
+        1. The client can update its password and re-authenticate immediately
+        2. The client remains operational after re-authentication
+        """
+        config_set_new_password(glide_sync_client, NEW_PASSWORD)
+        result = glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+        assert result == OK
+        # Verify that the client is still authenticated
+        assert glide_sync_client.set("test_key", "test_value") == OK
+        value = glide_sync_client.get("test_key")
+        assert value == b"test_value"
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_auth_non_valid_pass(
+        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication using a non-valid password.
+        Verifies that immediate re-authentication fails when the password is not valid.
+        """
+        with pytest.raises(RequestError):
+            glide_sync_client.update_connection_password(None, immediate_auth=True)
+        with pytest.raises(RequestError):
+            glide_sync_client.update_connection_password("", immediate_auth=True)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_with_acl_user(
+        self, acl_glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing the connection password for an ACL user without immediate re-authentication.
+        and not the default one.
+        Verifies that:
+        1. The client can update its internal password for the ACL user
+        2. The client remains connected with current auth
+        3. The client can reconnect using the new password after server password change (which is simulated by
+        deleting and reseting the user with a new password, which kills the connection).
+        """
+
+        # Create a new ACL user and authenticate the client as the new user
+        acl_glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=False
+        )
+
+        # Verify that the client is authenticated
+        assert acl_glide_sync_client.set("test_key", "test_value") == OK
+        value = acl_glide_sync_client.get("test_key")
+        assert value == b"test_value"
+
+        # Delete the username and reset it with new password (equivalent to config_set new password)
+        assert delete_acl_username_and_password(management_sync_client, USERNAME) == 1
+        set_new_acl_username_with_password(
+            management_sync_client, USERNAME, NEW_PASSWORD
+        )
+
+        # Sleep to allow enough time for reconnecting
+        time.sleep(2)
+
+        # The client should now reconnect with the new password automatically
+        # Verify that the client is still able to perform operations
+        value = acl_glide_sync_client.get("test_key")
+        assert value == b"test_value"
+
+        acl_glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+
+        assert acl_glide_sync_client.set("new_key", "new_value") == OK
+        value = acl_glide_sync_client.get("new_key")
+        assert value == b"new_value"
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_reconnection_with_immediate_auth_with_acl_user(
+        self, acl_glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication.
+        Verifies that:
+        1. Upon disconnection (which is caused by the user deletion), the client succeeds in re-authentication
+            with the correct password.
+        2. The client remains operational after re-authentication
+        This test is relevant only for cluster mode - in standalone, reconnection will fail and new requests for
+        the server won't be served.
+        """
+        assert delete_acl_username_and_password(management_sync_client, USERNAME) == 1
+        set_new_acl_username_with_password(
+            management_sync_client, USERNAME, NEW_PASSWORD
+        )
+
+        # Sleep to allow enough time for reconnecting
+        time.sleep(2)
+
+        # This command right after disconnection requires the acl_glide_sync_client to have a request timeout of 2000 ms
+        # for full matrix tests to pass (otherwise failing on linux-aarch64 architecture).
+        # TODO: We do not fully understand why such a long timeout is required.
+        result = acl_glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+        assert result == OK
+
+        # Verify client is authenticated
+        assert acl_glide_sync_client.set("test_key", "test_value") == OK
+        value = acl_glide_sync_client.get("test_key")
+        assert value == b"test_value"
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_connection_lost_before_password_update_acl_user(
+        self, acl_glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication.
+        Verifies that:
+        1. Upon disconnection (which is caused by the user deletion), the client succeeds in updating the password
+        with non-immediate auth (this is an internal operation not requiring a server connection).
+        2. Trying to connect with immediate authentication fails due to reconnection attempts with the previous password.
+        This test is relevant only for standalone - in standalone, reconnection will fail and new requests for
+        the server won't be served.
+        """
+        assert delete_acl_username_and_password(management_sync_client, USERNAME) == 1
+        set_new_acl_username_with_password(
+            management_sync_client, USERNAME, NEW_PASSWORD
+        )
+
+        # ensure client disconnection
+        time.sleep(2)
+
+        with pytest.raises(RequestError):
+            acl_glide_sync_client.update_connection_password(
+                NEW_PASSWORD, immediate_auth=True
+            )
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_replace_password_immediateAuth_acl_user(
+        self, acl_glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Tests adding a new password to the user, verifies that the client succeeds in immediate authentication with it.
+        """
+        set_new_acl_username_with_password(
+            management_sync_client, USERNAME, NEW_PASSWORD
+        )
+
+        result = acl_glide_sync_client.update_connection_password(
+            NEW_PASSWORD, immediate_auth=True
+        )
+
+        assert result == OK
+
+        assert acl_glide_sync_client.set("test_key", "test_value") == OK
+        value = acl_glide_sync_client.get("test_key")
+        assert value == b"test_value"
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_update_connection_password_auth_non_valid_pass_acl_user(
+        self, acl_glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+    ):
+        """
+        Test replacing connection password with immediate re-authentication using a non-valid password.
+        Verifies that immediate re-authentication fails when the password is not valid.
+        """
+        with pytest.raises(RequestError):
+            acl_glide_sync_client.update_connection_password(None, immediate_auth=True)
+        with pytest.raises(RequestError):
+            acl_glide_sync_client.update_connection_password("", immediate_auth=True)

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -424,19 +424,21 @@ def check_function_stats_response(
     assert expected == response.get(b"engines")
 
 
-async def set_new_acl_username_with_password(
-    client: TGlideClient, username: str, password: str
+def set_new_acl_username_with_password(
+    client: TAnyGlideClient, username: str, password: str
 ):
     """
-    Sets a new ACL user with the provided password
+    Sets a new ACL user with the provided password.
+    When passing a sync client, this returns the reuslt of the ACL SETUSER command.
+    When passing an async client, this returns a coroutine that should be awaited.
     """
     try:
-        if isinstance(client, GlideClient):
-            await client.custom_command(
+        if isinstance(client, (GlideClient, SyncGlideClient)):
+            return client.custom_command(
                 ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"]
             )
-        elif isinstance(client, GlideClusterClient):
-            await client.custom_command(
+        elif isinstance(client, (GlideClusterClient, SyncGlideClusterClient)):
+            return client.custom_command(
                 ["ACL", "SETUSER", username, "ON", f">{password}", "~*", "&*", "+@all"],
                 route=AllNodes(),
             )
@@ -444,17 +446,18 @@ async def set_new_acl_username_with_password(
         raise RuntimeError(f"Failed to set ACL user: {e}")
 
 
-async def delete_acl_username_and_password(client: TGlideClient, username: str):
+def delete_acl_username_and_password(client: TAnyGlideClient, username: str):
     """
-    Deletes the username and its password from the ACL list
+    Deletes the username and its password from the ACL list.
+    Sets a new ACL user with the provided password.
+    When passing a sync client, this returns the reuslt of the ACL DELUSER command.
+    When passing an async client, this returns a coroutine that should be awaited.
     """
-    if isinstance(client, GlideClient):
-        return await client.custom_command(["ACL", "DELUSER", username])
+    if isinstance(client, (GlideClient, SyncGlideClient)):
+        return client.custom_command(["ACL", "DELUSER", username])
 
-    elif isinstance(client, GlideClusterClient):
-        return await client.custom_command(
-            ["ACL", "DELUSER", username], route=AllNodes()
-        )
+    elif isinstance(client, (GlideClusterClient, SyncGlideClusterClient)):
+        return client.custom_command(["ACL", "DELUSER", username], route=AllNodes())
 
 
 def create_client_config(


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
This PR adds the update connection password function and tests to the python sync client.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4516

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
