### PR TITLE
Fix/empty hostname cluster slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * CORE: Track HELLO and AUTH state for reconnection ([#5145](https://github.com/valkey-io/valkey-glide/issues/5145))
 
 #### Fixes
+* CORE: Fix empty hostname in CLUSTER SLOTS metadata causing AllConnectionsUnavailable ([#5367](https://github.com/valkey-io/valkey-glide/issues/5367)). AWS ElastiCache (plaintext, cluster mode) returns `hostname: ""` in node metadata, which was used as the connection address instead of falling back to the IP.
 * Node: Fix to handle non-string types in toBuffersArray ([#4842](https://github.com/valkey-io/valkey-glide/issues/4842))
 * CORE: Enforce connection_timeout for initial standalone connection failures  ([#4991](https://github.com/valkey-io/valkey-glide/issues/4991))
 * Node: Fixed `Failed to convert napi value Undefined into rust type u32` error  ([#5128](https://github.com/valkey-io/valkey-glide/pull/5128))


### PR DESCRIPTION
### Summary

AWS ElastiCache (plaintext, cluster mode, Redis 7.2.4) returns `hostname: ""` (empty string) in the CLUSTER SLOTS metadata for every node. The parser was wrapping this in `Some("")`, which caused `unwrap_or_else` at line 252 to use the empty string instead of falling back to the IP address from the primary identifier.

This resulted in connection addresses like `:6379` (no host), which fail immediately. Because `refresh_slots_inner()` silently drops connection errors, `createClient` resolves successfully but the client has zero usable connections. Every subsequent command fails with `AllConnectionsUnavailable`.

### Issue link

This Pull Request is linked to issue (URL): [#5367](https://github.com/valkey-io/valkey-glide/issues/5367)

### Features / Behaviour Changes

The fix filters out empty hostname strings at parse time, so they are treated the same as absent hostnames, and the IP from the primary identifier is used instead.

### Implementation

Checks for a non-empty hostname.

### Limitations

### Testing

Unit test added.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
