### PR TITLE
feat(go): enable go mod vendor support via CI generation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,6 @@ Before submitting the PR make sure the following are checked:
 -   [ ] Commit message has a detailed description of what changed and why.
 -   [ ] Tests are added or updated.
 -   [ ] CHANGELOG.md and documentation files are updated.
+-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
 -   [ ] Destination branch is correct - main or release
 -   [ ] Create merge commit if merging release branch into main, squash otherwise.

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -154,11 +154,61 @@ jobs:
             - name: Copy generated files to repo
               run: |
                   cd artifacts
+
+                  # Collect all platforms for tools.go generation
+                  PLATFORMS=()
+
                   for dir in */; do
                     target_name=${dir%/}
+                    PLATFORMS+=("$target_name")
+                    
                     mkdir -p $GITHUB_WORKSPACE/go/rustbin/${target_name}
                     cp ${target_name}/ffi/target/release/libglide_ffi.a $GITHUB_WORKSPACE/go/rustbin/${target_name}/
+                    
+                    # Create doc.go marker file for vendoring support
+                    # Convert platform name to valid Go package name (hyphens to underscores)
+                    package_name="rustbin_${target_name//-/_}"
+                    
+                    cat > "$GITHUB_WORKSPACE/go/rustbin/${target_name}/doc.go" << EOF
+                  // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+                  // Package ${package_name} exists solely to ensure this directory is included
+                  // when using 'go mod vendor'.
+                  //
+                  // This directory contains libglide_ffi.a, the precompiled Rust FFI library
+                  // for the ${target_name} target.
+                  //
+                  // DO NOT IMPORT THIS PACKAGE. It contains no usable Go code and is never
+                  // compiled into binaries. This file only exists to make the directory a valid
+                  // Go package for vendoring purposes.
+                  //
+                  // See: https://github.com/valkey-io/valkey-glide/issues/4721
+                  package ${package_name}
+                  EOF
                   done
+
+                  # Generate tools.go to import all platform packages for vendoring
+                  cat > "$GITHUB_WORKSPACE/go/tools.go" << 'EOF'
+                  //go:build tools
+
+                  package glide
+
+                  // This file ensures rustbin platform directories are included when using 'go mod vendor'.
+                  //
+                  // This file is AUTO-GENERATED during releases. Do not edit manually.
+                  // It forces vendoring to include all platform-specific rustbin packages.
+                  //
+                  // See: https://github.com/valkey-io/valkey-glide/issues/4721
+                  import (
+                  EOF
+
+                  # Add imports for each platform
+                  for platform in "${PLATFORMS[@]}"; do
+                    echo "	_ \"github.com/valkey-io/valkey-glide/go/v2/rustbin/${platform}\"" >> "$GITHUB_WORKSPACE/go/tools.go"
+                  done
+
+                  echo ")" >> "$GITHUB_WORKSPACE/go/tools.go"
+
                   # TODO: move generation of protobuf and header file to a non-matrix step
                   cd x86_64-unknown-linux-gnu
                   cp go/lib.h $GITHUB_WORKSPACE/go/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * JAVA: Add IAM authentication support for ElastiCache/MemoryDB ([#4891](https://github.com/valkey-io/valkey-glide/pull/4891/))
 * FFI/GO: Add IAM authentication support with automatic token refresh ([#4892](https://github.com/valkey-io/valkey-glide/pull/4892))
 * GO: Add TLS Custom Root Certificate Support for Go Client ([#4921](https://github.com/valkey-io/valkey-glide/pull/4921))
+* GO: Enable `go mod vendor` support via CI-generated marker files ([#4721](https://github.com/valkey-io/valkey-glide/issues/4721))
 * Python: Add Custom Root Certificate Support for Python TLS Connections ([#4930](https://github.com/valkey-io/valkey-glide/pull/4930))
 * Python: Add Python 3.14 support ([#4897](https://github.com/valkey-io/valkey-glide/pull/4897))
 * JAVA: Implement TLS support for Java client ([#4905](https://github.com/valkey-io/valkey-glide/pull/4905))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all java java-test python python-test node node-test check-valkey-server go go-test
+.PHONY: all java java-test python python-test node node-test check-valkey-server go go-test prettier-check prettier-fix
 
 BLUE=\033[34m
 YELLOW=\033[33m
@@ -62,6 +62,23 @@ node-test: .build/node_deps check-valkey-server
 node-lint: .build/node_deps
 	@echo "$(GREEN)Running linters for NodeJS$(RESET)"
 	@cd node && npx run lint:fix
+
+##
+## Prettier targets
+##
+prettier-check:
+	@echo "$(GREEN)Checking formatting with Prettier$(RESET)"
+	@npx prettier --check .github/
+	@for folder in node benchmarks/node benchmarks/utilities; do \
+		npx prettier --check $$folder; \
+	done
+
+prettier-fix:
+	@echo "$(GREEN)Fixing formatting with Prettier$(RESET)"
+	@npx prettier --write .github/
+	@for folder in node benchmarks/node benchmarks/utilities; do \
+		npx prettier --write $$folder; \
+	done
 
 ##
 ## Go targets

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -15,4 +15,8 @@ benchmarks/gobenchmarks.json
 benchmarks/benchmarks
 
 # directory where compiled static library files are copied to
+# This entire directory is generated during releases and force-added via 'git add -f go'
 rustbin/
+
+# tools.go is auto-generated during releases for vendoring support
+tools.go


### PR DESCRIPTION
This change enables auto-generating marker files during releases, allowing 'go mod vendor' to work without manual intervention.

Implementation:
- Update `.gitignore` to ignore `tools.go`
- Modify `go-cd.yml` to generate `doc.go` for each platform during release
- Modify `go-cd.yml` to generate `tools.go` with all platform imports

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/4721

### Checklist

Before submitting the PR make sure the following are checked:

-   [X] This Pull Request is related to one issue.
-   [X] Commit message has a detailed description of what changed and why.
-   [N/A] Tests are added or updated.
-   [X] CHANGELOG.md and documentation files are updated.
-   [X] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [X] Destination branch is correct - main or release
-   [X] Create merge commit if merging release branch into main, squash otherwise.
