### PR TITLE
GO: Add TLS Custom Root Certificate Support for Go Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * PYTHON: Add IAM authentication support with manual token refresh ([#4890](https://github.com/valkey-io/valkey-glide/pull/4890))
 * JAVA: Add IAM authentication support for ElastiCache/MemoryDB ([#4891](https://github.com/valkey-io/valkey-glide/pull/4891/))
 * FFI/GO: Add IAM authentication support with automatic token refresh ([#4892](https://github.com/valkey-io/valkey-glide/pull/4892))
+* GO: Add TLS Custom Root Certificate Support for Go Client ([#4921](https://github.com/valkey-io/valkey-glide/pull/4921))
 * Python: Add Custom Root Certificate Support for Python TLS Connections ([#4930](https://github.com/valkey-io/valkey-glide/pull/4930))
 * Python: Add Python 3.14 support ([#4897](https://github.com/valkey-io/valkey-glide/pull/4897))
 * JAVA: Implement TLS support for Java client ([#4905](https://github.com/valkey-io/valkey-glide/pull/4905))

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
 )
 
+// Test certificate constants
+const (
+	testCertData1 = "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----"
+	testCertData2 = "-----BEGIN CERTIFICATE-----\nMIIC1...\n-----END CERTIFICATE-----\n"
+	testCertData3 = "-----BEGIN CERTIFICATE-----\nMIIC2...\n-----END CERTIFICATE-----\n"
+)
+
 func TestDefaultStandaloneConfig(t *testing.T) {
 	config := NewClientConfiguration()
 	expected := &protobuf.ConnectionRequest{
@@ -472,4 +479,350 @@ func TestClusterConfig_RefreshTopologyFromInitialNodes(t *testing.T) {
 		t.Fatalf("Failed to convert disabled cluster config to protobuf: %v", err)
 	}
 	assert.False(t, disabledResult.RefreshTopologyFromInitialNodes)
+}
+
+func TestTlsConfiguration_WithRootCertificates(t *testing.T) {
+	// Test with valid certificate data
+	certData := []byte(testCertData1)
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(certData)
+
+	assert.NotNil(t, tlsConfig)
+	assert.Equal(t, certData, tlsConfig.RootCertificates)
+}
+
+func TestTlsConfiguration_DefaultUsesNil(t *testing.T) {
+	// Test that default TLS config has nil certificates (uses platform verifier)
+	tlsConfig := NewTlsConfiguration()
+
+	assert.NotNil(t, tlsConfig)
+	assert.Nil(t, tlsConfig.RootCertificates)
+}
+
+func TestStandaloneConfig_WithTlsRootCertificates(t *testing.T) {
+	// Test standalone client with custom root certificates
+	certData := []byte(testCertData1)
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(certData)
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	assert.NotNil(t, result.RootCerts)
+	assert.Equal(t, 1, len(result.RootCerts))
+	assert.Equal(t, certData, result.RootCerts[0])
+}
+
+func TestClusterConfig_WithTlsRootCertificates(t *testing.T) {
+	// Test cluster client with custom root certificates
+	certData := []byte(testCertData1)
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(certData)
+	advancedConfig := NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClusterClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	assert.NotNil(t, result.RootCerts)
+	assert.Equal(t, 1, len(result.RootCerts))
+	assert.Equal(t, certData, result.RootCerts[0])
+}
+
+func TestStandaloneConfig_TlsWithNilCertificates(t *testing.T) {
+	// Test that nil certificates (default) uses platform verifier
+	tlsConfig := NewTlsConfiguration() // RootCertificates is nil by default
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	// RootCerts should not be set when using platform verifier
+	assert.Nil(t, result.RootCerts)
+}
+
+func TestClusterConfig_TlsWithNilCertificates(t *testing.T) {
+	// Test that nil certificates (default) uses platform verifier
+	tlsConfig := NewTlsConfiguration() // RootCertificates is nil by default
+	advancedConfig := NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClusterClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	// RootCerts should not be set when using platform verifier
+	assert.Nil(t, result.RootCerts)
+}
+
+func TestStandaloneConfig_TlsWithEmptyCertificates(t *testing.T) {
+	// Test that empty byte array (non-nil but length 0) returns an error
+	emptyCerts := []byte{}
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(emptyCerts)
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	_, err := config.ToProtobuf()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "root certificates cannot be an empty byte array")
+}
+
+func TestClusterConfig_TlsWithEmptyCertificates(t *testing.T) {
+	// Test that empty byte array (non-nil but length 0) returns an error
+	emptyCerts := []byte{}
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(emptyCerts)
+	advancedConfig := NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClusterClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	_, err := config.ToProtobuf()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "root certificates cannot be an empty byte array")
+}
+
+func TestStandaloneConfig_TlsWithoutAdvancedConfig(t *testing.T) {
+	// Test that TLS works without advanced config (uses platform verifier)
+	config := NewClientConfiguration().WithUseTLS(true)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	assert.Nil(t, result.RootCerts)
+}
+
+func TestClusterConfig_TlsWithoutAdvancedConfig(t *testing.T) {
+	// Test that TLS works without advanced config (uses platform verifier)
+	config := NewClusterClientConfiguration().WithUseTLS(true)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	assert.Nil(t, result.RootCerts)
+}
+
+func TestStandaloneConfig_TlsWithMultipleCertificates(t *testing.T) {
+	// Test with multiple certificates in PEM format (concatenated)
+	multiCertData := []byte(testCertData2 + testCertData3)
+
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(multiCertData)
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	assert.NotNil(t, result.RootCerts)
+	assert.Equal(t, 1, len(result.RootCerts))
+	assert.Equal(t, multiCertData, result.RootCerts[0])
+}
+
+func TestClusterConfig_TlsWithMultipleCertificates(t *testing.T) {
+	// Test with multiple certificates in PEM format (concatenated)
+	multiCertData := []byte(testCertData2 + testCertData3)
+
+	tlsConfig := NewTlsConfiguration().WithRootCertificates(multiCertData)
+	advancedConfig := NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClusterClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, result.TlsMode)
+	assert.NotNil(t, result.RootCerts)
+	assert.Equal(t, 1, len(result.RootCerts))
+	assert.Equal(t, multiCertData, result.RootCerts[0])
+}
+
+func TestConfig_TlsBackwardCompatibility(t *testing.T) {
+	// Test that existing TLS configurations without custom certificates still work
+	// This ensures backward compatibility
+
+	// Standalone client
+	standaloneConfig := NewClientConfiguration().WithUseTLS(true)
+	standaloneResult, err := standaloneConfig.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, standaloneResult.TlsMode)
+	assert.Nil(t, standaloneResult.RootCerts) // Should use platform verifier
+
+	// Cluster client
+	clusterConfig := NewClusterClientConfiguration().WithUseTLS(true)
+	clusterResult, err := clusterConfig.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, clusterResult.TlsMode)
+	assert.Nil(t, clusterResult.RootCerts) // Should use platform verifier
+}
+
+// ============================================================================
+// Insecure TLS Tests
+// ============================================================================
+
+func TestTlsConfiguration_WithInsecureTLS(t *testing.T) {
+	// Test enabling insecure TLS
+	tlsConfig := NewTlsConfiguration().WithInsecureTLS(true)
+
+	assert.NotNil(t, tlsConfig)
+	assert.True(t, tlsConfig.UseInsecureTLS)
+
+	// Test disabling insecure TLS
+	tlsConfig = NewTlsConfiguration().WithInsecureTLS(false)
+	assert.False(t, tlsConfig.UseInsecureTLS)
+}
+
+func TestStandaloneConfig_WithInsecureTLS(t *testing.T) {
+	// Test standalone client with insecure TLS
+	tlsConfig := NewTlsConfiguration().WithInsecureTLS(true)
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	request, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, request)
+	assert.Equal(t, protobuf.TlsMode_InsecureTls, request.TlsMode)
+}
+
+func TestClusterConfig_WithInsecureTLS(t *testing.T) {
+	// Test cluster client with insecure TLS
+	tlsConfig := NewTlsConfiguration().WithInsecureTLS(true)
+	advancedConfig := NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClusterClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	request, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, request)
+	assert.Equal(t, protobuf.TlsMode_InsecureTls, request.TlsMode)
+}
+
+func TestStandaloneConfig_InsecureTLSWithoutTLS(t *testing.T) {
+	// Test that insecure TLS fails when TLS is disabled
+	tlsConfig := NewTlsConfiguration().WithInsecureTLS(true)
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(false). // TLS disabled
+		WithAdvancedConfiguration(advancedConfig)
+
+	request, err := config.ToProtobuf()
+	assert.Error(t, err)
+	assert.Nil(t, request)
+	assert.Contains(t, err.Error(), "UseInsecureTLS cannot be enabled when UseTLS is disabled")
+}
+
+func TestClusterConfig_InsecureTLSWithoutTLS(t *testing.T) {
+	// Test that insecure TLS fails when TLS is disabled
+	tlsConfig := NewTlsConfiguration().WithInsecureTLS(true)
+	advancedConfig := NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClusterClientConfiguration().
+		WithUseTLS(false). // TLS disabled
+		WithAdvancedConfiguration(advancedConfig)
+
+	request, err := config.ToProtobuf()
+	assert.Error(t, err)
+	assert.Nil(t, request)
+	assert.Contains(t, err.Error(), "UseInsecureTLS cannot be enabled when UseTLS is disabled")
+}
+
+func TestTlsConfiguration_InsecureTLSWithRootCertificates(t *testing.T) {
+	// Test that insecure TLS can be combined with custom root certificates
+	certData := []byte(testCertData1)
+	tlsConfig := NewTlsConfiguration().
+		WithRootCertificates(certData).
+		WithInsecureTLS(true)
+
+	advancedConfig := NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig)
+
+	request, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, request)
+	assert.Equal(t, protobuf.TlsMode_InsecureTls, request.TlsMode)
+	assert.Len(t, request.RootCerts, 1)
+	assert.Equal(t, certData, request.RootCerts[0])
+}
+
+func TestStandaloneConfig_InsecureTLSFluentAPI(t *testing.T) {
+	// Test fluent API chaining with insecure TLS
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(
+			NewAdvancedClientConfiguration().
+				WithTlsConfiguration(
+					NewTlsConfiguration().WithInsecureTLS(true),
+				),
+		)
+
+	request, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, protobuf.TlsMode_InsecureTls, request.TlsMode)
+}
+
+func TestClusterConfig_InsecureTLSFluentAPI(t *testing.T) {
+	// Test fluent API chaining with insecure TLS for cluster
+	config := NewClusterClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(
+			NewAdvancedClusterClientConfiguration().
+				WithTlsConfiguration(
+					NewTlsConfiguration().WithInsecureTLS(true),
+				),
+		)
+
+	request, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, protobuf.TlsMode_InsecureTls, request.TlsMode)
+}
+
+func TestTlsConfiguration_InsecureTLSDefaultValue(t *testing.T) {
+	// Test that insecure TLS defaults to false
+	tlsConfig := NewTlsConfiguration()
+	assert.False(t, tlsConfig.UseInsecureTLS)
+
+	// Verify it results in SecureTls mode when TLS is enabled
+	config := NewClientConfiguration().
+		WithUseTLS(true).
+		WithAdvancedConfiguration(
+			NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig),
+		)
+
+	request, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, protobuf.TlsMode_SecureTls, request.TlsMode)
 }

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -218,6 +219,15 @@ func getServerVersion(suite *GlideTestSuite) string {
 			WithUseTLS(suite.tls).
 			WithRequestTimeout(5 * time.Second)
 
+		// If TLS is enabled, try to load custom certificates
+		if suite.tls {
+			if certData, certErr := loadCaCertificateForTests(); certErr == nil {
+				tlsConfig := config.NewTlsConfiguration().WithRootCertificates(certData)
+				advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+				clientConfig = clientConfig.WithAdvancedConfiguration(advancedConfig)
+			}
+		}
+
 		client, err := glide.NewClient(clientConfig)
 		if err == nil && client != nil {
 			defer client.Close()
@@ -239,6 +249,15 @@ func getServerVersion(suite *GlideTestSuite) string {
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
 		WithRequestTimeout(5 * time.Second)
+
+	// If TLS is enabled, try to load custom certificates
+	if suite.tls {
+		if certData, certErr := loadCaCertificateForTests(); certErr == nil {
+			tlsConfig := config.NewTlsConfiguration().WithRootCertificates(certData)
+			advancedConfig := config.NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+			clientConfig = clientConfig.WithAdvancedConfiguration(advancedConfig)
+		}
+	}
 
 	client, err := glide.NewClusterClient(clientConfig)
 	if err == nil && client != nil {
@@ -379,10 +398,21 @@ func (suite *GlideTestSuite) getTimeoutClients() []interfaces.BaseClientCommands
 }
 
 func (suite *GlideTestSuite) defaultClientConfig() *config.ClientConfiguration {
-	return config.NewClientConfiguration().
+	clientConfig := config.NewClientConfiguration().
 		WithAddress(&suite.standaloneHosts[0]).
 		WithUseTLS(suite.tls).
 		WithRequestTimeout(5 * time.Second)
+
+	// If TLS is enabled, try to load custom certificates
+	if suite.tls {
+		if certData, certErr := loadCaCertificateForTests(); certErr == nil {
+			tlsConfig := config.NewTlsConfiguration().WithRootCertificates(certData)
+			advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+			clientConfig = clientConfig.WithAdvancedConfiguration(advancedConfig)
+		}
+	}
+
+	return clientConfig
 }
 
 func (suite *GlideTestSuite) defaultClient() *glide.Client {
@@ -406,10 +436,21 @@ func (suite *GlideTestSuite) client(config *config.ClientConfiguration) (*glide.
 }
 
 func (suite *GlideTestSuite) defaultClusterClientConfig() *config.ClusterClientConfiguration {
-	return config.NewClusterClientConfiguration().
+	clientConfig := config.NewClusterClientConfiguration().
 		WithAddress(&suite.clusterHosts[0]).
 		WithUseTLS(suite.tls).
 		WithRequestTimeout(5 * time.Second)
+
+	// If TLS is enabled, try to load custom certificates
+	if suite.tls {
+		if certData, certErr := loadCaCertificateForTests(); certErr == nil {
+			tlsConfig := config.NewTlsConfiguration().WithRootCertificates(certData)
+			advancedConfig := config.NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+			clientConfig = clientConfig.WithAdvancedConfiguration(advancedConfig)
+		}
+	}
+
+	return clientConfig
 }
 
 func (suite *GlideTestSuite) defaultClusterClient() *glide.ClusterClient {
@@ -815,4 +856,22 @@ func getChannelMode(sharded bool) TestChannelMode {
 
 type PubSubQueuer interface {
 	GetQueue() (*glide.PubSubMessageQueue, error)
+}
+
+// loadCaCertificateForTests loads the CA certificate for TLS tests.
+// It looks for the certificate in the utils/tls_crts directory.
+// Returns the certificate data or an error if not found.
+func loadCaCertificateForTests() ([]byte, error) {
+	glideHome := os.Getenv("GLIDE_HOME_DIR")
+	if glideHome == "" {
+		glideHome = "../.."
+	}
+
+	caCertPath := filepath.Join(glideHome, "utils", "tls_crts", "ca.crt")
+	absPath, err := filepath.Abs(caCertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.LoadRootCertificatesFromFile(absPath)
 }

--- a/go/integTest/tls_test.go
+++ b/go/integTest/tls_test.go
@@ -1,0 +1,289 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+)
+
+// TestTlsWithoutCertificate_Standalone tests that connection fails without providing certificates
+func (suite *GlideTestSuite) TestTlsWithoutCertificate_Standalone() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&suite.standaloneHosts[0]).
+		WithUseTLS(true).
+		WithRequestTimeout(5 * time.Second)
+
+	_, err := glide.NewClient(clientConfig)
+	assert.Error(suite.T(), err, "Expected connection to fail without certificate")
+}
+
+// TestTlsWithSelfSignedCertificate_Standalone tests standalone client with custom root certificates
+func (suite *GlideTestSuite) TestTlsWithSelfSignedCertificate_Standalone() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	certData, err := getCaCertificate()
+	if err != nil {
+		suite.T().Skipf("CA certificate not found, skipping test: %v", err)
+	}
+
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(certData)
+	advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&suite.standaloneHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	client, err := glide.NewClient(clientConfig)
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), client)
+	defer client.Close()
+
+	result, err := client.Ping(context.Background())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "PONG", result)
+}
+
+// TestTlsWithMultipleCertificates_Standalone tests standalone client with multiple concatenated certificates
+func (suite *GlideTestSuite) TestTlsWithMultipleCertificates_Standalone() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	certData, err := getCaCertificate()
+	if err != nil {
+		suite.T().Skipf("CA certificate not found, skipping test: %v", err)
+	}
+
+	// Concatenate the same certificate twice to simulate multiple certificates
+	multipleCerts := append(certData, '\n')
+	multipleCerts = append(multipleCerts, certData...)
+
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(multipleCerts)
+	advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&suite.standaloneHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	client, err := glide.NewClient(clientConfig)
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), client)
+	defer client.Close()
+
+	result, err := client.Ping(context.Background())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "PONG", result)
+}
+
+// TestTlsWithoutCertificate_Cluster tests that connection fails without providing certificates
+func (suite *GlideTestSuite) TestTlsWithoutCertificate_Cluster() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	clientConfig := config.NewClusterClientConfiguration().
+		WithAddress(&suite.clusterHosts[0]).
+		WithUseTLS(true).
+		WithRequestTimeout(5 * time.Second)
+
+	_, err := glide.NewClusterClient(clientConfig)
+	assert.Error(suite.T(), err, "Expected connection to fail without certificate")
+}
+
+// TestTlsWithSelfSignedCertificate_Cluster tests cluster client with custom root certificates
+func (suite *GlideTestSuite) TestTlsWithSelfSignedCertificate_Cluster() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	certData, err := getCaCertificate()
+	if err != nil {
+		suite.T().Skipf("CA certificate not found, skipping test: %v", err)
+	}
+
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(certData)
+	advancedConfig := config.NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClusterClientConfiguration().
+		WithAddress(&suite.clusterHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), client)
+	defer client.Close()
+
+	result, err := client.Ping(context.Background())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "PONG", result)
+}
+
+// TestTlsWithMultipleCertificates_Cluster tests cluster client with multiple concatenated certificates
+func (suite *GlideTestSuite) TestTlsWithMultipleCertificates_Cluster() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	certData, err := getCaCertificate()
+	if err != nil {
+		suite.T().Skipf("CA certificate not found, skipping test: %v", err)
+	}
+
+	// Concatenate the same certificate twice to simulate multiple certificates
+	multipleCerts := append(certData, '\n')
+	multipleCerts = append(multipleCerts, certData...)
+
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(multipleCerts)
+	advancedConfig := config.NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClusterClientConfiguration().
+		WithAddress(&suite.clusterHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	require.NoError(suite.T(), err)
+	require.NotNil(suite.T(), client)
+	defer client.Close()
+
+	result, err := client.Ping(context.Background())
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "PONG", result)
+}
+
+// TestTlsWithEmptyCertificate_Standalone tests that empty certificate array returns an error
+func (suite *GlideTestSuite) TestTlsWithEmptyCertificate_Standalone() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	emptyCerts := []byte{}
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(emptyCerts)
+	advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&suite.standaloneHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	_, err := glide.NewClient(clientConfig)
+	assert.Error(suite.T(), err)
+}
+
+// TestTlsWithEmptyCertificate_Cluster tests that empty certificate array returns an error
+func (suite *GlideTestSuite) TestTlsWithEmptyCertificate_Cluster() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	emptyCerts := []byte{}
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(emptyCerts)
+	advancedConfig := config.NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClusterClientConfiguration().
+		WithAddress(&suite.clusterHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	_, err := glide.NewClusterClient(clientConfig)
+	assert.Error(suite.T(), err)
+}
+
+// TestTlsWithInvalidCertificate_Standalone tests that invalid certificate returns an error
+func (suite *GlideTestSuite) TestTlsWithInvalidCertificate_Standalone() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	invalidCert := []byte("-----BEGIN CERTIFICATE-----\nINVALID\n-----END CERTIFICATE-----")
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(invalidCert)
+	advancedConfig := config.NewAdvancedClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&suite.standaloneHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	_, err := glide.NewClient(clientConfig)
+	assert.Error(suite.T(), err)
+}
+
+// TestTlsWithInvalidCertificate_Cluster tests that invalid certificate returns an error
+func (suite *GlideTestSuite) TestTlsWithInvalidCertificate_Cluster() {
+	if !suite.tls {
+		suite.T().Skip("TLS is not enabled, skipping TLS tests")
+	}
+
+	invalidCert := []byte("-----BEGIN CERTIFICATE-----\nINVALID\n-----END CERTIFICATE-----")
+	tlsConfig := config.NewTlsConfiguration().WithRootCertificates(invalidCert)
+	advancedConfig := config.NewAdvancedClusterClientConfiguration().WithTlsConfiguration(tlsConfig)
+
+	clientConfig := config.NewClusterClientConfiguration().
+		WithAddress(&suite.clusterHosts[0]).
+		WithUseTLS(true).
+		WithAdvancedConfiguration(advancedConfig).
+		WithRequestTimeout(5 * time.Second)
+
+	_, err := glide.NewClusterClient(clientConfig)
+	assert.Error(suite.T(), err)
+}
+
+// TestTlsLoadCertificateFromFile tests the LoadRootCertificatesFromFile helper function
+func (suite *GlideTestSuite) TestTlsLoadCertificateFromFile() {
+	certData, err := getCaCertificate()
+	if err != nil {
+		suite.T().Skipf("CA certificate not found, skipping test: %v", err)
+	}
+
+	// Test successful certificate loading
+	assert.NotEmpty(suite.T(), certData)
+	assert.Contains(suite.T(), string(certData), "BEGIN CERTIFICATE")
+
+	// Test loading non-existent file
+	_, err = config.LoadRootCertificatesFromFile("/nonexistent/path/cert.pem")
+	assert.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "failed to read certificate file")
+}
+
+// getCaCertificate returns the CA certificate bytes in PEM format.
+// It looks for the certificate in the utils/tls_crts directory.
+func getCaCertificate() ([]byte, error) {
+	// Try to get GLIDE_HOME_DIR from environment, otherwise use relative path
+	glideHome := os.Getenv("GLIDE_HOME_DIR")
+	if glideHome == "" {
+		// Default to ../../ from the integTest directory
+		glideHome = "../.."
+	}
+
+	caCertPath := filepath.Join(glideHome, "utils", "tls_crts", "ca.crt")
+	absPath, err := filepath.Abs(caCertPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.LoadRootCertificatesFromFile(absPath)
+}


### PR DESCRIPTION
## Overview

This PR adds support for custom root certificates in TLS connections for the Go client, enabling connections to Valkey/Redis servers with self-signed certificates or custom certificate authorities.

## Changes

### Core Implementation

**New TLS Configuration API:**
- `TlsConfiguration` struct with `RootCertificates` field for PEM-encoded certificate data
- `NewTlsConfiguration()` constructor with default settings (uses platform verifier)
- `WithRootCertificates([]byte)` method for setting custom certificates
- `LoadRootCertificatesFromFile(path)` helper function for loading certificates from disk

**Configuration Integration:**
- Added `tlsConfig` field to `AdvancedClientConfiguration` (standalone)
- Added `tlsConfig` field to `AdvancedClusterClientConfiguration` (cluster)
- Added `WithTlsConfiguration()` methods to both advanced configuration types
- Updated `ToProtobuf()` methods to serialize custom certificates to protobuf


### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/500

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
