### PR TITLE
Pin usage of CodeQL 2.23.9 to prevent Rust analyzer hanging

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,6 +58,8 @@ jobs:
                   languages: ${{ matrix.language }}
                   build-mode: ${{ matrix.build-mode }}
                   config-file: .github/codeql/codeql-config.yml
+                  # Pin to 2.23.9 due to hang in 2.24.0 Rust analyzer
+                  tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-v2.23.9/codeql-bundle-linux64.tar.gz
 
             # C++ Build
             - name: Build C++ components


### PR DESCRIPTION
### Summary

CodeQL was upgraded from `2.23.9` to `2.24.0`. For reasons not yet understood, this causes the Rust analyzer in CI/CD to hang indefinitely.

`This may be a temporary fix to unblock CI/CD`, since the root cause is unknown.

### Issue link

This Pull Request is linked to issue: [CodeQL upgrade from 2.23.9 to 2.24.0 causes Rust analyzer in CICD to hang. #5271](https://github.com/valkey-io/valkey-glide/issues/5271)

### Features / Behaviour Changes

Explicity pin `CodeQL 2.23.9` to be used during the installation step of CodeQL

### Implementation

Update the `codeql.yml` file

### Limitations

This prevents further upgrade of CodeQL until we root cause.

### Testing

Passes CI/CD

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
