### PR TITLE
Fix pubsub configuration errors in Java and Python

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -538,12 +538,8 @@ public abstract class BaseClient
      * @return A message if any or <code>null</code> if there are no unread messages.
      */
     public PubSubMessage tryGetPubSubMessage() {
-        if (subscriptionConfiguration.isEmpty()) {
-            throw new ConfigurationError(
-                    "The operation will never complete since there was no pubsub subscriptions applied to the"
-                            + " client.");
-        }
-        if (subscriptionConfiguration.get().getCallback().isPresent()) {
+        if (subscriptionConfiguration.isPresent()
+                && subscriptionConfiguration.get().getCallback().isPresent()) {
             throw new ConfigurationError(
                     "The operation will never complete since messages will be passed to the configured"
                             + " callback.");
@@ -561,12 +557,8 @@ public abstract class BaseClient
      * @return A {@link CompletableFuture} which will asynchronously hold the next available message.
      */
     public CompletableFuture<PubSubMessage> getPubSubMessage() {
-        if (subscriptionConfiguration.isEmpty()) {
-            throw new ConfigurationError(
-                    "The operation will never complete since there was no pubsub subscriptions applied to the"
-                            + " client.");
-        }
-        if (subscriptionConfiguration.get().getCallback().isPresent()) {
+        if (subscriptionConfiguration.isPresent()
+                && subscriptionConfiguration.get().getCallback().isPresent()) {
             throw new ConfigurationError(
                     "The operation will never complete since messages will be passed to the configured"
                             + " callback.");

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1285,22 +1285,13 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createClient(
 
             // Direct client creation (no lazy loading for simplified implementation)
             let runtime = get_runtime();
-            // Enable push channel if pubsub subscriptions are present
-            let mut rx_opt: Option<tokio::sync::mpsc::UnboundedReceiver<redis::PushInfo>> = None;
 
-            // Check if pubsub subscriptions exist in the connection request
-            let has_pubsub = connection_request.pubsub_subscriptions.is_some();
+            // Always create push channel to support dynamic subscriptions via customCommand
+            // This matches the behavior of socket_listener.rs which always creates push channels
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<redis::PushInfo>();
 
-            let tx_opt: Option<tokio::sync::mpsc::UnboundedSender<redis::PushInfo>> = if has_pubsub
-            {
-                let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<redis::PushInfo>();
-                rx_opt = Some(rx);
-                Some(tx)
-            } else {
-                None
-            };
-
-            match runtime.block_on(async { create_glide_client(connection_request, tx_opt).await })
+            match runtime
+                .block_on(async { create_glide_client(connection_request, Some(tx)).await })
             {
                 Ok(client) => {
                     let safe_handle = jni_client::generate_safe_handle();
@@ -1309,20 +1300,19 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createClient(
                     // Store in handle table
                     handle_table.insert(safe_handle, client);
 
-                    // If we created a push channel, spawn a forwarder to deliver pushes to Java
-                    if let Some(mut rx) = rx_opt {
-                        let jvm_arc = jni_client::JVM.get().cloned();
-                        let handle_for_java = safe_handle as jlong;
-                        get_runtime().spawn(async move {
-                            while let Some(push) = rx.recv().await {
-                                if let Some(jvm) = jvm_arc.as_ref()
-                                    && let Ok(mut env) = jvm.attach_current_thread_as_daemon()
-                                {
-                                    handle_push_notification(&mut env, handle_for_java, push);
-                                }
+                    // Always spawn push forwarder to deliver pushes to Java
+                    let jvm_arc = jni_client::JVM.get().cloned();
+                    let handle_for_java = safe_handle as jlong;
+                    get_runtime().spawn(async move {
+                        let mut rx = rx;
+                        while let Some(push) = rx.recv().await {
+                            if let Some(jvm) = jvm_arc.as_ref()
+                                && let Ok(mut env) = jvm.attach_current_thread_as_daemon()
+                            {
+                                handle_push_notification(&mut env, handle_for_java, push);
                             }
-                        });
-                    }
+                        }
+                    });
 
                     Some(safe_handle as jlong)
                 }

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -46,6 +46,7 @@ from glide_shared.constants import (
 )
 from glide_shared.exceptions import (
     ClosingError,
+    ConfigurationError,
     ConnectionError,
     RequestError,
     get_request_error_class,
@@ -532,6 +533,11 @@ class BaseClient(CoreCommands):
                 "Unable to execute requests; the client is closed. Please create a new client."
             )
 
+        if self.config._get_pubsub_callback_and_context()[0] is not None:
+            raise ConfigurationError(
+                "The operation will never complete since messages will be passed to the configured callback."
+            )
+
         # locking might not be required
         response_future: "TFuture" = _get_new_future_instance()
         try:
@@ -547,6 +553,11 @@ class BaseClient(CoreCommands):
         if self._is_closed:
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
+            )
+
+        if self.config._get_pubsub_callback_and_context()[0] is not None:
+            raise ConfigurationError(
+                "The operation will never complete since messages will be passed to the configured callback."
             )
 
         # locking might not be required


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

This PR fixes 2 issues - 
1. In Java - deleted the ConfigurationError thrown in case getMessage or tryGetMessage are called with no subscriptions pre-configured. It also makes sure a push sender is sent to the core wether subscriptions were pre-configured or not. Also tests are added to java to make sure everything works as expected.
2. In python - a previous commit mistakenly removed both the error thrown when trying to getmessage when no subs are configured (should be removed), but it also removed the error thrown when getMessage was called when a callback is also configured, which should still be thrown (the callback will still catch the messages, no matter if channel were subscribed to dynamically or in config). So this is reverted, and 

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/4919

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
