### PR TITLE
Enabling cluster commands in request_type file

### DIFF
--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -718,7 +718,9 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ClusterAddSlots => RequestType::ClusterAddSlots,
             ProtobufRequestType::ClusterAddSlotsRange => RequestType::ClusterAddSlotsRange,
             ProtobufRequestType::ClusterBumpEpoch => RequestType::ClusterBumpEpoch,
-            ProtobufRequestType::ClusterCountFailureReports => RequestType::ClusterCountFailureReports,
+            ProtobufRequestType::ClusterCountFailureReports => {
+                RequestType::ClusterCountFailureReports
+            }
             ProtobufRequestType::ClusterCountKeysInSlot => RequestType::ClusterCountKeysInSlot,
             ProtobufRequestType::ClusterDelSlots => RequestType::ClusterDelSlots,
             ProtobufRequestType::ClusterDelSlotsRange => RequestType::ClusterDelSlotsRange,
@@ -744,7 +746,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ClusterSlots => RequestType::ClusterSlots,
             ProtobufRequestType::ReadOnly => RequestType::ReadOnly,
             ProtobufRequestType::ReadWrite => RequestType::ReadWrite,
-            
+
             _ => todo!(),
         }
     }
@@ -1028,16 +1030,26 @@ impl RequestType {
             RequestType::ModuleUnload => Some(get_two_word_command("MODULE", "UNLOAD")),
             RequestType::Asking => Some(cmd("ASKING")),
             RequestType::ClusterAddSlots => Some(get_two_word_command("CLUSTER", "ADDSLOTS")),
-            RequestType::ClusterAddSlotsRange => Some(get_two_word_command("CLUSTER", "ADDSLOTSRANGE")),
+            RequestType::ClusterAddSlotsRange => {
+                Some(get_two_word_command("CLUSTER", "ADDSLOTSRANGE"))
+            }
             RequestType::ClusterBumpEpoch => Some(get_two_word_command("CLUSTER", "BUMPEPOCH")),
-            RequestType::ClusterCountFailureReports => Some(get_two_word_command("CLUSTER", "COUNT-FAILURE-REPORTS")),
-            RequestType::ClusterCountKeysInSlot => Some(get_two_word_command("CLUSTER", "COUNTKEYSINSLOT")),
+            RequestType::ClusterCountFailureReports => {
+                Some(get_two_word_command("CLUSTER", "COUNT-FAILURE-REPORTS"))
+            }
+            RequestType::ClusterCountKeysInSlot => {
+                Some(get_two_word_command("CLUSTER", "COUNTKEYSINSLOT"))
+            }
             RequestType::ClusterDelSlots => Some(get_two_word_command("CLUSTER", "DELSLOTS")),
-            RequestType::ClusterDelSlotsRange => Some(get_two_word_command("CLUSTER", "DELSLOTSRANGE")),
+            RequestType::ClusterDelSlotsRange => {
+                Some(get_two_word_command("CLUSTER", "DELSLOTSRANGE"))
+            }
             RequestType::ClusterFailover => Some(get_two_word_command("CLUSTER", "FAILOVER")),
             RequestType::ClusterFlushSlots => Some(get_two_word_command("CLUSTER", "FLUSHSLOTS")),
             RequestType::ClusterForget => Some(get_two_word_command("CLUSTER", "FORGET")),
-            RequestType::ClusterGetKeysInSlot => Some(get_two_word_command("CLUSTER", "GETKEYSINSLOT")),
+            RequestType::ClusterGetKeysInSlot => {
+                Some(get_two_word_command("CLUSTER", "GETKEYSINSLOT"))
+            }
             RequestType::ClusterInfo => Some(get_two_word_command("CLUSTER", "INFO")),
             RequestType::ClusterKeySlot => Some(get_two_word_command("CLUSTER", "KEYSLOT")),
             RequestType::ClusterLinks => Some(get_two_word_command("CLUSTER", "LINKS")),
@@ -1049,13 +1061,15 @@ impl RequestType {
             RequestType::ClusterReplicate => Some(get_two_word_command("CLUSTER", "REPLICATE")),
             RequestType::ClusterReset => Some(get_two_word_command("CLUSTER", "RESET")),
             RequestType::ClusterSaveConfig => Some(get_two_word_command("CLUSTER", "SAVECONFIG")),
-            RequestType::ClusterSetConfigEpoch => Some(get_two_word_command("CLUSTER", "SET-CONFIG-EPOCH")),
+            RequestType::ClusterSetConfigEpoch => {
+                Some(get_two_word_command("CLUSTER", "SET-CONFIG-EPOCH"))
+            }
             RequestType::ClusterSetslot => Some(get_two_word_command("CLUSTER", "SETSLOT")),
             RequestType::ClusterShards => Some(get_two_word_command("CLUSTER", "SHARDS")),
             RequestType::ClusterSlaves => Some(get_two_word_command("CLUSTER", "SLAVES")),
             RequestType::ClusterSlots => Some(get_two_word_command("CLUSTER", "SLOTS")),
             RequestType::ReadOnly => Some(cmd("READONLY")),
-            RequestType::ReadWrite => Some(cmd("READWRITE")), 
+            RequestType::ReadWrite => Some(cmd("READWRITE")),
             _ => todo!(),
         }
     }


