### PR TITLE
fix(node): stabilize flaky TLS certificate test startup

### DIFF
--- a/node/tests/TlsCertificateTest.test.ts
+++ b/node/tests/TlsCertificateTest.test.ts
@@ -25,6 +25,12 @@ import {
 
 const TIMEOUT = 50000;
 const CLUSTER_CREATION_TIMEOUT = 120000; // Increased timeout for TLS cluster creation
+const TLS_REQUEST_TIMEOUT = 10000;
+
+const getTlsClientConfigurationOption = (addresses: [string, number][]) =>
+    getClientConfigurationOption(addresses, ProtocolVersion.RESP3, {
+        requestTimeout: TLS_REQUEST_TIMEOUT,
+    });
 
 describe("TLS with custom certificates", () => {
     let standaloneCluster: ValkeyCluster;
@@ -39,6 +45,7 @@ describe("TLS with custom certificates", () => {
         // The actual test connections will use proper certificate validation
         const startupTlsConfig: TestTLSConfig = {
             useTLS: true,
+            requestTimeout: TLS_REQUEST_TIMEOUT,
             advancedConfiguration: {
                 tlsAdvancedConfiguration: {
                     insecure: true,
@@ -114,9 +121,8 @@ describe("TLS with custom certificates", () => {
                 // Self-signed certificate will be rejected by platform verifier
                 await expect(
                     GlideClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             standaloneCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: true,
                     }),
@@ -126,12 +132,32 @@ describe("TLS with custom certificates", () => {
         );
 
         it(
+            "should connect when insecure TLS is enabled without certificate",
+            async () => {
+                standaloneClient = await GlideClient.createClient({
+                    ...getTlsClientConfigurationOption(
+                        standaloneCluster.getAddresses(),
+                    ),
+                    useTLS: true,
+                    advancedConfiguration: {
+                        tlsAdvancedConfiguration: {
+                            insecure: true,
+                        },
+                    },
+                });
+
+                const result = await standaloneClient.ping();
+                expect(result).toBe("PONG");
+            },
+            TIMEOUT,
+        );
+
+        it(
             "should connect with TLS using custom certificate as Buffer",
             async () => {
                 standaloneClient = await GlideClient.createClient({
-                    ...getClientConfigurationOption(
+                    ...getTlsClientConfigurationOption(
                         standaloneCluster.getAddresses(),
-                        ProtocolVersion.RESP3,
                     ),
                     useTLS: true,
                     advancedConfiguration: {
@@ -156,9 +182,8 @@ describe("TLS with custom certificates", () => {
                 const certString = caCertData.toString("utf-8");
 
                 standaloneClient = await GlideClient.createClient({
-                    ...getClientConfigurationOption(
+                    ...getTlsClientConfigurationOption(
                         standaloneCluster.getAddresses(),
-                        ProtocolVersion.RESP3,
                     ),
                     useTLS: true,
                     advancedConfiguration: {
@@ -183,9 +208,8 @@ describe("TLS with custom certificates", () => {
                 const certBundle = Buffer.from(multipleCerts, "utf-8");
 
                 standaloneClient = await GlideClient.createClient({
-                    ...getClientConfigurationOption(
+                    ...getTlsClientConfigurationOption(
                         standaloneCluster.getAddresses(),
-                        ProtocolVersion.RESP3,
                     ),
                     useTLS: true,
                     advancedConfiguration: {
@@ -208,9 +232,8 @@ describe("TLS with custom certificates", () => {
 
                 await expect(
                     GlideClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             standaloneCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: true,
                         advancedConfiguration: {
@@ -234,9 +257,8 @@ describe("TLS with custom certificates", () => {
 
                 await expect(
                     GlideClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             standaloneCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: true,
                         advancedConfiguration: {
@@ -255,9 +277,8 @@ describe("TLS with custom certificates", () => {
             async () => {
                 await expect(
                     GlideClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             standaloneCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: false,
                         advancedConfiguration: {
@@ -281,9 +302,8 @@ describe("TLS with custom certificates", () => {
                 // Self-signed certificate will be rejected by platform verifier
                 await expect(
                     GlideClusterClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             clusterModeCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: true,
                     }),
@@ -293,12 +313,32 @@ describe("TLS with custom certificates", () => {
         );
 
         it(
+            "should connect when insecure TLS is enabled without certificate",
+            async () => {
+                clusterClient = await GlideClusterClient.createClient({
+                    ...getTlsClientConfigurationOption(
+                        clusterModeCluster.getAddresses(),
+                    ),
+                    useTLS: true,
+                    advancedConfiguration: {
+                        tlsAdvancedConfiguration: {
+                            insecure: true,
+                        },
+                    },
+                });
+
+                const result = await clusterClient.ping();
+                expect(result).toBe("PONG");
+            },
+            TIMEOUT,
+        );
+
+        it(
             "should connect with TLS using custom certificate as Buffer",
             async () => {
                 clusterClient = await GlideClusterClient.createClient({
-                    ...getClientConfigurationOption(
+                    ...getTlsClientConfigurationOption(
                         clusterModeCluster.getAddresses(),
-                        ProtocolVersion.RESP3,
                     ),
                     useTLS: true,
                     advancedConfiguration: {
@@ -323,9 +363,8 @@ describe("TLS with custom certificates", () => {
                 const certString = caCertData.toString("utf-8");
 
                 clusterClient = await GlideClusterClient.createClient({
-                    ...getClientConfigurationOption(
+                    ...getTlsClientConfigurationOption(
                         clusterModeCluster.getAddresses(),
-                        ProtocolVersion.RESP3,
                     ),
                     useTLS: true,
                     advancedConfiguration: {
@@ -350,9 +389,8 @@ describe("TLS with custom certificates", () => {
                 const certBundle = Buffer.from(multipleCerts, "utf-8");
 
                 clusterClient = await GlideClusterClient.createClient({
-                    ...getClientConfigurationOption(
+                    ...getTlsClientConfigurationOption(
                         clusterModeCluster.getAddresses(),
-                        ProtocolVersion.RESP3,
                     ),
                     useTLS: true,
                     advancedConfiguration: {
@@ -375,9 +413,8 @@ describe("TLS with custom certificates", () => {
 
                 await expect(
                     GlideClusterClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             clusterModeCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: true,
                         advancedConfiguration: {
@@ -401,9 +438,8 @@ describe("TLS with custom certificates", () => {
 
                 await expect(
                     GlideClusterClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             clusterModeCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: true,
                         advancedConfiguration: {
@@ -422,9 +458,8 @@ describe("TLS with custom certificates", () => {
             async () => {
                 await expect(
                     GlideClusterClient.createClient({
-                        ...getClientConfigurationOption(
+                        ...getTlsClientConfigurationOption(
                             clusterModeCluster.getAddresses(),
-                            ProtocolVersion.RESP3,
                         ),
                         useTLS: false,
                         advancedConfiguration: {

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -12,12 +12,25 @@ function parseOutput(input: string): {
     addresses: [string, number][];
 } {
     const lines = input.split(/\r\n|\r|\n/);
-    const clusterFolder = lines
-        .find((line) => line.startsWith("CLUSTER_FOLDER"))
-        ?.split("=")[1];
-    const ports = lines
-        .find((line) => line.startsWith("CLUSTER_NODES"))
-        ?.split("=")[1]
+    const clusterFolderLine = lines.find((line) =>
+        line.startsWith("CLUSTER_FOLDER="),
+    );
+    const clusterNodesLine = lines.find((line) =>
+        line.startsWith("CLUSTER_NODES="),
+    );
+
+    if (!clusterFolderLine || !clusterNodesLine) {
+        throw new Error(`Insufficient data in input: ${input}`);
+    }
+
+    const clusterFolder = clusterFolderLine.substring("CLUSTER_FOLDER=".length);
+    const nodes = clusterNodesLine.substring("CLUSTER_NODES=".length);
+
+    if (!clusterFolder || !nodes) {
+        throw new Error(`Insufficient data in input: ${input}`);
+    }
+
+    const ports = nodes
         .split(",")
         .map((address) => address.split(":"))
         .map((address) => [address[0], Number(address[1])]) as [
@@ -25,22 +38,22 @@ function parseOutput(input: string): {
         number,
     ][];
 
-    if (clusterFolder === undefined || ports === undefined) {
-        throw new Error(`Insufficient data in input: ${input}`);
-    }
-
     return {
         clusterFolder,
         addresses: ports,
     };
 }
 
-export type TestTLSConfig = {useTLS: boolean; advancedConfiguration?: {
-                    tlsAdvancedConfiguration?: {
-                        insecure?: boolean,
-                        rootCertificates?: Buffer<ArrayBufferLike>,
-                    },
-                },};
+export type TestTLSConfig = {
+    useTLS: boolean;
+    requestTimeout?: number;
+    advancedConfiguration?: {
+        tlsAdvancedConfiguration?: {
+            insecure?: boolean;
+            rootCertificates?: Buffer<ArrayBufferLike>;
+        };
+    };
+};
 
 export class ValkeyCluster {
     private addresses: [string, number][];
@@ -71,16 +84,20 @@ export class ValkeyCluster {
         loadModule?: string[],
     ): Promise<ValkeyCluster> {
         return new Promise<ValkeyCluster>((resolve, reject) => {
-            let command = ``;
+            const commandArgs = [
+                "start",
+                "-r",
+                `${replicaCount}`,
+                "-n",
+                `${shardCount}`,
+            ];
 
             if (tls) {
-                command += "--tls ";
+                commandArgs.unshift("--tls");
             }
 
-            command += `start -r ${replicaCount} -n ${shardCount}`;
-            
             if (cluster_mode) {
-                command += " --cluster-mode";
+                commandArgs.push("--cluster-mode");
             }
 
             if (loadModule) {
@@ -91,13 +108,13 @@ export class ValkeyCluster {
                 }
 
                 for (const module of loadModule) {
-                    command += ` --load-module ${module}`;
+                    commandArgs.push("--load-module", module);
                 }
             }
 
             execFile(
                 "python3",
-                [PY_SCRIPT_PATH, ...command.split(" ")],
+                [PY_SCRIPT_PATH, ...commandArgs],
                 (error, stdout) => {
                     if (error) {
                         reject(error);
@@ -105,7 +122,11 @@ export class ValkeyCluster {
                         const { clusterFolder, addresses } =
                             parseOutput(stdout);
                         resolve(
-                            getVersionCallback(addresses, cluster_mode, tlsConfig).then(
+                            getVersionCallback(
+                                addresses,
+                                cluster_mode,
+                                tlsConfig,
+                            ).then(
                                 (ver) =>
                                     new ValkeyCluster(
                                         ver,


### PR DESCRIPTION
## Summary
- stabilize TLS certificate test startup by using an explicit TLS request timeout in the suite
- add positive insecure-TLS coverage for standalone and cluster clients to ensure startup assumptions stay validated
- harden `utils/TestUtils.ts` parsing and argument construction for cluster manager invocation

## Validation
- `npm run test -- --runInBand tests/TlsCertificateTest.test.ts`
- `npx prettier --check tests/TlsCertificateTest.test.ts ../utils/TestUtils.ts`

Closes #5386