### PR TITLE
Stabilize combined publish/subscribe test by using unique channel names

### DIFF
--- a/python/tests/async_tests/test_pubsub.py
+++ b/python/tests/async_tests/test_pubsub.py
@@ -1205,20 +1205,20 @@ class TestPubSub:
 
             # Create dictionaries of channels and their corresponding messages
             exact_channels_and_messages = {
-                "{{{}}}:{}".format("channel", get_random_string(5)): get_random_string(
+                "{{{}}}:{}:{}".format("channel", get_random_string(5), i): get_random_string(
                     10
                 )
-                for _ in range(NUM_CHANNELS)
+                for i in range(NUM_CHANNELS)
             }
             pattern_channels_and_messages = {
-                "{{{}}}:{}".format("pattern", get_random_string(5)): get_random_string(
+                "{{{}}}:{}:{}".format("pattern", get_random_string(5), i): get_random_string(
                     5
                 )
-                for _ in range(NUM_CHANNELS)
+                for i in range(NUM_CHANNELS)
             }
             sharded_channels_and_messages = {
-                f"{SHARD_PREFIX}: {get_random_string(10)}": get_random_string(7)
-                for _ in range(NUM_CHANNELS)
+                f"{SHARD_PREFIX}:{i}:{get_random_string(10)}": get_random_string(7)
+                for i in range(NUM_CHANNELS)
             }
 
             publish_response = 1


### PR DESCRIPTION
Fixes #4862

**Summary**
I addressed flakiness in TestPubSub::`test_pubsub_combined_exact_pattern_and_sharded_one_client`. The test occasionally reported an off-by-one result (e.g., 767/768). The root cause was key collisions across the randomly generated channel names for Exact, Pattern, and Sharded modes. When collisions occurred, dictionary entries were overwritten, reducing the number of distinct publishes and leading to a mismatched final count.

**What changed**

- Exact: "{channel}:{rand}:{i}"

- Pattern: "{pattern}:{rand}:{i}"

- Sharded: "{same-shard}:{i}:{rand}" (no space after the colon)

This preserves shard grouping via `{same-shard}` and eliminates accidental overwrites without relaxing any assertions. The expected message count remains `NUM_CHANNELS * 3`.

**Validation**
```
python -m pytest -c /dev/null -q \
  tests/async_tests/test_pubsub.py \
  -k "test_pubsub_combined_exact_pattern_and_sharded_one_client" \
  --count=200 -s --maxfail=1
```