### PR TITLE
Java: Change gradle to use JAVA_HOME when available (#5040)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Core/Java/Node: Fix default connection timeout value for clients ([#4966](https://github.com/valkey-io/valkey-glide/pull/4966))
 * JAVA: Fix java applications from hanging after logic completion ([#4984](https://github.com/valkey-io/valkey-glide/pull/4984))
 * JAVA: Fix classloader issues in JNI method caching ([#5029](https://github.com/valkey-io/valkey-glide/pull/5029))
+* JAVA: Fix Gradle toolchain provisioning conflicts on Windows self-hosted runners
 
 #### Operational Enhancements
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -55,8 +55,9 @@ subprojects {
     java {
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(11))
-            // Only specify vendor for non-container environments to allow flexibility in CI containers
-            if (!System.getenv("GLIDE_CONTAINER_BUILD")) {
+            // Only specify vendor when no JAVA_HOME is set (i.e., no setup-java used)
+            if (!System.getenv("GLIDE_CONTAINER_BUILD") && 
+                !System.getenv("JAVA_HOME")) {
                 vendor = JvmVendorSpec.ADOPTIUM // Temurin
             }
         }


### PR DESCRIPTION
* Change gradle to use JAVA_HOME when available

Use JAVA_HOME instead of auto-provisioning for non-container builds. This fixes issues with the Windows self-hosted runner.

---------

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Issue link

This Pull Request is linked to issue (URL): #5039 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
