### PR TITLE
FIX: resolve Valkey 9 compatibility issues across all clients

### DIFF
--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -1,6 +1,11 @@
 [
     {
         "type": "valkey",
+        "version": "9.0.0-rc1",
+        "run": "always"
+    },
+    {
+        "type": "valkey",
         "version": "8.1",
         "run": "always"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Java: Add lazy connection support to Java module ([#4350](https://github.com/valkey-io/valkey-glide/pull/4370))
 * Go: Add lazy connection support ([#4374](https://github.com/valkey-io/valkey-glide/pull/4374))
-$ Java/Go/Node/Python: Valkey 9 lolwut tests and jedi compatibility layer tests fix ([#4632](https://github.com/valkey-io/valkey-glide/pull/4632))
+* Java/Go/Node/Python: Fixed LOLWUT tests and Jedis compatibility layer tests for Valkey 9 ([#4632](https://github.com/valkey-io/valkey-glide/pull/4632))
 * Core/Python: fix 100% CPU when blocking command returning data after client closure ([#4612](https://github.com/valkey-io/valkey-glide/pull/4612))
 
 #### Operational Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Java: Add lazy connection support to Java module ([#4350](https://github.com/valkey-io/valkey-glide/pull/4370))
 * Go: Add lazy connection support ([#4374](https://github.com/valkey-io/valkey-glide/pull/4374))
+$ Java/Go/Node/Python: Valkey 9 lolwut tests and jedi compatibility layer tests fix ([#4632](https://github.com/valkey-io/valkey-glide/pull/4632))
 * Core/Python: fix 100% CPU when blocking command returning data after client closure ([#4612](https://github.com/valkey-io/valkey-glide/pull/4612))
 
 #### Operational Enhancements

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1148,7 +1149,10 @@ func (suite *GlideTestSuite) TestClusterLolwut() {
 	result, err := client.Lolwut(context.Background())
 	suite.NoError(err)
 	suite.NotEmpty(result)
-	suite.Contains(result, "Redis ver.")
+	// Support both Redis and Valkey version formats
+	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+	suite.True(versionPattern.MatchString(result),
+		"Expected output to contain server version information, got: %s", result)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllNodes() {
@@ -1167,7 +1171,10 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllNodes() {
 	multiValue := result.MultiValue()
 
 	for _, value := range multiValue {
-		suite.Contains(value, "Redis ver.")
+		// Support both Redis and Valkey version formats
+		versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+		suite.True(versionPattern.MatchString(value),
+			"Expected output to contain server version information, got: %s", value)
 	}
 }
 
@@ -1186,7 +1193,10 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllPrimaries() {
 	multiValue := result.MultiValue()
 
 	for _, value := range multiValue {
-		assert.Contains(suite.T(), value, "Redis ver.")
+		// Support both Redis and Valkey version formats
+		versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+		assert.True(suite.T(), versionPattern.MatchString(value),
+			"Expected output to contain server version information, got: %s", value)
 	}
 }
 
@@ -1203,7 +1213,10 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithRandomRoute() {
 
 	assert.True(suite.T(), result.IsSingleValue())
 	singleValue := result.SingleValue()
-	assert.Contains(suite.T(), singleValue, "Redis ver.")
+	// Support both Redis and Valkey version formats
+	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+	assert.True(suite.T(), versionPattern.MatchString(singleValue),
+		"Expected output to contain server version information, got: %s", singleValue)
 }
 
 func (suite *GlideTestSuite) TestClientIdCluster() {

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"regexp"
 	"strings"
 	"time"
 
@@ -1149,10 +1148,11 @@ func (suite *GlideTestSuite) TestClusterLolwut() {
 	result, err := client.Lolwut(context.Background())
 	suite.NoError(err)
 	suite.NotEmpty(result)
-	// Support both Redis and Valkey version formats
-	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-	suite.True(versionPattern.MatchString(result),
-		"Expected output to contain server version information, got: %s", result)
+	// Check for version string in LOLWUT output (dual contains approach)
+	hasVer := strings.Contains(result, "ver")
+	hasVersion := strings.Contains(result, suite.serverVersion)
+	suite.True(hasVer && hasVersion,
+		"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, result)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllNodes() {
@@ -1171,10 +1171,11 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllNodes() {
 	multiValue := result.MultiValue()
 
 	for _, value := range multiValue {
-		// Support both Redis and Valkey version formats
-		versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-		suite.True(versionPattern.MatchString(value),
-			"Expected output to contain server version information, got: %s", value)
+		// Check for version string in LOLWUT output (dual contains approach)
+		hasVer := strings.Contains(value, "ver")
+		hasVersion := strings.Contains(value, suite.serverVersion)
+		assert.True(suite.T(), hasVer && hasVersion,
+			"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, value)
 	}
 }
 
@@ -1193,10 +1194,11 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithAllPrimaries() {
 	multiValue := result.MultiValue()
 
 	for _, value := range multiValue {
-		// Support both Redis and Valkey version formats
-		versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-		assert.True(suite.T(), versionPattern.MatchString(value),
-			"Expected output to contain server version information, got: %s", value)
+		// Check for version string in LOLWUT output (dual contains approach)
+		hasVer := strings.Contains(value, "ver")
+		hasVersion := strings.Contains(value, suite.serverVersion)
+		assert.True(suite.T(), hasVer && hasVersion,
+			"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, value)
 	}
 }
 
@@ -1213,10 +1215,11 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithRandomRoute() {
 
 	assert.True(suite.T(), result.IsSingleValue())
 	singleValue := result.SingleValue()
-	// Support both Redis and Valkey version formats
-	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-	assert.True(suite.T(), versionPattern.MatchString(singleValue),
-		"Expected output to contain server version information, got: %s", singleValue)
+	// Check for version string in LOLWUT output (dual contains approach)
+	hasVer := strings.Contains(singleValue, "ver")
+	hasVersion := strings.Contains(singleValue, suite.serverVersion)
+	assert.True(suite.T(), hasVer && hasVersion,
+		"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, singleValue)
 }
 
 func (suite *GlideTestSuite) TestClientIdCluster() {

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -784,10 +783,11 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersion() {
 	options := options.NewLolwutOptions(8)
 	res, err := client.LolwutWithOptions(context.Background(), *options)
 	assert.NoError(suite.T(), err)
-	// Support both Redis and Valkey version formats
-	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-	assert.True(suite.T(), versionPattern.MatchString(res),
-		"Expected output to contain server version information, got: %s", res)
+	// Check for version string in LOLWUT output (dual contains approach)
+	hasVer := strings.Contains(res, "ver")
+	hasVersion := strings.Contains(res, suite.serverVersion)
+	assert.True(suite.T(), hasVer && hasVersion,
+		"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, res)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersionAndArgs() {
@@ -795,10 +795,11 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersionAndArgs() {
 	opts := options.NewLolwutOptions(8).SetArgs([]int{10, 20})
 	res, err := client.LolwutWithOptions(context.Background(), *opts)
 	assert.NoError(suite.T(), err)
-	// Support both Redis and Valkey version formats
-	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-	assert.True(suite.T(), versionPattern.MatchString(res),
-		"Expected output to contain server version information, got: %s", res)
+	// Check for version string in LOLWUT output (dual contains approach)
+	hasVer := strings.Contains(res, "ver")
+	hasVersion := strings.Contains(res, suite.serverVersion)
+	assert.True(suite.T(), hasVer && hasVersion,
+		"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, res)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_EmptyArgs() {
@@ -806,10 +807,11 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_EmptyArgs() {
 	opts := options.NewLolwutOptions(6).SetArgs([]int{})
 	res, err := client.LolwutWithOptions(context.Background(), *opts)
 	assert.NoError(suite.T(), err)
-	// Support both Redis and Valkey version formats
-	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
-	assert.True(suite.T(), versionPattern.MatchString(res),
-		"Expected output to contain server version information, got: %s", res)
+	// Check for version string in LOLWUT output (dual contains approach)
+	hasVer := strings.Contains(res, "ver")
+	hasVersion := strings.Contains(res, suite.serverVersion)
+	assert.True(suite.T(), hasVer && hasVersion,
+		"Expected output to contain 'ver' and version '%s', got: %s", suite.serverVersion, res)
 }
 
 func (suite *GlideTestSuite) TestClientId() {

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -783,7 +784,10 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersion() {
 	options := options.NewLolwutOptions(8)
 	res, err := client.LolwutWithOptions(context.Background(), *options)
 	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), res, "Redis ver.")
+	// Support both Redis and Valkey version formats
+	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+	assert.True(suite.T(), versionPattern.MatchString(res),
+		"Expected output to contain server version information, got: %s", res)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersionAndArgs() {
@@ -791,7 +795,10 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithVersionAndArgs() {
 	opts := options.NewLolwutOptions(8).SetArgs([]int{10, 20})
 	res, err := client.LolwutWithOptions(context.Background(), *opts)
 	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), res, "Redis ver.")
+	// Support both Redis and Valkey version formats
+	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+	assert.True(suite.T(), versionPattern.MatchString(res),
+		"Expected output to contain server version information, got: %s", res)
 }
 
 func (suite *GlideTestSuite) TestLolwutWithOptions_EmptyArgs() {
@@ -799,7 +806,10 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_EmptyArgs() {
 	opts := options.NewLolwutOptions(6).SetArgs([]int{})
 	res, err := client.LolwutWithOptions(context.Background(), *opts)
 	assert.NoError(suite.T(), err)
-	assert.Contains(suite.T(), res, "Redis ver.")
+	// Support both Redis and Valkey version formats
+	versionPattern := regexp.MustCompile(`(Redis|Valkey) ver\.`)
+	assert.True(suite.T(), versionPattern.MatchString(res),
+		"Expected output to contain server version information, got: %s", res)
 }
 
 func (suite *GlideTestSuite) TestClientId() {

--- a/java/client/src/main/java/redis/clients/jedis/Jedis.java
+++ b/java/client/src/main/java/redis/clients/jedis/Jedis.java
@@ -4920,6 +4920,11 @@ public final class Jedis implements Closeable {
                     args.add("HEXPIRE");
                     args.add(key);
                     args.add(String.valueOf(seconds));
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -4946,6 +4951,11 @@ public final class Jedis implements Closeable {
                     args.add(key);
                     args.add(String.valueOf(seconds));
                     args.add(condition.name());
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -4970,6 +4980,11 @@ public final class Jedis implements Closeable {
                     args.add("HPEXPIRE");
                     args.add(key);
                     args.add(String.valueOf(milliseconds));
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -4997,6 +5012,11 @@ public final class Jedis implements Closeable {
                     args.add(key);
                     args.add(String.valueOf(milliseconds));
                     args.add(condition.name());
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5021,6 +5041,11 @@ public final class Jedis implements Closeable {
                     args.add("HEXPIREAT");
                     args.add(key);
                     args.add(String.valueOf(unixTimeSeconds));
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5048,6 +5073,11 @@ public final class Jedis implements Closeable {
                     args.add(key);
                     args.add(String.valueOf(unixTimeSeconds));
                     args.add(condition.name());
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5072,6 +5102,11 @@ public final class Jedis implements Closeable {
                     args.add("HPEXPIREAT");
                     args.add(key);
                     args.add(String.valueOf(unixTimeMillis));
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5099,6 +5134,11 @@ public final class Jedis implements Closeable {
                     args.add(key);
                     args.add(String.valueOf(unixTimeMillis));
                     args.add(condition.name());
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5121,6 +5161,11 @@ public final class Jedis implements Closeable {
                     List<String> args = new ArrayList<>();
                     args.add("HEXPIRETIME");
                     args.add(key);
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5143,6 +5188,11 @@ public final class Jedis implements Closeable {
                     List<String> args = new ArrayList<>();
                     args.add("HPEXPIRETIME");
                     args.add(key);
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5165,6 +5215,11 @@ public final class Jedis implements Closeable {
                     List<String> args = new ArrayList<>();
                     args.add("HTTL");
                     args.add(key);
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5187,6 +5242,11 @@ public final class Jedis implements Closeable {
                     List<String> args = new ArrayList<>();
                     args.add("HPTTL");
                     args.add(key);
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5209,6 +5269,11 @@ public final class Jedis implements Closeable {
                     List<String> args = new ArrayList<>();
                     args.add("HPERSIST");
                     args.add(key);
+
+                    // Add FIELDS keyword and numfields count
+                    args.add(FIELDS_KEYWORD);
+                    args.add(String.valueOf(fields.length));
+
                     args.addAll(Arrays.asList(fields));
 
                     Object result = glideClient.customCommand(args.toArray(new String[0])).get();
@@ -5235,6 +5300,11 @@ public final class Jedis implements Closeable {
             args.add("HEXPIRE");
             args.add(new String(key));
             args.add(String.valueOf(seconds));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5266,6 +5336,11 @@ public final class Jedis implements Closeable {
             args.add(new String(key));
             args.add(String.valueOf(seconds));
             args.add(condition.name());
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5294,6 +5369,11 @@ public final class Jedis implements Closeable {
             args.add("HPEXPIRE");
             args.add(new String(key));
             args.add(String.valueOf(milliseconds));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5326,6 +5406,11 @@ public final class Jedis implements Closeable {
             args.add(new String(key));
             args.add(String.valueOf(milliseconds));
             args.add(condition.name());
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5354,6 +5439,11 @@ public final class Jedis implements Closeable {
             args.add("HEXPIREAT");
             args.add(new String(key));
             args.add(String.valueOf(unixTimeSeconds));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5386,6 +5476,11 @@ public final class Jedis implements Closeable {
             args.add(new String(key));
             args.add(String.valueOf(unixTimeSeconds));
             args.add(condition.name());
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5414,6 +5509,11 @@ public final class Jedis implements Closeable {
             args.add("HPEXPIREAT");
             args.add(new String(key));
             args.add(String.valueOf(unixTimeMillis));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5446,6 +5546,11 @@ public final class Jedis implements Closeable {
             args.add(new String(key));
             args.add(String.valueOf(unixTimeMillis));
             args.add(condition.name());
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5472,6 +5577,11 @@ public final class Jedis implements Closeable {
             List<String> args = new ArrayList<>();
             args.add("HEXPIRETIME");
             args.add(new String(key));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5499,6 +5609,11 @@ public final class Jedis implements Closeable {
             List<String> args = new ArrayList<>();
             args.add("HPEXPIRETIME");
             args.add(new String(key));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5525,6 +5640,11 @@ public final class Jedis implements Closeable {
             List<String> args = new ArrayList<>();
             args.add("HTTL");
             args.add(new String(key));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5551,6 +5671,11 @@ public final class Jedis implements Closeable {
             List<String> args = new ArrayList<>();
             args.add("HPTTL");
             args.add(new String(key));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }
@@ -5577,6 +5702,11 @@ public final class Jedis implements Closeable {
             List<String> args = new ArrayList<>();
             args.add("HPERSIST");
             args.add(new String(key));
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
+
             for (byte[] field : fields) {
                 args.add(new String(field));
             }

--- a/java/client/src/main/java/redis/clients/jedis/Jedis.java
+++ b/java/client/src/main/java/redis/clients/jedis/Jedis.java
@@ -100,6 +100,9 @@ public final class Jedis implements Closeable {
 
     /** Character encoding used for string-to-byte conversions in Valkey operations. */
     private static final Charset VALKEY_CHARSET = StandardCharsets.UTF_8;
+    
+    /** Keyword used in hash field expiration commands to specify the number of fields. */
+    private static final String FIELDS_KEYWORD = "FIELDS";
 
     private volatile GlideClient glideClient; // Changed from final to volatile for lazy init
     private final boolean isPooled;
@@ -4405,6 +4408,10 @@ public final class Jedis implements Closeable {
                 }
             }
 
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add("1"); // Single field
+
             args.add(field);
             args.add(value);
 
@@ -4446,6 +4453,10 @@ public final class Jedis implements Closeable {
                 }
             }
 
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(hash.size()));
+
             // Add field-value pairs
             for (Map.Entry<String, String> entry : hash.entrySet()) {
                 args.add(entry.getKey());
@@ -4484,6 +4495,10 @@ public final class Jedis implements Closeable {
                     args.add(params.getExpirationValue().toString());
                 }
             }
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
 
             // Add fields
             args.addAll(Arrays.asList(fields));
@@ -4569,6 +4584,10 @@ public final class Jedis implements Closeable {
                 }
             }
 
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add("1"); // Single field
+
             args.add(new String(field));
             args.add(new String(value));
 
@@ -4610,6 +4629,10 @@ public final class Jedis implements Closeable {
                 }
             }
 
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(hash.size()));
+
             // Add field-value pairs
             for (Map.Entry<byte[], byte[]> entry : hash.entrySet()) {
                 args.add(new String(entry.getKey()));
@@ -4648,6 +4671,10 @@ public final class Jedis implements Closeable {
                     args.add(params.getExpirationValue().toString());
                 }
             }
+
+            // Add FIELDS keyword and numfields count
+            args.add(FIELDS_KEYWORD);
+            args.add(String.valueOf(fields.length));
 
             // Add fields
             for (byte[] field : fields) {

--- a/java/client/src/main/java/redis/clients/jedis/Jedis.java
+++ b/java/client/src/main/java/redis/clients/jedis/Jedis.java
@@ -100,7 +100,7 @@ public final class Jedis implements Closeable {
 
     /** Character encoding used for string-to-byte conversions in Valkey operations. */
     private static final Charset VALKEY_CHARSET = StandardCharsets.UTF_8;
-    
+
     /** Keyword used in hash field expiration commands to specify the number of fields. */
     private static final String FIELDS_KEYWORD = "FIELDS";
 

--- a/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
@@ -2347,10 +2347,7 @@ public class JedisTest {
     @Order(126)
     @DisplayName("HGETDEL Command")
     void testHGETDEL() {
-        assumeTrue(
-                SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")
-                        && !SERVER_VERSION.toString().startsWith("8."),
-                "HGETDEL command requires Redis 7.9.0+ (not available in Valkey 8.x)");
+        assumeTrue(SERVER_VERSION.isGreaterThan("9.0.0"), "HGETDEL command requires Valkey 9.0.0+");
 
         String key = TEST_KEY_PREFIX + "hash_getdel";
         String field1 = "field1";
@@ -2601,7 +2598,7 @@ public class JedisTest {
         result = jedis.hpersist(key, field1);
         assertEquals(1, result.size(), "HPERSIST should return one result");
         assertEquals(
-                Long.valueOf(0), result.get(0), "HPERSIST should return 0 for field without expiration");
+                Long.valueOf(-1), result.get(0), "HPERSIST should return -1 for field without expiration");
 
         // Test HPERSIST on non-existing field
         result = jedis.hpersist(key, "nonexistent");
@@ -2734,10 +2731,11 @@ public class JedisTest {
     @Order(134)
     @DisplayName("Hash Commands - Binary Variants for Newer Commands")
     void testHashCommandsBinaryNewer() {
+        // Hash field expiration commands (HSETEX, HGETEX) are available in:
+        // - Valkey 9.0.0+ (HSETEX, HGETEX only - HGETDEL not available)
         assumeTrue(
-                SERVER_VERSION.isGreaterThanOrEqualTo("7.9.0")
-                        && !SERVER_VERSION.toString().startsWith("8."),
-                "Newer hash commands require Redis 7.9.0+ (not available in Valkey 8.x)");
+                SERVER_VERSION.isGreaterThan("9.0.0"),
+                "Newer hash commands require Valkey 9.0.0 and HGETDEL requires Valkey greater than 9");
 
         byte[] key = (TEST_KEY_PREFIX + "hash_binary_new").getBytes();
         byte[] field1 = "field1".getBytes();

--- a/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
@@ -2290,7 +2290,8 @@ public class JedisTest {
         // Test HSETEX with FXX condition (field exists)
         params = HSetExParams.hSetExParams().fxx().px(30000); // 30 seconds in milliseconds
         result = jedis.hsetex(key, params, field1, "updated_value");
-        assertEquals(0, result, "HSETEX with FXX should return 0 when updating existing field");
+        assertEquals(1, result, "HSETEX with FXX should return 1 when successfully updating existing field");
+        assertEquals("updated_value", jedis.hget(key, field1), "Field should have updated value");
 
         // Test HSETEX with multiple fields
         Map<String, String> hash = new HashMap<>();

--- a/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
@@ -2290,7 +2290,8 @@ public class JedisTest {
         // Test HSETEX with FXX condition (field exists)
         params = HSetExParams.hSetExParams().fxx().px(30000); // 30 seconds in milliseconds
         result = jedis.hsetex(key, params, field1, "updated_value");
-        assertEquals(1, result, "HSETEX with FXX should return 1 when successfully updating existing field");
+        assertEquals(
+                1, result, "HSETEX with FXX should return 1 when successfully updating existing field");
         assertEquals("updated_value", jedis.hget(key, field1), "Field should have updated value");
 
         // Test HSETEX with multiple fields

--- a/java/integTest/src/test/java/glide/BatchTestUtilities.java
+++ b/java/integTest/src/test/java/glide/BatchTestUtilities.java
@@ -856,7 +856,21 @@ public class BatchTestUtilities {
                     OK, // configSet(Map.of("timeout", "1000"))
                     Map.of("timeout", "1000"), // configGet(new String[] {"timeout"})
                     OK, // configResetStat()
-                    "ver. " + SERVER_VERSION + '\n', // lolwut(1)
+                    new Object() {
+                        @Override
+                        public boolean equals(Object obj) {
+                            if (obj instanceof String) {
+                                String response = (String) obj;
+                                return response.contains("ver") && response.contains(SERVER_VERSION.toString());
+                            }
+                            return false;
+                        }
+
+                        @Override
+                        public String toString() {
+                            return "LOLWUT version matcher for " + SERVER_VERSION;
+                        }
+                    }, // lolwut(1) - accepts both Redis and Valkey formats
                     OK, // flushall()
                     OK, // flushall(ASYNC)
                     OK, // flushdb()

--- a/java/integTest/src/test/java/glide/BatchTestUtilities.java
+++ b/java/integTest/src/test/java/glide/BatchTestUtilities.java
@@ -856,21 +856,7 @@ public class BatchTestUtilities {
                     OK, // configSet(Map.of("timeout", "1000"))
                     Map.of("timeout", "1000"), // configGet(new String[] {"timeout"})
                     OK, // configResetStat()
-                    new Object() {
-                        @Override
-                        public boolean equals(Object obj) {
-                            if (obj instanceof String) {
-                                String response = (String) obj;
-                                return response.contains("ver") && response.contains(SERVER_VERSION.toString());
-                            }
-                            return false;
-                        }
-
-                        @Override
-                        public String toString() {
-                            return "LOLWUT version matcher for " + SERVER_VERSION;
-                        }
-                    }, // lolwut(1) - accepts both Redis and Valkey formats
+                    "ver. " + SERVER_VERSION + '\n', // lolwut(1)
                     OK, // flushall()
                     OK, // flushall(ASYNC)
                     OK, // flushdb()

--- a/java/integTest/src/test/java/glide/BatchTestUtilities.java
+++ b/java/integTest/src/test/java/glide/BatchTestUtilities.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 
@@ -856,7 +857,7 @@ public class BatchTestUtilities {
                     OK, // configSet(Map.of("timeout", "1000"))
                     Map.of("timeout", "1000"), // configGet(new String[] {"timeout"})
                     OK, // configResetStat()
-                    "Redis ver. " + SERVER_VERSION + '\n', // lolwut(1)
+                    new VersionPatternMatcher(), // lolwut(1) - accepts both Redis and Valkey formats
                     OK, // flushall()
                     OK, // flushall(ASYNC)
                     OK, // flushdb()
@@ -1394,5 +1395,33 @@ public class BatchTestUtilities {
         return new Object[] {
             0L, // publish("message", "Tchannel")
         };
+    }
+}
+
+/** Custom matcher for LOLWUT version output that accepts both Redis and Valkey formats */
+class VersionPatternMatcher {
+    private final Pattern versionPattern;
+
+    public VersionPatternMatcher() {
+        // Pattern to match both "Redis ver." and "Valkey ver." formats
+        this.versionPattern = Pattern.compile("(Redis|Valkey) ver\\.");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof String) {
+            return versionPattern.matcher((String) obj).find();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return versionPattern.pattern().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "VersionPatternMatcher{pattern=" + versionPattern.pattern() + "}";
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -9756,7 +9756,11 @@ public class SharedCommandTests {
     public void objectEncoding_returns_string_embstr(BaseClient client) {
         String stringEmbstrKey = UUID.randomUUID().toString();
         assertEquals(OK, client.set(stringEmbstrKey, "value").get());
-        assertEquals("embstr", client.objectEncoding(stringEmbstrKey).get());
+        String encoding = client.objectEncoding(stringEmbstrKey).get();
+        // Valkey 9.0.0+ may return "raw" instead of "embstr" for short strings with long key names
+        assertTrue(
+                encoding.equals("embstr") || encoding.equals("raw"),
+                "Expected 'embstr' or 'raw' but got: " + encoding);
     }
 
     @SneakyThrows
@@ -9765,7 +9769,11 @@ public class SharedCommandTests {
     public void objectEncoding_binary_returns_string_embstr(BaseClient client) {
         GlideString stringEmbstrKey = gs(UUID.randomUUID().toString());
         assertEquals(OK, client.set(stringEmbstrKey, gs("value")).get());
-        assertEquals("embstr", client.objectEncoding(stringEmbstrKey).get());
+        String encoding = client.objectEncoding(stringEmbstrKey).get();
+        // Valkey 9.0.0+ may return "raw" instead of "embstr" for short strings with long key names
+        assertTrue(
+                encoding.equals("embstr") || encoding.equals("raw"),
+                "Expected 'embstr' or 'raw' but got: " + encoding);
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -98,6 +98,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
@@ -828,38 +829,57 @@ public class CommandTests {
     @MethodSource("getClients")
     @SneakyThrows
     public void lolwut_lolwut(GlideClusterClient clusterClient) {
+        // Pattern to match both "Redis ver." and "Valkey ver." formats
+        Pattern versionPattern = Pattern.compile("(Redis|Valkey) ver\\.");
+
         var response = clusterClient.lolwut().get();
         System.out.printf("%nLOLWUT cluster client standard response%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         response = clusterClient.lolwut(new int[] {50, 20}).get();
         System.out.printf(
                 "%nLOLWUT cluster client standard response with params 50 20%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         response = clusterClient.lolwut(6).get();
         System.out.printf("%nLOLWUT cluster client ver 6 response%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         response = clusterClient.lolwut(5, new int[] {30, 4, 4}).get();
         System.out.printf("%nLOLWUT cluster client ver 5 response with params 30 4 4%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         var clusterResponse = clusterClient.lolwut(ALL_NODES).get();
         for (var nodeResponse : clusterResponse.getMultiValue().values()) {
-            assertTrue(nodeResponse.contains("Redis ver. " + SERVER_VERSION));
+            assertTrue(
+                    versionPattern.matcher(nodeResponse).find(),
+                    "Expected LOLWUT output to contain server version information");
         }
 
         clusterResponse = clusterClient.lolwut(new int[] {10, 20}, ALL_NODES).get();
         for (var nodeResponse : clusterResponse.getMultiValue().values()) {
-            assertTrue(nodeResponse.contains("Redis ver. " + SERVER_VERSION));
+            assertTrue(
+                    versionPattern.matcher(nodeResponse).find(),
+                    "Expected LOLWUT output to contain server version information");
         }
 
         clusterResponse = clusterClient.lolwut(2, RANDOM).get();
-        assertTrue(clusterResponse.getSingleValue().contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(clusterResponse.getSingleValue()).find(),
+                "Expected LOLWUT output to contain server version information");
 
         clusterResponse = clusterClient.lolwut(2, new int[] {10, 20}, RANDOM).get();
-        assertTrue(clusterResponse.getSingleValue().contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(clusterResponse.getSingleValue()).find(),
+                "Expected LOLWUT output to contain server version information");
     }
 
     @ParameterizedTest

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -98,7 +98,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
@@ -829,57 +828,56 @@ public class CommandTests {
     @MethodSource("getClients")
     @SneakyThrows
     public void lolwut_lolwut(GlideClusterClient clusterClient) {
-        // Pattern to match both "Redis ver." and "Valkey ver." formats
-        Pattern versionPattern = Pattern.compile("(Redis|Valkey) ver\\.");
-
         var response = clusterClient.lolwut().get();
         System.out.printf("%nLOLWUT cluster client standard response%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         response = clusterClient.lolwut(new int[] {50, 20}).get();
         System.out.printf(
                 "%nLOLWUT cluster client standard response with params 50 20%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         response = clusterClient.lolwut(6).get();
         System.out.printf("%nLOLWUT cluster client ver 6 response%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         response = clusterClient.lolwut(5, new int[] {30, 4, 4}).get();
         System.out.printf("%nLOLWUT cluster client ver 5 response with params 30 4 4%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         var clusterResponse = clusterClient.lolwut(ALL_NODES).get();
         for (var nodeResponse : clusterResponse.getMultiValue().values()) {
             assertTrue(
-                    versionPattern.matcher(nodeResponse).find(),
-                    "Expected LOLWUT output to contain server version information");
+                    nodeResponse.contains("ver") && nodeResponse.contains(SERVER_VERSION.toString()),
+                    "Expected LOLWUT output to contain version string");
         }
 
         clusterResponse = clusterClient.lolwut(new int[] {10, 20}, ALL_NODES).get();
         for (var nodeResponse : clusterResponse.getMultiValue().values()) {
             assertTrue(
-                    versionPattern.matcher(nodeResponse).find(),
-                    "Expected LOLWUT output to contain server version information");
+                    nodeResponse.contains("ver") && nodeResponse.contains(SERVER_VERSION.toString()),
+                    "Expected LOLWUT output to contain version string");
         }
 
         clusterResponse = clusterClient.lolwut(2, RANDOM).get();
         assertTrue(
-                versionPattern.matcher(clusterResponse.getSingleValue()).find(),
-                "Expected LOLWUT output to contain server version information");
+                clusterResponse.getSingleValue().contains("ver")
+                        && clusterResponse.getSingleValue().contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         clusterResponse = clusterClient.lolwut(2, new int[] {10, 20}, RANDOM).get();
         assertTrue(
-                versionPattern.matcher(clusterResponse.getSingleValue()).find(),
-                "Expected LOLWUT output to contain server version information");
+                clusterResponse.getSingleValue().contains("ver")
+                        && clusterResponse.getSingleValue().contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
     }
 
     @ParameterizedTest

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -67,6 +67,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.ArrayUtils;
@@ -440,23 +441,34 @@ public class CommandTests {
     @MethodSource("getClients")
     @SneakyThrows
     public void lolwut_lolwut(GlideClient regularClient) {
+        // Pattern to match both "Redis ver." and "Valkey ver." formats
+        Pattern versionPattern = Pattern.compile("(Redis|Valkey) ver\\.");
+
         var response = regularClient.lolwut().get();
         System.out.printf("%nLOLWUT standalone client standard response%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         response = regularClient.lolwut(new int[] {30, 4, 4}).get();
         System.out.printf(
                 "%nLOLWUT standalone client standard response with params 30 4 4%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         response = regularClient.lolwut(5).get();
         System.out.printf("%nLOLWUT standalone client ver 5 response%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
 
         response = regularClient.lolwut(6, new int[] {50, 20}).get();
         System.out.printf(
                 "%nLOLWUT standalone client ver 6 response with params 50 20%n%s%n", response);
-        assertTrue(response.contains("Redis ver. " + SERVER_VERSION));
+        assertTrue(
+                versionPattern.matcher(response).find(),
+                "Expected LOLWUT output to contain server version information");
     }
 
     @ParameterizedTest

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -67,7 +67,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.ArrayUtils;
@@ -441,34 +440,31 @@ public class CommandTests {
     @MethodSource("getClients")
     @SneakyThrows
     public void lolwut_lolwut(GlideClient regularClient) {
-        // Pattern to match both "Redis ver." and "Valkey ver." formats
-        Pattern versionPattern = Pattern.compile("(Redis|Valkey) ver\\.");
-
         var response = regularClient.lolwut().get();
         System.out.printf("%nLOLWUT standalone client standard response%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         response = regularClient.lolwut(new int[] {30, 4, 4}).get();
         System.out.printf(
                 "%nLOLWUT standalone client standard response with params 30 4 4%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         response = regularClient.lolwut(5).get();
         System.out.printf("%nLOLWUT standalone client ver 5 response%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
 
         response = regularClient.lolwut(6, new int[] {50, 20}).get();
         System.out.printf(
                 "%nLOLWUT standalone client ver 6 response with params 50 20%n%s%n", response);
         assertTrue(
-                versionPattern.matcher(response).find(),
-                "Expected LOLWUT output to contain server version information");
+                response.contains("ver") && response.contains(SERVER_VERSION.toString()),
+                "Expected LOLWUT output to contain version string");
     }
 
     @ParameterizedTest

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -582,23 +582,36 @@ describe("GlideClient", () => {
                 getClientConfigurationOption(cluster.getAddresses(), protocol),
             );
 
+            // Check for version string in LOLWUT output (dual string contains approach)
+            const serverVersion = cluster.getVersion().trim();
+
             const result = await client.lolwut();
-            expect(result).toMatch(/(Redis|Valkey) ver\./);
+            expect(
+                result.includes("ver") && result.includes(serverVersion),
+            ).toBe(true);
 
             const result2 = await client.lolwut({ parameters: [] });
-            expect(result2).toMatch(/(Redis|Valkey) ver\./);
+            expect(
+                result2.includes("ver") && result2.includes(serverVersion),
+            ).toBe(true);
 
             const result3 = await client.lolwut({ parameters: [50, 20] });
-            expect(result3).toMatch(/(Redis|Valkey) ver\./);
+            expect(
+                result3.includes("ver") && result3.includes(serverVersion),
+            ).toBe(true);
 
             const result4 = await client.lolwut({ version: 6 });
-            expect(result4).toMatch(/(Redis|Valkey) ver\./);
+            expect(
+                result4.includes("ver") && result4.includes(serverVersion),
+            ).toBe(true);
 
             const result5 = await client.lolwut({
                 version: 5,
                 parameters: [30, 4, 4],
             });
-            expect(result5).toMatch(/(Redis|Valkey) ver\./);
+            expect(
+                result5.includes("ver") && result5.includes(serverVersion),
+            ).toBe(true);
 
             // batch tests
             for (const isAtomic of [true, false]) {
@@ -611,7 +624,11 @@ describe("GlideClient", () => {
 
                 if (results) {
                     for (const element of results) {
-                        expect(element).toMatch(/(Redis|Valkey) ver\./);
+                        const elementStr = element?.toString() || "";
+                        expect(
+                            elementStr.includes("ver") &&
+                                elementStr.includes(serverVersion),
+                        ).toBe(true);
                     }
                 } else {
                     throw new Error("Invalid LOLWUT batch test results.");

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -583,22 +583,22 @@ describe("GlideClient", () => {
             );
 
             const result = await client.lolwut();
-            expect(result).toEqual(expect.stringContaining("Redis ver. "));
+            expect(result).toMatch(/(Redis|Valkey) ver\./);
 
             const result2 = await client.lolwut({ parameters: [] });
-            expect(result2).toEqual(expect.stringContaining("Redis ver. "));
+            expect(result2).toMatch(/(Redis|Valkey) ver\./);
 
             const result3 = await client.lolwut({ parameters: [50, 20] });
-            expect(result3).toEqual(expect.stringContaining("Redis ver. "));
+            expect(result3).toMatch(/(Redis|Valkey) ver\./);
 
             const result4 = await client.lolwut({ version: 6 });
-            expect(result4).toEqual(expect.stringContaining("Redis ver. "));
+            expect(result4).toMatch(/(Redis|Valkey) ver\./);
 
             const result5 = await client.lolwut({
                 version: 5,
                 parameters: [30, 4, 4],
             });
-            expect(result5).toEqual(expect.stringContaining("Redis ver. "));
+            expect(result5).toMatch(/(Redis|Valkey) ver\./);
 
             // batch tests
             for (const isAtomic of [true, false]) {
@@ -611,9 +611,7 @@ describe("GlideClient", () => {
 
                 if (results) {
                     for (const element of results) {
-                        expect(element).toEqual(
-                            expect.stringContaining("Redis ver. "),
-                        );
+                        expect(element).toMatch(/(Redis|Valkey) ver\./);
                     }
                 } else {
                     throw new Error("Invalid LOLWUT batch test results.");

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -751,33 +751,25 @@ describe("GlideClusterClient", () => {
 
             // test with multi-node route
             const result1 = await client.lolwut({ route: "allNodes" });
-            expect(intoString(result1)).toEqual(
-                expect.stringContaining("Redis ver. "),
-            );
+            expect(intoString(result1)).toMatch(/(Redis|Valkey) ver\./);
 
             const result2 = await client.lolwut({
                 version: 2,
                 parameters: [10, 20],
                 route: "allNodes",
             });
-            expect(intoString(result2)).toEqual(
-                expect.stringContaining("Redis ver. "),
-            );
+            expect(intoString(result2)).toMatch(/(Redis|Valkey) ver\./);
 
             // test with single-node route
             const result3 = await client.lolwut({ route: "randomNode" });
-            expect(intoString(result3)).toEqual(
-                expect.stringContaining("Redis ver. "),
-            );
+            expect(intoString(result3)).toMatch(/(Redis|Valkey) ver\./);
 
             const result4 = await client.lolwut({
                 version: 2,
                 parameters: [10, 20],
                 route: "randomNode",
             });
-            expect(intoString(result4)).toEqual(
-                expect.stringContaining("Redis ver. "),
-            );
+            expect(intoString(result4)).toMatch(/(Redis|Valkey) ver\./);
 
             // batch tests
             for (const isAtomic of [true, false]) {
@@ -790,8 +782,8 @@ describe("GlideClusterClient", () => {
 
                 if (results) {
                     for (const element of results) {
-                        expect(intoString(element)).toEqual(
-                            expect.stringContaining("Redis ver. "),
+                        expect(intoString(element)).toMatch(
+                            /(Redis|Valkey) ver\./,
                         );
                     }
                 } else {

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -749,27 +749,46 @@ describe("GlideClusterClient", () => {
                 getClientConfigurationOption(cluster.getAddresses(), protocol),
             );
 
+            // Check for version string in LOLWUT output (dual string contains approach)
+            const serverVersion = cluster.getVersion().trim();
+
             // test with multi-node route
             const result1 = await client.lolwut({ route: "allNodes" });
-            expect(intoString(result1)).toMatch(/(Redis|Valkey) ver\./);
+            const result1Str = intoString(result1);
+            expect(
+                result1Str.includes("ver") &&
+                    result1Str.includes(serverVersion),
+            ).toBe(true);
 
             const result2 = await client.lolwut({
                 version: 2,
                 parameters: [10, 20],
                 route: "allNodes",
             });
-            expect(intoString(result2)).toMatch(/(Redis|Valkey) ver\./);
+            const result2Str = intoString(result2);
+            expect(
+                result2Str.includes("ver") &&
+                    result2Str.includes(serverVersion),
+            ).toBe(true);
 
             // test with single-node route
             const result3 = await client.lolwut({ route: "randomNode" });
-            expect(intoString(result3)).toMatch(/(Redis|Valkey) ver\./);
+            const result3Str = intoString(result3);
+            expect(
+                result3Str.includes("ver") &&
+                    result3Str.includes(serverVersion),
+            ).toBe(true);
 
             const result4 = await client.lolwut({
                 version: 2,
                 parameters: [10, 20],
                 route: "randomNode",
             });
-            expect(intoString(result4)).toMatch(/(Redis|Valkey) ver\./);
+            const result4Str = intoString(result4);
+            expect(
+                result4Str.includes("ver") &&
+                    result4Str.includes(serverVersion),
+            ).toBe(true);
 
             // batch tests
             for (const isAtomic of [true, false]) {
@@ -782,9 +801,11 @@ describe("GlideClusterClient", () => {
 
                 if (results) {
                     for (const element of results) {
-                        expect(intoString(element)).toMatch(
-                            /(Redis|Valkey) ver\./,
-                        );
+                        const elementStr = intoString(element);
+                        expect(
+                            elementStr.includes("ver") &&
+                                elementStr.includes(serverVersion),
+                        ).toBe(true);
                     }
                 } else {
                     throw new Error("Invalid LOLWUT batch test results.");

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9173,15 +9173,15 @@ class TestCommands:
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_lolwut(self, glide_client: TGlideClient):
         result = await glide_client.lolwut()
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = await glide_client.lolwut(parameters=[])
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = await glide_client.lolwut(parameters=[50, 20])
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = await glide_client.lolwut(6)
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = await glide_client.lolwut(5, [30, 4, 4])
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
 
         if isinstance(glide_client, GlideClusterClient):
             # test with multi-node route
@@ -9190,23 +9190,23 @@ class TestCommands:
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
+                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
 
             result = await glide_client.lolwut(parameters=[10, 20], route=AllNodes())
             assert isinstance(result, dict)
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
+                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
 
             # test with single-node route
             result = await glide_client.lolwut(2, route=RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ", result)
+            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
 
             result = await glide_client.lolwut(2, [10, 20], RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ", result)
+            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+import re
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Mapping, Optional, Union, cast
@@ -9172,15 +9173,15 @@ class TestCommands:
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_lolwut(self, glide_client: TGlideClient):
         result = await glide_client.lolwut()
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = await glide_client.lolwut(parameters=[])
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = await glide_client.lolwut(parameters=[50, 20])
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = await glide_client.lolwut(6)
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = await glide_client.lolwut(5, [30, 4, 4])
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
 
         if isinstance(glide_client, GlideClusterClient):
             # test with multi-node route
@@ -9189,23 +9190,23 @@ class TestCommands:
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert "Redis ver. " in node_result
+                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
 
             result = await glide_client.lolwut(parameters=[10, 20], route=AllNodes())
             assert isinstance(result, dict)
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert "Redis ver. " in node_result
+                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
 
             # test with single-node route
             result = await glide_client.lolwut(2, route=RandomNode())
             assert isinstance(result, bytes)
-            assert b"Redis ver. " in result
+            assert re.search(rb"(Redis|Valkey) ver\. ", result)
 
             result = await glide_client.lolwut(2, [10, 20], RandomNode())
             assert isinstance(result, bytes)
-            assert b"Redis ver. " in result
+            assert re.search(rb"(Redis|Valkey) ver\. ", result)
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import math
-import re
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Dict, List, Mapping, Optional, Union, cast
@@ -102,6 +101,7 @@ from tests.utils.utils import (
     generate_lua_lib_code,
     get_first_result,
     get_random_string,
+    get_version,
     parse_info_response,
     round_values,
 )
@@ -9172,16 +9172,19 @@ class TestCommands:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_lolwut(self, glide_client: TGlideClient):
+        server_version = await get_version(glide_client)
+        server_version_bytes = server_version.encode()
+
         result = await glide_client.lolwut()
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = await glide_client.lolwut(parameters=[])
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = await glide_client.lolwut(parameters=[50, 20])
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = await glide_client.lolwut(6)
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = await glide_client.lolwut(5, [30, 4, 4])
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
 
         if isinstance(glide_client, GlideClusterClient):
             # test with multi-node route
@@ -9190,23 +9193,23 @@ class TestCommands:
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
+                assert "ver" in node_result and server_version in node_result
 
             result = await glide_client.lolwut(parameters=[10, 20], route=AllNodes())
             assert isinstance(result, dict)
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
+                assert "ver" in node_result and server_version in node_result
 
             # test with single-node route
             result = await glide_client.lolwut(2, route=RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+            assert b"ver" in result and server_version_bytes in result
 
             result = await glide_client.lolwut(2, [10, 20], RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+            assert b"ver" in result and server_version_bytes in result
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1,6 +1,7 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 
+import re
 import time
 from datetime import date, timedelta
 from typing import List, Optional, Union, cast
@@ -431,7 +432,7 @@ class TestBatch:
 
         for element in results:
             assert isinstance(element, bytes)
-            assert b"Redis ver. " in element
+            assert re.search(rb"(Redis|Valkey) ver\. ?", element)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1,6 +1,7 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 
+import re
 import time
 from datetime import date, timedelta
 from typing import List, Optional, Union, cast
@@ -433,7 +434,7 @@ class TestSyncBatch:
 
         for element in results:
             assert isinstance(element, bytes)
-            assert b"Redis ver. " in element
+            assert re.search(rb"(Redis|Valkey) ver\. ?", element)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9147,15 +9147,15 @@ class TestCommands:
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_lolwut(self, glide_sync_client: TGlideClient):
         result = glide_sync_client.lolwut()
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = glide_sync_client.lolwut(parameters=[])
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = glide_sync_client.lolwut(parameters=[50, 20])
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = glide_sync_client.lolwut(6)
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
         result = glide_sync_client.lolwut(5, [30, 4, 4])
-        assert re.search(rb"(Redis|Valkey) ver\. ", result)
+        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
 
         if isinstance(glide_sync_client, GlideClusterClient):
             # test with multi-node route
@@ -9164,23 +9164,23 @@ class TestCommands:
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
+                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
 
             result = glide_sync_client.lolwut(parameters=[10, 20], route=AllNodes())
             assert isinstance(result, dict)
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
+                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
 
             # test with single-node route
             result = glide_sync_client.lolwut(2, route=RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ", result)
+            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
 
             result = glide_sync_client.lolwut(2, [10, 20], RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ", result)
+            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import os
+import re
 import threading
 import time
 from datetime import date, datetime, timedelta, timezone
@@ -9146,15 +9147,15 @@ class TestCommands:
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_lolwut(self, glide_sync_client: TGlideClient):
         result = glide_sync_client.lolwut()
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = glide_sync_client.lolwut(parameters=[])
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = glide_sync_client.lolwut(parameters=[50, 20])
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = glide_sync_client.lolwut(6)
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
         result = glide_sync_client.lolwut(5, [30, 4, 4])
-        assert b"Redis ver. " in result
+        assert re.search(rb"(Redis|Valkey) ver\. ", result)
 
         if isinstance(glide_sync_client, GlideClusterClient):
             # test with multi-node route
@@ -9163,23 +9164,23 @@ class TestCommands:
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert "Redis ver. " in node_result
+                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
 
             result = glide_sync_client.lolwut(parameters=[10, 20], route=AllNodes())
             assert isinstance(result, dict)
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert "Redis ver. " in node_result
+                assert re.search(r"(Redis|Valkey) ver\. ", node_result)
 
             # test with single-node route
             result = glide_sync_client.lolwut(2, route=RandomNode())
             assert isinstance(result, bytes)
-            assert b"Redis ver. " in result
+            assert re.search(rb"(Redis|Valkey) ver\. ", result)
 
             result = glide_sync_client.lolwut(2, [10, 20], RandomNode())
             assert isinstance(result, bytes)
-            assert b"Redis ver. " in result
+            assert re.search(rb"(Redis|Valkey) ver\. ", result)
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import math
 import os
-import re
 import threading
 import time
 from datetime import date, datetime, timedelta, timezone
@@ -107,6 +106,7 @@ from tests.utils.utils import (
     round_values,
     run_sync_func_with_timeout_in_thread,
     sync_check_if_server_version_lt,
+    sync_get_version,
 )
 
 
@@ -9146,16 +9146,19 @@ class TestCommands:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_lolwut(self, glide_sync_client: TGlideClient):
+        server_version = sync_get_version(glide_sync_client)
+        server_version_bytes = server_version.encode()
+
         result = glide_sync_client.lolwut()
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = glide_sync_client.lolwut(parameters=[])
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = glide_sync_client.lolwut(parameters=[50, 20])
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = glide_sync_client.lolwut(6)
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
         result = glide_sync_client.lolwut(5, [30, 4, 4])
-        assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+        assert b"ver" in result and server_version_bytes in result
 
         if isinstance(glide_sync_client, GlideClusterClient):
             # test with multi-node route
@@ -9164,23 +9167,23 @@ class TestCommands:
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
+                assert "ver" in node_result and server_version in node_result
 
             result = glide_sync_client.lolwut(parameters=[10, 20], route=AllNodes())
             assert isinstance(result, dict)
             result_decoded = cast(dict, convert_bytes_to_string_object(result))
             assert result_decoded is not None
             for node_result in result_decoded.values():
-                assert re.search(r"(Redis|Valkey) ver\. ?", node_result)
+                assert "ver" in node_result and server_version in node_result
 
             # test with single-node route
             result = glide_sync_client.lolwut(2, route=RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+            assert b"ver" in result and server_version_bytes in result
 
             result = glide_sync_client.lolwut(2, [10, 20], RandomNode())
             assert isinstance(result, bytes)
-            assert re.search(rb"(Redis|Valkey) ver\. ?", result)
+            assert b"ver" in result and server_version_bytes in result
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])


### PR DESCRIPTION
### Summary

This PR addresses compatibility issues with Valkey 9 by updating test assertions and fixing hash field expiration command implementations across multiple language clients (Go, Java, Node.js, Python).

### Changes Made

#### 1. LOLWUT Command Test Fixes
Updated test assertions across all language clients to support both Redis and Valkey version output formats:

- **Go**: Updated `cluster_commands_test.go` and `standalone_commands_test.go` to use regex pattern matching for version strings
- **Java**: Modified test files in `cluster/CommandTests.java`, `standalone/CommandTests.java`, and `BatchTestUtilities.java` to accept both "Redis ver." and "Valkey ver." formats
- **Node.js**: Updated `GlideClient.test.ts` and `GlideClusterClient.test.ts` to use regex matching instead of string contains
- **Python**: Modified async and sync test files to use regex pattern matching for version detection

#### 2. Hash Field Expiration Command Fixes (Java)
Fixed the Jedis compatibility layer implementation for hash field expiration commands:

- Added proper `FIELDS` keyword and field count parameters to `hsetex`, `hmsetex`, and `hexpire` commands
- Updated both string and byte array variants of these methods
- Fixed test expectations in `JedisTest.java` for proper return values

### Technical Details

#### LOLWUT Version Pattern Matching
- Changed from hardcoded "Redis ver." string matching to regex pattern `(Redis|Valkey) ver\.`
- Ensures compatibility with both Redis and Valkey server outputs
- Maintains backward compatibility while supporting new Valkey format

#### Hash Field Expiration Protocol
- Added missing `FIELDS` keyword before field specifications
- Added proper field count parameter as required by the protocol
- Fixed return value expectations for existing field updates

### Issue link

This Pull Request is linked to issue (URL): #4496 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
