### PR TITLE
JAVA: Client-Side Caching Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * FFI: Add OpenTelemetry DB semantic convention attributes to FFI path ([#5596](https://github.com/valkey-io/valkey-glide/issues/5596))
 * JAVA: Add cluster management commands (CLUSTER MEET, CLUSTER FORGET, CLUSTER REPLICATE, CLUSTER REPLICAS, CLUSTER COUNT-FAILURE-REPORTS, CLUSTER FAILOVER, CLUSTER SETSLOT, CLUSTER BUMPEPOCH, CLUSTER SET-CONFIG-EPOCH, CLUSTER FLUSHSLOTS, CLUSTER RESET, READONLY, READWRITE, ASKING, CLUSTER SAVECONFIG, CLUSTER GETKEYSINSLOT) ([#5503](https://github.com/valkey-io/valkey-glide/pull/5503))
 * Go: Client-Side Caching Support ([#5721](https://github.com/valkey-io/valkey-glide/pull/5721))
+* JAVA: Client-Side Caching Support([#5172](https://github.com/valkey-io/valkey-glide/pull/5172))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * FFI: Add OpenTelemetry DB semantic convention attributes to FFI path ([#5596](https://github.com/valkey-io/valkey-glide/issues/5596))
 * JAVA: Add cluster management commands (CLUSTER MEET, CLUSTER FORGET, CLUSTER REPLICATE, CLUSTER REPLICAS, CLUSTER COUNT-FAILURE-REPORTS, CLUSTER FAILOVER, CLUSTER SETSLOT, CLUSTER BUMPEPOCH, CLUSTER SET-CONFIG-EPOCH, CLUSTER FLUSHSLOTS, CLUSTER RESET, READONLY, READWRITE, ASKING, CLUSTER SAVECONFIG, CLUSTER GETKEYSINSLOT) ([#5503](https://github.com/valkey-io/valkey-glide/pull/5503))
 * Go: Client-Side Caching Support ([#5721](https://github.com/valkey-io/valkey-glide/pull/5721))
-* JAVA: Client-Side Caching Support([#5172](https://github.com/valkey-io/valkey-glide/pull/5172))
+* JAVA: Client-Side Caching Support ([#5172](https://github.com/valkey-io/valkey-glide/pull/5172))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1,6 +1,7 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
+import static command_request.CommandRequestOuterClass.CacheMetricsType;
 import static command_request.CommandRequestOuterClass.RequestType.AclCat;
 import static command_request.CommandRequestOuterClass.RequestType.AclDelUser;
 import static command_request.CommandRequestOuterClass.RequestType.AclDryRun;
@@ -1106,6 +1107,117 @@ public abstract class BaseClient
         }
 
         return commandManager.submitRefreshIamToken(this::handleStringResponse);
+    }
+
+    /**
+     * Get cache metrics.
+     *
+     * <p>This is the internal method that communicates with the core to retrieve cache metrics. All
+     * public cache metric methods delegate to this method.
+     *
+     * @param metricsType The type of metric to retrieve.
+     * @return A CompletableFuture that resolves to the requested cache metric.
+     * @throws RequestException if caching is not enabled or metrics are disabled.
+     */
+    private CompletableFuture<Object> getCacheMetrics(CacheMetricsType metricsType) {
+        return commandManager.submitGetCacheMetrics(metricsType, this::handleObjectOrNullResponse);
+    }
+
+    /**
+     * Get the cache hit rate metric.
+     *
+     * <p>This method returns the percentage of cache hits out of total cache requests. Only available
+     * when client-side caching is enabled with metrics collection.
+     *
+     * @return A CompletableFuture that resolves to the cache hit rate as a percentage (0.0 to 100.0).
+     * @throws RequestException if caching is not enabled or metrics are disabled.
+     * @example
+     *     <pre>{@code
+     * // Get cache hit rate
+     * Double hitRate = client.getCacheHitRate().get();
+     * System.out.println("Cache hit rate: " + hitRate + "%");
+     * }</pre>
+     */
+    public CompletableFuture<Double> getCacheHitRate() {
+        return getCacheMetrics(CacheMetricsType.HitRate).thenApply(result -> (Double) result);
+    }
+
+    /**
+     * Get the cache miss rate metric.
+     *
+     * <p>This method returns the percentage of cache misses out of total cache requests. Only
+     * available when client-side caching is enabled with metrics collection.
+     *
+     * @return A CompletableFuture that resolves to the cache miss rate as a percentage (0.0 to
+     *     100.0).
+     * @throws RequestException if caching is not enabled or metrics are disabled.
+     * @example
+     *     <pre>{@code
+     * // Get cache miss rate
+     * Double missRate = client.getCacheMissRate().get();
+     * System.out.println("Cache miss rate: " + missRate + "%");
+     * }</pre>
+     */
+    public CompletableFuture<Double> getCacheMissRate() {
+        return getCacheMetrics(CacheMetricsType.MissRate).thenApply(result -> (Double) result);
+    }
+
+    /**
+     * Get the current number of entries in the cache.
+     *
+     * <p>This method returns the total count of cached entries currently stored in the client-side
+     * cache. Available when client-side caching is enabled.
+     *
+     * @return A CompletableFuture that resolves to the number of cache entries.
+     * @throws RequestException if caching is not enabled.
+     * @example
+     *     <pre>{@code
+     * // Get cache entry count
+     * Long entryCount = client.getCacheEntryCount().get();
+     * System.out.println("Cache entries: " + entryCount);
+     * }</pre>
+     */
+    public CompletableFuture<Long> getCacheEntryCount() {
+        return getCacheMetrics(CacheMetricsType.EntryCount).thenApply(result -> (Long) result);
+    }
+
+    /**
+     * Get the total number of cache evictions.
+     *
+     * <p>This method returns the count of entries that have been evicted from the cache due to memory
+     * limits or eviction policies. Only available when client-side caching is enabled with metrics
+     * collection.
+     *
+     * @return A CompletableFuture that resolves to the total number of evictions.
+     * @throws RequestException if caching is not enabled or metrics are disabled.
+     * @example
+     *     <pre>{@code
+     * // Get cache evictions count
+     * Long evictions = client.getCacheEvictions().get();
+     * System.out.println("Cache evictions: " + evictions);
+     * }</pre>
+     */
+    public CompletableFuture<Long> getCacheEvictions() {
+        return getCacheMetrics(CacheMetricsType.Evictions).thenApply(result -> (Long) result);
+    }
+
+    /**
+     * Get the total number of cache expirations.
+     *
+     * <p>This method returns the count of entries that have expired from the cache due to TTL
+     * settings. Only available when client-side caching is enabled with metrics collection.
+     *
+     * @return A CompletableFuture that resolves to the total number of expirations.
+     * @throws RequestException if caching is not enabled or metrics are disabled.
+     * @example
+     *     <pre>{@code
+     * // Get cache expirations count
+     * Long expirations = client.getCacheExpirations().get();
+     * System.out.println("Cache expirations: " + expirations);
+     * }</pre>
+     */
+    public CompletableFuture<Long> getCacheExpirations() {
+        return getCacheMetrics(CacheMetricsType.Expirations).thenApply(result -> (Long) result);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1220,6 +1220,26 @@ public abstract class BaseClient
         return getCacheMetrics(CacheMetricsType.Expirations).thenApply(result -> (Long) result);
     }
 
+    /**
+     * Get the total number of cache lookups (hits + misses).
+     *
+     * <p>This method returns the sum of cache hits and misses, representing the total number of cache
+     * lookup operations performed. Only available when client-side caching is enabled with metrics
+     * collection.
+     *
+     * @return A CompletableFuture that resolves to the total number of cache lookups.
+     * @throws RequestException if caching is not enabled or metrics are disabled.
+     * @example
+     *     <pre>{@code
+     * // Get total cache lookups
+     * Long totalLookups = client.getCacheTotalLookups().get();
+     * System.out.println("Total cache lookups: " + totalLookups);
+     * }</pre>
+     */
+    public CompletableFuture<Long> getCacheTotalLookups() {
+        return getCacheMetrics(CacheMetricsType.TotalLookups).thenApply(result -> (Long) result);
+    }
+
     @Override
     public CompletableFuture<Long> del(@NonNull String[] keys) {
         return commandManager.submitNewCommand(Del, keys, this::handleLongResponse);

--- a/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
@@ -33,6 +33,9 @@ public abstract class BaseClientConfiguration {
     @Singular
     private final List<NodeAddress> addresses;
 
+    /** Client-side cache configuration. If provided, enables caching for this client. */
+    public abstract ClientSideCache getClientSideCache();
+
     /**
      * True if communication with the cluster should use Transport Level Security.
      *

--- a/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
@@ -18,7 +18,7 @@ import lombok.NonNull;
  * // Create cache with custom configuration
  * ClientSideCache cache = ClientSideCache.builder()
  *     .maxCacheKb(2048)
- *     .entryTtlSeconds(300)
+ *     .entryTtlMs(300)
  *     .evictionPolicy(EvictionPolicy.LRU)
  *     .enableMetrics(true)
  *     .build();
@@ -34,8 +34,8 @@ public class ClientSideCache {
     /** Maximum memory limit for the cache in kilobytes. */
     private final long maxCacheKb;
 
-    /** Optional TTL (Time-To-Live) for cache entries in seconds. */
-    private final Long entryTtlSeconds;
+    /** Optional TTL (Time-To-Live) for cache entries in milliseconds. */
+    private final Long entryTtlMs;
 
     /** Eviction policy to use when cache reaches memory limit. Defaults to LRU if not specified. */
     @Builder.Default private final EvictionPolicy evictionPolicy = EvictionPolicy.LRU;

--- a/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
@@ -13,7 +13,7 @@ import lombok.NonNull;
  * @example
  *     <pre>{@code
  * // Create cache with auto-generated ID
- * ClientSideCache cache = ClientSideCache.create(1024);
+ * ClientSideCache cache = ClientSideCache.create(1024, 60000);
  *
  * // Create cache with custom configuration
  * ClientSideCache cache = ClientSideCache.builder()
@@ -34,8 +34,11 @@ public class ClientSideCache {
     /** Maximum memory limit for the cache in kilobytes. */
     private final long maxCacheKb;
 
-    /** Optional TTL (Time-To-Live) for cache entries in milliseconds. */
-    private final Long entryTtlMs;
+    /**
+     * TTL (Time-To-Live) for cache entries in milliseconds. A value of 0 means no expiration. This
+     * field is required.
+     */
+    private final long entryTtlMs;
 
     /** Eviction policy to use when cache reaches memory limit. Defaults to LRU if not specified. */
     @Builder.Default private final EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
@@ -47,10 +50,11 @@ public class ClientSideCache {
      * Creates a ClientSideCache with auto-generated cache ID and default settings.
      *
      * @param maxCacheKb Maximum memory limit for the cache in kilobytes.
+     * @param entryTtlMs TTL for cache entries in milliseconds. Use 0 for no expiration.
      * @return A new ClientSideCache instance with auto-generated ID.
      */
-    public static ClientSideCache create(long maxCacheKb) {
-        return ClientSideCache.builder().maxCacheKb(maxCacheKb).build();
+    public static ClientSideCache create(long maxCacheKb, long entryTtlMs) {
+        return ClientSideCache.builder().maxCacheKb(maxCacheKb).entryTtlMs(entryTtlMs).build();
     }
 
     /**

--- a/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
@@ -1,18 +1,24 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
-import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 
 /**
  * Configuration for client-side caching. Client-side caching reduces network round-trips and server
  * load by storing frequently accessed data locally on the client.
  *
+ * <p>Use the {@link #create} factory method or the builder to create instances. The cache ID is
+ * auto-generated internally.
+ *
+ * <p>In order for 2 clients to share the same cache, they must be created with the same {@code
+ * ClientSideCache} instance. Clients with different {@code ClientSideCache} instances will have
+ * separate caches, even if the configurations are identical.
+ *
  * @example
  *     <pre>{@code
- * // Create cache with auto-generated ID
+ * // Create cache with default settings
  * ClientSideCache cache = ClientSideCache.create(1024, 60000);
  *
  * // Create cache with custom configuration
@@ -28,8 +34,14 @@ import lombok.NonNull;
 @Builder
 public class ClientSideCache {
 
-    /** Unique identifier for the cache instance. */
-    @NonNull @Builder.Default private final String cacheId = generateCacheId();
+    /** Thread-safe counter for generating unique cache IDs, matching Python's counter approach. */
+    private static final AtomicLong ID_COUNTER = new AtomicLong(0);
+
+    /**
+     * Unique identifier for the cache instance. Auto-generated internally. Used to determine cache
+     * sharing between clients.
+     */
+    @Builder.Default private final String cacheId = generateCacheId();
 
     /** Maximum memory limit for the cache in kilobytes. */
     private final long maxCacheKb;
@@ -58,11 +70,24 @@ public class ClientSideCache {
     }
 
     /**
-     * Generates a unique cache identifier.
+     * Generates a unique cache identifier using an incrementing counter, consistent with the Python
+     * client implementation.
      *
      * @return A unique cache ID string.
      */
     private static String generateCacheId() {
-        return "cache-" + UUID.randomUUID().toString();
+        return String.valueOf(ID_COUNTER.getAndIncrement());
+    }
+
+    /**
+     * Customized builder that hides the {@code cacheId} setter. The cache ID is always auto-generated
+     * and should not be set by users.
+     */
+    public static class ClientSideCacheBuilder {
+        // Hide the cacheId setter from the public API. Lombok will still use the
+        // @Builder.Default initializer internally, so the auto-generated ID is applied.
+        private ClientSideCacheBuilder cacheId(String cacheId) {
+            return this;
+        }
     }
 }

--- a/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
@@ -55,8 +55,8 @@ public class ClientSideCache {
     /** Eviction policy to use when cache reaches memory limit. Defaults to LRU if not specified. */
     @Builder.Default private final EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
 
-    /** Whether to enable metrics collection for the cache. Defaults to true. */
-    @Builder.Default private final boolean enableMetrics = true;
+    /** Whether to enable metrics collection for the cache. Defaults to false. */
+    @Builder.Default private final boolean enableMetrics = false;
 
     /**
      * Creates a ClientSideCache with auto-generated cache ID and default settings.
@@ -80,8 +80,8 @@ public class ClientSideCache {
     }
 
     /**
-     * Customized builder that hides the {@code cacheId} setter. The cache ID is always auto-generated
-     * and should not be set by users.
+     * Customized builder that hides the {@code cacheId} setter and adds validation. The cache ID is
+     * always auto-generated and should not be set by users.
      */
     public static class ClientSideCacheBuilder {
         // Hide the cacheId setter from the public API. Lombok will still use the
@@ -89,5 +89,25 @@ public class ClientSideCache {
         private ClientSideCacheBuilder cacheId(String cacheId) {
             return this;
         }
+    }
+
+    // Private constructor with validation, called by Lombok's generated build() method.
+    private ClientSideCache(
+            String cacheId,
+            long maxCacheKb,
+            long entryTtlMs,
+            EvictionPolicy evictionPolicy,
+            boolean enableMetrics) {
+        if (maxCacheKb <= 0) {
+            throw new IllegalArgumentException("maxCacheKb must be positive");
+        }
+        if (entryTtlMs < 0) {
+            throw new IllegalArgumentException("entryTtlMs must be non-negative (0 = no expiration)");
+        }
+        this.cacheId = cacheId;
+        this.maxCacheKb = maxCacheKb;
+        this.entryTtlMs = entryTtlMs;
+        this.evictionPolicy = evictionPolicy;
+        this.enableMetrics = enableMetrics;
     }
 }

--- a/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
@@ -32,7 +32,7 @@ public class ClientSideCache {
     @NonNull @Builder.Default private final String cacheId = generateCacheId();
 
     /** Maximum memory limit for the cache in kilobytes. */
-    @NonNull private final Long maxCacheKb;
+    private final long maxCacheKb;
 
     /** Optional TTL (Time-To-Live) for cache entries in seconds. */
     private final Long entryTtlSeconds;

--- a/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClientSideCache.java
@@ -1,0 +1,64 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.configuration;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Configuration for client-side caching. Client-side caching reduces network round-trips and server
+ * load by storing frequently accessed data locally on the client.
+ *
+ * @example
+ *     <pre>{@code
+ * // Create cache with auto-generated ID
+ * ClientSideCache cache = ClientSideCache.create(1024);
+ *
+ * // Create cache with custom configuration
+ * ClientSideCache cache = ClientSideCache.builder()
+ *     .maxCacheKb(2048)
+ *     .entryTtlSeconds(300)
+ *     .evictionPolicy(EvictionPolicy.LRU)
+ *     .enableMetrics(true)
+ *     .build();
+ * }</pre>
+ */
+@Getter
+@Builder
+public class ClientSideCache {
+
+    /** Unique identifier for the cache instance. */
+    @NonNull @Builder.Default private final String cacheId = generateCacheId();
+
+    /** Maximum memory limit for the cache in kilobytes. */
+    @NonNull private final Long maxCacheKb;
+
+    /** Optional TTL (Time-To-Live) for cache entries in seconds. */
+    private final Long entryTtlSeconds;
+
+    /** Eviction policy to use when cache reaches memory limit. Defaults to LRU if not specified. */
+    @Builder.Default private final EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
+
+    /** Whether to enable metrics collection for the cache. Defaults to true. */
+    @Builder.Default private final boolean enableMetrics = true;
+
+    /**
+     * Creates a ClientSideCache with auto-generated cache ID and default settings.
+     *
+     * @param maxCacheKb Maximum memory limit for the cache in kilobytes.
+     * @return A new ClientSideCache instance with auto-generated ID.
+     */
+    public static ClientSideCache create(long maxCacheKb) {
+        return ClientSideCache.builder().maxCacheKb(maxCacheKb).build();
+    }
+
+    /**
+     * Generates a unique cache identifier.
+     *
+     * @return A unique cache ID string.
+     */
+    private static String generateCacheId() {
+        return "cache-" + UUID.randomUUID().toString();
+    }
+}

--- a/java/client/src/main/java/glide/api/models/configuration/EvictionPolicy.java
+++ b/java/client/src/main/java/glide/api/models/configuration/EvictionPolicy.java
@@ -1,0 +1,25 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.configuration;
+
+/** Represents the eviction policy for client-side caching. */
+public enum EvictionPolicy {
+    /** Least Recently Used - evicts the least recently accessed entries first. */
+    LRU(0),
+    /** Least Frequently Used - evicts the least frequently accessed entries first. */
+    LFU(1);
+
+    private final int value;
+
+    EvictionPolicy(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the numeric value of the eviction policy.
+     *
+     * @return The numeric value.
+     */
+    public int getValue() {
+        return value;
+    }
+}

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClientConfiguration.java
@@ -25,6 +25,7 @@ import lombok.experimental.SuperBuilder;
  *         .clientName("GLIDE")
  *         .subscriptionConfiguration(subscriptionConfiguration)
  *         .inflightRequestsLimit(1000)
+ *         .clientSideCache(ClientSideCache.create(1024))
  *         .advancedConfiguration(AdvancedGlideClientConfiguration.builder().connectionTimeout(500).build())
  *         .readOnly(true)
  *         .build();
@@ -34,6 +35,9 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @ToString
 public class GlideClientConfiguration extends BaseClientConfiguration {
+
+    /** Client-side cache configuration. If provided, enables caching for this client. */
+    private final ClientSideCache clientSideCache;
 
     /** Subscription configuration for the current client. */
     private final StandaloneSubscriptionConfiguration subscriptionConfiguration;

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClientConfiguration.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
  *         .clientName("GLIDE")
  *         .subscriptionConfiguration(subscriptionConfiguration)
  *         .inflightRequestsLimit(1000)
- *         .clientSideCache(ClientSideCache.create(1024))
+ *         .clientSideCache(ClientSideCache.create(1024, 60000))
  *         .advancedConfiguration(AdvancedGlideClientConfiguration.builder().connectionTimeout(500).build())
  *         .readOnly(true)
  *         .build();

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
  *         .subscriptionConfiguration(subscriptionConfiguration)
  *         .reconnectStrategy(reconnectionConfiguration)
  *         .inflightRequestsLimit(1000)
+ *         .clientSideCache(ClientSideCache.create(1024))
  *         .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder().connectionTimeout(500).build())
  *         .build();
  * }</pre>
@@ -30,6 +31,9 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Getter
 public class GlideClusterClientConfiguration extends BaseClientConfiguration {
+
+    /** Client-side cache configuration. If provided, enables caching for this client. */
+    private final ClientSideCache clientSideCache;
 
     /** Subscription configuration for the current client. */
     private final ClusterSubscriptionConfiguration subscriptionConfiguration;

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
  *         .subscriptionConfiguration(subscriptionConfiguration)
  *         .reconnectStrategy(reconnectionConfiguration)
  *         .inflightRequestsLimit(1000)
- *         .clientSideCache(ClientSideCache.create(1024))
+ *         .clientSideCache(ClientSideCache.create(1024, 60000))
  *         .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder().connectionTimeout(500).build())
  *         .build();
  * }</pre>

--- a/java/client/src/main/java/glide/internal/GlideCoreClient.java
+++ b/java/client/src/main/java/glide/internal/GlideCoreClient.java
@@ -1,6 +1,7 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.internal;
 
+import command_request.CommandRequestOuterClass.CacheMetricsType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import glide.api.BaseClient;
 import glide.api.logging.Logger;
@@ -406,6 +407,31 @@ public class GlideCoreClient implements AutoCloseable {
         }
 
         GlideNativeBridge.refreshIamToken(handle, correlationId);
+        return future;
+    }
+
+    /** Get cache metrics */
+    public CompletableFuture<Object> getCacheMetrics(CacheMetricsType metricsType) {
+        CompletableFuture<Object> future = new CompletableFuture<>();
+
+        long handle = nativeClientHandle.get();
+        if (handle == 0) {
+            future.completeExceptionally(
+                    new glide.api.models.exceptions.ClosingException("Client is closed"));
+            return future;
+        }
+
+        long correlationId;
+        try {
+            correlationId =
+                    AsyncRegistry.register(
+                            future, this.maxInflightRequests, handle, this.requestTimeoutMillis);
+        } catch (glide.api.models.exceptions.RequestException e) {
+            future.completeExceptionally(e);
+            return future;
+        }
+
+        GlideNativeBridge.getCacheMetrics(handle, correlationId, metricsType.getNumber());
         return future;
     }
 

--- a/java/client/src/main/java/glide/internal/GlideNativeBridge.java
+++ b/java/client/src/main/java/glide/internal/GlideNativeBridge.java
@@ -87,4 +87,7 @@ public class GlideNativeBridge {
 
     /** Mark a callback as timed out on the native side. */
     public static native void markTimedOut(long callbackId);
+
+    /** Get cache metrics */
+    public static native void getCacheMetrics(long clientPtr, long callbackId, int metricsType);
 }

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -4,6 +4,7 @@ package glide.managers;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
 import command_request.CommandRequestOuterClass;
+import command_request.CommandRequestOuterClass.CacheMetricsType;
 import command_request.CommandRequestOuterClass.Command;
 import command_request.CommandRequestOuterClass.Command.ArgsArray;
 import command_request.CommandRequestOuterClass.CommandRequest;
@@ -666,6 +667,26 @@ public class CommandManager {
                             Response.Builder responseBuilder = Response.newBuilder();
                             if ("OK".equals(result)) {
                                 responseBuilder.setConstantResponse(ConstantResponse.OK);
+                            }
+                            return responseHandler.apply(responseBuilder.build());
+                        });
+    }
+
+    /** Submit a cache metrics request to GLIDE core. */
+    public <T> CompletableFuture<T> submitGetCacheMetrics(
+            CacheMetricsType metricsType, GlideExceptionCheckedFunction<Response, T> responseHandler) {
+
+        return coreClient
+                .getCacheMetrics(metricsType)
+                .thenApply(
+                        result -> {
+                            // Convert JNI result to protobuf Response format
+                            Response.Builder responseBuilder = Response.newBuilder();
+                            if (result != null) {
+                                long objectId = JniResponseRegistry.storeObject(result);
+                                responseBuilder.setRespPointer(objectId);
+                            } else {
+                                responseBuilder.setRespPointer(0L);
                             }
                             return responseHandler.apply(responseBuilder.build());
                         });

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -688,7 +688,7 @@ public class CommandManager {
                             } else {
                                 responseBuilder.setRespPointer(0L);
                             }
-                            return responseHandler.apply(responseBuilder.build());
+                            return applyHandlerWithCleanup(responseBuilder.build(), responseHandler);
                         });
     }
 

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -423,10 +423,8 @@ public class ConnectionManager {
                             cacheBuilder.setMaxCacheKb(clientSideCache.getMaxCacheKb());
                             cacheBuilder.setEnableMetrics(clientSideCache.isEnableMetrics());
 
-                            // Set optional TTL
-                            if (clientSideCache.getEntryTtlMs() != null) {
-                                cacheBuilder.setEntryTtlMs(clientSideCache.getEntryTtlMs());
-                            }
+                            // Set TTL (0 = no expiration)
+                            cacheBuilder.setEntryTtlMs(clientSideCache.getEntryTtlMs());
 
                             // Set optional eviction policy
                             if (clientSideCache.getEvictionPolicy() != null) {

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -424,8 +424,8 @@ public class ConnectionManager {
                             cacheBuilder.setEnableMetrics(clientSideCache.isEnableMetrics());
 
                             // Set optional TTL
-                            if (clientSideCache.getEntryTtlSeconds() != null) {
-                                cacheBuilder.setEntryTtlSeconds(clientSideCache.getEntryTtlSeconds());
+                            if (clientSideCache.getEntryTtlMs() != null) {
+                                cacheBuilder.setEntryTtlMs(clientSideCache.getEntryTtlMs());
                             }
 
                             // Set optional eviction policy

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -9,6 +9,7 @@ import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
 import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.BaseClientConfiguration;
 import glide.api.models.configuration.BaseSubscriptionConfiguration;
+import glide.api.models.configuration.ClientSideCache;
 import glide.api.models.configuration.ClusterSubscriptionConfiguration;
 import glide.api.models.configuration.CompressionBackend;
 import glide.api.models.configuration.CompressionConfiguration;
@@ -409,6 +410,39 @@ public class ConnectionManager {
                                 compressionBuilder.setCompressionLevel(cc.getCompressionLevel());
                             }
                             requestBuilder.setCompressionConfig(compressionBuilder.build());
+                        }
+
+                        // Set client-side cache configuration if provided
+                        ClientSideCache clientSideCache = configuration.getClientSideCache();
+                        if (clientSideCache != null) {
+                            connection_request.ConnectionRequestOuterClass.ClientSideCache.Builder cacheBuilder =
+                                    connection_request.ConnectionRequestOuterClass.ClientSideCache.newBuilder();
+
+                            // Set required fields
+                            cacheBuilder.setCacheId(clientSideCache.getCacheId());
+                            cacheBuilder.setMaxCacheKb(clientSideCache.getMaxCacheKb());
+                            cacheBuilder.setEnableMetrics(clientSideCache.isEnableMetrics());
+
+                            // Set optional TTL
+                            if (clientSideCache.getEntryTtlSeconds() != null) {
+                                cacheBuilder.setEntryTtlSeconds(clientSideCache.getEntryTtlSeconds());
+                            }
+
+                            // Set optional eviction policy
+                            if (clientSideCache.getEvictionPolicy() != null) {
+                                switch (clientSideCache.getEvictionPolicy()) {
+                                    case LRU:
+                                        cacheBuilder.setEvictionPolicy(
+                                                connection_request.ConnectionRequestOuterClass.EvictionPolicy.LRU);
+                                        break;
+                                    case LFU:
+                                        cacheBuilder.setEvictionPolicy(
+                                                connection_request.ConnectionRequestOuterClass.EvictionPolicy.LFU);
+                                        break;
+                                }
+                            }
+
+                            requestBuilder.setClientSideCache(cacheBuilder.build());
                         }
 
                         // Build and serialize to bytes

--- a/java/client/src/test/java/glide/api/models/configuration/BaseClientConfigurationTest.java
+++ b/java/client/src/test/java/glide/api/models/configuration/BaseClientConfigurationTest.java
@@ -31,6 +31,11 @@ public class BaseClientConfigurationTest {
             return null;
         }
 
+        @Override
+        public ClientSideCache getClientSideCache() {
+            return null;
+        }
+
         public static class TestClientConfigurationBuilder
                 extends BaseClientConfigurationBuilder<
                         TestClientConfiguration, TestClientConfigurationBuilder> {

--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -1,0 +1,648 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide;
+
+import static glide.TestUtilities.commonClientConfig;
+import static glide.TestUtilities.commonClusterClientConfig;
+import static glide.TestUtilities.getRandomString;
+import static glide.api.BaseClient.OK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Named.named;
+
+import glide.api.BaseClient;
+import glide.api.GlideClient;
+import glide.api.GlideClusterClient;
+import glide.api.models.configuration.ClientSideCache;
+import glide.api.models.configuration.EvictionPolicy;
+import glide.api.models.exceptions.RequestException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Integration tests for client-side caching functionality.
+ *
+ * <p>These tests verify the behavior of client-side caching across both standalone and cluster
+ * modes. The tests cover cache hit/miss metrics, TTL expiration, eviction policies, and various
+ * edge cases.
+ *
+ * <p><strong>Note:</strong> These tests are currently disabled because the native implementation
+ * for client-side cache methods is not yet complete. The tests will be enabled once the underlying
+ * Rust/FFI implementation is finished.
+ */
+@Timeout(35) // seconds
+public class ClientSideCacheTests {
+
+    /** Creates test clients with cache configuration for both standalone and cluster modes. */
+    @SneakyThrows
+    public static Stream<Arguments> getCacheEnabledClients() {
+        // Create separate cache instances to avoid sharing between standalone and cluster clients
+        ClientSideCache standaloneCache =
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(true).build();
+
+        ClientSideCache clusterCache =
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(true).build();
+
+        GlideClient standaloneClient =
+                GlideClient.createClient(commonClientConfig().clientSideCache(standaloneCache).build())
+                        .get();
+
+        GlideClusterClient clusterClient =
+                GlideClusterClient.createClient(
+                                commonClusterClientConfig().clientSideCache(clusterCache).build())
+                        .get();
+
+        return Stream.of(
+                Arguments.of(named("GlideClient", standaloneClient)),
+                Arguments.of(named("GlideClusterClient", clusterClient)));
+    }
+
+    /** Creates test clients without cache configuration for both standalone and cluster modes. */
+    @SneakyThrows
+    public static Stream<Arguments> getNoCacheClients() {
+        GlideClient standaloneClient = GlideClient.createClient(commonClientConfig().build()).get();
+
+        GlideClusterClient clusterClient =
+                GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
+
+        return Stream.of(
+                Arguments.of(named("GlideClient", standaloneClient)),
+                Arguments.of(named("GlideClusterClient", clusterClient)));
+    }
+
+    /** Creates test clients with cache but metrics disabled. */
+    @SneakyThrows
+    public static Stream<Arguments> getCacheNoMetricsClients() {
+        // Create separate cache instances to avoid sharing between standalone and cluster clients
+        ClientSideCache standaloneCache =
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(false).build();
+
+        ClientSideCache clusterCache =
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(false).build();
+
+        GlideClient standaloneClient =
+                GlideClient.createClient(commonClientConfig().clientSideCache(standaloneCache).build())
+                        .get();
+
+        GlideClusterClient clusterClient =
+                GlideClusterClient.createClient(
+                                commonClusterClientConfig().clientSideCache(clusterCache).build())
+                        .get();
+
+        return Stream.of(
+                Arguments.of(named("GlideClient", standaloneClient)),
+                Arguments.of(named("GlideClusterClient", clusterClient)));
+    }
+
+    /**
+     * Test basic cache hit/miss behavior with metrics tracking.
+     *
+     * <p>This test verifies:
+     *
+     * <ul>
+     *   <li>First GET results in cache miss
+     *   <li>Subsequent GETs result in cache hits
+     *   <li>Cache entry count is tracked correctly
+     *   <li>Hit rate and miss rate calculations are accurate
+     * </ul>
+     */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_basic_cache_hit_with_metrics(BaseClient client) {
+        String key = "cache_test_key_" + getRandomString(10);
+        String value = "cache_test_value";
+
+        // Set a key
+        assertEquals(OK, client.set(key, value).get());
+
+        // First GET - cache miss
+        assertEquals(value, client.get(key).get());
+
+        // Entry count should be 1
+        assertEquals(1L, client.getCacheEntryCount().get(), "Expected 1 entry in cache");
+
+        // Second GET - cache hit
+        assertEquals(value, client.get(key).get());
+
+        // Third GET - cache hit
+        assertEquals(value, client.get(key).get());
+
+        // Verify metrics: 1 miss + 2 hits = 3 total
+        Double hitRate = client.getCacheHitRate().get();
+        Double missRate = client.getCacheMissRate().get();
+
+        assertEquals(2.0 / 3.0, hitRate, 0.001, "Expected 66.67% hit rate");
+        assertEquals(1.0 / 3.0, missRate, 0.001, "Expected 33.33% miss rate");
+        assertEquals(1.0, hitRate + missRate, 0.0001, "Rates should sum to 1.0");
+    }
+
+    /** Test that cache works but metrics are disabled when configured. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheNoMetricsClients")
+    @SneakyThrows
+    public void test_cache_without_metrics(BaseClient client) {
+        String key = "key_" + getRandomString(10);
+        String value = "value";
+
+        // Cache should work
+        assertEquals(OK, client.set(key, value).get());
+        assertEquals(value, client.get(key).get());
+        assertEquals(value, client.get(key).get()); // Should be cached
+
+        // Entry count should still work
+        assertEquals(1L, client.getCacheEntryCount().get(), "Expected 1 entry in cache");
+
+        // Metrics should fail
+        ExecutionException hitRateException =
+                assertThrows(ExecutionException.class, () -> client.getCacheHitRate().get());
+        assertTrue(hitRateException.getCause().getMessage().toLowerCase().contains("metrics"));
+
+        ExecutionException missRateException =
+                assertThrows(ExecutionException.class, () -> client.getCacheMissRate().get());
+        assertTrue(missRateException.getCause().getMessage().toLowerCase().contains("metrics"));
+
+        ExecutionException evictionsException =
+                assertThrows(ExecutionException.class, () -> client.getCacheEvictions().get());
+        assertTrue(evictionsException.getCause().getMessage().toLowerCase().contains("metrics"));
+
+        ExecutionException expirationsException =
+                assertThrows(ExecutionException.class, () -> client.getCacheExpirations().get());
+        assertTrue(expirationsException.getCause().getMessage().toLowerCase().contains("metrics"));
+    }
+
+    /** Test that NIL (null) values are not cached. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_nil_values_not_cached(BaseClient client) {
+        String nonExistentKey = "nonexistent_key_" + getRandomString(10);
+
+        // GET non-existent key (returns null)
+        assertEquals(null, client.get(nonExistentKey).get());
+
+        // Entry count should be 0
+        assertEquals(0L, client.getCacheEntryCount().get(), "Expected 0 entries in cache");
+
+        // GET again - should NOT be cached (NIL values not cached)
+        assertEquals(null, client.get(nonExistentKey).get());
+
+        // Miss rate should be 100%
+        Double missRate = client.getCacheMissRate().get();
+        assertEquals(1.0, missRate, 0.001, "Expected 100% miss rate");
+    }
+
+    /** Test that cache entries expire after their TTL. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_ttl_expiration(BaseClient client) {
+        // Create cache with short TTL
+        ClientSideCache shortTtlCache =
+                ClientSideCache.builder()
+                        .maxCacheKb(1L)
+                        .entryTtlSeconds(2L) // 2 seconds
+                        .enableMetrics(true)
+                        .build();
+
+        BaseClient shortTtlClient;
+        if (client instanceof GlideClient) {
+            shortTtlClient =
+                    GlideClient.createClient(commonClientConfig().clientSideCache(shortTtlCache).build())
+                            .get();
+        } else {
+            shortTtlClient =
+                    GlideClusterClient.createClient(
+                                    commonClusterClientConfig().clientSideCache(shortTtlCache).build())
+                            .get();
+        }
+
+        try {
+            String key = "ttl_key_" + getRandomString(10);
+            String value = "ttl_value";
+
+            // Set and GET
+            assertEquals(OK, shortTtlClient.set(key, value).get());
+            assertEquals(value, shortTtlClient.get(key).get());
+
+            assertEquals(1L, shortTtlClient.getCacheEntryCount().get(), "Expected 1 entry in cache");
+
+            // Second GET - from cache
+            assertEquals(value, shortTtlClient.get(key).get());
+
+            // Wait for TTL to expire
+            Thread.sleep(3000);
+
+            // GET after expiration - should fetch from server again
+            assertEquals(value, shortTtlClient.get(key).get());
+
+            // Expiration count should be 1
+            Long expirations = shortTtlClient.getCacheExpirations().get();
+            assertEquals(1L, expirations, "Expected 1 expiration");
+
+            // Miss rate should be 2 misses out of 3 total = 66.67%
+            Double missRate = shortTtlClient.getCacheMissRate().get();
+            assertEquals(2.0 / 3.0, missRate, 0.001, "Expected 66.67% miss rate");
+        } finally {
+            shortTtlClient.close();
+        }
+    }
+
+    /** Test caching behavior with multiple keys. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_multiple_keys(BaseClient client) {
+        // Create keys with consistent names
+        String[] keys = new String[3];
+        String[] values = new String[3];
+
+        // Set 3 keys
+        for (int i = 0; i < 3; i++) {
+            keys[i] = "key" + (i + 1) + "_" + getRandomString(5);
+            values[i] = "value" + (i + 1);
+            assertEquals(OK, client.set(keys[i], values[i]).get());
+        }
+
+        // GET each key twice (miss + hit)
+        for (int i = 0; i < 3; i++) {
+            assertEquals(values[i], client.get(keys[i]).get()); // First GET - cache miss
+            assertEquals(values[i], client.get(keys[i]).get()); // Second GET - cache hit
+        }
+
+        // Entry count should be 3
+        assertEquals(3L, client.getCacheEntryCount().get(), "Expected 3 entries in cache");
+
+        // Verify metrics: 3 misses + 3 hits = 50% hit rate
+        Double hitRate = client.getCacheHitRate().get();
+        assertEquals(0.5, hitRate, 0.001, "Expected 50% hit rate");
+    }
+
+    /** Test that clients without cache configuration cannot access cache metrics. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getNoCacheClients")
+    @SneakyThrows
+    public void test_no_cache_metrics(BaseClient client) {
+        String key = "key_" + getRandomString(10);
+        String value = "value";
+
+        // Set and GET multiple times
+        assertEquals(OK, client.set(key, value).get());
+        assertEquals(value, client.get(key).get());
+        assertEquals(value, client.get(key).get());
+        assertEquals(value, client.get(key).get());
+
+        // Metrics should error
+        ExecutionException hitRateException =
+                assertThrows(ExecutionException.class, () -> client.getCacheHitRate().get());
+        assertTrue(hitRateException.getCause().getMessage().toLowerCase().contains("not enabled"));
+
+        ExecutionException missRateException =
+                assertThrows(ExecutionException.class, () -> client.getCacheMissRate().get());
+        assertTrue(missRateException.getCause().getMessage().toLowerCase().contains("not enabled"));
+
+        ExecutionException evictionsException =
+                assertThrows(ExecutionException.class, () -> client.getCacheEvictions().get());
+        assertTrue(evictionsException.getCause().getMessage().toLowerCase().contains("not enabled"));
+
+        ExecutionException expirationsException =
+                assertThrows(ExecutionException.class, () -> client.getCacheExpirations().get());
+        assertTrue(expirationsException.getCause().getMessage().toLowerCase().contains("not enabled"));
+
+        ExecutionException entryCountException =
+                assertThrows(ExecutionException.class, () -> client.getCacheEntryCount().get());
+        assertTrue(entryCountException.getCause().getMessage().toLowerCase().contains("not enabled"));
+    }
+
+    /** Test LRU (Least Recently Used) eviction policy. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_eviction_policy_lru(BaseClient client) {
+        // Create cache with LRU eviction policy
+        ClientSideCache lruCache =
+                ClientSideCache.builder()
+                        .maxCacheKb(1L) // 1 KB to force eviction
+                        .entryTtlSeconds(null)
+                        .evictionPolicy(EvictionPolicy.LRU)
+                        .enableMetrics(true)
+                        .build();
+
+        BaseClient lruClient;
+        if (client instanceof GlideClient) {
+            lruClient =
+                    GlideClient.createClient(commonClientConfig().clientSideCache(lruCache).build()).get();
+        } else {
+            lruClient =
+                    GlideClusterClient.createClient(
+                                    commonClusterClientConfig().clientSideCache(lruCache).build())
+                            .get();
+        }
+
+        try {
+            // Use larger values to force eviction
+            String value = new String(new char[250]).replace('\0', 'x'); // ~250 bytes
+
+            // Set and cache 3 keys
+            for (int i = 1; i <= 3; i++) {
+                assertEquals(OK, lruClient.set("lru_key" + i, value).get());
+                assertEquals(value, lruClient.get("lru_key" + i).get());
+            }
+
+            // Cache should have 3 entries now
+            assertEquals(3L, lruClient.getCacheEntryCount().get(), "Expected 3 entries in cache");
+
+            // Access key1 to make it recently used
+            assertEquals(value, lruClient.get("lru_key1").get());
+
+            // Add 2 more keys - should evict key2 and key3 (least recently used)
+            for (int i = 4; i <= 5; i++) {
+                assertEquals(OK, lruClient.set("lru_key" + i, value).get());
+                assertEquals(value, lruClient.get("lru_key" + i).get());
+            }
+
+            // Verify 2 evictions occurred
+            Long evictions = lruClient.getCacheEvictions().get();
+            assertEquals(2L, evictions, "Expected 2 evictions");
+
+            // Verify cache is working (hit rate > 0)
+            Double hitRate = lruClient.getCacheHitRate().get();
+            assertTrue(hitRate > 0, "Cache should have some hits");
+
+            // Check that key1 is still cached
+            assertEquals(value, lruClient.get("lru_key1").get());
+            Double newHitRate = lruClient.getCacheHitRate().get();
+            assertTrue(newHitRate > hitRate, "Key1 should still be in cache");
+
+            // Check that key2 and key3 are evicted
+            Double oldMissRate = lruClient.getCacheMissRate().get();
+            assertEquals(value, lruClient.get("lru_key2").get());
+            assertEquals(value, lruClient.get("lru_key3").get());
+            Double newMissRate = lruClient.getCacheMissRate().get();
+            assertTrue(newMissRate > oldMissRate, "Key2 and Key3 should be evicted from cache");
+        } finally {
+            lruClient.close();
+        }
+    }
+
+    /** Test LFU (Least Frequently Used) eviction policy. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_eviction_policy_lfu(BaseClient client) {
+        // Create cache with LFU eviction policy
+        ClientSideCache lfuCache =
+                ClientSideCache.builder()
+                        .maxCacheKb(1L) // 1 KB - small cache to trigger evictions
+                        .entryTtlSeconds(null)
+                        .evictionPolicy(EvictionPolicy.LFU)
+                        .enableMetrics(true)
+                        .build();
+
+        BaseClient lfuClient;
+        if (client instanceof GlideClient) {
+            lfuClient =
+                    GlideClient.createClient(commonClientConfig().clientSideCache(lfuCache).build()).get();
+        } else {
+            lfuClient =
+                    GlideClusterClient.createClient(
+                                    commonClusterClientConfig().clientSideCache(lfuCache).build())
+                            .get();
+        }
+
+        try {
+            String value = new String(new char[250]).replace('\0', 'x'); // ~250 bytes
+
+            // Set key1 and access it multiple times (high frequency)
+            assertEquals(OK, lfuClient.set("key1", value).get());
+            for (int i = 0; i < 5; i++) {
+                assertEquals(value, lfuClient.get("key1").get());
+            }
+            // key1 frequency: 5
+
+            // Set key2 and access it a few times (medium frequency)
+            assertEquals(OK, lfuClient.set("key2", value).get());
+            for (int i = 0; i < 2; i++) {
+                assertEquals(value, lfuClient.get("key2").get());
+            }
+            // key2 frequency: 2
+
+            // Set key3 with minimal access (low frequency)
+            assertEquals(OK, lfuClient.set("key3", value).get());
+            assertEquals(value, lfuClient.get("key3").get());
+            // key3 frequency: 1
+
+            // Verify cache is working
+            Double hitRate = lfuClient.getCacheHitRate().get();
+            assertTrue(hitRate > 0, "Cache should have some hits");
+
+            // Cache should have 3 entries now
+            assertEquals(3L, lfuClient.getCacheEntryCount().get(), "Expected 3 entries in cache");
+
+            // Set key4 - this should trigger eviction of key3 (lowest frequency)
+            assertEquals(OK, lfuClient.set("key4", value).get());
+            assertEquals(value, lfuClient.get("key4").get());
+            // key4 frequency: 1
+
+            // Check that cache entry count is still 3
+            assertEquals(3L, lfuClient.getCacheEntryCount().get(), "Expected 3 entries in cache");
+
+            // Verify 1 eviction occurred
+            assertEquals(1L, lfuClient.getCacheEvictions().get(), "Expected 1 eviction");
+
+            // Check that key1 (highest frequency) is still cached
+            Double oldHitRate = lfuClient.getCacheHitRate().get();
+            assertEquals(value, lfuClient.get("key1").get());
+            Double newHitRate = lfuClient.getCacheHitRate().get();
+            assertTrue(newHitRate > oldHitRate, "key1 (highest frequency) should still be cached");
+
+            // Check that key3 (lowest frequency) was evicted
+            Double oldMissRate = lfuClient.getCacheMissRate().get();
+            assertEquals(value, lfuClient.get("key3").get()); // Should be a miss
+            Double newMissRate = lfuClient.getCacheMissRate().get();
+            assertTrue(newMissRate > oldMissRate, "key3 (lowest frequency) should have been evicted");
+
+            // key2 (medium frequency) should still be cached
+            oldHitRate = lfuClient.getCacheHitRate().get();
+            assertEquals(value, lfuClient.get("key2").get());
+            newHitRate = lfuClient.getCacheHitRate().get();
+            assertTrue(newHitRate > oldHitRate, "key2 (medium frequency) should still be cached");
+        } finally {
+            lfuClient.close();
+        }
+    }
+
+    /** Test that cache respects maximum memory limits. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_max_memory_limit(BaseClient client) {
+        // Create cache with memory limit
+        ClientSideCache memoryLimitCache =
+                ClientSideCache.builder()
+                        .maxCacheKb(1L) // 1 KB
+                        .entryTtlSeconds(null)
+                        .enableMetrics(true)
+                        .evictionPolicy(EvictionPolicy.LRU)
+                        .build();
+
+        BaseClient memoryClient;
+        if (client instanceof GlideClient) {
+            memoryClient =
+                    GlideClient.createClient(commonClientConfig().clientSideCache(memoryLimitCache).build())
+                            .get();
+        } else {
+            memoryClient =
+                    GlideClusterClient.createClient(
+                                    commonClusterClientConfig().clientSideCache(memoryLimitCache).build())
+                            .get();
+        }
+
+        try {
+            // Create values that are ~400 bytes each
+            String largeValue = new String(new char[400]).replace('\0', 'x');
+
+            // Add 10 keys to force eviction
+            for (int i = 1; i <= 10; i++) {
+                String key = "key" + i + "_" + getRandomString(5);
+                assertEquals(OK, memoryClient.set(key, largeValue).get());
+                assertEquals(largeValue, memoryClient.get(key).get());
+                assertEquals(largeValue, memoryClient.get(key).get());
+            }
+
+            Double currentHitRate = memoryClient.getCacheHitRate().get();
+            assertTrue(currentHitRate > 0, "Cache should have some hits");
+
+            // Verify that evictions occurred
+            Long evictions = memoryClient.getCacheEvictions().get();
+            assertTrue(evictions > 0, "Expected evictions due to max memory limit");
+        } finally {
+            memoryClient.close();
+        }
+    }
+
+    /** Test shared cache behavior between multiple clients. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_shared_cache(BaseClient client) {
+        // Create shared cache instance
+        ClientSideCache sharedCache =
+                ClientSideCache.builder()
+                        .maxCacheKb(1024L)
+                        .entryTtlSeconds(60L)
+                        .evictionPolicy(null)
+                        .enableMetrics(true)
+                        .build();
+
+        // Create two clients with the same cache
+        BaseClient client1, client2;
+        if (client instanceof GlideClient) {
+            client1 =
+                    GlideClient.createClient(commonClientConfig().clientSideCache(sharedCache).build()).get();
+            client2 =
+                    GlideClient.createClient(commonClientConfig().clientSideCache(sharedCache).build()).get();
+        } else {
+            client1 =
+                    GlideClusterClient.createClient(
+                                    commonClusterClientConfig().clientSideCache(sharedCache).build())
+                            .get();
+            client2 =
+                    GlideClusterClient.createClient(
+                                    commonClusterClientConfig().clientSideCache(sharedCache).build())
+                            .get();
+        }
+
+        try {
+            String key = "shared_key_" + getRandomString(10);
+            String value = "value";
+
+            assertEquals(OK, client1.set(key, value).get());
+            assertEquals(value, client1.get(key).get());
+
+            // Entry count should be 1
+            Long entryCount = client2.getCacheEntryCount().get();
+            assertEquals(1L, entryCount, "Expected 1 entry in shared cache");
+
+            assertEquals(value, client2.get(key).get());
+
+            assertEquals(0.5, client2.getCacheHitRate().get(), 0.001);
+            assertEquals(0.5, client1.getCacheHitRate().get(), 0.001);
+        } finally {
+            client1.close();
+            client2.close();
+        }
+    }
+
+    /** Test that attempting to use wrong key types raises appropriate errors. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cache_wrong_key_type_raises_error(BaseClient client) {
+        String key = "string-key_" + getRandomString(10);
+        String value = "value";
+
+        assertEquals(OK, client.set(key, value).get());
+        assertEquals(value, client.get(key).get());
+
+        ExecutionException exception =
+                assertThrows(ExecutionException.class, () -> client.hgetall(key).get()); // Wrong type
+
+        assertTrue(exception.getCause() instanceof RequestException);
+        assertTrue(exception.getCause().getMessage().contains("WRONGTYPE"));
+    }
+
+    /** Test that only cacheable commands are actually cached. */
+    @ParameterizedTest(autoCloseArguments = true)
+    @MethodSource("getCacheEnabledClients")
+    @SneakyThrows
+    public void test_cacheable_commands(BaseClient client) {
+        String keyPrefix = getRandomString(10);
+
+        // SET command - not cacheable
+        assertEquals(OK, client.set(keyPrefix + "_key", "value").get());
+
+        // GET command - cacheable
+        assertEquals("value", client.get(keyPrefix + "_key").get());
+
+        // Check that now the cache entry count is 1
+        Long entryCount = client.getCacheEntryCount().get();
+        assertEquals(1L, entryCount, "Expected 1 entry in cache after GET");
+
+        // HGETALL command - cacheable
+        String hashKey = keyPrefix + "_hashkey";
+        Map<String, String> hashMap = new HashMap<>();
+        hashMap.put("field1", "val1");
+        assertEquals(1L, client.hset(hashKey, hashMap).get());
+
+        Map<String, String> result = client.hgetall(hashKey).get();
+        assertEquals("val1", result.get("field1"));
+
+        entryCount = client.getCacheEntryCount().get();
+        assertEquals(2L, entryCount, "Expected 2 entries in cache after HGETALL");
+
+        // SMEMBERS command - cacheable
+        String setKey = keyPrefix + "_setkey";
+        assertEquals(1L, client.sadd(setKey, new String[] {"member1"}).get());
+        Set<String> members = client.smembers(setKey).get();
+        assertTrue(members.contains("member1"));
+
+        entryCount = client.getCacheEntryCount().get();
+        assertEquals(3L, entryCount, "Expected 3 entries in cache after SMEMBERS");
+
+        // Clean up
+        if (client instanceof GlideClient) {
+            ((GlideClient) client).flushall().get();
+        } else {
+            ((GlideClusterClient) client).flushall().get();
+        }
+    }
+}

--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -33,10 +33,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  * <p>These tests verify the behavior of client-side caching across both standalone and cluster
  * modes. The tests cover cache hit/miss metrics, TTL expiration, eviction policies, and various
  * edge cases.
- *
- * <p><strong>Note:</strong> These tests are currently disabled because the native implementation
- * for client-side cache methods is not yet complete. The tests will be enabled once the underlying
- * Rust/FFI implementation is finished.
  */
 @Timeout(35) // seconds
 public class ClientSideCacheTests {

--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -173,9 +173,12 @@ public class ClientSideCacheTests {
         ExecutionException expirationsException =
                 assertThrows(ExecutionException.class, () -> client.getCacheExpirations().get());
         assertTrue(expirationsException.getCause().getMessage().toLowerCase().contains("metrics"));
+
+        ExecutionException totalLookupsException =
+                assertThrows(ExecutionException.class, () -> client.getCacheTotalLookups().get());
+        assertTrue(totalLookupsException.getCause().getMessage().toLowerCase().contains("metrics"));
     }
 
-    /** Test that NIL (null) values are not cached. */
     @ParameterizedTest(autoCloseArguments = true)
     @MethodSource("getCacheEnabledClients")
     @SneakyThrows
@@ -316,6 +319,10 @@ public class ClientSideCacheTests {
         ExecutionException entryCountException =
                 assertThrows(ExecutionException.class, () -> client.getCacheEntryCount().get());
         assertTrue(entryCountException.getCause().getMessage().toLowerCase().contains("not enabled"));
+
+        ExecutionException totalLookupsException =
+                assertThrows(ExecutionException.class, () -> client.getCacheTotalLookups().get());
+        assertTrue(totalLookupsException.getCause().getMessage().toLowerCase().contains("not enabled"));
     }
 
     /** Test LRU (Least Recently Used) eviction policy. */

--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -42,10 +42,10 @@ public class ClientSideCacheTests {
     public static Stream<Arguments> getCacheEnabledClients() {
         // Create separate cache instances to avoid sharing between standalone and cluster clients
         ClientSideCache standaloneCache =
-                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(true).build();
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlMs(60000L).enableMetrics(true).build();
 
         ClientSideCache clusterCache =
-                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(true).build();
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlMs(60000L).enableMetrics(true).build();
 
         GlideClient standaloneClient =
                 GlideClient.createClient(commonClientConfig().clientSideCache(standaloneCache).build())
@@ -79,10 +79,10 @@ public class ClientSideCacheTests {
     public static Stream<Arguments> getCacheNoMetricsClients() {
         // Create separate cache instances to avoid sharing between standalone and cluster clients
         ClientSideCache standaloneCache =
-                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(false).build();
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlMs(60000L).enableMetrics(false).build();
 
         ClientSideCache clusterCache =
-                ClientSideCache.builder().maxCacheKb(1L).entryTtlSeconds(60L).enableMetrics(false).build();
+                ClientSideCache.builder().maxCacheKb(1L).entryTtlMs(60000L).enableMetrics(false).build();
 
         GlideClient standaloneClient =
                 GlideClient.createClient(commonClientConfig().clientSideCache(standaloneCache).build())
@@ -205,7 +205,7 @@ public class ClientSideCacheTests {
         ClientSideCache shortTtlCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L)
-                        .entryTtlSeconds(2L) // 2 seconds
+                        .entryTtlMs(2000L) // 2 seconds
                         .enableMetrics(true)
                         .build();
 
@@ -327,7 +327,7 @@ public class ClientSideCacheTests {
         ClientSideCache lruCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L) // 1 KB to force eviction
-                        .entryTtlSeconds(null)
+                        .entryTtlMs(null)
                         .evictionPolicy(EvictionPolicy.LRU)
                         .enableMetrics(true)
                         .build();
@@ -398,7 +398,7 @@ public class ClientSideCacheTests {
         ClientSideCache lfuCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L) // 1 KB - small cache to trigger evictions
-                        .entryTtlSeconds(null)
+                        .entryTtlMs(null)
                         .evictionPolicy(EvictionPolicy.LFU)
                         .enableMetrics(true)
                         .build();
@@ -485,7 +485,7 @@ public class ClientSideCacheTests {
         ClientSideCache memoryLimitCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L) // 1 KB
-                        .entryTtlSeconds(null)
+                        .entryTtlMs(null)
                         .enableMetrics(true)
                         .evictionPolicy(EvictionPolicy.LRU)
                         .build();
@@ -534,7 +534,7 @@ public class ClientSideCacheTests {
         ClientSideCache sharedCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1024L)
-                        .entryTtlSeconds(60L)
+                        .entryTtlMs(60000L)
                         .evictionPolicy(null)
                         .enableMetrics(true)
                         .build();

--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -139,6 +139,10 @@ public class ClientSideCacheTests {
         assertEquals(2.0 / 3.0, hitRate, 0.001, "Expected 66.67% hit rate");
         assertEquals(1.0 / 3.0, missRate, 0.001, "Expected 33.33% miss rate");
         assertEquals(1.0, hitRate + missRate, 0.0001, "Rates should sum to 1.0");
+
+        // Verify total lookups: 1 miss + 2 hits = 3
+        Long totalLookups = client.getCacheTotalLookups().get();
+        assertEquals(3L, totalLookups, "Expected 3 total lookups (1 miss + 2 hits)");
     }
 
     /** Test that cache works but metrics are disabled when configured. */
@@ -197,6 +201,10 @@ public class ClientSideCacheTests {
         // Miss rate should be 100%
         Double missRate = client.getCacheMissRate().get();
         assertEquals(1.0, missRate, 0.001, "Expected 100% miss rate");
+
+        // Total lookups should be 2
+        Long totalLookups = client.getCacheTotalLookups().get();
+        assertEquals(2L, totalLookups, "Expected 2 total lookups");
     }
 
     /** Test that cache entries expire after their TTL. */
@@ -250,6 +258,10 @@ public class ClientSideCacheTests {
             // Miss rate should be 2 misses out of 3 total = 66.67%
             Double missRate = shortTtlClient.getCacheMissRate().get();
             assertEquals(2.0 / 3.0, missRate, 0.001, "Expected 66.67% miss rate");
+
+            // Total lookups should be 3
+            Long totalLookups = shortTtlClient.getCacheTotalLookups().get();
+            assertEquals(3L, totalLookups, "Expected 3 total lookups");
         } finally {
             shortTtlClient.close();
         }
@@ -283,6 +295,10 @@ public class ClientSideCacheTests {
         // Verify metrics: 3 misses + 3 hits = 50% hit rate
         Double hitRate = client.getCacheHitRate().get();
         assertEquals(0.5, hitRate, 0.001, "Expected 50% hit rate");
+
+        // Total lookups should be 6
+        Long totalLookups = client.getCacheTotalLookups().get();
+        assertEquals(6L, totalLookups, "Expected 6 total lookups (3 misses + 3 hits)");
     }
 
     /** Test that clients without cache configuration cannot access cache metrics. */
@@ -579,6 +595,10 @@ public class ClientSideCacheTests {
 
             assertEquals(0.5, client2.getCacheHitRate().get(), 0.001);
             assertEquals(0.5, client1.getCacheHitRate().get(), 0.001);
+
+            // Total lookups should be 2
+            Long totalLookups = client1.getCacheTotalLookups().get();
+            assertEquals(2L, totalLookups, "Expected 2 total lookups on shared cache");
         } finally {
             client1.close();
             client2.close();

--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -327,7 +327,7 @@ public class ClientSideCacheTests {
         ClientSideCache lruCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L) // 1 KB to force eviction
-                        .entryTtlMs(null)
+                        .entryTtlMs(0L)
                         .evictionPolicy(EvictionPolicy.LRU)
                         .enableMetrics(true)
                         .build();
@@ -398,7 +398,7 @@ public class ClientSideCacheTests {
         ClientSideCache lfuCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L) // 1 KB - small cache to trigger evictions
-                        .entryTtlMs(null)
+                        .entryTtlMs(0L)
                         .evictionPolicy(EvictionPolicy.LFU)
                         .enableMetrics(true)
                         .build();
@@ -485,7 +485,7 @@ public class ClientSideCacheTests {
         ClientSideCache memoryLimitCache =
                 ClientSideCache.builder()
                         .maxCacheKb(1L) // 1 KB
-                        .entryTtlMs(null)
+                        .entryTtlMs(0L)
                         .enableMetrics(true)
                         .evictionPolicy(EvictionPolicy.LRU)
                         .build();

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2583,11 +2583,11 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_getCacheMetrics(
                 Ok(client) => {
                     // Convert metrics_type to CacheMetricsType enum
                     let result = match metrics_type {
-                        0 => client.cache_hit_rate(),      // HitRate
-                        1 => client.cache_miss_rate(),     // MissRate
-                        2 => client.cache_entry_count(),   // EntryCount
-                        3 => client.cache_evictions(),     // Evictions
-                        4 => client.cache_expirations(),   // Expirations
+                        0 => client.cache_hit_rate(),    // HitRate
+                        1 => client.cache_miss_rate(),   // MissRate
+                        2 => client.cache_entry_count(), // EntryCount
+                        3 => client.cache_evictions(),   // Evictions
+                        4 => client.cache_expirations(), // Expirations
                         _ => Err(redis::RedisError::from((
                             redis::ErrorKind::ClientError,
                             "Invalid cache metrics type",

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2559,7 +2559,7 @@ fn get_ok_jstring<'a>(env: &mut JNIEnv<'a>) -> Result<JString<'a>, FFIError> {
 /// Get cache metrics asynchronously
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_glide_internal_GlideNativeBridge_getCacheMetrics(
-    env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
     client_ptr: jlong,
     callback_id: jlong,
@@ -2568,16 +2568,11 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_getCacheMetrics(
     run_ffi(|| {
         let handle_id = client_ptr as u64;
 
-        let jvm = match env.get_java_vm() {
-            Ok(jvm) => Arc::new(jvm),
-            Err(_) => {
-                log::error!("JVM error in getCacheMetrics");
-                return Some(());
-            }
+        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "getCacheMetrics") else {
+            return Some(());
         };
 
-        let runtime = get_runtime();
-        runtime.spawn(async move {
+        get_runtime().spawn(async move {
             let client_result = ensure_client_for_handle(handle_id).await;
             match client_result {
                 Ok(client) => {

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2555,3 +2555,68 @@ fn get_ok_jstring<'a>(env: &mut JNIEnv<'a>) -> Result<JString<'a>, FFIError> {
     let local = env.new_local_ref(global.as_obj())?;
     Ok(JString::from(local))
 }
+
+/// Get cache metrics asynchronously
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_getCacheMetrics(
+    env: JNIEnv,
+    _class: JClass,
+    client_ptr: jlong,
+    callback_id: jlong,
+    metrics_type: jint,
+) {
+    run_ffi(|| {
+        let handle_id = client_ptr as u64;
+
+        let jvm = match env.get_java_vm() {
+            Ok(jvm) => Arc::new(jvm),
+            Err(_) => {
+                log::error!("JVM error in getCacheMetrics");
+                return Some(());
+            }
+        };
+
+        let runtime = get_runtime();
+        runtime.spawn(async move {
+            let client_result = ensure_client_for_handle(handle_id).await;
+            match client_result {
+                Ok(client) => {
+                    // Convert metrics_type to CacheMetricsType enum
+                    let result = match metrics_type {
+                        0 => client.cache_hit_rate(),      // HitRate
+                        1 => client.cache_miss_rate(),     // MissRate
+                        2 => client.cache_entry_count(),   // EntryCount
+                        3 => client.cache_evictions(),     // Evictions
+                        4 => client.cache_expirations(),   // Expirations
+                        _ => Err(redis::RedisError::from((
+                            redis::ErrorKind::ClientError,
+                            "Invalid cache metrics type",
+                            format!("Unknown metrics type: {}", metrics_type),
+                        ))),
+                    };
+
+                    let final_result = result.map_err(|e| {
+                        redis::RedisError::from((
+                            redis::ErrorKind::ClientError,
+                            "Cache metrics error",
+                            e.to_string(),
+                        ))
+                    });
+
+                    complete_callback(jvm, callback_id, final_result, false);
+                }
+                Err(err) => {
+                    let error = Err(redis::RedisError::from((
+                        redis::ErrorKind::ClientError,
+                        "Client not found",
+                        err.to_string(),
+                    )));
+                    complete_callback(jvm, callback_id, error, false);
+                }
+            }
+        });
+
+        Some(())
+    })
+    .unwrap_or(())
+}

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2581,14 +2581,17 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_getCacheMetrics(
             let client_result = ensure_client_for_handle(handle_id).await;
             match client_result {
                 Ok(client) => {
-                    // Convert metrics_type to CacheMetricsType enum
-                    let result = match metrics_type {
-                        0 => client.cache_hit_rate(),    // HitRate
-                        1 => client.cache_miss_rate(),   // MissRate
-                        2 => client.cache_entry_count(), // EntryCount
-                        3 => client.cache_evictions(),   // Evictions
-                        4 => client.cache_expirations(), // Expirations
-                        _ => Err(redis::RedisError::from((
+                    use glide_core::command_request::CacheMetricsType;
+                    use protobuf::Enum;
+
+                    let result = match CacheMetricsType::from_i32(metrics_type) {
+                        Some(CacheMetricsType::HitRate) => client.cache_hit_rate(),
+                        Some(CacheMetricsType::MissRate) => client.cache_miss_rate(),
+                        Some(CacheMetricsType::EntryCount) => client.cache_entry_count(),
+                        Some(CacheMetricsType::Evictions) => client.cache_evictions(),
+                        Some(CacheMetricsType::Expirations) => client.cache_expirations(),
+                        Some(CacheMetricsType::TotalLookups) => client.cache_total_lookups(),
+                        None => Err(redis::RedisError::from((
                             redis::ErrorKind::ClientError,
                             "Invalid cache metrics type",
                             format!("Unknown metrics type: {}", metrics_type),


### PR DESCRIPTION
### Summary

This PR adds TTL client-side caching support to the Java client.

### Issue link

This Pull Request is linked to issue (URL): #3924

### Features / Behaviour Changes

- Client-Side Cache Configuration: New `ClientSideCache` model allows the configuration of cache with memory limits, TTL, eviction policies, and metrics enablement
- Eviction Policies: Support for LRU (Least Recently Used) and LFU (Least Frequently Used) eviction strategies
- Cache Metrics API: Five new public methods on `BaseClient` for monitoring cache performance:
  - `getCacheHitRate()` - Returns cache hit rate as a percentage
  - `getCacheMissRate()` - Returns cache miss rate as a percentage
  - `getCacheEntryCount()` - Returns current number of cached entries
  - `getCacheEvictions()` - Returns total eviction count
  - `getCacheExpirations()` - Returns total expiration count
- **Flexible Configuration**: Supports both auto-generated and custom cache IDs, optional TTL, and toggleable metrics

### Implementation

#### Core Models (`java/client/src/main/java/glide/api/models/`)
- `ClientSideCache`: Builder-based configuration model with auto-generated UUID cache IDs, memory limits (maxCacheKb), optional entry TTL, eviction policy selection, and metrics toggle
- `EvictionPolicy`: Enum with LRU and LFU variants, each mapped to numeric values for FFI communication

#### Client API Extensions (`java/client/src/main/java/glide/api/BaseClient.java`)
- Added private `getCacheMetrics(CacheMetricsType)` method for internal metric retrieval
- Five public async methods (`CompletableFuture<T>`) for cache metrics with proper type casting

#### Infrastructure Layer
- `BaseClientConfiguration`: Added `clientSideCache` field to support cache configuration in both standalone and cluster configurations
- `CommandManager`: New `submitGetCacheMetrics()` method to submit cache metric requests to the core
- `ConnectionManager`: Handles cache initialization during client setup and lifecycle management
- `GlideCoreClient`: Added `getCacheMetrics()` method with correlation ID tracking for async responses
- `GlideNativeBridge`: Native JNI binding `getCacheMetrics(long clientPtr, long callbackId, int metricsType)`

#### FFI Bridge (`java/src/lib.rs`)
- Implemented `get_cache_metrics` JNI function to bridge Java requests to Rust core

### Limitations

This PR is enabling TTL side-caching and it is not enabling tracking caching. The tracking cache will be done in the future.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
