### PR TITLE
Java: add more output when config_reset_stat failed

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -566,7 +566,12 @@ public class CommandTests {
         firstNodeInfo = getFirstEntryFromMultiValue(data);
         long valueAfter = getValueFromInfo(firstNodeInfo, "total_net_input_bytes");
 
-        assertTrue(valueAfter < valueBefore);
+        assertTrue(
+                valueAfter < valueBefore,
+                () ->
+                        String.format(
+                                "Expected valueAfter (%d) to be less than valueBefore (%d)",
+                                valueAfter, valueBefore));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4574

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.

This PR is an effort to try to get more information on the flakey test config_reset_stat, to at least get the value of both `valueBefore` and `valueAfter`, instead of current useless message of `expected: <true> but was: <false>`
