### PR TITLE
Add RUSTSEC-2025-0141 to ignore list in deny.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 * CORE: Enforce connection_timeout for initial standalone connection failures  ([#4991](https://github.com/valkey-io/valkey-glide/issues/4991))
+* CORE: Rust Lint is failing due to unmaintained advisory detected (RUSTSEC-2025-0141)  ([#5136](https://github.com/valkey-io/valkey-glide/issues/5136))
 * Node: Fixed `Failed to convert napi value Undefined into rust type u32` error  ([#5128](https://github.com/valkey-io/valkey-glide/pull/5128))
 
 #### Operational Enhancements

--- a/deny.toml
+++ b/deny.toml
@@ -22,9 +22,10 @@ yanked = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # suppress this validation until #3226 not resolved
-    # https://github.com/valkey-io/valkey-glide/issues/3226
-    "RUSTSEC-2025-0007",
+    # bincode is unmaintained but only used as a transitive dev dependency
+    # via iai-callgrind for benchmarking. No security impact.
+    # https://rustsec.org/advisories/RUSTSEC-2025-0141
+    "RUSTSEC-2025-0141",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
This PR will do the following:
- Add `RUSTSEC-2025-0141` to ignore list in `/valkey-glide/deny.toml`
- Remove `"RUSTSEC-2025-0007"` from the ignore list in `/valkey-glide/deny.toml`
   - The task to resolve the issue has been completed/closed and CICD does not detect this advisory anymore

`RUSTSEC-2025-0141` is an "unmaintained" advisory warning, not a security vulnerability. Due to a doxxing and harassment incident, the `bincode` team has taken the decision to cease development permanently.

Note: The dependency chain is `bincode v1.3.3` → `iai-callgrind v0.15.2` → `(dev) glide-core v0.1.0` and is used as a dev benchmark tool, which only affects development and not end users.

Created a tracking ticket to look into replacing this library in the future: https://github.com/valkey-io/valkey-glide/issues/5140

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
