### PR TITLE
Re-enable tests that were skipped due to issue #2277

### DIFF
--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -2612,8 +2612,6 @@ func (suite *GlideTestSuite) TestScriptKillWithoutRoute() {
 }
 
 func (suite *GlideTestSuite) TestScriptKillWithRoute() {
-	suite.T().Skip("Flaky Test: Wait until #2277 is resolved")
-
 	invokeClient, err := suite.clusterClient(suite.defaultClusterClientConfig())
 	require.NoError(suite.T(), err)
 	killClient := suite.defaultClusterClient()
@@ -2683,8 +2681,6 @@ func (suite *GlideTestSuite) TestScriptKillUnkillableWithoutRoute() {
 }
 
 func (suite *GlideTestSuite) TestScriptKillUnkillableWithRoute() {
-	suite.T().Skip("Flaky Test: Wait until #2277 is resolved")
-
 	key := uuid.NewString()
 	invokeClient, err := suite.clusterClient(suite.defaultClusterClientConfig())
 	require.NoError(suite.T(), err)

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -102,7 +102,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1826,7 +1825,6 @@ public class CommandTests {
         assertEquals(OK, clusterClient.functionDelete(libName, route).get());
     }
 
-    @Disabled("flaky test") // Related to issue #2277, #2642
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("getClients")
@@ -3456,7 +3454,6 @@ public class CommandTests {
         script.close();
     }
 
-    @Disabled("flaky test") // Possibly related to issue #2277
     @ParameterizedTest
     @MethodSource("getClients")
     @SneakyThrows
@@ -3519,7 +3516,6 @@ public class CommandTests {
                         .contains("no scripts in execution right now"));
     }
 
-    @Disabled("flaky test") // Possibly related to #2277
     @Timeout(20)
     @SneakyThrows
     @ParameterizedTest


### PR DESCRIPTION
This PR re-enables all the skipped/disabled tests that were previously failing due to [Cluster client ignores route a command #2277](https://github.com/valkey-io/valkey-glide/issues/2277).

- Go: TestScriptKillWithRoute
- Go: TestScriptKillUnkillableWithRoute
- Java: fcall_readonly_function
- Java: scriptKill_with_route
- Java: scriptKill_unkillable

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
