### PR TITLE
[Java] Update default connectionTimeout for Java CommandTests from 2000ms to 10000ms

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -78,6 +78,7 @@ import glide.api.models.commands.geospatial.GeoSearchStoreOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.scan.ClusterScanCursor;
 import glide.api.models.commands.scan.ScanOptions;
+import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
 import glide.api.models.configuration.ProtocolVersion;
 import glide.api.models.configuration.RequestRoutingConfiguration;
 import glide.api.models.configuration.RequestRoutingConfiguration.ByAddressRoute;
@@ -167,6 +168,10 @@ public class CommandTests {
                                 GlideClusterClient.createClient(
                                                 commonClusterClientConfig()
                                                         .requestTimeout(7000)
+                                                        .advancedConfiguration(
+                                                                AdvancedGlideClusterClientConfiguration.builder()
+                                                                        .connectionTimeout(10000)
+                                                                        .build())
                                                         .protocol(ProtocolVersion.RESP2)
                                                         .build())
                                         .get())),
@@ -176,6 +181,10 @@ public class CommandTests {
                                 GlideClusterClient.createClient(
                                                 commonClusterClientConfig()
                                                         .requestTimeout(7000)
+                                                        .advancedConfiguration(
+                                                                AdvancedGlideClusterClientConfiguration.builder()
+                                                                        .connectionTimeout(10000)
+                                                                        .build())
                                                         .protocol(ProtocolVersion.RESP3)
                                                         .build())
                                         .get())));


### PR DESCRIPTION
### Summary

There have been multiple flaky tests failing regularly with `glide.api.models.exceptions.ClosingException: Failed to create client - Connection refused`. These tests are longer running tests, which have some increased level of latency resulting in a connection timeout. Increasing the default connectionTimeout value for the test client connection will reduce flakiness from these tests.

Update default `connectionTimeout` for Java test client from `2000ms` to `10000ms`. This will bring it in line with the default for Python as well.
- https://github.com/valkey-io/valkey-glide/pull/5236

The change to 10000ms will bring the test clients back to what it was prior to the fix in [Fix: Remove DEFAULT_CLIENT_CREATION_TIMEOUT and honor user-provided connection timeout by centralizing timeout logic in ConnectionRequest #5198](https://github.com/valkey-io/valkey-glide/pull/5198)

### Issue link

This Pull Request is linked to issue: This should resolve multiple flaky test issues in the Java CICD.
 - https://github.com/valkey-io/valkey-glide/issues/5219
 - https://github.com/valkey-io/valkey-glide/issues/5220

### Features / Behaviour Changes

Increase the timeout as 2000ms was too aggressive for certain tests.

### Implementation

Add in explicitly connectionTimeout value for the test client generator.

### Limitations

timeout will be increased from 2000ms to 10000ms. If a test were to fail/hang and require a timeout, they will take longer to fail.

### Testing

Ran CICD multiple times, and did not see related flaky test failures

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
