### PR TITLE
Fix the auto-labeling behavior when issues are created from templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,7 @@
 name: "🐛 Bug Report"
 description: Report a bug
 title: "(topic): (short issue description)"
-labels: [bug, needs-triage]
+labels: ["bug 🐞", "Untriaged user issue"]
 assignees: []
 body:
     - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,7 @@
 name: 🚀 Feature Request
 description: Suggest an idea for this project
 title: "(topic): (short issue description)"
-labels: [feature-request, needs-triage]
+labels: ["Feature ✨", "Untriaged user issue"]
 assignees: []
 body:
     - type: textarea

--- a/.github/ISSUE_TEMPLATE/flaky-ci-test-issue.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-ci-test-issue.yml
@@ -1,7 +1,7 @@
 name: Flaky CI Test Issue
 description: Report a flaky test in the CI pipeline
 title: "[Flaky Test] <test-name>"
-labels: ["bug", "flaky-test"]
+labels: ["Flaky-tests 🐦", "CI/CD ⚒️"]
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/inquiry.yml
+++ b/.github/ISSUE_TEMPLATE/inquiry.yml
@@ -1,7 +1,7 @@
 name: Inquiry
 description: Use this template for asking questions
 title: "[Inquiry] "
-labels: ["Inquiry"]
+labels: ["Inquiry ❓"]
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,7 @@
 name: Task
 description: Create a task to manage work
 title: "[Task]"
-labels: ["task"]
+labels: ["Task 🔧"]
 assignees: []
 
 body:
@@ -21,8 +21,8 @@ body:
           label: Checklist
           description: Add items to be completed
           value: |
-              1. 
-              2. 
+              1.
+              2.
               ...
 
     - type: textarea


### PR DESCRIPTION
### Summary

Updates the yaml files in the .github/ISSUE_TEMPLATE directory to match the existing labels. This will allow newly created issues from the templates to be correctly labelled.

### Issue link

This Pull Request is linked to issue (URL): [REPLACE ME]

### Features / Behaviour Changes

Adds in auto labelling for newly created issues when using the pre-existing templates

### Implementation

Change label names in the yaml files.

### Limitations

If labels for github change then they will stop auto labelling

### Testing

Can only be tested after merging.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
