### PR TITLE
CI/CD: Fix Python sync client Docker build container image

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -383,6 +383,8 @@ jobs:
               env:
                   CIBW_BUILD: ${{ github.event_name != 'pull_request' && 'cp39-* cp310-* cp311-* cp312-* cp313-* pp39-* pp310-* pp311-*' || 'cp313-*' }}
                   CIBW_SKIP: "*-musl* *i686* *i386*"
+                  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+                  CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
                   CIBW_ARCHS_LINUX: auto
                   CIBW_ARCHS_MACOS: auto
                   CIBW_ENABLE: ${{ steps.cibw_config.outputs.enable_flags }}


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR fixes the python sync manylinux wheels to be built inside manylinux2014 linux containers. Previously they were built inside manylinux_2_28 containers (the cibuildwheel default for x86_64), which produced wheels requiring glibc 2.28+, not matching our requirements.

This fix was tested by using the wheels produced as artifacts in the `pypi-cd` workflows of this PR (https://github.com/valkey-io/valkey-glide/actions/runs/18682479683) and trying to pip install it on an AL2 (centos 7) machine.


### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
