### PR TITLE
Fix: Use try_init() for graceful logger initialization

### DIFF
--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -176,11 +176,15 @@ pub fn init(minimal_level: Option<Level>, file_name: Option<&str>) -> Level {
             .with_target("logger_core", log_level)
             .with_target(std::env!("CARGO_PKG_NAME"), log_level);
 
+        // Use try_init() instead of init() to gracefully handle the case where
+        // a tracing subscriber has already been set by the application.
+        // This allows applications to control their own logging configuration.
         tracing_subscriber::registry()
             .with(stdout_layer)
             .with(file_layer)
             .with(targets_filter)
-            .init();
+            .try_init()
+            .ok(); // Ignore the error if subscriber already set
 
         let reloads: Reloads = Reloads {
             console_reload: RwLock::new(stdout_reload),


### PR DESCRIPTION
## Problem
  GLIDE's `logger_core` currently uses `init()` to set up the global tracing subscriber, which panics if a subscriber is already configured. This prevents applications from initializing their own logging before using GLIDE.

  **Error encountered:**
  thread '' panicked at 'failed to set global default subscriber'

  This occurs when applications need custom log targets before creating GLIDE Redis clients.

  ## Root Cause
  In `logger_core/src/lib.rs:183`, the code calls `.init()` which unconditionally panics if another tracing subscriber exists:

  ```rust
  tracing_subscriber::registry()
      .with(stdout_layer)
      .with(file_layer)
      .with(targets_filter)
      .init();  // Panics if subscriber already set

  Applications that need custom log outputs (UDP syslog, custom file appenders, in-memory buffers) must initialize their tracing subscriber before creating GLIDE clients. This creates an unavoidable conflict.

  Solution

  Changed GLIDE's logger initialization to use try_init() instead of init(), which returns a Result rather than panicking:

  // Use try_init() instead of init() to gracefully handle the case where
  // a tracing subscriber has already been set by the application.
  // This allows applications to control their own logging configuration.
  tracing_subscriber::registry()
      .with(stdout_layer)
      .with(file_layer)
      .with(targets_filter)
      .try_init()
      .ok(); // Gracefully ignore if subscriber already set

  Changes

  - File: logger_core/src/lib.rs
  - Lines: 179-187
  - Change: Replace .init() with .try_init().ok()
  - Added: Explanatory comments

  Testing

  Tested with a production application (ap-engine) that requires custom logging:

  Test Configurations

  ✅ UDP Syslog: App initializes UDP logger → GLIDE logs to app's logger
  ✅ Stdout: App initializes stdout → GLIDE logs to stdout
  ✅ Stderr: App initializes stderr → GLIDE logs to stderr
  ✅ Endpoint: App initializes in-memory buffer → GLIDE logs to buffer
  ✅ Default: App doesn't initialize → GLIDE initializes its own logger

  Test Code

  // Application initializes tracing BEFORE creating GLIDE clients
  std::env::set_var("GLIDE_LOG_DIR", "");
  let vec_logger = init_tracing_logger(); // Sets up custom logger
  log_panics::init();

  // Create GLIDE Redis pools - no panic!
  let rate_limit_redis_pool = create_redis_client(&settings.redis, ...).await?;
  let tag_redis_pool = create_redis_client(&settings.redis, ...).await?;

  Results

  - ✅ No panics during initialization
  - ✅ Application's logger receives GLIDE logs
  - ✅ Custom log targets work correctly
  - ✅ Multiple Redis pool creation succeeds
  - ✅ Integration tests pass

  Backward Compatibility

  This change is fully backward compatible:
  ┌────────────────────────────────┬──────────────────────┬──────────────────────┐
  │            Scenario            │        Before        │        After         │
  ├────────────────────────────────┼──────────────────────┼──────────────────────┤
  │ App doesn't initialize logging │ GLIDE initializes ✅ │ GLIDE initializes ✅ │
  ├────────────────────────────────┼──────────────────────┼──────────────────────┤
  │ App initializes logging first  │ Panic ❌             │ App's logger used ✅ │
  ├────────────────────────────────┼──────────────────────┼──────────────────────┤
  │ GLIDE called before app logger │ GLIDE initializes ✅ │ GLIDE initializes ✅ │
  └────────────────────────────────┴──────────────────────┴──────────────────────┘
  No breaking changes - applications that don't initialize their own logging will continue to work exactly as before.

  Use Case

  This fix is critical for applications that require:
  - UDP syslog for centralized logging (ELK, Splunk, etc.)
  - Custom log formatters (JSON, structured logging)
  - Multi-target logging (console + file + network simultaneously)
  - In-memory log buffers (for /log endpoints, debugging)
  - Integration with existing logging infrastructure

  Related Issues

  This addresses the common pattern where applications need to configure logging before any library initialization, as recommended by the tracing documentation.

  Checklist

  - Code changes implemented
  - Tested with multiple log configurations
  - Backward compatibility verified
  - Comments added to explain the change
  - No breaking changes
  - Integration tests pass