### PR TITLE
Util: Updated wait time for retries from 0.5s to 1s

### DIFF
--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -714,7 +714,7 @@ def wait_for_all_topology_views(
                 break
             else:
                 retries -= 1
-                time.sleep(0.5)
+                time.sleep(1)
                 continue
 
         if retries < 0:


### PR DESCRIPTION
Fixes a flaky test described in the issue below.
The change is to increase wait time for retries from 0.5s to 1s.

### Issue link

This Pull Request is linked to issue (URL): [#4652](https://github.com/valkey-io/valkey-glide/issues/4652)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
