### PR TITLE
[Java] Unshadow commons-lang3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+* JAVA: Unshadow Apache Commons Lang3 to avoid failures due to dependency conflicts
+
 ## 2.2.2
 
 #### Security Fixes

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'io.freefair.lombok' version '8.6'
     id 'com.github.spotbugs' version '6.4.2'
     id 'com.google.osdetector' version '1.7.3'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '9.1.0'
 }
 
 repositories {
@@ -24,9 +24,15 @@ tasks.withType(Javadoc) {
     options.docEncoding = 'UTF-8'
 }
 
+
+configurations {
+    testImplementation { extendsFrom shadow }
+}
+
 dependencies {
     implementation group: 'com.google.protobuf', name:'protobuf-java', version: '4.29.1'
-    api group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
+
+    shadow group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
 
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.6'
 
@@ -195,8 +201,7 @@ tasks.register('sourcesJar', Jar) {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            // Use shadowJar instead of regular jar
-            artifact shadowJar
+            from components.shadow
             artifact tasks.named('javadocJar')
             artifact tasks.named('sourcesJar')
             groupId = 'io.valkey'


### PR DESCRIPTION
### Problem
commons-lang3 is currently shadowed inappropraitely, causing classpath conflicts in consuming applications.

This is evidenced by counting the number of classes with `org/apache/commons/lang3` in their path:
```
$ unzip -l valkey-glide-2.1.1-linux-x86_64.jar | grep org/apache/commons/lang3 | wc -l
0

$ unzip -l valkey-glide-2.2.0-linux-x86_64.jar | grep org/apache/commons/lang3 | wc -l
0

$ unzip -l valkey-glide-2.2.1-linux-x86_64.jar | grep org/apache/commons/lang3 | wc -l
0

$ unzip -l valkey-glide-2.2.2-linux-x86_64.jar | grep org/apache/commons/lang3 | wc -l
439
```

Inside the POMs you can see the `commons-lang3` dependency get lost between [2.2.1](https://central.sonatype.com/artifact/io.valkey/valkey-glide/2.2.1) and [2.2.2](https://central.sonatype.com/artifact/io.valkey/valkey-glide/2.2.2).

### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/5073

### Changes
* Reverted back to **not** shadowing commons-lang3
  * Confusingly, the `shadow` configuration communicates to gradle shadow to **not** shadow the dependency
* Updated back to the never version of the gradle shaodw plugin -- `com.github.johnrengelman.shadow` has moved to `com.gradleup.shadow`

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
