### PR TITLE
JAVA: Add SELECT command support for cluster mode

### DIFF
--- a/java/client/src/main/java/glide/api/GlideClusterClient.java
+++ b/java/client/src/main/java/glide/api/GlideClusterClient.java
@@ -33,6 +33,7 @@ import static command_request.CommandRequestOuterClass.RequestType.SPublish;
 import static command_request.CommandRequestOuterClass.RequestType.ScriptExists;
 import static command_request.CommandRequestOuterClass.RequestType.ScriptFlush;
 import static command_request.CommandRequestOuterClass.RequestType.ScriptKill;
+import static command_request.CommandRequestOuterClass.RequestType.Select;
 import static command_request.CommandRequestOuterClass.RequestType.Time;
 import static command_request.CommandRequestOuterClass.RequestType.UnWatch;
 import static glide.api.commands.ServerManagementCommands.VERSION_VALKEY_API;
@@ -326,6 +327,12 @@ public class GlideClusterClient extends BaseClient
                 Info,
                 Stream.of(sections).map(Enum::toString).toArray(String[]::new),
                 response -> ClusterValue.of(handleMapResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<String> select(long index) {
+        return commandManager.submitNewCommand(
+                Select, new String[] {Long.toString(index)}, this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -249,4 +249,18 @@ public interface ConnectionManagementClusterCommands {
      * }</pre>
      */
     CompletableFuture<ClusterValue<GlideString>> echo(GlideString message, Route route);
+
+    /**
+     * Changes the currently selected database.
+     *
+     * @see <a href="https://valkey.io/commands/select/">valkey.io</a> for details.
+     * @param index The index of the database to select.
+     * @return A simple <code>OK</code> response.
+     * @example
+     *     <pre>{@code
+     * String response = regularClient.select(0).get();
+     * assert response.equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<String> select(long index);
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -110,23 +110,6 @@ public interface ConnectionManagementCommands {
     /**
      * Changes the currently selected database.
      *
-     * <p><b>WARNING:</b> This command is <b>NOT RECOMMENDED</b> for production use. Upon
-     * reconnection, the client will revert to the database_id specified in the client configuration
-     * (default: 0), NOT the database selected via this command.
-     *
-     * <p><b>RECOMMENDED APPROACH:</b> Use the database_id parameter in client configuration instead:
-     *
-     * <p><b>RECOMMENDED EXAMPLE:</b>
-     *
-     * <pre>{@code
-     * GlideClient client = GlideClient.createClient(
-     *     GlideClientConfiguration.builder()
-     *         .address(NodeAddress.builder().host("localhost").port(6379).build())
-     *         .databaseId(5)  // Recommended: persists across reconnections
-     *         .build()
-     * ).get();
-     * }</pre>
-     *
      * @see <a href="https://valkey.io/commands/select/">valkey.io</a> for details.
      * @param index The index of the database to select.
      * @return A simple <code>OK</code> response.

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -14052,16 +14052,16 @@ public class SharedCommandTests {
         client.set(source, "one");
         assertTrue(client.copy(source, destination, 1, false).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
 
         assertEquals("one", client.get(destination).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClusterClient) client).select(0).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClient) client).select(0).get();
         }
 
         // setting new value for source
@@ -14071,23 +14071,23 @@ public class SharedCommandTests {
         assertFalse(client.copy(source, destination, 1).get());
         assertFalse(client.copy(source, destination, 1, false).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
         assertEquals("one", client.get(destination).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClusterClient) client).select(0).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClient) client).select(0).get();
         }
 
         // both exists, with REPLACE
         assertTrue(client.copy(source, destination, 1, true).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
         assertEquals("two", client.get(destination).get());
     }
@@ -14112,30 +14112,30 @@ public class SharedCommandTests {
         // neither key exists, returns false
         assertFalse(client.copy(source, destination, 1, false).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
         assertFalse(client.copy(source, destination).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClusterClient) client).select(0).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClient) client).select(0).get();
         }
 
         // source exists, destination does not
         client.set(source, gs("one"));
         assertTrue(client.copy(source, destination, 1, false).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
         assertEquals(gs("one"), client.get(destination).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClusterClient) client).select(0).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClient) client).select(0).get();
         }
 
         // setting new value for source
@@ -14145,23 +14145,23 @@ public class SharedCommandTests {
         assertFalse(client.copy(source, destination, 1).get());
         assertFalse(client.copy(source, destination, 1, false).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
         assertEquals(gs("one"), client.get(destination).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClusterClient) client).select(0).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "0"}).get();
+            ((GlideClient) client).select(0).get();
         }
 
         // both exists, with REPLACE
         assertTrue(client.copy(source, destination, 1, true).get());
         if (isCluster) {
-            ((GlideClusterClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClusterClient) client).select(1).get();
         } else {
-            ((GlideClient) client).customCommand(new String[] {"select", "1"}).get();
+            ((GlideClient) client).select(1).get();
         }
         assertEquals(gs("two"), client.get(destination).get());
     }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -3640,6 +3640,28 @@ public class CommandTests {
                 "Expected NOSCRIPT error after script is fully released and flushed");
     }
 
+    @ParameterizedTest
+    @MethodSource("getClients")
+    @SneakyThrows
+    public void simple_select_test(GlideClusterClient clusterClient) {
+        // Skip test if Valkey version is less than 9.0.0
+        assumeTrue(
+                SERVER_VERSION.isGreaterThanOrEqualTo("9.0.0"),
+                "SELECT command in cluster mode requires Valkey 9.0.0 or higher");
+
+        assertEquals(OK, clusterClient.select(0).get());
+
+        String key = UUID.randomUUID().toString();
+        String value = UUID.randomUUID().toString();
+        assertEquals(OK, clusterClient.set(key, value).get());
+
+        assertEquals(OK, clusterClient.select(1).get());
+        assertNull(clusterClient.get(key).get());
+
+        assertEquals(OK, clusterClient.select(0).get());
+        assertEquals(value, clusterClient.get(key).get());
+    }
+
     @SneakyThrows
     @Test
     public void move_cluster_mode() {


### PR DESCRIPTION
## Description

This PR adds native support for the `SELECT` command in cluster mode for the Java client, available in Valkey 9.0.0+.

## Changes

### API Changes
- **Added** `select(long index)` method to `ConnectionManagementClusterCommands` interface
- **Implemented** `select()` in `GlideClusterClient` class
- **Removed** production warning from `ConnectionManagementCommands` documentation for the `SELECT` command

### Test Updates
- **Refactored** `SharedCommandTests` to use the new `select()` method instead of `customCommand()`
- **Added** `simple_select_test()` integration test in `CommandTests` to verify SELECT functionality in cluster mode
  - Test validates database switching behavior
  - Skips automatically on Valkey versions < 9.0.0

## Testing

The new test verifies:
- Successful database selection (returns "OK")
- Data isolation between databases
- Ability to switch between databases and access appropriate data

## Requirements

- Valkey 9.0.0 or higher for cluster mode SELECT support

### Issue link

This Pull Request is linked to issue (URL): [#4691]

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
