### PR TITLE
CI: Added self hosted macOS runners

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -22,6 +22,15 @@
     {
         "OS": "macos",
         "NAMED_OS": "darwin",
+        "RUNNER": ["self-hosted", "macOS", "ARM64", "ephemeral"],
+        "ARCH": "arm64",
+        "TARGET": "aarch64-apple-darwin",
+        "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
+        "languages": ["python", "node", "java", "go"]
+    },
+    {
+        "OS": "macos",
+        "NAMED_OS": "darwin",
         "RUNNER": "macos-15",
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -14,8 +14,11 @@ inputs:
         required: true
         type: boolean
     run-with-macos:
-        description: "Run with macos included"
-        type: boolean
+        type: choice
+        options:
+            - false
+            - use-self-hosted
+            - use-github
         default: false
     containers:
         description: "Run in containers"
@@ -83,10 +86,13 @@ runs:
               fi
                         
               # Add macOS runners if specified
-              if [[ "$RUN_WITH_MACOS" == "true" ]]; then
-                echo "Including macOS runners separately"
-                MAC_RUNNERS=$(jq --arg lang "$LANGUAGE_NAME" -c '[.[] | select(.languages? and any(.languages[] == $lang; .) and '"$CONDITION"' and .TARGET == "aarch64-apple-darwin")]' < .github/json_matrices/build-matrix.json)
-                            
+              if [[ "$RUN_WITH_MACOS" == "use-self-hosted" ]]; then
+                echo "Including only self-hosted macOS runners"
+                MAC_RUNNERS=$(jq --arg lang "$LANGUAGE_NAME" -c '[.[] | select(.languages? and any(.languages[] == $lang; .) and '"$CONDITION"' and .TARGET == "aarch64-apple-darwin" and (.RUNNER == ["self-hosted","macOS","ARM64","ephemeral"]))]' < .github/json_matrices/build-matrix.json)
+                FINAL_MATRIX=$(echo "$BASE_MATRIX" "$MAC_RUNNERS" | jq -sc 'add')
+              elif [[ "$RUN_WITH_MACOS" == "use-github" ]]; then
+                echo "Including only GitHub-hosted macOS runners"
+                MAC_RUNNERS=$(jq --arg lang "$LANGUAGE_NAME" -c '[.[] | select(.languages? and any(.languages[] == $lang; .) and '"$CONDITION"' and .TARGET == "aarch64-apple-darwin" and .RUNNER == "macos-15")]' < .github/json_matrices/build-matrix.json)
                 FINAL_MATRIX=$(echo "$BASE_MATRIX" "$MAC_RUNNERS" | jq -sc 'add')
               else
                 FINAL_MATRIX="$BASE_MATRIX"

--- a/.github/workflows/full-matrix-tests.yml
+++ b/.github/workflows/full-matrix-tests.yml
@@ -14,8 +14,12 @@ on:
                 default: true
 
             run-with-macos:
-                description: "Run with macos included (only when necessary)"
-                type: boolean
+                description: "Run with macos inclauded (only when necessary)"
+                type: choice
+                options:
+                    - false
+                    - use-self-hosted
+                    - use-github
                 default: false
 
             run-modules-tests:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,11 @@ on:
                 default: false
             run-with-macos:
                 description: "Run with macos included (only when needed)"
-                type: boolean
+                type: choice
+                options:
+                    - false
+                    - use-self-hosted
+                    - use-github
                 default: false
             rc-version:
                 required: false
@@ -61,8 +65,8 @@ on:
     workflow_call:
         inputs:
             run-with-macos:
-                description: "Run with macos included (only when needed)"
-                type: boolean
+                description: "Run with macos included (only when necessary)"
+                type: string
                 default: false
 
 concurrency:
@@ -92,7 +96,7 @@ jobs:
                   language-name: go
                   # Run full test matrix if job started by cron or it was explictly specified by a person who triggered the workflow
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
-                  run-with-macos: ${{ github.event.inputs.run-with-macos == 'true' }}
+                  run-with-macos: ${{ github.event.inputs.run-with-macos }}
 
     test-go:
         name: Go Tests - ${{ matrix.go }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -44,7 +44,11 @@ on:
                 default: false
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: choice
+                options:
+                    - false
+                    - use-self-hosted
+                    - use-github
                 default: false
             name:
                 required: false
@@ -59,7 +63,7 @@ on:
         inputs:
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: string
                 default: false
 
 concurrency:
@@ -85,7 +89,7 @@ jobs:
                   language-name: java
                   # Run full test matrix if job started by cron or it was explictly specified by a person who triggered the workflow
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
-                  run-with-macos: ${{ (github.event.inputs.run-with-macos == 'true') }}
+                  run-with-macos: ${{ (github.event.inputs.run-with-macos) }}
 
     test-java:
         name: Java Tests - ${{ matrix.java }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -42,7 +42,11 @@ on:
                 default: false
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: choice
+                options:
+                    - false
+                    - use-self-hosted
+                    - use-github
                 default: false
             name:
                 required: false
@@ -57,7 +61,7 @@ on:
         inputs:
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: string
                 default: false
 
 concurrency:
@@ -86,7 +90,7 @@ jobs:
               with:
                   language-name: node
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
-                  run-with-macos: ${{ github.event.run-with-macos == 'true' }}
+                  run-with-macos: ${{ github.event.run-with-macos }}
 
     test-node:
         name: Node Tests - ${{ matrix.node }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -149,7 +149,7 @@ jobs:
               id: load-platform-matrix
               shell: bash
               run: |
-                  # Filter entries with npm in PACKAGE_MANAGERS and use CD_RUNNER if available
+                  # Filter entries with npm in PACKAGE_MANAGERS and use CD_RUNNER if available, replace "ephemeral" with "persistent" in RUNNER
                   export PLATFORM_MATRIX=$(jq 'map(
                       select(.PACKAGE_MANAGERS != null and (.PACKAGE_MANAGERS | contains(["npm"])))
                       | .runner = (
@@ -168,10 +168,15 @@ jobs:
                           end
                       )
                       | if .RUNNER == "macos13" then .["test-runner"] = "macos13" else . end
+                      | .RUNNER = (
+                          if (.RUNNER | type == "array") 
+                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end))
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end)
+                          end
+                      )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)
                   echo "platform_matrix=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
                   echo "Platform matrix loaded: ${PLATFORM_MATRIX}"
-
     build-native-modules:
         needs: [get-build-parameters]
         strategy:
@@ -271,7 +276,7 @@ jobs:
             - name: Upload Native Modules
               uses: actions/upload-artifact@v4
               with:
-                  name: bindings-${{ matrix.TARGET }}
+                  name: bindings-${{ matrix.TARGET }}-${{ matrix.RUNNER }}
                   path: ./node/${{ matrix.TARGET }}
                   retention-days: 1
                   if-no-files-found: error

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,11 @@ on:
                 default: false
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: choice
+                options:
+                    - false
+                    - use-self-hosted
+                    - use-github
                 default: false
             name:
                 required: false
@@ -70,7 +74,7 @@ on:
         inputs:
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: string
                 default: false
 
 concurrency:
@@ -89,7 +93,7 @@ run-name:
 env:
     # Run full test matrix if job started by cron or it was explictly specified by a person who triggered the workflow
     RUN_FULL_MATRIX: ${{ (github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule') }}
-    RUN_WITH_MACOS: ${{ (github.event.inputs.run-with-macos == 'true') }}
+    RUN_WITH_MACOS: ${{ (github.event.inputs.run-with-macos) }}
     RUN_SYNC_ONLY: ${{ (github.event.inputs.run_sync_tests == 'true' && github.event.inputs.run_async_tests == 'false') }}
     RUN_ASYNC_ONLY: ${{ (github.event.inputs.run_async_tests == 'true' && github.event.inputs.run_sync_tests == 'false') }}
 
@@ -107,7 +111,7 @@ jobs:
               with:
                   language-name: python
                   run-full-matrix: ${{ env.RUN_FULL_MATRIX == 'true' }}
-                  run-with-macos: ${{ env.RUN_WITH_MACOS == 'true' }}
+                  run-with-macos: ${{ env.RUN_WITH_MACOS }}
 
     test-python:
         name: Python Tests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,11 @@ on:
                 default: false
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: choice
+                options:
+                    - false
+                    - use-self-hosted
+                    - use-github
                 default: false
             name:
                 required: false
@@ -55,7 +59,7 @@ on:
         inputs:
             run-with-macos:
                 description: "Run with macos included (only when necessary)"
-                type: boolean
+                type: string
                 default: false
 
 concurrency:
@@ -87,7 +91,7 @@ jobs:
                   language-name: rust
                   # Run full test matrix if job started by cron or it was explictly specified by a person who triggered the workflow
                   run-full-matrix: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
-                  run-with-macos: ${{ github.event.inputs.run-with-macos == 'true' }}
+                  run-with-macos: ${{ github.event.inputs.run-with-macos }}
 
     tests:
         runs-on: ${{ matrix.host.RUNNER }}


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR adds the option to run tests on Mac self hosted runners. Scheduled tests are still disabled on self hosted runners until it's stable. It adds an option to choose between running on self hosted vs running on `macos-15` github runners on manual triggers of the tests. 

In addition it fixes the `npm-cd` to avoid running on ephemeral runners, this was previously in the code and was mistakenly deleted in https://github.com/valkey-io/valkey-glide/pull/3930

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4627

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
