### PR TITLE
NODE:  Valkey 9 support - Add Hash Field Expiration Commands Support

### DIFF
--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -6,7 +6,8 @@
     },
     {
         "type": "valkey",
-        "version": "8.1"
+        "version": "8.1",
+        "run": "always"
     },
     {
         "type": "valkey",

--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -6,8 +6,7 @@
     },
     {
         "type": "valkey",
-        "version": "8.1",
-        "run": "always"
+        "version": "8.1"
     },
     {
         "type": "valkey",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * GO: Hash Field Expiration commands for Valkey 9 ([#4554](https://github.com/valkey-io/valkey-glide/pull/4554))
 * JAVA: Valkey 9 new commands HASH items expiration ([#4556](https://github.com/valkey-io/valkey-glide/pull/4556))
+* NODE: Valkey 9 support - Add Hash Field Expiration Commands Support ([#4598](https://github.com/valkey-io/valkey-glide/pull/4598))
 
 #### Fixes
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -268,7 +268,7 @@ import {
     createZUnionStore,
     dropOtelSpan,
     getStatistics,
-    valueFromSplitPointer
+    valueFromSplitPointer,
 } from ".";
 import {
     command_request,
@@ -1061,7 +1061,7 @@ export class BaseClient {
                 if (split.length !== 2) {
                     throw new RequestError(
                         "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                        host,
+                            host,
                     );
                 }
 
@@ -1127,8 +1127,8 @@ export class BaseClient {
                     err instanceof ValkeyError
                         ? err
                         : new Error(
-                            `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
-                        ),
+                              `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
+                          ),
                 );
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {
@@ -2975,13 +2975,13 @@ export class BaseClient {
      * // Example usage of hgetex command
      * const result1 = await client.hgetex("my_hash", ["field1", "field2"]);
      * console.log(result1); // [value1, value2] or [null, null] if fields don't exist
-     * 
+     *
      * // Get fields and set expiration to 10 seconds
      * const result2 = await client.hgetex("my_hash", ["field1", "field2"], {
      *     expiry: { type: TimeUnit.Seconds, count: 10 }
      * });
      * console.log(result2); // [value1, value2] with fields expiring in 10 seconds
-     * 
+     *
      * // Get fields and remove their expiration
      * const result3 = await client.hgetex("my_hash", ["field1", "field2"], {
      *     expiry: "PERSIST"
@@ -2999,9 +2999,9 @@ export class BaseClient {
 
     /**
      * Sets expiration time for hash fields in seconds. Creates the hash if it doesn't exist.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hexpire/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param seconds - The expiration time in seconds.
      * @param fields - The fields to set expiration for.
@@ -3011,14 +3011,14 @@ export class BaseClient {
      *          - `0` if the specified condition (NX, XX, GT, LT) was not met
      *          - `-2` if the field does not exist or the key does not exist
      *          - `2` when called with 0 seconds (field deleted)
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration for hash fields
      * const result = await client.hexpire("my_hash", 60, ["field1", "field2"]);
      * console.log(result); // [true, true] - expiration set for both fields
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration only if fields don't have expiration
@@ -3027,7 +3027,7 @@ export class BaseClient {
      * });
      * console.log(result); // [true, false] - expiration set only for field1
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration with greater than condition
@@ -3043,28 +3043,30 @@ export class BaseClient {
         fields: GlideString[],
         options?: HExpireOptions,
     ): Promise<number[]> {
-        return this.createWritePromise(createHExpire(key, seconds, fields, options));
+        return this.createWritePromise(
+            createHExpire(key, seconds, fields, options),
+        );
     }
 
     /**
      * Removes the expiration time associated with each specified field, causing them to persist.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hpersist/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param fields - The fields in the hash to remove expiration from.
      * @returns An array of numbers indicating the result for each field:
      *     - `1` if the field's expiration was removed successfully.
      *     - `-1` if the field exists but has no associated expiration.
      *     - `-2` if the field does not exist or the key does not exist.
-     * 
+     *
      * @example
      * ```typescript
      * // Remove expiration from hash fields
      * const result = await client.hpersist("my_hash", ["field1", "field2"]);
      * console.log(result); // [true, false] - expiration removed from field1, field2 had no expiration
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Remove expiration from a single field
@@ -3081,9 +3083,9 @@ export class BaseClient {
 
     /**
      * Sets expiration time for hash fields in milliseconds. Creates the hash if it doesn't exist.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hpexpire/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param milliseconds - The expiration time in milliseconds.
      * @param fields - The fields to set expiration for.
@@ -3093,14 +3095,14 @@ export class BaseClient {
      *          - `0` if the specified condition (NX, XX, GT, LT) was not met
      *          - `-2` if the field does not exist or the key does not exist
      *          - `2` when called with 0 milliseconds (field deleted)
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration for hash fields in milliseconds
      * const result = await client.hpexpire("my_hash", 60000, ["field1", "field2"]);
      * console.log(result); // [true, true] - expiration set for both fields
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration only if fields don't have expiration
@@ -3108,7 +3110,7 @@ export class BaseClient {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration with greater than condition
@@ -3123,14 +3125,16 @@ export class BaseClient {
         fields: GlideString[],
         options?: HPExpireOptions,
     ): Promise<number[]> {
-        return this.createWritePromise(createHPExpire(key, milliseconds, fields, options));
+        return this.createWritePromise(
+            createHPExpire(key, milliseconds, fields, options),
+        );
     }
 
     /**
      * Sets expiration time for hash fields using an absolute Unix timestamp in seconds. Creates the hash if it doesn't exist.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hexpireat/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param unixTimestampSeconds - The expiration time as a Unix timestamp in seconds.
      * @param fields - The fields to set expiration for.
@@ -3140,7 +3144,7 @@ export class BaseClient {
      *          - `0` if the specified condition (NX, XX, GT, LT) was not met
      *          - `-2` if the field does not exist or the key does not exist
      *          - `2` when called with 0 seconds (field deleted)
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration for hash fields using Unix timestamp
@@ -3148,7 +3152,7 @@ export class BaseClient {
      * const result = await client.hexpireat("my_hash", futureTimestamp, ["field1", "field2"]);
      * console.log(result); // [true, true] - expiration set for both fields
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration only if fields don't have expiration
@@ -3157,7 +3161,7 @@ export class BaseClient {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration with greater than condition
@@ -3173,14 +3177,16 @@ export class BaseClient {
         fields: GlideString[],
         options?: HExpireAtOptions,
     ): Promise<number[]> {
-        return this.createWritePromise(createHExpireAt(key, unixTimestampSeconds, fields, options));
+        return this.createWritePromise(
+            createHExpireAt(key, unixTimestampSeconds, fields, options),
+        );
     }
 
     /**
      * Sets expiration time for hash fields using an absolute Unix timestamp in milliseconds. Creates the hash if it doesn't exist.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hpexpireat/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param unixTimestampMilliseconds - The expiration time as a Unix timestamp in milliseconds.
      * @param fields - The fields to set expiration for.
@@ -3190,7 +3196,7 @@ export class BaseClient {
      *          - `0` if the specified condition (NX, XX, GT, LT) was not met
      *          - `-2` if the field does not exist or the key does not exist
      *          - `2` when called with 0 milliseconds (field deleted)
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration for hash fields using Unix timestamp in milliseconds
@@ -3198,7 +3204,7 @@ export class BaseClient {
      * const result = await client.hpexpireat("my_hash", futureTimestamp, ["field1", "field2"]);
      * console.log(result); // [true, true] - expiration set for both fields
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration only if fields don't have expiration
@@ -3207,7 +3213,7 @@ export class BaseClient {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Set expiration with greater than condition
@@ -3223,28 +3229,30 @@ export class BaseClient {
         fields: GlideString[],
         options?: HPExpireAtOptions,
     ): Promise<number[]> {
-        return this.createWritePromise(createHPExpireAt(key, unixTimestampMilliseconds, fields, options));
+        return this.createWritePromise(
+            createHPExpireAt(key, unixTimestampMilliseconds, fields, options),
+        );
     }
 
     /**
      * Returns the remaining time to live of hash fields that have a timeout, in seconds.
-     * 
+     *
      * @see {@link https://valkey.io/commands/httl/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param fields - The fields in the hash stored at `key` to retrieve the TTL for.
      * @returns An array of TTL values in seconds for the specified fields.
      *     - For fields with a timeout, returns the remaining time in seconds.
      *     - For fields that exist but have no associated expire, returns -1.
      *     - For fields that do not exist, returns -2.
-     * 
+     *
      * @example
      * ```typescript
      * // Get TTL for hash fields
      * const result = await client.httl("my_hash", ["field1", "field2", "field3"]);
      * console.log(result); // [120, -1, -2] - field1 expires in 120 seconds, field2 has no expiration, field3 doesn't exist
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Get TTL for a single field
@@ -3261,23 +3269,23 @@ export class BaseClient {
 
     /**
      * Returns the absolute Unix timestamp (in seconds) at which hash fields will expire.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hexpiretime/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param fields - The list of fields to get the expiration timestamp for.
      * @returns An array of expiration timestamps in seconds for the specified fields:
      *   - For fields with a timeout, returns the absolute Unix timestamp in seconds.
      *   - For fields without a timeout, returns -1.
      *   - For fields that do not exist, returns -2.
-     * 
+     *
      * @example
      * ```typescript
      * // Get expiration timestamps for hash fields
      * const result = await client.hexpiretime("my_hash", ["field1", "field2", "field3"]);
      * console.log(result); // [1672531200, -1, -2] - field1 expires at timestamp 1672531200, field2 has no expiration, field3 doesn't exist
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Get expiration timestamp for a single field
@@ -3294,23 +3302,23 @@ export class BaseClient {
 
     /**
      * Returns the absolute Unix timestamp (in milliseconds) at which hash fields will expire.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hpexpiretime/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param fields - The list of fields to get the expiration timestamp for.
      * @returns An array of expiration timestamps in milliseconds for the specified fields:
      *   - For fields with a timeout, returns the absolute Unix timestamp in milliseconds.
      *   - For fields without a timeout, returns -1.
      *   - For fields that do not exist, returns -2.
-     * 
+     *
      * @example
      * ```typescript
      * // Get expiration timestamps for hash fields in milliseconds
      * const result = await client.hpexpiretime("my_hash", ["field1", "field2", "field3"]);
      * console.log(result); // [1672531200000, -1, -2] - field1 expires at timestamp 1672531200000, field2 has no expiration, field3 doesn't exist
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Get expiration timestamp for a single field in milliseconds
@@ -3327,23 +3335,23 @@ export class BaseClient {
 
     /**
      * Returns the remaining time to live of hash fields that have a timeout, in milliseconds.
-     * 
+     *
      * @see {@link https://valkey.io/commands/hpttl/|valkey.io} for details.
-     * 
+     *
      * @param key - The key of the hash.
      * @param fields - The list of fields to get the TTL for.
      * @returns An array of TTL values in milliseconds for the specified fields:
      *   - For fields with a timeout, returns the remaining TTL in milliseconds.
      *   - For fields without a timeout, returns -1.
      *   - For fields that do not exist, returns -2.
-     * 
+     *
      * @example
      * ```typescript
      * // Get TTL for hash fields in milliseconds
      * const result = await client.hpttl("my_hash", ["field1", "field2", "field3"]);
      * console.log(result); // [120000, -1, -2] - field1 expires in 120000 ms, field2 has no expiration, field3 doesn't exist
      * ```
-     * 
+     *
      * @example
      * ```typescript
      * // Get TTL for a single field in milliseconds
@@ -7188,12 +7196,12 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-            primary: connection_request.ReadFrom.Primary,
-            preferReplica: connection_request.ReadFrom.PreferReplica,
-            AZAffinity: connection_request.ReadFrom.AZAffinity,
-            AZAffinityReplicasAndPrimary:
-                connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
-        };
+        primary: connection_request.ReadFrom.Primary,
+        preferReplica: connection_request.ReadFrom.PreferReplica,
+        AZAffinity: connection_request.ReadFrom.AZAffinity,
+        AZAffinityReplicasAndPrimary:
+            connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
+    };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -8604,8 +8612,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                    return { key: r.key, elements: r.value };
-                })[0],
+                      return { key: r.key, elements: r.value };
+                  })[0],
         );
     }
 
@@ -8648,8 +8656,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                    return { key: r.key, elements: r.value };
-                })[0],
+                      return { key: r.key, elements: r.value };
+                  })[0],
         );
     }
 
@@ -8869,11 +8877,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-                "password" in options.credentials
+            "password" in options.credentials
                 ? {
-                    password: options.credentials.password,
-                    username: options.credentials.username,
-                }
+                      password: options.credentials.password,
+                      username: options.credentials.username,
+                  }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3006,8 +3006,11 @@ export class BaseClient {
      * @param seconds - The expiration time in seconds.
      * @param fields - The fields to set expiration for.
      * @param options - Optional parameters for the command.
-     * @returns A Promise that resolves to an array of boolean values indicating whether expiration was set for each field.
-     *          `true` if expiration was set, `false` if the field doesn't exist or the condition wasn't met.
+     * @returns A Promise that resolves to an array of numbers indicating the result for each field:
+     *          - `1` if expiration was set successfully
+     *          - `0` if the specified condition (NX, XX, GT, LT) was not met
+     *          - `-2` if the field does not exist or the key does not exist
+     *          - `2` when called with 0 seconds (field deleted)
      * 
      * @example
      * ```typescript
@@ -3039,7 +3042,7 @@ export class BaseClient {
         seconds: number,
         fields: GlideString[],
         options?: HExpireOptions,
-    ): Promise<boolean[]> {
+    ): Promise<number[]> {
         return this.createWritePromise(createHExpire(key, seconds, fields, options));
     }
 
@@ -3050,9 +3053,10 @@ export class BaseClient {
      * 
      * @param key - The key of the hash.
      * @param fields - The fields in the hash to remove expiration from.
-     * @returns An array of boolean values indicating whether expiration was successfully removed for each field.
-     *     - `true` if the field's expiration was removed.
-     *     - `false` if the field does not exist or does not have an associated expiration.
+     * @returns An array of numbers indicating the result for each field:
+     *     - `1` if the field's expiration was removed successfully.
+     *     - `-1` if the field exists but has no associated expiration.
+     *     - `-2` if the field does not exist or the key does not exist.
      * 
      * @example
      * ```typescript
@@ -3071,7 +3075,7 @@ export class BaseClient {
     public async hpersist(
         key: GlideString,
         fields: GlideString[],
-    ): Promise<boolean[]> {
+    ): Promise<number[]> {
         return this.createWritePromise(createHPersist(key, fields));
     }
 
@@ -3084,7 +3088,11 @@ export class BaseClient {
      * @param milliseconds - The expiration time in milliseconds.
      * @param fields - The fields to set expiration for.
      * @param options - Optional arguments for the HPEXPIRE command. See {@link HPExpireOptions}.
-     * @returns An array of boolean values indicating whether expiration was set for each field.
+     * @returns An array of numbers indicating the result for each field:
+     *          - `1` if expiration was set successfully
+     *          - `0` if the specified condition (NX, XX, GT, LT) was not met
+     *          - `-2` if the field does not exist or the key does not exist
+     *          - `2` when called with 0 milliseconds (field deleted)
      * 
      * @example
      * ```typescript
@@ -3114,7 +3122,7 @@ export class BaseClient {
         milliseconds: number,
         fields: GlideString[],
         options?: HPExpireOptions,
-    ): Promise<boolean[]> {
+    ): Promise<number[]> {
         return this.createWritePromise(createHPExpire(key, milliseconds, fields, options));
     }
 
@@ -3127,7 +3135,11 @@ export class BaseClient {
      * @param unixTimestampSeconds - The expiration time as a Unix timestamp in seconds.
      * @param fields - The fields to set expiration for.
      * @param options - Optional arguments for the HEXPIREAT command. See {@link HExpireAtOptions}.
-     * @returns An array of boolean values indicating whether expiration was set for each field.
+     * @returns An array of numbers indicating the result for each field:
+     *          - `1` if expiration was set successfully
+     *          - `0` if the specified condition (NX, XX, GT, LT) was not met
+     *          - `-2` if the field does not exist or the key does not exist
+     *          - `2` when called with 0 seconds (field deleted)
      * 
      * @example
      * ```typescript
@@ -3160,7 +3172,7 @@ export class BaseClient {
         unixTimestampSeconds: number,
         fields: GlideString[],
         options?: HExpireAtOptions,
-    ): Promise<boolean[]> {
+    ): Promise<number[]> {
         return this.createWritePromise(createHExpireAt(key, unixTimestampSeconds, fields, options));
     }
 
@@ -3173,7 +3185,11 @@ export class BaseClient {
      * @param unixTimestampMilliseconds - The expiration time as a Unix timestamp in milliseconds.
      * @param fields - The fields to set expiration for.
      * @param options - Optional arguments for the HPEXPIREAT command. See {@link HPExpireAtOptions}.
-     * @returns An array of boolean values indicating whether expiration was set for each field.
+     * @returns An array of numbers indicating the result for each field:
+     *          - `1` if expiration was set successfully
+     *          - `0` if the specified condition (NX, XX, GT, LT) was not met
+     *          - `-2` if the field does not exist or the key does not exist
+     *          - `2` when called with 0 milliseconds (field deleted)
      * 
      * @example
      * ```typescript
@@ -3206,7 +3222,7 @@ export class BaseClient {
         unixTimestampMilliseconds: number,
         fields: GlideString[],
         options?: HPExpireAtOptions,
-    ): Promise<boolean[]> {
+    ): Promise<number[]> {
         return this.createWritePromise(createHPExpireAt(key, unixTimestampMilliseconds, fields, options));
     }
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1061,7 +1061,7 @@ export class BaseClient {
                 if (split.length !== 2) {
                     throw new RequestError(
                         "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                            host,
+                        host,
                     );
                 }
 
@@ -1127,8 +1127,8 @@ export class BaseClient {
                     err instanceof ValkeyError
                         ? err
                         : new Error(
-                              `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
-                          ),
+                            `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
+                        ),
                 );
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {
@@ -2924,8 +2924,8 @@ export class BaseClient {
      *     }
      * );
      * console.log(result);
-     * // Output: 2
-     * // Indicates that 2 fields were added to the hash with 60 seconds expiration.
+     * // Output: 1
+     * // Indicates that all fields were successfully set with expiration.
      * ```
      *
      * @example
@@ -2941,7 +2941,7 @@ export class BaseClient {
      * );
      * console.log(result);
      * // Output: 1
-     * // Indicates that 1 field was added only because it didn't exist.
+     * // Indicates that the field was successfully set because it didn't exist.
      * ```
      */
     public async hsetex(
@@ -3016,7 +3016,7 @@ export class BaseClient {
      * ```typescript
      * // Set expiration for hash fields
      * const result = await client.hexpire("my_hash", 60, ["field1", "field2"]);
-     * console.log(result); // [true, true] - expiration set for both fields
+     * console.log(result); // [1, 1] - expiration set for both fields
      * ```
      *
      * @example
@@ -3025,7 +3025,7 @@ export class BaseClient {
      * const result = await client.hexpire("my_hash", 120, ["field1", "field2"], {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
-     * console.log(result); // [true, false] - expiration set only for field1
+     * console.log(result); // [1, 0] - expiration set for field1, condition not met for field2
      * ```
      *
      * @example
@@ -3034,7 +3034,7 @@ export class BaseClient {
      * const result = await client.hexpire("my_hash", 300, ["field1"], {
      *     condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT
      * });
-     * console.log(result); // [true] - expiration set because 300 > current TTL
+     * console.log(result); // [1] - expiration set because 300 > current TTL
      * ```
      */
     public async hexpire(
@@ -3064,14 +3064,14 @@ export class BaseClient {
      * ```typescript
      * // Remove expiration from hash fields
      * const result = await client.hpersist("my_hash", ["field1", "field2"]);
-     * console.log(result); // [true, false] - expiration removed from field1, field2 had no expiration
+     * console.log(result); // [1, -1] - expiration removed from field1, field2 had no expiration
      * ```
      *
      * @example
      * ```typescript
      * // Remove expiration from a single field
      * const result = await client.hpersist("my_hash", ["field1"]);
-     * console.log(result); // [true] - expiration removed from field1
+     * console.log(result); // [1] - expiration removed from field1
      * ```
      */
     public async hpersist(
@@ -3100,7 +3100,7 @@ export class BaseClient {
      * ```typescript
      * // Set expiration for hash fields in milliseconds
      * const result = await client.hpexpire("my_hash", 60000, ["field1", "field2"]);
-     * console.log(result); // [true, true] - expiration set for both fields
+     * console.log(result); // [1, 1] - expiration set for both fields
      * ```
      *
      * @example
@@ -3109,6 +3109,7 @@ export class BaseClient {
      * const result = await client.hpexpire("my_hash", 120000, ["field1", "field2"], {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
+     * console.log(result); // [1, 0] - expiration set for field1, condition not met for field2
      * ```
      *
      * @example
@@ -3117,6 +3118,7 @@ export class BaseClient {
      * const result = await client.hpexpire("my_hash", 300000, ["field1"], {
      *     condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT
      * });
+     * console.log(result); // [1] - expiration set because 300000 ms > current TTL
      * ```
      */
     public async hpexpire(
@@ -3150,7 +3152,7 @@ export class BaseClient {
      * // Set expiration for hash fields using Unix timestamp
      * const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
      * const result = await client.hexpireat("my_hash", futureTimestamp, ["field1", "field2"]);
-     * console.log(result); // [true, true] - expiration set for both fields
+     * console.log(result); // [1, 1] - expiration set for both fields
      * ```
      *
      * @example
@@ -3160,6 +3162,7 @@ export class BaseClient {
      * const result = await client.hexpireat("my_hash", futureTimestamp, ["field1", "field2"], {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
+     * console.log(result); // [1, 0] - expiration set for field1, condition not met for field2
      * ```
      *
      * @example
@@ -3169,6 +3172,7 @@ export class BaseClient {
      * const result = await client.hexpireat("my_hash", futureTimestamp, ["field1"], {
      *     condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT
      * });
+     * console.log(result); // [1] - expiration set because timestamp > current expiration
      * ```
      */
     public async hexpireat(
@@ -3202,7 +3206,7 @@ export class BaseClient {
      * // Set expiration for hash fields using Unix timestamp in milliseconds
      * const futureTimestamp = Date.now() + 3600000; // 1 hour from now
      * const result = await client.hpexpireat("my_hash", futureTimestamp, ["field1", "field2"]);
-     * console.log(result); // [true, true] - expiration set for both fields
+     * console.log(result); // [1, 1] - expiration set for both fields
      * ```
      *
      * @example
@@ -3212,6 +3216,7 @@ export class BaseClient {
      * const result = await client.hpexpireat("my_hash", futureTimestamp, ["field1", "field2"], {
      *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
      * });
+     * console.log(result); // [1, 0] - expiration set for field1, condition not met for field2
      * ```
      *
      * @example
@@ -3221,6 +3226,7 @@ export class BaseClient {
      * const result = await client.hpexpireat("my_hash", futureTimestamp, ["field1"], {
      *     condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT
      * });
+     * console.log(result); // [1] - expiration set because timestamp > current expiration
      * ```
      */
     public async hpexpireat(
@@ -7196,12 +7202,12 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-        primary: connection_request.ReadFrom.Primary,
-        preferReplica: connection_request.ReadFrom.PreferReplica,
-        AZAffinity: connection_request.ReadFrom.AZAffinity,
-        AZAffinityReplicasAndPrimary:
-            connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
-    };
+            primary: connection_request.ReadFrom.Primary,
+            preferReplica: connection_request.ReadFrom.PreferReplica,
+            AZAffinity: connection_request.ReadFrom.AZAffinity,
+            AZAffinityReplicasAndPrimary:
+                connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
+        };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -8612,8 +8618,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                      return { key: r.key, elements: r.value };
-                  })[0],
+                    return { key: r.key, elements: r.value };
+                })[0],
         );
     }
 
@@ -8656,8 +8662,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                      return { key: r.key, elements: r.value };
-                  })[0],
+                    return { key: r.key, elements: r.value };
+                })[0],
         );
     }
 
@@ -8877,11 +8883,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-            "password" in options.credentials
+                "password" in options.credentials
                 ? {
-                      password: options.credentials.password,
-                      username: options.credentials.username,
-                  }
+                    password: options.credentials.password,
+                    username: options.credentials.username,
+                }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1058,7 +1058,7 @@ export class BaseClient {
                 if (split.length !== 2) {
                     throw new RequestError(
                         "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                        host,
+                            host,
                     );
                 }
 
@@ -1124,8 +1124,8 @@ export class BaseClient {
                     err instanceof ValkeyError
                         ? err
                         : new Error(
-                            `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
-                        ),
+                              `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
+                          ),
                 );
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {
@@ -7236,12 +7236,12 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-            primary: connection_request.ReadFrom.Primary,
-            preferReplica: connection_request.ReadFrom.PreferReplica,
-            AZAffinity: connection_request.ReadFrom.AZAffinity,
-            AZAffinityReplicasAndPrimary:
-                connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
-        };
+        primary: connection_request.ReadFrom.Primary,
+        preferReplica: connection_request.ReadFrom.PreferReplica,
+        AZAffinity: connection_request.ReadFrom.AZAffinity,
+        AZAffinityReplicasAndPrimary:
+            connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
+    };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -8652,8 +8652,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                    return { key: r.key, elements: r.value };
-                })[0],
+                      return { key: r.key, elements: r.value };
+                  })[0],
         );
     }
 
@@ -8696,8 +8696,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                    return { key: r.key, elements: r.value };
-                })[0],
+                      return { key: r.key, elements: r.value };
+                  })[0],
         );
     }
 
@@ -8917,11 +8917,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-                "password" in options.credentials
+            "password" in options.credentials
                 ? {
-                    password: options.credentials.password,
-                    username: options.credentials.username,
-                }
+                      password: options.credentials.password,
+                      username: options.credentials.username,
+                  }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1061,7 +1061,7 @@ export class BaseClient {
                 if (split.length !== 2) {
                     throw new RequestError(
                         "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                        host,
+                            host,
                     );
                 }
 
@@ -1127,8 +1127,8 @@ export class BaseClient {
                     err instanceof ValkeyError
                         ? err
                         : new Error(
-                            `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
-                        ),
+                              `Decoding error: '${err}'. \n NOTE: If this was thrown during a command with write operations, the data could be UNRECOVERABLY LOST.`,
+                          ),
                 );
             }
         } else if (message.constantResponse === response.ConstantResponse.OK) {
@@ -2907,7 +2907,6 @@ export class BaseClient {
      * @param key - The key of the hash.
      * @param fieldsAndValues - A map or array of field-value pairs to set in the hash.
      * @param options - (Optional) Additional parameters:
-     *   - `conditionalChange`: Options for handling existing hash objects (NX | XX).
      *   - `fieldConditionalChange`: Options for handling existing fields (FNX | FXX).
      *   - `expiry`: Expiry settings for the fields (EX | PX | EXAT | PXAT | KEEPTTL).
      * @returns The number of fields that were added to the hash.
@@ -2919,13 +2918,12 @@ export class BaseClient {
      *     "my_hash",
      *     {"field1": "value1", "field2": "value2"},
      *     {
-     *         expiry: { type: TimeUnit.Seconds, count: 60 },
-     *         conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST
+     *         expiry: { type: TimeUnit.Seconds, count: 60 }
      *     }
      * );
      * console.log(result);
-     * // Output: 1
-     * // Indicates that all fields were successfully set with expiration.
+     * // Output: 2
+     * // Indicates that 2 fields were successfully set with expiration.
      * ```
      *
      * @example
@@ -7202,12 +7200,12 @@ export class BaseClient {
         ReadFrom,
         connection_request.ReadFrom
     > = {
-            primary: connection_request.ReadFrom.Primary,
-            preferReplica: connection_request.ReadFrom.PreferReplica,
-            AZAffinity: connection_request.ReadFrom.AZAffinity,
-            AZAffinityReplicasAndPrimary:
-                connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
-        };
+        primary: connection_request.ReadFrom.Primary,
+        preferReplica: connection_request.ReadFrom.PreferReplica,
+        AZAffinity: connection_request.ReadFrom.AZAffinity,
+        AZAffinityReplicasAndPrimary:
+            connection_request.ReadFrom.AZAffinityReplicasAndPrimary,
+    };
 
     /**
      * Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
@@ -8618,8 +8616,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                    return { key: r.key, elements: r.value };
-                })[0],
+                      return { key: r.key, elements: r.value };
+                  })[0],
         );
     }
 
@@ -8662,8 +8660,8 @@ export class BaseClient {
             res === null
                 ? null
                 : res!.map((r) => {
-                    return { key: r.key, elements: r.value };
-                })[0],
+                      return { key: r.key, elements: r.value };
+                  })[0],
         );
     }
 
@@ -8883,11 +8881,11 @@ export class BaseClient {
             : connection_request.ReadFrom.Primary;
         const authenticationInfo =
             options.credentials !== undefined &&
-                "password" in options.credentials
+            "password" in options.credentials
                 ? {
-                    password: options.credentials.password,
-                    username: options.credentials.username,
-                }
+                      password: options.credentials.password,
+                      username: options.credentials.username,
+                  }
                 : undefined;
         const protocol = options.protocol as
             | connection_request.ProtocolVersion

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2975,7 +2975,7 @@ export class BaseClient {
      *
      * @param key - The key of the hash.
      * @param fields - The fields in the hash stored at `key` to retrieve from the database.
-     * @param options - Optional arguments for the HGETEX command. See {@link HGetExOptions}.
+     * @param options - Optional arguments for the HGETEX command. See {@link HGetExOptions} and see {@link DecoderOption}.
      * @returns An array of values associated with the given fields,
      *          in the same order as they are requested. For every field that does not exist
      *          in the hash, a null value is returned. If `key` does not exist, returns an

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2902,7 +2902,7 @@ export class BaseClient {
      * @param fieldsAndValues - A map or array of field-value pairs to set.
      * @param options - Optional parameters including field conditional changes and expiry settings.
      *                  See {@link HSetExOptions}.
-     * @returns A promise that resolves to the number of fields that were set.
+     * @returns A number of fields that were set.
      *
      * @example
      * ```typescript
@@ -2954,7 +2954,7 @@ export class BaseClient {
      * ```
      *
      * @since Valkey 9.0.0
-     * @see https://valkey.io/commands/hsetex/
+     * @see {@link https://valkey.io/commands/hsetex/|valkey.io}
      */
     public async hsetex(
         key: GlideString,
@@ -2976,7 +2976,7 @@ export class BaseClient {
      * @param key - The key of the hash.
      * @param fields - The fields in the hash stored at `key` to retrieve from the database.
      * @param options - Optional arguments for the HGETEX command. See {@link HGetExOptions}.
-     * @returns A promise that resolves to an array of values associated with the given fields,
+     * @returns An array of values associated with the given fields,
      *          in the same order as they are requested. For every field that does not exist
      *          in the hash, a null value is returned. If `key` does not exist, returns an
      *          array of null values.
@@ -3021,14 +3021,17 @@ export class BaseClient {
      * ```
      *
      * @since Valkey 9.0.0
-     * @see https://valkey.io/commands/hgetex/
+     * @see {@link https://valkey.io/commands/hgetex/|valkey.io}
      */
     public async hgetex(
         key: GlideString,
         fields: GlideString[],
-        options?: HGetExOptions,
+        options?: HGetExOptions & DecoderOption,
     ): Promise<(GlideString | null)[]> {
-        return this.createWritePromise(createHGetEx(key, fields, options));
+        return this.createWritePromise(
+            createHGetEx(key, fields, options),
+            options,
+        );
     }
 
     /**
@@ -3040,7 +3043,7 @@ export class BaseClient {
      * @param seconds - The expiration time in seconds.
      * @param fields - The fields to set expiration for.
      * @param options - Optional parameters for the command.
-     * @returns A Promise that resolves to an array of numbers indicating the result for each field:
+     * @returns An array of numbers indicating the result for each field:
      *          - `1` if expiration was set successfully
      *          - `0` if the specified condition (NX, XX, GT, LT) was not met
      *          - `-2` if the field does not exist or the key does not exist

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -37,7 +37,6 @@ import {
     GlideString,
     HExpireOptions,
     HGetExOptions,
-
     HScanOptions,
     HSetExOptions,
     HashDataType,
@@ -310,7 +309,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     batch will be executed as an atomic `transaction`. If `false`, the batch will be
      *     executed as a non-atomic `pipeline`.
      */
-    constructor(public readonly isAtomic: boolean) { }
+    constructor(public readonly isAtomic: boolean) {}
 
     /**
      * Adds a command to the batch and returns the batch instance.

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -279,7 +279,7 @@ import {
     createZScan,
     createZScore,
     createZUnion,
-    createZUnionStore
+    createZUnionStore,
 } from ".";
 import { command_request } from "../build-ts/ProtobufMessage";
 
@@ -312,7 +312,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     batch will be executed as an atomic `transaction`. If `false`, the batch will be
      *     executed as a non-atomic `pipeline`.
      */
-    constructor(public readonly isAtomic: boolean) { }
+    constructor(public readonly isAtomic: boolean) {}
 
     /**
      * Adds a command to the batch and returns the batch instance.
@@ -1132,10 +1132,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     - `-1` if the field exists but has no associated expiration.
      *     - `-2` if the field does not exist or the key does not exist.
      */
-    public hpersist(
-        key: GlideString,
-        fields: GlideString[],
-    ): T {
+    public hpersist(key: GlideString, fields: GlideString[]): T {
         return this.addAndReturn(createHPersist(key, fields));
     }
 
@@ -1157,7 +1154,9 @@ export class BaseBatch<T extends BaseBatch<T>> {
         fields: GlideString[],
         options?: HPExpireOptions,
     ): T {
-        return this.addAndReturn(createHPExpire(key, milliseconds, fields, options));
+        return this.addAndReturn(
+            createHPExpire(key, milliseconds, fields, options),
+        );
     }
 
     /**
@@ -1181,7 +1180,9 @@ export class BaseBatch<T extends BaseBatch<T>> {
         fields: GlideString[],
         options?: HExpireAtOptions,
     ): T {
-        return this.addAndReturn(createHExpireAt(key, unixTimestampSeconds, fields, options));
+        return this.addAndReturn(
+            createHExpireAt(key, unixTimestampSeconds, fields, options),
+        );
     }
 
     /**
@@ -1202,7 +1203,9 @@ export class BaseBatch<T extends BaseBatch<T>> {
         fields: GlideString[],
         options?: HPExpireAtOptions,
     ): T {
-        return this.addAndReturn(createHPExpireAt(key, unixTimestampMilliseconds, fields, options));
+        return this.addAndReturn(
+            createHPExpireAt(key, unixTimestampMilliseconds, fields, options),
+        );
     }
 
     /**
@@ -1217,10 +1220,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     - For fields that exist but have no associated expire, returns -1.
      *     - For fields that do not exist, returns -2.
      */
-    public httl(
-        key: GlideString,
-        fields: GlideString[],
-    ): T {
+    public httl(key: GlideString, fields: GlideString[]): T {
         return this.addAndReturn(createHTtl(key, fields));
     }
 
@@ -1236,10 +1236,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     - For fields without a timeout, returns -1.
      *     - For fields that do not exist, returns -2.
      */
-    public hexpiretime(
-        key: GlideString,
-        fields: GlideString[],
-    ): T {
+    public hexpiretime(key: GlideString, fields: GlideString[]): T {
         return this.addAndReturn(createHExpireTime(key, fields));
     }
 
@@ -1255,10 +1252,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     - For fields without a timeout, returns -1.
      *     - For fields that do not exist, returns -2.
      */
-    public hpexpiretime(
-        key: GlideString,
-        fields: GlideString[],
-    ): T {
+    public hpexpiretime(key: GlideString, fields: GlideString[]): T {
         return this.addAndReturn(createHPExpireTime(key, fields));
     }
 
@@ -1274,10 +1268,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *     - For fields without a timeout, returns -1.
      *     - For fields that do not exist, returns -2.
      */
-    public hpttl(
-        key: GlideString,
-        fields: GlideString[],
-    ): T {
+    public hpttl(key: GlideString, fields: GlideString[]): T {
         return this.addAndReturn(createHPTtl(key, fields));
     }
 

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -1057,7 +1057,6 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * @param key - The key of the hash.
      * @param fieldsAndValues - A map or array of field-value pairs to set in the hash.
      * @param options - (Optional) Additional parameters:
-     *   - `conditionalChange`: Options for handling existing hash objects (NX | XX).
      *   - `fieldConditionalChange`: Options for handling existing fields (FNX | FXX).
      *   - `expiry`: Expiry settings for the fields (EX | PX | EXAT | PXAT | KEEPTTL).
      *

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -1105,8 +1105,11 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * @param fields - The fields to set expiration for.
      * @param options - Optional arguments for the HEXPIRE command. See {@link HExpireOptions}.
      *
-     * Command Response - An array of boolean values indicating whether expiration was set for each field.
-     *     `true` if expiration was set, `false` if the field doesn't exist or the condition wasn't met.
+     * Command Response - An array of numbers indicating the result for each field:
+     *     - `1` if expiration was set successfully
+     *     - `0` if the specified condition (NX, XX, GT, LT) was not met
+     *     - `-2` if the field does not exist or the key does not exist
+     *     - `2` when called with 0 seconds (field deleted)
      */
     public hexpire(
         key: GlideString,
@@ -1124,9 +1127,10 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * @param key - The key of the hash.
      * @param fields - The fields in the hash to remove expiration from.
      *
-     * Command Response - An array of boolean values indicating whether expiration was successfully removed for each field.
-     *     - `true` if the field's expiration was removed.
-     *     - `false` if the field does not exist or does not have an associated expiration.
+     * Command Response - An array of numbers indicating the result for each field:
+     *     - `1` if the field's expiration was removed successfully.
+     *     - `-1` if the field exists but has no associated expiration.
+     *     - `-2` if the field does not exist or the key does not exist.
      */
     public hpersist(
         key: GlideString,
@@ -1165,8 +1169,11 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * @param fields - The fields to set expiration for.
      * @param options - Optional arguments for the HEXPIREAT command. See {@link HExpireAtOptions}.
      *
-     * Command Response - An array of boolean values indicating whether expiration was set for each field.
-     *     `true` if expiration was set, `false` if the field doesn't exist or the condition wasn't met.
+     * Command Response - An array of numbers indicating the result for each field:
+     *     - `1` if expiration was set successfully
+     *     - `0` if the specified condition (NX, XX, GT, LT) was not met
+     *     - `-2` if the field does not exist or the key does not exist
+     *     - `2` when called with 0 seconds (field deleted)
      */
     public hexpireat(
         key: GlideString,

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -128,26 +128,26 @@ export function createGetRange(
 
 export type SetOptions = (
     | {
-        /**
-         * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
-         * `NX` in the Valkey API.
-         *
-         * `onlyIfExists` - Only set the key if it already exists.
-         * `EX` in the Valkey API.
-         */
-        conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
-    }
+          /**
+           * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
+           * `NX` in the Valkey API.
+           *
+           * `onlyIfExists` - Only set the key if it already exists.
+           * `EX` in the Valkey API.
+           */
+          conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
+      }
     | {
-        /**
-         * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
-         * `IFEQ` in the Valkey API.
-         */
-        conditionalSet: "onlyIfEqual";
-        /**
-         * The value to compare the existing value with.
-         */
-        comparisonValue: GlideString;
-    }
+          /**
+           * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
+           * `IFEQ` in the Valkey API.
+           */
+          conditionalSet: "onlyIfEqual";
+          /**
+           * The value to compare the existing value with.
+           */
+          comparisonValue: GlideString;
+      }
 ) & {
     /**
      * Return the old string stored at key, or nil if key did not exist. An error
@@ -175,11 +175,11 @@ export type SetOptions = (
      * Equivalent to `KEEPTTL` in the Valkey API.
      */
     expiry?:
-    | "keepExisting"
-    | {
-        type: TimeUnit;
-        count: number;
-    };
+        | "keepExisting"
+        | {
+              type: TimeUnit;
+              count: number;
+          };
 };
 
 /**
@@ -513,14 +513,6 @@ export function createHSetEx(
     options?: HSetExOptions,
 ): command_request.Command {
     const args: GlideString[] = [key];
-
-    // HSETEX does not support hash-level conditional changes (NX | XX)
-    // Only field-level conditional changes (FNX | FXX) are supported
-    if (options?.conditionalChange) {
-        throw new Error(
-            `HSETEX does not support hash-level conditional changes (${options.conditionalChange}). Use fieldConditionalChange instead.`,
-        );
-    }
 
     // Add field conditional change options (FNX | FXX)
     if (options?.fieldConditionalChange) {
@@ -1744,7 +1736,7 @@ export function createZAdd(
         if (options.conditionalChange) {
             if (
                 options.conditionalChange ===
-                ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
+                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
                 options.updateOptions
             ) {
                 throw new Error(
@@ -2020,15 +2012,15 @@ export type Boundary<T> =
      *  Represents a specific boundary.
      */
     | {
-        /**
-         * The comparison value.
-         */
-        value: T;
-        /**
-         * Whether the value is inclusive. Defaults to `true`.
-         */
-        isInclusive?: boolean;
-    };
+          /**
+           * The comparison value.
+           */
+          value: T;
+          /**
+           * Whether the value is inclusive. Defaults to `true`.
+           */
+          isInclusive?: boolean;
+      };
 
 /**
  * Represents a range by index (rank) in a sorted set.
@@ -2395,21 +2387,21 @@ export function createZRank(
 
 export type StreamTrimOptions = (
     | {
-        /**
-         * Trim the stream according to entry ID.
-         * Equivalent to `MINID` in the Valkey API.
-         */
-        method: "minid";
-        threshold: GlideString;
-    }
+          /**
+           * Trim the stream according to entry ID.
+           * Equivalent to `MINID` in the Valkey API.
+           */
+          method: "minid";
+          threshold: GlideString;
+      }
     | {
-        /**
-         * Trim the stream according to length.
-         * Equivalent to `MAXLEN` in the Valkey API.
-         */
-        method: "maxlen";
-        threshold: number;
-    }
+          /**
+           * Trim the stream according to length.
+           * Equivalent to `MAXLEN` in the Valkey API.
+           */
+          method: "maxlen";
+          threshold: number;
+      }
 ) & {
     /**
      * If `true`, the stream will be trimmed exactly. Equivalent to `=` in the
@@ -3551,9 +3543,9 @@ export enum HashFieldConditionalChange {
  */
 export type ExpirySet =
     | {
-        type: TimeUnit;
-        count: number;
-    }
+          type: TimeUnit;
+          count: number;
+      }
     | "KEEPTTL";
 
 /**
@@ -3562,12 +3554,6 @@ export type ExpirySet =
  * See https://valkey.io/commands/hsetex/ for more details.
  */
 export interface HSetExOptions {
-    /** 
-     * Options for handling existing hash objects. See {@link ConditionalChange}.
-     * Note: HSETEX does not support hash-level conditional changes (NX/XX).
-     * Use fieldConditionalChange for field-level conditions instead.
-     */
-    conditionalChange?: ConditionalChange;
     /** Options for handling existing fields. See {@link HashFieldConditionalChange}. */
     fieldConditionalChange?: HashFieldConditionalChange;
     /** Expiry settings for the fields. See {@link ExpirySet}. */

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -128,26 +128,26 @@ export function createGetRange(
 
 export type SetOptions = (
     | {
-        /**
-         * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
-         * `NX` in the Valkey API.
-         *
-         * `onlyIfExists` - Only set the key if it already exists.
-         * `EX` in the Valkey API.
-         */
-        conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
-    }
+          /**
+           * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
+           * `NX` in the Valkey API.
+           *
+           * `onlyIfExists` - Only set the key if it already exists.
+           * `EX` in the Valkey API.
+           */
+          conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
+      }
     | {
-        /**
-         * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
-         * `IFEQ` in the Valkey API.
-         */
-        conditionalSet: "onlyIfEqual";
-        /**
-         * The value to compare the existing value with.
-         */
-        comparisonValue: GlideString;
-    }
+          /**
+           * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
+           * `IFEQ` in the Valkey API.
+           */
+          conditionalSet: "onlyIfEqual";
+          /**
+           * The value to compare the existing value with.
+           */
+          comparisonValue: GlideString;
+      }
 ) & {
     /**
      * Return the old string stored at key, or nil if key did not exist. An error
@@ -175,11 +175,11 @@ export type SetOptions = (
      * Equivalent to `KEEPTTL` in the Valkey API.
      */
     expiry?:
-    | "keepExisting"
-    | {
-        type: TimeUnit;
-        count: number;
-    };
+        | "keepExisting"
+        | {
+              type: TimeUnit;
+              count: number;
+          };
 };
 
 /**
@@ -526,7 +526,10 @@ export function createHSetEx(
 
     // Add expiry options (EX | PX | EXAT | PXAT | KEEPTTL)
     if (options?.expiry) {
-        if (options.expiry !== "KEEPTTL" && !Number.isInteger(options.expiry.count)) {
+        if (
+            options.expiry !== "KEEPTTL" &&
+            !Number.isInteger(options.expiry.count)
+        ) {
             throw new Error(
                 `Received expiry '${JSON.stringify(
                     options.expiry,
@@ -576,6 +579,7 @@ export function createHGetEx(
                     )}'. Count must be an integer`,
                 );
             }
+
             args.push(options.expiry.type, options.expiry.count.toString());
         }
     }
@@ -1742,7 +1746,7 @@ export function createZAdd(
         if (options.conditionalChange) {
             if (
                 options.conditionalChange ===
-                ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
+                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
                 options.updateOptions
             ) {
                 throw new Error(
@@ -2018,15 +2022,15 @@ export type Boundary<T> =
      *  Represents a specific boundary.
      */
     | {
-        /**
-         * The comparison value.
-         */
-        value: T;
-        /**
-         * Whether the value is inclusive. Defaults to `true`.
-         */
-        isInclusive?: boolean;
-    };
+          /**
+           * The comparison value.
+           */
+          value: T;
+          /**
+           * Whether the value is inclusive. Defaults to `true`.
+           */
+          isInclusive?: boolean;
+      };
 
 /**
  * Represents a range by index (rank) in a sorted set.
@@ -2393,21 +2397,21 @@ export function createZRank(
 
 export type StreamTrimOptions = (
     | {
-        /**
-         * Trim the stream according to entry ID.
-         * Equivalent to `MINID` in the Valkey API.
-         */
-        method: "minid";
-        threshold: GlideString;
-    }
+          /**
+           * Trim the stream according to entry ID.
+           * Equivalent to `MINID` in the Valkey API.
+           */
+          method: "minid";
+          threshold: GlideString;
+      }
     | {
-        /**
-         * Trim the stream according to length.
-         * Equivalent to `MAXLEN` in the Valkey API.
-         */
-        method: "maxlen";
-        threshold: number;
-    }
+          /**
+           * Trim the stream according to length.
+           * Equivalent to `MAXLEN` in the Valkey API.
+           */
+          method: "maxlen";
+          threshold: number;
+      }
 ) & {
     /**
      * If `true`, the stream will be trimmed exactly. Equivalent to `=` in the
@@ -3547,14 +3551,16 @@ export enum HashFieldConditionalChange {
  * Expiry set options for hash field expiration commands.
  * Supports setting expiration time in various formats.
  */
-export type ExpirySet = {
-    type: TimeUnit;
-    count: number;
-} | "KEEPTTL";
+export type ExpirySet =
+    | {
+          type: TimeUnit;
+          count: number;
+      }
+    | "KEEPTTL";
 
 /**
  * Optional arguments for the HSETEX command.
- * 
+ *
  * See https://valkey.io/commands/hsetex/ for more details.
  */
 export interface HSetExOptions {
@@ -3568,7 +3574,7 @@ export interface HSetExOptions {
 
 /**
  * Optional arguments for the HGETEX command.
- * 
+ *
  * See https://valkey.io/commands/hgetex/ for more details.
  */
 export interface HGetExOptions {
@@ -3604,7 +3610,7 @@ export enum HashExpirationCondition {
 
 /**
  * Optional arguments for the HEXPIRE command.
- * 
+ *
  * See https://valkey.io/commands/hexpire/ for more details.
  */
 export interface HExpireOptions {
@@ -3614,7 +3620,7 @@ export interface HExpireOptions {
 
 /**
  * Optional arguments for the HPEXPIRE command.
- * 
+ *
  * See https://valkey.io/commands/hpexpire/ for more details.
  */
 export interface HPExpireOptions {
@@ -3624,7 +3630,7 @@ export interface HPExpireOptions {
 
 /**
  * Optional arguments for the HEXPIREAT command.
- * 
+ *
  * See https://valkey.io/commands/hexpireat/ for more details.
  */
 export interface HExpireAtOptions {
@@ -3634,7 +3640,7 @@ export interface HExpireAtOptions {
 
 /**
  * Optional arguments for the HPEXPIREAT command.
- * 
+ *
  * See https://valkey.io/commands/hpexpireat/ for more details.
  */
 export interface HPExpireAtOptions {

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -580,6 +580,9 @@ export function createHGetEx(
         }
     }
 
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
+
     // Add field names
     args.push(...fields);
 
@@ -602,6 +605,9 @@ export function createHExpire(
         args.push(options.condition);
     }
 
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
+
     // Add field names
     args.push(...fields);
 
@@ -616,6 +622,9 @@ export function createHPersist(
     fields: GlideString[],
 ): command_request.Command {
     const args: GlideString[] = [key];
+
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
 
     // Add field names
     args.push(...fields);
@@ -639,6 +648,9 @@ export function createHPExpire(
         args.push(options.condition);
     }
 
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
+
     // Add field names
     args.push(...fields);
 
@@ -660,6 +672,9 @@ export function createHExpireAt(
     if (options?.condition) {
         args.push(options.condition);
     }
+
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
 
     // Add field names
     args.push(...fields);
@@ -683,6 +698,9 @@ export function createHPExpireAt(
         args.push(options.condition);
     }
 
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
+
     // Add field names
     args.push(...fields);
 
@@ -697,6 +715,9 @@ export function createHTtl(
     fields: GlideString[],
 ): command_request.Command {
     const args: GlideString[] = [key];
+
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
 
     // Add field names
     args.push(...fields);
@@ -713,6 +734,9 @@ export function createHPTtl(
 ): command_request.Command {
     const args: GlideString[] = [key];
 
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
+
     // Add field names
     args.push(...fields);
 
@@ -728,6 +752,9 @@ export function createHExpireTime(
 ): command_request.Command {
     const args: GlideString[] = [key];
 
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
+
     // Add field names
     args.push(...fields);
 
@@ -742,6 +769,9 @@ export function createHPExpireTime(
     fields: GlideString[],
 ): command_request.Command {
     const args: GlideString[] = [key];
+
+    // Add FIELDS keyword and field count
+    args.push("FIELDS", fields.length.toString());
 
     // Add field names
     args.push(...fields);

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -128,26 +128,26 @@ export function createGetRange(
 
 export type SetOptions = (
     | {
-          /**
-           * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
-           * `NX` in the Valkey API.
-           *
-           * `onlyIfExists` - Only set the key if it already exists.
-           * `EX` in the Valkey API.
-           */
-          conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
-      }
+        /**
+         * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
+         * `NX` in the Valkey API.
+         *
+         * `onlyIfExists` - Only set the key if it already exists.
+         * `EX` in the Valkey API.
+         */
+        conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
+    }
     | {
-          /**
-           * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
-           * `IFEQ` in the Valkey API.
-           */
-          conditionalSet: "onlyIfEqual";
-          /**
-           * The value to compare the existing value with.
-           */
-          comparisonValue: GlideString;
-      }
+        /**
+         * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
+         * `IFEQ` in the Valkey API.
+         */
+        conditionalSet: "onlyIfEqual";
+        /**
+         * The value to compare the existing value with.
+         */
+        comparisonValue: GlideString;
+    }
 ) & {
     /**
      * Return the old string stored at key, or nil if key did not exist. An error
@@ -175,11 +175,11 @@ export type SetOptions = (
      * Equivalent to `KEEPTTL` in the Valkey API.
      */
     expiry?:
-        | "keepExisting"
-        | {
-              type: TimeUnit;
-              count: number;
-          };
+    | "keepExisting"
+    | {
+        type: TimeUnit;
+        count: number;
+    };
 };
 
 /**
@@ -520,21 +520,20 @@ export function createHSetEx(
     }
 
     // Add expiry options (EX | PX | EXAT | PXAT | KEEPTTL)
+    // Note: PERSIST is not supported by HSETEX
     if (options?.expiry) {
-        if (
-            options.expiry !== "KEEPTTL" &&
-            !Number.isInteger(options.expiry.count)
-        ) {
-            throw new Error(
-                `Received expiry '${JSON.stringify(
-                    options.expiry,
-                )}'. Count must be an integer`,
-            );
-        }
-
         if (options.expiry === "KEEPTTL") {
             args.push("KEEPTTL");
         } else {
+            // Validate that count is an integer
+            if (!Number.isInteger(options.expiry.count)) {
+                throw new Error(
+                    `HSETEX received expiry '${JSON.stringify(
+                        options.expiry,
+                    )}'. Count must be an integer`,
+                );
+            }
+
             args.push(options.expiry.type, options.expiry.count.toString());
         }
     }
@@ -567,14 +566,11 @@ export function createHGetEx(
     if (options?.expiry) {
         if (options.expiry === "PERSIST") {
             args.push("PERSIST");
-        } else if (options.expiry === "KEEPTTL") {
-            throw new Error(
-                "HGETEX does not support KEEPTTL option. Use PERSIST to remove expiration or specify a new expiry time.",
-            );
         } else {
+            // Validate that count is an integer
             if (!Number.isInteger(options.expiry.count)) {
                 throw new Error(
-                    `Received expiry '${JSON.stringify(
+                    `HGETEX received expiry '${JSON.stringify(
                         options.expiry,
                     )}'. Count must be an integer`,
                 );
@@ -640,7 +636,7 @@ export function createHPExpire(
     key: GlideString,
     milliseconds: number,
     fields: GlideString[],
-    options?: HPExpireOptions,
+    options?: HExpireOptions,
 ): command_request.Command {
     const args: GlideString[] = [key, milliseconds.toString()];
 
@@ -664,7 +660,7 @@ export function createHExpireAt(
     key: GlideString,
     unixTimestampSeconds: number,
     fields: GlideString[],
-    options?: HExpireAtOptions,
+    options?: HExpireOptions,
 ): command_request.Command {
     const args: GlideString[] = [key, unixTimestampSeconds.toString()];
 
@@ -688,7 +684,7 @@ export function createHPExpireAt(
     key: GlideString,
     unixTimestampMilliseconds: number,
     fields: GlideString[],
-    options?: HPExpireAtOptions,
+    options?: HExpireOptions,
 ): command_request.Command {
     const args: GlideString[] = [key, unixTimestampMilliseconds.toString()];
 
@@ -1736,7 +1732,7 @@ export function createZAdd(
         if (options.conditionalChange) {
             if (
                 options.conditionalChange ===
-                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
+                ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
                 options.updateOptions
             ) {
                 throw new Error(
@@ -2012,15 +2008,15 @@ export type Boundary<T> =
      *  Represents a specific boundary.
      */
     | {
-          /**
-           * The comparison value.
-           */
-          value: T;
-          /**
-           * Whether the value is inclusive. Defaults to `true`.
-           */
-          isInclusive?: boolean;
-      };
+        /**
+         * The comparison value.
+         */
+        value: T;
+        /**
+         * Whether the value is inclusive. Defaults to `true`.
+         */
+        isInclusive?: boolean;
+    };
 
 /**
  * Represents a range by index (rank) in a sorted set.
@@ -2387,21 +2383,21 @@ export function createZRank(
 
 export type StreamTrimOptions = (
     | {
-          /**
-           * Trim the stream according to entry ID.
-           * Equivalent to `MINID` in the Valkey API.
-           */
-          method: "minid";
-          threshold: GlideString;
-      }
+        /**
+         * Trim the stream according to entry ID.
+         * Equivalent to `MINID` in the Valkey API.
+         */
+        method: "minid";
+        threshold: GlideString;
+    }
     | {
-          /**
-           * Trim the stream according to length.
-           * Equivalent to `MAXLEN` in the Valkey API.
-           */
-          method: "maxlen";
-          threshold: number;
-      }
+        /**
+         * Trim the stream according to length.
+         * Equivalent to `MAXLEN` in the Valkey API.
+         */
+        method: "maxlen";
+        threshold: number;
+    }
 ) & {
     /**
      * If `true`, the stream will be trimmed exactly. Equivalent to `=` in the
@@ -3543,31 +3539,98 @@ export enum HashFieldConditionalChange {
  */
 export type ExpirySet =
     | {
-          type: TimeUnit;
-          count: number;
-      }
+        type: TimeUnit;
+        count: number;
+    }
     | "KEEPTTL";
 
 /**
+ * Expiry options specifically for HSETEX command.
+ * Supports standard expiry options (EX/PX/EXAT/PXAT) and KEEPTTL, but excludes PERSIST.
+ *
+ * @example
+ * ```typescript
+ * // Set expiration to 60 seconds
+ * const expiry: HSetExExpiry = { type: TimeUnit.Seconds, count: 60 };
+ *
+ * // Keep existing TTL
+ * const keepTtl: HSetExExpiry = "KEEPTTL";
+ * ```
+ */
+export type HSetExExpiry =
+    | {
+        type: TimeUnit;
+        count: number;
+    }
+    | "KEEPTTL";
+
+/**
+ * Expiry options specifically for HGETEX command.
+ * Supports standard expiry options (EX/PX/EXAT/PXAT) and PERSIST, but excludes KEEPTTL.
+ *
+ * @example
+ * ```typescript
+ * // Set expiration to 30 seconds
+ * const expiry: HGetExExpiry = { type: TimeUnit.Seconds, count: 30 };
+ *
+ * // Remove expiration
+ * const persist: HGetExExpiry = "PERSIST";
+ * ```
+ */
+export type HGetExExpiry =
+    | {
+        type: TimeUnit;
+        count: number;
+    }
+    | "PERSIST";
+
+/**
  * Optional arguments for the HSETEX command.
+ *
+ * @example
+ * ```typescript
+ * // Set fields with 60 second expiration, only if none exist
+ * const options: HSetExOptions = {
+ *     fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
+ *     expiry: { type: TimeUnit.Seconds, count: 60 }
+ * };
+ *
+ * // Set fields and keep existing TTL
+ * const keepTtlOptions: HSetExOptions = {
+ *     expiry: "KEEPTTL"
+ * };
+ * ```
  *
  * See https://valkey.io/commands/hsetex/ for more details.
  */
 export interface HSetExOptions {
     /** Options for handling existing fields. See {@link HashFieldConditionalChange}. */
     fieldConditionalChange?: HashFieldConditionalChange;
-    /** Expiry settings for the fields. See {@link ExpirySet}. */
-    expiry?: ExpirySet;
+    /** Expiry settings for the fields. See {@link HSetExExpiry}. */
+    expiry?: HSetExExpiry;
 }
 
 /**
  * Optional arguments for the HGETEX command.
  *
+ * @example
+ * ```typescript
+ * // Get fields and set 30 second expiration
+ * const options: HGetExOptions = {
+ *     expiry: { type: TimeUnit.Seconds, count: 30 }
+ * };
+ *
+ * // Get fields and remove expiration
+ * const persistOptions: HGetExOptions = {
+ *     expiry: "PERSIST"
+ * };
+ * ```
+ *
  * See https://valkey.io/commands/hgetex/ for more details.
  */
 export interface HGetExOptions {
-    /** Expiry settings for the fields. Can be an ExpirySet or "PERSIST" to remove expiration. */
-    expiry?: ExpirySet | "PERSIST";
+    /** Expiry settings for the fields. Can be a time-based expiry or "PERSIST" to remove expiration. */
+    expiry?: HGetExExpiry;
 }
 
 /**
@@ -3597,42 +3660,45 @@ export enum HashExpirationCondition {
 }
 
 /**
- * Optional arguments for the HEXPIRE command.
- *
- * See https://valkey.io/commands/hexpire/ for more details.
+ * Shared optional arguments for HEXPIRE, HPEXPIRE, HEXPIREAT, and HPEXPIREAT commands.
+ * 
+ * This interface provides a unified way to specify expiration conditions for hash field
+ * expiration commands that support conditional expiration setting.
+ * 
+ * @example
+ * ```typescript
+ * // Set expiration only if field has no existing expiration
+ * const options: HExpireOptions = {
+ *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
+ * };
+ * 
+ * // Set expiration only if new expiration is greater than current
+ * const gtOptions: HExpireOptions = {
+ *     condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT
+ * };
+ * 
+ * // Set expiration only if field has existing expiration
+ * const xxOptions: HExpireOptions = {
+ *     condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY
+ * };
+ * 
+ * // Set expiration only if new expiration is less than current
+ * const ltOptions: HExpireOptions = {
+ *     condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT
+ * };
+ * ```
+ * 
+ * @see {@link https://valkey.io/commands/hexpire/|HEXPIRE}
+ * @see {@link https://valkey.io/commands/hpexpire/|HPEXPIRE}
+ * @see {@link https://valkey.io/commands/hexpireat/|HEXPIREAT}
+ * @see {@link https://valkey.io/commands/hpexpireat/|HPEXPIREAT}
  */
 export interface HExpireOptions {
-    /** Condition for setting expiration. See {@link HashExpirationCondition}. */
-    condition?: HashExpirationCondition;
-}
-
-/**
- * Optional arguments for the HPEXPIRE command.
- *
- * See https://valkey.io/commands/hpexpire/ for more details.
- */
-export interface HPExpireOptions {
-    /** Condition for setting expiration. See {@link HashExpirationCondition}. */
-    condition?: HashExpirationCondition;
-}
-
-/**
- * Optional arguments for the HEXPIREAT command.
- *
- * See https://valkey.io/commands/hexpireat/ for more details.
- */
-export interface HExpireAtOptions {
-    /** Condition for setting expiration. See {@link HashExpirationCondition}. */
-    condition?: HashExpirationCondition;
-}
-
-/**
- * Optional arguments for the HPEXPIREAT command.
- *
- * See https://valkey.io/commands/hpexpireat/ for more details.
- */
-export interface HPExpireAtOptions {
-    /** Condition for setting expiration. See {@link HashExpirationCondition}. */
+    /** 
+     * Condition for setting expiration. Controls when the expiration should be set
+     * based on the current state of the field's expiration.
+     * See {@link HashExpirationCondition} for available options.
+     */
     condition?: HashExpirationCondition;
 }
 

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -128,26 +128,26 @@ export function createGetRange(
 
 export type SetOptions = (
     | {
-        /**
-         * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
-         * `NX` in the Valkey API.
-         *
-         * `onlyIfExists` - Only set the key if it already exists.
-         * `EX` in the Valkey API.
-         */
-        conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
-    }
+          /**
+           * `onlyIfDoesNotExist` - Only set the key if it does not already exist.
+           * `NX` in the Valkey API.
+           *
+           * `onlyIfExists` - Only set the key if it already exists.
+           * `EX` in the Valkey API.
+           */
+          conditionalSet?: "onlyIfExists" | "onlyIfDoesNotExist";
+      }
     | {
-        /**
-         * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
-         * `IFEQ` in the Valkey API.
-         */
-        conditionalSet: "onlyIfEqual";
-        /**
-         * The value to compare the existing value with.
-         */
-        comparisonValue: GlideString;
-    }
+          /**
+           * `onlyIfEqual` - Only set the key if the comparison value equals the current value of key.
+           * `IFEQ` in the Valkey API.
+           */
+          conditionalSet: "onlyIfEqual";
+          /**
+           * The value to compare the existing value with.
+           */
+          comparisonValue: GlideString;
+      }
 ) & {
     /**
      * Return the old string stored at key, or nil if key did not exist. An error
@@ -175,11 +175,11 @@ export type SetOptions = (
      * Equivalent to `KEEPTTL` in the Valkey API.
      */
     expiry?:
-    | "keepExisting"
-    | {
-        type: TimeUnit;
-        count: number;
-    };
+        | "keepExisting"
+        | {
+              type: TimeUnit;
+              count: number;
+          };
 };
 
 /**
@@ -1732,7 +1732,7 @@ export function createZAdd(
         if (options.conditionalChange) {
             if (
                 options.conditionalChange ===
-                ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
+                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST &&
                 options.updateOptions
             ) {
                 throw new Error(
@@ -2008,15 +2008,15 @@ export type Boundary<T> =
      *  Represents a specific boundary.
      */
     | {
-        /**
-         * The comparison value.
-         */
-        value: T;
-        /**
-         * Whether the value is inclusive. Defaults to `true`.
-         */
-        isInclusive?: boolean;
-    };
+          /**
+           * The comparison value.
+           */
+          value: T;
+          /**
+           * Whether the value is inclusive. Defaults to `true`.
+           */
+          isInclusive?: boolean;
+      };
 
 /**
  * Represents a range by index (rank) in a sorted set.
@@ -2383,21 +2383,21 @@ export function createZRank(
 
 export type StreamTrimOptions = (
     | {
-        /**
-         * Trim the stream according to entry ID.
-         * Equivalent to `MINID` in the Valkey API.
-         */
-        method: "minid";
-        threshold: GlideString;
-    }
+          /**
+           * Trim the stream according to entry ID.
+           * Equivalent to `MINID` in the Valkey API.
+           */
+          method: "minid";
+          threshold: GlideString;
+      }
     | {
-        /**
-         * Trim the stream according to length.
-         * Equivalent to `MAXLEN` in the Valkey API.
-         */
-        method: "maxlen";
-        threshold: number;
-    }
+          /**
+           * Trim the stream according to length.
+           * Equivalent to `MAXLEN` in the Valkey API.
+           */
+          method: "maxlen";
+          threshold: number;
+      }
 ) & {
     /**
      * If `true`, the stream will be trimmed exactly. Equivalent to `=` in the
@@ -3539,9 +3539,9 @@ export enum HashFieldConditionalChange {
  */
 export type ExpirySet =
     | {
-        type: TimeUnit;
-        count: number;
-    }
+          type: TimeUnit;
+          count: number;
+      }
     | "KEEPTTL";
 
 /**
@@ -3559,9 +3559,9 @@ export type ExpirySet =
  */
 export type HSetExExpiry =
     | {
-        type: TimeUnit;
-        count: number;
-    }
+          type: TimeUnit;
+          count: number;
+      }
     | "KEEPTTL";
 
 /**
@@ -3579,9 +3579,9 @@ export type HSetExExpiry =
  */
 export type HGetExExpiry =
     | {
-        type: TimeUnit;
-        count: number;
-    }
+          type: TimeUnit;
+          count: number;
+      }
     | "PERSIST";
 
 /**
@@ -3661,40 +3661,40 @@ export enum HashExpirationCondition {
 
 /**
  * Shared optional arguments for HEXPIRE, HPEXPIRE, HEXPIREAT, and HPEXPIREAT commands.
- * 
+ *
  * This interface provides a unified way to specify expiration conditions for hash field
  * expiration commands that support conditional expiration setting.
- * 
+ *
  * @example
  * ```typescript
  * // Set expiration only if field has no existing expiration
  * const options: HExpireOptions = {
  *     condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY
  * };
- * 
+ *
  * // Set expiration only if new expiration is greater than current
  * const gtOptions: HExpireOptions = {
  *     condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT
  * };
- * 
+ *
  * // Set expiration only if field has existing expiration
  * const xxOptions: HExpireOptions = {
  *     condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY
  * };
- * 
+ *
  * // Set expiration only if new expiration is less than current
  * const ltOptions: HExpireOptions = {
  *     condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT
  * };
  * ```
- * 
+ *
  * @see {@link https://valkey.io/commands/hexpire/|HEXPIRE}
  * @see {@link https://valkey.io/commands/hpexpire/|HPEXPIRE}
  * @see {@link https://valkey.io/commands/hexpireat/|HEXPIREAT}
  * @see {@link https://valkey.io/commands/hpexpireat/|HPEXPIREAT}
  */
 export interface HExpireOptions {
-    /** 
+    /**
      * Condition for setting expiration. Controls when the expiration should be set
      * based on the current state of the field's expiration.
      * See {@link HashExpirationCondition} for available options.

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -327,10 +327,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                              await client.info({
-                                  sections: [InfoOptions.Commandstats],
-                              }),
-                          ).join();
+                            await client.info({
+                                sections: [InfoOptions.Commandstats],
+                            }),
+                        ).join();
                 expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
@@ -338,10 +338,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                              await client.info({
-                                  sections: [InfoOptions.Commandstats],
-                              }),
-                          ).join();
+                            await client.info({
+                                sections: [InfoOptions.Commandstats],
+                            }),
+                        ).join();
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },
@@ -368,13 +368,13 @@ export function runBaseTests(config: {
                     const response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic).lastsave(),
-                                  isAtomic,
-                              )
+                                new Batch(isAtomic).lastsave(),
+                                isAtomic,
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic).lastsave(),
-                                  isAtomic,
-                              );
+                                new ClusterBatch(isAtomic).lastsave(),
+                                isAtomic,
+                            );
 
                     expect(response?.[0]).toBeGreaterThan(yesterday);
                 }
@@ -2535,9 +2535,9 @@ export function runBaseTests(config: {
                         client instanceof GlideClient
                             ? await client.exec(batch as Batch, false)
                             : await (client as GlideClusterClient).exec(
-                                  batch as ClusterBatch,
-                                  false,
-                              );
+                                batch as ClusterBatch,
+                                false,
+                            );
 
                     expect(results).toHaveLength(4);
                     expect(results![0]).toBe(1); // hsetex result for key1
@@ -2734,9 +2734,9 @@ export function runBaseTests(config: {
                         client instanceof GlideClient
                             ? client.exec(batch as Batch, true)
                             : (client as GlideClusterClient).exec(
-                                  batch as ClusterBatch,
-                                  true,
-                              );
+                                batch as ClusterBatch,
+                                true,
+                            );
 
                     await expect(execPromise).rejects.toThrow(RequestError);
                 },
@@ -2787,13 +2787,6 @@ export function runBaseTests(config: {
                         expiry: "PERSIST",
                     });
                     expect(result3).toEqual([value1]);
-
-                    // Test that HGETEX does not support KEEPTTL
-                    await expect(
-                        client.hgetex(key, [field1], {
-                            expiry: "KEEPTTL",
-                        }),
-                    ).rejects.toThrow("HGETEX does not support KEEPTTL option");
 
                     // Test HGETEX on non-existent key
                     const nonExistentKey = getRandomKey();
@@ -2907,9 +2900,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                              batch as ClusterBatch,
-                              false,
-                          ));
+                            batch as ClusterBatch,
+                            false,
+                        ));
 
                     expect(results).toHaveLength(2);
                     expect(results![0]).toEqual([value1]);
@@ -3223,9 +3216,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                              batch as ClusterBatch,
-                              false,
-                          ));
+                            batch as ClusterBatch,
+                            false,
+                        ));
                     expect(results).toEqual([[1], [1]]);
 
                     // Verify expiration was set using HTTL
@@ -3448,9 +3441,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                              batch as ClusterBatch,
-                              false,
-                          ));
+                            batch as ClusterBatch,
+                            false,
+                        ));
                     expect(results).toEqual([[1], [1]]);
                 },
                 protocol,
@@ -3761,9 +3754,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                              batch as ClusterBatch,
-                              false,
-                          ));
+                            batch as ClusterBatch,
+                            false,
+                        ));
 
                     expect(results).toEqual([[1], [1]]);
                 },
@@ -4102,9 +4095,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                              batch as ClusterBatch,
-                              false,
-                          ));
+                            batch as ClusterBatch,
+                            false,
+                        ));
 
                     expect(results).toEqual([[1], [1]]);
                 },
@@ -4453,9 +4446,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                              batch as ClusterBatch,
-                              false,
-                          ));
+                            batch as ClusterBatch,
+                            false,
+                        ));
                     expect(results).toEqual([[1], [1]]);
 
                     // Verify fields still exist
@@ -9347,27 +9340,27 @@ export function runBaseTests(config: {
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, {
-                              decoder: Decoder.String,
-                          })
+                            decoder: Decoder.String,
+                        })
                         : await client.echo(message, {
-                              decoder: Decoder.String,
-                          }),
+                            decoder: Decoder.String,
+                        }),
                 ).toEqual(message);
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, { decoder: Decoder.Bytes })
                         : await client.echo(message, {
-                              decoder: Decoder.Bytes,
-                          }),
+                            decoder: Decoder.Bytes,
+                        }),
                 ).toEqual(Buffer.from(message));
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(Buffer.from(message), {
-                              decoder: Decoder.String,
-                          })
+                            decoder: Decoder.String,
+                        })
                         : await client.echo(Buffer.from(message), {
-                              decoder: Decoder.String,
-                          }),
+                            decoder: Decoder.String,
+                        }),
                 ).toEqual(message);
                 expect(await client.echo(Buffer.from(message))).toEqual(
                     message,
@@ -11079,17 +11072,17 @@ export function runBaseTests(config: {
                     let response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic).dump(key1),
-                                  true,
-                                  {
-                                      decoder: Decoder.Bytes,
-                                  },
-                              )
+                                new Batch(isAtomic).dump(key1),
+                                true,
+                                {
+                                    decoder: Decoder.Bytes,
+                                },
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic).dump(key1),
-                                  true,
-                                  { decoder: Decoder.Bytes },
-                              );
+                                new ClusterBatch(isAtomic).dump(key1),
+                                true,
+                                { decoder: Decoder.Bytes },
+                            );
                     expect(response?.[0]).not.toBeNull();
                     data = response?.[0] as Buffer;
 
@@ -11097,19 +11090,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic)
-                                      .restore(key4, 0, data)
-                                      .get(key4),
-                                  true,
-                                  { decoder: Decoder.String },
-                              )
+                                new Batch(isAtomic)
+                                    .restore(key4, 0, data)
+                                    .get(key4),
+                                true,
+                                { decoder: Decoder.String },
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic)
-                                      .restore(key4, 0, data)
-                                      .get(key4),
-                                  true,
-                                  { decoder: Decoder.String },
-                              );
+                                new ClusterBatch(isAtomic)
+                                    .restore(key4, 0, data)
+                                    .get(key4),
+                                true,
+                                { decoder: Decoder.String },
+                            );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(value);
 
@@ -11117,19 +11110,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic)
-                                      .restore(key5, 0, data)
-                                      .get(key5),
-                                  true,
-                                  { decoder: Decoder.Bytes },
-                              )
+                                new Batch(isAtomic)
+                                    .restore(key5, 0, data)
+                                    .get(key5),
+                                true,
+                                { decoder: Decoder.Bytes },
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic)
-                                      .restore(key5, 0, data)
-                                      .get(key5),
-                                  true,
-                                  { decoder: Decoder.Bytes },
-                              );
+                                new ClusterBatch(isAtomic)
+                                    .restore(key5, 0, data)
+                                    .get(key5),
+                                true,
+                                { decoder: Decoder.Bytes },
+                            );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(valueEncode);
                 }
@@ -11601,13 +11594,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                          type:
-                              | TimeUnit.Seconds
-                              | TimeUnit.Milliseconds
-                              | TimeUnit.UnixSeconds
-                              | TimeUnit.UnixMilliseconds;
-                          count: number;
-                      },
+                        type:
+                        | TimeUnit.Seconds
+                        | TimeUnit.Milliseconds
+                        | TimeUnit.UnixSeconds
+                        | TimeUnit.UnixMilliseconds;
+                        count: number;
+                    },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -11628,13 +11621,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                          type:
-                              | TimeUnit.Seconds
-                              | TimeUnit.Milliseconds
-                              | TimeUnit.UnixSeconds
-                              | TimeUnit.UnixMilliseconds;
-                          count: number;
-                      },
+                        type:
+                        | TimeUnit.Seconds
+                        | TimeUnit.Milliseconds
+                        | TimeUnit.UnixSeconds
+                        | TimeUnit.UnixMilliseconds;
+                        count: number;
+                    },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -11653,13 +11646,13 @@ export function runBaseTests(config: {
                     expiry: expiryVal as
                         | "keepExisting"
                         | {
-                              type:
-                                  | TimeUnit.Seconds
-                                  | TimeUnit.Milliseconds
-                                  | TimeUnit.UnixSeconds
-                                  | TimeUnit.UnixMilliseconds;
-                              count: number;
-                          },
+                            type:
+                            | TimeUnit.Seconds
+                            | TimeUnit.Milliseconds
+                            | TimeUnit.UnixSeconds
+                            | TimeUnit.UnixMilliseconds;
+                            count: number;
+                        },
                     conditionalSet: "onlyIfEqual",
                     comparisonValue: value, // Ensure it matches the current key's value
                 });
@@ -13139,7 +13132,7 @@ export function runBaseTests(config: {
                     for (let i = 0; i < fullResultMapArray.length; i += 2) {
                         expect(
                             (fullResultMapArray[i] as string) in
-                                expectedFullMap,
+                            expectedFullMap,
                         ).toEqual(true);
                     }
 
@@ -14064,23 +14057,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(Buffer.from(key))).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                                  "entries-read": null,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                                "entries-read": null,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 expect(
@@ -14117,23 +14110,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                                  "entries-read": null,
-                                  lag: 3,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                                "entries-read": null,
+                                lag: 3,
+                            },
+                        ],
                 );
 
                 const xreadgroup = await client.xreadgroup(
@@ -14158,23 +14151,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 3,
-                                  "last-delivered-id": streamId3,
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 3,
+                                "last-delivered-id": streamId3,
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 3,
-                                  "last-delivered-id": streamId3,
-                                  "entries-read": 3,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 3,
+                                "last-delivered-id": streamId3,
+                                "entries-read": 3,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 expect(await client.xack(key, groupName1, [streamId1])).toEqual(
@@ -14184,23 +14177,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 2,
-                                  "last-delivered-id": streamId3,
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 2,
+                                "last-delivered-id": streamId3,
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 2,
-                                  "last-delivered-id": streamId3,
-                                  "entries-read": 3,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 2,
+                                "last-delivered-id": streamId3,
+                                "entries-read": 3,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 // key exists, but it is not a stream
@@ -14424,16 +14417,16 @@ export function runBaseTests(config: {
                     Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                              start: InfBoundary.NegativeInfinity,
-                              end: InfBoundary.PositiveInfinity,
-                              count: 1,
-                          }
+                            start: InfBoundary.NegativeInfinity,
+                            end: InfBoundary.PositiveInfinity,
+                            count: 1,
+                        }
                         : {
-                              start: InfBoundary.NegativeInfinity,
-                              end: InfBoundary.PositiveInfinity,
-                              count: 1,
-                              minIdleTime: 42,
-                          },
+                            start: InfBoundary.NegativeInfinity,
+                            end: InfBoundary.PositiveInfinity,
+                            count: 1,
+                            minIdleTime: 42,
+                        },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);
@@ -15651,9 +15644,9 @@ export function runBaseTests(config: {
                             client instanceof GlideClient
                                 ? await client.exec(batch as Batch, true)
                                 : await client.exec(
-                                      batch as ClusterBatch,
-                                      true,
-                                  );
+                                    batch as ClusterBatch,
+                                    true,
+                                );
                         expect(result).toEqual(expectedResult);
                     }
 
@@ -15703,13 +15696,13 @@ export function runBaseTests(config: {
                 // Retry with a longer timeout
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                          batch as ClusterBatch,
-                          true,
-                          { timeout: 1000 },
-                      )
+                        batch as ClusterBatch,
+                        true,
+                        { timeout: 1000 },
+                    )
                     : await (client as GlideClient).exec(batch as Batch, true, {
-                          timeout: 1000,
-                      });
+                        timeout: 1000,
+                    });
 
                 expect(result?.length).toBe(1);
             }, protocol);
@@ -15738,9 +15731,9 @@ export function runBaseTests(config: {
 
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                          batch as ClusterBatch,
-                          false,
-                      )
+                        batch as ClusterBatch,
+                        false,
+                    )
                     : await (client as GlideClient).exec(batch as Batch, false);
 
                 expect(result?.length).toBe(4);
@@ -15913,9 +15906,9 @@ export function runCommonTests(config: {
                 const result = clusterMode
                     ? await client.exec(batch as ClusterTransaction, true)
                     : await (client as GlideClient).exec(
-                          batch as Transaction,
-                          true,
-                      );
+                        batch as Transaction,
+                        true,
+                    );
                 expect(result?.length).toBe(2);
                 expect(result?.[0]).toBe("OK");
                 expect(result?.[1]).toBe("hello");

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -36,6 +36,8 @@ import {
     GlideReturnType,
     GlideString,
     HashDataType,
+    HashExpirationCondition,
+    HashFieldConditionalChange,
     InfBoundary,
     InfoOptions,
     InsertPosition,
@@ -325,10 +327,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                              await client.info({
-                                  sections: [InfoOptions.Commandstats],
-                              }),
-                          ).join();
+                            await client.info({
+                                sections: [InfoOptions.Commandstats],
+                            }),
+                        ).join();
                 expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
@@ -336,10 +338,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                              await client.info({
-                                  sections: [InfoOptions.Commandstats],
-                              }),
-                          ).join();
+                            await client.info({
+                                sections: [InfoOptions.Commandstats],
+                            }),
+                        ).join();
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },
@@ -366,13 +368,13 @@ export function runBaseTests(config: {
                     const response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic).lastsave(),
-                                  isAtomic,
-                              )
+                                new Batch(isAtomic).lastsave(),
+                                isAtomic,
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic).lastsave(),
-                                  isAtomic,
-                              );
+                                new ClusterBatch(isAtomic).lastsave(),
+                                isAtomic,
+                            );
 
                     expect(response?.[0]).toBeGreaterThan(yesterday);
                 }
@@ -2143,6 +2145,2295 @@ export function runBaseTests(config: {
                 await expect(
                     client.hrandfieldWithValues(key2, 42),
                 ).rejects.toThrow(RequestError);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Test basic HSETEX with expiry
+                const fieldValueMap = { [field1]: value1, [field2]: value2 };
+                expect(
+                    await client.hsetex(key, fieldValueMap, {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    }),
+                ).toEqual(2);
+
+                // Verify fields were set
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+
+                // Test with KEEPTTL
+                const field3 = getRandomKey();
+                const value3 = getRandomKey();
+                expect(
+                    await client.hsetex(key, { [field3]: value3 }, {
+                        expiry: "KEEPTTL",
+                    }),
+                ).toEqual(1);
+                expect(await client.hget(key, field3)).toEqual(value3);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex with conditional changes_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Test with NX (only if hash doesn't exist)
+                expect(
+                    await client.hsetex(
+                        key,
+                        { [field1]: value1 },
+                        {
+                            conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(1);
+
+                // Should not set because hash already exists
+                expect(
+                    await client.hsetex(
+                        key,
+                        { [field2]: value2 },
+                        {
+                            conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(0);
+
+                // Test with XX (only if hash exists)
+                const key2 = getRandomKey();
+                expect(
+                    await client.hsetex(
+                        key2,
+                        { [field1]: value1 },
+                        {
+                            conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(0);
+
+                // Should work because hash exists
+                expect(
+                    await client.hsetex(
+                        key,
+                        { [field2]: value2 },
+                        {
+                            conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(1);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex with field conditional changes_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+                const value3 = getRandomKey();
+
+                // Set up initial fields
+                expect(await client.hset(key, { [field1]: value1 })).toEqual(1);
+
+                // Test FXX (only if all fields exist)
+                expect(
+                    await client.hsetex(
+                        key,
+                        { [field1]: value2, [field2]: value2 },
+                        {
+                            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_ALL_EXIST,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(0); // field2 doesn't exist
+
+                // Test FNX (only if none of the fields exist)
+                expect(
+                    await client.hsetex(
+                        key,
+                        { [field2]: value2, [field3]: value3 },
+                        {
+                            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(2); // both fields don't exist
+
+                // Should fail because field2 now exists
+                expect(
+                    await client.hsetex(
+                        key,
+                        { [field2]: value2, [field3]: value3 },
+                        {
+                            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    ),
+                ).toEqual(0);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex with different expiry types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const field4 = getRandomKey();
+                const value = getRandomKey();
+
+                // Test EX (seconds)
+                expect(
+                    await client.hsetex(key, { [field1]: value }, {
+                        expiry: { type: TimeUnit.Seconds, count: 1 },
+                    }),
+                ).toEqual(1);
+
+                // Test PX (milliseconds)
+                expect(
+                    await client.hsetex(key, { [field2]: value }, {
+                        expiry: { type: TimeUnit.Milliseconds, count: 1000 },
+                    }),
+                ).toEqual(1);
+
+                // Test EXAT (Unix timestamp in seconds)
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 60;
+                expect(
+                    await client.hsetex(key, { [field3]: value }, {
+                        expiry: { type: TimeUnit.UnixSeconds, count: futureTimestamp },
+                    }),
+                ).toEqual(1);
+
+                // Test PXAT (Unix timestamp in milliseconds)
+                const futureTimestampMs = Date.now() + 60000;
+                expect(
+                    await client.hsetex(key, { [field4]: value }, {
+                        expiry: { type: TimeUnit.UnixMilliseconds, count: futureTimestampMs },
+                    }),
+                ).toEqual(1);
+
+                // Verify all fields were set
+                expect(await client.hget(key, field1)).toEqual(value);
+                expect(await client.hget(key, field2)).toEqual(value);
+                expect(await client.hget(key, field3)).toEqual(value);
+                expect(await client.hget(key, field4)).toEqual(value);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex with HashDataType and Record types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Test with Record<string, GlideString>
+                const recordMap: Record<string, GlideString> = {
+                    [field1]: value1,
+                    [field2]: Buffer.from(value2),
+                };
+                expect(
+                    await client.hsetex(key, recordMap, {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    }),
+                ).toEqual(2);
+
+                // Test with HashDataType
+                const hashDataType: HashDataType = [
+                    { field: Buffer.from(field1), value: Buffer.from(value1) },
+                    { field: field2, value: value2 },
+                ];
+                const key2 = getRandomKey();
+                expect(
+                    await client.hsetex(key2, hashDataType, {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    }),
+                ).toEqual(2);
+
+                // Verify values
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+                expect(await client.hget(key2, field1)).toEqual(value1);
+                expect(await client.hget(key2, field2)).toEqual(value2);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+                const value = getRandomKey();
+
+                // Test invalid expiry count (non-integer)
+                await expect(
+                    client.hsetex(key, { [field]: value }, {
+                        expiry: { type: TimeUnit.Seconds, count: 1.5 },
+                    }),
+                ).rejects.toThrow("Count must be an integer");
+
+                // Test with non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hsetex(key, { [field]: value }, {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    }),
+                ).rejects.toThrow(RequestError);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex with version compatibility and batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                // Skip test if server version is less than 9.0.0
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Test batch operations with HSETEX
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+
+                batch.hsetex(key1, { [field1]: value1 }, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                batch.hsetex(key2, { [field2]: value2 }, {
+                    expiry: { type: TimeUnit.Milliseconds, count: 60000 },
+                });
+                batch.hget(key1, field1);
+                batch.hget(key2, field2);
+
+                const results = client instanceof GlideClient
+                    ? await client.exec(batch as Batch, false)
+                    : await (client as GlideClusterClient).exec(batch as ClusterBatch, false);
+
+                expect(results).toHaveLength(4);
+                expect(results![0]).toBe(1); // hsetex result for key1
+                expect(results![1]).toBe(1); // hsetex result for key2
+                expect(results![2]).toBe(value1); // hget result for key1
+                expect(results![3]).toBe(value2); // hget result for key2
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex with comprehensive parameter types and edge cases_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                // Skip test if server version is less than 9.0.0
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Test with mixed GlideString types (Buffer and string)
+                const keyBuffer = Buffer.from(getRandomKey());
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                const result1 = await client.hsetex(keyBuffer, {
+                    [field1]: valueBuffer,
+                    [fieldBuffer.toString()]: value1
+                }, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result1).toBe(2);
+
+                // Verify values with different decoders
+                expect(await client.hget(keyBuffer, field1)).toBe(valueBuffer.toString());
+                expect(await client.hget(keyBuffer, field1, { decoder: Decoder.Bytes })).toEqual(valueBuffer);
+                expect(await client.hget(keyBuffer, fieldBuffer)).toBe(value1);
+
+                // Test with empty field-value map
+                const result2 = await client.hsetex(getRandomKey(), {}, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result2).toBe(0);
+
+                // Test with very long field and value names
+                const longKey = getRandomKey();
+                const longField = "a".repeat(100);
+                const longValue = "b".repeat(100);
+
+                const result3 = await client.hsetex(longKey, { [longField]: longValue }, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result3).toBe(1);
+                expect(await client.hget(longKey, longField)).toBe(longValue);
+
+                // Test with special characters
+                const specialKey = getRandomKey();
+                const specialField = "field:with:special:chars:!@#$%^&*()";
+                const specialValue = "value:with:special:chars:!@#$%^&*()";
+
+                const result4 = await client.hsetex(specialKey, { [specialField]: specialValue }, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result4).toBe(1);
+                expect(await client.hget(specialKey, specialField)).toBe(specialValue);
+
+                // Test with Unicode characters
+                const unicodeKey = getRandomKey();
+                const unicodeField = "field_🚀_测试_🎉";
+                const unicodeValue = "value_🌟_测试_🎊";
+
+                const result5 = await client.hsetex(unicodeKey, { [unicodeField]: unicodeValue }, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result5).toBe(1);
+                expect(await client.hget(unicodeKey, unicodeField)).toBe(unicodeValue);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hsetex Promise-based error handling and validation_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                // Skip test if server version is less than 9.0.0
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+                const value = getRandomKey();
+
+                // Test Promise rejection for non-integer expiry count
+                let errorCaught = false;
+                try {
+                    await client.hsetex(key, { [field]: value }, {
+                        expiry: { type: TimeUnit.Seconds, count: 1.5 },
+                    });
+                } catch (error) {
+                    errorCaught = true;
+                    expect(error).toBeInstanceOf(Error);
+                    expect((error as Error).message).toContain("Count must be an integer");
+                }
+                expect(errorCaught).toBe(true);
+
+                // Test Promise rejection when used on non-hash key
+                await client.set(key, "string_value");
+
+                errorCaught = false;
+                try {
+                    await client.hsetex(key, { [field]: value }, {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    });
+                } catch (error) {
+                    errorCaught = true;
+                    expect(error).toBeInstanceOf(RequestError);
+                }
+                expect(errorCaught).toBe(true);
+
+                // Test batch operation error handling
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                batch.hsetex(key, { [field]: value }, {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+
+                const execPromise = client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false);
+
+                await expect(execPromise).rejects.toThrow(RequestError);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hgetex basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Test basic HGETEX without options
+                const result1 = await client.hgetex(key, [field1, field2, field3]);
+                expect(result1).toEqual([value1, value2, null]);
+
+                // Test HGETEX with expiry setting
+                const result2 = await client.hgetex(key, [field1, field2], {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result2).toEqual([value1, value2]);
+
+                // Test HGETEX with PERSIST option
+                const result3 = await client.hgetex(key, [field1], {
+                    expiry: "PERSIST",
+                });
+                expect(result3).toEqual([value1]);
+
+                // Test HGETEX with KEEPTTL option
+                const result4 = await client.hgetex(key, [field1], {
+                    expiry: "KEEPTTL",
+                });
+                expect(result4).toEqual([value1]);
+
+                // Test HGETEX on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result5 = await client.hgetex(nonExistentKey, [field1, field2]);
+                expect(result5).toEqual([null, null]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hgetex with different expiry types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const field4 = getRandomKey();
+                const value = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, {
+                    [field1]: value,
+                    [field2]: value,
+                    [field3]: value,
+                    [field4]: value
+                });
+
+                // Test EX (seconds)
+                const result1 = await client.hgetex(key, [field1], {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result1).toEqual([value]);
+
+                // Test PX (milliseconds)
+                const result2 = await client.hgetex(key, [field2], {
+                    expiry: { type: TimeUnit.Milliseconds, count: 60000 },
+                });
+                expect(result2).toEqual([value]);
+
+                // Test EXAT (Unix timestamp in seconds)
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 60;
+                const result3 = await client.hgetex(key, [field3], {
+                    expiry: { type: TimeUnit.UnixSeconds, count: futureTimestamp },
+                });
+                expect(result3).toEqual([value]);
+
+                // Test PXAT (Unix timestamp in milliseconds)
+                const futureTimestampMs = Date.now() + 60000;
+                const result4 = await client.hgetex(key, [field4], {
+                    expiry: { type: TimeUnit.UnixMilliseconds, count: futureTimestampMs },
+                });
+                expect(result4).toEqual([value]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hgetex with batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+
+                // Test batch operations with HGETEX
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+
+                batch.hgetex(key1, [field1], {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                batch.hgetex(key2, [field2], {
+                    expiry: "PERSIST",
+                });
+
+                const results = await (client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+
+                expect(results).toHaveLength(2);
+                expect(results![0]).toEqual([value1]);
+                expect(results![1]).toEqual([value2]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hgetex error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+                const value = getRandomKey();
+
+                // Test invalid expiry count (non-integer)
+                await expect(
+                    client.hgetex(key, [field], {
+                        expiry: { type: TimeUnit.Seconds, count: 1.5 },
+                    }),
+                ).rejects.toThrow("Count must be an integer");
+
+                // Test HGETEX on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hgetex(key, [field], {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    }),
+                ).rejects.toThrow(RequestError);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hgetex with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const field1 = getRandomKey();
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const value1 = getRandomKey();
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                // Set up hash with mixed types
+                await client.hset(keyBuffer, {
+                    [field1]: valueBuffer,
+                    [fieldBuffer.toString()]: value1
+                });
+
+                // Test with Buffer keys and fields
+                const result1 = await client.hgetex(keyBuffer, [field1, fieldBuffer]);
+                expect(result1).toHaveLength(2);
+                expect(result1[0]).toEqual(valueBuffer);
+                expect(result1[1]).toEqual(value1);
+
+                // Test with empty field array
+                const result2 = await client.hgetex(key, []);
+                expect(result2).toEqual([]);
+
+                // Test with large field names and values
+                const longKey = getRandomKey();
+                const longField = "f".repeat(100);
+                const longValue = "v".repeat(100);
+
+                await client.hset(longKey, { [longField]: longValue });
+                const result3 = await client.hgetex(longKey, [longField], {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result3).toEqual([longValue]);
+
+                // Test with special characters
+                const specialKey = getRandomKey();
+                const specialField = "field:with:special:chars:!@#$%^&*()";
+                const specialValue = "value:with:special:chars:!@#$%^&*()";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                const result4 = await client.hgetex(specialKey, [specialField], {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result4).toEqual([specialValue]);
+
+                // Test with Unicode characters
+                const unicodeKey = getRandomKey();
+                const unicodeField = "field_🚀_测试_🎉";
+                const unicodeValue = "value_🌟_测试_🎊";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                const result5 = await client.hgetex(unicodeKey, [unicodeField], {
+                    expiry: { type: TimeUnit.Seconds, count: 60 },
+                });
+                expect(result5).toEqual([unicodeValue]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpire basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Test basic HEXPIRE
+                const result1 = await client.hexpire(key, 60, [field1, field2, field3]);
+                expect(result1).toEqual([true, true, false]); // field3 doesn't exist
+
+                // Verify fields still exist
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+
+                // Test with 0 seconds (immediate deletion)
+                const result2 = await client.hexpire(key, 0, [field1]);
+                expect(result2).toEqual([true]);
+                expect(await client.hget(key, field1)).toEqual(null);
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hexpire(nonExistentKey, 60, [field1]);
+                expect(result3).toEqual([false]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpire with conditions_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set initial expiration on field1
+                await client.hexpire(key, 120, [field1]);
+
+                // Test NX condition (only if no expiry)
+                const result1 = await client.hexpire(key, 60, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+                expect(result1).toEqual([false, true]); // field1 already has expiry, field2 doesn't
+
+                // Test XX condition (only if has expiry)
+                const result2 = await client.hexpire(key, 180, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                });
+                expect(result2).toEqual([true, true]); // both should have expiry now
+
+                // Test GT condition (only if greater than current)
+                const result3 = await client.hexpire(key, 300, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                });
+                expect(result3).toEqual([true]); // 300 > 180
+
+                // Test LT condition (only if less than current)
+                const result4 = await client.hexpire(key, 150, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                });
+                expect(result4).toEqual([true]); // 150 < 300
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpire batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+
+                // Test batch operations with HEXPIRE
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                batch.hexpire(key1, 60, [field1]);
+                batch.hexpire(key2, 120, [field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+
+                const results = await (client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+                expect(results).toEqual([[true], [true]]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpire error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+
+                // Test HEXPIRE on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hexpire(key, 60, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test with empty field array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hexpire(hashKey, 60, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpire with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const field1 = getRandomKey();
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const value1 = getRandomKey();
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                // Set up hash with mixed types
+                await client.hset(keyBuffer, {
+                    [field1]: valueBuffer,
+                    [fieldBuffer.toString()]: value1
+                });
+
+                // Test with Buffer keys and fields
+                const result1 = await client.hexpire(keyBuffer, 60, [field1, fieldBuffer]);
+                expect(result1).toEqual([true, true]);
+
+                // Test with large field names
+                const longKey = getRandomKey();
+                const longField = "f".repeat(100);
+                const longValue = "v".repeat(100);
+
+                await client.hset(longKey, { [longField]: longValue });
+                const result2 = await client.hexpire(longKey, 60, [longField]);
+                expect(result2).toEqual([true]);
+
+                // Test with special characters
+                const specialKey = getRandomKey();
+                const specialField = "field:with:special:chars:!@#$%^&*()";
+                const specialValue = "value:with:special:chars:!@#$%^&*()";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                const result3 = await client.hexpire(specialKey, 60, [specialField]);
+                expect(result3).toEqual([true]);
+
+                // Test with Unicode characters
+                const unicodeKey = getRandomKey();
+                const unicodeField = "field_🚀_测试_🎉";
+                const unicodeValue = "value_🌟_测试_🎊";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                const result4 = await client.hexpire(unicodeKey, 60, [unicodeField]);
+                expect(result4).toEqual([true]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpersist basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey(); // non-existent field
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields
+                await client.hexpire(key, 60, [field1, field2]);
+
+                // Test basic HPERSIST
+                const result1 = await client.hpersist(key, [field1, field2, field3]);
+                expect(result1).toEqual([true, true, false]); // field3 doesn't exist
+
+                // Verify fields still exist but no longer have expiration
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result2 = await client.hpersist(nonExistentKey, [field1]);
+                expect(result2).toEqual([false]);
+
+                // Test on fields without expiration
+                const key2 = getRandomKey();
+                await client.hset(key2, { [field1]: value1 });
+                const result3 = await client.hpersist(key2, [field1]);
+                expect(result3).toEqual([false]); // field has no expiration to remove
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpersist with batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes with fields and expiration
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+                await client.hexpire(key1, 60, [field1]);
+                await client.hexpire(key2, 120, [field2]);
+
+                // Test batch operations with HPERSIST
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                batch.hpersist(key1, [field1]);
+                batch.hpersist(key2, [field2]);
+
+                const results = await (client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+                expect(results).toEqual([[true], [true]]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpersist error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+
+                // Test HPERSIST on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hpersist(key, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test with empty field array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hpersist(hashKey, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpersist with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const field1 = getRandomKey();
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const value = getRandomKey();
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                // Test with Buffer keys and fields
+                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
+                await client.hexpire(keyBuffer, 60, [field1, fieldBuffer.toString()]);
+                const result1 = await client.hpersist(keyBuffer, [field1, fieldBuffer]);
+                expect(result1).toEqual([true, true]);
+
+                // Test with long field names and values
+                const longKey = getRandomKey();
+                const longField = "f".repeat(100);
+                const longValue = "v".repeat(100);
+
+                await client.hset(longKey, { [longField]: longValue });
+                await client.hexpire(longKey, 60, [longField]);
+                const result2 = await client.hpersist(longKey, [longField]);
+                expect(result2).toEqual([true]);
+
+                // Test with special characters
+                const specialKey = getRandomKey();
+                const specialField = "field:with:special:chars:!@#$%^&*()";
+                const specialValue = "value:with:special:chars:!@#$%^&*()";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                await client.hexpire(specialKey, 60, [specialField]);
+                const result3 = await client.hpersist(specialKey, [specialField]);
+                expect(result3).toEqual([true]);
+
+                // Test with Unicode characters
+                const unicodeKey = getRandomKey();
+                const unicodeField = "field_🚀_测试_🎉";
+                const unicodeValue = "value_🌟_测试_🎊";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                await client.hexpire(unicodeKey, 60, [unicodeField]);
+                const result4 = await client.hpersist(unicodeKey, [unicodeField]);
+                expect(result4).toEqual([true]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpire basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Test basic HPEXPIRE
+                const result1 = await client.hpexpire(key, 60000, [field1, field2, field3]);
+                expect(result1).toEqual([true, true, false]); // field3 doesn't exist
+
+                // Verify fields still exist
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+
+                // Test with 0 milliseconds (immediate deletion)
+                const result2 = await client.hpexpire(key, 0, [field1]);
+                expect(result2).toEqual([true]);
+                expect(await client.hget(key, field1)).toEqual(null);
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hpexpire(nonExistentKey, 60000, [field1]);
+                expect(result3).toEqual([false]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpire with conditions_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set initial expiration on field1
+                await client.hpexpire(key, 120000, [field1]);
+
+                // Test NX condition (only if no expiry)
+                const result1 = await client.hpexpire(key, 60000, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+                expect(result1).toEqual([false, true]); // field1 already has expiry, field2 doesn't
+
+                // Test XX condition (only if has expiry)
+                const result2 = await client.hpexpire(key, 180000, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                });
+                expect(result2).toEqual([true, true]); // both should have expiry now
+
+                // Test GT condition (only if greater than current)
+                const result3 = await client.hpexpire(key, 300000, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                });
+                expect(result3).toEqual([true]); // 300000 > 180000
+
+                // Test LT condition (only if less than current)
+                const result4 = await client.hpexpire(key, 150000, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                });
+                expect(result4).toEqual([true]); // 150000 < 300000
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpire batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+
+                // Test batch operations with HPEXPIRE
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                batch.hpexpire(key1, 60000, [field1]);
+                batch.hpexpire(key2, 120000, [field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+
+                const results = await (client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+
+                expect(results).toEqual([[true], [true]]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpire error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+
+                // Test HPEXPIRE on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hpexpire(key, 60000, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test with empty field array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hpexpire(hashKey, 60000, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpire with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const field1 = getRandomKey();
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const value = getRandomKey();
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                // Test with Buffer keys and fields
+                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
+                const result1 = await client.hpexpire(keyBuffer, 60000, [field1, fieldBuffer]);
+                expect(result1).toEqual([true, true]);
+
+                // Test with long field names and values
+                const longKey = getRandomKey();
+                const longField = "f".repeat(100);
+                const longValue = "v".repeat(100);
+
+                await client.hset(longKey, { [longField]: longValue });
+                const result2 = await client.hpexpire(longKey, 60000, [longField]);
+                expect(result2).toEqual([true]);
+
+                // Test with special characters
+                const specialKey = getRandomKey();
+                const specialField = "field:with:special:chars:!@#$%^&*()";
+                const specialValue = "value:with:special:chars:!@#$%^&*()";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                const result3 = await client.hpexpire(specialKey, 60000, [specialField]);
+                expect(result3).toEqual([true]);
+
+                // Test with Unicode characters
+                const unicodeKey = getRandomKey();
+                const unicodeField = "field_🚀_测试_🎉";
+                const unicodeValue = "value_🌟_测试_🎊";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                const result4 = await client.hpexpire(unicodeKey, 60000, [unicodeField]);
+                expect(result4).toEqual([true]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpireat basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Test basic HEXPIREAT with future timestamp
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                const result1 = await client.hexpireat(key, futureTimestamp, [field1, field2, field3]);
+                expect(result1).toEqual([true, true, false]); // field3 doesn't exist
+
+                // Verify fields still exist
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+
+                // Test with past timestamp (immediate deletion)
+                const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+                const result2 = await client.hexpireat(key, pastTimestamp, [field1]);
+                expect(result2).toEqual([true]);
+                expect(await client.hget(key, field1)).toEqual(null);
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hexpireat(nonExistentKey, futureTimestamp, [field1]);
+                expect(result3).toEqual([false]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpireat with conditions_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with some fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                const futureTimestamp1 = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                const futureTimestamp2 = Math.floor(Date.now() / 1000) + 7200; // 2 hours from now
+
+                // Test NX condition (only if no expiry)
+                const result1 = await client.hexpireat(key, futureTimestamp1, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+                expect(result1).toEqual([true, true]);
+
+                // Test NX condition again (should fail because fields now have expiry)
+                const result2 = await client.hexpireat(key, futureTimestamp2, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+                expect(result2).toEqual([false, false]);
+
+                // Test XX condition (only if has expiry)
+                const result3 = await client.hexpireat(key, futureTimestamp2, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                });
+                expect(result3).toEqual([true, true]);
+
+                // Test GT condition (only if greater than current)
+                const result4 = await client.hexpireat(key, futureTimestamp2, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                });
+                expect(result4).toEqual([true]);
+
+                // Test LT condition (only if less than current)
+                const result5 = await client.hexpireat(key, futureTimestamp1, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                });
+                expect(result5).toEqual([true]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpireat batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+
+                const futureTimestamp1 = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                const futureTimestamp2 = Math.floor(Date.now() / 1000) + 7200; // 2 hours from now
+
+                // Test batch operations with HEXPIREAT
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                batch.hexpireat(key1, futureTimestamp1, [field1]);
+                batch.hexpireat(key2, futureTimestamp2, [field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+
+                const results = await (client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+
+                expect(results).toEqual([[true], [true]]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpireat error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+
+                // Test HEXPIREAT on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hexpireat(key, futureTimestamp, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test with empty field array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hexpireat(hashKey, futureTimestamp, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpireat with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const field1 = getRandomKey();
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const value = getRandomKey();
+                const valueBuffer = Buffer.from(getRandomKey());
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+
+                // Test with Buffer keys and fields
+                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
+                const result1 = await client.hexpireat(keyBuffer, futureTimestamp, [field1, fieldBuffer]);
+                expect(result1).toEqual([true, true]);
+
+                // Test with long field names and values
+                const longKey = getRandomKey();
+                const longField = "f".repeat(100);
+                const longValue = "v".repeat(100);
+
+                await client.hset(longKey, { [longField]: longValue });
+                const result2 = await client.hexpireat(longKey, futureTimestamp, [longField]);
+                expect(result2).toEqual([true]);
+
+                // Test with special characters
+                const specialKey = getRandomKey();
+                const specialField = "field:with:special:chars:!@#$%^&*()";
+                const specialValue = "value:with:special:chars:!@#$%^&*()";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                const result3 = await client.hexpireat(specialKey, futureTimestamp, [specialField]);
+                expect(result3).toEqual([true]);
+
+                // Test with Unicode characters
+                const unicodeKey = getRandomKey();
+                const unicodeField = "field_🚀_测试_🎉";
+                const unicodeValue = "value_🌟_测试_🎊";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                const result4 = await client.hexpireat(unicodeKey, futureTimestamp, [unicodeField]);
+                expect(result4).toEqual([true]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpireat basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Test basic HPEXPIREAT with future timestamp in milliseconds
+                const futureTimestamp = Date.now() + 3600000; // 1 hour from now
+                const result1 = await client.hpexpireat(key, futureTimestamp, [field1, field2, field3]);
+                expect(result1).toEqual([true, true, false]); // field3 doesn't exist
+
+                // Verify fields still exist and have expiration
+                expect(await client.hget(key, field1)).toEqual(value1);
+                expect(await client.hget(key, field2)).toEqual(value2);
+
+                // Test with past timestamp (immediate deletion)
+                const pastTimestamp = Date.now() - 3600000; // 1 hour ago
+                const result2 = await client.hpexpireat(key, pastTimestamp, [field1]);
+                expect(result2).toEqual([true]);
+                expect(await client.hget(key, field1)).toEqual(null);
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hpexpireat(nonExistentKey, futureTimestamp, [field1]);
+                expect(result3).toEqual([false]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpireat with conditions_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                const futureTimestamp1 = Date.now() + 3600000; // 1 hour from now
+                const futureTimestamp2 = Date.now() + 7200000; // 2 hours from now
+
+                // Test NX condition (only if no expiry)
+                const result1 = await client.hpexpireat(key, futureTimestamp1, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+                expect(result1).toEqual([true, true]);
+
+                // Test NX condition again (should fail because fields now have expiry)
+                const result2 = await client.hpexpireat(key, futureTimestamp2, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+                expect(result2).toEqual([false, false]);
+
+                // Test XX condition (only if has expiry)
+                const result3 = await client.hpexpireat(key, futureTimestamp2, [field1, field2], {
+                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                });
+                expect(result3).toEqual([true, true]);
+
+                // Test GT condition (only if greater than current)
+                const result4 = await client.hpexpireat(key, futureTimestamp2, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                });
+                expect(result4).toEqual([false]); // futureTimestamp2 is not greater than current expiry
+
+                // Test LT condition (only if less than current)
+                const result5 = await client.hpexpireat(key, futureTimestamp1, [field1], {
+                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                });
+                expect(result5).toEqual([true]); // futureTimestamp1 is less than current expiry
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpireat batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes with fields
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+
+                const futureTimestamp1 = Date.now() + 3600000; // 1 hour from now
+                const futureTimestamp2 = Date.now() + 7200000; // 2 hours from now
+
+                // Test batch operations with HPEXPIREAT
+                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                batch.hpexpireat(key1, futureTimestamp1, [field1]);
+                batch.hpexpireat(key2, futureTimestamp2, [field2], {
+                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                });
+
+                const results = await (client instanceof GlideClient
+                    ? client.exec(batch as Batch, false)
+                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+                expect(results).toEqual([[true], [true]]);
+
+                // Verify fields still exist
+                expect(await client.hget(key1, field1)).toEqual(value1);
+                expect(await client.hget(key2, field2)).toEqual(value2);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpireat error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+                const futureTimestamp = Date.now() + 3600000;
+
+                // Test HPEXPIREAT on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hpexpireat(key, futureTimestamp, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test with empty fields array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hpexpireat(hashKey, futureTimestamp, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpireat with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const field1 = getRandomKey();
+                const value = getRandomKey();
+                const futureTimestamp = Date.now() + 3600000; // 1 hour from now
+
+                // Test with Buffer keys and fields
+                const keyBuffer = Buffer.from(getRandomKey());
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
+                const result1 = await client.hpexpireat(keyBuffer, futureTimestamp, [field1, fieldBuffer]);
+                expect(result1).toEqual([true, true]);
+
+                // Test with very long key and field names
+                const longKey = "a".repeat(1000);
+                const longField = "b".repeat(1000);
+                const longValue = "c".repeat(1000);
+
+                await client.hset(longKey, { [longField]: longValue });
+                const result2 = await client.hpexpireat(longKey, futureTimestamp, [longField]);
+                expect(result2).toEqual([true]);
+
+                // Test with special characters
+                const specialKey = "key:with:special:chars";
+                const specialField = "field@with#special$chars";
+                const specialValue = "value%with&special*chars";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                const result3 = await client.hpexpireat(specialKey, futureTimestamp, [specialField]);
+                expect(result3).toEqual([true]);
+
+                // Test with Unicode characters
+                const unicodeKey = "🔑key";
+                const unicodeField = "🏷️field";
+                const unicodeValue = "💎value";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                const result4 = await client.hpexpireat(unicodeKey, futureTimestamp, [unicodeField]);
+                expect(result4).toEqual([true]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `httl basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields
+                await client.hexpire(key, 60, [field1, field2]);
+
+                // Test basic HTTL
+                const result1 = await client.httl(key, [field1, field2, field3]);
+                expect(result1.length).toEqual(3);
+                expect(result1[0]).toBeGreaterThan(0); // field1 has TTL
+                expect(result1[1]).toBeGreaterThan(0); // field2 has TTL
+                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+
+                // Remove expiration from field1
+                await client.hpersist(key, [field1]);
+
+                // Test HTTL after persist
+                const result2 = await client.httl(key, [field1, field2]);
+                expect(result2[0]).toEqual(-1); // field1 has no expiration
+                expect(result2[1]).toBeGreaterThan(0); // field2 still has TTL
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.httl(nonExistentKey, [field1]);
+                expect(result3).toEqual([-2]);
+
+                // Test on fields without expiration
+                const key2 = getRandomKey();
+                await client.hset(key2, { [field1]: value1 });
+                const result4 = await client.httl(key2, [field1]);
+                expect(result4).toEqual([-1]); // field has no expiration
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `httl with batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes with fields and expiration
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+                await client.hexpire(key1, 60, [field1]);
+                await client.hexpire(key2, 120, [field2]);
+
+                // Test batch operations with HTTL
+                if (client instanceof GlideClient) {
+                    const batch = new Batch(false);
+                    batch.httl(key1, [field1]);
+                    batch.httl(key2, [field2]);
+                    const results = await client.exec(batch, false);
+                    expect(results).not.toBeNull();
+                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                } else {
+                    const batch = new ClusterBatch(false);
+                    batch.httl(key1, [field1]);
+                    batch.httl(key2, [field2]);
+                    const results = await (client as GlideClusterClient).exec(batch, false);
+                    expect(results).not.toBeNull();
+                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                }
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `httl error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+
+                // Test HTTL on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.httl(key, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test HTTL with empty fields array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.httl(hashKey, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `httl with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const field1 = getRandomKey();
+                const value = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                // Test with Buffer keys and fields
+                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
+                await client.hexpire(keyBuffer, 60, [field1, fieldBuffer.toString()]);
+                const result1 = await client.httl(keyBuffer, [field1, fieldBuffer]);
+                expect(result1.length).toEqual(2);
+                expect(result1[0]).toBeGreaterThan(0);
+                expect(result1[1]).toBeGreaterThan(0);
+
+                // Test with long keys and fields
+                const longKey = "a".repeat(1000);
+                const longField = "b".repeat(1000);
+                const longValue = "c".repeat(1000);
+
+                await client.hset(longKey, { [longField]: longValue });
+                await client.hexpire(longKey, 60, [longField]);
+                const result2 = await client.httl(longKey, [longField]);
+                expect(result2[0]).toBeGreaterThan(0);
+
+                // Test with special characters
+                const specialKey = "key:with:special:chars";
+                const specialField = "field@with#special$chars";
+                const specialValue = "value%with&special*chars";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                await client.hexpire(specialKey, 60, [specialField]);
+                const result3 = await client.httl(specialKey, [specialField]);
+                expect(result3[0]).toBeGreaterThan(0);
+
+                // Test with Unicode characters
+                const unicodeKey = "🔑key";
+                const unicodeField = "🏷️field";
+                const unicodeValue = "💎value";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                await client.hexpire(unicodeKey, 60, [unicodeField]);
+                const result4 = await client.httl(unicodeKey, [unicodeField]);
+                expect(result4[0]).toBeGreaterThan(0);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpiretime basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields using absolute timestamp
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                await client.hexpireat(key, futureTimestamp, [field1, field2]);
+
+                // Test basic HEXPIRETIME
+                const result1 = await client.hexpiretime(key, [field1, field2, field3]);
+                expect(result1.length).toEqual(3);
+                expect(result1[0]).toBeGreaterThan(0); // field1 has expiration timestamp
+                expect(result1[1]).toBeGreaterThan(0); // field2 has expiration timestamp
+                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+
+                // Remove expiration from field1
+                await client.hpersist(key, [field1]);
+
+                // Test HEXPIRETIME after persist
+                const result2 = await client.hexpiretime(key, [field1, field2]);
+                expect(result2[0]).toEqual(-1); // field1 has no expiration
+                expect(result2[1]).toBeGreaterThan(0); // field2 still has expiration timestamp
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hexpiretime(nonExistentKey, [field1]);
+                expect(result3).toEqual([-2]);
+
+                // Test on fields without expiration
+                const key2 = getRandomKey();
+                await client.hset(key2, { [field1]: value1 });
+                const result4 = await client.hexpiretime(key2, [field1]);
+                expect(result4).toEqual([-1]); // field has no expiration
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hexpiretime with batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields
+                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                await client.hexpireat(key, futureTimestamp, [field1, field2]);
+
+                // Test batch operations with HEXPIRETIME
+                if (client instanceof GlideClient) {
+                    const batch = new Batch(false);
+                    batch.hexpiretime(key, [field1, field2]);
+                    const results = await client.exec(batch, false);
+                    expect(results).not.toBeNull();
+                    const result = results![0] as number[];
+                    expect(result.length).toEqual(2);
+                    expect(result[0]).toBeGreaterThan(0);
+                    expect(result[1]).toBeGreaterThan(0);
+                }
+
+                // Test error cases
+                const field = getRandomKey();
+
+                // Test HEXPIRETIME on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hexpiretime(key, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test HEXPIRETIME with empty fields array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hexpiretime(hashKey, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpiretime basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields using absolute timestamp in milliseconds
+                const futureTimestampMs = Date.now() + 3600000; // 1 hour from now in milliseconds
+                await client.hpexpireat(key, futureTimestampMs, [field1, field2]);
+
+                // Test basic HPEXPIRETIME
+                const result1 = await client.hpexpiretime(key, [field1, field2, field3]);
+                expect(result1.length).toEqual(3);
+                expect(result1[0]).toBeGreaterThan(0); // field1 has expiration timestamp in milliseconds
+                expect(result1[1]).toBeGreaterThan(0); // field2 has expiration timestamp in milliseconds
+                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+
+                // Verify timestamp is in milliseconds (should be much larger than seconds)
+                expect(result1[0]).toBeGreaterThan(Date.now()); // Should be in the future
+                expect(result1[1]).toBeGreaterThan(Date.now()); // Should be in the future
+
+                // Remove expiration from field1
+                await client.hpersist(key, [field1]);
+
+                // Test HPEXPIRETIME after persist
+                const result2 = await client.hpexpiretime(key, [field1, field2]);
+                expect(result2[0]).toEqual(-1); // field1 has no expiration
+                expect(result2[1]).toBeGreaterThan(0); // field2 still has expiration timestamp
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hpexpiretime(nonExistentKey, [field1]);
+                expect(result3).toEqual([-2]);
+
+                // Test on fields without expiration
+                const key2 = getRandomKey();
+                await client.hset(key2, { [field1]: value1 });
+                const result4 = await client.hpexpiretime(key2, [field1]);
+                expect(result4).toEqual([-1]); // field has no expiration
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpexpiretime with batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields
+                const futureTimestampMs = Date.now() + 3600000; // 1 hour from now in milliseconds
+                await client.hpexpireat(key, futureTimestampMs, [field1, field2]);
+
+                // Test batch operations with HPEXPIRETIME
+                if (client instanceof GlideClient) {
+                    const batch = new Batch(false);
+                    batch.hpexpiretime(key, [field1, field2]);
+                    const results = await client.exec(batch, false);
+                    expect(results).not.toBeNull();
+                    const result = results![0] as number[];
+                    expect(result.length).toEqual(2);
+                    expect(result[0]).toBeGreaterThan(0);
+                    expect(result[1]).toBeGreaterThan(0);
+                }
+
+                // Test error cases
+                const field = getRandomKey();
+
+                // Test HPEXPIRETIME on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hpexpiretime(key, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test HPEXPIRETIME with empty fields array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hpexpiretime(hashKey, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpttl basic functionality_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const field3 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hash with fields
+                await client.hset(key, { [field1]: value1, [field2]: value2 });
+
+                // Set expiration on fields using HPEXPIRE (milliseconds)
+                await client.hpexpire(key, 60000, [field1, field2]);
+
+                // Test basic HPTTL
+                const result1 = await client.hpttl(key, [field1, field2, field3]);
+                expect(result1.length).toEqual(3);
+                expect(result1[0]).toBeGreaterThan(0); // field1 has TTL in milliseconds
+                expect(result1[1]).toBeGreaterThan(0); // field2 has TTL in milliseconds
+                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+
+                // Verify TTL is in milliseconds (should be much larger than seconds)
+                expect(result1[0]).toBeGreaterThan(1000); // Should be > 1 second in ms
+                expect(result1[1]).toBeGreaterThan(1000); // Should be > 1 second in ms
+
+                // Remove expiration from field1
+                await client.hpersist(key, [field1]);
+
+                // Test HPTTL after persist
+                const result2 = await client.hpttl(key, [field1, field2]);
+                expect(result2[0]).toEqual(-1); // field1 has no expiration
+                expect(result2[1]).toBeGreaterThan(0); // field2 still has TTL
+
+                // Test on non-existent key
+                const nonExistentKey = getRandomKey();
+                const result3 = await client.hpttl(nonExistentKey, [field1]);
+                expect(result3).toEqual([-2]);
+
+                // Test on fields without expiration
+                const key2 = getRandomKey();
+                await client.hset(key2, { [field1]: value1 });
+                const result4 = await client.hpttl(key2, [field1]);
+                expect(result4).toEqual([-1]); // field has no expiration
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpttl with batch operations_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key1 = getRandomKey();
+                const key2 = getRandomKey();
+                const field1 = getRandomKey();
+                const field2 = getRandomKey();
+                const value1 = getRandomKey();
+                const value2 = getRandomKey();
+
+                // Set up hashes with fields and expiration
+                await client.hset(key1, { [field1]: value1 });
+                await client.hset(key2, { [field2]: value2 });
+                await client.hpexpire(key1, 60000, [field1]);
+                await client.hpexpire(key2, 120000, [field2]);
+
+                // Test batch operations with HPTTL
+                if (client instanceof GlideClient) {
+                    const batch = new Batch(false);
+                    batch.hpttl(key1, [field1]);
+                    batch.hpttl(key2, [field2]);
+                    const results = await client.exec(batch, false);
+                    expect(results).not.toBeNull();
+                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                } else {
+                    const batch = new ClusterBatch(false);
+                    batch.hpttl(key1, [field1]);
+                    batch.hpttl(key2, [field2]);
+                    const results = await (client as GlideClusterClient).exec(batch, false);
+                    expect(results).not.toBeNull();
+                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                }
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpttl error handling_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const key = getRandomKey();
+                const field = getRandomKey();
+
+                // Test HPTTL on non-hash key
+                expect(await client.set(key, "string_value")).toEqual("OK");
+                await expect(
+                    client.hpttl(key, [field]),
+                ).rejects.toThrow(RequestError);
+
+                // Test HPTTL with empty fields array
+                const hashKey = getRandomKey();
+                await client.hset(hashKey, { [field]: "value" });
+                const result = await client.hpttl(hashKey, []);
+                expect(result).toEqual([]);
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `hpttl with comprehensive parameter types_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
+                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                    return;
+                }
+
+                const field1 = getRandomKey();
+                const value = getRandomKey();
+                const keyBuffer = Buffer.from(getRandomKey());
+                const fieldBuffer = Buffer.from(getRandomKey());
+                const valueBuffer = Buffer.from(getRandomKey());
+
+                // Test with Buffer keys and fields
+                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
+                await client.hpexpire(keyBuffer, 60000, [field1, fieldBuffer.toString()]);
+                const result1 = await client.hpttl(keyBuffer, [field1, fieldBuffer]);
+                expect(result1.length).toEqual(2);
+                expect(result1[0]).toBeGreaterThan(0);
+                expect(result1[1]).toBeGreaterThan(0);
+
+                // Test with long keys and fields
+                const longKey = "a".repeat(1000);
+                const longField = "b".repeat(1000);
+                const longValue = "c".repeat(1000);
+
+                await client.hset(longKey, { [longField]: longValue });
+                await client.hpexpire(longKey, 60000, [longField]);
+                const result2 = await client.hpttl(longKey, [longField]);
+                expect(result2[0]).toBeGreaterThan(0);
+
+                // Test with special characters
+                const specialKey = "key:with:special:chars";
+                const specialField = "field@with#special$chars";
+                const specialValue = "value%with&special*chars";
+
+                await client.hset(specialKey, { [specialField]: specialValue });
+                await client.hpexpire(specialKey, 60000, [specialField]);
+                const result3 = await client.hpttl(specialKey, [specialField]);
+                expect(result3[0]).toBeGreaterThan(0);
+
+                // Test with Unicode characters
+                const unicodeKey = "🔑key";
+                const unicodeField = "🏷️field";
+                const unicodeValue = "💎value";
+
+                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
+                await client.hpexpire(unicodeKey, 60000, [unicodeField]);
+                const result4 = await client.hpttl(unicodeKey, [unicodeField]);
+                expect(result4[0]).toBeGreaterThan(0);
             }, protocol);
         },
         config.timeout,
@@ -6207,27 +8498,27 @@ export function runBaseTests(config: {
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, {
-                              decoder: Decoder.String,
-                          })
+                            decoder: Decoder.String,
+                        })
                         : await client.echo(message, {
-                              decoder: Decoder.String,
-                          }),
+                            decoder: Decoder.String,
+                        }),
                 ).toEqual(message);
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, { decoder: Decoder.Bytes })
                         : await client.echo(message, {
-                              decoder: Decoder.Bytes,
-                          }),
+                            decoder: Decoder.Bytes,
+                        }),
                 ).toEqual(Buffer.from(message));
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(Buffer.from(message), {
-                              decoder: Decoder.String,
-                          })
+                            decoder: Decoder.String,
+                        })
                         : await client.echo(Buffer.from(message), {
-                              decoder: Decoder.String,
-                          }),
+                            decoder: Decoder.String,
+                        }),
                 ).toEqual(message);
                 expect(await client.echo(Buffer.from(message))).toEqual(
                     message,
@@ -7939,17 +10230,17 @@ export function runBaseTests(config: {
                     let response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic).dump(key1),
-                                  true,
-                                  {
-                                      decoder: Decoder.Bytes,
-                                  },
-                              )
+                                new Batch(isAtomic).dump(key1),
+                                true,
+                                {
+                                    decoder: Decoder.Bytes,
+                                },
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic).dump(key1),
-                                  true,
-                                  { decoder: Decoder.Bytes },
-                              );
+                                new ClusterBatch(isAtomic).dump(key1),
+                                true,
+                                { decoder: Decoder.Bytes },
+                            );
                     expect(response?.[0]).not.toBeNull();
                     data = response?.[0] as Buffer;
 
@@ -7957,19 +10248,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic)
-                                      .restore(key4, 0, data)
-                                      .get(key4),
-                                  true,
-                                  { decoder: Decoder.String },
-                              )
+                                new Batch(isAtomic)
+                                    .restore(key4, 0, data)
+                                    .get(key4),
+                                true,
+                                { decoder: Decoder.String },
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic)
-                                      .restore(key4, 0, data)
-                                      .get(key4),
-                                  true,
-                                  { decoder: Decoder.String },
-                              );
+                                new ClusterBatch(isAtomic)
+                                    .restore(key4, 0, data)
+                                    .get(key4),
+                                true,
+                                { decoder: Decoder.String },
+                            );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(value);
 
@@ -7977,19 +10268,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                  new Batch(isAtomic)
-                                      .restore(key5, 0, data)
-                                      .get(key5),
-                                  true,
-                                  { decoder: Decoder.Bytes },
-                              )
+                                new Batch(isAtomic)
+                                    .restore(key5, 0, data)
+                                    .get(key5),
+                                true,
+                                { decoder: Decoder.Bytes },
+                            )
                             : await client.exec(
-                                  new ClusterBatch(isAtomic)
-                                      .restore(key5, 0, data)
-                                      .get(key5),
-                                  true,
-                                  { decoder: Decoder.Bytes },
-                              );
+                                new ClusterBatch(isAtomic)
+                                    .restore(key5, 0, data)
+                                    .get(key5),
+                                true,
+                                { decoder: Decoder.Bytes },
+                            );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(valueEncode);
                 }
@@ -8461,13 +10752,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                          type:
-                              | TimeUnit.Seconds
-                              | TimeUnit.Milliseconds
-                              | TimeUnit.UnixSeconds
-                              | TimeUnit.UnixMilliseconds;
-                          count: number;
-                      },
+                        type:
+                        | TimeUnit.Seconds
+                        | TimeUnit.Milliseconds
+                        | TimeUnit.UnixSeconds
+                        | TimeUnit.UnixMilliseconds;
+                        count: number;
+                    },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -8488,13 +10779,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                          type:
-                              | TimeUnit.Seconds
-                              | TimeUnit.Milliseconds
-                              | TimeUnit.UnixSeconds
-                              | TimeUnit.UnixMilliseconds;
-                          count: number;
-                      },
+                        type:
+                        | TimeUnit.Seconds
+                        | TimeUnit.Milliseconds
+                        | TimeUnit.UnixSeconds
+                        | TimeUnit.UnixMilliseconds;
+                        count: number;
+                    },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -8513,13 +10804,13 @@ export function runBaseTests(config: {
                     expiry: expiryVal as
                         | "keepExisting"
                         | {
-                              type:
-                                  | TimeUnit.Seconds
-                                  | TimeUnit.Milliseconds
-                                  | TimeUnit.UnixSeconds
-                                  | TimeUnit.UnixMilliseconds;
-                              count: number;
-                          },
+                            type:
+                            | TimeUnit.Seconds
+                            | TimeUnit.Milliseconds
+                            | TimeUnit.UnixSeconds
+                            | TimeUnit.UnixMilliseconds;
+                            count: number;
+                        },
                     conditionalSet: "onlyIfEqual",
                     comparisonValue: value, // Ensure it matches the current key's value
                 });
@@ -9999,7 +12290,7 @@ export function runBaseTests(config: {
                     for (let i = 0; i < fullResultMapArray.length; i += 2) {
                         expect(
                             (fullResultMapArray[i] as string) in
-                                expectedFullMap,
+                            expectedFullMap,
                         ).toEqual(true);
                     }
 
@@ -10924,23 +13215,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(Buffer.from(key))).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                                  "entries-read": null,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                                "entries-read": null,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 expect(
@@ -10977,23 +13268,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 0,
-                                  pending: 0,
-                                  "last-delivered-id": "0-0",
-                                  "entries-read": null,
-                                  lag: 3,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 0,
+                                pending: 0,
+                                "last-delivered-id": "0-0",
+                                "entries-read": null,
+                                lag: 3,
+                            },
+                        ],
                 );
 
                 const xreadgroup = await client.xreadgroup(
@@ -11018,23 +13309,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 3,
-                                  "last-delivered-id": streamId3,
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 3,
+                                "last-delivered-id": streamId3,
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 3,
-                                  "last-delivered-id": streamId3,
-                                  "entries-read": 3,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 3,
+                                "last-delivered-id": streamId3,
+                                "entries-read": 3,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 expect(await client.xack(key, groupName1, [streamId1])).toEqual(
@@ -11044,23 +13335,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 2,
-                                  "last-delivered-id": streamId3,
-                              },
-                          ]
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 2,
+                                "last-delivered-id": streamId3,
+                            },
+                        ]
                         : [
-                              {
-                                  name: groupName1,
-                                  consumers: 1,
-                                  pending: 2,
-                                  "last-delivered-id": streamId3,
-                                  "entries-read": 3,
-                                  lag: 0,
-                              },
-                          ],
+                            {
+                                name: groupName1,
+                                consumers: 1,
+                                pending: 2,
+                                "last-delivered-id": streamId3,
+                                "entries-read": 3,
+                                lag: 0,
+                            },
+                        ],
                 );
 
                 // key exists, but it is not a stream
@@ -11284,16 +13575,16 @@ export function runBaseTests(config: {
                     Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                              start: InfBoundary.NegativeInfinity,
-                              end: InfBoundary.PositiveInfinity,
-                              count: 1,
-                          }
+                            start: InfBoundary.NegativeInfinity,
+                            end: InfBoundary.PositiveInfinity,
+                            count: 1,
+                        }
                         : {
-                              start: InfBoundary.NegativeInfinity,
-                              end: InfBoundary.PositiveInfinity,
-                              count: 1,
-                              minIdleTime: 42,
-                          },
+                            start: InfBoundary.NegativeInfinity,
+                            end: InfBoundary.PositiveInfinity,
+                            count: 1,
+                            minIdleTime: 42,
+                        },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);
@@ -12511,9 +14802,9 @@ export function runBaseTests(config: {
                             client instanceof GlideClient
                                 ? await client.exec(batch as Batch, true)
                                 : await client.exec(
-                                      batch as ClusterBatch,
-                                      true,
-                                  );
+                                    batch as ClusterBatch,
+                                    true,
+                                );
                         expect(result).toEqual(expectedResult);
                     }
 
@@ -12563,13 +14854,13 @@ export function runBaseTests(config: {
                 // Retry with a longer timeout
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                          batch as ClusterBatch,
-                          true,
-                          { timeout: 1000 },
-                      )
+                        batch as ClusterBatch,
+                        true,
+                        { timeout: 1000 },
+                    )
                     : await (client as GlideClient).exec(batch as Batch, true, {
-                          timeout: 1000,
-                      });
+                        timeout: 1000,
+                    });
 
                 expect(result?.length).toBe(1);
             }, protocol);
@@ -12598,9 +14889,9 @@ export function runBaseTests(config: {
 
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                          batch as ClusterBatch,
-                          false,
-                      )
+                        batch as ClusterBatch,
+                        false,
+                    )
                     : await (client as GlideClient).exec(batch as Batch, false);
 
                 expect(result?.length).toBe(4);
@@ -12773,9 +15064,9 @@ export function runCommonTests(config: {
                 const result = clusterMode
                     ? await client.exec(batch as ClusterTransaction, true)
                     : await (client as GlideClient).exec(
-                          batch as Transaction,
-                          true,
-                      );
+                        batch as Transaction,
+                        true,
+                    );
                 expect(result?.length).toBe(2);
                 expect(result?.[0]).toBe("OK");
                 expect(result?.[1]).toBe("hello");

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -327,10 +327,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                            await client.info({
-                                sections: [InfoOptions.Commandstats],
-                            }),
-                        ).join();
+                              await client.info({
+                                  sections: [InfoOptions.Commandstats],
+                              }),
+                          ).join();
                 expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
@@ -338,10 +338,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                            await client.info({
-                                sections: [InfoOptions.Commandstats],
-                            }),
-                        ).join();
+                              await client.info({
+                                  sections: [InfoOptions.Commandstats],
+                              }),
+                          ).join();
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },
@@ -368,13 +368,13 @@ export function runBaseTests(config: {
                     const response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic).lastsave(),
-                                isAtomic,
-                            )
+                                  new Batch(isAtomic).lastsave(),
+                                  isAtomic,
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic).lastsave(),
-                                isAtomic,
-                            );
+                                  new ClusterBatch(isAtomic).lastsave(),
+                                  isAtomic,
+                              );
 
                     expect(response?.[0]).toBeGreaterThan(yesterday);
                 }
@@ -2153,39 +2153,49 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Test basic HSETEX with expiry
-                const fieldValueMap = { [field1]: value1, [field2]: value2 };
-                expect(
-                    await client.hsetex(key, fieldValueMap, {
-                        expiry: { type: TimeUnit.Seconds, count: 60 },
-                    }),
-                ).toEqual(2);
+                    // Test basic HSETEX with expiry
+                    const fieldValueMap = {
+                        [field1]: value1,
+                        [field2]: value2,
+                    };
+                    expect(
+                        await client.hsetex(key, fieldValueMap, {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        }),
+                    ).toEqual(2);
 
-                // Verify fields were set
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
+                    // Verify fields were set
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
 
-                // Test with KEEPTTL
-                const field3 = getRandomKey();
-                const value3 = getRandomKey();
-                expect(
-                    await client.hsetex(key, { [field3]: value3 }, {
-                        expiry: "KEEPTTL",
-                    }),
-                ).toEqual(1);
-                expect(await client.hget(key, field3)).toEqual(value3);
-            }, protocol);
+                    // Test with KEEPTTL
+                    const field3 = getRandomKey();
+                    const value3 = getRandomKey();
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field3]: value3 },
+                            {
+                                expiry: "KEEPTTL",
+                            },
+                        ),
+                    ).toEqual(1);
+                    expect(await client.hget(key, field3)).toEqual(value3);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2193,66 +2203,73 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex with conditional changes_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Test with NX (only if hash doesn't exist)
-                expect(
-                    await client.hsetex(
-                        key,
-                        { [field1]: value1 },
-                        {
-                            conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(1);
+                    // Test with NX (only if hash doesn't exist)
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field1]: value1 },
+                            {
+                                conditionalChange:
+                                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(1);
 
-                // Should not set because hash already exists
-                expect(
-                    await client.hsetex(
-                        key,
-                        { [field2]: value2 },
-                        {
-                            conditionalChange: ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(0);
+                    // Should not set because hash already exists
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field2]: value2 },
+                            {
+                                conditionalChange:
+                                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(0);
 
-                // Test with XX (only if hash exists)
-                const key2 = getRandomKey();
-                expect(
-                    await client.hsetex(
-                        key2,
-                        { [field1]: value1 },
-                        {
-                            conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(0);
+                    // Test with XX (only if hash exists)
+                    const key2 = getRandomKey();
+                    expect(
+                        await client.hsetex(
+                            key2,
+                            { [field1]: value1 },
+                            {
+                                conditionalChange:
+                                    ConditionalChange.ONLY_IF_EXISTS,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(0);
 
-                // Should work because hash exists
-                expect(
-                    await client.hsetex(
-                        key,
-                        { [field2]: value2 },
-                        {
-                            conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(1);
-            }, protocol);
+                    // Should work because hash exists
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field2]: value2 },
+                            {
+                                conditionalChange:
+                                    ConditionalChange.ONLY_IF_EXISTS,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(1);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2260,58 +2277,66 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex with field conditional changes_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
-                const value3 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
+                    const value3 = getRandomKey();
 
-                // Set up initial fields
-                expect(await client.hset(key, { [field1]: value1 })).toEqual(1);
+                    // Set up initial fields
+                    expect(
+                        await client.hset(key, { [field1]: value1 }),
+                    ).toEqual(1);
 
-                // Test FXX (only if all fields exist)
-                expect(
-                    await client.hsetex(
-                        key,
-                        { [field1]: value2, [field2]: value2 },
-                        {
-                            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_ALL_EXIST,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(0); // field2 doesn't exist
+                    // Test FXX (only if all fields exist)
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field1]: value2, [field2]: value2 },
+                            {
+                                fieldConditionalChange:
+                                    HashFieldConditionalChange.ONLY_IF_ALL_EXIST,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(0); // field2 doesn't exist
 
-                // Test FNX (only if none of the fields exist)
-                expect(
-                    await client.hsetex(
-                        key,
-                        { [field2]: value2, [field3]: value3 },
-                        {
-                            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(2); // both fields don't exist
+                    // Test FNX (only if none of the fields exist)
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field2]: value2, [field3]: value3 },
+                            {
+                                fieldConditionalChange:
+                                    HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(2); // both fields don't exist
 
-                // Should fail because field2 now exists
-                expect(
-                    await client.hsetex(
-                        key,
-                        { [field2]: value2, [field3]: value3 },
-                        {
-                            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
-                            expiry: { type: TimeUnit.Seconds, count: 60 },
-                        },
-                    ),
-                ).toEqual(0);
-            }, protocol);
+                    // Should fail because field2 now exists
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field2]: value2, [field3]: value3 },
+                            {
+                                fieldConditionalChange:
+                                    HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).toEqual(0);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2319,54 +2344,82 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex with different expiry types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const field4 = getRandomKey();
-                const value = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const field4 = getRandomKey();
+                    const value = getRandomKey();
 
-                // Test EX (seconds)
-                expect(
-                    await client.hsetex(key, { [field1]: value }, {
-                        expiry: { type: TimeUnit.Seconds, count: 1 },
-                    }),
-                ).toEqual(1);
+                    // Test EX (seconds)
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field1]: value },
+                            {
+                                expiry: { type: TimeUnit.Seconds, count: 1 },
+                            },
+                        ),
+                    ).toEqual(1);
 
-                // Test PX (milliseconds)
-                expect(
-                    await client.hsetex(key, { [field2]: value }, {
-                        expiry: { type: TimeUnit.Milliseconds, count: 1000 },
-                    }),
-                ).toEqual(1);
+                    // Test PX (milliseconds)
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field2]: value },
+                            {
+                                expiry: {
+                                    type: TimeUnit.Milliseconds,
+                                    count: 1000,
+                                },
+                            },
+                        ),
+                    ).toEqual(1);
 
-                // Test EXAT (Unix timestamp in seconds)
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 60;
-                expect(
-                    await client.hsetex(key, { [field3]: value }, {
-                        expiry: { type: TimeUnit.UnixSeconds, count: futureTimestamp },
-                    }),
-                ).toEqual(1);
+                    // Test EXAT (Unix timestamp in seconds)
+                    const futureTimestamp = Math.floor(Date.now() / 1000) + 60;
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field3]: value },
+                            {
+                                expiry: {
+                                    type: TimeUnit.UnixSeconds,
+                                    count: futureTimestamp,
+                                },
+                            },
+                        ),
+                    ).toEqual(1);
 
-                // Test PXAT (Unix timestamp in milliseconds)
-                const futureTimestampMs = Date.now() + 60000;
-                expect(
-                    await client.hsetex(key, { [field4]: value }, {
-                        expiry: { type: TimeUnit.UnixMilliseconds, count: futureTimestampMs },
-                    }),
-                ).toEqual(1);
+                    // Test PXAT (Unix timestamp in milliseconds)
+                    const futureTimestampMs = Date.now() + 60000;
+                    expect(
+                        await client.hsetex(
+                            key,
+                            { [field4]: value },
+                            {
+                                expiry: {
+                                    type: TimeUnit.UnixMilliseconds,
+                                    count: futureTimestampMs,
+                                },
+                            },
+                        ),
+                    ).toEqual(1);
 
-                // Verify all fields were set
-                expect(await client.hget(key, field1)).toEqual(value);
-                expect(await client.hget(key, field2)).toEqual(value);
-                expect(await client.hget(key, field3)).toEqual(value);
-                expect(await client.hget(key, field4)).toEqual(value);
-            }, protocol);
+                    // Verify all fields were set
+                    expect(await client.hget(key, field1)).toEqual(value);
+                    expect(await client.hget(key, field2)).toEqual(value);
+                    expect(await client.hget(key, field3)).toEqual(value);
+                    expect(await client.hget(key, field4)).toEqual(value);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2374,46 +2427,52 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex with HashDataType and Record types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Test with Record<string, GlideString>
-                const recordMap: Record<string, GlideString> = {
-                    [field1]: value1,
-                    [field2]: Buffer.from(value2),
-                };
-                expect(
-                    await client.hsetex(key, recordMap, {
-                        expiry: { type: TimeUnit.Seconds, count: 60 },
-                    }),
-                ).toEqual(2);
+                    // Test with Record<string, GlideString>
+                    const recordMap: Record<string, GlideString> = {
+                        [field1]: value1,
+                        [field2]: Buffer.from(value2),
+                    };
+                    expect(
+                        await client.hsetex(key, recordMap, {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        }),
+                    ).toEqual(2);
 
-                // Test with HashDataType
-                const hashDataType: HashDataType = [
-                    { field: Buffer.from(field1), value: Buffer.from(value1) },
-                    { field: field2, value: value2 },
-                ];
-                const key2 = getRandomKey();
-                expect(
-                    await client.hsetex(key2, hashDataType, {
-                        expiry: { type: TimeUnit.Seconds, count: 60 },
-                    }),
-                ).toEqual(2);
+                    // Test with HashDataType
+                    const hashDataType: HashDataType = [
+                        {
+                            field: Buffer.from(field1),
+                            value: Buffer.from(value1),
+                        },
+                        { field: field2, value: value2 },
+                    ];
+                    const key2 = getRandomKey();
+                    expect(
+                        await client.hsetex(key2, hashDataType, {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        }),
+                    ).toEqual(2);
 
-                // Verify values
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
-                expect(await client.hget(key2, field1)).toEqual(value1);
-                expect(await client.hget(key2, field2)).toEqual(value2);
-            }, protocol);
+                    // Verify values
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
+                    expect(await client.hget(key2, field1)).toEqual(value1);
+                    expect(await client.hget(key2, field2)).toEqual(value2);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2421,30 +2480,41 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
-                const value = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
+                    const value = getRandomKey();
 
-                // Test invalid expiry count (non-integer)
-                await expect(
-                    client.hsetex(key, { [field]: value }, {
-                        expiry: { type: TimeUnit.Seconds, count: 1.5 },
-                    }),
-                ).rejects.toThrow("Count must be an integer");
+                    // Test invalid expiry count (non-integer)
+                    await expect(
+                        client.hsetex(
+                            key,
+                            { [field]: value },
+                            {
+                                expiry: { type: TimeUnit.Seconds, count: 1.5 },
+                            },
+                        ),
+                    ).rejects.toThrow("Count must be an integer");
 
-                // Test with non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hsetex(key, { [field]: value }, {
-                        expiry: { type: TimeUnit.Seconds, count: 60 },
-                    }),
-                ).rejects.toThrow(RequestError);
-            }, protocol);
+                    // Test with non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hsetex(
+                            key,
+                            { [field]: value },
+                            {
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        ),
+                    ).rejects.toThrow(RequestError);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2452,41 +2522,62 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex with version compatibility and batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                // Skip test if server version is less than 9.0.0
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    // Skip test if server version is less than 9.0.0
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Test batch operations with HSETEX
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                    // Test batch operations with HSETEX
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
 
-                batch.hsetex(key1, { [field1]: value1 }, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                batch.hsetex(key2, { [field2]: value2 }, {
-                    expiry: { type: TimeUnit.Milliseconds, count: 60000 },
-                });
-                batch.hget(key1, field1);
-                batch.hget(key2, field2);
+                    batch.hsetex(
+                        key1,
+                        { [field1]: value1 },
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    batch.hsetex(
+                        key2,
+                        { [field2]: value2 },
+                        {
+                            expiry: {
+                                type: TimeUnit.Milliseconds,
+                                count: 60000,
+                            },
+                        },
+                    );
+                    batch.hget(key1, field1);
+                    batch.hget(key2, field2);
 
-                const results = client instanceof GlideClient
-                    ? await client.exec(batch as Batch, false)
-                    : await (client as GlideClusterClient).exec(batch as ClusterBatch, false);
+                    const results =
+                        client instanceof GlideClient
+                            ? await client.exec(batch as Batch, false)
+                            : await (client as GlideClusterClient).exec(
+                                  batch as ClusterBatch,
+                                  false,
+                              );
 
-                expect(results).toHaveLength(4);
-                expect(results![0]).toBe(1); // hsetex result for key1
-                expect(results![1]).toBe(1); // hsetex result for key2
-                expect(results![2]).toBe(value1); // hget result for key1
-                expect(results![3]).toBe(value2); // hget result for key2
-            }, protocol);
+                    expect(results).toHaveLength(4);
+                    expect(results![0]).toBe(1); // hsetex result for key1
+                    expect(results![1]).toBe(1); // hsetex result for key2
+                    expect(results![2]).toBe(value1); // hget result for key1
+                    expect(results![3]).toBe(value2); // hget result for key2
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2494,75 +2585,109 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex with comprehensive parameter types and edge cases_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                // Skip test if server version is less than 9.0.0
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    // Skip test if server version is less than 9.0.0
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const value1 = getRandomKey();
 
-                // Test with mixed GlideString types (Buffer and string)
-                const keyBuffer = Buffer.from(getRandomKey());
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const valueBuffer = Buffer.from(getRandomKey());
+                    // Test with mixed GlideString types (Buffer and string)
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                const result1 = await client.hsetex(keyBuffer, {
-                    [field1]: valueBuffer,
-                    [fieldBuffer.toString()]: value1
-                }, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result1).toBe(2);
+                    const result1 = await client.hsetex(
+                        keyBuffer,
+                        {
+                            [field1]: valueBuffer,
+                            [fieldBuffer.toString()]: value1,
+                        },
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result1).toBe(2);
 
-                // Verify values with different decoders
-                expect(await client.hget(keyBuffer, field1)).toBe(valueBuffer.toString());
-                expect(await client.hget(keyBuffer, field1, { decoder: Decoder.Bytes })).toEqual(valueBuffer);
-                expect(await client.hget(keyBuffer, fieldBuffer)).toBe(value1);
+                    // Verify values with different decoders
+                    expect(await client.hget(keyBuffer, field1)).toBe(
+                        valueBuffer.toString(),
+                    );
+                    expect(
+                        await client.hget(keyBuffer, field1, {
+                            decoder: Decoder.Bytes,
+                        }),
+                    ).toEqual(valueBuffer);
+                    expect(await client.hget(keyBuffer, fieldBuffer)).toBe(
+                        value1,
+                    );
 
-                // Test with empty field-value map
-                const result2 = await client.hsetex(getRandomKey(), {}, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result2).toBe(0);
+                    // Test with empty field-value map
+                    const result2 = await client.hsetex(
+                        getRandomKey(),
+                        {},
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result2).toBe(0);
 
-                // Test with very long field and value names
-                const longKey = getRandomKey();
-                const longField = "a".repeat(100);
-                const longValue = "b".repeat(100);
+                    // Test with very long field and value names
+                    const longKey = getRandomKey();
+                    const longField = "a".repeat(100);
+                    const longValue = "b".repeat(100);
 
-                const result3 = await client.hsetex(longKey, { [longField]: longValue }, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result3).toBe(1);
-                expect(await client.hget(longKey, longField)).toBe(longValue);
+                    const result3 = await client.hsetex(
+                        longKey,
+                        { [longField]: longValue },
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result3).toBe(1);
+                    expect(await client.hget(longKey, longField)).toBe(
+                        longValue,
+                    );
 
-                // Test with special characters
-                const specialKey = getRandomKey();
-                const specialField = "field:with:special:chars:!@#$%^&*()";
-                const specialValue = "value:with:special:chars:!@#$%^&*()";
+                    // Test with special characters
+                    const specialKey = getRandomKey();
+                    const specialField = "field:with:special:chars:!@#$%^&*()";
+                    const specialValue = "value:with:special:chars:!@#$%^&*()";
 
-                const result4 = await client.hsetex(specialKey, { [specialField]: specialValue }, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result4).toBe(1);
-                expect(await client.hget(specialKey, specialField)).toBe(specialValue);
+                    const result4 = await client.hsetex(
+                        specialKey,
+                        { [specialField]: specialValue },
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result4).toBe(1);
+                    expect(await client.hget(specialKey, specialField)).toBe(
+                        specialValue,
+                    );
 
-                // Test with Unicode characters
-                const unicodeKey = getRandomKey();
-                const unicodeField = "field_🚀_测试_🎉";
-                const unicodeValue = "value_🌟_测试_🎊";
+                    // Test with Unicode characters
+                    const unicodeKey = getRandomKey();
+                    const unicodeField = "field_🚀_测试_🎉";
+                    const unicodeValue = "value_🌟_测试_🎊";
 
-                const result5 = await client.hsetex(unicodeKey, { [unicodeField]: unicodeValue }, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result5).toBe(1);
-                expect(await client.hget(unicodeKey, unicodeField)).toBe(unicodeValue);
-            }, protocol);
+                    const result5 = await client.hsetex(
+                        unicodeKey,
+                        { [unicodeField]: unicodeValue },
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result5).toBe(1);
+                    expect(await client.hget(unicodeKey, unicodeField)).toBe(
+                        unicodeValue,
+                    );
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2570,55 +2695,83 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hsetex Promise-based error handling and validation_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                // Skip test if server version is less than 9.0.0
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    // Skip test if server version is less than 9.0.0
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
-                const value = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
+                    const value = getRandomKey();
 
-                // Test Promise rejection for non-integer expiry count
-                let errorCaught = false;
-                try {
-                    await client.hsetex(key, { [field]: value }, {
-                        expiry: { type: TimeUnit.Seconds, count: 1.5 },
-                    });
-                } catch (error) {
-                    errorCaught = true;
-                    expect(error).toBeInstanceOf(Error);
-                    expect((error as Error).message).toContain("Count must be an integer");
-                }
-                expect(errorCaught).toBe(true);
+                    // Test Promise rejection for non-integer expiry count
+                    let errorCaught = false;
 
-                // Test Promise rejection when used on non-hash key
-                await client.set(key, "string_value");
+                    try {
+                        await client.hsetex(
+                            key,
+                            { [field]: value },
+                            {
+                                expiry: { type: TimeUnit.Seconds, count: 1.5 },
+                            },
+                        );
+                    } catch (error) {
+                        errorCaught = true;
+                        expect(error).toBeInstanceOf(Error);
+                        expect((error as Error).message).toContain(
+                            "Count must be an integer",
+                        );
+                    }
 
-                errorCaught = false;
-                try {
-                    await client.hsetex(key, { [field]: value }, {
-                        expiry: { type: TimeUnit.Seconds, count: 60 },
-                    });
-                } catch (error) {
-                    errorCaught = true;
-                    expect(error).toBeInstanceOf(RequestError);
-                }
-                expect(errorCaught).toBe(true);
+                    expect(errorCaught).toBe(true);
 
-                // Test batch operation error handling
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
-                batch.hsetex(key, { [field]: value }, {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
+                    // Test Promise rejection when used on non-hash key
+                    await client.set(key, "string_value");
 
-                const execPromise = client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false);
+                    errorCaught = false;
 
-                await expect(execPromise).rejects.toThrow(RequestError);
-            }, protocol);
+                    try {
+                        await client.hsetex(
+                            key,
+                            { [field]: value },
+                            {
+                                expiry: { type: TimeUnit.Seconds, count: 60 },
+                            },
+                        );
+                    } catch (error) {
+                        errorCaught = true;
+                        expect(error).toBeInstanceOf(RequestError);
+                    }
+
+                    expect(errorCaught).toBe(true);
+
+                    // Test batch operation error handling
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
+                    batch.hsetex(
+                        key,
+                        { [field]: value },
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+
+                    const execPromise =
+                        client instanceof GlideClient
+                            ? client.exec(batch as Batch, false)
+                            : (client as GlideClusterClient).exec(
+                                  batch as ClusterBatch,
+                                  false,
+                              );
+
+                    await expect(execPromise).rejects.toThrow(RequestError);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2626,48 +2779,61 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hgetex basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Test basic HGETEX without options
-                const result1 = await client.hgetex(key, [field1, field2, field3]);
-                expect(result1).toEqual([value1, value2, null]);
+                    // Test basic HGETEX without options
+                    const result1 = await client.hgetex(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1).toEqual([value1, value2, null]);
 
-                // Test HGETEX with expiry setting
-                const result2 = await client.hgetex(key, [field1, field2], {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result2).toEqual([value1, value2]);
+                    // Test HGETEX with expiry setting
+                    const result2 = await client.hgetex(key, [field1, field2], {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    });
+                    expect(result2).toEqual([value1, value2]);
 
-                // Test HGETEX with PERSIST option
-                const result3 = await client.hgetex(key, [field1], {
-                    expiry: "PERSIST",
-                });
-                expect(result3).toEqual([value1]);
+                    // Test HGETEX with PERSIST option
+                    const result3 = await client.hgetex(key, [field1], {
+                        expiry: "PERSIST",
+                    });
+                    expect(result3).toEqual([value1]);
 
-                // Test HGETEX with KEEPTTL option
-                const result4 = await client.hgetex(key, [field1], {
-                    expiry: "KEEPTTL",
-                });
-                expect(result4).toEqual([value1]);
+                    // Test HGETEX with KEEPTTL option
+                    const result4 = await client.hgetex(key, [field1], {
+                        expiry: "KEEPTTL",
+                    });
+                    expect(result4).toEqual([value1]);
 
-                // Test HGETEX on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result5 = await client.hgetex(nonExistentKey, [field1, field2]);
-                expect(result5).toEqual([null, null]);
-            }, protocol);
+                    // Test HGETEX on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result5 = await client.hgetex(nonExistentKey, [
+                        field1,
+                        field2,
+                    ]);
+                    expect(result5).toEqual([null, null]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2675,52 +2841,61 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hgetex with different expiry types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const field4 = getRandomKey();
-                const value = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const field4 = getRandomKey();
+                    const value = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, {
-                    [field1]: value,
-                    [field2]: value,
-                    [field3]: value,
-                    [field4]: value
-                });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value,
+                        [field2]: value,
+                        [field3]: value,
+                        [field4]: value,
+                    });
 
-                // Test EX (seconds)
-                const result1 = await client.hgetex(key, [field1], {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result1).toEqual([value]);
+                    // Test EX (seconds)
+                    const result1 = await client.hgetex(key, [field1], {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    });
+                    expect(result1).toEqual([value]);
 
-                // Test PX (milliseconds)
-                const result2 = await client.hgetex(key, [field2], {
-                    expiry: { type: TimeUnit.Milliseconds, count: 60000 },
-                });
-                expect(result2).toEqual([value]);
+                    // Test PX (milliseconds)
+                    const result2 = await client.hgetex(key, [field2], {
+                        expiry: { type: TimeUnit.Milliseconds, count: 60000 },
+                    });
+                    expect(result2).toEqual([value]);
 
-                // Test EXAT (Unix timestamp in seconds)
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 60;
-                const result3 = await client.hgetex(key, [field3], {
-                    expiry: { type: TimeUnit.UnixSeconds, count: futureTimestamp },
-                });
-                expect(result3).toEqual([value]);
+                    // Test EXAT (Unix timestamp in seconds)
+                    const futureTimestamp = Math.floor(Date.now() / 1000) + 60;
+                    const result3 = await client.hgetex(key, [field3], {
+                        expiry: {
+                            type: TimeUnit.UnixSeconds,
+                            count: futureTimestamp,
+                        },
+                    });
+                    expect(result3).toEqual([value]);
 
-                // Test PXAT (Unix timestamp in milliseconds)
-                const futureTimestampMs = Date.now() + 60000;
-                const result4 = await client.hgetex(key, [field4], {
-                    expiry: { type: TimeUnit.UnixMilliseconds, count: futureTimestampMs },
-                });
-                expect(result4).toEqual([value]);
-            }, protocol);
+                    // Test PXAT (Unix timestamp in milliseconds)
+                    const futureTimestampMs = Date.now() + 60000;
+                    const result4 = await client.hgetex(key, [field4], {
+                        expiry: {
+                            type: TimeUnit.UnixMilliseconds,
+                            count: futureTimestampMs,
+                        },
+                    });
+                    expect(result4).toEqual([value]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2728,40 +2903,49 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hgetex with batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
+                    // Set up hashes
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
 
-                // Test batch operations with HGETEX
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
+                    // Test batch operations with HGETEX
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
 
-                batch.hgetex(key1, [field1], {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                batch.hgetex(key2, [field2], {
-                    expiry: "PERSIST",
-                });
+                    batch.hgetex(key1, [field1], {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    });
+                    batch.hgetex(key2, [field2], {
+                        expiry: "PERSIST",
+                    });
 
-                const results = await (client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+                    const results = await (client instanceof GlideClient
+                        ? client.exec(batch as Batch, false)
+                        : (client as GlideClusterClient).exec(
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
-                expect(results).toHaveLength(2);
-                expect(results![0]).toEqual([value1]);
-                expect(results![1]).toEqual([value2]);
-            }, protocol);
+                    expect(results).toHaveLength(2);
+                    expect(results![0]).toEqual([value1]);
+                    expect(results![1]).toEqual([value2]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2769,30 +2953,32 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hgetex error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
-                const value = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
 
-                // Test invalid expiry count (non-integer)
-                await expect(
-                    client.hgetex(key, [field], {
-                        expiry: { type: TimeUnit.Seconds, count: 1.5 },
-                    }),
-                ).rejects.toThrow("Count must be an integer");
+                    // Test invalid expiry count (non-integer)
+                    await expect(
+                        client.hgetex(key, [field], {
+                            expiry: { type: TimeUnit.Seconds, count: 1.5 },
+                        }),
+                    ).rejects.toThrow("Count must be an integer");
 
-                // Test HGETEX on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hgetex(key, [field], {
-                        expiry: { type: TimeUnit.Seconds, count: 60 },
-                    }),
-                ).rejects.toThrow(RequestError);
-            }, protocol);
+                    // Test HGETEX on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hgetex(key, [field], {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        }),
+                    ).rejects.toThrow(RequestError);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2800,67 +2986,85 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hgetex with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const field1 = getRandomKey();
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const value1 = getRandomKey();
-                const valueBuffer = Buffer.from(getRandomKey());
+                    const key = getRandomKey();
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const value1 = getRandomKey();
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                // Set up hash with mixed types
-                await client.hset(keyBuffer, {
-                    [field1]: valueBuffer,
-                    [fieldBuffer.toString()]: value1
-                });
+                    // Set up hash with mixed types
+                    await client.hset(keyBuffer, {
+                        [field1]: valueBuffer,
+                        [fieldBuffer.toString()]: value1,
+                    });
 
-                // Test with Buffer keys and fields
-                const result1 = await client.hgetex(keyBuffer, [field1, fieldBuffer]);
-                expect(result1).toHaveLength(2);
-                expect(result1[0]).toEqual(valueBuffer);
-                expect(result1[1]).toEqual(value1);
+                    // Test with Buffer keys and fields
+                    const result1 = await client.hgetex(keyBuffer, [
+                        field1,
+                        fieldBuffer,
+                    ]);
+                    expect(result1).toHaveLength(2);
+                    expect(result1[0]).toEqual(valueBuffer);
+                    expect(result1[1]).toEqual(value1);
 
-                // Test with empty field array
-                const result2 = await client.hgetex(key, []);
-                expect(result2).toEqual([]);
+                    // Test with empty field array
+                    const result2 = await client.hgetex(key, []);
+                    expect(result2).toEqual([]);
 
-                // Test with large field names and values
-                const longKey = getRandomKey();
-                const longField = "f".repeat(100);
-                const longValue = "v".repeat(100);
+                    // Test with large field names and values
+                    const longKey = getRandomKey();
+                    const longField = "f".repeat(100);
+                    const longValue = "v".repeat(100);
 
-                await client.hset(longKey, { [longField]: longValue });
-                const result3 = await client.hgetex(longKey, [longField], {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result3).toEqual([longValue]);
+                    await client.hset(longKey, { [longField]: longValue });
+                    const result3 = await client.hgetex(longKey, [longField], {
+                        expiry: { type: TimeUnit.Seconds, count: 60 },
+                    });
+                    expect(result3).toEqual([longValue]);
 
-                // Test with special characters
-                const specialKey = getRandomKey();
-                const specialField = "field:with:special:chars:!@#$%^&*()";
-                const specialValue = "value:with:special:chars:!@#$%^&*()";
+                    // Test with special characters
+                    const specialKey = getRandomKey();
+                    const specialField = "field:with:special:chars:!@#$%^&*()";
+                    const specialValue = "value:with:special:chars:!@#$%^&*()";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                const result4 = await client.hgetex(specialKey, [specialField], {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result4).toEqual([specialValue]);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    const result4 = await client.hgetex(
+                        specialKey,
+                        [specialField],
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result4).toEqual([specialValue]);
 
-                // Test with Unicode characters
-                const unicodeKey = getRandomKey();
-                const unicodeField = "field_🚀_测试_🎉";
-                const unicodeValue = "value_🌟_测试_🎊";
+                    // Test with Unicode characters
+                    const unicodeKey = getRandomKey();
+                    const unicodeField = "field_🚀_测试_🎉";
+                    const unicodeValue = "value_🌟_测试_🎊";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                const result5 = await client.hgetex(unicodeKey, [unicodeField], {
-                    expiry: { type: TimeUnit.Seconds, count: 60 },
-                });
-                expect(result5).toEqual([unicodeValue]);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    const result5 = await client.hgetex(
+                        unicodeKey,
+                        [unicodeField],
+                        {
+                            expiry: { type: TimeUnit.Seconds, count: 60 },
+                        },
+                    );
+                    expect(result5).toEqual([unicodeValue]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2868,47 +3072,63 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpire basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Test basic HEXPIRE
-                const result1 = await client.hexpire(key, 60, [field1, field2, field3]);
-                expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
+                    // Test basic HEXPIRE
+                    const result1 = await client.hexpire(key, 60, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
 
-                // Verify fields still exist
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
+                    // Verify fields still exist
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
 
-                // Verify expiration was set using HTTL
-                const ttlResult = await client.httl(key, [field1, field2, field3]);
-                expect(ttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
-                expect(ttlResult[0]).toBeLessThanOrEqual(60); // should be <= 60 seconds
-                expect(ttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
-                expect(ttlResult[1]).toBeLessThanOrEqual(60); // should be <= 60 seconds
-                expect(ttlResult[2]).toEqual(-2); // field3 doesn't exist
+                    // Verify expiration was set using HTTL
+                    const ttlResult = await client.httl(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(ttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
+                    expect(ttlResult[0]).toBeLessThanOrEqual(60); // should be <= 60 seconds
+                    expect(ttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
+                    expect(ttlResult[1]).toBeLessThanOrEqual(60); // should be <= 60 seconds
+                    expect(ttlResult[2]).toEqual(-2); // field3 doesn't exist
 
-                // Test with 0 seconds (immediate deletion)
-                const result2 = await client.hexpire(key, 0, [field1]);
-                expect(result2).toEqual([2]);
-                expect(await client.hget(key, field1)).toEqual(null);
+                    // Test with 0 seconds (immediate deletion)
+                    const result2 = await client.hexpire(key, 0, [field1]);
+                    expect(result2).toEqual([2]);
+                    expect(await client.hget(key, field1)).toEqual(null);
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hexpire(nonExistentKey, 60, [field1]);
-                expect(result3).toEqual([-2]);
-            }, protocol);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hexpire(nonExistentKey, 60, [
+                        field1,
+                    ]);
+                    expect(result3).toEqual([-2]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2916,64 +3136,84 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpire with conditions_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set initial expiration on field1
-                await client.hexpire(key, 120, [field1]);
+                    // Set initial expiration on field1
+                    await client.hexpire(key, 120, [field1]);
 
-                // Test NX condition (only if no expiry)
-                const result1 = await client.hexpire(key, 60, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
-                expect(result1).toEqual([0, 1]); // field1 already has expiry, field2 doesn't
+                    // Test NX condition (only if no expiry)
+                    const result1 = await client.hexpire(
+                        key,
+                        60,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                        },
+                    );
+                    expect(result1).toEqual([0, 1]); // field1 already has expiry, field2 doesn't
 
-                // Test XX condition (only if has expiry)
-                const result2 = await client.hexpire(key, 180, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
-                });
-                expect(result2).toEqual([1, 1]); // both should have expiry now
+                    // Test XX condition (only if has expiry)
+                    const result2 = await client.hexpire(
+                        key,
+                        180,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                        },
+                    );
+                    expect(result2).toEqual([1, 1]); // both should have expiry now
 
-                // Verify expiration was updated using HTTL
-                const ttlResult2 = await client.httl(key, [field1, field2]);
-                expect(ttlResult2[0]).toBeGreaterThan(0);
-                expect(ttlResult2[0]).toBeLessThanOrEqual(180);
-                expect(ttlResult2[1]).toBeGreaterThan(0);
-                expect(ttlResult2[1]).toBeLessThanOrEqual(180);
+                    // Verify expiration was updated using HTTL
+                    const ttlResult2 = await client.httl(key, [field1, field2]);
+                    expect(ttlResult2[0]).toBeGreaterThan(0);
+                    expect(ttlResult2[0]).toBeLessThanOrEqual(180);
+                    expect(ttlResult2[1]).toBeGreaterThan(0);
+                    expect(ttlResult2[1]).toBeLessThanOrEqual(180);
 
-                // Test GT condition (only if greater than current)
-                const result3 = await client.hexpire(key, 300, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
-                });
-                expect(result3).toEqual([1]); // 300 > 180
+                    // Test GT condition (only if greater than current)
+                    const result3 = await client.hexpire(key, 300, [field1], {
+                        condition:
+                            HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                    });
+                    expect(result3).toEqual([1]); // 300 > 180
 
-                // Verify expiration was updated using HTTL
-                const ttlResult3 = await client.httl(key, [field1]);
-                expect(ttlResult3[0]).toBeGreaterThan(180); // Should be greater than previous TTL
-                expect(ttlResult3[0]).toBeLessThanOrEqual(300);
+                    // Verify expiration was updated using HTTL
+                    const ttlResult3 = await client.httl(key, [field1]);
+                    expect(ttlResult3[0]).toBeGreaterThan(180); // Should be greater than previous TTL
+                    expect(ttlResult3[0]).toBeLessThanOrEqual(300);
 
-                // Test LT condition (only if less than current)
-                const result4 = await client.hexpire(key, 150, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
-                });
-                expect(result4).toEqual([1]); // 150 < 300
+                    // Test LT condition (only if less than current)
+                    const result4 = await client.hexpire(key, 150, [field1], {
+                        condition:
+                            HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                    });
+                    expect(result4).toEqual([1]); // 150 < 300
 
-                // Verify expiration was updated using HTTL
-                const ttlResult4 = await client.httl(key, [field1]);
-                expect(ttlResult4[0]).toBeGreaterThan(0);
-                expect(ttlResult4[0]).toBeLessThanOrEqual(150);
-            }, protocol);
+                    // Verify expiration was updated using HTTL
+                    const ttlResult4 = await client.httl(key, [field1]);
+                    expect(ttlResult4[0]).toBeGreaterThan(0);
+                    expect(ttlResult4[0]).toBeLessThanOrEqual(150);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -2981,43 +3221,52 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpire batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
+                    // Set up hashes
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
 
-                // Test batch operations with HEXPIRE
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
-                batch.hexpire(key1, 60, [field1]);
-                batch.hexpire(key2, 120, [field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
+                    // Test batch operations with HEXPIRE
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
+                    batch.hexpire(key1, 60, [field1]);
+                    batch.hexpire(key2, 120, [field2], {
+                        condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                    });
 
-                const results = await (client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
-                expect(results).toEqual([[1], [1]]);
+                    const results = await (client instanceof GlideClient
+                        ? client.exec(batch as Batch, false)
+                        : (client as GlideClusterClient).exec(
+                              batch as ClusterBatch,
+                              false,
+                          ));
+                    expect(results).toEqual([[1], [1]]);
 
-                // Verify expiration was set using HTTL
-                const ttlResult1 = await client.httl(key1, [field1]);
-                expect(ttlResult1[0]).toBeGreaterThan(0);
-                expect(ttlResult1[0]).toBeLessThanOrEqual(60);
+                    // Verify expiration was set using HTTL
+                    const ttlResult1 = await client.httl(key1, [field1]);
+                    expect(ttlResult1[0]).toBeGreaterThan(0);
+                    expect(ttlResult1[0]).toBeLessThanOrEqual(60);
 
-                const ttlResult2 = await client.httl(key2, [field2]);
-                expect(ttlResult2[0]).toBeGreaterThan(0);
-                expect(ttlResult2[0]).toBeLessThanOrEqual(120);
-            }, protocol);
+                    const ttlResult2 = await client.httl(key2, [field2]);
+                    expect(ttlResult2[0]).toBeGreaterThan(0);
+                    expect(ttlResult2[0]).toBeLessThanOrEqual(120);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3025,26 +3274,29 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpire error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
 
-                // Test HEXPIRE on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hexpire(key, 60, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HEXPIRE on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hexpire(key, 60, [field]),
+                    ).rejects.toThrow(RequestError);
 
-                // Test with empty field array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hexpire(hashKey, 60, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test with empty field array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hexpire(hashKey, 60, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3052,65 +3304,84 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpire with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const field1 = getRandomKey();
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const value1 = getRandomKey();
-                const valueBuffer = Buffer.from(getRandomKey());
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const value1 = getRandomKey();
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                // Set up hash with mixed types
-                await client.hset(keyBuffer, {
-                    [field1]: valueBuffer,
-                    [fieldBuffer.toString()]: value1
-                });
+                    // Set up hash with mixed types
+                    await client.hset(keyBuffer, {
+                        [field1]: valueBuffer,
+                        [fieldBuffer.toString()]: value1,
+                    });
 
-                // Test with Buffer keys and fields
-                const result1 = await client.hexpire(keyBuffer, 60, [field1, fieldBuffer]);
-                expect(result1).toEqual([1, 1]);
+                    // Test with Buffer keys and fields
+                    const result1 = await client.hexpire(keyBuffer, 60, [
+                        field1,
+                        fieldBuffer,
+                    ]);
+                    expect(result1).toEqual([1, 1]);
 
-                // Test with large field names
-                const longKey = getRandomKey();
-                const longField = "f".repeat(100);
-                const longValue = "v".repeat(100);
+                    // Test with large field names
+                    const longKey = getRandomKey();
+                    const longField = "f".repeat(100);
+                    const longValue = "v".repeat(100);
 
-                await client.hset(longKey, { [longField]: longValue });
-                const result2 = await client.hexpire(longKey, 60, [longField]);
-                expect(result2).toEqual([1]);
+                    await client.hset(longKey, { [longField]: longValue });
+                    const result2 = await client.hexpire(longKey, 60, [
+                        longField,
+                    ]);
+                    expect(result2).toEqual([1]);
 
-                // Test with special characters
-                const specialKey = getRandomKey();
-                const specialField = "field:with:special:chars:!@#$%^&*()";
-                const specialValue = "value:with:special:chars:!@#$%^&*()";
+                    // Test with special characters
+                    const specialKey = getRandomKey();
+                    const specialField = "field:with:special:chars:!@#$%^&*()";
+                    const specialValue = "value:with:special:chars:!@#$%^&*()";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                const result3 = await client.hexpire(specialKey, 60, [specialField]);
-                expect(result3).toEqual([1]);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    const result3 = await client.hexpire(specialKey, 60, [
+                        specialField,
+                    ]);
+                    expect(result3).toEqual([1]);
 
-                // Verify expiration was set using HTTL
-                const ttlResult3 = await client.httl(specialKey, [specialField]);
-                expect(ttlResult3[0]).toBeGreaterThan(0);
-                expect(ttlResult3[0]).toBeLessThanOrEqual(60);
+                    // Verify expiration was set using HTTL
+                    const ttlResult3 = await client.httl(specialKey, [
+                        specialField,
+                    ]);
+                    expect(ttlResult3[0]).toBeGreaterThan(0);
+                    expect(ttlResult3[0]).toBeLessThanOrEqual(60);
 
-                // Test with Unicode characters
-                const unicodeKey = getRandomKey();
-                const unicodeField = "field_🚀_测试_🎉";
-                const unicodeValue = "value_🌟_测试_🎊";
+                    // Test with Unicode characters
+                    const unicodeKey = getRandomKey();
+                    const unicodeField = "field_🚀_测试_🎉";
+                    const unicodeValue = "value_🌟_测试_🎊";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                const result4 = await client.hexpire(unicodeKey, 60, [unicodeField]);
-                expect(result4).toEqual([1]);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    const result4 = await client.hexpire(unicodeKey, 60, [
+                        unicodeField,
+                    ]);
+                    expect(result4).toEqual([1]);
 
-                // Verify expiration was set using HTTL
-                const ttlResult4 = await client.httl(unicodeKey, [unicodeField]);
-                expect(ttlResult4[0]).toBeGreaterThan(0);
-                expect(ttlResult4[0]).toBeLessThanOrEqual(60);
-            }, protocol);
+                    // Verify expiration was set using HTTL
+                    const ttlResult4 = await client.httl(unicodeKey, [
+                        unicodeField,
+                    ]);
+                    expect(ttlResult4[0]).toBeGreaterThan(0);
+                    expect(ttlResult4[0]).toBeLessThanOrEqual(60);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3118,43 +3389,55 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpersist basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey(); // non-existent field
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey(); // non-existent field
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields
-                await client.hexpire(key, 60, [field1, field2]);
+                    // Set expiration on fields
+                    await client.hexpire(key, 60, [field1, field2]);
 
-                // Test basic HPERSIST
-                const result1 = await client.hpersist(key, [field1, field2, field3]);
-                expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
+                    // Test basic HPERSIST
+                    const result1 = await client.hpersist(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
 
-                // Verify fields still exist but no longer have expiration
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
+                    // Verify fields still exist but no longer have expiration
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result2 = await client.hpersist(nonExistentKey, [field1]);
-                expect(result2).toEqual([false]);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result2 = await client.hpersist(nonExistentKey, [
+                        field1,
+                    ]);
+                    expect(result2).toEqual([false]);
 
-                // Test on fields without expiration
-                const key2 = getRandomKey();
-                await client.hset(key2, { [field1]: value1 });
-                const result3 = await client.hpersist(key2, [field1]);
-                expect(result3).toEqual([false]); // field has no expiration to remove
-            }, protocol);
+                    // Test on fields without expiration
+                    const key2 = getRandomKey();
+                    await client.hset(key2, { [field1]: value1 });
+                    const result3 = await client.hpersist(key2, [field1]);
+                    expect(result3).toEqual([false]); // field has no expiration to remove
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3162,34 +3445,43 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpersist with batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes with fields and expiration
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
-                await client.hexpire(key1, 60, [field1]);
-                await client.hexpire(key2, 120, [field2]);
+                    // Set up hashes with fields and expiration
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
+                    await client.hexpire(key1, 60, [field1]);
+                    await client.hexpire(key2, 120, [field2]);
 
-                // Test batch operations with HPERSIST
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
-                batch.hpersist(key1, [field1]);
-                batch.hpersist(key2, [field2]);
+                    // Test batch operations with HPERSIST
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
+                    batch.hpersist(key1, [field1]);
+                    batch.hpersist(key2, [field2]);
 
-                const results = await (client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
-                expect(results).toEqual([[true], [true]]);
-            }, protocol);
+                    const results = await (client instanceof GlideClient
+                        ? client.exec(batch as Batch, false)
+                        : (client as GlideClusterClient).exec(
+                              batch as ClusterBatch,
+                              false,
+                          ));
+                    expect(results).toEqual([[true], [true]]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3197,26 +3489,29 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpersist error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
 
-                // Test HPERSIST on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hpersist(key, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HPERSIST on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(client.hpersist(key, [field])).rejects.toThrow(
+                        RequestError,
+                    );
 
-                // Test with empty field array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hpersist(hashKey, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test with empty field array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hpersist(hashKey, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3224,54 +3519,73 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpersist with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const field1 = getRandomKey();
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const value = getRandomKey();
-                const valueBuffer = Buffer.from(getRandomKey());
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const value = getRandomKey();
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                // Test with Buffer keys and fields
-                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
-                await client.hexpire(keyBuffer, 60, [field1, fieldBuffer.toString()]);
-                const result1 = await client.hpersist(keyBuffer, [field1, fieldBuffer]);
-                expect(result1).toEqual([1, 1]);
+                    // Test with Buffer keys and fields
+                    await client.hset(keyBuffer, {
+                        [field1]: value,
+                        [fieldBuffer.toString()]: valueBuffer,
+                    });
+                    await client.hexpire(keyBuffer, 60, [
+                        field1,
+                        fieldBuffer.toString(),
+                    ]);
+                    const result1 = await client.hpersist(keyBuffer, [
+                        field1,
+                        fieldBuffer,
+                    ]);
+                    expect(result1).toEqual([1, 1]);
 
-                // Test with long field names and values
-                const longKey = getRandomKey();
-                const longField = "f".repeat(100);
-                const longValue = "v".repeat(100);
+                    // Test with long field names and values
+                    const longKey = getRandomKey();
+                    const longField = "f".repeat(100);
+                    const longValue = "v".repeat(100);
 
-                await client.hset(longKey, { [longField]: longValue });
-                await client.hexpire(longKey, 60, [longField]);
-                const result2 = await client.hpersist(longKey, [longField]);
-                expect(result2).toEqual([1]);
+                    await client.hset(longKey, { [longField]: longValue });
+                    await client.hexpire(longKey, 60, [longField]);
+                    const result2 = await client.hpersist(longKey, [longField]);
+                    expect(result2).toEqual([1]);
 
-                // Test with special characters
-                const specialKey = getRandomKey();
-                const specialField = "field:with:special:chars:!@#$%^&*()";
-                const specialValue = "value:with:special:chars:!@#$%^&*()";
+                    // Test with special characters
+                    const specialKey = getRandomKey();
+                    const specialField = "field:with:special:chars:!@#$%^&*()";
+                    const specialValue = "value:with:special:chars:!@#$%^&*()";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                await client.hexpire(specialKey, 60, [specialField]);
-                const result3 = await client.hpersist(specialKey, [specialField]);
-                expect(result3).toEqual([1]);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    await client.hexpire(specialKey, 60, [specialField]);
+                    const result3 = await client.hpersist(specialKey, [
+                        specialField,
+                    ]);
+                    expect(result3).toEqual([1]);
 
-                // Test with Unicode characters
-                const unicodeKey = getRandomKey();
-                const unicodeField = "field_🚀_测试_🎉";
-                const unicodeValue = "value_🌟_测试_🎊";
+                    // Test with Unicode characters
+                    const unicodeKey = getRandomKey();
+                    const unicodeField = "field_🚀_测试_🎉";
+                    const unicodeValue = "value_🌟_测试_🎊";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                await client.hexpire(unicodeKey, 60, [unicodeField]);
-                const result4 = await client.hpersist(unicodeKey, [unicodeField]);
-                expect(result4).toEqual([1]);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    await client.hexpire(unicodeKey, 60, [unicodeField]);
+                    const result4 = await client.hpersist(unicodeKey, [
+                        unicodeField,
+                    ]);
+                    expect(result4).toEqual([1]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3279,47 +3593,65 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpire basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Test basic HPEXPIRE
-                const result1 = await client.hpexpire(key, 60000, [field1, field2, field3]);
-                expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
+                    // Test basic HPEXPIRE
+                    const result1 = await client.hpexpire(key, 60000, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
 
-                // Verify fields still exist
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
+                    // Verify fields still exist
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
 
-                // Verify expiration was set using HPTTL
-                const pttlResult = await client.hpttl(key, [field1, field2, field3]);
-                expect(pttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
-                expect(pttlResult[0]).toBeLessThanOrEqual(60000); // should be <= 60000 milliseconds
-                expect(pttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
-                expect(pttlResult[1]).toBeLessThanOrEqual(60000); // should be <= 60000 milliseconds
-                expect(pttlResult[2]).toEqual(-2); // field3 doesn't exist
+                    // Verify expiration was set using HPTTL
+                    const pttlResult = await client.hpttl(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(pttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
+                    expect(pttlResult[0]).toBeLessThanOrEqual(60000); // should be <= 60000 milliseconds
+                    expect(pttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
+                    expect(pttlResult[1]).toBeLessThanOrEqual(60000); // should be <= 60000 milliseconds
+                    expect(pttlResult[2]).toEqual(-2); // field3 doesn't exist
 
-                // Test with 0 milliseconds (immediate deletion)
-                const result2 = await client.hpexpire(key, 0, [field1]);
-                expect(result2).toEqual([2]);
-                expect(await client.hget(key, field1)).toEqual(null);
+                    // Test with 0 milliseconds (immediate deletion)
+                    const result2 = await client.hpexpire(key, 0, [field1]);
+                    expect(result2).toEqual([2]);
+                    expect(await client.hget(key, field1)).toEqual(null);
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hpexpire(nonExistentKey, 60000, [field1]);
-                expect(result3).toEqual([-2]);
-            }, protocol);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hpexpire(
+                        nonExistentKey,
+                        60000,
+                        [field1],
+                    );
+                    expect(result3).toEqual([-2]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3327,64 +3659,97 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpire with conditions_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set initial expiration on field1
-                await client.hpexpire(key, 120000, [field1]);
+                    // Set initial expiration on field1
+                    await client.hpexpire(key, 120000, [field1]);
 
-                // Test NX condition (only if no expiry)
-                const result1 = await client.hpexpire(key, 60000, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
-                expect(result1).toEqual([0, 1]); // field1 already has expiry, field2 doesn't
+                    // Test NX condition (only if no expiry)
+                    const result1 = await client.hpexpire(
+                        key,
+                        60000,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                        },
+                    );
+                    expect(result1).toEqual([0, 1]); // field1 already has expiry, field2 doesn't
 
-                // Test XX condition (only if has expiry)
-                const result2 = await client.hpexpire(key, 180000, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
-                });
-                expect(result2).toEqual([1, 1]); // both should have expiry now
+                    // Test XX condition (only if has expiry)
+                    const result2 = await client.hpexpire(
+                        key,
+                        180000,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                        },
+                    );
+                    expect(result2).toEqual([1, 1]); // both should have expiry now
 
-                // Verify expiration was updated using HPTTL
-                const pttlResult2 = await client.hpttl(key, [field1, field2]);
-                expect(pttlResult2[0]).toBeGreaterThan(0);
-                expect(pttlResult2[0]).toBeLessThanOrEqual(180000);
-                expect(pttlResult2[1]).toBeGreaterThan(0);
-                expect(pttlResult2[1]).toBeLessThanOrEqual(180000);
+                    // Verify expiration was updated using HPTTL
+                    const pttlResult2 = await client.hpttl(key, [
+                        field1,
+                        field2,
+                    ]);
+                    expect(pttlResult2[0]).toBeGreaterThan(0);
+                    expect(pttlResult2[0]).toBeLessThanOrEqual(180000);
+                    expect(pttlResult2[1]).toBeGreaterThan(0);
+                    expect(pttlResult2[1]).toBeLessThanOrEqual(180000);
 
-                // Test GT condition (only if greater than current)
-                const result3 = await client.hpexpire(key, 300000, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
-                });
-                expect(result3).toEqual([1]); // 300000 > 180000
+                    // Test GT condition (only if greater than current)
+                    const result3 = await client.hpexpire(
+                        key,
+                        300000,
+                        [field1],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                        },
+                    );
+                    expect(result3).toEqual([1]); // 300000 > 180000
 
-                // Verify expiration was updated using HPTTL
-                const pttlResult3 = await client.hpttl(key, [field1]);
-                expect(pttlResult3[0]).toBeGreaterThan(180000); // Should be greater than previous TTL
-                expect(pttlResult3[0]).toBeLessThanOrEqual(300000);
+                    // Verify expiration was updated using HPTTL
+                    const pttlResult3 = await client.hpttl(key, [field1]);
+                    expect(pttlResult3[0]).toBeGreaterThan(180000); // Should be greater than previous TTL
+                    expect(pttlResult3[0]).toBeLessThanOrEqual(300000);
 
-                // Test LT condition (only if less than current)
-                const result4 = await client.hpexpire(key, 150000, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
-                });
-                expect(result4).toEqual([1]); // 150000 < 300000
+                    // Test LT condition (only if less than current)
+                    const result4 = await client.hpexpire(
+                        key,
+                        150000,
+                        [field1],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                        },
+                    );
+                    expect(result4).toEqual([1]); // 150000 < 300000
 
-                // Verify expiration was updated using HPTTL
-                const pttlResult4 = await client.hpttl(key, [field1]);
-                expect(pttlResult4[0]).toBeGreaterThan(0);
-                expect(pttlResult4[0]).toBeLessThanOrEqual(150000);
-            }, protocol);
+                    // Verify expiration was updated using HPTTL
+                    const pttlResult4 = await client.hpttl(key, [field1]);
+                    expect(pttlResult4[0]).toBeGreaterThan(0);
+                    expect(pttlResult4[0]).toBeLessThanOrEqual(150000);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3392,35 +3757,44 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpire batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
+                    // Set up hashes
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
 
-                // Test batch operations with HPEXPIRE
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
-                batch.hpexpire(key1, 60000, [field1]);
-                batch.hpexpire(key2, 120000, [field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
+                    // Test batch operations with HPEXPIRE
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
+                    batch.hpexpire(key1, 60000, [field1]);
+                    batch.hpexpire(key2, 120000, [field2], {
+                        condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                    });
 
-                const results = await (client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+                    const results = await (client instanceof GlideClient
+                        ? client.exec(batch as Batch, false)
+                        : (client as GlideClusterClient).exec(
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
-                expect(results).toEqual([[true], [true]]);
-            }, protocol);
+                    expect(results).toEqual([[true], [true]]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3428,26 +3802,29 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpire error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
 
-                // Test HPEXPIRE on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hpexpire(key, 60000, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HPEXPIRE on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hpexpire(key, 60000, [field]),
+                    ).rejects.toThrow(RequestError);
 
-                // Test with empty field array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hpexpire(hashKey, 60000, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test with empty field array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hpexpire(hashKey, 60000, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3455,50 +3832,68 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpire with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const field1 = getRandomKey();
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const value = getRandomKey();
-                const valueBuffer = Buffer.from(getRandomKey());
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const value = getRandomKey();
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                // Test with Buffer keys and fields
-                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
-                const result1 = await client.hpexpire(keyBuffer, 60000, [field1, fieldBuffer]);
-                expect(result1).toEqual([1, 1]);
+                    // Test with Buffer keys and fields
+                    await client.hset(keyBuffer, {
+                        [field1]: value,
+                        [fieldBuffer.toString()]: valueBuffer,
+                    });
+                    const result1 = await client.hpexpire(keyBuffer, 60000, [
+                        field1,
+                        fieldBuffer,
+                    ]);
+                    expect(result1).toEqual([1, 1]);
 
-                // Test with long field names and values
-                const longKey = getRandomKey();
-                const longField = "f".repeat(100);
-                const longValue = "v".repeat(100);
+                    // Test with long field names and values
+                    const longKey = getRandomKey();
+                    const longField = "f".repeat(100);
+                    const longValue = "v".repeat(100);
 
-                await client.hset(longKey, { [longField]: longValue });
-                const result2 = await client.hpexpire(longKey, 60000, [longField]);
-                expect(result2).toEqual([1]);
+                    await client.hset(longKey, { [longField]: longValue });
+                    const result2 = await client.hpexpire(longKey, 60000, [
+                        longField,
+                    ]);
+                    expect(result2).toEqual([1]);
 
-                // Test with special characters
-                const specialKey = getRandomKey();
-                const specialField = "field:with:special:chars:!@#$%^&*()";
-                const specialValue = "value:with:special:chars:!@#$%^&*()";
+                    // Test with special characters
+                    const specialKey = getRandomKey();
+                    const specialField = "field:with:special:chars:!@#$%^&*()";
+                    const specialValue = "value:with:special:chars:!@#$%^&*()";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                const result3 = await client.hpexpire(specialKey, 60000, [specialField]);
-                expect(result3).toEqual([1]);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    const result3 = await client.hpexpire(specialKey, 60000, [
+                        specialField,
+                    ]);
+                    expect(result3).toEqual([1]);
 
-                // Test with Unicode characters
-                const unicodeKey = getRandomKey();
-                const unicodeField = "field_🚀_测试_🎉";
-                const unicodeValue = "value_🌟_测试_🎊";
+                    // Test with Unicode characters
+                    const unicodeKey = getRandomKey();
+                    const unicodeField = "field_🚀_测试_🎉";
+                    const unicodeValue = "value_🌟_测试_🎊";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                const result4 = await client.hpexpire(unicodeKey, 60000, [unicodeField]);
-                expect(result4).toEqual([1]);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    const result4 = await client.hpexpire(unicodeKey, 60000, [
+                        unicodeField,
+                    ]);
+                    expect(result4).toEqual([1]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3506,56 +3901,89 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpireat basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Test basic HEXPIREAT with future timestamp
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-                const result1 = await client.hexpireat(key, futureTimestamp, [field1, field2, field3]);
-                expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
+                    // Test basic HEXPIREAT with future timestamp
+                    const futureTimestamp =
+                        Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                    const result1 = await client.hexpireat(
+                        key,
+                        futureTimestamp,
+                        [field1, field2, field3],
+                    );
+                    expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
 
-                // Verify fields still exist
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
+                    // Verify fields still exist
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
 
-                // Verify expiration was set using HTTL and HEXPIRETIME
-                const ttlResult = await client.httl(key, [field1, field2, field3]);
-                expect(ttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
-                expect(ttlResult[0]).toBeLessThanOrEqual(3600); // should be <= 3600 seconds
-                expect(ttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
-                expect(ttlResult[1]).toBeLessThanOrEqual(3600); // should be <= 3600 seconds
-                expect(ttlResult[2]).toEqual(-2); // field3 doesn't exist
+                    // Verify expiration was set using HTTL and HEXPIRETIME
+                    const ttlResult = await client.httl(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(ttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
+                    expect(ttlResult[0]).toBeLessThanOrEqual(3600); // should be <= 3600 seconds
+                    expect(ttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
+                    expect(ttlResult[1]).toBeLessThanOrEqual(3600); // should be <= 3600 seconds
+                    expect(ttlResult[2]).toEqual(-2); // field3 doesn't exist
 
-                const expireTimeResult = await client.hexpiretime(key, [field1, field2, field3]);
-                expect(expireTimeResult[0]).toBeGreaterThan(Math.floor(Date.now() / 1000)); // Should be in the future
-                expect(expireTimeResult[0]).toBeLessThanOrEqual(futureTimestamp); // Should be <= set timestamp
-                expect(expireTimeResult[1]).toBeGreaterThan(Math.floor(Date.now() / 1000)); // Should be in the future
-                expect(expireTimeResult[1]).toBeLessThanOrEqual(futureTimestamp); // Should be <= set timestamp
-                expect(expireTimeResult[2]).toEqual(-2); // field3 doesn't exist
+                    const expireTimeResult = await client.hexpiretime(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(expireTimeResult[0]).toBeGreaterThan(
+                        Math.floor(Date.now() / 1000),
+                    ); // Should be in the future
+                    expect(expireTimeResult[0]).toBeLessThanOrEqual(
+                        futureTimestamp,
+                    ); // Should be <= set timestamp
+                    expect(expireTimeResult[1]).toBeGreaterThan(
+                        Math.floor(Date.now() / 1000),
+                    ); // Should be in the future
+                    expect(expireTimeResult[1]).toBeLessThanOrEqual(
+                        futureTimestamp,
+                    ); // Should be <= set timestamp
+                    expect(expireTimeResult[2]).toEqual(-2); // field3 doesn't exist
 
-                // Test with past timestamp (immediate deletion)
-                const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
-                const result2 = await client.hexpireat(key, pastTimestamp, [field1]);
-                expect(result2).toEqual([1]);
-                expect(await client.hget(key, field1)).toEqual(null);
+                    // Test with past timestamp (immediate deletion)
+                    const pastTimestamp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+                    const result2 = await client.hexpireat(key, pastTimestamp, [
+                        field1,
+                    ]);
+                    expect(result2).toEqual([1]);
+                    expect(await client.hget(key, field1)).toEqual(null);
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hexpireat(nonExistentKey, futureTimestamp, [field1]);
-                expect(result3).toEqual([-2]);
-            }, protocol);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hexpireat(
+                        nonExistentKey,
+                        futureTimestamp,
+                        [field1],
+                    );
+                    expect(result3).toEqual([-2]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3563,60 +3991,98 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpireat with conditions_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with some fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with some fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                const futureTimestamp1 = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-                const futureTimestamp2 = Math.floor(Date.now() / 1000) + 7200; // 2 hours from now
+                    const futureTimestamp1 =
+                        Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                    const futureTimestamp2 =
+                        Math.floor(Date.now() / 1000) + 7200; // 2 hours from now
 
-                // Test NX condition (only if no expiry)
-                const result1 = await client.hexpireat(key, futureTimestamp1, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
-                expect(result1).toEqual([1, 1]);
+                    // Test NX condition (only if no expiry)
+                    const result1 = await client.hexpireat(
+                        key,
+                        futureTimestamp1,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                        },
+                    );
+                    expect(result1).toEqual([1, 1]);
 
-                // Test NX condition again (should fail because fields now have expiry)
-                const result2 = await client.hexpireat(key, futureTimestamp2, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
-                expect(result2).toEqual([0, 0]);
+                    // Test NX condition again (should fail because fields now have expiry)
+                    const result2 = await client.hexpireat(
+                        key,
+                        futureTimestamp2,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                        },
+                    );
+                    expect(result2).toEqual([0, 0]);
 
-                // Test XX condition (only if has expiry)
-                const result3 = await client.hexpireat(key, futureTimestamp2, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
-                });
-                expect(result3).toEqual([1, 1]);
+                    // Test XX condition (only if has expiry)
+                    const result3 = await client.hexpireat(
+                        key,
+                        futureTimestamp2,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                        },
+                    );
+                    expect(result3).toEqual([1, 1]);
 
-                // Verify expiration was updated using HTTL
-                const ttlResult3 = await client.httl(key, [field1, field2]);
-                expect(ttlResult3[0]).toBeGreaterThan(3600); // Should be greater than 1 hour
-                expect(ttlResult3[0]).toBeLessThanOrEqual(7200); // Should be <= 2 hours
-                expect(ttlResult3[1]).toBeGreaterThan(3600); // Should be greater than 1 hour
-                expect(ttlResult3[1]).toBeLessThanOrEqual(7200); // Should be <= 2 hours
+                    // Verify expiration was updated using HTTL
+                    const ttlResult3 = await client.httl(key, [field1, field2]);
+                    expect(ttlResult3[0]).toBeGreaterThan(3600); // Should be greater than 1 hour
+                    expect(ttlResult3[0]).toBeLessThanOrEqual(7200); // Should be <= 2 hours
+                    expect(ttlResult3[1]).toBeGreaterThan(3600); // Should be greater than 1 hour
+                    expect(ttlResult3[1]).toBeLessThanOrEqual(7200); // Should be <= 2 hours
 
-                // Test GT condition (only if greater than current)
-                const result4 = await client.hexpireat(key, futureTimestamp2, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
-                });
-                expect(result4).toEqual([1]);
+                    // Test GT condition (only if greater than current)
+                    const result4 = await client.hexpireat(
+                        key,
+                        futureTimestamp2,
+                        [field1],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                        },
+                    );
+                    expect(result4).toEqual([1]);
 
-                // Test LT condition (only if less than current)
-                const result5 = await client.hexpireat(key, futureTimestamp1, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
-                });
-                expect(result5).toEqual([1]);
-            }, protocol);
+                    // Test LT condition (only if less than current)
+                    const result5 = await client.hexpireat(
+                        key,
+                        futureTimestamp1,
+                        [field1],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                        },
+                    );
+                    expect(result5).toEqual([1]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3624,38 +4090,49 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpireat batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
+                    // Set up hashes
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
 
-                const futureTimestamp1 = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-                const futureTimestamp2 = Math.floor(Date.now() / 1000) + 7200; // 2 hours from now
+                    const futureTimestamp1 =
+                        Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                    const futureTimestamp2 =
+                        Math.floor(Date.now() / 1000) + 7200; // 2 hours from now
 
-                // Test batch operations with HEXPIREAT
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
-                batch.hexpireat(key1, futureTimestamp1, [field1]);
-                batch.hexpireat(key2, futureTimestamp2, [field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
+                    // Test batch operations with HEXPIREAT
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
+                    batch.hexpireat(key1, futureTimestamp1, [field1]);
+                    batch.hexpireat(key2, futureTimestamp2, [field2], {
+                        condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                    });
 
-                const results = await (client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
+                    const results = await (client instanceof GlideClient
+                        ? client.exec(batch as Batch, false)
+                        : (client as GlideClusterClient).exec(
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
-                expect(results).toEqual([[true], [true]]);
-            }, protocol);
+                    expect(results).toEqual([[true], [true]]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3663,27 +4140,35 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpireat error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+                    const key = getRandomKey();
+                    const field = getRandomKey();
+                    const futureTimestamp =
+                        Math.floor(Date.now() / 1000) + 3600;
 
-                // Test HEXPIREAT on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hexpireat(key, futureTimestamp, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HEXPIREAT on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hexpireat(key, futureTimestamp, [field]),
+                    ).rejects.toThrow(RequestError);
 
-                // Test with empty field array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hexpireat(hashKey, futureTimestamp, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test with empty field array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hexpireat(
+                        hashKey,
+                        futureTimestamp,
+                        [],
+                    );
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3691,51 +4176,77 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpireat with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const field1 = getRandomKey();
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const value = getRandomKey();
-                const valueBuffer = Buffer.from(getRandomKey());
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600;
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const value = getRandomKey();
+                    const valueBuffer = Buffer.from(getRandomKey());
+                    const futureTimestamp =
+                        Math.floor(Date.now() / 1000) + 3600;
 
-                // Test with Buffer keys and fields
-                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
-                const result1 = await client.hexpireat(keyBuffer, futureTimestamp, [field1, fieldBuffer]);
-                expect(result1).toEqual([1, 1]);
+                    // Test with Buffer keys and fields
+                    await client.hset(keyBuffer, {
+                        [field1]: value,
+                        [fieldBuffer.toString()]: valueBuffer,
+                    });
+                    const result1 = await client.hexpireat(
+                        keyBuffer,
+                        futureTimestamp,
+                        [field1, fieldBuffer],
+                    );
+                    expect(result1).toEqual([1, 1]);
 
-                // Test with long field names and values
-                const longKey = getRandomKey();
-                const longField = "f".repeat(100);
-                const longValue = "v".repeat(100);
+                    // Test with long field names and values
+                    const longKey = getRandomKey();
+                    const longField = "f".repeat(100);
+                    const longValue = "v".repeat(100);
 
-                await client.hset(longKey, { [longField]: longValue });
-                const result2 = await client.hexpireat(longKey, futureTimestamp, [longField]);
-                expect(result2).toEqual([1]);
+                    await client.hset(longKey, { [longField]: longValue });
+                    const result2 = await client.hexpireat(
+                        longKey,
+                        futureTimestamp,
+                        [longField],
+                    );
+                    expect(result2).toEqual([1]);
 
-                // Test with special characters
-                const specialKey = getRandomKey();
-                const specialField = "field:with:special:chars:!@#$%^&*()";
-                const specialValue = "value:with:special:chars:!@#$%^&*()";
+                    // Test with special characters
+                    const specialKey = getRandomKey();
+                    const specialField = "field:with:special:chars:!@#$%^&*()";
+                    const specialValue = "value:with:special:chars:!@#$%^&*()";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                const result3 = await client.hexpireat(specialKey, futureTimestamp, [specialField]);
-                expect(result3).toEqual([1]);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    const result3 = await client.hexpireat(
+                        specialKey,
+                        futureTimestamp,
+                        [specialField],
+                    );
+                    expect(result3).toEqual([1]);
 
-                // Test with Unicode characters
-                const unicodeKey = getRandomKey();
-                const unicodeField = "field_🚀_测试_🎉";
-                const unicodeValue = "value_🌟_测试_🎊";
+                    // Test with Unicode characters
+                    const unicodeKey = getRandomKey();
+                    const unicodeField = "field_🚀_测试_🎉";
+                    const unicodeValue = "value_🌟_测试_🎊";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                const result4 = await client.hexpireat(unicodeKey, futureTimestamp, [unicodeField]);
-                expect(result4).toEqual([1]);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    const result4 = await client.hexpireat(
+                        unicodeKey,
+                        futureTimestamp,
+                        [unicodeField],
+                    );
+                    expect(result4).toEqual([1]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3743,56 +4254,86 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpireat basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Test basic HPEXPIREAT with future timestamp in milliseconds
-                const futureTimestamp = Date.now() + 3600000; // 1 hour from now
-                const result1 = await client.hpexpireat(key, futureTimestamp, [field1, field2, field3]);
-                expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
+                    // Test basic HPEXPIREAT with future timestamp in milliseconds
+                    const futureTimestamp = Date.now() + 3600000; // 1 hour from now
+                    const result1 = await client.hpexpireat(
+                        key,
+                        futureTimestamp,
+                        [field1, field2, field3],
+                    );
+                    expect(result1).toEqual([1, 1, -2]); // field3 doesn't exist
 
-                // Verify fields still exist and have expiration
-                expect(await client.hget(key, field1)).toEqual(value1);
-                expect(await client.hget(key, field2)).toEqual(value2);
+                    // Verify fields still exist and have expiration
+                    expect(await client.hget(key, field1)).toEqual(value1);
+                    expect(await client.hget(key, field2)).toEqual(value2);
 
-                // Verify expiration was set using HPTTL and HPEXPIRETIME
-                const pttlResult = await client.hpttl(key, [field1, field2, field3]);
-                expect(pttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
-                expect(pttlResult[0]).toBeLessThanOrEqual(3600000); // should be <= 3600000 milliseconds
-                expect(pttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
-                expect(pttlResult[1]).toBeLessThanOrEqual(3600000); // should be <= 3600000 milliseconds
-                expect(pttlResult[2]).toEqual(-2); // field3 doesn't exist
+                    // Verify expiration was set using HPTTL and HPEXPIRETIME
+                    const pttlResult = await client.hpttl(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(pttlResult[0]).toBeGreaterThan(0); // field1 should have TTL
+                    expect(pttlResult[0]).toBeLessThanOrEqual(3600000); // should be <= 3600000 milliseconds
+                    expect(pttlResult[1]).toBeGreaterThan(0); // field2 should have TTL
+                    expect(pttlResult[1]).toBeLessThanOrEqual(3600000); // should be <= 3600000 milliseconds
+                    expect(pttlResult[2]).toEqual(-2); // field3 doesn't exist
 
-                const pexpireTimeResult = await client.hpexpiretime(key, [field1, field2, field3]);
-                expect(pexpireTimeResult[0]).toBeGreaterThan(Date.now()); // Should be in the future
-                expect(pexpireTimeResult[0]).toBeLessThanOrEqual(futureTimestamp); // Should be <= set timestamp
-                expect(pexpireTimeResult[1]).toBeGreaterThan(Date.now()); // Should be in the future
-                expect(pexpireTimeResult[1]).toBeLessThanOrEqual(futureTimestamp); // Should be <= set timestamp
-                expect(pexpireTimeResult[2]).toEqual(-2); // field3 doesn't exist
+                    const pexpireTimeResult = await client.hpexpiretime(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(pexpireTimeResult[0]).toBeGreaterThan(Date.now()); // Should be in the future
+                    expect(pexpireTimeResult[0]).toBeLessThanOrEqual(
+                        futureTimestamp,
+                    ); // Should be <= set timestamp
+                    expect(pexpireTimeResult[1]).toBeGreaterThan(Date.now()); // Should be in the future
+                    expect(pexpireTimeResult[1]).toBeLessThanOrEqual(
+                        futureTimestamp,
+                    ); // Should be <= set timestamp
+                    expect(pexpireTimeResult[2]).toEqual(-2); // field3 doesn't exist
 
-                // Test with past timestamp (immediate deletion)
-                const pastTimestamp = Date.now() - 3600000; // 1 hour ago
-                const result2 = await client.hpexpireat(key, pastTimestamp, [field1]);
-                expect(result2).toEqual([1]);
-                expect(await client.hget(key, field1)).toEqual(null);
+                    // Test with past timestamp (immediate deletion)
+                    const pastTimestamp = Date.now() - 3600000; // 1 hour ago
+                    const result2 = await client.hpexpireat(
+                        key,
+                        pastTimestamp,
+                        [field1],
+                    );
+                    expect(result2).toEqual([1]);
+                    expect(await client.hget(key, field1)).toEqual(null);
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hpexpireat(nonExistentKey, futureTimestamp, [field1]);
-                expect(result3).toEqual([-2]);
-            }, protocol);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hpexpireat(
+                        nonExistentKey,
+                        futureTimestamp,
+                        [field1],
+                    );
+                    expect(result3).toEqual([-2]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3800,65 +4341,104 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpireat with conditions_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                const futureTimestamp1 = Date.now() + 3600000; // 1 hour from now
-                const futureTimestamp2 = Date.now() + 7200000; // 2 hours from now
+                    const futureTimestamp1 = Date.now() + 3600000; // 1 hour from now
+                    const futureTimestamp2 = Date.now() + 7200000; // 2 hours from now
 
-                // Test NX condition (only if no expiry)
-                const result1 = await client.hpexpireat(key, futureTimestamp1, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
-                expect(result1).toEqual([1, 1]);
+                    // Test NX condition (only if no expiry)
+                    const result1 = await client.hpexpireat(
+                        key,
+                        futureTimestamp1,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                        },
+                    );
+                    expect(result1).toEqual([1, 1]);
 
-                // Test NX condition again (should fail because fields now have expiry)
-                const result2 = await client.hpexpireat(key, futureTimestamp2, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
-                expect(result2).toEqual([0, 0]);
+                    // Test NX condition again (should fail because fields now have expiry)
+                    const result2 = await client.hpexpireat(
+                        key,
+                        futureTimestamp2,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                        },
+                    );
+                    expect(result2).toEqual([0, 0]);
 
-                // Test XX condition (only if has expiry)
-                const result3 = await client.hpexpireat(key, futureTimestamp2, [field1, field2], {
-                    condition: HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
-                });
-                expect(result3).toEqual([1, 1]);
+                    // Test XX condition (only if has expiry)
+                    const result3 = await client.hpexpireat(
+                        key,
+                        futureTimestamp2,
+                        [field1, field2],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_HAS_EXPIRY,
+                        },
+                    );
+                    expect(result3).toEqual([1, 1]);
 
-                // Verify expiration was updated using HPTTL
-                const pttlResult3 = await client.hpttl(key, [field1, field2]);
-                expect(pttlResult3[0]).toBeGreaterThan(3600000); // Should be greater than 1 hour
-                expect(pttlResult3[0]).toBeLessThanOrEqual(7200000); // Should be <= 2 hours
-                expect(pttlResult3[1]).toBeGreaterThan(3600000); // Should be greater than 1 hour
-                expect(pttlResult3[1]).toBeLessThanOrEqual(7200000); // Should be <= 2 hours
+                    // Verify expiration was updated using HPTTL
+                    const pttlResult3 = await client.hpttl(key, [
+                        field1,
+                        field2,
+                    ]);
+                    expect(pttlResult3[0]).toBeGreaterThan(3600000); // Should be greater than 1 hour
+                    expect(pttlResult3[0]).toBeLessThanOrEqual(7200000); // Should be <= 2 hours
+                    expect(pttlResult3[1]).toBeGreaterThan(3600000); // Should be greater than 1 hour
+                    expect(pttlResult3[1]).toBeLessThanOrEqual(7200000); // Should be <= 2 hours
 
-                // Test GT condition (only if greater than current)
-                const result4 = await client.hpexpireat(key, futureTimestamp2, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
-                });
-                expect(result4).toEqual([0]); // futureTimestamp2 is not greater than current expiry
+                    // Test GT condition (only if greater than current)
+                    const result4 = await client.hpexpireat(
+                        key,
+                        futureTimestamp2,
+                        [field1],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_GREATER_THAN_CURRENT,
+                        },
+                    );
+                    expect(result4).toEqual([0]); // futureTimestamp2 is not greater than current expiry
 
-                // Test LT condition (only if less than current)
-                const result5 = await client.hpexpireat(key, futureTimestamp1, [field1], {
-                    condition: HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
-                });
-                expect(result5).toEqual([1]); // futureTimestamp1 is less than current expiry
+                    // Test LT condition (only if less than current)
+                    const result5 = await client.hpexpireat(
+                        key,
+                        futureTimestamp1,
+                        [field1],
+                        {
+                            condition:
+                                HashExpirationCondition.ONLY_IF_LESS_THAN_CURRENT,
+                        },
+                    );
+                    expect(result5).toEqual([1]); // futureTimestamp1 is less than current expiry
 
-                // Verify expiration was updated using HPTTL
-                const pttlResult5 = await client.hpttl(key, [field1]);
-                expect(pttlResult5[0]).toBeGreaterThan(0);
-                expect(pttlResult5[0]).toBeLessThanOrEqual(3600000); // Should be <= 1 hour
-            }, protocol);
+                    // Verify expiration was updated using HPTTL
+                    const pttlResult5 = await client.hpttl(key, [field1]);
+                    expect(pttlResult5[0]).toBeGreaterThan(0);
+                    expect(pttlResult5[0]).toBeLessThanOrEqual(3600000); // Should be <= 1 hour
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3866,41 +4446,50 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpireat batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes with fields
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
+                    // Set up hashes with fields
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
 
-                const futureTimestamp1 = Date.now() + 3600000; // 1 hour from now
-                const futureTimestamp2 = Date.now() + 7200000; // 2 hours from now
+                    const futureTimestamp1 = Date.now() + 3600000; // 1 hour from now
+                    const futureTimestamp2 = Date.now() + 7200000; // 2 hours from now
 
-                // Test batch operations with HPEXPIREAT
-                const batch = client instanceof GlideClient ? new Batch(false) : new ClusterBatch(false);
-                batch.hpexpireat(key1, futureTimestamp1, [field1]);
-                batch.hpexpireat(key2, futureTimestamp2, [field2], {
-                    condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
-                });
+                    // Test batch operations with HPEXPIREAT
+                    const batch =
+                        client instanceof GlideClient
+                            ? new Batch(false)
+                            : new ClusterBatch(false);
+                    batch.hpexpireat(key1, futureTimestamp1, [field1]);
+                    batch.hpexpireat(key2, futureTimestamp2, [field2], {
+                        condition: HashExpirationCondition.ONLY_IF_NO_EXPIRY,
+                    });
 
-                const results = await (client instanceof GlideClient
-                    ? client.exec(batch as Batch, false)
-                    : (client as GlideClusterClient).exec(batch as ClusterBatch, false));
-                expect(results).toEqual([[true], [true]]);
+                    const results = await (client instanceof GlideClient
+                        ? client.exec(batch as Batch, false)
+                        : (client as GlideClusterClient).exec(
+                              batch as ClusterBatch,
+                              false,
+                          ));
+                    expect(results).toEqual([[true], [true]]);
 
-                // Verify fields still exist
-                expect(await client.hget(key1, field1)).toEqual(value1);
-                expect(await client.hget(key2, field2)).toEqual(value2);
-            }, protocol);
+                    // Verify fields still exist
+                    expect(await client.hget(key1, field1)).toEqual(value1);
+                    expect(await client.hget(key2, field2)).toEqual(value2);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3908,27 +4497,34 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpireat error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
-                const futureTimestamp = Date.now() + 3600000;
+                    const key = getRandomKey();
+                    const field = getRandomKey();
+                    const futureTimestamp = Date.now() + 3600000;
 
-                // Test HPEXPIREAT on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hpexpireat(key, futureTimestamp, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HPEXPIREAT on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hpexpireat(key, futureTimestamp, [field]),
+                    ).rejects.toThrow(RequestError);
 
-                // Test with empty fields array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hpexpireat(hashKey, futureTimestamp, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test with empty fields array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hpexpireat(
+                        hashKey,
+                        futureTimestamp,
+                        [],
+                    );
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3936,51 +4532,77 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpireat with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const field1 = getRandomKey();
-                const value = getRandomKey();
-                const futureTimestamp = Date.now() + 3600000; // 1 hour from now
+                    const field1 = getRandomKey();
+                    const value = getRandomKey();
+                    const futureTimestamp = Date.now() + 3600000; // 1 hour from now
 
-                // Test with Buffer keys and fields
-                const keyBuffer = Buffer.from(getRandomKey());
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const valueBuffer = Buffer.from(getRandomKey());
+                    // Test with Buffer keys and fields
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
-                const result1 = await client.hpexpireat(keyBuffer, futureTimestamp, [field1, fieldBuffer]);
-                expect(result1).toEqual([1, 1]);
+                    await client.hset(keyBuffer, {
+                        [field1]: value,
+                        [fieldBuffer.toString()]: valueBuffer,
+                    });
+                    const result1 = await client.hpexpireat(
+                        keyBuffer,
+                        futureTimestamp,
+                        [field1, fieldBuffer],
+                    );
+                    expect(result1).toEqual([1, 1]);
 
-                // Test with very long key and field names
-                const longKey = "a".repeat(1000);
-                const longField = "b".repeat(1000);
-                const longValue = "c".repeat(1000);
+                    // Test with very long key and field names
+                    const longKey = "a".repeat(1000);
+                    const longField = "b".repeat(1000);
+                    const longValue = "c".repeat(1000);
 
-                await client.hset(longKey, { [longField]: longValue });
-                const result2 = await client.hpexpireat(longKey, futureTimestamp, [longField]);
-                expect(result2).toEqual([1]);
+                    await client.hset(longKey, { [longField]: longValue });
+                    const result2 = await client.hpexpireat(
+                        longKey,
+                        futureTimestamp,
+                        [longField],
+                    );
+                    expect(result2).toEqual([1]);
 
-                // Test with special characters
-                const specialKey = "key:with:special:chars";
-                const specialField = "field@with#special$chars";
-                const specialValue = "value%with&special*chars";
+                    // Test with special characters
+                    const specialKey = "key:with:special:chars";
+                    const specialField = "field@with#special$chars";
+                    const specialValue = "value%with&special*chars";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                const result3 = await client.hpexpireat(specialKey, futureTimestamp, [specialField]);
-                expect(result3).toEqual([1]);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    const result3 = await client.hpexpireat(
+                        specialKey,
+                        futureTimestamp,
+                        [specialField],
+                    );
+                    expect(result3).toEqual([1]);
 
-                // Test with Unicode characters
-                const unicodeKey = "🔑key";
-                const unicodeField = "🏷️field";
-                const unicodeValue = "💎value";
+                    // Test with Unicode characters
+                    const unicodeKey = "🔑key";
+                    const unicodeField = "🏷️field";
+                    const unicodeValue = "💎value";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                const result4 = await client.hpexpireat(unicodeKey, futureTimestamp, [unicodeField]);
-                expect(result4).toEqual([1]);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    const result4 = await client.hpexpireat(
+                        unicodeKey,
+                        futureTimestamp,
+                        [unicodeField],
+                    );
+                    expect(result4).toEqual([1]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -3988,50 +4610,60 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `httl basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields
-                await client.hexpire(key, 60, [field1, field2]);
+                    // Set expiration on fields
+                    await client.hexpire(key, 60, [field1, field2]);
 
-                // Test basic HTTL
-                const result1 = await client.httl(key, [field1, field2, field3]);
-                expect(result1.length).toEqual(3);
-                expect(result1[0]).toBeGreaterThan(0); // field1 has TTL
-                expect(result1[1]).toBeGreaterThan(0); // field2 has TTL
-                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+                    // Test basic HTTL
+                    const result1 = await client.httl(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1.length).toEqual(3);
+                    expect(result1[0]).toBeGreaterThan(0); // field1 has TTL
+                    expect(result1[1]).toBeGreaterThan(0); // field2 has TTL
+                    expect(result1[2]).toEqual(-2); // field3 doesn't exist
 
-                // Remove expiration from field1
-                await client.hpersist(key, [field1]);
+                    // Remove expiration from field1
+                    await client.hpersist(key, [field1]);
 
-                // Test HTTL after persist
-                const result2 = await client.httl(key, [field1, field2]);
-                expect(result2[0]).toEqual(-1); // field1 has no expiration
-                expect(result2[1]).toBeGreaterThan(0); // field2 still has TTL
+                    // Test HTTL after persist
+                    const result2 = await client.httl(key, [field1, field2]);
+                    expect(result2[0]).toEqual(-1); // field1 has no expiration
+                    expect(result2[1]).toBeGreaterThan(0); // field2 still has TTL
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.httl(nonExistentKey, [field1]);
-                expect(result3).toEqual([-2]);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.httl(nonExistentKey, [field1]);
+                    expect(result3).toEqual([-2]);
 
-                // Test on fields without expiration
-                const key2 = getRandomKey();
-                await client.hset(key2, { [field1]: value1 });
-                const result4 = await client.httl(key2, [field1]);
-                expect(result4).toEqual([-1]); // field has no expiration
-            }, protocol);
+                    // Test on fields without expiration
+                    const key2 = getRandomKey();
+                    await client.hset(key2, { [field1]: value1 });
+                    const result4 = await client.httl(key2, [field1]);
+                    expect(result4).toEqual([-1]); // field has no expiration
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4039,43 +4671,48 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `httl with batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes with fields and expiration
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
-                await client.hexpire(key1, 60, [field1]);
-                await client.hexpire(key2, 120, [field2]);
+                    // Set up hashes with fields and expiration
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
+                    await client.hexpire(key1, 60, [field1]);
+                    await client.hexpire(key2, 120, [field2]);
 
-                // Test batch operations with HTTL
-                if (client instanceof GlideClient) {
-                    const batch = new Batch(false);
-                    batch.httl(key1, [field1]);
-                    batch.httl(key2, [field2]);
-                    const results = await client.exec(batch, false);
-                    expect(results).not.toBeNull();
-                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
-                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
-                } else {
-                    const batch = new ClusterBatch(false);
-                    batch.httl(key1, [field1]);
-                    batch.httl(key2, [field2]);
-                    const results = await (client as GlideClusterClient).exec(batch, false);
-                    expect(results).not.toBeNull();
-                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
-                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
-                }
-            }, protocol);
+                    // Test batch operations with HTTL
+                    if (client instanceof GlideClient) {
+                        const batch = new Batch(false);
+                        batch.httl(key1, [field1]);
+                        batch.httl(key2, [field2]);
+                        const results = await client.exec(batch, false);
+                        expect(results).not.toBeNull();
+                        expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                        expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                    } else {
+                        const batch = new ClusterBatch(false);
+                        batch.httl(key1, [field1]);
+                        batch.httl(key2, [field2]);
+                        const results = await (
+                            client as GlideClusterClient
+                        ).exec(batch, false);
+                        expect(results).not.toBeNull();
+                        expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                        expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                    }
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4083,26 +4720,29 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `httl error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
 
-                // Test HTTL on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.httl(key, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HTTL on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(client.httl(key, [field])).rejects.toThrow(
+                        RequestError,
+                    );
 
-                // Test HTTL with empty fields array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.httl(hashKey, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test HTTL with empty fields array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.httl(hashKey, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4110,55 +4750,75 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `httl with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const field1 = getRandomKey();
-                const value = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const valueBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const value = getRandomKey();
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                // Test with Buffer keys and fields
-                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
-                await client.hexpire(keyBuffer, 60, [field1, fieldBuffer.toString()]);
-                const result1 = await client.httl(keyBuffer, [field1, fieldBuffer]);
-                expect(result1.length).toEqual(2);
-                expect(result1[0]).toBeGreaterThan(0);
-                expect(result1[1]).toBeGreaterThan(0);
+                    // Test with Buffer keys and fields
+                    await client.hset(keyBuffer, {
+                        [field1]: value,
+                        [fieldBuffer.toString()]: valueBuffer,
+                    });
+                    await client.hexpire(keyBuffer, 60, [
+                        field1,
+                        fieldBuffer.toString(),
+                    ]);
+                    const result1 = await client.httl(keyBuffer, [
+                        field1,
+                        fieldBuffer,
+                    ]);
+                    expect(result1.length).toEqual(2);
+                    expect(result1[0]).toBeGreaterThan(0);
+                    expect(result1[1]).toBeGreaterThan(0);
 
-                // Test with long keys and fields
-                const longKey = "a".repeat(1000);
-                const longField = "b".repeat(1000);
-                const longValue = "c".repeat(1000);
+                    // Test with long keys and fields
+                    const longKey = "a".repeat(1000);
+                    const longField = "b".repeat(1000);
+                    const longValue = "c".repeat(1000);
 
-                await client.hset(longKey, { [longField]: longValue });
-                await client.hexpire(longKey, 60, [longField]);
-                const result2 = await client.httl(longKey, [longField]);
-                expect(result2[0]).toBeGreaterThan(0);
+                    await client.hset(longKey, { [longField]: longValue });
+                    await client.hexpire(longKey, 60, [longField]);
+                    const result2 = await client.httl(longKey, [longField]);
+                    expect(result2[0]).toBeGreaterThan(0);
 
-                // Test with special characters
-                const specialKey = "key:with:special:chars";
-                const specialField = "field@with#special$chars";
-                const specialValue = "value%with&special*chars";
+                    // Test with special characters
+                    const specialKey = "key:with:special:chars";
+                    const specialField = "field@with#special$chars";
+                    const specialValue = "value%with&special*chars";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                await client.hexpire(specialKey, 60, [specialField]);
-                const result3 = await client.httl(specialKey, [specialField]);
-                expect(result3[0]).toBeGreaterThan(0);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    await client.hexpire(specialKey, 60, [specialField]);
+                    const result3 = await client.httl(specialKey, [
+                        specialField,
+                    ]);
+                    expect(result3[0]).toBeGreaterThan(0);
 
-                // Test with Unicode characters
-                const unicodeKey = "🔑key";
-                const unicodeField = "🏷️field";
-                const unicodeValue = "💎value";
+                    // Test with Unicode characters
+                    const unicodeKey = "🔑key";
+                    const unicodeField = "🏷️field";
+                    const unicodeValue = "💎value";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                await client.hexpire(unicodeKey, 60, [unicodeField]);
-                const result4 = await client.httl(unicodeKey, [unicodeField]);
-                expect(result4[0]).toBeGreaterThan(0);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    await client.hexpire(unicodeKey, 60, [unicodeField]);
+                    const result4 = await client.httl(unicodeKey, [
+                        unicodeField,
+                    ]);
+                    expect(result4[0]).toBeGreaterThan(0);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4166,51 +4826,70 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpiretime basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields using absolute timestamp
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-                await client.hexpireat(key, futureTimestamp, [field1, field2]);
+                    // Set expiration on fields using absolute timestamp
+                    const futureTimestamp =
+                        Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                    await client.hexpireat(key, futureTimestamp, [
+                        field1,
+                        field2,
+                    ]);
 
-                // Test basic HEXPIRETIME
-                const result1 = await client.hexpiretime(key, [field1, field2, field3]);
-                expect(result1.length).toEqual(3);
-                expect(result1[0]).toBeGreaterThan(0); // field1 has expiration timestamp
-                expect(result1[1]).toBeGreaterThan(0); // field2 has expiration timestamp
-                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+                    // Test basic HEXPIRETIME
+                    const result1 = await client.hexpiretime(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1.length).toEqual(3);
+                    expect(result1[0]).toBeGreaterThan(0); // field1 has expiration timestamp
+                    expect(result1[1]).toBeGreaterThan(0); // field2 has expiration timestamp
+                    expect(result1[2]).toEqual(-2); // field3 doesn't exist
 
-                // Remove expiration from field1
-                await client.hpersist(key, [field1]);
+                    // Remove expiration from field1
+                    await client.hpersist(key, [field1]);
 
-                // Test HEXPIRETIME after persist
-                const result2 = await client.hexpiretime(key, [field1, field2]);
-                expect(result2[0]).toEqual(-1); // field1 has no expiration
-                expect(result2[1]).toBeGreaterThan(0); // field2 still has expiration timestamp
+                    // Test HEXPIRETIME after persist
+                    const result2 = await client.hexpiretime(key, [
+                        field1,
+                        field2,
+                    ]);
+                    expect(result2[0]).toEqual(-1); // field1 has no expiration
+                    expect(result2[1]).toBeGreaterThan(0); // field2 still has expiration timestamp
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hexpiretime(nonExistentKey, [field1]);
-                expect(result3).toEqual([-2]);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hexpiretime(nonExistentKey, [
+                        field1,
+                    ]);
+                    expect(result3).toEqual([-2]);
 
-                // Test on fields without expiration
-                const key2 = getRandomKey();
-                await client.hset(key2, { [field1]: value1 });
-                const result4 = await client.hexpiretime(key2, [field1]);
-                expect(result4).toEqual([-1]); // field has no expiration
-            }, protocol);
+                    // Test on fields without expiration
+                    const key2 = getRandomKey();
+                    await client.hset(key2, { [field1]: value1 });
+                    const result4 = await client.hexpiretime(key2, [field1]);
+                    expect(result4).toEqual([-1]); // field has no expiration
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4218,51 +4897,61 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hexpiretime with batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields
-                const futureTimestamp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
-                await client.hexpireat(key, futureTimestamp, [field1, field2]);
+                    // Set expiration on fields
+                    const futureTimestamp =
+                        Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+                    await client.hexpireat(key, futureTimestamp, [
+                        field1,
+                        field2,
+                    ]);
 
-                // Test batch operations with HEXPIRETIME
-                if (client instanceof GlideClient) {
-                    const batch = new Batch(false);
-                    batch.hexpiretime(key, [field1, field2]);
-                    const results = await client.exec(batch, false);
-                    expect(results).not.toBeNull();
-                    const result = results![0] as number[];
-                    expect(result.length).toEqual(2);
-                    expect(result[0]).toBeGreaterThan(0);
-                    expect(result[1]).toBeGreaterThan(0);
-                }
+                    // Test batch operations with HEXPIRETIME
+                    if (client instanceof GlideClient) {
+                        const batch = new Batch(false);
+                        batch.hexpiretime(key, [field1, field2]);
+                        const results = await client.exec(batch, false);
+                        expect(results).not.toBeNull();
+                        const result = results![0] as number[];
+                        expect(result.length).toEqual(2);
+                        expect(result[0]).toBeGreaterThan(0);
+                        expect(result[1]).toBeGreaterThan(0);
+                    }
 
-                // Test error cases
-                const field = getRandomKey();
+                    // Test error cases
+                    const field = getRandomKey();
 
-                // Test HEXPIRETIME on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hexpiretime(key, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HEXPIRETIME on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hexpiretime(key, [field]),
+                    ).rejects.toThrow(RequestError);
 
-                // Test HEXPIRETIME with empty fields array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hexpiretime(hashKey, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test HEXPIRETIME with empty fields array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hexpiretime(hashKey, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4270,55 +4959,73 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpiretime basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields using absolute timestamp in milliseconds
-                const futureTimestampMs = Date.now() + 3600000; // 1 hour from now in milliseconds
-                await client.hpexpireat(key, futureTimestampMs, [field1, field2]);
+                    // Set expiration on fields using absolute timestamp in milliseconds
+                    const futureTimestampMs = Date.now() + 3600000; // 1 hour from now in milliseconds
+                    await client.hpexpireat(key, futureTimestampMs, [
+                        field1,
+                        field2,
+                    ]);
 
-                // Test basic HPEXPIRETIME
-                const result1 = await client.hpexpiretime(key, [field1, field2, field3]);
-                expect(result1.length).toEqual(3);
-                expect(result1[0]).toBeGreaterThan(0); // field1 has expiration timestamp in milliseconds
-                expect(result1[1]).toBeGreaterThan(0); // field2 has expiration timestamp in milliseconds
-                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+                    // Test basic HPEXPIRETIME
+                    const result1 = await client.hpexpiretime(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1.length).toEqual(3);
+                    expect(result1[0]).toBeGreaterThan(0); // field1 has expiration timestamp in milliseconds
+                    expect(result1[1]).toBeGreaterThan(0); // field2 has expiration timestamp in milliseconds
+                    expect(result1[2]).toEqual(-2); // field3 doesn't exist
 
-                // Verify timestamp is in milliseconds (should be much larger than seconds)
-                expect(result1[0]).toBeGreaterThan(Date.now()); // Should be in the future
-                expect(result1[1]).toBeGreaterThan(Date.now()); // Should be in the future
+                    // Verify timestamp is in milliseconds (should be much larger than seconds)
+                    expect(result1[0]).toBeGreaterThan(Date.now()); // Should be in the future
+                    expect(result1[1]).toBeGreaterThan(Date.now()); // Should be in the future
 
-                // Remove expiration from field1
-                await client.hpersist(key, [field1]);
+                    // Remove expiration from field1
+                    await client.hpersist(key, [field1]);
 
-                // Test HPEXPIRETIME after persist
-                const result2 = await client.hpexpiretime(key, [field1, field2]);
-                expect(result2[0]).toEqual(-1); // field1 has no expiration
-                expect(result2[1]).toBeGreaterThan(0); // field2 still has expiration timestamp
+                    // Test HPEXPIRETIME after persist
+                    const result2 = await client.hpexpiretime(key, [
+                        field1,
+                        field2,
+                    ]);
+                    expect(result2[0]).toEqual(-1); // field1 has no expiration
+                    expect(result2[1]).toBeGreaterThan(0); // field2 still has expiration timestamp
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hpexpiretime(nonExistentKey, [field1]);
-                expect(result3).toEqual([-2]);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hpexpiretime(nonExistentKey, [
+                        field1,
+                    ]);
+                    expect(result3).toEqual([-2]);
 
-                // Test on fields without expiration
-                const key2 = getRandomKey();
-                await client.hset(key2, { [field1]: value1 });
-                const result4 = await client.hpexpiretime(key2, [field1]);
-                expect(result4).toEqual([-1]); // field has no expiration
-            }, protocol);
+                    // Test on fields without expiration
+                    const key2 = getRandomKey();
+                    await client.hset(key2, { [field1]: value1 });
+                    const result4 = await client.hpexpiretime(key2, [field1]);
+                    expect(result4).toEqual([-1]); // field has no expiration
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4326,51 +5033,60 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpexpiretime with batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields
-                const futureTimestampMs = Date.now() + 3600000; // 1 hour from now in milliseconds
-                await client.hpexpireat(key, futureTimestampMs, [field1, field2]);
+                    // Set expiration on fields
+                    const futureTimestampMs = Date.now() + 3600000; // 1 hour from now in milliseconds
+                    await client.hpexpireat(key, futureTimestampMs, [
+                        field1,
+                        field2,
+                    ]);
 
-                // Test batch operations with HPEXPIRETIME
-                if (client instanceof GlideClient) {
-                    const batch = new Batch(false);
-                    batch.hpexpiretime(key, [field1, field2]);
-                    const results = await client.exec(batch, false);
-                    expect(results).not.toBeNull();
-                    const result = results![0] as number[];
-                    expect(result.length).toEqual(2);
-                    expect(result[0]).toBeGreaterThan(0);
-                    expect(result[1]).toBeGreaterThan(0);
-                }
+                    // Test batch operations with HPEXPIRETIME
+                    if (client instanceof GlideClient) {
+                        const batch = new Batch(false);
+                        batch.hpexpiretime(key, [field1, field2]);
+                        const results = await client.exec(batch, false);
+                        expect(results).not.toBeNull();
+                        const result = results![0] as number[];
+                        expect(result.length).toEqual(2);
+                        expect(result[0]).toBeGreaterThan(0);
+                        expect(result[1]).toBeGreaterThan(0);
+                    }
 
-                // Test error cases
-                const field = getRandomKey();
+                    // Test error cases
+                    const field = getRandomKey();
 
-                // Test HPEXPIRETIME on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hpexpiretime(key, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HPEXPIRETIME on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(
+                        client.hpexpiretime(key, [field]),
+                    ).rejects.toThrow(RequestError);
 
-                // Test HPEXPIRETIME with empty fields array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hpexpiretime(hashKey, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test HPEXPIRETIME with empty fields array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hpexpiretime(hashKey, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4378,54 +5094,66 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpttl basic functionality_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const field3 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const field3 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hash with fields
-                await client.hset(key, { [field1]: value1, [field2]: value2 });
+                    // Set up hash with fields
+                    await client.hset(key, {
+                        [field1]: value1,
+                        [field2]: value2,
+                    });
 
-                // Set expiration on fields using HPEXPIRE (milliseconds)
-                await client.hpexpire(key, 60000, [field1, field2]);
+                    // Set expiration on fields using HPEXPIRE (milliseconds)
+                    await client.hpexpire(key, 60000, [field1, field2]);
 
-                // Test basic HPTTL
-                const result1 = await client.hpttl(key, [field1, field2, field3]);
-                expect(result1.length).toEqual(3);
-                expect(result1[0]).toBeGreaterThan(0); // field1 has TTL in milliseconds
-                expect(result1[1]).toBeGreaterThan(0); // field2 has TTL in milliseconds
-                expect(result1[2]).toEqual(-2); // field3 doesn't exist
+                    // Test basic HPTTL
+                    const result1 = await client.hpttl(key, [
+                        field1,
+                        field2,
+                        field3,
+                    ]);
+                    expect(result1.length).toEqual(3);
+                    expect(result1[0]).toBeGreaterThan(0); // field1 has TTL in milliseconds
+                    expect(result1[1]).toBeGreaterThan(0); // field2 has TTL in milliseconds
+                    expect(result1[2]).toEqual(-2); // field3 doesn't exist
 
-                // Verify TTL is in milliseconds (should be much larger than seconds)
-                expect(result1[0]).toBeGreaterThan(1000); // Should be > 1 second in ms
-                expect(result1[1]).toBeGreaterThan(1000); // Should be > 1 second in ms
+                    // Verify TTL is in milliseconds (should be much larger than seconds)
+                    expect(result1[0]).toBeGreaterThan(1000); // Should be > 1 second in ms
+                    expect(result1[1]).toBeGreaterThan(1000); // Should be > 1 second in ms
 
-                // Remove expiration from field1
-                await client.hpersist(key, [field1]);
+                    // Remove expiration from field1
+                    await client.hpersist(key, [field1]);
 
-                // Test HPTTL after persist
-                const result2 = await client.hpttl(key, [field1, field2]);
-                expect(result2[0]).toEqual(-1); // field1 has no expiration
-                expect(result2[1]).toBeGreaterThan(0); // field2 still has TTL
+                    // Test HPTTL after persist
+                    const result2 = await client.hpttl(key, [field1, field2]);
+                    expect(result2[0]).toEqual(-1); // field1 has no expiration
+                    expect(result2[1]).toBeGreaterThan(0); // field2 still has TTL
 
-                // Test on non-existent key
-                const nonExistentKey = getRandomKey();
-                const result3 = await client.hpttl(nonExistentKey, [field1]);
-                expect(result3).toEqual([-2]);
+                    // Test on non-existent key
+                    const nonExistentKey = getRandomKey();
+                    const result3 = await client.hpttl(nonExistentKey, [
+                        field1,
+                    ]);
+                    expect(result3).toEqual([-2]);
 
-                // Test on fields without expiration
-                const key2 = getRandomKey();
-                await client.hset(key2, { [field1]: value1 });
-                const result4 = await client.hpttl(key2, [field1]);
-                expect(result4).toEqual([-1]); // field has no expiration
-            }, protocol);
+                    // Test on fields without expiration
+                    const key2 = getRandomKey();
+                    await client.hset(key2, { [field1]: value1 });
+                    const result4 = await client.hpttl(key2, [field1]);
+                    expect(result4).toEqual([-1]); // field has no expiration
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4433,43 +5161,48 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpttl with batch operations_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key1 = getRandomKey();
-                const key2 = getRandomKey();
-                const field1 = getRandomKey();
-                const field2 = getRandomKey();
-                const value1 = getRandomKey();
-                const value2 = getRandomKey();
+                    const key1 = getRandomKey();
+                    const key2 = getRandomKey();
+                    const field1 = getRandomKey();
+                    const field2 = getRandomKey();
+                    const value1 = getRandomKey();
+                    const value2 = getRandomKey();
 
-                // Set up hashes with fields and expiration
-                await client.hset(key1, { [field1]: value1 });
-                await client.hset(key2, { [field2]: value2 });
-                await client.hpexpire(key1, 60000, [field1]);
-                await client.hpexpire(key2, 120000, [field2]);
+                    // Set up hashes with fields and expiration
+                    await client.hset(key1, { [field1]: value1 });
+                    await client.hset(key2, { [field2]: value2 });
+                    await client.hpexpire(key1, 60000, [field1]);
+                    await client.hpexpire(key2, 120000, [field2]);
 
-                // Test batch operations with HPTTL
-                if (client instanceof GlideClient) {
-                    const batch = new Batch(false);
-                    batch.hpttl(key1, [field1]);
-                    batch.hpttl(key2, [field2]);
-                    const results = await client.exec(batch, false);
-                    expect(results).not.toBeNull();
-                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
-                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
-                } else {
-                    const batch = new ClusterBatch(false);
-                    batch.hpttl(key1, [field1]);
-                    batch.hpttl(key2, [field2]);
-                    const results = await (client as GlideClusterClient).exec(batch, false);
-                    expect(results).not.toBeNull();
-                    expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
-                    expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
-                }
-            }, protocol);
+                    // Test batch operations with HPTTL
+                    if (client instanceof GlideClient) {
+                        const batch = new Batch(false);
+                        batch.hpttl(key1, [field1]);
+                        batch.hpttl(key2, [field2]);
+                        const results = await client.exec(batch, false);
+                        expect(results).not.toBeNull();
+                        expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                        expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                    } else {
+                        const batch = new ClusterBatch(false);
+                        batch.hpttl(key1, [field1]);
+                        batch.hpttl(key2, [field2]);
+                        const results = await (
+                            client as GlideClusterClient
+                        ).exec(batch, false);
+                        expect(results).not.toBeNull();
+                        expect(results![0]).toBeGreaterThan(0); // key1 field1 has TTL
+                        expect(results![1]).toBeGreaterThan(0); // key2 field2 has TTL
+                    }
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4477,26 +5210,29 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpttl error handling_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const key = getRandomKey();
-                const field = getRandomKey();
+                    const key = getRandomKey();
+                    const field = getRandomKey();
 
-                // Test HPTTL on non-hash key
-                expect(await client.set(key, "string_value")).toEqual("OK");
-                await expect(
-                    client.hpttl(key, [field]),
-                ).rejects.toThrow(RequestError);
+                    // Test HPTTL on non-hash key
+                    expect(await client.set(key, "string_value")).toEqual("OK");
+                    await expect(client.hpttl(key, [field])).rejects.toThrow(
+                        RequestError,
+                    );
 
-                // Test HPTTL with empty fields array
-                const hashKey = getRandomKey();
-                await client.hset(hashKey, { [field]: "value" });
-                const result = await client.hpttl(hashKey, []);
-                expect(result).toEqual([]);
-            }, protocol);
+                    // Test HPTTL with empty fields array
+                    const hashKey = getRandomKey();
+                    await client.hset(hashKey, { [field]: "value" });
+                    const result = await client.hpttl(hashKey, []);
+                    expect(result).toEqual([]);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -4504,55 +5240,75 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `hpttl with comprehensive parameter types_%p`,
         async (protocol) => {
-            await runTest(async (client: BaseClient, cluster: ValkeyCluster) => {
-                if (cluster.checkIfServerVersionLessThan("9.0.0")) {
-                    return;
-                }
+            await runTest(
+                async (client: BaseClient, cluster: ValkeyCluster) => {
+                    if (cluster.checkIfServerVersionLessThan("9.0.0")) {
+                        return;
+                    }
 
-                const field1 = getRandomKey();
-                const value = getRandomKey();
-                const keyBuffer = Buffer.from(getRandomKey());
-                const fieldBuffer = Buffer.from(getRandomKey());
-                const valueBuffer = Buffer.from(getRandomKey());
+                    const field1 = getRandomKey();
+                    const value = getRandomKey();
+                    const keyBuffer = Buffer.from(getRandomKey());
+                    const fieldBuffer = Buffer.from(getRandomKey());
+                    const valueBuffer = Buffer.from(getRandomKey());
 
-                // Test with Buffer keys and fields
-                await client.hset(keyBuffer, { [field1]: value, [fieldBuffer.toString()]: valueBuffer });
-                await client.hpexpire(keyBuffer, 60000, [field1, fieldBuffer.toString()]);
-                const result1 = await client.hpttl(keyBuffer, [field1, fieldBuffer]);
-                expect(result1.length).toEqual(2);
-                expect(result1[0]).toBeGreaterThan(0);
-                expect(result1[1]).toBeGreaterThan(0);
+                    // Test with Buffer keys and fields
+                    await client.hset(keyBuffer, {
+                        [field1]: value,
+                        [fieldBuffer.toString()]: valueBuffer,
+                    });
+                    await client.hpexpire(keyBuffer, 60000, [
+                        field1,
+                        fieldBuffer.toString(),
+                    ]);
+                    const result1 = await client.hpttl(keyBuffer, [
+                        field1,
+                        fieldBuffer,
+                    ]);
+                    expect(result1.length).toEqual(2);
+                    expect(result1[0]).toBeGreaterThan(0);
+                    expect(result1[1]).toBeGreaterThan(0);
 
-                // Test with long keys and fields
-                const longKey = "a".repeat(1000);
-                const longField = "b".repeat(1000);
-                const longValue = "c".repeat(1000);
+                    // Test with long keys and fields
+                    const longKey = "a".repeat(1000);
+                    const longField = "b".repeat(1000);
+                    const longValue = "c".repeat(1000);
 
-                await client.hset(longKey, { [longField]: longValue });
-                await client.hpexpire(longKey, 60000, [longField]);
-                const result2 = await client.hpttl(longKey, [longField]);
-                expect(result2[0]).toBeGreaterThan(0);
+                    await client.hset(longKey, { [longField]: longValue });
+                    await client.hpexpire(longKey, 60000, [longField]);
+                    const result2 = await client.hpttl(longKey, [longField]);
+                    expect(result2[0]).toBeGreaterThan(0);
 
-                // Test with special characters
-                const specialKey = "key:with:special:chars";
-                const specialField = "field@with#special$chars";
-                const specialValue = "value%with&special*chars";
+                    // Test with special characters
+                    const specialKey = "key:with:special:chars";
+                    const specialField = "field@with#special$chars";
+                    const specialValue = "value%with&special*chars";
 
-                await client.hset(specialKey, { [specialField]: specialValue });
-                await client.hpexpire(specialKey, 60000, [specialField]);
-                const result3 = await client.hpttl(specialKey, [specialField]);
-                expect(result3[0]).toBeGreaterThan(0);
+                    await client.hset(specialKey, {
+                        [specialField]: specialValue,
+                    });
+                    await client.hpexpire(specialKey, 60000, [specialField]);
+                    const result3 = await client.hpttl(specialKey, [
+                        specialField,
+                    ]);
+                    expect(result3[0]).toBeGreaterThan(0);
 
-                // Test with Unicode characters
-                const unicodeKey = "🔑key";
-                const unicodeField = "🏷️field";
-                const unicodeValue = "💎value";
+                    // Test with Unicode characters
+                    const unicodeKey = "🔑key";
+                    const unicodeField = "🏷️field";
+                    const unicodeValue = "💎value";
 
-                await client.hset(unicodeKey, { [unicodeField]: unicodeValue });
-                await client.hpexpire(unicodeKey, 60000, [unicodeField]);
-                const result4 = await client.hpttl(unicodeKey, [unicodeField]);
-                expect(result4[0]).toBeGreaterThan(0);
-            }, protocol);
+                    await client.hset(unicodeKey, {
+                        [unicodeField]: unicodeValue,
+                    });
+                    await client.hpexpire(unicodeKey, 60000, [unicodeField]);
+                    const result4 = await client.hpttl(unicodeKey, [
+                        unicodeField,
+                    ]);
+                    expect(result4[0]).toBeGreaterThan(0);
+                },
+                protocol,
+            );
         },
         config.timeout,
     );
@@ -8616,27 +9372,27 @@ export function runBaseTests(config: {
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, {
-                            decoder: Decoder.String,
-                        })
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(message, {
-                            decoder: Decoder.String,
-                        }),
+                              decoder: Decoder.String,
+                          }),
                 ).toEqual(message);
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, { decoder: Decoder.Bytes })
                         : await client.echo(message, {
-                            decoder: Decoder.Bytes,
-                        }),
+                              decoder: Decoder.Bytes,
+                          }),
                 ).toEqual(Buffer.from(message));
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(Buffer.from(message), {
-                            decoder: Decoder.String,
-                        })
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(Buffer.from(message), {
-                            decoder: Decoder.String,
-                        }),
+                              decoder: Decoder.String,
+                          }),
                 ).toEqual(message);
                 expect(await client.echo(Buffer.from(message))).toEqual(
                     message,
@@ -10348,17 +11104,17 @@ export function runBaseTests(config: {
                     let response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic).dump(key1),
-                                true,
-                                {
-                                    decoder: Decoder.Bytes,
-                                },
-                            )
+                                  new Batch(isAtomic).dump(key1),
+                                  true,
+                                  {
+                                      decoder: Decoder.Bytes,
+                                  },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic).dump(key1),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            );
+                                  new ClusterBatch(isAtomic).dump(key1),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              );
                     expect(response?.[0]).not.toBeNull();
                     data = response?.[0] as Buffer;
 
@@ -10366,19 +11122,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic)
-                                    .restore(key4, 0, data)
-                                    .get(key4),
-                                true,
-                                { decoder: Decoder.String },
-                            )
+                                  new Batch(isAtomic)
+                                      .restore(key4, 0, data)
+                                      .get(key4),
+                                  true,
+                                  { decoder: Decoder.String },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic)
-                                    .restore(key4, 0, data)
-                                    .get(key4),
-                                true,
-                                { decoder: Decoder.String },
-                            );
+                                  new ClusterBatch(isAtomic)
+                                      .restore(key4, 0, data)
+                                      .get(key4),
+                                  true,
+                                  { decoder: Decoder.String },
+                              );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(value);
 
@@ -10386,19 +11142,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic)
-                                    .restore(key5, 0, data)
-                                    .get(key5),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            )
+                                  new Batch(isAtomic)
+                                      .restore(key5, 0, data)
+                                      .get(key5),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic)
-                                    .restore(key5, 0, data)
-                                    .get(key5),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            );
+                                  new ClusterBatch(isAtomic)
+                                      .restore(key5, 0, data)
+                                      .get(key5),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(valueEncode);
                 }
@@ -10870,13 +11626,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -10897,13 +11653,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -10922,13 +11678,13 @@ export function runBaseTests(config: {
                     expiry: expiryVal as
                         | "keepExisting"
                         | {
-                            type:
-                            | TimeUnit.Seconds
-                            | TimeUnit.Milliseconds
-                            | TimeUnit.UnixSeconds
-                            | TimeUnit.UnixMilliseconds;
-                            count: number;
-                        },
+                              type:
+                                  | TimeUnit.Seconds
+                                  | TimeUnit.Milliseconds
+                                  | TimeUnit.UnixSeconds
+                                  | TimeUnit.UnixMilliseconds;
+                              count: number;
+                          },
                     conditionalSet: "onlyIfEqual",
                     comparisonValue: value, // Ensure it matches the current key's value
                 });
@@ -12408,7 +13164,7 @@ export function runBaseTests(config: {
                     for (let i = 0; i < fullResultMapArray.length; i += 2) {
                         expect(
                             (fullResultMapArray[i] as string) in
-                            expectedFullMap,
+                                expectedFullMap,
                         ).toEqual(true);
                     }
 
@@ -13333,23 +14089,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(Buffer.from(key))).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(
@@ -13386,23 +14142,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 3,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 3,
+                              },
+                          ],
                 );
 
                 const xreadgroup = await client.xreadgroup(
@@ -13427,23 +14183,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(await client.xack(key, groupName1, [streamId1])).toEqual(
@@ -13453,23 +14209,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 // key exists, but it is not a stream
@@ -13693,16 +14449,16 @@ export function runBaseTests(config: {
                     Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                        }
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                          }
                         : {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                            minIdleTime: 42,
-                        },
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                              minIdleTime: 42,
+                          },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);
@@ -14920,9 +15676,9 @@ export function runBaseTests(config: {
                             client instanceof GlideClient
                                 ? await client.exec(batch as Batch, true)
                                 : await client.exec(
-                                    batch as ClusterBatch,
-                                    true,
-                                );
+                                      batch as ClusterBatch,
+                                      true,
+                                  );
                         expect(result).toEqual(expectedResult);
                     }
 
@@ -14972,13 +15728,13 @@ export function runBaseTests(config: {
                 // Retry with a longer timeout
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                        batch as ClusterBatch,
-                        true,
-                        { timeout: 1000 },
-                    )
+                          batch as ClusterBatch,
+                          true,
+                          { timeout: 1000 },
+                      )
                     : await (client as GlideClient).exec(batch as Batch, true, {
-                        timeout: 1000,
-                    });
+                          timeout: 1000,
+                      });
 
                 expect(result?.length).toBe(1);
             }, protocol);
@@ -15007,9 +15763,9 @@ export function runBaseTests(config: {
 
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                        batch as ClusterBatch,
-                        false,
-                    )
+                          batch as ClusterBatch,
+                          false,
+                      )
                     : await (client as GlideClient).exec(batch as Batch, false);
 
                 expect(result?.length).toBe(4);
@@ -15182,9 +15938,9 @@ export function runCommonTests(config: {
                 const result = clusterMode
                     ? await client.exec(batch as ClusterTransaction, true)
                     : await (client as GlideClient).exec(
-                        batch as Transaction,
-                        true,
-                    );
+                          batch as Transaction,
+                          true,
+                      );
                 expect(result?.length).toBe(2);
                 expect(result?.[0]).toBe("OK");
                 expect(result?.[1]).toBe("hello");

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -327,10 +327,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                            await client.info({
-                                sections: [InfoOptions.Commandstats],
-                            }),
-                        ).join();
+                              await client.info({
+                                  sections: [InfoOptions.Commandstats],
+                              }),
+                          ).join();
                 expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
@@ -338,10 +338,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                            await client.info({
-                                sections: [InfoOptions.Commandstats],
-                            }),
-                        ).join();
+                              await client.info({
+                                  sections: [InfoOptions.Commandstats],
+                              }),
+                          ).join();
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },
@@ -368,13 +368,13 @@ export function runBaseTests(config: {
                     const response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic).lastsave(),
-                                isAtomic,
-                            )
+                                  new Batch(isAtomic).lastsave(),
+                                  isAtomic,
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic).lastsave(),
-                                isAtomic,
-                            );
+                                  new ClusterBatch(isAtomic).lastsave(),
+                                  isAtomic,
+                              );
 
                     expect(response?.[0]).toBeGreaterThan(yesterday);
                 }
@@ -2535,9 +2535,9 @@ export function runBaseTests(config: {
                         client instanceof GlideClient
                             ? await client.exec(batch as Batch, false)
                             : await (client as GlideClusterClient).exec(
-                                batch as ClusterBatch,
-                                false,
-                            );
+                                  batch as ClusterBatch,
+                                  false,
+                              );
 
                     expect(results).toHaveLength(4);
                     expect(results![0]).toBe(1); // hsetex result for key1
@@ -2734,9 +2734,9 @@ export function runBaseTests(config: {
                         client instanceof GlideClient
                             ? client.exec(batch as Batch, true)
                             : (client as GlideClusterClient).exec(
-                                batch as ClusterBatch,
-                                true,
-                            );
+                                  batch as ClusterBatch,
+                                  true,
+                              );
 
                     await expect(execPromise).rejects.toThrow(RequestError);
                 },
@@ -2900,9 +2900,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
                     expect(results).toHaveLength(2);
                     expect(results![0]).toEqual([value1]);
@@ -3216,9 +3216,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
                     expect(results).toEqual([[1], [1]]);
 
                     // Verify expiration was set using HTTL
@@ -3441,9 +3441,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
                     expect(results).toEqual([[1], [1]]);
                 },
                 protocol,
@@ -3754,9 +3754,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
                     expect(results).toEqual([[1], [1]]);
                 },
@@ -4095,9 +4095,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
                     expect(results).toEqual([[1], [1]]);
                 },
@@ -4446,9 +4446,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
                     expect(results).toEqual([[1], [1]]);
 
                     // Verify fields still exist
@@ -9340,27 +9340,27 @@ export function runBaseTests(config: {
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, {
-                            decoder: Decoder.String,
-                        })
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(message, {
-                            decoder: Decoder.String,
-                        }),
+                              decoder: Decoder.String,
+                          }),
                 ).toEqual(message);
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, { decoder: Decoder.Bytes })
                         : await client.echo(message, {
-                            decoder: Decoder.Bytes,
-                        }),
+                              decoder: Decoder.Bytes,
+                          }),
                 ).toEqual(Buffer.from(message));
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(Buffer.from(message), {
-                            decoder: Decoder.String,
-                        })
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(Buffer.from(message), {
-                            decoder: Decoder.String,
-                        }),
+                              decoder: Decoder.String,
+                          }),
                 ).toEqual(message);
                 expect(await client.echo(Buffer.from(message))).toEqual(
                     message,
@@ -11072,17 +11072,17 @@ export function runBaseTests(config: {
                     let response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic).dump(key1),
-                                true,
-                                {
-                                    decoder: Decoder.Bytes,
-                                },
-                            )
+                                  new Batch(isAtomic).dump(key1),
+                                  true,
+                                  {
+                                      decoder: Decoder.Bytes,
+                                  },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic).dump(key1),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            );
+                                  new ClusterBatch(isAtomic).dump(key1),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              );
                     expect(response?.[0]).not.toBeNull();
                     data = response?.[0] as Buffer;
 
@@ -11090,19 +11090,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic)
-                                    .restore(key4, 0, data)
-                                    .get(key4),
-                                true,
-                                { decoder: Decoder.String },
-                            )
+                                  new Batch(isAtomic)
+                                      .restore(key4, 0, data)
+                                      .get(key4),
+                                  true,
+                                  { decoder: Decoder.String },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic)
-                                    .restore(key4, 0, data)
-                                    .get(key4),
-                                true,
-                                { decoder: Decoder.String },
-                            );
+                                  new ClusterBatch(isAtomic)
+                                      .restore(key4, 0, data)
+                                      .get(key4),
+                                  true,
+                                  { decoder: Decoder.String },
+                              );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(value);
 
@@ -11110,19 +11110,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic)
-                                    .restore(key5, 0, data)
-                                    .get(key5),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            )
+                                  new Batch(isAtomic)
+                                      .restore(key5, 0, data)
+                                      .get(key5),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic)
-                                    .restore(key5, 0, data)
-                                    .get(key5),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            );
+                                  new ClusterBatch(isAtomic)
+                                      .restore(key5, 0, data)
+                                      .get(key5),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(valueEncode);
                 }
@@ -11594,13 +11594,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -11621,13 +11621,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -11646,13 +11646,13 @@ export function runBaseTests(config: {
                     expiry: expiryVal as
                         | "keepExisting"
                         | {
-                            type:
-                            | TimeUnit.Seconds
-                            | TimeUnit.Milliseconds
-                            | TimeUnit.UnixSeconds
-                            | TimeUnit.UnixMilliseconds;
-                            count: number;
-                        },
+                              type:
+                                  | TimeUnit.Seconds
+                                  | TimeUnit.Milliseconds
+                                  | TimeUnit.UnixSeconds
+                                  | TimeUnit.UnixMilliseconds;
+                              count: number;
+                          },
                     conditionalSet: "onlyIfEqual",
                     comparisonValue: value, // Ensure it matches the current key's value
                 });
@@ -13132,7 +13132,7 @@ export function runBaseTests(config: {
                     for (let i = 0; i < fullResultMapArray.length; i += 2) {
                         expect(
                             (fullResultMapArray[i] as string) in
-                            expectedFullMap,
+                                expectedFullMap,
                         ).toEqual(true);
                     }
 
@@ -14057,23 +14057,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(Buffer.from(key))).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(
@@ -14110,23 +14110,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 3,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 3,
+                              },
+                          ],
                 );
 
                 const xreadgroup = await client.xreadgroup(
@@ -14151,23 +14151,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(await client.xack(key, groupName1, [streamId1])).toEqual(
@@ -14177,23 +14177,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 // key exists, but it is not a stream
@@ -14417,16 +14417,16 @@ export function runBaseTests(config: {
                     Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                        }
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                          }
                         : {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                            minIdleTime: 42,
-                        },
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                              minIdleTime: 42,
+                          },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);
@@ -15644,9 +15644,9 @@ export function runBaseTests(config: {
                             client instanceof GlideClient
                                 ? await client.exec(batch as Batch, true)
                                 : await client.exec(
-                                    batch as ClusterBatch,
-                                    true,
-                                );
+                                      batch as ClusterBatch,
+                                      true,
+                                  );
                         expect(result).toEqual(expectedResult);
                     }
 
@@ -15696,13 +15696,13 @@ export function runBaseTests(config: {
                 // Retry with a longer timeout
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                        batch as ClusterBatch,
-                        true,
-                        { timeout: 1000 },
-                    )
+                          batch as ClusterBatch,
+                          true,
+                          { timeout: 1000 },
+                      )
                     : await (client as GlideClient).exec(batch as Batch, true, {
-                        timeout: 1000,
-                    });
+                          timeout: 1000,
+                      });
 
                 expect(result?.length).toBe(1);
             }, protocol);
@@ -15731,9 +15731,9 @@ export function runBaseTests(config: {
 
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                        batch as ClusterBatch,
-                        false,
-                    )
+                          batch as ClusterBatch,
+                          false,
+                      )
                     : await (client as GlideClient).exec(batch as Batch, false);
 
                 expect(result?.length).toBe(4);
@@ -15906,9 +15906,9 @@ export function runCommonTests(config: {
                 const result = clusterMode
                     ? await client.exec(batch as ClusterTransaction, true)
                     : await (client as GlideClient).exec(
-                        batch as Transaction,
-                        true,
-                    );
+                          batch as Transaction,
+                          true,
+                      );
                 expect(result?.length).toBe(2);
                 expect(result?.[0]).toBe("OK");
                 expect(result?.[1]).toBe("hello");

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -327,10 +327,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                            await client.info({
-                                sections: [InfoOptions.Commandstats],
-                            }),
-                        ).join();
+                              await client.info({
+                                  sections: [InfoOptions.Commandstats],
+                              }),
+                          ).join();
                 expect(oldResult).toContain("cmdstat_set");
                 expect(await client.configResetStat()).toEqual("OK");
 
@@ -338,10 +338,10 @@ export function runBaseTests(config: {
                     client instanceof GlideClient
                         ? await client.info([InfoOptions.Commandstats])
                         : Object.values(
-                            await client.info({
-                                sections: [InfoOptions.Commandstats],
-                            }),
-                        ).join();
+                              await client.info({
+                                  sections: [InfoOptions.Commandstats],
+                              }),
+                          ).join();
                 expect(result).not.toContain("cmdstat_set");
             }, protocol);
         },
@@ -368,13 +368,13 @@ export function runBaseTests(config: {
                     const response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic).lastsave(),
-                                isAtomic,
-                            )
+                                  new Batch(isAtomic).lastsave(),
+                                  isAtomic,
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic).lastsave(),
-                                isAtomic,
-                            );
+                                  new ClusterBatch(isAtomic).lastsave(),
+                                  isAtomic,
+                              );
 
                     expect(response?.[0]).toBeGreaterThan(yesterday);
                 }
@@ -2201,7 +2201,7 @@ export function runBaseTests(config: {
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
-        `hsetex with conditional changes_%p`,
+        `hsetex interface validation_%p`,
         async (protocol) => {
             await runTest(
                 async (client: BaseClient, cluster: ValkeyCluster) => {
@@ -2215,22 +2215,7 @@ export function runBaseTests(config: {
                     const value1 = getRandomKey();
                     const value2 = getRandomKey();
 
-                    // Test that hash-level conditional changes are not supported
-                    await expect(
-                        client.hsetex(
-                            key,
-                            { [field1]: value1 },
-                            {
-                                conditionalChange:
-                                    ConditionalChange.ONLY_IF_DOES_NOT_EXIST,
-                                expiry: { type: TimeUnit.Seconds, count: 60 },
-                            },
-                        ),
-                    ).rejects.toThrow(
-                        "HSETEX does not support hash-level conditional changes",
-                    );
-
-                    // Test basic functionality without conditional changes
+                    // Test basic functionality
                     expect(
                         await client.hsetex(
                             key,
@@ -2550,9 +2535,9 @@ export function runBaseTests(config: {
                         client instanceof GlideClient
                             ? await client.exec(batch as Batch, false)
                             : await (client as GlideClusterClient).exec(
-                                batch as ClusterBatch,
-                                false,
-                            );
+                                  batch as ClusterBatch,
+                                  false,
+                              );
 
                     expect(results).toHaveLength(4);
                     expect(results![0]).toBe(1); // hsetex result for key1
@@ -2749,9 +2734,9 @@ export function runBaseTests(config: {
                         client instanceof GlideClient
                             ? client.exec(batch as Batch, true)
                             : (client as GlideClusterClient).exec(
-                                batch as ClusterBatch,
-                                true,
-                            );
+                                  batch as ClusterBatch,
+                                  true,
+                              );
 
                     await expect(execPromise).rejects.toThrow(RequestError);
                 },
@@ -2808,9 +2793,7 @@ export function runBaseTests(config: {
                         client.hgetex(key, [field1], {
                             expiry: "KEEPTTL",
                         }),
-                    ).rejects.toThrow(
-                        "HGETEX does not support KEEPTTL option",
-                    );
+                    ).rejects.toThrow("HGETEX does not support KEEPTTL option");
 
                     // Test HGETEX on non-existent key
                     const nonExistentKey = getRandomKey();
@@ -2924,9 +2907,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
                     expect(results).toHaveLength(2);
                     expect(results![0]).toEqual([value1]);
@@ -3003,9 +2986,9 @@ export function runBaseTests(config: {
                     expect(result1[1]).toEqual(value1);
 
                     // Test with empty field array - server should return error
-                    await expect(
-                        client.hgetex(key, []),
-                    ).rejects.toThrow(RequestError);
+                    await expect(client.hgetex(key, [])).rejects.toThrow(
+                        RequestError,
+                    );
 
                     // Test with large field names and values
                     const longKey = getRandomKey();
@@ -3240,9 +3223,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
                     expect(results).toEqual([[1], [1]]);
 
                     // Verify expiration was set using HTTL
@@ -3465,9 +3448,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
                     expect(results).toEqual([[1], [1]]);
                 },
                 protocol,
@@ -3497,9 +3480,9 @@ export function runBaseTests(config: {
                     // Test with empty field array - server should return error
                     const hashKey = getRandomKey();
                     await client.hset(hashKey, { [field]: "value" });
-                    await expect(
-                        client.hpersist(hashKey, []),
-                    ).rejects.toThrow(RequestError);
+                    await expect(client.hpersist(hashKey, [])).rejects.toThrow(
+                        RequestError,
+                    );
                 },
                 protocol,
             );
@@ -3778,9 +3761,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
                     expect(results).toEqual([[1], [1]]);
                 },
@@ -4119,9 +4102,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
 
                     expect(results).toEqual([[1], [1]]);
                 },
@@ -4470,9 +4453,9 @@ export function runBaseTests(config: {
                     const results = await (client instanceof GlideClient
                         ? client.exec(batch as Batch, false)
                         : (client as GlideClusterClient).exec(
-                            batch as ClusterBatch,
-                            false,
-                        ));
+                              batch as ClusterBatch,
+                              false,
+                          ));
                     expect(results).toEqual([[1], [1]]);
 
                     // Verify fields still exist
@@ -4726,9 +4709,9 @@ export function runBaseTests(config: {
                     // Test HTTL with empty fields array - server should return error
                     const hashKey = getRandomKey();
                     await client.hset(hashKey, { [field]: "value" });
-                    await expect(
-                        client.httl(hashKey, []),
-                    ).rejects.toThrow(RequestError);
+                    await expect(client.httl(hashKey, [])).rejects.toThrow(
+                        RequestError,
+                    );
                 },
                 protocol,
             );
@@ -5219,9 +5202,9 @@ export function runBaseTests(config: {
                     // Test HPTTL with empty fields array - server should return error
                     const hashKey = getRandomKey();
                     await client.hset(hashKey, { [field]: "value" });
-                    await expect(
-                        client.hpttl(hashKey, []),
-                    ).rejects.toThrow(RequestError);
+                    await expect(client.hpttl(hashKey, [])).rejects.toThrow(
+                        RequestError,
+                    );
                 },
                 protocol,
             );
@@ -9364,27 +9347,27 @@ export function runBaseTests(config: {
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, {
-                            decoder: Decoder.String,
-                        })
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(message, {
-                            decoder: Decoder.String,
-                        }),
+                              decoder: Decoder.String,
+                          }),
                 ).toEqual(message);
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(message, { decoder: Decoder.Bytes })
                         : await client.echo(message, {
-                            decoder: Decoder.Bytes,
-                        }),
+                              decoder: Decoder.Bytes,
+                          }),
                 ).toEqual(Buffer.from(message));
                 expect(
                     client instanceof GlideClient
                         ? await client.echo(Buffer.from(message), {
-                            decoder: Decoder.String,
-                        })
+                              decoder: Decoder.String,
+                          })
                         : await client.echo(Buffer.from(message), {
-                            decoder: Decoder.String,
-                        }),
+                              decoder: Decoder.String,
+                          }),
                 ).toEqual(message);
                 expect(await client.echo(Buffer.from(message))).toEqual(
                     message,
@@ -11096,17 +11079,17 @@ export function runBaseTests(config: {
                     let response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic).dump(key1),
-                                true,
-                                {
-                                    decoder: Decoder.Bytes,
-                                },
-                            )
+                                  new Batch(isAtomic).dump(key1),
+                                  true,
+                                  {
+                                      decoder: Decoder.Bytes,
+                                  },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic).dump(key1),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            );
+                                  new ClusterBatch(isAtomic).dump(key1),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              );
                     expect(response?.[0]).not.toBeNull();
                     data = response?.[0] as Buffer;
 
@@ -11114,19 +11097,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic)
-                                    .restore(key4, 0, data)
-                                    .get(key4),
-                                true,
-                                { decoder: Decoder.String },
-                            )
+                                  new Batch(isAtomic)
+                                      .restore(key4, 0, data)
+                                      .get(key4),
+                                  true,
+                                  { decoder: Decoder.String },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic)
-                                    .restore(key4, 0, data)
-                                    .get(key4),
-                                true,
-                                { decoder: Decoder.String },
-                            );
+                                  new ClusterBatch(isAtomic)
+                                      .restore(key4, 0, data)
+                                      .get(key4),
+                                  true,
+                                  { decoder: Decoder.String },
+                              );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(value);
 
@@ -11134,19 +11117,19 @@ export function runBaseTests(config: {
                     response =
                         client instanceof GlideClient
                             ? await client.exec(
-                                new Batch(isAtomic)
-                                    .restore(key5, 0, data)
-                                    .get(key5),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            )
+                                  new Batch(isAtomic)
+                                      .restore(key5, 0, data)
+                                      .get(key5),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              )
                             : await client.exec(
-                                new ClusterBatch(isAtomic)
-                                    .restore(key5, 0, data)
-                                    .get(key5),
-                                true,
-                                { decoder: Decoder.Bytes },
-                            );
+                                  new ClusterBatch(isAtomic)
+                                      .restore(key5, 0, data)
+                                      .get(key5),
+                                  true,
+                                  { decoder: Decoder.Bytes },
+                              );
                     expect(response?.[0]).toEqual("OK");
                     expect(response?.[1]).toEqual(valueEncode);
                 }
@@ -11618,13 +11601,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
                 conditionalSet: "onlyIfDoesNotExist",
             });
 
@@ -11645,13 +11628,13 @@ export function runBaseTests(config: {
                 expiry: expiryVal as
                     | "keepExisting"
                     | {
-                        type:
-                        | TimeUnit.Seconds
-                        | TimeUnit.Milliseconds
-                        | TimeUnit.UnixSeconds
-                        | TimeUnit.UnixMilliseconds;
-                        count: number;
-                    },
+                          type:
+                              | TimeUnit.Seconds
+                              | TimeUnit.Milliseconds
+                              | TimeUnit.UnixSeconds
+                              | TimeUnit.UnixMilliseconds;
+                          count: number;
+                      },
 
                 conditionalSet: "onlyIfExists",
                 returnOldValue: true,
@@ -11670,13 +11653,13 @@ export function runBaseTests(config: {
                     expiry: expiryVal as
                         | "keepExisting"
                         | {
-                            type:
-                            | TimeUnit.Seconds
-                            | TimeUnit.Milliseconds
-                            | TimeUnit.UnixSeconds
-                            | TimeUnit.UnixMilliseconds;
-                            count: number;
-                        },
+                              type:
+                                  | TimeUnit.Seconds
+                                  | TimeUnit.Milliseconds
+                                  | TimeUnit.UnixSeconds
+                                  | TimeUnit.UnixMilliseconds;
+                              count: number;
+                          },
                     conditionalSet: "onlyIfEqual",
                     comparisonValue: value, // Ensure it matches the current key's value
                 });
@@ -13156,7 +13139,7 @@ export function runBaseTests(config: {
                     for (let i = 0; i < fullResultMapArray.length; i += 2) {
                         expect(
                             (fullResultMapArray[i] as string) in
-                            expectedFullMap,
+                                expectedFullMap,
                         ).toEqual(true);
                     }
 
@@ -14081,23 +14064,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(Buffer.from(key))).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(
@@ -14134,23 +14117,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 0,
-                                pending: 0,
-                                "last-delivered-id": "0-0",
-                                "entries-read": null,
-                                lag: 3,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 0,
+                                  pending: 0,
+                                  "last-delivered-id": "0-0",
+                                  "entries-read": null,
+                                  lag: 3,
+                              },
+                          ],
                 );
 
                 const xreadgroup = await client.xreadgroup(
@@ -14175,23 +14158,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 3,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 3,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 expect(await client.xack(key, groupName1, [streamId1])).toEqual(
@@ -14201,23 +14184,23 @@ export function runBaseTests(config: {
                 expect(await client.xinfoGroups(key)).toEqual(
                     cluster.checkIfServerVersionLessThan("7.0.0")
                         ? [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                            },
-                        ]
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                              },
+                          ]
                         : [
-                            {
-                                name: groupName1,
-                                consumers: 1,
-                                pending: 2,
-                                "last-delivered-id": streamId3,
-                                "entries-read": 3,
-                                lag: 0,
-                            },
-                        ],
+                              {
+                                  name: groupName1,
+                                  consumers: 1,
+                                  pending: 2,
+                                  "last-delivered-id": streamId3,
+                                  "entries-read": 3,
+                                  lag: 0,
+                              },
+                          ],
                 );
 
                 // key exists, but it is not a stream
@@ -14441,16 +14424,16 @@ export function runBaseTests(config: {
                     Buffer.from(group),
                     cluster.checkIfServerVersionLessThan("6.2.0")
                         ? {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                        }
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                          }
                         : {
-                            start: InfBoundary.NegativeInfinity,
-                            end: InfBoundary.PositiveInfinity,
-                            count: 1,
-                            minIdleTime: 42,
-                        },
+                              start: InfBoundary.NegativeInfinity,
+                              end: InfBoundary.PositiveInfinity,
+                              count: 1,
+                              minIdleTime: 42,
+                          },
                 );
                 result[0][2] = 0; // overwrite msec counter to avoid test flakyness
                 expect(result).toEqual([["0-1", "consumer", 0, 1]]);
@@ -15668,9 +15651,9 @@ export function runBaseTests(config: {
                             client instanceof GlideClient
                                 ? await client.exec(batch as Batch, true)
                                 : await client.exec(
-                                    batch as ClusterBatch,
-                                    true,
-                                );
+                                      batch as ClusterBatch,
+                                      true,
+                                  );
                         expect(result).toEqual(expectedResult);
                     }
 
@@ -15720,13 +15703,13 @@ export function runBaseTests(config: {
                 // Retry with a longer timeout
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                        batch as ClusterBatch,
-                        true,
-                        { timeout: 1000 },
-                    )
+                          batch as ClusterBatch,
+                          true,
+                          { timeout: 1000 },
+                      )
                     : await (client as GlideClient).exec(batch as Batch, true, {
-                        timeout: 1000,
-                    });
+                          timeout: 1000,
+                      });
 
                 expect(result?.length).toBe(1);
             }, protocol);
@@ -15755,9 +15738,9 @@ export function runBaseTests(config: {
 
                 const result = isCluster
                     ? await (client as GlideClusterClient).exec(
-                        batch as ClusterBatch,
-                        false,
-                    )
+                          batch as ClusterBatch,
+                          false,
+                      )
                     : await (client as GlideClient).exec(batch as Batch, false);
 
                 expect(result?.length).toBe(4);
@@ -15930,9 +15913,9 @@ export function runCommonTests(config: {
                 const result = clusterMode
                     ? await client.exec(batch as ClusterTransaction, true)
                     : await (client as GlideClient).exec(
-                        batch as Transaction,
-                        true,
-                    );
+                          batch as Transaction,
+                          true,
+                      );
                 expect(result?.length).toBe(2);
                 expect(result?.[0]).toBe("OK");
                 expect(result?.[1]).toBe("hello");

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -626,7 +626,7 @@ export function checkFunctionListResponse(
             typeof libName === "string"
                 ? libName === lib["library_name"]
                 : (libName as Buffer).compare(lib["library_name"] as Buffer) ==
-                0;
+                  0;
 
         if (hasLib) {
             const functions = lib["functions"];
@@ -679,7 +679,7 @@ export function checkFunctionStatsResponse(
     if (response.running_script !== null && runningFunction.length == 0) {
         fail(
             "Unexpected running function info: " +
-            (response.running_script.command as string[]).join(" "),
+                (response.running_script.command as string[]).join(" "),
         );
     }
 
@@ -749,6 +749,7 @@ export function checkAndHandleFlakyTests(
                 expect(ttlArray[2]).toEqual(-2);
                 return true;
             }
+
             return false;
         }
 
@@ -793,10 +794,10 @@ export function validateBatchResponse(
             const actual =
                 response?.[i] instanceof Map
                     ? JSON.stringify(
-                        Array.from(
-                            (response?.[i] as ReturnTypeMap)?.entries(),
-                        ),
-                    )
+                          Array.from(
+                              (response?.[i] as ReturnTypeMap)?.entries(),
+                          ),
+                      )
                     : JSON.stringify(response?.[i]);
             failedChecks.push(
                 `${testName} failed, expected <${expected}>, actual <${actual}>`,
@@ -971,33 +972,33 @@ export async function batchTest(
         palermo,
         catania,
     ] = [
-            decodeString(fieldStr, decoder),
-            decodeString(fieldStr + 1, decoder),
-            decodeString(fieldStr + 2, decoder),
-            decodeString(fieldStr + 3, decoder),
-            decodeString(fieldStr + 4, decoder),
-            decodeString("value1", decoder),
-            decodeString("value2", decoder),
-            decodeString("value3", decoder),
-            decodeString("foo", decoder),
-            decodeString("bar", decoder),
-            decodeString("baz", decoder),
-            decodeString("test_message", decoder),
-            decodeString("one", decoder),
-            decodeString("two", decoder),
-            decodeString("three", decoder),
-            decodeString("_", decoder),
-            decodeString("non_existing_member", decoder),
-            decodeString("member1", decoder),
-            decodeString("member2", decoder),
-            decodeString("member3", decoder),
-            decodeString("member4", decoder),
-            decodeString("member5", decoder),
-            decodeString("member6", decoder),
-            decodeString("member7", decoder),
-            decodeString("Palermo", decoder),
-            decodeString("Catania", decoder),
-        ];
+        decodeString(fieldStr, decoder),
+        decodeString(fieldStr + 1, decoder),
+        decodeString(fieldStr + 2, decoder),
+        decodeString(fieldStr + 3, decoder),
+        decodeString(fieldStr + 4, decoder),
+        decodeString("value1", decoder),
+        decodeString("value2", decoder),
+        decodeString("value3", decoder),
+        decodeString("foo", decoder),
+        decodeString("bar", decoder),
+        decodeString("baz", decoder),
+        decodeString("test_message", decoder),
+        decodeString("one", decoder),
+        decodeString("two", decoder),
+        decodeString("three", decoder),
+        decodeString("_", decoder),
+        decodeString("non_existing_member", decoder),
+        decodeString("member1", decoder),
+        decodeString("member2", decoder),
+        decodeString("member3", decoder),
+        decodeString("member4", decoder),
+        decodeString("member5", decoder),
+        decodeString("member6", decoder),
+        decodeString("member7", decoder),
+        decodeString("Palermo", decoder),
+        decodeString("Catania", decoder),
+    ];
 
     // array of tuples - first element is test name/description, second - expected return value
     const responseData: [string, GlideReturnType][] = [];
@@ -1152,52 +1153,94 @@ export async function batchTest(
     // HSETEX tests - only run if server version is 9.0.0 or higher
     if (!cluster.checkIfServerVersionLessThan("9.0.0")) {
         // Test basic HSETEX with expiry
-        baseBatch.hsetex(key4, { [field.toString()]: value }, {
-            expiry: { type: TimeUnit.Seconds, count: 60 },
-        });
-        responseData.push(["hsetex(key4, { [field]: value }, { expiry: { type: TimeUnit.Seconds, count: 60 } })", 1]);
+        baseBatch.hsetex(
+            key4,
+            { [field.toString()]: value },
+            {
+                expiry: { type: TimeUnit.Seconds, count: 60 },
+            },
+        );
+        responseData.push([
+            "hsetex(key4, { [field]: value }, { expiry: { type: TimeUnit.Seconds, count: 60 } })",
+            1,
+        ]);
 
         // Test HSETEX with KEEPTTL
-        baseBatch.hsetex(key4, { [field2.toString()]: value }, {
-            expiry: "KEEPTTL",
-        });
-        responseData.push(["hsetex(key4, { [field2]: value }, { expiry: 'KEEPTTL' })", 1]);
+        baseBatch.hsetex(
+            key4,
+            { [field2.toString()]: value },
+            {
+                expiry: "KEEPTTL",
+            },
+        );
+        responseData.push([
+            "hsetex(key4, { [field2]: value }, { expiry: 'KEEPTTL' })",
+            1,
+        ]);
 
         // Test HSETEX with conditional changes
-        baseBatch.hsetex(key4, { [field3.toString()]: value }, {
-            conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
-            expiry: { type: TimeUnit.Seconds, count: 60 },
-        });
-        responseData.push(["hsetex(key4, { [field3]: value }, { conditionalChange: ConditionalChange.ONLY_IF_EXISTS, expiry: { type: TimeUnit.Seconds, count: 60 } })", 1]);
+        baseBatch.hsetex(
+            key4,
+            { [field3.toString()]: value },
+            {
+                conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
+                expiry: { type: TimeUnit.Seconds, count: 60 },
+            },
+        );
+        responseData.push([
+            "hsetex(key4, { [field3]: value }, { conditionalChange: ConditionalChange.ONLY_IF_EXISTS, expiry: { type: TimeUnit.Seconds, count: 60 } })",
+            1,
+        ]);
 
         // Test HSETEX with field conditional changes
-        baseBatch.hsetex(key4, { [field4.toString()]: value }, {
-            fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
-            expiry: { type: TimeUnit.Seconds, count: 60 },
-        });
-        responseData.push(["hsetex(key4, { [field4]: value }, { fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST, expiry: { type: TimeUnit.Seconds, count: 60 } })", 1]);
+        baseBatch.hsetex(
+            key4,
+            { [field4.toString()]: value },
+            {
+                fieldConditionalChange:
+                    HashFieldConditionalChange.ONLY_IF_NONE_EXIST,
+                expiry: { type: TimeUnit.Seconds, count: 60 },
+            },
+        );
+        responseData.push([
+            "hsetex(key4, { [field4]: value }, { fieldConditionalChange: HashFieldConditionalChange.ONLY_IF_NONE_EXIST, expiry: { type: TimeUnit.Seconds, count: 60 } })",
+            1,
+        ]);
 
         // HGETEX tests - only run if server version is 9.0.0 or higher
         // Test basic HGETEX with expiry
         baseBatch.hgetex(key4, [field.toString(), field2.toString()], {
             expiry: { type: TimeUnit.Seconds, count: 60 },
         });
-        responseData.push(["hgetex(key4, [field, field2], { expiry: { type: TimeUnit.Seconds, count: 60 } })", [value, value]]);
+        responseData.push([
+            "hgetex(key4, [field, field2], { expiry: { type: TimeUnit.Seconds, count: 60 } })",
+            [value, value],
+        ]);
 
         // Test HGETEX with PERSIST
         baseBatch.hgetex(key4, [field.toString()], {
             expiry: "PERSIST",
         });
-        responseData.push(["hgetex(key4, [field], { expiry: 'PERSIST' })", [value]]);
+        responseData.push([
+            "hgetex(key4, [field], { expiry: 'PERSIST' })",
+            [value],
+        ]);
 
         // Test HGETEX with KEEPTTL
         baseBatch.hgetex(key4, [field2.toString()], {
             expiry: "KEEPTTL",
         });
-        responseData.push(["hgetex(key4, [field2], { expiry: 'KEEPTTL' })", [value]]);
+        responseData.push([
+            "hgetex(key4, [field2], { expiry: 'KEEPTTL' })",
+            [value],
+        ]);
 
         // Test HTTL
-        baseBatch.httl(key4, [field.toString(), field2.toString(), field3.toString()]);
+        baseBatch.httl(key4, [
+            field.toString(),
+            field2.toString(),
+            field3.toString(),
+        ]);
         // Note: TTL values are dynamic, so we'll validate the structure rather than exact values
         responseData.push(["httl(key4, [field, field2, field3])", "TTL_ARRAY"]);
     }
@@ -1759,18 +1802,18 @@ export async function batchTest(
             'xautoclaim(key9, groupName1, consumer, 0, "0-0", { count: 1 })',
             !cluster.checkIfServerVersionLessThan("7.0.0")
                 ? [
-                    "0-0",
-                    convertRecordToGlideRecord({
-                        "0-2": [[field.toString(), value2.toString()]],
-                    }),
-                    [],
-                ]
+                      "0-0",
+                      convertRecordToGlideRecord({
+                          "0-2": [[field.toString(), value2.toString()]],
+                      }),
+                      [],
+                  ]
                 : [
-                    "0-0",
-                    convertRecordToGlideRecord({
-                        "0-2": [[field.toString(), value2.toString()]],
-                    }),
-                ],
+                      "0-0",
+                      convertRecordToGlideRecord({
+                          "0-2": [[field.toString(), value2.toString()]],
+                      }),
+                  ],
         ]);
         baseBatch.xautoclaimJustId(key9, groupName1, consumer, 0, "0-0");
         responseData.push([

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -625,7 +625,7 @@ export function checkFunctionListResponse(
             typeof libName === "string"
                 ? libName === lib["library_name"]
                 : (libName as Buffer).compare(lib["library_name"] as Buffer) ==
-                  0;
+                0;
 
         if (hasLib) {
             const functions = lib["functions"];
@@ -678,7 +678,7 @@ export function checkFunctionStatsResponse(
     if (response.running_script !== null && runningFunction.length == 0) {
         fail(
             "Unexpected running function info: " +
-                (response.running_script.command as string[]).join(" "),
+            (response.running_script.command as string[]).join(" "),
         );
     }
 
@@ -793,10 +793,10 @@ export function validateBatchResponse(
             const actual =
                 response?.[i] instanceof Map
                     ? JSON.stringify(
-                          Array.from(
-                              (response?.[i] as ReturnTypeMap)?.entries(),
-                          ),
-                      )
+                        Array.from(
+                            (response?.[i] as ReturnTypeMap)?.entries(),
+                        ),
+                    )
                     : JSON.stringify(response?.[i]);
             failedChecks.push(
                 `${testName} failed, expected <${expected}>, actual <${actual}>`,
@@ -971,33 +971,33 @@ export async function batchTest(
         palermo,
         catania,
     ] = [
-        decodeString(fieldStr, decoder),
-        decodeString(fieldStr + 1, decoder),
-        decodeString(fieldStr + 2, decoder),
-        decodeString(fieldStr + 3, decoder),
-        decodeString(fieldStr + 4, decoder),
-        decodeString("value1", decoder),
-        decodeString("value2", decoder),
-        decodeString("value3", decoder),
-        decodeString("foo", decoder),
-        decodeString("bar", decoder),
-        decodeString("baz", decoder),
-        decodeString("test_message", decoder),
-        decodeString("one", decoder),
-        decodeString("two", decoder),
-        decodeString("three", decoder),
-        decodeString("_", decoder),
-        decodeString("non_existing_member", decoder),
-        decodeString("member1", decoder),
-        decodeString("member2", decoder),
-        decodeString("member3", decoder),
-        decodeString("member4", decoder),
-        decodeString("member5", decoder),
-        decodeString("member6", decoder),
-        decodeString("member7", decoder),
-        decodeString("Palermo", decoder),
-        decodeString("Catania", decoder),
-    ];
+            decodeString(fieldStr, decoder),
+            decodeString(fieldStr + 1, decoder),
+            decodeString(fieldStr + 2, decoder),
+            decodeString(fieldStr + 3, decoder),
+            decodeString(fieldStr + 4, decoder),
+            decodeString("value1", decoder),
+            decodeString("value2", decoder),
+            decodeString("value3", decoder),
+            decodeString("foo", decoder),
+            decodeString("bar", decoder),
+            decodeString("baz", decoder),
+            decodeString("test_message", decoder),
+            decodeString("one", decoder),
+            decodeString("two", decoder),
+            decodeString("three", decoder),
+            decodeString("_", decoder),
+            decodeString("non_existing_member", decoder),
+            decodeString("member1", decoder),
+            decodeString("member2", decoder),
+            decodeString("member3", decoder),
+            decodeString("member4", decoder),
+            decodeString("member5", decoder),
+            decodeString("member6", decoder),
+            decodeString("member7", decoder),
+            decodeString("Palermo", decoder),
+            decodeString("Catania", decoder),
+        ];
 
     // array of tuples - first element is test name/description, second - expected return value
     const responseData: [string, GlideReturnType][] = [];
@@ -1212,7 +1212,7 @@ export async function batchTest(
         });
         responseData.push([
             "hgetex(key4, [field, field2], { expiry: { type: TimeUnit.Seconds, count: 60 } })",
-            [value, value],
+            [value.toString(), value.toString()],
         ]);
 
         // Test HGETEX with PERSIST
@@ -1221,16 +1221,7 @@ export async function batchTest(
         });
         responseData.push([
             "hgetex(key4, [field], { expiry: 'PERSIST' })",
-            [value],
-        ]);
-
-        // Test HGETEX with KEEPTTL
-        baseBatch.hgetex(key4, [field2.toString()], {
-            expiry: "KEEPTTL",
-        });
-        responseData.push([
-            "hgetex(key4, [field2], { expiry: 'KEEPTTL' })",
-            [value],
+            [value.toString()],
         ]);
 
         // Test HTTL
@@ -1240,7 +1231,7 @@ export async function batchTest(
             field3.toString(),
         ]);
         // Note: TTL values are dynamic, so we'll validate the structure rather than exact values
-        responseData.push(["httl(key4, [field, field2, field3])", "TTL_ARRAY"]);
+        responseData.push(["httl(key4, [field, field2, field3])", [-1, 60, 60]]);
     }
 
     baseBatch.lpush(key5, [field1, field2, field3, field4]);
@@ -1800,18 +1791,18 @@ export async function batchTest(
             'xautoclaim(key9, groupName1, consumer, 0, "0-0", { count: 1 })',
             !cluster.checkIfServerVersionLessThan("7.0.0")
                 ? [
-                      "0-0",
-                      convertRecordToGlideRecord({
-                          "0-2": [[field.toString(), value2.toString()]],
-                      }),
-                      [],
-                  ]
+                    "0-0",
+                    convertRecordToGlideRecord({
+                        "0-2": [[field.toString(), value2.toString()]],
+                    }),
+                    [],
+                ]
                 : [
-                      "0-0",
-                      convertRecordToGlideRecord({
-                          "0-2": [[field.toString(), value2.toString()]],
-                      }),
-                  ],
+                    "0-0",
+                    convertRecordToGlideRecord({
+                        "0-2": [[field.toString(), value2.toString()]],
+                    }),
+                ],
         ]);
         baseBatch.xautoclaimJustId(key9, groupName1, consumer, 0, "0-0");
         responseData.push([

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -18,7 +18,6 @@ import {
     BitmapIndexType,
     BitwiseOperation,
     ClusterBatch,
-    ConditionalChange,
     Decoder,
     FlushMode,
     FunctionListResponse,
@@ -1178,17 +1177,16 @@ export async function batchTest(
             1,
         ]);
 
-        // Test HSETEX with conditional changes
+        // Test HSETEX with basic expiry
         baseBatch.hsetex(
             key4,
             { [field3.toString()]: value },
             {
-                conditionalChange: ConditionalChange.ONLY_IF_EXISTS,
                 expiry: { type: TimeUnit.Seconds, count: 60 },
             },
         );
         responseData.push([
-            "hsetex(key4, { [field3]: value }, { conditionalChange: ConditionalChange.ONLY_IF_EXISTS, expiry: { type: TimeUnit.Seconds, count: 60 } })",
+            "hsetex(key4, { [field3]: value }, { expiry: { type: TimeUnit.Seconds, count: 60 } })",
             1,
         ]);
 

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -625,7 +625,7 @@ export function checkFunctionListResponse(
             typeof libName === "string"
                 ? libName === lib["library_name"]
                 : (libName as Buffer).compare(lib["library_name"] as Buffer) ==
-                0;
+                  0;
 
         if (hasLib) {
             const functions = lib["functions"];
@@ -678,7 +678,7 @@ export function checkFunctionStatsResponse(
     if (response.running_script !== null && runningFunction.length == 0) {
         fail(
             "Unexpected running function info: " +
-            (response.running_script.command as string[]).join(" "),
+                (response.running_script.command as string[]).join(" "),
         );
     }
 
@@ -793,10 +793,10 @@ export function validateBatchResponse(
             const actual =
                 response?.[i] instanceof Map
                     ? JSON.stringify(
-                        Array.from(
-                            (response?.[i] as ReturnTypeMap)?.entries(),
-                        ),
-                    )
+                          Array.from(
+                              (response?.[i] as ReturnTypeMap)?.entries(),
+                          ),
+                      )
                     : JSON.stringify(response?.[i]);
             failedChecks.push(
                 `${testName} failed, expected <${expected}>, actual <${actual}>`,
@@ -971,33 +971,33 @@ export async function batchTest(
         palermo,
         catania,
     ] = [
-            decodeString(fieldStr, decoder),
-            decodeString(fieldStr + 1, decoder),
-            decodeString(fieldStr + 2, decoder),
-            decodeString(fieldStr + 3, decoder),
-            decodeString(fieldStr + 4, decoder),
-            decodeString("value1", decoder),
-            decodeString("value2", decoder),
-            decodeString("value3", decoder),
-            decodeString("foo", decoder),
-            decodeString("bar", decoder),
-            decodeString("baz", decoder),
-            decodeString("test_message", decoder),
-            decodeString("one", decoder),
-            decodeString("two", decoder),
-            decodeString("three", decoder),
-            decodeString("_", decoder),
-            decodeString("non_existing_member", decoder),
-            decodeString("member1", decoder),
-            decodeString("member2", decoder),
-            decodeString("member3", decoder),
-            decodeString("member4", decoder),
-            decodeString("member5", decoder),
-            decodeString("member6", decoder),
-            decodeString("member7", decoder),
-            decodeString("Palermo", decoder),
-            decodeString("Catania", decoder),
-        ];
+        decodeString(fieldStr, decoder),
+        decodeString(fieldStr + 1, decoder),
+        decodeString(fieldStr + 2, decoder),
+        decodeString(fieldStr + 3, decoder),
+        decodeString(fieldStr + 4, decoder),
+        decodeString("value1", decoder),
+        decodeString("value2", decoder),
+        decodeString("value3", decoder),
+        decodeString("foo", decoder),
+        decodeString("bar", decoder),
+        decodeString("baz", decoder),
+        decodeString("test_message", decoder),
+        decodeString("one", decoder),
+        decodeString("two", decoder),
+        decodeString("three", decoder),
+        decodeString("_", decoder),
+        decodeString("non_existing_member", decoder),
+        decodeString("member1", decoder),
+        decodeString("member2", decoder),
+        decodeString("member3", decoder),
+        decodeString("member4", decoder),
+        decodeString("member5", decoder),
+        decodeString("member6", decoder),
+        decodeString("member7", decoder),
+        decodeString("Palermo", decoder),
+        decodeString("Catania", decoder),
+    ];
 
     // array of tuples - first element is test name/description, second - expected return value
     const responseData: [string, GlideReturnType][] = [];
@@ -1231,7 +1231,10 @@ export async function batchTest(
             field3.toString(),
         ]);
         // Note: TTL values are dynamic, so we'll validate the structure rather than exact values
-        responseData.push(["httl(key4, [field, field2, field3])", [-1, 60, 60]]);
+        responseData.push([
+            "httl(key4, [field, field2, field3])",
+            [-1, 60, 60],
+        ]);
     }
 
     baseBatch.lpush(key5, [field1, field2, field3, field4]);
@@ -1791,18 +1794,18 @@ export async function batchTest(
             'xautoclaim(key9, groupName1, consumer, 0, "0-0", { count: 1 })',
             !cluster.checkIfServerVersionLessThan("7.0.0")
                 ? [
-                    "0-0",
-                    convertRecordToGlideRecord({
-                        "0-2": [[field.toString(), value2.toString()]],
-                    }),
-                    [],
-                ]
+                      "0-0",
+                      convertRecordToGlideRecord({
+                          "0-2": [[field.toString(), value2.toString()]],
+                      }),
+                      [],
+                  ]
                 : [
-                    "0-0",
-                    convertRecordToGlideRecord({
-                        "0-2": [[field.toString(), value2.toString()]],
-                    }),
-                ],
+                      "0-0",
+                      convertRecordToGlideRecord({
+                          "0-2": [[field.toString(), value2.toString()]],
+                      }),
+                  ],
         ]);
         baseBatch.xautoclaimJustId(key9, groupName1, consumer, 0, "0-0");
         responseData.push([


### PR DESCRIPTION
## Add Hash Field Expiration Commands Support

### Overview

This PR implements comprehensive support for Valkey's new hash field expiration commands, enabling field-level TTL management within hash data structures. This feature allows individual fields in a hash to expire independently, providing fine-grained control over data lifecycle management.

### What's New

### Core Infrastructure
- **Protobuf & Rust Core**: Added 11 new RequestType enums (617-627) for all hash field expiration commands
- **Command Mapping**: Updated Rust request_type.rs with proper command string mappings for all new commands

#### Implemented Commands

##### HSETEX
Sets hash fields with optional expiration and conditional logic:
- **Conditional Options**: `FNX` (fields don't exist), `FXX` (all fields exist)
- **Expiry Options**: `EX` (seconds), `PX` (milliseconds), `EXAT` (Unix timestamp seconds), `PXAT` (Unix timestamp milliseconds), `KEEPTTL`
- **Returns**: Number of fields added to the hash

##### HGETEX
Retrieves hash field values and optionally sets their expiration:
- **Expiry Options**: `EX`, `PX`, `EXAT`, `PXAT`, `PERSIST` (remove expiration)
- **Returns**: Array of field values (null for non-existent fields)

##### HEXPIRE / HPEXPIRE
Sets expiration time for hash fields in seconds/milliseconds:
- **Conditional Options**: `NX` (no expiry), `XX` (has expiry), `GT` (greater than current), `LT` (less than current)
- **Returns**: Array indicating success/failure for each field

##### HEXPIREAT / HPEXPIREAT
Sets expiration using absolute Unix timestamps in seconds/milliseconds:
- **Same conditional options** as HEXPIRE/HPEXPIRE
- **Returns**: Array indicating success/failure for each field

##### HPERSIST
Removes expiration from hash fields, making them persistent:
- **Returns**: Array indicating persistence success for each field

##### HTTL / HPTTL
Returns remaining TTL for hash fields in seconds/milliseconds:
- **Returns**: Array of TTL values (-1 for persistent, -2 for non-existent)

##### HEXPIRETIME / HPEXPIRETIME
Returns absolute expiration timestamps in seconds/milliseconds:
- **Returns**: Array of expiration timestamps (-1 for persistent, -2 for non-existent)

## Implementation Details

### Version Compatibility
- **Minimum Version**: Valkey 9.0.0
- **Graceful Degradation**: Version checks prevent execution on unsupported servers
- **Test Coverage**: Comprehensive version-aware testing

### Testing

#### Test Coverage
- **Unit Tests**: Option validation, argument building, type safety
- **Integration Tests**: Real server interaction with version checks
- **Batch Tests**: Pipeline/batch operation validation
- **Error Handling**: Invalid arguments, server errors, version mismatches

---

### Issue link

This Pull Request is linked to issue (URL): #4496 

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
