### PR TITLE
Cherry pick 5062 to release 2.2

### DIFF
--- a/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/JedisTest.java
@@ -2113,6 +2113,7 @@ public class JedisTest {
 
     @Test
     @Disabled("HGETDEL command is currently unsupported")
+    // Keep this disabled until https://github.com/valkey-io/valkey-glide/issues/5069 is completed
     void hgetdel_command() {
 
         String key = UUID.randomUUID().toString();
@@ -2480,7 +2481,7 @@ public class JedisTest {
     }
 
     @Test
-    void hash_commands_binary_newer() {
+    void hash_commands_binary_hsetex_hgetex() {
         // Hash field expiration commands (HSETEX, HGETEX) are available in Valkey 9.0.0+
         assumeTrue(
                 SERVER_VERSION.isGreaterThanOrEqualTo("9.0.0"),
@@ -2515,6 +2516,7 @@ public class JedisTest {
 
     @Test
     @Disabled("HGETDEL command is currently unsupported")
+    // Keep this disabled until https://github.com/valkey-io/valkey-glide/issues/5069 is completed
     void hash_commands_binary_hgetdel() {
 
         byte[] key = (UUID.randomUUID().toString()).getBytes();


### PR DESCRIPTION
Cherry-pick the disabling of HGETDEL test to fix java CICD

### Issue link

This Pull Request is linked to issue: [Java] Unshadow commons-lang3 #5074

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
