### PR TITLE
Python: fixed pypi-cd workflow, fixed release tests

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.repository_owner == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
-        timeout-minutes: 60
+        timeout-minutes: 120
         strategy:
             fail-fast: false
             matrix:
@@ -422,6 +422,7 @@ jobs:
             - name: Async client - Download binaries
               uses: actions/download-artifact@v4
               with:
+                  pattern: wheels-*-async
                   path: python/glide-async/wheels
                   merge-multiple: true
 
@@ -459,6 +460,7 @@ jobs:
             - name: Sync client - Download binaries
               uses: actions/download-artifact@v4
               with:
+                  pattern: wheels-*-sync
                   path: python/glide-sync/wheels
                   merge-multiple: true
 

--- a/utils/release-candidate-testing/python/sync_rc_test.py
+++ b/utils/release-candidate-testing/python/sync_rc_test.py
@@ -1,11 +1,30 @@
 
-from typing import List
-from utils import start_servers, stop_servers, parse_cluster_script_start_output, create_client
+from typing import List, Union
 
-from glide_sync import (
-    GlideClient,
-    NodeAddress,
-)
+from glide_sync import (GlideClient, GlideClientConfiguration,
+                        GlideClusterClient, GlideClusterClientConfiguration,
+                        NodeAddress)
+
+from utils import (parse_cluster_script_start_output, start_servers,
+                   stop_servers)
+
+
+def create_client(
+    nodes_list: List[NodeAddress] = [("localhost", 6379)], is_cluster: bool = False
+) -> Union[GlideClusterClient, GlideClient]:
+    addresses: List[NodeAddress] = nodes_list
+    if is_cluster:
+        config_class = GlideClusterClientConfiguration
+        client_class = GlideClusterClient
+    else:
+        config_class = GlideClientConfiguration
+        client_class = GlideClient
+    config = config_class(
+        addresses=addresses,
+        client_name=f"test_{'cluster' if is_cluster else 'standalone'}_client",
+    )
+    return client_class.create(config)
+
 
 def run_commands(client: GlideClient) -> None:
     print("Executing commands")
@@ -84,7 +103,7 @@ def test_standalone_client() -> None:
     output = start_servers(False, 1, 1)
     servers, folder = parse_cluster_script_start_output(output)
     servers = [NodeAddress(hp.host, hp.port) for hp in servers]
-    standalone_client = create_client(servers, is_cluster=False, is_sync=True)
+    standalone_client = create_client(servers, is_cluster=False)
     run_commands(standalone_client)
     stop_servers(folder)
     print("Standalone client test completed")
@@ -95,7 +114,7 @@ def test_cluster_client() -> None:
     output = start_servers(True, 3, 1)
     servers, folder = parse_cluster_script_start_output(output)
     servers = [NodeAddress(hp.host, hp.port) for hp in servers]
-    cluster_client = create_client(servers, is_cluster=True, is_sync=True)
+    cluster_client = create_client(servers, is_cluster=True)
     run_commands(cluster_client)
     stop_servers(folder)
     print("Cluster client test completed")

--- a/utils/release-candidate-testing/python/utils.py
+++ b/utils/release-candidate-testing/python/utils.py
@@ -1,24 +1,8 @@
-from dataclasses import dataclass
 import os
 import subprocess
 import sys
-from typing import List, Tuple, Union
-
-from glide import (
-    GlideClient,
-    GlideClientConfiguration,
-    GlideClusterClient,
-    GlideClusterClientConfiguration,
-    NodeAddress,
-)
-
-from glide_sync import (
-    GlideClient as SyncGlideClient,
-    GlideClientConfiguration as SyncGlideClientConfiguration,
-    GlideClusterClient as SyncGlideClusterClient,
-    GlideClusterClientConfiguration as SyncGlideClusterClientConfiguration,
-    NodeAddress as SyncNodeAddress,
-)
+from dataclasses import dataclass
+from typing import List, Tuple
 
 SCRIPT_FILE = os.path.abspath(f"{__file__}/../../../cluster_manager.py")
 
@@ -27,7 +11,8 @@ SCRIPT_FILE = os.path.abspath(f"{__file__}/../../../cluster_manager.py")
 class HostPort:
     host: str
     port: int
-    
+
+
 def start_servers(cluster_mode: bool, shard_count: int, replica_count: int) -> str:
     args_list: List[str] = [sys.executable, SCRIPT_FILE]
     args_list.append("start")
@@ -86,20 +71,3 @@ def stop_servers(folder: str) -> str:
         raise Exception(f"Failed to stop the cluster. Executed: {p}:\n{err}")
     print("Servers stopped successfully")
     return output
-
-
-def create_client(
-    nodes_list: List[Union[NodeAddress, SyncNodeAddress]] = [("localhost", 6379)], is_cluster: bool = False, is_sync: bool = False
-) -> GlideClusterClient:
-    addresses: List[Union[NodeAddress, SyncNodeAddress]] = nodes_list
-    if is_cluster:
-        config_class = SyncGlideClusterClientConfiguration if is_sync else GlideClusterClientConfiguration
-        client_class = SyncGlideClusterClient if is_sync else GlideClusterClient
-    else:
-        config_class = SyncGlideClientConfiguration if is_sync else GlideClientConfiguration
-        client_class = SyncGlideClient if is_sync else GlideClient
-    config = config_class(
-        addresses=addresses,
-        client_name=f"test_{'cluster' if is_cluster else 'standalone'}_client",
-    )
-    return client_class.create(config)


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR fixes the pypi-cd workflow, following rc releases that failed. It - 
1. makes sure only the async/sync appropriate wheels are uploaded (previously it succeeded in uploading the wheel, but  `twine` mistook other unrelated files as dist file, which failed the command). 
2. raises the job's timeout (takes longer now that sync wheels have to be built too) 
3. Fixes the release tests, since they failed on a `glide_sync not found` error, which was imported in `utils/release-candidate-testing/python/utils.py`. Thus moved the async/sync specific function away from the utils.py, it could be shared between the 2 tests. 

### Issue link

This Pull Request is linked to issue: [#3285](https://github.com/valkey-io/valkey-glide/issues/3285)

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
