### PR TITLE
Set default route for CLIENT LIST to be Random

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -700,6 +700,7 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"CLIENT ID"
         | b"CLIENT INFO"
         | b"CLIENT KILL"
+        | b"CLIENT LIST"
         | b"CLIENT PAUSE"
         | b"CLIENT REPLY"
         | b"CLIENT TRACKINGINFO"
@@ -2026,5 +2027,17 @@ mod tests_routing {
         let shard_addrs = create_shard_addrs("node1:6379", vec!["node2:6379", "node3:6379"]);
         let result = shard_addrs.attempt_shard_role_update(Arc::new("node4:6379".to_string()));
         assert_eq!(result, ShardUpdateResult::NodeNotFound);
+    }
+
+    #[test]
+    fn test_client_list_routing() {
+        let mut cmd = cmd("CLIENT");
+        cmd.arg("LIST");
+        let routing = RoutingInfo::for_routable(&cmd);
+        assert_eq!(
+            routing,
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)),
+            "CLIENT LIST should be routed to a random node"
+        );
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->
Set default route for CLIENT LIST to be Random and added a test

### Issue link

This Pull Request is linked to issue https://github.com/valkey-io/valkey-glide/issues/4974

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
