### PR TITLE
Fix benchmark execution for CSharp

### DIFF
--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -282,7 +282,7 @@ do
     then
         csharpResults=$(resultFileName csharp $currentDataSize)
         resultFiles+=$csharpResults" "
-        echo "csharpResults = $csharpResults"
+        echo "csharpResults = "$csharpResults
         runCSharpBenchmark $csharpResults $currentDataSize
     fi
 

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -69,12 +69,7 @@ function runCSharpBenchmark(){
   cd ${GLIDE_HOME_FOLDER}/../benchmarks
   dotnet clean
   dotnet build --configuration Release /warnaserror
-  echo "Begin Benchmarking"
   dotnet run --framework $dotnetFramework --configuration Release --resultsFile=$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
-
-  ls -la ${BENCH_RESULTS_FOLDER}
-
-  echo "End Benchmarking"
 }
 
 function runJavaBenchmark(){

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -70,7 +70,7 @@ function runCSharpBenchmark(){
   dotnet clean
   dotnet build --configuration Release /warnaserror
   echo "Begin Benchmarking"
-  dotnet run --framework $dotnetFramework --configuration Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
+  dotnet run --framework $dotnetFramework --configuration Release --resultsFile=$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
 
   ls -la ${BENCH_RESULTS_FOLDER}
 

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -66,11 +66,14 @@ function runNodeBenchmark(){
 }
 
 function runCSharpBenchmark(){
-  cd ${CSHARP_BENCH_FOLDER}
+  cd ${GLIDE_HOME_FOLDER}/../benchmarks
   dotnet clean
   dotnet build --configuration Release /warnaserror
   echo "Begin Benchmarking"
   dotnet run --framework $dotnetFramework --configuration Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
+
+  ls -la ${BENCH_RESULTS_FOLDER}
+
   echo "End Benchmarking"
 }
 

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -280,7 +280,6 @@ do
     then
         csharpResults=$(resultFileName csharp $currentDataSize)
         resultFiles+=$csharpResults" "
-        echo "csharpResults = "$csharpResults
         runCSharpBenchmark $csharpResults $currentDataSize
     fi
 

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -69,7 +69,9 @@ function runCSharpBenchmark(){
   cd ${CSHARP_BENCH_FOLDER}
   dotnet clean
   dotnet build --configuration Release /warnaserror
+  echo "Begin Benchmarking"
   dotnet run --framework $dotnetFramework --configuration Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
+  echo "End Benchmarking"
 }
 
 function runJavaBenchmark(){

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -282,6 +282,7 @@ do
     then
         csharpResults=$(resultFileName csharp $currentDataSize)
         resultFiles+=$csharpResults" "
+        echo "csharpResults = $csharpResults"
         runCSharpBenchmark $csharpResults $currentDataSize
     fi
 

--- a/benchmarks/utilities/csv_exporter.py
+++ b/benchmarks/utilities/csv_exporter.py
@@ -37,7 +37,10 @@ with open(output_file_name, "w+") as output_file:
 
     writer.writerow(base_fields)
 
+    print("Current working directory:", os.getcwd())
+
     for json_file_full_path in sys.argv[1:-1]:
+        print("Trying to open:", os.path.abspath(json_file_full_path))
         with open(json_file_full_path) as file:
             json_objects = json.load(file)
 

--- a/benchmarks/utilities/csv_exporter.py
+++ b/benchmarks/utilities/csv_exporter.py
@@ -37,10 +37,7 @@ with open(output_file_name, "w+") as output_file:
 
     writer.writerow(base_fields)
 
-    print("Current working directory:", os.getcwd())
-
     for json_file_full_path in sys.argv[1:-1]:
-        print("Trying to open:", os.path.abspath(json_file_full_path))
         with open(json_file_full_path) as file:
             json_objects = json.load(file)
 


### PR DESCRIPTION
The benchmark tests in Valkey-Glide-CSharp kept breaking due to path differences in how the benchmark results folder location is calculated. See https://github.com/valkey-io/valkey-glide-csharp/pull/43

### Issue link

This Pull Request is linked to issue (#4532 ): 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
