### PR TITLE
Fix the skip for unsupported HGETDEL test

### DIFF
--- a/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
@@ -2113,6 +2113,7 @@ public class JedisTest {
 
     @Test
     @Disabled("HGETDEL command is currently unsupported")
+    // Keep this disabled until https://github.com/valkey-io/valkey-glide/issues/5069 is completed
     void hgetdel_command() {
 
         String key = UUID.randomUUID().toString();
@@ -2480,7 +2481,7 @@ public class JedisTest {
     }
 
     @Test
-    void hash_commands_binary_newer() {
+    void hash_commands_binary_hsetex_hgetex() {
         // Hash field expiration commands (HSETEX, HGETEX) are available in Valkey 9.0.0+
         assumeTrue(
                 SERVER_VERSION.isGreaterThanOrEqualTo("9.0.0"),
@@ -2515,6 +2516,7 @@ public class JedisTest {
 
     @Test
     @Disabled("HGETDEL command is currently unsupported")
+    // Keep this disabled until https://github.com/valkey-io/valkey-glide/issues/5069 is completed
     void hash_commands_binary_hgetdel() {
 
         byte[] key = (UUID.randomUUID().toString()).getBytes();


### PR DESCRIPTION
Valkey released version 9.0.1 with their latest tag. The integration tests are pulling the latest version from the main Valkey repo, causing the unsupported tests to not be skipped.

The `HGETDEL` tests are normally skipped with a check to see if the Valkey version is Greater than 9. With the new Valkey release this is not true anymore, hence the failing of the tests

This issue is also preventing new PRs from being merged


Valkey does not currently support the `HGETDEL` command. Search for it here: https://valkey.io/commands/

### Issue link

This Pull Request is linked to issue:
- [[Java][Flaky Test] compatibility.jedis.JedisTest.hash_commands_binary_newer() #5060](https://github.com/valkey-io/valkey-glide/issues/5060)
- [[Java][Flaky Test] compatibility.jedis.JedisTest.hgetdel_command() #5059](https://github.com/valkey-io/valkey-glide/issues/5059)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