### PR DESCRIPTION
<!--

Thanks for contributing to Valkey GLIDE!



Please make sure you are aware of our contributing guidelines [available

here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)



-->



### Issue link



This Pull Request is linked to issue (URL): [#5005](https://github.com/valkey-io/valkey-glide/issues/5005)



### Description



This PR implements support for all CLUSTER commands in the `get_command()` method and the protobuf conversion layer. Previously, these commands were defined in the `RequestType` enum but were not implemented, causing panics when attempting to use them.



**Commands Implemented:**

- ASKING
- CLUSTER ADDSLOTS
- CLUSTER ADDSLOTSRANGE
- CLUSTER BUMPEPOCH
- CLUSTER COUNT-FAILURE-REPORTS
- CLUSTER COUNTKEYSINSLOT
- CLUSTER DELSLOTS
- CLUSTER DELSLOTSRANGE
- CLUSTER FAILOVER
- CLUSTER FLUSHSLOTS
- CLUSTER FORGET
- CLUSTER GETKEYSINSLOT
- CLUSTER INFO
- CLUSTER KEYSLOT
- CLUSTER LINKS
- CLUSTER MEET
- CLUSTER MYID
- CLUSTER MYSHARDID
- CLUSTER NODES
- CLUSTER REPLICAS
- CLUSTER REPLICATE
- CLUSTER RESET
- CLUSTER SAVECONFIG
- CLUSTER SET-CONFIG-EPOCH
- CLUSTER SETSLOT
- CLUSTER SHARDS
- CLUSTER SLAVES
- CLUSTER SLOTS
- READONLY
- READWRITE



**Changes Made:**

1. Added implementations in `get_command()` method for all CLUSTER command variants using `get_two_word_command("CLUSTER", <subcommand>)` for multi-word commands and `cmd("<command>")` for single-word commands (ASKING, READONLY, READWRITE).

2. Added mappings in the `From<ProtobufRequestType>` implementation to convert protobuf enum variants to Rust `RequestType` enum variants.



**Impact:**

This fix enables all language bindings (Java, Python, Node.js, Go) to use CLUSTER commands through the FFI layer without panicking. These commands are essential for cluster management, topology discovery, and cluster administration operations.



### Checklist



Before submitting the PR make sure the following are checked:



-   [x] This Pull Request is related to one issue.

-   [x] Commit message has a detailed description of what changed and why.

-   [ ] Tests are added or updated.

-   [ ] CHANGELOG.md and documentation files are updated.

-   [x] Destination branch is correct - main or release

-   [ ] Create merge commit if merging release branch into main, squash otherwise.

