### PR TITLE
Add explicit rustfmt and clippy components to install-rust-and-protoc action

### DIFF
--- a/.github/workflows/install-rust-and-protoc/action.yml
+++ b/.github/workflows/install-rust-and-protoc/action.yml
@@ -23,6 +23,7 @@ runs:
           uses: dtolnay/rust-toolchain@stable
           with:
               targets: ${{ inputs.target }}
+              components: rustfmt, clippy
 
         - name: Install protoc (protobuf)
           uses: arduino/setup-protoc@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Fixes 
 
+* Rust: Updates the `install-rust-and-protoc` action to explicitly include the `rustfmt` and `clippy` components. ([#4816](https://github.com/valkey-io/valkey-glide/issues/4816))
+
 ## 2.1
 
 #### Changes


### PR DESCRIPTION
Updates the `install-rust-and-protoc` action to explicitly include the `rustfmt` and `clippy` components. This ensures that the linter does not fail due to missing tools during CI runs.

Tested locally using `act` to run the Github Action within Docker.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): [#4816](https://github.com/valkey-io/valkey-glide/issues/4816)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
