### PR TITLE
Fix exclusion name comparison for python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * CORE: Enforce connection_timeout for initial standalone connection failures  ([#4991](https://github.com/valkey-io/valkey-glide/issues/4991))
 * CORE: Rust Lint is failing due to unmaintained advisory detected (RUSTSEC-2025-0141)  ([#5136](https://github.com/valkey-io/valkey-glide/issues/5136))
 * Node: Fixed `Failed to convert napi value Undefined into rust type u32` error  ([#5128](https://github.com/valkey-io/valkey-glide/pull/5128))
+* Python: Fix Sphinx docs build failure with duplicate object warnings  ([#5163](https://github.com/valkey-io/valkey-glide/issues/5163))
 
 #### Operational Enhancements
 

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -64,10 +64,9 @@ def avoid_duplicate(app, what, name, obj, skip, options):
         "compression_level",
         "min_compression_size",
     )
-    module = getattr(obj, "__module__", "")
-    formatted = f"{module}.{name}" if module else name
-    if formatted in exclusions:
-        return formatted
+    # Check if the attribute name itself is in exclusions
+    if name in exclusions:
+        return True
     return None
 
 


### PR DESCRIPTION
`Sphinx 9.x` changed how autodoc warnings are categorized, causing suppress_warnings = ["autodoc"] to no longer suppress duplicate object description warnings. This exposed a latent bug in the `avoid_duplicate` callback - it was comparing full module paths (e.g., glide_shared.config.GlideClientConfiguration.PubSubSubscriptions.callback) against short exclusion names (e.g., callback), which never matched.

Our CI recently started pulling `Sphinx 9.1.0 (released Dec 31, 2025)` due to the unpinned `sphinx >= 7.4.7` dependency in `dev_requirements.txt`. Previous CI runs were using `Sphinx 8.x` where the blanket warning suppression masked this bug.

The fix compares the name parameter directly against exclusions and returns the correct boolean type.


### Issue link

This Pull Request is linked to issue: [[Python] Fix Sphinx docs build failure with duplicate object warnings #5163](https://github.com/valkey-io/valkey-glide/issues/5163)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
