### PR TITLE
Fix flaky test: increase timeout to match others in TlsTest

### DIFF
--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -37,7 +37,7 @@ describe("tls GlideClusterClient", () => {
             true,
             TLS_OPTIONS,
         );
-    }, 40000);
+    }, TIMEOUT);
 
     afterEach(async () => {
         await flushAndCloseClient(
@@ -99,7 +99,7 @@ describe("tls GlideClient", () => {
             true,
             TLS_OPTIONS,
         );
-    }, 40000);
+    }, TIMEOUT);
 
     afterEach(async () => {
         await flushAndCloseClient(


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
### Summary 
The test seems to occasionally timeout just slightly over 40 seconds. Other tests in the same suite are using 50 seconds via a constant.

### Issue link
This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4359


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
