### PR TITLE
[Go] Implement Go bindings for Transparent Compression

### DIFF
--- a/go/benchmarks/benchmarking.go
+++ b/go/benchmarks/benchmarking.go
@@ -128,6 +128,8 @@ func createClients(config *benchmarkConfig) ([]benchmarkClient, error) {
 			client = &goRedisBenchmarkClient{}
 		case valkeyGlide:
 			client = &glideBenchmarkClient{}
+		case valkeyGlideCompressed:
+			client = &glideCompressedBenchmarkClient{}
 		}
 
 		err := client.connect(config.connectionSettings)

--- a/go/benchmarks/glide_compressed_benchmark_client.go
+++ b/go/benchmarks/glide_compressed_benchmark_client.go
@@ -1,0 +1,64 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
+)
+
+type glideCompressedBenchmarkClient struct {
+	client interfaces.BaseClientCommands
+}
+
+func (c *glideCompressedBenchmarkClient) connect(connectionSettings *connectionSettings) error {
+	compressionConfig := config.NewCompressionConfiguration()
+
+	if connectionSettings.clusterModeEnabled {
+		cfg := config.NewClusterClientConfiguration().
+			WithAddress(&config.NodeAddress{Host: connectionSettings.host, Port: connectionSettings.port}).
+			WithUseTLS(connectionSettings.useTLS).
+			WithCompressionConfiguration(compressionConfig)
+		glideClient, err := glide.NewClusterClient(cfg)
+		if err != nil {
+			return err
+		}
+		c.client = glideClient
+		return nil
+	}
+
+	cfg := config.NewClientConfiguration().
+		WithAddress(&config.NodeAddress{Host: connectionSettings.host, Port: connectionSettings.port}).
+		WithUseTLS(connectionSettings.useTLS).
+		WithCompressionConfiguration(compressionConfig)
+	glideClient, err := glide.NewClient(cfg)
+	if err != nil {
+		return err
+	}
+	c.client = glideClient
+	return nil
+}
+
+func (c *glideCompressedBenchmarkClient) get(key string) (string, error) {
+	result, err := c.client.Get(context.Background(), key)
+	if err != nil {
+		return "", err
+	}
+	return result.Value(), nil
+}
+
+func (c *glideCompressedBenchmarkClient) set(key string, value string) (string, error) {
+	return c.client.Set(context.Background(), key, value)
+}
+
+func (c *glideCompressedBenchmarkClient) close() error {
+	c.client.Close()
+	return nil
+}
+
+func (c *glideCompressedBenchmarkClient) getName() string {
+	return "glide-compressed"
+}

