### PR TITLE
Fix flaky TLS test timeouts by increasing cluster creation timeout and improving cleanup

### DIFF
--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -567,7 +567,9 @@ export async function flushAndCloseClient(
 
         // Add a small delay to allow sockets to be properly released
         // This prevents socket exhaustion when running many tests sequentially
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        // Use longer delay for TLS connections as they need more cleanup time
+        const delay = tlsConfig?.useTLS ? 50 : 10;
+        await new Promise((resolve) => setTimeout(resolve, delay));
     }
 }
 

--- a/node/tests/TlsCertificateTest.test.ts
+++ b/node/tests/TlsCertificateTest.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./TestUtilities";
 
 const TIMEOUT = 50000;
+const CLUSTER_CREATION_TIMEOUT = 120000; // Increased timeout for TLS cluster creation
 
 describe("TLS with custom certificates", () => {
     let standaloneCluster: ValkeyCluster;
@@ -70,7 +71,10 @@ describe("TLS with custom certificates", () => {
             process.env.GLIDE_HOME_DIR || process.cwd() + "/..";
         const caCertPath = `${glideHomeDir}/utils/tls_crts/ca.crt`;
         caCertData = fs.readFileSync(caCertPath);
-    }, TIMEOUT);
+
+        // Small delay to ensure cluster is fully ready after TLS setup
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }, CLUSTER_CREATION_TIMEOUT);
 
     afterEach(async () => {
         if (standaloneClient) {

--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -16,6 +16,7 @@ import {
     getServerVersion,
 } from "./TestUtilities";
 const TIMEOUT = 50000;
+const CLUSTER_CREATION_TIMEOUT = 120000; // Increased timeout for TLS cluster creation
 const TLS_OPTIONS = {
     advancedConfiguration: {
         tlsAdvancedConfiguration: { insecure: true },
@@ -37,7 +38,9 @@ describe("tls GlideClusterClient", () => {
             true,
             TLS_OPTIONS,
         );
-    }, TIMEOUT);
+        // Small delay to ensure cluster is fully ready after TLS setup
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }, CLUSTER_CREATION_TIMEOUT);
 
     afterEach(async () => {
         await flushAndCloseClient(
@@ -63,6 +66,9 @@ describe("tls GlideClusterClient", () => {
                 error as Error,
             );
         }
+
+        // Additional delay to ensure proper TLS cleanup
+        await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -99,7 +105,9 @@ describe("tls GlideClient", () => {
             true,
             TLS_OPTIONS,
         );
-    }, TIMEOUT);
+        // Small delay to ensure cluster is fully ready after TLS setup
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }, CLUSTER_CREATION_TIMEOUT);
 
     afterEach(async () => {
         await flushAndCloseClient(
@@ -125,6 +133,9 @@ describe("tls GlideClient", () => {
                 error as Error,
             );
         }
+
+        // Additional delay to ensure proper TLS cleanup
+        await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(


### PR DESCRIPTION
The TLS tests in `tests/TlsTest.test.ts` and `test/TlsCertificateTest.test.ts` were experiencing intermittent failures with timeout errors during cluster creation. The tests were failing with a 50-second timeout in the `beforeAll` hook, affecting both RESP2 and RESP3 protocol versions for cluster mode (standalone TLS tests were passing).

## Root Cause

TLS cluster creation can legitimately exceed the 50-second Jest timeout, especially in CI environments where resources may be constrained or there may be interference from other test runs. The timeout was insufficient for the complex TLS setup process which involves certificate generation, secure handshakes, and multi-node cluster coordination.

## Changes Made

**Increased timeout for TLS operations:**
- Added `CLUSTER_CREATION_TIMEOUT = 120000` (2 minutes) specifically for TLS cluster creation
- Updated both cluster and standalone TLS test `beforeAll` hooks to use the new timeout

**Enhanced stability and cleanup:**
- Added 1-second stabilization delay after cluster creation to ensure TLS setup is fully complete
- Added 100ms cleanup delay in `afterAll` hooks to ensure proper TLS resource cleanup
- Extended socket cleanup delay in `flushAndCloseClient` from 10ms to 50ms for TLS connections

**Maintained robustness:**
- Preserved existing error handling patterns that log errors without throwing
- Kept individual test timeout at 50 seconds for fast execution
- Added targeted delays only where needed for TLS-specific operations

These minimal changes address the timeout issue while maintaining test performance and ensuring proper resource cleanup to prevent interference between test runs.

This PR will replace and close the following:
- [[Node][Flaky Test] GlideClusterClient › clusterClient connect with insecure TLS (protocol: 1) #4366](https://github.com/valkey-io/valkey-glide/issues/4366)
- [fix(node): increase timeout in TlsCertificateTest to prevent flaky fa… #5064](https://github.com/valkey-io/valkey-glide/pull/5064)
   - Thank you @hank95179 for your initial contribution.

### Issue link

This Pull Request is linked to issue: 
- [[Node][Flaky Test] GlideClusterClient › clusterClient connect with insecure TLS (protocol: 1) #4366 ](https://github.com/valkey-io/valkey-glide/issues/4366)
- [[Node][Flaky Test] TLS with custom certificates #4989](https://github.com/valkey-io/valkey-glide/issues/4989)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
