### PR TITLE
Core: Fix unnecessary unwrap() warning in connection.rs

### DIFF
--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -979,10 +979,10 @@ fn setup_connection(
         }
     }
 
-    if connection_info.client_name.is_some() {
+    if let Some(client_name) = &connection_info.client_name {
         match cmd("CLIENT")
             .arg("SETNAME")
-            .arg(connection_info.client_name.as_ref().unwrap())
+            .arg(client_name)
             .query::<Value>(&mut rv)
         {
             Ok(Value::Okay) => {}


### PR DESCRIPTION
Fix build error due to calling unwrap after is_some() in redis-rs/redis/src/connection.rs


### Issue link

This Pull Request is linked to issue (URL): https://github.com/valkey-io/valkey-glide/issues/5213

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
