### PR TITLE
Python: added async-sync API consistency test, re-export test

### DIFF
--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -33,8 +33,6 @@ from glide_shared.commands.core_options import (
     ConditionalChange,
     ExpireOptions,
     ExpiryGetEx,
-    ExpirySet,
-    ExpiryType,
     ExpiryTypeGetEx,
     FlushMode,
     FunctionRestorePolicy,
@@ -103,7 +101,6 @@ from tests.utils.utils import (
     generate_lua_lib_code,
     get_first_result,
     get_random_string,
-    is_single_response,
     parse_info_response,
     round_values,
 )
@@ -9684,110 +9681,6 @@ class TestMultiKeyCommandCrossSlot:
         await glide_client.mset({"abc": "1", "zxy": "2", "lkn": "3"})
         await glide_client.touch(["abc", "zxy", "lkn"])
         await glide_client.watch(["abc", "zxy", "lkn"])
-
-
-class TestCommandsUnitTests:
-    def test_expiry_cmd_args(self):
-        exp_sec = ExpirySet(ExpiryType.SEC, 5)
-        assert exp_sec.get_cmd_args() == ["EX", "5"]
-
-        exp_sec_timedelta = ExpirySet(ExpiryType.SEC, timedelta(seconds=5))
-        assert exp_sec_timedelta.get_cmd_args() == ["EX", "5"]
-
-        exp_millsec = ExpirySet(ExpiryType.MILLSEC, 5)
-        assert exp_millsec.get_cmd_args() == ["PX", "5"]
-
-        exp_millsec_timedelta = ExpirySet(ExpiryType.MILLSEC, timedelta(seconds=5))
-        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
-
-        exp_millsec_timedelta = ExpirySet(ExpiryType.MILLSEC, timedelta(seconds=5))
-        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
-
-        exp_unix_sec = ExpirySet(ExpiryType.UNIX_SEC, 1682575739)
-        assert exp_unix_sec.get_cmd_args() == ["EXAT", "1682575739"]
-
-        exp_unix_sec_datetime = ExpirySet(
-            ExpiryType.UNIX_SEC,
-            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
-        )
-        assert exp_unix_sec_datetime.get_cmd_args() == ["EXAT", "1682639759"]
-
-        exp_unix_millisec = ExpirySet(ExpiryType.UNIX_MILLSEC, 1682586559964)
-        assert exp_unix_millisec.get_cmd_args() == ["PXAT", "1682586559964"]
-
-        exp_unix_millisec_datetime = ExpirySet(
-            ExpiryType.UNIX_MILLSEC,
-            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
-        )
-        assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]
-
-    def test_get_expiry_cmd_args(self):
-        exp_sec = ExpiryGetEx(ExpiryTypeGetEx.SEC, 5)
-        assert exp_sec.get_cmd_args() == ["EX", "5"]
-
-        exp_sec_timedelta = ExpiryGetEx(ExpiryTypeGetEx.SEC, timedelta(seconds=5))
-        assert exp_sec_timedelta.get_cmd_args() == ["EX", "5"]
-
-        exp_millsec = ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 5)
-        assert exp_millsec.get_cmd_args() == ["PX", "5"]
-
-        exp_millsec_timedelta = ExpiryGetEx(
-            ExpiryTypeGetEx.MILLSEC, timedelta(seconds=5)
-        )
-        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
-
-        exp_millsec_timedelta = ExpiryGetEx(
-            ExpiryTypeGetEx.MILLSEC, timedelta(seconds=5)
-        )
-        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
-
-        exp_unix_sec = ExpiryGetEx(ExpiryTypeGetEx.UNIX_SEC, 1682575739)
-        assert exp_unix_sec.get_cmd_args() == ["EXAT", "1682575739"]
-
-        exp_unix_sec_datetime = ExpiryGetEx(
-            ExpiryTypeGetEx.UNIX_SEC,
-            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
-        )
-        assert exp_unix_sec_datetime.get_cmd_args() == ["EXAT", "1682639759"]
-
-        exp_unix_millisec = ExpiryGetEx(ExpiryTypeGetEx.UNIX_MILLSEC, 1682586559964)
-        assert exp_unix_millisec.get_cmd_args() == ["PXAT", "1682586559964"]
-
-        exp_unix_millisec_datetime = ExpiryGetEx(
-            ExpiryTypeGetEx.UNIX_MILLSEC,
-            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
-        )
-        assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]
-
-        exp_persist = ExpiryGetEx(
-            ExpiryTypeGetEx.PERSIST,
-            None,
-        )
-        assert exp_persist.get_cmd_args() == ["PERSIST"]
-
-    def test_expiry_raises_on_value_error(self):
-        with pytest.raises(ValueError):
-            ExpirySet(ExpiryType.SEC, 5.5)
-
-    def test_expiry_equality(self):
-        assert ExpirySet(ExpiryType.SEC, 2) == ExpirySet(ExpiryType.SEC, 2)
-        assert ExpirySet(
-            ExpiryType.UNIX_SEC,
-            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
-        ) == ExpirySet(
-            ExpiryType.UNIX_SEC,
-            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
-        )
-
-        assert not ExpirySet(ExpiryType.SEC, 1) == 1
-
-    def test_is_single_response(self):
-        assert is_single_response("This is a string value", "")
-        assert is_single_response(["value", "value"], [""])
-        assert not is_single_response(
-            [["value", ["value"]], ["value", ["valued"]]], [""]
-        )
-        assert is_single_response(None, None)
 
 
 @pytest.mark.anyio

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -427,6 +427,13 @@ class TestCommands:
         assert int(result[b"proto"]) == 3
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2])
+    def test_sync_allow_opt_in_to_resp2_protocol(self, glide_sync_client: TGlideClient):
+        result = cast(Dict[bytes, bytes], glide_sync_client.custom_command(["HELLO"]))
+
+        assert int(result[b"proto"]) == 2
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_conditional_set(self, glide_sync_client: TGlideClient):
         key = get_random_string(10)

