### PR TITLE
Update ORT to 59.0.0 to fix Synopsys repo 403 error

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -38,6 +38,7 @@ jobs:
             INPUT_TARGET_BRANCH: ${{ github.event.inputs.branch_name }}
             EVENT_NAME: ${{ github.event_name }}
             HEAD_REF: ${{ github.head_ref }}
+            ORT_VERSION: "59.0.0"
 
         steps:
             - name: Setup target branch and commit
@@ -60,11 +61,11 @@ jobs:
               run: |
                   echo "TARGET_COMMIT=`git rev-parse HEAD`" >> $GITHUB_ENV
 
-            - name: Set up JDK 11 for the ORT package
+            - name: Set up JDK 21 for the ORT package
               uses: actions/setup-java@v4
               with:
                   distribution: "temurin"
-                  java-version: 11
+                  java-version: 21
 
             - name: Cache ORT and Gradle packages
               uses: actions/cache@v4
@@ -74,7 +75,7 @@ jobs:
                       ./ort
                       ~/.gradle/caches
                       ~/.gradle/wrapper
-                  key: ${{ runner.os }}-ort
+                  key: ${{ runner.os }}-ort-${{ env.ORT_VERSION }}
 
             - name: Checkout ORT Repository
               if: steps.cache-ort.outputs.cache-hit != 'true'
@@ -82,7 +83,7 @@ jobs:
               with:
                   repository: "oss-review-toolkit/ort"
                   path: "./ort"
-                  ref: "46.0.0"
+                  ref: ${{ env.ORT_VERSION }}
                   submodules: recursive
 
             - name: Install Rust toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 #### Operational Enhancements
 
+* CI: Upgrade ORT from 46.0.0 to 59.0.0 to fix Synopsys repository 403 error ([#5169](https://github.com/valkey-io/valkey-glide/pull/5169))
+
 ## 2.2
 
 #### Changes


### PR DESCRIPTION
### Description
This PR will update ORT from `46.0.0` to `59.0.0`, it will also install `JDK 21` for the purpose of installing ORT.
- Synopsys Software Integrity Group is now known as Black Duck Software and SIG-Repo is now https://repo.blackduck.com.
   - The `sig-repo.synopsys.com` repository now returns 403 Forbidden, because it does not exist anymore

### Solution
- ORT is currently at version 46.0.0. ORT has fixed this issue in version 59.0.0.
- Java 21 is required for version 59.0.0+.


### Notes
ORTs latest version is 79.0.0, but due to some issues with the internal logic, it fails to resolve dependencies as it is not able to find the `package.json`
- refer to the [commit below](https://github.com/valkey-io/valkey-glide/pull/5170#issuecomment-3752173139) for stack trace

### Issue link

This Pull Request is linked to issue: [[CICD] Upgrade ORT to resolve Synopsys repository 403 error #5169](https://github.com/valkey-io/valkey-glide/issues/5169)


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
