### PR TITLE
Core: Fix unnecessary unwrap() warning in test utilities

### DIFF
--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -584,10 +584,10 @@ fn set_connection_info_to_connection_request(
     connection_request: &mut connection_request::ConnectionRequest,
 ) {
     connection_request.protocol = convert_to_protobuf_protocol(connection_info.protocol).into();
-    if connection_info.password.is_some() {
+    if let Some(password) = connection_info.password {
         connection_request.authentication_info =
             protobuf::MessageField(Some(Box::new(AuthenticationInfo {
-                password: connection_info.password.unwrap().into(),
+                password: password.into(),
                 username: connection_info.username.unwrap_or_default().into(),
                 iam_credentials: protobuf::MessageField::none(),
                 ..Default::default()


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
Fix build error due to calling unwrap after is_some() in tests/utilties/mod.rs.

### Issue link

This Pull Request is linked to issue (URL): #5213 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
