### PR TITLE
Fix IAM callback immediate auth

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, Ordering};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Duration;
 use tokio::runtime::{Builder, Handle};
 pub use types::*;
 
@@ -40,6 +39,8 @@ use crate::request_type::RequestType;
 use redis::InfoDict;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use telemetrylib::GlideOpenTelemetry;
 use tokio::sync::{Notify, RwLock, mpsc, oneshot};
 use versions::Versioning;
@@ -1119,27 +1120,72 @@ impl Client {
         }
     }
 
-    /// IAM token refresh callback function
+    /// IAM token refresh callback.
     ///
-    /// On new token, spawns a task that write-locks the `Client` and calls
-    /// `update_connection_password(Some(new_token), true)`. Uses a strong `Arc<RwLock<Client>>`.
-    /// Note: this can form a retain cycle; call `stop_refresh_task()` and drop the manager to tear down.
+    /// Updates the connection password on each new token.
+    /// Uses `immediate_auth = false` for most refreshes and performs an explicit
+    /// `AUTH` at most once every 10 hours (and on the first call).
+    ///
+    /// Briefly write-locks the `Client` to apply the update.
+    /// Captures a strong `Arc<RwLock<Client>>`, which may form a retain cycle;
+    /// call `stop_refresh_task()` and drop the manager to shut down.
+    ///
+    /// Failed immediate `AUTH` retries on the next refresh.
     fn iam_callback(
         client_arc: Arc<tokio::sync::RwLock<Client>>,
     ) -> impl Fn(String) + Send + 'static {
+        let last_immediate_auth: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+        // Can be up to 12 hours
+        const REFRESH_TIME: Duration = Duration::from_secs(11 * 60 * 60); // 11 hours
+
         move |new_token: String| {
             let client_arc = Arc::clone(&client_arc);
+            let last_immediate_auth = Arc::clone(&last_immediate_auth);
+
             tokio::spawn(async move {
+                // Determine if we should use immediate auth
+                let (use_immediate_auth, previous_value) = {
+                    let mut last = last_immediate_auth.lock().unwrap();
+                    let previous = *last;
+                    match *last {
+                        None => {
+                            *last = Some(Instant::now());
+                            (true, previous)
+                        }
+                        Some(instant) if instant.elapsed() >= REFRESH_TIME => {
+                            *last = Some(Instant::now());
+                            (true, previous)
+                        }
+                        Some(_) => (false, previous),
+                    }
+                };
+
+                if use_immediate_auth {
+                    log_info(
+                        "IAM token refresh",
+                        "Performing immediate AUTH across connections",
+                    );
+                }
+
                 let mut client = client_arc.write().await;
                 let result = client
-                    .update_connection_password(Some(new_token.clone()), true)
+                    .update_connection_password(Some(new_token.clone()), use_immediate_auth)
                     .await;
 
                 if let Err(e) = result {
                     log_error(
                         "IAM token refresh",
-                        format!("Failed to update connection password with immediate auth: {e}"),
+                        format!(
+                            "Failed to update connection password (immediate={}): {e}",
+                            use_immediate_auth
+                        ),
                     );
+
+                    // Reset timestamp on failure so next call retries with immediate auth
+                    if use_immediate_auth {
+                        let mut last = last_immediate_auth.lock().unwrap();
+                        *last = previous_value;
+                    }
                 }
             });
         }


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

<!--
Add a summary describing the changes
-->
Updated the IAM token authentication behavior to perform immediate re-authentication only once every 10 hours instead of on every token generation.

Tokens are still generated regularly, however, 
`update_connection_password(Some(new_token.clone()), false)` is used for most refreshes, 
while `update_connection_password(Some(new_token.clone()), true)` is triggered only after the 10-hour interval.
If authentication fails, the client retries on the next refresh attempt until it succeeds.

This change removes redundant authentication calls and reduces unnecessary load on the AWS IAM service

### Issue link

This Pull Request is linked to issue https://github.com/valkey-io/valkey-glide/issues/5239

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!-- 
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

<!-- 
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
