### PR TITLE
Python: increase test workflow timeout

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -113,7 +113,7 @@ jobs:
         name: Python Tests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: get-matrices
-        timeout-minutes: 90
+        timeout-minutes: 120
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

Because python sync tests were added, the slower runners struggle to finish the job in 90 mins.
This is the solution just to get the jobs to stop timing out for now, in the future we can consider separating the python sync and async jobs.

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
