### PR TITLE
Python: replace asyncio.sleep with anyio.sleep in async tests

### DIFF
--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -11238,10 +11238,7 @@ class TestScripts:
         result = await glide_client.hexpire(key, 1, [field1])  # 1 second
         assert result == [1]  # Should set expiration
 
-        # Wait a moment and check if it's still there or expired
-        import asyncio
-
-        await asyncio.sleep(0.1)  # Small delay
+        await anyio.sleep(0.1)  # Small delay
         ttl_result = await glide_client.httl(key, [field1])
         assert (
             ttl_result[0] == 1 or ttl_result[0] == -2
@@ -11411,9 +11408,7 @@ class TestScripts:
         assert result == [1]  # Should set expiration
 
         # Wait a moment and check if it's still there or expired
-        import asyncio
-
-        await asyncio.sleep(0.1)  # Small delay
+        await anyio.sleep(0.1)  # Small delay
         ttl_result = await glide_client.httl(key, [field1])
         assert (
             ttl_result[0] == 1 or ttl_result[0] == -2


### PR DESCRIPTION
Fixes RuntimeError: no running event loop by using anyio.sleep() instead of asyncio.sleep() in test_async_client.py test cases.

### Issue link

This Pull Request is linked to issue (URL): [#4677 ]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