--- a/go/benchmarks/main.go
+++ b/go/benchmarks/main.go
@@ -43,9 +43,10 @@ type runConfiguration struct {
 }
 
 const (
-	goRedis     = "go-redis"
-	valkeyGlide = "glide"
-	all         = "all"
+	goRedis               = "go-redis"
+	valkeyGlide           = "glide"
+	valkeyGlideCompressed = "glide-compressed"
+	all                   = "all"
 )
 
 func main() {
@@ -78,7 +79,7 @@ func parseArguments() *options {
 	resultsFile := flag.String("resultsFile", "results/go-results.json", "Result filepath")
 	dataSize := flag.String("dataSize", "[100]", "Data block size")
 	concurrentTasks := flag.String("concurrentTasks", "[1 10 100 1000]", "Number of concurrent tasks")
-	clientNames := flag.String("clients", "all", "One of: all|go-redis|glide")
+	clientNames := flag.String("clients", "all", "One of: all|go-redis|glide|glide-compressed")
 	host := flag.String("host", config.DefaultHost, "Hostname")
 	port := flag.Int("port", config.DefaultPort, "Port number")
 	clientCount := flag.String("clientCount", "[1]", "Number of clients to run")
@@ -152,10 +153,13 @@ func verifyOptions(opts *options) (*runConfiguration, error) {
 	case strings.EqualFold(opts.clients, valkeyGlide):
 		runConfig.clientNames = append(runConfig.clientNames, valkeyGlide)
 
+	case strings.EqualFold(opts.clients, valkeyGlideCompressed):
+		runConfig.clientNames = append(runConfig.clientNames, valkeyGlideCompressed)
+
 	case strings.EqualFold(opts.clients, all):
-		runConfig.clientNames = append(runConfig.clientNames, goRedis, valkeyGlide)
+		runConfig.clientNames = append(runConfig.clientNames, goRedis, valkeyGlide, valkeyGlideCompressed)
 	default:
-		return nil, fmt.Errorf("invalid clients option, should be one of: all|go-redis|glide")
+		return nil, fmt.Errorf("invalid clients option, should be one of: all|go-redis|glide|glide-compressed")
 	}
 
 	runConfig.host = opts.host

--- a/go/compression_example_test.go
+++ b/go/compression_example_test.go
@@ -1,0 +1,269 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+)
+
+// This example demonstrates creating a standalone client with ZSTD compression enabled
+// using default settings (level: default, min size: 64 bytes).
+// It validates that compression actually reduces the data size using client statistics.
+func ExampleClient_compressionZSTD() {
+	compressionConfig := config.NewCompressionConfiguration()
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&getStandaloneAddresses()[0]).
+		WithCompressionConfiguration(compressionConfig)
+
+	client, err := NewClient(clientConfig)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	defer client.Close()
+
+	// Capture statistics before the SET to isolate this operation's metrics
+	statsBefore := client.GetStatistics()
+	originalBytesBefore := statsBefore["total_original_bytes"]
+	compressedBytesBefore := statsBefore["total_bytes_compressed"]
+	compressedCountBefore := statsBefore["total_values_compressed"]
+
+	// Values >= 64 bytes will be automatically compressed before sending to the server
+	value := strings.Repeat("hello world ", 100) // ~1200 bytes, will be compressed
+	result, err := client.Set(context.Background(), "compressed_key", value)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	fmt.Println(result)
+
+	// Values are automatically decompressed on retrieval
+	retrieved, err := client.Get(context.Background(), "compressed_key")
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	fmt.Println("Data integrity check:", retrieved.Value() == value)
+
+	// Validate compression using client statistics
+	statsAfter := client.GetStatistics()
+	originalBytes := statsAfter["total_original_bytes"] - originalBytesBefore
+	compressedBytes := statsAfter["total_bytes_compressed"] - compressedBytesBefore
+	compressedCount := statsAfter["total_values_compressed"] - compressedCountBefore
+
+	fmt.Println("Value was compressed:", compressedCount > 0)
+	fmt.Println("Compressed bytes < original bytes:", compressedBytes < originalBytes)
+
+	// Output:
+	// OK
+	// Data integrity check: true
+	// Value was compressed: true
+	// Compressed bytes < original bytes: true
+}
+
+// This example demonstrates creating a standalone client with LZ4 compression.
+// It validates that compression actually reduces the data size using client statistics.
+func ExampleClient_compressionLZ4() {
+	compressionConfig := config.NewCompressionConfiguration().
+		WithBackend(config.LZ4)
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&getStandaloneAddresses()[0]).
+		WithCompressionConfiguration(compressionConfig)
+
+	client, err := NewClient(clientConfig)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	defer client.Close()
+
+	// Capture statistics before the SET
+	statsBefore := client.GetStatistics()
+	originalBytesBefore := statsBefore["total_original_bytes"]
+	compressedBytesBefore := statsBefore["total_bytes_compressed"]
+	compressedCountBefore := statsBefore["total_values_compressed"]
+
+	value := strings.Repeat("data ", 200)
+	result, err := client.Set(context.Background(), "lz4_key", value)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	fmt.Println(result)
+
+	// Validate compression using client statistics
+	statsAfter := client.GetStatistics()
+	originalBytes := statsAfter["total_original_bytes"] - originalBytesBefore
+	compressedBytes := statsAfter["total_bytes_compressed"] - compressedBytesBefore
+	compressedCount := statsAfter["total_values_compressed"] - compressedCountBefore
+
+	fmt.Println("Value was compressed:", compressedCount > 0)
+	fmt.Println("Compressed bytes < original bytes:", compressedBytes < originalBytes)
+
+	// Output:
+	// OK
+	// Value was compressed: true
+	// Compressed bytes < original bytes: true
+}
+
+// This example demonstrates creating a client with a custom compression level and min size.
+// It validates that values below the minimum size threshold are not compressed,
+// while larger values are compressed and the compressed size is smaller than the original.
+func ExampleClient_compressionCustomLevel() {
+	compressionConfig := config.NewCompressionConfiguration().
+		WithBackend(config.ZSTD).
+		WithCompressionLevel(10).
+		WithMinCompressionSize(256)
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&getStandaloneAddresses()[0]).
+		WithCompressionConfiguration(compressionConfig)
+
+	client, err := NewClient(clientConfig)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	defer client.Close()
+
+	// Capture statistics before operations
+	statsBefore := client.GetStatistics()
+	compressedCountBefore := statsBefore["total_values_compressed"]
+	skippedCountBefore := statsBefore["compression_skipped_count"]
+
+	// Only values >= 256 bytes will be compressed — this short value should be skipped
+	smallValue := "short"
+	result, err := client.Set(context.Background(), "small_key", smallValue)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	fmt.Println(result)
+
+	statsAfterSmall := client.GetStatistics()
+	fmt.Println("Small value compression skipped:",
+		statsAfterSmall["compression_skipped_count"] > skippedCountBefore)
+	fmt.Println("Small value was not compressed:",
+		statsAfterSmall["total_values_compressed"] == compressedCountBefore)
+
+	// Now send a large value that exceeds the 256-byte threshold
+	originalBytesBefore := statsAfterSmall["total_original_bytes"]
+	compressedBytesBefore := statsAfterSmall["total_bytes_compressed"]
+
+	largeValue := strings.Repeat("compressible data pattern ", 50) // ~1300 bytes
+	result, err = client.Set(context.Background(), "large_key", largeValue)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	fmt.Println(result)
+
+	statsAfterLarge := client.GetStatistics()
+	originalBytes := statsAfterLarge["total_original_bytes"] - originalBytesBefore
+	compressedBytes := statsAfterLarge["total_bytes_compressed"] - compressedBytesBefore
+
+	fmt.Println("Large value was compressed:",
+		statsAfterLarge["total_values_compressed"] > compressedCountBefore)
+	fmt.Println("Compressed bytes < original bytes:", compressedBytes < originalBytes)
+
+	// Output:
+	// OK
+	// Small value compression skipped: true
+	// Small value was not compressed: true
+	// OK
+	// Large value was compressed: true
+	// Compressed bytes < original bytes: true
+}
+
+// This example demonstrates creating a cluster client with compression enabled.
+// It validates that compression actually reduces the data size using client statistics.
+func ExampleClusterClient_compression() {
+	compressionConfig := config.NewCompressionConfiguration()
+
+	clientConfig := config.NewClusterClientConfiguration().
+		WithAddress(&getClusterAddresses()[0]).
+		WithCompressionConfiguration(compressionConfig)
+
+	client, err := NewClusterClient(clientConfig)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	defer client.Close()
+
+	// Capture statistics before the SET
+	statsBefore := client.GetStatistics()
+	originalBytesBefore := statsBefore["total_original_bytes"]
+	compressedBytesBefore := statsBefore["total_bytes_compressed"]
+	compressedCountBefore := statsBefore["total_values_compressed"]
+
+	value := strings.Repeat("cluster data ", 100)
+	result, err := client.Set(context.Background(), "cluster_compressed_key", value)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	fmt.Println(result)
+
+	// Validate compression using client statistics
+	statsAfter := client.GetStatistics()
+	originalBytes := statsAfter["total_original_bytes"] - originalBytesBefore
+	compressedBytes := statsAfter["total_bytes_compressed"] - compressedBytesBefore
+	compressedCount := statsAfter["total_values_compressed"] - compressedCountBefore
+
+	fmt.Println("Value was compressed:", compressedCount > 0)
+	fmt.Println("Compressed bytes < original bytes:", compressedBytes < originalBytes)
+
+	// Output:
+	// OK
+	// Value was compressed: true
+	// Compressed bytes < original bytes: true
+}
+
+// This example demonstrates reading compression statistics from the client
+// and validating that compressed bytes are smaller than the original value.
+func ExampleClient_compressionStatistics() {
+	compressionConfig := config.NewCompressionConfiguration()
+
+	clientConfig := config.NewClientConfiguration().
+		WithAddress(&getStandaloneAddresses()[0]).
+		WithCompressionConfiguration(compressionConfig)
+
+	client, err := NewClient(clientConfig)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+	defer client.Close()
+
+	// Capture statistics before the SET to isolate this operation's metrics
+	statsBefore := client.GetStatistics()
+	originalBytesBefore := statsBefore["total_original_bytes"]
+	compressedBytesBefore := statsBefore["total_bytes_compressed"]
+
+	// Perform a SET with a compressible value
+	value := strings.Repeat("statistics test ", 100)
+	_, err = client.Set(context.Background(), "stats_key", value)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
+
+	// Read compression statistics and validate compression occurred
+	stats := client.GetStatistics()
+	originalBytes := stats["total_original_bytes"] - originalBytesBefore
+	compressedBytes := stats["total_bytes_compressed"] - compressedBytesBefore
+
+	fmt.Println("total_values_compressed exists:", stats["total_values_compressed"] > 0)
+	fmt.Println("Compressed bytes < original bytes:", compressedBytes < originalBytes)
+
+	// Output:
+	// total_values_compressed exists: true
+	// Compressed bytes < original bytes: true
+}

