### PR TITLE
Stabilize flaky PUBSUB multi-client test by waiting for subscriptions

### DIFF
--- a/node/tests/PubSub.test.ts
+++ b/node/tests/PubSub.test.ts
@@ -1750,6 +1750,9 @@ describe("PubSub", () => {
                     pubSubPattern,
                 );
 
+                // Wait for subscriptions to be established in cluster mode
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+
                 // Publish messages to all channels
                 for (const [channel, message] of allChannelsAndMessages) {
                     const result = await publishingClient.publish(


### PR DESCRIPTION


# Stabilize flaky PUBSUB test by waiting for subscriptions to establish

### Issue link
This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4695

_Similar fix for reference:_ https://github.com/valkey-io/valkey-glide/issues/4623

---

## What & Why

**Flaky test:** `PubSub › pubsub combined exact and pattern multiple clients test_true_0`

**Root cause**  
Right after creating clients with PUBSUB subscriptions, the test immediately publishes messages. On slower or contended environments, publishes can race ahead of the subscription handshake (server hasn’t fully registered the subscriber yet), causing dropped messages and timeouts.

**Fix (minimal, no hooks, no new helpers):**  
Insert a short await after subscription setup and **before** publishing. This gives the subscription time to become active.

```ts
// Wait for subscriptions to be established (cluster & standalone)
await new Promise((resolve) => setTimeout(resolve, 1000));