### PR TITLE
Drop support for Node.js 16.x and 18.x. Minimum supported version is now Node.js 20.x.

### DIFF
--- a/.github/json_matrices/supported-languages-versions.json
+++ b/.github/json_matrices/supported-languages-versions.json
@@ -11,8 +11,8 @@
     },
     {
         "language": "node",
-        "versions": ["16.x", "20.x", "22.x", "23.x"],
-        "always-run-versions": ["20.x", "23.x"]
+        "versions": ["20.x", "22.x", "24.x"],
+        "always-run-versions": ["20.x", "24.x"]
     },
     {
         "language": "go",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2.3
 
+#### Breaking Changes
+
+* Node: Remove support for EOL Node.js 16.x and 18.x ([#5276](https://github.com/valkey-io/valkey-glide/issues/5276))
+    * Node: Drop support for Node.js 16.x and 18.x. Minimum supported version is now Node.js 20.x.
+
 #### Changes
 
 * JAVA: Add EVAL_RO, EVALSHA_RO, and SCRIPT DEBUG commands ([#5125](https://github.com/valkey-io/valkey-glide/pull/5125))

--- a/examples/node/README.MD
+++ b/examples/node/README.MD
@@ -1,8 +1,8 @@
-### Install node 16 (or newer)
+### Install node 20 (or newer)
 ```
-curl -s https://deb.nodesource.com/setup_16.x | sudo bash
+curl -s https://deb.nodesource.com/setup_20.x | sudo bash
 apt-get install nodejs npm
-npm i -g npm@8
+npm i -g npm@10
 ```
 
 ## Install GLIDE package and build the example

--- a/node/AGENTS.md
+++ b/node/AGENTS.md
@@ -27,7 +27,7 @@ This is the Node.js/TypeScript client binding for Valkey GLIDE, providing both s
 **Supported Platforms:**
 - Linux: glibc 2.17+, musl libc 1.2.3+ (Alpine)
 - macOS: 13.5+ (x86_64), 15.0+ (aarch64/Apple Silicon)
-- Node.js: 16+ (npm 11+ recommended for Linux)
+- Node.js: 20+ (npm 11+ recommended for Linux)
 
 **Package:** `@valkey/valkey-glide` on npm
 
@@ -167,7 +167,7 @@ cargo fmt --manifest-path ./Cargo.toml --all
 - `package-lock.json`, `yarn.lock` - Lock files (project uses npm)
 
 ### Node.js-Specific Rules
-- **Node.js 16+ Required:** Minimum runtime version
+- **Node.js 20+ Required:** Minimum runtime version
 - **npm 11+ Recommended:** For Linux users (better libc support)
 - **Promise-based APIs:** All client methods return Promises
 - **Resource Management:** Call `client.close()` to cleanup connections
@@ -221,7 +221,7 @@ node/
 **Key Features:** TypeScript support, NAPI-RS native bindings, protobuf communication
 **Testing:** Jest test framework, interactive REPL, package manager compatibility tests
 **Platforms:** Linux (glibc/musl), macOS (Intel/Apple Silicon)
-**Dependencies:** Node.js 16+, protobufjs, long, platform-specific native binaries
+**Dependencies:** Node.js 20+, protobufjs, long, platform-specific native binaries
 
 ## If You Need More
 

--- a/node/README.md
+++ b/node/README.md
@@ -46,7 +46,7 @@ Tests are running on:
 
 ## NodeJS supported version
 
-Node.js 18 or higher.
+Node.js 20 or higher.
 **For npm users on linux it is recommended to use npm >=11 since it support optional download base on libc, yarn users should not be concerned**
 
 - Note: The library is dependent on the [protobufjs library](https://protobufjs.github.io/protobuf.js/#installation), which add a size to the package. The package is using the protobufjs/minimal version, hence, if size matter, bundlers should be able to strip the unused code. It should reduce the size of the dependency from 19kb gzipped to 6.5kb gzipped.

--- a/node/package.json
+++ b/node/package.json
@@ -118,7 +118,7 @@
         "access": "public"
     },
     "engines": {
-        "node": ">=18"
+        "node": ">=20"
     },
     "napi": {
         "binaryName": "valkey-glide",


### PR DESCRIPTION
### Summary

Drop support for Node.js `16.x` and `18.x`. Minimum supported version is now Node.js `20.x` up until `24.x`.

### Issue link

This Pull Request is linked to issue: [Node: Remove support for EOL Node.js 16.x and 18.x #5276](https://github.com/valkey-io/valkey-glide/issues/5276)

### Features / Behaviour Changes

- Removed testing against Nodejs `16.x` and `18.x` from CICD and FMT.
- Added support for Nodejs `24.x`.

### Limitations

This is a `BREAKING CHANGE` as we will no longer support Nodejs `16.x` and `18.x`

### Testing

Testing via CICD and FMT

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