--- a/go/config/compression_config.go
+++ b/go/config/compression_config.go
@@ -1,0 +1,114 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/valkey-io/valkey-glide/go/v2/internal/protobuf"
+)
+
+// MinCompressionSize is the absolute minimum allowed value for CompressionConfiguration.MinCompressionSize.
+// This corresponds to the compression header size (5 bytes) plus 1 byte of payload.
+// TO-DO: Update this to be something more descriptive and less confusing, MinMinCompressionSize ?
+// Should be kept in sync with the Rust core's MIN_COMPRESSED_SIZE (HEADER_SIZE + 1).
+const MinCompressionSize = 6
+
+// DefaultMinCompressionSize is the default threshold below which values will not be compressed.
+// Operators can lower this to MinCompressionSize if they have highly compressible small values.
+const DefaultMinCompressionSize = 64
+
+// CompressionBackend represents the compression algorithm to use.
+type CompressionBackend int
+
+const (
+	// ZSTD uses the Zstandard compression algorithm. Default compression level is 3.
+	ZSTD CompressionBackend = iota
+	// LZ4 uses the LZ4 compression algorithm. Default compression level is 0.
+	LZ4
+)
+
+// CompressionConfiguration represents the configuration for automatic value compression.
+//
+// When enabled, values sent to the server will be compressed using the specified backend
+// if they meet the minimum size threshold. Compressed values are automatically decompressed
+// on retrieval.
+type CompressionConfiguration struct {
+	// Whether compression is enabled.
+	enabled bool
+	// The compression backend to use. Defaults to ZSTD.
+	backend CompressionBackend
+	// The compression level. If nil, the backend's default level is used.
+	// Valid ranges are backend-specific and validated by the Rust core.
+	compressionLevel *int32
+	// Minimum size in bytes for values to be compressed. Defaults to 64.
+	minCompressionSize uint32
+}
+
+// NewCompressionConfiguration returns a [CompressionConfiguration] with compression enabled,
+// ZSTD backend, default compression level, and minimum compression size of 64 bytes.
+func NewCompressionConfiguration() *CompressionConfiguration {
+	return &CompressionConfiguration{
+		enabled:            true,
+		backend:            ZSTD,
+		minCompressionSize: DefaultMinCompressionSize,
+	}
+}
+
+// WithEnabled sets whether compression is enabled.
+// This allows toggling compression on or off without removing the configuration entirely.
+func (c *CompressionConfiguration) WithEnabled(enabled bool) *CompressionConfiguration {
+	c.enabled = enabled
+	return c
+}
+
+// WithBackend sets the compression backend.
+func (c *CompressionConfiguration) WithBackend(backend CompressionBackend) *CompressionConfiguration {
+	c.backend = backend
+	return c
+}
+
+// WithCompressionLevel sets the compression level. Valid ranges are backend-specific:
+// ZSTD supports levels from -131072 to 22 (default 3).
+// LZ4 supports levels from -128 to 12 (default 0).
+func (c *CompressionConfiguration) WithCompressionLevel(level int32) *CompressionConfiguration {
+	c.compressionLevel = &level
+	return c
+}
+
+// WithMinCompressionSize sets the minimum size in bytes for values to be compressed.
+// Must be at least MinCompressionSize (6) bytes. Defaults to DefaultMinCompressionSize (64) bytes.
+func (c *CompressionConfiguration) WithMinCompressionSize(size uint32) *CompressionConfiguration {
+	c.minCompressionSize = size
+	return c
+}
+
+// Validate checks that the compression configuration is valid.
+func (c *CompressionConfiguration) Validate() error {
+	if c.minCompressionSize < MinCompressionSize {
+		return fmt.Errorf(
+			"min_compression_size must be at least %d bytes, got %d",
+			MinCompressionSize,
+			c.minCompressionSize,
+		)
+	}
+	return nil
+}
+
+func (c *CompressionConfiguration) toProtobuf() (*protobuf.CompressionConfig, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	pbConfig := &protobuf.CompressionConfig{
+		Enabled:            c.enabled,
+		Backend:            protobuf.CompressionBackend(c.backend),
+		MinCompressionSize: c.minCompressionSize,
+	}
+
+	if c.compressionLevel != nil {
+		pbConfig.CompressionLevel = c.compressionLevel
+	}
+
+	return pbConfig, nil
+}

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -196,6 +196,7 @@ type baseClientConfiguration struct {
 	reconnectStrategy *BackoffStrategy
 	lazyConnect       bool
 	DatabaseId        *int `json:"database_id,omitempty"`
+	compressionConfig *CompressionConfiguration
 }
 
 func (config *baseClientConfiguration) toProtobuf() (*protobuf.ConnectionRequest, error) {
@@ -248,6 +249,14 @@ func (config *baseClientConfiguration) toProtobuf() (*protobuf.ConnectionRequest
 
 	if config.DatabaseId != nil {
 		request.DatabaseId = uint32(*config.DatabaseId)
+	}
+
+	if config.compressionConfig != nil {
+		compressionPb, err := config.compressionConfig.toProtobuf()
+		if err != nil {
+			return nil, fmt.Errorf("invalid compression configuration: %w", err)
+		}
+		request.CompressionConfig = compressionPb
 	}
 
 	return &request, nil
@@ -461,6 +470,16 @@ func (config *ClientConfiguration) WithDatabaseId(id int) *ClientConfiguration {
 	return config
 }
 
+// WithCompressionConfiguration sets the compression configuration for the client.
+// When configured, values sent to the server will be automatically compressed if they
+// meet the minimum size threshold.
+func (config *ClientConfiguration) WithCompressionConfiguration(
+	compressionConfig *CompressionConfiguration,
+) *ClientConfiguration {
+	config.compressionConfig = compressionConfig
+	return config
+}
+
 // WithAdvancedConfiguration sets the advanced configuration settings for the client.
 func (config *ClientConfiguration) WithAdvancedConfiguration(
 	advancedConfig *AdvancedClientConfiguration,
@@ -646,6 +665,16 @@ func (config *ClusterClientConfiguration) WithReconnectStrategy(
 // WithDatabaseId sets the index of the logical database to connect to.
 func (config *ClusterClientConfiguration) WithDatabaseId(id int) *ClusterClientConfiguration {
 	config.DatabaseId = &id
+	return config
+}
+
+// WithCompressionConfiguration sets the compression configuration for the cluster client.
+// When configured, values sent to the server will be automatically compressed if they
+// meet the minimum size threshold.
+func (config *ClusterClientConfiguration) WithCompressionConfiguration(
+	compressionConfig *CompressionConfiguration,
+) *ClusterClientConfiguration {
+	config.compressionConfig = compressionConfig
 	return config
 }
 

--- a/go/examples/examples.md
+++ b/go/examples/examples.md
@@ -3,6 +3,7 @@
 Go provides native support for Examples which are a great way to document how to use the Valkey Glide Go client. Examples are also run as tests, so they can be used to ensure that the client code behaves as expected. For more details on running the example tests, or writing your own examples, please see the [Developer Guide](../DEVELOPER.md). In place of creating an arbitrary example, you can find examples for each of the supported commands in the following files:
 
 - [bitmap_commands_test.go](../bitmap_commands_test.go)
+- [compression_example_test.go](../compression_example_test.go)
 - [connection_management_commands_test.go](../connection_management_commands_test.go)
 - [generic_base_commands_test.go](../generic_base_commands_test.go)
 - [generic_commands_test.go](../generic_commands_test.go)

--- a/go/integTest/compression_test.go
+++ b/go/integTest/compression_test.go
@@ -1,0 +1,959 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/pipeline"
+)
+
+// --- Data generation helpers ---
+
+func generateCompressibleText(sizeBytes int) string {
+	pattern := strings.Repeat("A", 10) + strings.Repeat("B", 10) + strings.Repeat("C", 10)
+	repeats := (sizeBytes / len(pattern)) + 1
+	return strings.Repeat(pattern, repeats)[:sizeBytes]
+}
+
+func generateJSONData(sizeBytes int) string {
+	obj := map[string]interface{}{
+		"id":          12345,
+		"name":        "Test User",
+		"email":       "test@example.com",
+		"description": strings.Repeat("A", 100),
+		"metadata":    map[string]string{"key": "value"},
+		"tags":        []string{"tag1", "tag2", "tag3"},
+	}
+	jsonStr, _ := json.Marshal(obj)
+	s := string(jsonStr)
+	repeats := (sizeBytes / len(s)) + 1
+	return strings.Repeat(s, repeats)[:sizeBytes]
+}
+
+func generateBase64Data(sizeBytes int) string {
+	raw := make([]byte, sizeBytes/2)
+	for i := range raw {
+		raw[i] = byte(rand.Intn(256))
+	}
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	if len(encoded) > sizeBytes {
+		return encoded[:sizeBytes]
+	}
+	return encoded
+}
+
+func randomString(n int) string {
+	return uuid.New().String()[:n]
+}
+
+// --- Helper to create compression-enabled clients ---
+
+func (suite *GlideTestSuite) compressionClient() *glide.Client {
+	compressionConfig := config.NewCompressionConfiguration()
+	clientConfig := suite.defaultClientConfig().
+		WithCompressionConfiguration(compressionConfig)
+	client, err := suite.client(clientConfig)
+	assert.NoError(suite.T(), err)
+	return client
+}
+
+func (suite *GlideTestSuite) compressionClusterClient() *glide.ClusterClient {
+	compressionConfig := config.NewCompressionConfiguration()
+	clientConfig := suite.defaultClusterClientConfig().
+		WithCompressionConfiguration(compressionConfig)
+	client, err := suite.clusterClient(clientConfig)
+	assert.NoError(suite.T(), err)
+	return client
+}
+
+func (suite *GlideTestSuite) compressionClientWithBackend(
+	backend config.CompressionBackend,
+) *glide.Client {
+	compressionConfig := config.NewCompressionConfiguration().
+		WithBackend(backend)
+	clientConfig := suite.defaultClientConfig().
+		WithCompressionConfiguration(compressionConfig)
+	client, err := suite.client(clientConfig)
+	assert.NoError(suite.T(), err)
+	return client
+}
+
+func (suite *GlideTestSuite) compressionClientWithLevel(
+	backend config.CompressionBackend,
+	level int32,
+) (*glide.Client, error) {
+	compressionConfig := config.NewCompressionConfiguration().
+		WithBackend(backend).
+		WithCompressionLevel(level)
+	clientConfig := suite.defaultClientConfig().
+		WithCompressionConfiguration(compressionConfig)
+	return glide.NewClient(clientConfig)
+}
+
+// ============================================================================
+// Basic Compression Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionBasicSetGet() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	dataSizes := []int{512, 1024, 10240, 102400}
+
+	for _, size := range dataSizes {
+		suite.T().Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			key := fmt.Sprintf("test_compression_%d_%s", size, randomString(8))
+			value := generateCompressibleText(size)
+
+			// Get initial statistics
+			initialStats := client.GetStatistics()
+			initialCompressed := initialStats["total_values_compressed"]
+			initialOriginalBytes := initialStats["total_original_bytes"]
+			initialBytesCompressed := initialStats["total_bytes_compressed"]
+
+			// Set value with compression
+			result, err := client.Set(context.Background(), key, value)
+			assert.NoError(t, err)
+			assert.Equal(t, "OK", result)
+
+			// Get value and verify it matches
+			retrieved, err := client.Get(context.Background(), key)
+			assert.NoError(t, err)
+			assert.Equal(t, value, retrieved.Value())
+
+			// Verify compression was applied
+			stats := client.GetStatistics()
+			assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+				"Compression should be applied for %dB value", size)
+
+			// Verify invariant: compressed bytes <= original bytes
+			bytesAddedOriginal := stats["total_original_bytes"] - initialOriginalBytes
+			bytesAddedCompressed := stats["total_bytes_compressed"] - initialBytesCompressed
+			assert.LessOrEqual(t, bytesAddedCompressed, bytesAddedOriginal,
+				"Compressed size should be <= original size")
+
+			// Cleanup
+			client.Del(context.Background(), []string{key})
+		})
+	}
+}
+
+func (suite *GlideTestSuite) TestCompressionMinSizeThreshold() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	// Get initial statistics
+	initialStats := client.GetStatistics()
+	initialSkipped := initialStats["compression_skipped_count"]
+	initialCompressed := initialStats["total_values_compressed"]
+
+	// Test values below threshold (should be skipped)
+	for _, size := range []int{32, 48, 63} {
+		key := fmt.Sprintf("below_threshold_%d_%s", size, randomString(8))
+		value := generateCompressibleText(size)
+
+		_, err := client.Set(context.Background(), key, value)
+		assert.NoError(t, err)
+
+		retrieved, err := client.Get(context.Background(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, value, retrieved.Value())
+
+		stats := client.GetStatistics()
+		assert.Greater(t, stats["compression_skipped_count"], initialSkipped,
+			"Size %d: Compression should be skipped below threshold", size)
+		assert.Equal(t, initialCompressed, stats["total_values_compressed"],
+			"Size %d: No values should be compressed below threshold", size)
+
+		initialSkipped = stats["compression_skipped_count"]
+		client.Del(context.Background(), []string{key})
+	}
+
+	// Test values at/above threshold (should be compressed)
+	for _, size := range []int{64, 128, 256} {
+		key := fmt.Sprintf("above_threshold_%d_%s", size, randomString(8))
+		value := generateCompressibleText(size)
+
+		_, err := client.Set(context.Background(), key, value)
+		assert.NoError(t, err)
+
+		retrieved, err := client.Get(context.Background(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, value, retrieved.Value())
+
+		stats := client.GetStatistics()
+		assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+			"Size %d: Compression should be applied at/above threshold", size)
+
+		initialCompressed = stats["total_values_compressed"]
+		client.Del(context.Background(), []string{key})
+	}
+}
+
+func (suite *GlideTestSuite) TestCompressionDisabledByDefault() {
+	client := suite.defaultClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+	initialSkipped := initialStats["compression_skipped_count"]
+
+	sizes := []int{64, 1024, 10240}
+	for _, size := range sizes {
+		key := fmt.Sprintf("no_compression_%d_%s", size, randomString(8))
+		value := generateCompressibleText(size)
+
+		result, err := client.Set(context.Background(), key, value)
+		assert.NoError(t, err)
+		assert.Equal(t, "OK", result)
+
+		retrieved, err := client.Get(context.Background(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, value, retrieved.Value())
+
+		stats := client.GetStatistics()
+		assert.Equal(t, initialCompressed, stats["total_values_compressed"],
+			"No compression should be applied when disabled. Size: %dB", size)
+		assert.Equal(t, initialSkipped, stats["compression_skipped_count"],
+			"Compression should not even be attempted when disabled. Size: %dB", size)
+
+		client.Del(context.Background(), []string{key})
+	}
+}
+
+// ============================================================================
+// Data Type Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionDataTypes() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	type dataGenerator struct {
+		name     string
+		generate func(int) string
+	}
+
+	generators := []dataGenerator{
+		{"compressible_text", generateCompressibleText},
+		{"json", generateJSONData},
+		{"base64", generateBase64Data},
+	}
+
+	for _, gen := range generators {
+		for _, size := range []int{1024, 10240} {
+			suite.T().Run(fmt.Sprintf("%s_%d", gen.name, size), func(_ *testing.T) {
+				key := fmt.Sprintf("test_%s_%d_%s", gen.name, size, randomString(8))
+				value := gen.generate(size)
+
+				initialStats := client.GetStatistics()
+				initialCompressed := initialStats["total_values_compressed"]
+
+				result, err := client.Set(context.Background(), key, value)
+				assert.NoError(t, err)
+				assert.Equal(t, "OK", result)
+
+				retrieved, err := client.Get(context.Background(), key)
+				assert.NoError(t, err)
+				assert.Equal(t, value, retrieved.Value())
+
+				stats := client.GetStatistics()
+				assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+					"Compression should be applied for %s %dB value", gen.name, size)
+
+				client.Del(context.Background(), []string{key})
+			})
+		}
+	}
+}
+
+// ============================================================================
+// Backend Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionZSTDBackend() {
+	client := suite.compressionClientWithBackend(config.ZSTD)
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("zstd_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	result, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionLZ4Backend() {
+	client := suite.compressionClientWithBackend(config.LZ4)
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("lz4_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	result, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed)
+
+	client.Del(context.Background(), []string{key})
+}
+
+// ============================================================================
+// Compression Level Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionValidLevels() {
+	t := suite.T()
+
+	testCases := []struct {
+		backend config.CompressionBackend
+		level   int32
+	}{
+		{config.ZSTD, 1},
+		{config.ZSTD, 3},
+		{config.ZSTD, 10},
+		{config.ZSTD, 22},
+		{config.ZSTD, -5},
+		{config.LZ4, 0},
+		{config.LZ4, 1},
+		{config.LZ4, 6},
+		{config.LZ4, 12},
+		{config.LZ4, -10},
+		{config.LZ4, -128},
+	}
+
+	for _, tc := range testCases {
+		backendName := "ZSTD"
+		if tc.backend == config.LZ4 {
+			backendName = "LZ4"
+		}
+		suite.T().Run(fmt.Sprintf("%s_level_%d", backendName, tc.level), func(_ *testing.T) {
+			client, err := suite.compressionClientWithLevel(tc.backend, tc.level)
+			if err != nil {
+				t.Fatalf("Failed to create client with %s level %d: %v", backendName, tc.level, err)
+			}
+			defer client.Close()
+
+			key := fmt.Sprintf("level_test_%s_%d_%s", backendName, tc.level, randomString(8))
+			value := generateCompressibleText(1024)
+
+			initialStats := client.GetStatistics()
+			initialCompressed := initialStats["total_values_compressed"]
+
+			result, err := client.Set(context.Background(), key, value)
+			assert.NoError(t, err)
+			assert.Equal(t, "OK", result)
+
+			retrieved, err := client.Get(context.Background(), key)
+			assert.NoError(t, err)
+			assert.Equal(t, value, retrieved.Value())
+
+			stats := client.GetStatistics()
+			assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+				"Compression should be applied for %s level %d", backendName, tc.level)
+
+			client.Del(context.Background(), []string{key})
+		})
+	}
+}
+
+func (suite *GlideTestSuite) TestCompressionInvalidLevels() {
+	t := suite.T()
+
+	testCases := []struct {
+		backend config.CompressionBackend
+		level   int32
+	}{
+		{config.ZSTD, 23},
+		{config.ZSTD, 100},
+		{config.ZSTD, -200000},
+		{config.LZ4, 13},
+		{config.LZ4, 100},
+		{config.LZ4, -129},
+		{config.LZ4, -1000},
+	}
+
+	for _, tc := range testCases {
+		backendName := "ZSTD"
+		if tc.backend == config.LZ4 {
+			backendName = "LZ4"
+		}
+		suite.T().Run(fmt.Sprintf("%s_invalid_level_%d", backendName, tc.level), func(_ *testing.T) {
+			_, err := suite.compressionClientWithLevel(tc.backend, tc.level)
+			assert.Error(t, err, "Creating client with %s level %d should fail", backendName, tc.level)
+
+			errMsg := strings.ToLower(err.Error())
+			assert.True(t, strings.Contains(errMsg, "compression") || strings.Contains(errMsg, "level"),
+				"Error should mention compression level issue: %v", err)
+		})
+	}
+}
+
+// ============================================================================
+// Edge Case Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionEmptyValues() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("empty_test_%s", randomString(8))
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+	initialSkipped := initialStats["compression_skipped_count"]
+
+	result, err := client.Set(context.Background(), key, "")
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, "", retrieved.Value())
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["compression_skipped_count"], initialSkipped,
+		"Empty value should be skipped")
+	assert.Equal(t, initialCompressed, stats["total_values_compressed"],
+		"Empty value should not be compressed")
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionVeryLargeValues() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("very_large_%s", randomString(8))
+	size := 10 * 1024 * 1024 // 10MB
+	value := generateCompressibleText(size)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+	initialOriginalBytes := initialStats["total_original_bytes"]
+	initialBytesCompressed := initialStats["total_bytes_compressed"]
+
+	result, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+		"Compression should be applied for 10MB value")
+
+	bytesAddedOriginal := stats["total_original_bytes"] - initialOriginalBytes
+	bytesAddedCompressed := stats["total_bytes_compressed"] - initialBytesCompressed
+	assert.LessOrEqual(t, bytesAddedCompressed, bytesAddedOriginal,
+		"Large value: Compressed size should be <= original size")
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionBackendMismatch() {
+	// Write with ZSTD, read with LZ4 - data should still be readable
+	zstdClient := suite.compressionClientWithBackend(config.ZSTD)
+	defer zstdClient.Close()
+
+	lz4Client := suite.compressionClientWithBackend(config.LZ4)
+	defer lz4Client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("backend_mismatch_%s", randomString(8))
+	value := generateCompressibleText(10240)
+
+	result, err := zstdClient.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	// Read with LZ4 client - should still work (decompression is transparent)
+	retrieved, err := lz4Client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	zstdClient.Del(context.Background(), []string{key})
+}
+
+// ============================================================================
+// Compatibility Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionWithTTL() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("ttl_test_%s", randomString(8))
+	value := generateCompressibleText(10240)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	result, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	ok, err := client.Expire(context.Background(), key, 10*time.Second)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	ttl, err := client.TTL(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Greater(t, ttl, int64(0))
+	assert.LessOrEqual(t, ttl, int64(10))
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+		"Compression should be applied with TTL")
+
+	client.Del(context.Background(), []string{key})
+}
+
+// ============================================================================
+// Cluster Compression Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionClusterBasicSetGet() {
+	client := suite.compressionClusterClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	for _, size := range []int{512, 1024, 10240} {
+		key := fmt.Sprintf("cluster_compression_%d_%s", size, randomString(8))
+		value := generateCompressibleText(size)
+
+		initialStats := client.GetStatistics()
+		initialCompressed := initialStats["total_values_compressed"]
+
+		result, err := client.Set(context.Background(), key, value)
+		assert.NoError(t, err)
+		assert.Equal(t, "OK", result)
+
+		retrieved, err := client.Get(context.Background(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, value, retrieved.Value())
+
+		stats := client.GetStatistics()
+		assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+			"Cluster: Compression should be applied for %dB value", size)
+
+		client.Del(context.Background(), []string{key})
+	}
+}
+
+func (suite *GlideTestSuite) TestCompressionClusterMultiSlot() {
+	client := suite.compressionClusterClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	numKeys := 50
+	keysAndValues := make(map[string]string, numKeys)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("multislot_%d_%s", i, randomString(8))
+		value := generateCompressibleText(5120)
+		keysAndValues[key] = value
+
+		result, err := client.Set(context.Background(), key, value)
+		assert.NoError(t, err)
+		assert.Equal(t, "OK", result)
+	}
+
+	stats := client.GetStatistics()
+	compressedCount := stats["total_values_compressed"] - initialCompressed
+	assert.Equal(t, uint64(numKeys), compressedCount,
+		"All %d values should be compressed across slots", numKeys)
+
+	// Verify all values
+	keys := make([]string, 0, numKeys)
+	for key, expectedValue := range keysAndValues {
+		retrieved, err := client.Get(context.Background(), key)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedValue, retrieved.Value())
+		keys = append(keys, key)
+	}
+
+	client.Del(context.Background(), keys)
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+// ============================================================================
+// Batch Compression Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionBatchSetGet() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	numKeys := 100
+	keyPrefix := fmt.Sprintf("batch_test_%s", randomString(8))
+
+	// Get initial statistics
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+	initialOriginalBytes := initialStats["total_original_bytes"]
+	initialBytesCompressed := initialStats["total_bytes_compressed"]
+
+	// Create pipeline batch with SET commands
+	batch := pipeline.NewStandaloneBatch(false)
+	type kv struct {
+		key   string
+		value string
+	}
+	keysAndValues := make([]kv, 0, numKeys)
+
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("%s_%d", keyPrefix, i)
+		size := 1024 + rand.Intn(9216) // 1KB to 10KB
+		value := generateCompressibleText(size)
+		keysAndValues = append(keysAndValues, kv{key, value})
+		batch.Set(key, value)
+	}
+
+	// Execute batch
+	results, err := client.Exec(context.Background(), *batch, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	for i, r := range results {
+		assert.Equal(t, "OK", r, "SET result %d should be OK", i)
+	}
+
+	// Verify compression was applied to all values
+	stats := client.GetStatistics()
+	compressedCount := stats["total_values_compressed"] - initialCompressed
+	assert.Equal(t, uint64(numKeys), compressedCount,
+		"All %d values should be compressed", numKeys)
+
+	// Verify invariant: compressed bytes <= original bytes
+	bytesAddedOriginal := stats["total_original_bytes"] - initialOriginalBytes
+	bytesAddedCompressed := stats["total_bytes_compressed"] - initialBytesCompressed
+	assert.LessOrEqual(t, bytesAddedCompressed, bytesAddedOriginal,
+		"Batch: Compressed size should be <= original size")
+
+	// Verify all values are retrievable and correct
+	keys := make([]string, 0, numKeys)
+	for _, entry := range keysAndValues {
+		retrieved, err := client.Get(context.Background(), entry.key)
+		assert.NoError(t, err)
+		assert.Equal(t, entry.value, retrieved.Value())
+		keys = append(keys, entry.key)
+	}
+
+	client.Del(context.Background(), keys)
+}
+
+func (suite *GlideTestSuite) TestCompressionBatchMixedSizes() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	keyPrefix := fmt.Sprintf("mixed_batch_%s", randomString(8))
+
+	// Get initial statistics
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+	initialSkipped := initialStats["compression_skipped_count"]
+	initialOriginalBytes := initialStats["total_original_bytes"]
+	initialBytesCompressed := initialStats["total_bytes_compressed"]
+
+	// Create batch with mixed sizes
+	batch := pipeline.NewStandaloneBatch(false)
+	type kv struct {
+		key   string
+		value string
+	}
+	keysAndValues := make([]kv, 0, 30)
+
+	// 10 small values (below 64-byte threshold)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_small_%d", keyPrefix, i)
+		value := generateCompressibleText(32)
+		keysAndValues = append(keysAndValues, kv{key, value})
+		batch.Set(key, value)
+	}
+
+	// 10 medium values (5KB)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_medium_%d", keyPrefix, i)
+		value := generateCompressibleText(5120)
+		keysAndValues = append(keysAndValues, kv{key, value})
+		batch.Set(key, value)
+	}
+
+	// 10 large values (100KB)
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("%s_large_%d", keyPrefix, i)
+		value := generateCompressibleText(102400)
+		keysAndValues = append(keysAndValues, kv{key, value})
+		batch.Set(key, value)
+	}
+
+	// Execute batch
+	results, err := client.Exec(context.Background(), *batch, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	for i, r := range results {
+		assert.Equal(t, "OK", r, "SET result %d should be OK", i)
+	}
+
+	// Verify statistics: 10 small values skipped, 20 medium+large compressed
+	stats := client.GetStatistics()
+	skippedCount := stats["compression_skipped_count"] - initialSkipped
+	compressedCount := stats["total_values_compressed"] - initialCompressed
+
+	assert.Equal(t, uint64(10), skippedCount,
+		"10 small values should be skipped")
+	assert.Equal(t, uint64(20), compressedCount,
+		"20 medium+large values should be compressed")
+
+	// Verify invariant: compressed bytes <= original bytes
+	bytesAddedOriginal := stats["total_original_bytes"] - initialOriginalBytes
+	bytesAddedCompressed := stats["total_bytes_compressed"] - initialBytesCompressed
+	assert.LessOrEqual(t, bytesAddedCompressed, bytesAddedOriginal,
+		"Mixed batch: Compressed size should be <= original size")
+
+	// Verify all values
+	keys := make([]string, 0, 30)
+	for _, entry := range keysAndValues {
+		retrieved, err := client.Get(context.Background(), entry.key)
+		assert.NoError(t, err)
+		assert.Equal(t, entry.value, retrieved.Value())
+		keys = append(keys, entry.key)
+	}
+
+	client.Del(context.Background(), keys)
+}
+
+func (suite *GlideTestSuite) TestCompressionBatchLargePayload() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	numKeys := 1000
+	valueSize := 10240 // 10KB each, ~10MB total
+	keyPrefix := fmt.Sprintf("large_batch_%s", randomString(8))
+
+	// Get initial statistics
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+	initialOriginalBytes := initialStats["total_original_bytes"]
+	initialBytesCompressed := initialStats["total_bytes_compressed"]
+
+	// Create batch
+	batch := pipeline.NewStandaloneBatch(false)
+	value := generateCompressibleText(valueSize)
+	keys := make([]string, 0, numKeys)
+
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("%s_%d", keyPrefix, i)
+		keys = append(keys, key)
+		batch.Set(key, value)
+	}
+
+	// Execute batch
+	results, err := client.Exec(context.Background(), *batch, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	assert.Len(t, results, numKeys)
+	for i, r := range results {
+		assert.Equal(t, "OK", r, "SET result %d should be OK", i)
+	}
+
+	// Verify compression was applied to all values
+	stats := client.GetStatistics()
+	compressedCount := stats["total_values_compressed"] - initialCompressed
+	assert.Equal(t, uint64(numKeys), compressedCount,
+		"All %d values should be compressed", numKeys)
+
+	// Verify invariant: compressed bytes <= original bytes
+	bytesAddedOriginal := stats["total_original_bytes"] - initialOriginalBytes
+	bytesAddedCompressed := stats["total_bytes_compressed"] - initialBytesCompressed
+	assert.LessOrEqual(t, bytesAddedCompressed, bytesAddedOriginal,
+		"Large batch: Compressed size should be <= original size")
+
+	// Verify a sample of values
+	for i := 0; i < numKeys; i += 100 {
+		retrieved, err := client.Get(context.Background(), keys[i])
+		assert.NoError(t, err)
+		assert.Equal(t, value, retrieved.Value())
+	}
+
+	client.Del(context.Background(), keys)
+}
+
+func (suite *GlideTestSuite) TestCompressionClusterBatchSetGet() {
+	client := suite.compressionClusterClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	numKeys := 50
+	keyPrefix := fmt.Sprintf("cluster_batch_%s", randomString(8))
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	batch := pipeline.NewClusterBatch(false)
+	type kv struct {
+		key   string
+		value string
+	}
+	keysAndValues := make([]kv, 0, numKeys)
+
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("%s_%d", keyPrefix, i)
+		size := 1024 + rand.Intn(9216)
+		value := generateCompressibleText(size)
+		keysAndValues = append(keysAndValues, kv{key, value})
+		batch.Set(key, value)
+	}
+
+	results, err := client.Exec(context.Background(), *batch, true)
+	assert.NoError(t, err)
+	assert.NotNil(t, results)
+	for i, r := range results {
+		assert.Equal(t, "OK", r, "Cluster batch SET result %d should be OK", i)
+	}
+
+	stats := client.GetStatistics()
+	compressedCount := stats["total_values_compressed"] - initialCompressed
+	assert.Equal(t, uint64(numKeys), compressedCount,
+		"Cluster: All %d values should be compressed in batch", numKeys)
+
+	keys := make([]string, 0, numKeys)
+	for _, entry := range keysAndValues {
+		retrieved, err := client.Get(context.Background(), entry.key)
+		assert.NoError(t, err)
+		assert.Equal(t, entry.value, retrieved.Value())
+		keys = append(keys, entry.key)
+	}
+
+	client.Del(context.Background(), keys)
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionStatistics() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	// Get initial statistics
+	initialStats := client.GetStatistics()
+
+	// Verify all compression-related keys exist
+	compressionKeys := []string{
+		"total_values_compressed",
+		"total_values_decompressed",
+		"total_original_bytes",
+		"total_bytes_compressed",
+		"total_bytes_decompressed",
+		"compression_skipped_count",
+	}
+
+	for _, key := range compressionKeys {
+		_, exists := initialStats[key]
+		assert.True(t, exists, "Expected key %s to exist in statistics", key)
+	}
+
+	// Perform some operations and verify stats change
+	key := fmt.Sprintf("stats_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	_, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+
+	_, err = client.Get(context.Background(), key)
+	assert.NoError(t, err)
+
+	afterStats := client.GetStatistics()
+
+	assert.Greater(t, afterStats["total_values_compressed"],
+		initialStats["total_values_compressed"],
+		"total_values_compressed should increase after SET")
+	assert.Greater(t, afterStats["total_original_bytes"],
+		initialStats["total_original_bytes"],
+		"total_original_bytes should increase after SET")
+	assert.Greater(t, afterStats["total_bytes_compressed"],
+		initialStats["total_bytes_compressed"],
+		"total_bytes_compressed should increase after SET")
+	assert.Greater(t, afterStats["total_values_decompressed"],
+		initialStats["total_values_decompressed"],
+		"total_values_decompressed should increase after GET")
+	assert.Greater(t, afterStats["total_bytes_decompressed"],
+		initialStats["total_bytes_decompressed"],
+		"total_bytes_decompressed should increase after GET")
+
+	client.Del(context.Background(), []string{key})
+}


