### PR TITLE
Cherry-pick from 2.2: Node: Fix build time type error #5052

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -88,6 +88,7 @@
         "@jest/globals": "29",
         "@types/jest": "29",
         "@types/minimist": "1",
+        "@types/node": "24",
         "@types/semver": "7",
         "@types/uuid": "11",
         "find-free-port": "2",


### PR DESCRIPTION
### Issue link

This Pull Request is linked to issue: [Node: Fix build time type error #5052](https://github.com/valkey-io/valkey-glide/pull/5052)

This is to cherry-pick PR for the changes added to the `release-2.2` branch to help fix the Node build time type error

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