--- a/python/tests/test_api_consistency.py
+++ b/python/tests/test_api_consistency.py
@@ -1,0 +1,220 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+from typing import Callable, Dict, Optional, Set
+
+PYTHON_DIR = Path(__file__).resolve().parent.parent
+GLIDE_SYNC_COMMANDS_DIR = PYTHON_DIR / "glide-sync" / "glide_sync"
+GLIDE_ASYNC_COMMANDS_DIR = PYTHON_DIR / "glide-async" / "python" / "glide"
+TESTS_ASYNC_DIR = PYTHON_DIR / "tests" / "async_tests"
+TESTS_SYNC_DIR = PYTHON_DIR / "tests" / "sync_tests"
+
+
+EXCLUDED_API_FUNCTIONS = {
+    "async_only": [
+        # Script
+        "script_flush",
+        "script_exists",
+        "invoke_script",
+        "invoke_script_route",
+        "script_kill",
+        # PubSub
+        "pubsub_shardchannels",
+        "pubsub_shardnumsub",
+        "pubsub_numsub",
+        "pubsub_numpat",
+        "publish",
+        "pubsub_channels",
+        "get_pubsub_message",
+        "try_get_pubsub_message",
+        # scan
+        "scan",
+        "unwatch",
+        # batch
+        "exec",
+        # _CompatFuture
+        "done",
+        "result",
+        "set_exception",
+        "set_result",
+        # others
+        "init_callback",
+        "get_statistics",
+    ],
+    "sync_only": [
+        "find_libglide_ffi",
+    ],
+}
+
+EXCLUDED_API_FILENAMES = {
+    "async_only": [
+        "ft.py",
+        "glide_json.py",
+        "opentelemetry.py",
+    ],
+    "sync_only": [],
+}
+
+EXCLUDED_TESTS = {
+    "async_only": [
+        # Script
+        "test_script",
+        "test_script_kill_no_route",
+        "test_script_flush",
+        "test_script_large_keys_no_args",
+        "test_inflight_request_limit",
+        "test_script_isnt_removed_while_another_instance_exists",
+        "test_statistics",
+        "test_script_kill_unkillable",
+        "test_script_large_args_no_keys",
+        "test_script_show",
+        "run_long_script",
+        "test_script_exists",
+        "attempt_kill_writing_script",
+        "test_script_binary",
+        "script_kill_tests",
+        "wait_and_kill_script",
+        "test_script_large_keys_and_args",
+        "test_script_kill_route",
+        "run_writing_script",
+        # Batch
+        "test_watch",
+        "test_unwatch",
+        "test_unwatch_with_route",
+    ],
+    "sync_only": ["test_sync_fork"],
+}
+
+EXCLUDED_TESTS_FILENAMES = {
+    "async_only": [
+        "test_json.py",
+        "test_opentelemetry.py",
+        "test_batch.py",
+        "test_pubsub.py",
+        "test_scan.py",
+        "test_ft.py",
+    ],
+    "sync_only": [],
+}
+
+
+def get_functions_from_file(file_path: Path) -> Set[str]:
+    """Parse a Python file & return all top-level (non-private) function names."""
+    with open(file_path, "r") as f:
+        tree = ast.parse(f.read(), filename=str(file_path))
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not node.name.startswith("_")
+    }
+
+
+def get_all_functions_in_directory(
+    directory: Path, exclude_filenames: Set[str], filename_prefix: Optional[str] = None
+) -> Dict[str, Set[str]]:
+    """
+    Collect function names mapped to the files they appear in,
+    excluding `__init__.py` files and excluded files.
+    """
+    functions_by_file = defaultdict(set)
+    for file in directory.rglob("*.py"):
+        if file.name.startswith("__") or file.name in exclude_filenames:
+            continue
+        if filename_prefix and not file.name.startswith(filename_prefix):
+            continue
+        for func in get_functions_from_file(file):
+            functions_by_file[func].add(str(file))
+    return functions_by_file
+
+
+def remove_sync_prefix_from_test_name(name: str) -> str:
+    """Strip sync test prefix for comparison."""
+    return (
+        name.replace("test_sync_", "test_", 1)
+        if name.startswith("test_sync_")
+        else name
+    )
+
+
+def filter_and_remove_prefix(
+    functions: Dict[str, Set[str]],
+    exclude: Set[str],
+    normalize: Optional[Callable[[str], str]] = None,
+) -> Dict[str, Set[str]]:
+    """Filter out excluded/private functions and optionally normalize names."""
+    result = {}
+    for func, files in functions.items():
+        if func in exclude or func.startswith("_"):
+            continue
+        normalized = normalize(func) if normalize else func
+        result[normalized] = files
+    return result
+
+
+def compare_function_sets(
+    async_dir,
+    sync_dir,
+    excluded_functions,
+    excluded_filenames,
+    error_message_prefix="Functions missing",
+    normalize_sync: Optional[Callable[[str], str]] = None,
+    filename_prefix: Optional[str] = None,
+):
+    async_functions = get_all_functions_in_directory(
+        async_dir, set(excluded_filenames["async_only"]), filename_prefix
+    )
+    sync_functions = get_all_functions_in_directory(
+        sync_dir, set(excluded_filenames["sync_only"]), filename_prefix
+    )
+
+    filtered_async = filter_and_remove_prefix(
+        async_functions, set(excluded_functions["async_only"])
+    )
+    filtered_sync = filter_and_remove_prefix(
+        sync_functions, set(excluded_functions["sync_only"]), normalize_sync
+    )
+
+    missing_in_async = set(filtered_sync) - set(filtered_async)
+    missing_in_sync = set(filtered_async) - set(filtered_sync)
+
+    def fmt_missing(missing, source):
+        return "\n".join(
+            f"  {func} from {', '.join(source.get(func, {'<unknown>'}))}"
+            for func in sorted(missing)
+        )
+
+    assert not missing_in_async, (
+        f"⚠️  {error_message_prefix} in async:\n"
+        f"{fmt_missing(missing_in_async, sync_functions)}\n"
+        "Please implement the async version or add it to `sync_only` in the appropriate exclusion list."
+    )
+    assert not missing_in_sync, (
+        f"⚠️  {error_message_prefix} in sync:\n"
+        f"{fmt_missing(missing_in_sync, async_functions)}\n"
+        "Please implement the sync version or add it to `async_only` in the appropriate exclusion list."
+    )
+
+
+class TestConsistency:
+    def test_api_consistency(self):
+        compare_function_sets(
+            GLIDE_ASYNC_COMMANDS_DIR,
+            GLIDE_SYNC_COMMANDS_DIR,
+            EXCLUDED_API_FUNCTIONS,
+            EXCLUDED_API_FILENAMES,
+            error_message_prefix="API Functions missing",
+        )
+
+    def test_tests_consistency(self):
+        compare_function_sets(
+            TESTS_ASYNC_DIR,
+            TESTS_SYNC_DIR,
+            EXCLUDED_TESTS,
+            EXCLUDED_TESTS_FILENAMES,
+            error_message_prefix="Tests missing",
+            normalize_sync=remove_sync_prefix_from_test_name,
+            filename_prefix="test",
+        )

