### PR TITLE
CD: removed self hosted mac arm runners from required CD platforms

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -25,7 +25,6 @@
         "RUNNER": ["self-hosted", "macOS", "ARM64", "ephemeral"],
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",
-        "PACKAGE_MANAGERS": ["pypi", "npm", "maven", "pkg_go_dev"],
         "languages": ["python", "node", "java", "go"]
     },
     {

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -168,15 +168,10 @@ jobs:
                           end
                       )
                       | if .RUNNER == "macos13" then .["test-runner"] = "macos13" else . end
-                      | .RUNNER = (
-                          if (.RUNNER | type == "array") 
-                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end))
-                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end)
-                          end
-                      )
                   )' < .github/json_matrices/build-matrix.json | jq -c .)
                   echo "platform_matrix=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
                   echo "Platform matrix loaded: ${PLATFORM_MATRIX}"
+
     build-native-modules:
         needs: [get-build-parameters]
         strategy:


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR fixes a previous PR - https://github.com/valkey-io/valkey-glide/pull/4683 
The previous PR introduced a new matrix to the `build-matrix.json` file (for mac self hosted runners), which causes the CD workflows to try to run the macOS ARM jobs on self hosted runners in addition to the github runners, which is unnecessary. This PR disables this, as well as reverts the changed that were made to the`npm-cd` workflow in the previous commit. 

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4627

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
