### PR TITLE
Python sync: fix flaky test_sync_script_isnt_removed_while_another_instance_exists

### DIFF
--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -600,7 +600,7 @@ class BaseClient(CoreCommands):
         args_c_args, args_c_lengths, args_buffers = self._to_c_strings(args)
 
         # Convert script hash to C string
-        hash_bytes = script_hash.encode(ENCODING)
+        hash_bytes = script_hash.encode(ENCODING) + b"\0"
         hash_buffer = self._ffi.from_buffer(hash_bytes)
 
         # Route bytes should be kept alive in the scope of the FFI call

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -10561,12 +10561,15 @@ class TestSyncScripts:
         instance with the same hash still exists, even after the original reference is released
         and the server-side script cache is flushed.
         """
-        script_1 = Script("return 'Script Exists'")
-        script_2 = Script("return 'Script Exists'")
+        random_str = get_random_string(10)
+
+        # Create two scripts with the same content
+        script_1 = Script(f"return '{random_str}'")
+        script_2 = Script(f"return '{random_str}'")
         assert script_1.get_hash() == script_2.get_hash()
 
         # Run first script and drop reference
-        assert glide_sync_client.invoke_script(script_1) == b"Script Exists"
+        assert glide_sync_client.invoke_script(script_1) == f"{random_str}".encode()
         script_1.__del__()
 
         # Flush the script from the server
@@ -10576,7 +10579,7 @@ class TestSyncScripts:
         assert glide_sync_client.script_exists([script_1.get_hash()]) == [False]
 
         # Run second script; it should not exist on the server but must be found in the local script cache
-        assert glide_sync_client.invoke_script(script_2) == b"Script Exists"
+        assert glide_sync_client.invoke_script(script_2) == f"{random_str}".encode()
 
         # Release script_2 and flush again
         script_2.__del__()


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR fixes the flaky test - test_sync_script_isnt_removed_while_another_instance_exists 
The issue was probably one of test isolation - because the script local cache is global, it created a situation where python's gc was called on a script from a previous test (that has the same hash as the current test's script), and removed the current script's hash from the local cache prematurely. 

This issue was reproduced locally in this run - https://github.com/liorsve/valkey-glide/actions/runs/17211793410
And then was not observed with the fix in 2 runs - https://github.com/liorsve/valkey-glide/actions/runs/17235924639, https://github.com/liorsve/valkey-glide/actions/runs/17261715315
So hopefully this will solve the issue 

In addition this PR makes sure the hash buffer param that's being sent to the FFI layer's `invoke_script()` function is null terminated - that's a safety instruction for `CStr::from_ptr(hash)` that's later being called.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4650

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
