### PR TITLE
Docs: Add missing references to windows-x86_64 classifier

### DIFF
--- a/java/AGENTS.md
+++ b/java/AGENTS.md
@@ -29,7 +29,14 @@ This is the Java client binding for Valkey GLIDE, providing both standalone and 
 - macOS: 13.7+ (x86_64), 14.7+ (aarch64)
 - **Note:** Alpine Linux/MUSL not supported due to native Java component incompatibility
 
-**Classifiers Available:** `osx-aarch_64`, `osx-x86_64`, `linux-aarch_64`, `linux-x86_64`, `linux_musl-aarch_64`, `linux_musl-x86_64`
+**Classifiers Available:**
+- `osx-aarch_64`
+- `osx-x86_64`
+- `linux-aarch_64`
+- `linux-x86_64`
+- `linux_musl-aarch_64`
+- `linux_musl-x86_64`
+- `windows-x86_64`
 
 ## Build and Test Rules (Agents)
 

--- a/java/README.md
+++ b/java/README.md
@@ -66,6 +66,7 @@ linux-aarch_64
 linux-x86_64
 linux_musl-aarch_64
 linux_musl-x86_64
+windows-x86_64
 ```
 
 Gradle:
@@ -100,6 +101,11 @@ dependencies {
 // linux_musl-x86_64
 dependencies {
     implementation group: 'io.valkey', name: 'valkey-glide', version: '1.+', classifier: 'linux_musl-x86_64'
+}
+
+// windows-x86_64
+dependencies {
+    implementation group: 'io.valkey', name: 'valkey-glide', version: '1.+', classifier: 'windows-x86_64'
 }
 
 // with osdetector - does not work for musl
@@ -163,6 +169,14 @@ Maven:
    <version>[1.0.0,)</version>
 </dependency>
 
+<!-- windows-x86_64 -->
+<dependency>
+   <groupId>io.valkey</groupId>
+   <artifactId>valkey-glide</artifactId>
+   <classifier>windows-x86_64</classifier>
+   <version>[1.0.0,)</version>
+</dependency>
+
 <!-- with os-maven-plugin -->
 <build>
     <extensions>
@@ -202,6 +216,9 @@ libraryDependencies += "io.valkey" % "valkey-glide" % "1.+" classifier "linux_mu
 
 // linux_musl-x86_64
 libraryDependencies += "io.valkey" % "valkey-glide" % "1.+" classifier "linux_musl-x86_64"
+
+// windows-x86_64
+libraryDependencies += "io.valkey" % "valkey-glide" % "1.+" classifier "windows-x86_64"
 ```
 
 ## Setting up the Java module
@@ -358,4 +375,4 @@ The following arguments are accepted:
 * `tls`: Valkey TLS configured
 
 ### Known issues
-* Conflict in netty and protobuf internal valkey glide dependencies with project dependencies using valkey glide. Issue link: https://github.com/valkey-io/valkey-glide/issues/3402. Workarounds mentioned in this issue: https://github.com/valkey-io/valkey-glide/issues/3367 
+* Conflict in netty and protobuf internal valkey glide dependencies with project dependencies using valkey glide. Issue link: https://github.com/valkey-io/valkey-glide/issues/3402. Workarounds mentioned in this issue: https://github.com/valkey-io/valkey-glide/issues/3367


### PR DESCRIPTION
Update Java documentation to mention the windows-x86_64 classifier.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/5036

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
