### PR TITLE
Increase reliably for catching the correct exception for fcall_readonly_function

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1864,13 +1864,13 @@ public class CommandTests {
 
         // Wait for function to replicate to replica, retrying if needed
         ExecutionException fcallReplicaException = null;
-        for (int i = 0; i < 10 && fcallReplicaException == null; i++) {
+        for (int i = 0; i < 20 && fcallReplicaException == null; i++) {
             try {
                 clusterClient.fcall(funcName, replicaRoute).get();
                 Thread.sleep(100); // Function not yet on replica, wait and retry
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof RequestException
-                        && e.getMessage().toLowerCase().contains("readonly")) {
+                        && e.getCause().getMessage().toLowerCase().contains("readonly")) {
                     fcallReplicaException = e;
                 }
             }
@@ -1932,13 +1932,13 @@ public class CommandTests {
 
         // Wait for function to replicate to replica, retrying if needed
         ExecutionException fcallReplicaException = null;
-        for (int i = 0; i < 10 && fcallReplicaException == null; i++) {
+        for (int i = 0; i < 20 && fcallReplicaException == null; i++) {
             try {
                 clusterClient.fcall(funcName, replicaRoute).get();
                 Thread.sleep(100); // Function not yet on replica, wait and retry
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof RequestException
-                        && e.getMessage().toLowerCase().contains("readonly")) {
+                        && e.getCause().getMessage().toLowerCase().contains("readonly")) {
                     fcallReplicaException = e;
                 }
             }


### PR DESCRIPTION
### Summary

Increases the number of iterations in the exception catching loop to wait for the script to load in `fcall_readonly_function`

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] CommandTests > fcall_readonly_function (GlideClusterClient) #5218](https://github.com/valkey-io/valkey-glide/issues/5218)

### Testing

CICD

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
