### PR TITLE
[Java] Updated fcall readonly binary function to be similar to fcall readonly function

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1963,7 +1963,7 @@ public class CommandTests {
                 fcallReadOnlyPrimaryException
                         .getMessage()
                         .toLowerCase()
-                        .contains("Can not execute a script with write flag using *_ro command"));
+                        .contains("can not execute a script with write flag using"));
 
         // create the same function, but with RO flag
         String funcNameRO = funcName.toString() + "_ro";


### PR DESCRIPTION
### Summary
The `fcall_readonly_binary_function` test was flaky because it did not have a unique library name, in which cause if the `RESP2` protocol failed it wouldn't exit the library and also cause the following `RESP3` protocol test to fail with the error below.

```
glide.cluster.CommandTests.fcall_readonly_binary_function(GlideClusterClient)[1]: FAILURE 0.006s

CommandTests > fcall readonly binary function (GlideClusterClient) > [1] RESP2 FAILED
    org.opentest4j.AssertionFailedError: Expected java.util.concurrent.ExecutionException to be thrown, but nothing was thrown.
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:152)
        at app//org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:73)
        at app//org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
        at app//org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3115)
        at app//glide.cluster.CommandTests.fcall_readonly_binary_function(CommandTests.java:1925)


glide.cluster.CommandTests.fcall_readonly_binary_function(GlideClusterClient)[2]: FAILURE 0.026s

CommandTests > fcall readonly binary function (GlideClusterClient) > [2] RESP3 FAILED
    java.util.concurrent.ExecutionException: glide.api.models.exceptions.RequestException: An error was signalled by the server: - ResponseError: Library 'fcall_readonly_function' already exists
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2005)
        at glide.cluster.CommandTests.fcall_readonly_binary_function(CommandTests.java:1921)

        Caused by:
        glide.api.models.exceptions.RequestException: An error was signalled by the server: - ResponseError: Library 'fcall_readonly_function' already exists
            at app//glide.internal.AsyncRegistry.completeCallbackWithErrorCode(AsyncRegistry.java:262)
```

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] CommandTests > fcall readonly binary function (GlideClusterClient) #5303](https://github.com/valkey-io/valkey-glide/issues/5303)

### Features / Behaviour Changes

- Update `fcall_readonly_binary_function` to be similar to `fcall_readonly_function` and make lib name unique.
    - This reduces complexity to helps better understand what the test is doing, and it will prevent issues with subsequent protocol testing
- Increase Java test client creation connectionTime out from the default 2000ms to be 10000ms. 

### Implementation

Make the library name unique with a UUID

### Limitations

If there is an issue with a test the timeout will take 10000ms instead of 2000ms

### Testing

CI/CD

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
