### PR TITLE
[Backport 2.1] Node: Add Multi-Database Support for Cluster Mode (Valkey 9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * JAVA: Valkey 9 new commands HASH items expiration ([#4556](https://github.com/valkey-io/valkey-glide/pull/4556))
 * NODE: Valkey 9 support - Add Hash Field Expiration Commands Support ([#4598](https://github.com/valkey-io/valkey-glide/pull/4598))
 * Python: Valkey 9 new hash field expiration commands ([#4610](https://github.com/valkey-io/valkey-glide/pull/4610))
+* Node: Add Multi-Database Support for Cluster Mode (Valkey 9.0) ([#4657](https://github.com/valkey-io/valkey-glide/pull/4657))
 * Java: Multi-Database Support for Cluster Mode Valkey 9.0 ([#4658](https://github.com/valkey-io/valkey-glide/pull/4658))
 * Go: Add Multi-Database Support for Cluster Mode Valkey 9.0 ([#4660](https://github.com/valkey-io/valkey-glide/pull/4660))
 * Python: Add Multi-Database Support for Cluster Mode Valkey 9.0 ([#4659](https://github.com/valkey-io/valkey-glide/pull/4659))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -563,6 +563,13 @@ export type ReadFrom =
  *   - **Standalone Mode**: In standalone mode, only the provided nodes will be used.
  * - **Lazy Connect**: Set `lazyConnect` to `true` to defer connection establishment until the first command is sent.
  *
+ * ### Database Selection
+ *
+ * - **Database ID**: Use `databaseId` to specify which logical database to connect to (0-15 by default).
+ *   - **Cluster Mode**: Requires Valkey 9.0+ with multi-database cluster mode enabled.
+ *   - **Standalone Mode**: Works with all Valkey versions.
+ *   - **Reconnection**: Database selection persists across reconnections.
+ *
  * ### Security Settings
  *
  * - **TLS**: Enable secure communication using `useTLS`.
@@ -610,6 +617,7 @@ export type ReadFrom =
  *     { host: 'redis-node-1.example.com', port: 6379 },
  *     { host: 'redis-node-2.example.com' }, // Defaults to port 6379
  *   ],
+ *   databaseId: 5, // Connect to database 5
  *   useTLS: true,
  *   credentials: {
  *     username: 'myUser',
@@ -655,6 +663,33 @@ export interface BaseClientConfiguration {
          */
         port?: number;
     }[];
+    /**
+     * Index of the logical database to connect to.
+     *
+     * @remarks
+     * - **Standalone Mode**: Works with all Valkey versions.
+     * - **Cluster Mode**: Requires Valkey 9.0+ with multi-database cluster mode enabled.
+     * - **Reconnection**: Database selection persists across reconnections.
+     * - **Default**: If not specified, defaults to database 0.
+     * - **Range**: Must be non-negative. The server will validate the upper limit based on its configuration.
+     * - **Server Validation**: The server determines the maximum database ID based on its `databases` configuration (standalone) or `cluster-databases` configuration (cluster mode).
+     *
+     * @example
+     * ```typescript
+     * // Connect to database 5
+     * const config: BaseClientConfiguration = {
+     *   addresses: [{ host: 'localhost', port: 6379 }],
+     *   databaseId: 5
+     * };
+     *
+     * // Connect to a higher database ID (server will validate the limit)
+     * const configHighDb: BaseClientConfiguration = {
+     *   addresses: [{ host: 'localhost', port: 6379 }],
+     *   databaseId: 100
+     * };
+     * ```
+     */
+    databaseId?: number;
     /**
      * True if communication with the cluster should use Transport Level Security.
      * Should match the TLS configuration of the server/cluster,
@@ -1164,15 +1199,13 @@ export class BaseClient {
         }
     }
 
-    /**
-     * @internal
-     */
     protected constructor(
         socket: net.Socket,
         options?: BaseClientConfiguration,
     ) {
         // if logger has been initialized by the external-user on info level this log will be shown
         Logger.log("info", "Client lifetime", `construct client`);
+
         this.config = options;
         this.requestTimeout =
             options?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_IN_MILLISECONDS;
@@ -8952,6 +8985,7 @@ export class BaseClient {
             clusterModeEnabled: false,
             readFrom,
             authenticationInfo,
+            databaseId: options.databaseId,
             inflightRequestsLimit: options.inflightRequestsLimit,
             clientAz: options.clientAz ?? null,
             connectionRetryStrategy: options.connectionBackoff,

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -4384,6 +4384,14 @@ export class Batch extends BaseBatch<Batch> {
     /**
      * Change the currently selected database.
      *
+     * **WARNING**: This command is NOT RECOMMENDED for production use.
+     * Upon reconnection, the client will revert to the database_id specified
+     * in the client configuration (default: 0), NOT the database selected
+     * via this command.
+     *
+     * **RECOMMENDED APPROACH**: Use the `databaseId` parameter in client
+     * configuration instead of using SELECT in batch operations.
+     *
      * @see {@link https://valkey.io/commands/select/|valkey.io} for details.
      *
      * @param index - The index of the database to select.

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -102,19 +102,19 @@ export namespace GlideClientConfiguration {
 /**
  * Configuration options for creating a {@link GlideClient | GlideClient}.
  *
- * Extends `BaseClientConfiguration` with properties specific to `GlideClient`, such as database selection,
+ * Extends `BaseClientConfiguration` with properties specific to `GlideClient`, such as
  * reconnection strategies, and Pub/Sub subscription settings.
  *
  * @remarks
  * This configuration allows you to tailor the client's behavior when connecting to a standalone Valkey Glide server.
  *
- * - **Database Selection**: Use `databaseId` to specify which logical database to connect to.
+ * - **Database Selection**: Use `databaseId` (inherited from BaseClientConfiguration) to specify which logical database to connect to.
  * - **Pub/Sub Subscriptions**: Predefine Pub/Sub channels and patterns to subscribe to upon connection establishment.
  *
  * @example
  * ```typescript
  * const config: GlideClientConfiguration = {
- *   databaseId: 1,
+ *   databaseId: 1, // Inherited from BaseClientConfiguration
  *   pubsubSubscriptions: {
  *     channelsAndPatterns: {
  *       [GlideClientConfiguration.PubSubChannelModes.Pattern]: new Set(['news.*']),
@@ -127,10 +127,6 @@ export namespace GlideClientConfiguration {
  * ```
  */
 export type GlideClientConfiguration = BaseClientConfiguration & {
-    /**
-     * index of the logical database to connect to.
-     */
-    databaseId?: number;
     /**
      * PubSub subscriptions to be used for the client.
      * Will be applied via SUBSCRIBE/PSUBSCRIBE commands during connection establishment.
@@ -173,7 +169,6 @@ export class GlideClient extends BaseClient {
         options: GlideClientConfiguration,
     ): connection_request.IConnectionRequest {
         const configuration = super.createClientRequest(options);
-        configuration.databaseId = options.databaseId;
 
         this.configurePubsub(options, configuration);
 
@@ -409,6 +404,21 @@ export class GlideClient extends BaseClient {
     /**
      * Changes the currently selected database.
      *
+     * **WARNING**: This command is NOT RECOMMENDED for production use.
+     * Upon reconnection, the client will revert to the database_id specified
+     * in the client configuration (default: 0), NOT the database selected
+     * via this command.
+     *
+     * **RECOMMENDED APPROACH**: Use the `databaseId` parameter in client
+     * configuration instead:
+     *
+     * ```typescript
+     * const client = await GlideClient.createClient({
+     *     addresses: [{ host: "localhost", port: 6379 }],
+     *     databaseId: 5  // Recommended: persists across reconnections
+     * });
+     * ```
+     *
      * @see {@link https://valkey.io/commands/select/|valkey.io} for details.
      *
      * @param index - The index of the database to select.
@@ -416,9 +426,10 @@ export class GlideClient extends BaseClient {
      *
      * @example
      * ```typescript
-     * // Example usage of select method
+     * // Example usage of select method (NOT RECOMMENDED)
      * const result = await client.select(2);
      * console.log(result); // Output: 'OK'
+     * // Note: Database selection will be lost on reconnection!
      * ```
      */
     public async select(index: number): Promise<"OK"> {

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -166,6 +166,11 @@ export namespace GlideClusterClientConfiguration {
  * @example
  * ```typescript
  * const config: GlideClusterClientConfiguration = {
+ *   addresses: [
+ *     { host: 'cluster-node-1.example.com', port: 6379 },
+ *     { host: 'cluster-node-2.example.com', port: 6379 },
+ *   ],
+ *   databaseId: 5, // Connect to database 5 (requires Valkey 9.0+ with multi-database cluster mode)
  *   periodicChecks: {
  *     duration_in_sec: 30, // Perform periodic checks every 30 seconds
  *   },
@@ -544,12 +549,12 @@ export class GlideClusterClient extends BaseClient {
     /**
      * Creates a new `GlideClusterClient` instance and establishes connections to a Valkey Cluster.
      *
-     * @param options - The configuration options for the client, including cluster addresses, authentication credentials, TLS settings, periodic checks, and Pub/Sub subscriptions.
+     * @param options - The configuration options for the client, including cluster addresses, database selection, authentication credentials, TLS settings, periodic checks, and Pub/Sub subscriptions.
      * @returns A promise that resolves to a connected `GlideClusterClient` instance.
      *
      * @remarks
      * Use this static method to create and connect a `GlideClusterClient` to a Valkey Cluster.
-     * The client will automatically handle connection establishment, including cluster topology discovery and handling of authentication and TLS configurations.
+     * The client will automatically handle connection establishment, including cluster topology discovery, database selection, and handling of authentication and TLS configurations.
      *
      * @example
      * ```typescript
@@ -561,6 +566,7 @@ export class GlideClusterClient extends BaseClient {
      *     { host: 'address1.example.com', port: 6379 },
      *     { host: 'address2.example.com', port: 6379 },
      *   ],
+     *   databaseId: 5, // Connect to database 5 (requires Valkey 9.0+)
      *   credentials: {
      *     username: 'user1',
      *     password: 'passwordA',
@@ -589,6 +595,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * @remarks
      * - **Cluster Topology Discovery**: The client will automatically discover the cluster topology based on the seed addresses provided.
+     * - **Database Selection**: Use `databaseId` to specify which logical database to connect to. Requires Valkey 9.0+ with multi-database cluster mode enabled.
      * - **Authentication**: If `credentials` are provided, the client will attempt to authenticate using the specified username and password.
      * - **TLS**: If `useTLS` is set to `true`, the client will establish secure connections using TLS.
      *      Should match the TLS configuration of the server/cluster, otherwise the connection attempt will fail.

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -2868,4 +2868,26 @@ describe("GlideClusterClient", () => {
         },
         TIMEOUT,
     );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "should pass database id for cluster client_%p",
+        async (protocol) => {
+            // Skip test if version is below 9.0.0 (Valkey 9)
+            if (cluster.checkIfServerVersionLessThan("9.0.0")) return;
+
+            const client = await GlideClusterClient.createClient(
+                getClientConfigurationOption(cluster.getAddresses(), protocol, {
+                    databaseId: 1,
+                }),
+            );
+
+            try {
+                // Simple test to verify the client works with the database ID
+                expect(await client.ping()).toEqual("PONG");
+            } finally {
+                client.close();
+            }
+        },
+        TIMEOUT,
+    );
 });


### PR DESCRIPTION
# Add Multi-Database Support for Cluster Mode (Valkey 9.0)

## Overview

This PR implements comprehensive multi-database support for both standalone and cluster modes, with special focus on enabling database selection in cluster mode for Valkey 9.0+ servers. The implementation includes client-side validation, server-side database selection.

## Key Features

### 🎯 Core Functionality
- **Database Selection**: Added `databaseId` parameter to client configurations for both standalone and cluster modes
- **Cluster Mode Support**: Enables multi-database functionality in cluster mode (requires Valkey 9.0+ with `cluster-databases` configured)
- **Reconnection Persistence**: Database selection persists across reconnections when configured via client options
- **Cross-Language Support**: Implementation spans Rust (glide-core), Node.js, and Java clients

### 🔧 Implementation Details

#### Node.js Client
- **BaseClient Configuration**: Added `databaseId` parameter to `BaseClientConfiguration`
- **Client-Side Validation**: Validates `databaseId` as non-negative integer (rejects NaN, Infinity, negative values)
- **Documentation**: Extensive JSDoc with warnings about SELECT command limitations vs configuration approach

#### Version Compatibility
- **Standalone Mode**: Works with all Valkey/Redis versions
- **Cluster Mode**: Requires Valkey 9.0+ with `cluster-databases` configuration > 1

## Documentation

- Updated JSDoc with comprehensive examples and warnings
- Added configuration examples for both standalone and cluster modes
- Documented version requirements and limitations

### Issue link

This Pull Request is linked to issue (URL): [#4500]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [X] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [X] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
