### PR TITLE
Python: improve UDS socket error handling

### DIFF
--- a/python/tests/test_api_consistency.py
+++ b/python/tests/test_api_consistency.py
@@ -69,6 +69,7 @@ EXCLUDED_TESTS = {
         "test_inflight_request_limit",
         "test_statistics",
         "test_select",
+        "test_UDS_socket_connection_failure",
     ],
     "sync_only": ["test_sync_fork"],
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR improves error handling for unexpected UDS socket closures. Previously, there were two issues:

1. When a write to the UDS socket failed, the raised exception was directly set on the future instead of raising a ClosingError.
2. When the UDS socket closed, both the reader loop and writer task attempted to set an exception on the same future almost simultaneously. Since the reader loop calls `client.close()` and tries to set exceptions for all pending futures, by the time the second task attempted to do the same, the future was already completed, resulting in an `asyncio.exceptions.InvalidStateError: invalid state`

This PR resolves these issues by:

1. Raising a `ClosingError` when a write to the socket fails.
2. Ensuring an exception is only set on a future if it is not already completed.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4653

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
