### PR TITLE
[Python] Fix flaky test `test_zscan` assertion logic #4952

### DIFF
--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -10426,11 +10426,8 @@ class TestClusterRoutes:
             assert result[result_cursor_index] != b"0"
             values_array = cast(List[bytes], result[result_collection_index])
             # Verify that scores are not included
-            valid_char_keys = {b"a", b"b", b"c", b"d", b"e"}
             assert all(
-                (item.startswith(b"value") or item in valid_char_keys)
-                and item.isascii()
-                for item in values_array
+                item.startswith(b"value") and item.isascii() for item in values_array
             )
 
         # Exceptions

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -10229,11 +10229,8 @@ class TestClusterRoutes:
             assert result[result_cursor_index] != b"0"
             values_array = cast(List[bytes], result[result_collection_index])
             # Verify that scores are not included
-            valid_char_keys = {b"a", b"b", b"c", b"d", b"e"}
             assert all(
-                (item.startswith(b"value") or item in valid_char_keys)
-                and item.isascii()
-                for item in values_array
+                item.startswith(b"value") and item.isascii() for item in values_array
             )
 
         # Exceptions


### PR DESCRIPTION
### Description
This PR addresses the flakiness observed in `test_zscan` and `test_sync_zscan`.
The test seeds the database with two sets of data: a `char_map` (keys: 'a', 'b', 'c'...) and a large `num_map` (keys: 'value 0', 'value 1'...).
The previous assertion strictly required all items returned by `zscan` to start with `"value"`. However, since `zscan` iterates through the set, it occasionally returns items from the `char_map`. When this happened, the strict assertion caused the test to fail incorrectly.

### Solution
Updated the logic of zscan to only match results starting with value

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4952