--- a/python/tests/test_options.py
+++ b/python/tests/test_options.py
@@ -1,0 +1,117 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from glide_shared.commands.core_options import (
+    ExpiryGetEx,
+    ExpirySet,
+    ExpiryType,
+    ExpiryTypeGetEx,
+)
+
+from tests.utils.utils import is_single_response
+
+
+class TestCommandsUnitTests:
+    def test_expiry_cmd_args(self):
+        exp_sec = ExpirySet(ExpiryType.SEC, 5)
+        assert exp_sec.get_cmd_args() == ["EX", "5"]
+
+        exp_sec_timedelta = ExpirySet(ExpiryType.SEC, timedelta(seconds=5))
+        assert exp_sec_timedelta.get_cmd_args() == ["EX", "5"]
+
+        exp_millsec = ExpirySet(ExpiryType.MILLSEC, 5)
+        assert exp_millsec.get_cmd_args() == ["PX", "5"]
+
+        exp_millsec_timedelta = ExpirySet(ExpiryType.MILLSEC, timedelta(seconds=5))
+        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
+
+        exp_millsec_timedelta = ExpirySet(ExpiryType.MILLSEC, timedelta(seconds=5))
+        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
+
+        exp_unix_sec = ExpirySet(ExpiryType.UNIX_SEC, 1682575739)
+        assert exp_unix_sec.get_cmd_args() == ["EXAT", "1682575739"]
+
+        exp_unix_sec_datetime = ExpirySet(
+            ExpiryType.UNIX_SEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+        assert exp_unix_sec_datetime.get_cmd_args() == ["EXAT", "1682639759"]
+
+        exp_unix_millisec = ExpirySet(ExpiryType.UNIX_MILLSEC, 1682586559964)
+        assert exp_unix_millisec.get_cmd_args() == ["PXAT", "1682586559964"]
+
+        exp_unix_millisec_datetime = ExpirySet(
+            ExpiryType.UNIX_MILLSEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+        assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]
+
+    def test_get_expiry_cmd_args(self):
+        exp_sec = ExpiryGetEx(ExpiryTypeGetEx.SEC, 5)
+        assert exp_sec.get_cmd_args() == ["EX", "5"]
+
+        exp_sec_timedelta = ExpiryGetEx(ExpiryTypeGetEx.SEC, timedelta(seconds=5))
+        assert exp_sec_timedelta.get_cmd_args() == ["EX", "5"]
+
+        exp_millsec = ExpiryGetEx(ExpiryTypeGetEx.MILLSEC, 5)
+        assert exp_millsec.get_cmd_args() == ["PX", "5"]
+
+        exp_millsec_timedelta = ExpiryGetEx(
+            ExpiryTypeGetEx.MILLSEC, timedelta(seconds=5)
+        )
+        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
+
+        exp_millsec_timedelta = ExpiryGetEx(
+            ExpiryTypeGetEx.MILLSEC, timedelta(seconds=5)
+        )
+        assert exp_millsec_timedelta.get_cmd_args() == ["PX", "5000"]
+
+        exp_unix_sec = ExpiryGetEx(ExpiryTypeGetEx.UNIX_SEC, 1682575739)
+        assert exp_unix_sec.get_cmd_args() == ["EXAT", "1682575739"]
+
+        exp_unix_sec_datetime = ExpiryGetEx(
+            ExpiryTypeGetEx.UNIX_SEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+        assert exp_unix_sec_datetime.get_cmd_args() == ["EXAT", "1682639759"]
+
+        exp_unix_millisec = ExpiryGetEx(ExpiryTypeGetEx.UNIX_MILLSEC, 1682586559964)
+        assert exp_unix_millisec.get_cmd_args() == ["PXAT", "1682586559964"]
+
+        exp_unix_millisec_datetime = ExpiryGetEx(
+            ExpiryTypeGetEx.UNIX_MILLSEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+        assert exp_unix_millisec_datetime.get_cmd_args() == ["PXAT", "1682639759342"]
+
+        exp_persist = ExpiryGetEx(
+            ExpiryTypeGetEx.PERSIST,
+            None,
+        )
+        assert exp_persist.get_cmd_args() == ["PERSIST"]
+
+    def test_expiry_raises_on_value_error(self):
+        with pytest.raises(ValueError):
+            ExpirySet(ExpiryType.SEC, 5.5)
+
+    def test_expiry_equality(self):
+        assert ExpirySet(ExpiryType.SEC, 2) == ExpirySet(ExpiryType.SEC, 2)
+        assert ExpirySet(
+            ExpiryType.UNIX_SEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        ) == ExpirySet(
+            ExpiryType.UNIX_SEC,
+            datetime(2023, 4, 27, 23, 55, 59, 342380, timezone.utc),
+        )
+
+        assert not ExpirySet(ExpiryType.SEC, 1) == 1
+
+    def test_is_single_response(self):
+        assert is_single_response("This is a string value", "")
+        assert is_single_response(["value", "value"], [""])
+        assert not is_single_response(
+            [["value", ["value"]], ["value", ["valued"]]], [""]
+        )
+        assert is_single_response(None, None)


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR - 
1. Adds a `test_api_consistency.py` file that includes 2 test - 
   - A test that finds all function names in the sync/async class and makes sure there are no unapproved functions that exist only in one of them.
   - A test that finds all test names in the sync/async test dirs and makes sure there are no unapproved tests that exist only in one of them.
  
2. Adds a test called `test_shared_symbols_reexported` to the `test_api_export.py` file, which checks that all public symbols exported from the shared package are then also exported by both the async and sync packages.
2. Moves the tests in the TestCommandsUnitTests class, that are relevant to both async and sync, from the `test_async_client` file to a new `test_options` file.
3.  Adds the test `test_sync_allow_opt_in_to_resp2_protocol` to the sync (was missing).

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/3500
### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
