### PR TITLE
Util: Fix cluster manager flaky function `is_address_already_in_use()`

### DIFF
--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -815,7 +815,7 @@ def wait_for_regex_in_log(
 def is_address_already_in_use(
     server: Server,
     log_file: str,
-    timeout: int = 5,
+    timeout: int = 10,
 ):
     logging.debug(f"checking is address already bind for: {server}")
     timeout_start = time.time()
@@ -825,6 +825,10 @@ def is_address_already_in_use(
         "address in use",
     ]
     while time.time() < timeout_start + timeout:
+        if not os.path.exists(log_file):
+            time.sleep(0.1)
+            continue
+        
         with open(log_file, "r") as f:
             server_log = f.read()
             # Check for known error message variants because different C libraries


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4666

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
