### PR TITLE
Python: Fix  pyproject.toml license

### DIFF
--- a/python/glide-sync/pyproject.toml
+++ b/python/glide-sync/pyproject.toml
@@ -2,7 +2,7 @@
 dynamic = ["version", "readme"]
 name = "valkey-glide-sync"
 description = "Valkey GLIDE Sync client. Supports Valkey and Redis OSS."
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 dependencies = [
     # ⚠️  Note: If you add a dependency here, make sure to also add it to glide-sync/requirements.txt
     # Once issue https://github.com/aboutcode-org/python-inspector/issues/197 is resolved, the requirements.txt file can be removed.


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4728

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.


The issue is in glide-sync/pyproject.toml. The license = "Apache-2.0" format is incorrect according to PEP 621. It should be either:

1. license = {text = "Apache-2.0"} (inline text)
2. license = {file = "LICENSE"} (file reference)

The string format license = "Apache-2.0" is not valid in PEP 621.