### PR TITLE
Python Sync: revert license format

### DIFF
--- a/python/glide-sync/pyproject.toml
+++ b/python/glide-sync/pyproject.toml
@@ -2,7 +2,7 @@
 dynamic = ["version", "readme"]
 name = "valkey-glide-sync"
 description = "Valkey GLIDE Sync client. Supports Valkey and Redis OSS."
-license = "Apache-2.0"
+license = { text = "Apache-2.0" }
 dependencies = [
     # ⚠️  Note: If you add a dependency here, make sure to also add it to glide-sync/requirements.txt
     # Once issue https://github.com/aboutcode-org/python-inspector/issues/197 is resolved, the requirements.txt file can be removed.


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR reverts the license format in the sync client's `pyproject.toml` file. This was changed originally because the `licence = { text = "..."} ` format triggers a deprecation warning, but it's still required in python 3.10 and 3.11 so it will be reverted. 

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4728

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
