### PR TITLE
Fix java benchmark hanging after completion

### DIFF
--- a/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
@@ -60,6 +60,7 @@ public class BenchmarkingApp {
                     break;
             }
         }
+        System.exit(0);
     }
 
     private static Options getOptions() {


### PR DESCRIPTION
Add in System.exit(0) to force JVM termination after benchmark completion

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
