### PR TITLE
Fix duplicate artifact name error during FMT report upload

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -192,7 +192,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.RUNNER }}
+                  name: test-reports-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
                       java/client/build/reports/**
                       java/integTest/build/reports/**


### PR DESCRIPTION
This PR resolves the issue where multiple Java FMT suites had conflicting artifact names during upload.


The problem is that matrix.host.RUNNER can be the same for different matrix combinations. From the error, the artifact name is test-reports-java-11-valkey-8.1-Array — notice the Array at the end. This happens when matrix.host.RUNNER is an array (like [self-hosted, macOS, ARM64]) and gets stringified as "Array" instead of a unique identifier.

Looking at the container job (line 410), it uses a better pattern with ${{ env.IMAGE }}-${{ matrix.host.ARCH }}.

The fix is to use a more unique identifier, which will replace `${{ matrix.host.RUNNER }}` with `${{ matrix.host.OS }}-${{ matrix.host.ARCH }}`

This solution follows the same standard approaches we normally use. For example, inside of the same java.yml file we use  `name: test-reports-java-${{ matrix.java }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ env.IMAGE }}-${{ matrix.host.ARCH }}` for out PubSub artifact uploading.

### Issue link

This Pull Request is linked to issue (URL): [Java FMT error during "Upload test & spotbugs reports" stage](https://github.com/valkey-io/valkey-glide/issues/5160)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
