### PR TITLE
Fix for Nodetest failures: make type `Buffer` explicit

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1264,7 +1264,7 @@ export class BaseClient {
             options?.requestTimeout ?? DEFAULT_REQUEST_TIMEOUT_IN_MILLISECONDS;
         this.socket = socket;
         this.socket
-            .on("data", (data) => this.handleReadData(data))
+            .on("data", (data) => this.handleReadData(data as Buffer))
             .on("error", (err) => {
                 console.error(`Server closed: ${err}`);
                 this.close();

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -142,7 +142,7 @@ function getConnectionAndSocket(
         let connectionPromise: Promise<GlideClient | GlideClusterClient>; // eslint-disable-line prefer-const
         const server = net
             .createServer(async (socket) => {
-                socket.once("data", (data) => {
+                socket.once("data", (data: Buffer) => {
                     const reader = Reader.create(data);
                     const request =
                         connection_request.ConnectionRequest.decodeDelimited(
@@ -244,7 +244,7 @@ async function testSentValueMatches(config: {
 }) {
     let counter = 0;
     await testWithResources(async (connection, socket) => {
-        socket.on("data", (data) => {
+        socket.on("data", (data: Buffer) => {
             const reader = Reader.create(data);
             const request =
                 command_request.CommandRequest.decodeDelimited(reader);
@@ -293,7 +293,7 @@ describe("SocketConnectionInternals", () => {
             expected: GlideReturnType, // value received from rust
         ) => {
             await testWithResources(async (connection, socket) => {
-                socket.once("data", (data) => {
+                socket.once("data", (data: Buffer) => {
                     const reader = Reader.create(data);
                     const request = CommandRequest.decodeDelimited(reader);
                     expect(request.singleCommand?.requestType).toEqual(
@@ -372,7 +372,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should pass null returned from socket", async () => {
         await testWithResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
@@ -391,7 +391,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should pass transaction (deprecated) with SlotKeyType", async () => {
         await testWithClusterResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
 
@@ -423,7 +423,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should pass transaction (deprecated) with random node", async () => {
         await testWithClusterResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
 
@@ -453,7 +453,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should pass batch with all params", async () => {
         await testWithClusterResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
 
@@ -490,7 +490,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should pass OK returned from socket", async () => {
         await testWithResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
@@ -510,7 +510,7 @@ describe("SocketConnectionInternals", () => {
     it("should reject requests that received a response error", async () => {
         await testWithResources(async (connection, socket) => {
             const error = "check";
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
@@ -535,7 +535,7 @@ describe("SocketConnectionInternals", () => {
     it("should close all requests when receiving a closing error", async () => {
         await testWithResources(async (connection, socket) => {
             const error = "check";
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
@@ -562,7 +562,7 @@ describe("SocketConnectionInternals", () => {
     it("should fail all requests when receiving a closing error with an unknown callback index", async () => {
         await testWithResources(async (connection, socket) => {
             const error = "check";
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request =
                     command_request.CommandRequest.decodeDelimited(reader);
@@ -586,7 +586,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should pass SET arguments", async () => {
         await testWithResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request = CommandRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
@@ -619,7 +619,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should send pointer for request with large size arguments", async () => {
         await testWithResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request =
                     command_request.CommandRequest.decodeDelimited(reader);
@@ -640,7 +640,7 @@ describe("SocketConnectionInternals", () => {
 
     it("should send vector of strings for request with small size arguments", async () => {
         await testWithResources(async (connection, socket) => {
-            socket.once("data", (data) => {
+            socket.once("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request =
                     command_request.CommandRequest.decodeDelimited(reader);
@@ -733,7 +733,7 @@ describe("SocketConnectionInternals", () => {
             key: "foo",
         };
         await testWithClusterResources(async (connection, socket) => {
-            socket.on("data", (data) => {
+            socket.on("data", (data: Buffer) => {
                 const reader = Reader.create(data);
                 const request =
                     command_request.CommandRequest.decodeDelimited(reader);


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

[A recent change in @nodes/type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/45aa16796155f951c4ed6751bb81a7360bdc4fb7/types/node/net.d.ts#L79) changed a type in the Socket API to be `string | NonSharedBuffer` vs. previous type of just `NonSharedBuffer`.

This lead to failures in CI as we are now pulling the new version. 
```
src/BaseClient.ts:1267:55 - error TS2345: Argument of type 'string | NonSharedBuffer' is not assignable to parameter of type 'Buffer'.
  Type 'string' is not assignable to type 'Uint8Array<ArrayBufferLike>'.

1267             .on("data", (data) => this.handleReadData(data))
                                                           ~~~~

Found 1 error in src/BaseClient.ts:1267
```

Since we never set an encoding on the socket, it always emits Buffer.
Added explicit type assertion to resolve the type mismatch.

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