### PR DESCRIPTION
### Summary
This PR implements the Go bindings for the Transparent Compression feature added in https://github.com/valkey-io/valkey-glide/pull/4759/


### Issue link

This Pull Request is linked to issue: ([5119](https://github.com/valkey-io/valkey-glide/issues/5119))

### Features / Behaviour Changes
* Adds the necessary language bindings in Go to configure a client with compression enabled.
* Benchmarks in `go/benchmarks` updated to include the glide client with compression enabled
* Go example for compression added
* Added tests to Go for compression scenarios

Checklist from issue:
[x] Implement support for creating and providing a CompressionConfig during client creation
[x] Validate CompressionConfig inputs on creation and return relevant validation errors
[x] Support sync and async client configurations
[x] Write tests covering basic compression functionality, CompressionConfig validation, both backends, and relevant edge cases following the patterns outlined in the existing python compression tests
[x] Implement support for reading the new compression-related statistics and utilize these in the test cases
[x] Include an example file demonstrating client creation with compression configurations

### Implementation
Implementation was straightforward, just had to add the CompressionConfiguration support to client construction and Rust handles the rest 🎉

### Testing
Ran existing test suite + benchmarks, performance looks great

<img width="2386" height="925" alt="graph_scaling_set" src="https://github.com/user-attachments/assets/2bba7cc6-6b58-4dcb-bc3c-40bfc24d3714" />

### Checklist
Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
