### PR TITLE
Update wiki links to documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Visit our official documentation at [glide.valkey.io](https://glide.valkey.io).
 
 ## Key Features
 - **[AZ Affinity](https://valkey.io/blog/az-affinity-strategy/)** – Ensures low-latency connections and minimal cross-zone costs by routing read traffic to replicas in the clients availability zone. **(Requires Valkey server version 8.0+ or AWS ElastiCache for Valkey 7.2+)**.
-- **[PubSub Auto-Reconnection](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#pubsub-support:~:text=PubSub%20Support,Receiving%2C%20and%20Unsubscribing.)** – Seamless background resubscription on topology updates or disconnection.
-- **[Sharded PubSub](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#pubsub-support:~:text=Receiving%2C%20and%20Unsubscribing.-,Subscribing,routed%20to%20the%20server%20holding%20the%20slot%20for%20the%20command%27s%20channel.,-Receiving)** – Native support for sharded PubSub across cluster slots.
-- **[Cluster-Aware MGET/MSET/DEL/FLUSHALL](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#multi-slot-command-handling:~:text=Multi%2DSlot%20Command%20Execution,JSON.MGET)** – Execute multi-key commands across cluster slots without manual key grouping.
-- **[Cluster Scan](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan)** – Unified key iteration across shards using a consistent, high-level API for cluster environments.
+- **[PubSub Auto-Reconnection](https://glide.valkey.io/concepts/client-features/pubsub-model/)** – Seamless background resubscription on topology updates or disconnection.
+- **[Sharded PubSub](https://glide.valkey.io/concepts/client-features/pubsub-model/)** – Native support for sharded PubSub across cluster slots.
+- **[Cluster-Aware MGET/MSET/DEL/FLUSHALL](https://glide.valkey.io/concepts/client-features/multi-slot-command-handling/)** – Execute multi-key commands across cluster slots without manual key grouping.
+- **[Cluster Scan](https://glide.valkey.io/concepts/client-features/cluster-scan/)** – Unified key iteration across shards using a consistent, high-level API for cluster environments.
 - **Support for TS / CJS / MJS** – Fully compatible with modern and legacy JavaScript/TypeScript runtimes.
 - **Support for asyncio / anyio / trio** – Native compatibility with modern Python async frameworks, enabling efficient and seamless integration into asynchronous workflows.
-- **[Batching (Pipeline and Transaction)](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#batching-pipeline-and-transaction)** – Efficiently execute multiple commands in a single network roundtrip, significantly reducing latency and improving throughput.
-- **[OpenTelemetry](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#opentelemetry)** – Integrated tracing support for enhanced observability and easier debugging in distributed environments.
+- **[Batching (Pipeline and Transaction)](https://glide.valkey.io/concepts/client-features/batch-commands/)** – Efficiently execute multiple commands in a single network roundtrip, significantly reducing latency and improving throughput.
+- **[OpenTelemetry](https://glide.valkey.io/concepts/client-features/open-telemetry/)** – Integrated tracing support for enhanced observability and easier debugging in distributed environments.
 
 ## Supported Engine Versions
 
@@ -69,13 +69,14 @@ The client currently supports Python, Java, Node.js, Go, C#, and PHP. C# and PHP
 ## Getting Started
 
 **Documentation**
-GLIDE's [documentation site](https://valkey.io/valkey-glide/) currently offers documentation for the Python and Node wrappers.
+Visit our official Valkey GLIDE's documentation [site](https://glide.valkey.io/overview/).
 
-**SDKs**
-- [Java](./java/README.md)
-- [Python](./python/README.md)
-- [Node](./node/README.md)
-- [Go](./go/README.md)
+**Supported Languages**
+- [Java](https://glide.valkey.io/getting-started/quickstart/?lang=java)
+- [Python](https://glide.valkey.io/getting-started/quickstart/?lang=python)
+- [Node](https://glide.valkey.io/getting-started/quickstart/?lang=node)
+- [Go](https://glide.valkey.io/getting-started/quickstart/?lang=go)
+- [Php](https://glide.valkey.io/getting-started/quickstart/?lang=php)
 
 **Under Development SDKs**
 - [C#](https://github.com/valkey-io/valkey-glide-csharp)
@@ -83,31 +84,29 @@ GLIDE's [documentation site](https://valkey.io/valkey-glide/) currently offers d
 - [Ruby](https://github.com/valkey-io/valkey-glide-ruby)
 
 **General Concepts:**
-- [Custom Command](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
-- [Connection Management](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#connection-management)
-- [Multi-Slot Command Handling](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#multi-slot-command-handling)
-- [Inflight Request Limit](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#inflight-request-limit)
-- [PubSub Support](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#pubsub-support)
-- [Cluster Scan](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan)
-- [Dynamic Password Management](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#dynamic-password-management)
-- [Modules API](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#modules-api)
-- [Batching (Pipeline and Transaction)](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#batching-pipeline-and-transaction)
-- [OpenTelemetry](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#opentelemetry)
+- [Custom Command](https://glide.valkey.io/concepts/client-features/custom-command/)
+- [Connection Management](https://glide.valkey.io/how-to/connection-management/)
+- [Multi-Slot Command Handling](https://glide.valkey.io/concepts/client-features/multi-slot-command-handling/)
+- [Inflight Request Limit](https://glide.valkey.io/how-to/connections/limit-inflight-requests/)
+- [PubSub Support](https://glide.valkey.io/concepts/client-features/pubsub-model/)
+- [Cluster Scan](https://glide.valkey.io/concepts/client-features/cluster-scan/)
+- [Dynamic Password Management](https://glide.valkey.io/how-to/security/dynamic-authentication/)
+- [Modules API](https://glide.valkey.io/concepts/client-features/modules-api/)
+- [Batching (Pipeline and Transaction)](https://glide.valkey.io/concepts/client-features/batch-commands/)
+- [OpenTelemetry](https://glide.valkey.io/concepts/client-features/open-telemetry/)
 
 **Migration Guides**
-- [go-redis](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-go%E2%80%90redis)
-- [ioredis](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-ioredis)
-- [Jedis](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-Jedis)
-- [Lettuce](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-Lettuce)
-- [Redisson](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-redisson)
-- [redis-py](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-redis%E2%80%90py)
+- [go-redis](https://glide.valkey.io/migration/go/go-redis/)
+- [ioredis](https://glide.valkey.io/migration/nodejs/ioredis/)
+- [Jedis](https://glide.valkey.io/migration/java/jedis/)
+- [Lettuce](https://glide.valkey.io/migration/java/lettuce/)
+- [Redisson](https://glide.valkey.io/migration/java/redisson/)
+- [redis-py](https://glide.valkey.io/migration/python/redis-py/)
 - [StackExchange.Redis](https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-StackExchange.Redis)
-- [PHPRedis](https://github.com/valkey-io/valkey-glide-php/wiki/Migration-Guide-PHPRedis)
+- [PHPRedis](https://glide.valkey.io/migration/php/phpredis/)
 
 **Community**
 - [Contributors meeting](https://github.com/valkey-io/valkey-glide/wiki/Contributors-meeting)
-
-Looking for more? Check out the [Valkey Glide Wiki](https://github.com/valkey-io/valkey-glide/wiki).
 
 ## Ecosystem
 

--- a/docs/markdown/index.md
+++ b/docs/markdown/index.md
@@ -158,16 +158,16 @@ macOS:
 === "Python"
     - [Python standalone example][1]
     - [Python cluster example][2]
-    - [Python wiki for examples and further details on TLS, Read strategy, Timeouts and various other configurations][3]
+    - [Python documentation for examples and further details on TLS, Read strategy, Timeouts and various other configurations][3]
 
 === "TypeScript"
     - [TypeScript standalone example][5]
     - [TypeScript cluster example][6]
-    - [TypeScript wiki for examples and further details on TLS, Read strategy, Timeouts and various other configurations][4]
+    - [TypeScript documentation for examples and further details on TLS, Read strategy, Timeouts and various other configurations][4]
 
 [1]: https://github.com/valkey-io/valkey-glide/blob/main/examples/python/standalone_example.py
 [2]: https://github.com/valkey-io/valkey-glide/blob/main/examples/python/cluster_example.py
-[3]: https://github.com/valkey-io/valkey-glide/wiki/Python-wrapper
-[4]: https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper
+[3]: https://glide.valkey.io/getting-started/quickstart/?lang=python
+[4]: https://glide.valkey.io/getting-started/quickstart/?lang=node
 [5]: https://github.com/valkey-io/valkey-glide/blob/main/examples/node/standalone_example.ts
 [6]: https://github.com/valkey-io/valkey-glide/blob/main/examples/node/cluster_example.ts

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -3507,7 +3507,7 @@ func (client *baseClient) LInsert(
 //	If no element could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BLPop(ctx context.Context, keys []string, timeout time.Duration) ([]string, error) {
 	result, err := client.executeCommand(ctx, C.BLPop, append(keys, utils.FloatToString(timeout.Seconds())))
 	if err != nil {
@@ -3540,7 +3540,7 @@ func (client *baseClient) BLPop(ctx context.Context, keys []string, timeout time
 //	If no element could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/brpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BRPop(ctx context.Context, keys []string, timeout time.Duration) ([]string, error) {
 	result, err := client.executeCommand(ctx, C.BRPop, append(keys, utils.FloatToString(timeout.Seconds())))
 	if err != nil {
@@ -3732,7 +3732,7 @@ func (client *baseClient) LMPopCount(
 //	If no member could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BLMPop(
 	ctx context.Context,
 	keys []string,
@@ -3791,7 +3791,7 @@ func (client *baseClient) BLMPop(
 //	If no member could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BLMPopCount(
 	ctx context.Context,
 	keys []string,
@@ -3922,7 +3922,7 @@ func (client *baseClient) LMove(
 //	the operation timed-out.
 //
 // [valkey.io]: https://valkey.io/commands/blmove/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BLMove(
 	ctx context.Context,
 	source string,
@@ -5209,7 +5209,7 @@ func (client *baseClient) ZCard(ctx context.Context, key string) (int64, error) 
 //
 // [valkey.io]: https://valkey.io/commands/bzpopmin/
 //
-// [Blocking commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BZPopMin(
 	ctx context.Context,
 	keys []string,
@@ -5254,7 +5254,7 @@ func (client *baseClient) BZPopMin(
 //	Returns `nil` if no member could be popped and the timeout expired.
 //
 // [valkey.io]: https://valkey.io/commands/bzmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BZMPop(
 	ctx context.Context,
 	keys []string,
@@ -5317,7 +5317,7 @@ func (client *baseClient) BZMPop(
 //	Returns `nil` if no member could be popped and the timeout expired.
 //
 // [valkey.io]: https://valkey.io/commands/bzmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BZMPopWithOptions(
 	ctx context.Context,
 	keys []string,
@@ -8280,7 +8280,7 @@ func (client *baseClient) ZLexCount(ctx context.Context, key string, rangeQuery 
 //	returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/bzpopmax/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (client *baseClient) BZPopMax(
 	ctx context.Context,
 	keys []string,
@@ -9709,7 +9709,7 @@ func (client *baseClient) ScriptKill(ctx context.Context) (string, error) {
 // Transactions will only execute commands if the watched keys are not modified before execution of the
 // transaction.
 //
-// See [valkey.io] and [Valkey Glide Wiki] for details.
+// See [valkey.io] and [Valkey GLIDE Documentation] for details.
 //
 // Note:
 //
@@ -9731,7 +9731,7 @@ func (client *baseClient) ScriptKill(ctx context.Context) (string, error) {
 //	A simple "OK" response.
 //
 // [valkey.io]: https://valkey.io/commands/watch
-// [Valkey Glide Wiki]: https://valkey.io/topics/transactions/#cas
+// [Valkey GLIDE Documentation]: https://valkey.io/topics/transactions/#cas
 func (client *baseClient) Watch(ctx context.Context, keys []string) (string, error) {
 	result, err := client.executeCommand(ctx, C.Watch, keys)
 	if err != nil {

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -24,9 +24,9 @@ var _ interfaces.GlideClientCommands = (*Client)(nil)
 // Client used for connection to standalone servers.
 // Use [NewClient] to request a client.
 //
-// For full documentation refer to [Valkey Glide Wiki].
+// For full documentation refer to [Valkey GLIDE Documentation].
 //
-// [Valkey Glide Wiki]: https://github.com/valkey-io/valkey-glide/wiki/Golang-wrapper#standalone
+// [Valkey GLIDE Documentation]: https://glide.valkey.io/how-to/client-initialization/#standalone
 type Client struct {
 	baseClient
 }
@@ -132,7 +132,7 @@ func (client *Client) ExecWithOptions(
 // including the command name and subcommands, should be added as a separate value in args. The returning value depends on
 // the executed command.
 //
-// See [Valkey GLIDE Wiki] for details on the restrictions and limitations of the custom command API.
+// See [Valkey GLIDE Documentation] for details on the restrictions and limitations of the custom command API.
 //
 // This function should only be used for single-response commands. Commands that don't return complete response and awaits
 // (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
@@ -147,7 +147,7 @@ func (client *Client) ExecWithOptions(
 //
 //	The returned value for the custom command.
 //
-// [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
+// [Valkey GLIDE Documentation]: https://glide.valkey.io/concepts/client-features/custom-commands/
 func (client *Client) CustomCommand(ctx context.Context, args []string) (any, error) {
 	res, err := client.executeCommand(ctx, C.CustomCommand, args)
 	if err != nil {
@@ -941,7 +941,7 @@ func (client *Client) Publish(ctx context.Context, channel string, message strin
 // Flushes all the previously watched keys for a transaction. Executing a transaction will
 // automatically flush all previously watched keys.
 //
-// See [valkey.io] and [Valkey Glide Wiki] for details.
+// See [valkey.io] and [Valkey GLIDE Documentation] for details.
 //
 // Parameters:
 //
@@ -952,7 +952,7 @@ func (client *Client) Publish(ctx context.Context, channel string, message strin
 //	A simple "OK" response.
 //
 // [valkey.io]: https://valkey.io/commands/unwatch
-// [Valkey Glide Wiki]: https://valkey.io/topics/transactions/#cas
+// [Valkey GLIDE Documentation]: https://valkey.io/topics/transactions/#cas
 func (client *Client) Unwatch(ctx context.Context) (string, error) {
 	result, err := client.executeCommand(ctx, C.UnWatch, []string{})
 	if err != nil {

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -27,9 +27,9 @@ var _ interfaces.GlideClusterClientCommands = (*ClusterClient)(nil)
 // Client used for connection to cluster servers.
 // Use [NewClusterClient] to request a client.
 //
-// For full documentation refer to [Valkey Glide Wiki].
+// For full documentation refer to [Valkey GLIDE Documentation].
 //
-// [Valkey Glide Wiki]: https://github.com/valkey-io/valkey-glide/wiki/Golang-wrapper#cluster
+// [Valkey GLIDE Documentation]: https://glide.valkey.io/how-to/client-initialization/#cluster
 type ClusterClient struct {
 	baseClient
 }
@@ -192,7 +192,7 @@ func (client *ClusterClient) ExecWithOptions(
 //
 // The command will be routed automatically based on the passed command's default request policy.
 //
-// See [Valkey GLIDE Wiki] for details on the restrictions and limitations of the custom command API.
+// See [Valkey GLIDE Documentation] for details on the restrictions and limitations of the custom command API.
 //
 // This function should only be used for single-response commands. Commands that don't return complete response and awaits
 // (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
@@ -207,7 +207,7 @@ func (client *ClusterClient) ExecWithOptions(
 //
 //	The returned value for the custom command.
 //
-// [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
+// [Valkey GLIDE Documentation]: https://glide.valkey.io/concepts/client-features/custom-commands/
 func (client *ClusterClient) CustomCommand(ctx context.Context, args []string) (models.ClusterValue[any], error) {
 	res, err := client.executeCommand(ctx, C.CustomCommand, args)
 	if err != nil {
@@ -328,7 +328,7 @@ func (client *ClusterClient) InfoWithOptions(
 // including the command name and subcommands, should be added as a separate value in args. The returning value depends on
 // the executed command.
 //
-// See [Valkey GLIDE Wiki] for details on the restrictions and limitations of the custom command API.
+// See [Valkey GLIDE Documentation] for details on the restrictions and limitations of the custom command API.
 //
 // Parameters:
 //
@@ -341,7 +341,7 @@ func (client *ClusterClient) InfoWithOptions(
 //
 //	The returning value depends on the executed command and route.
 //
-// [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
+// [Valkey GLIDE Documentation]: https://glide.valkey.io/concepts/client-features/custom-commands/
 func (client *ClusterClient) CustomCommandWithRoute(ctx context.Context,
 	args []string,
 	route config.Route,
@@ -736,7 +736,7 @@ func (client *ClusterClient) clusterScan(
 // For each iteration, a new cursor object should be used to continue the scan.
 // Using the same cursor object for multiple iterations will result in the same keys or unexpected behavior.
 // For more information about the Cluster Scan implementation, see
-// https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan.
+// https://glide.valkey.io/concepts/client-features/cluster-scan/.
 //
 // Like the SCAN command, the method can be used to iterate over the keys in the database,
 // returning all keys the database has from when the scan started until the scan ends.
@@ -777,7 +777,7 @@ func (client *ClusterClient) Scan(
 // For each iteration, a new cursor object should be used to continue the scan.
 // Using the same cursor object for multiple iterations will result in the same keys or unexpected behavior.
 // For more information about the Cluster Scan implementation, see
-// https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan.
+// https://glide.valkey.io/concepts/client-features/cluster-scan/.
 //
 // Like the SCAN command, the method can be used to iterate over the keys in the database,
 // returning all keys the database has from when the scan started until the scan ends.
@@ -2588,7 +2588,7 @@ func (client *ClusterClient) ScriptKillWithRoute(ctx context.Context, route opti
 // automatically flush all previously watched keys.
 // The command will be routed to all primary nodes.
 //
-// See [valkey.io] and [Valkey Glide Wiki] for details.
+// See [valkey.io] and [Valkey GLIDE Documentation] for details.
 //
 // Parameters:
 //
@@ -2599,7 +2599,7 @@ func (client *ClusterClient) ScriptKillWithRoute(ctx context.Context, route opti
 //	A simple "OK" response.
 //
 // [valkey.io]: https://valkey.io/commands/unwatch
-// [Valkey Glide Wiki]: https://valkey.io/topics/transactions/#cas
+// [Valkey GLIDE Documentation]: https://valkey.io/topics/transactions/#cas
 func (client *ClusterClient) Unwatch(ctx context.Context) (string, error) {
 	result, err := client.executeCommand(ctx, C.UnWatch, []string{})
 	if err != nil {
@@ -2611,7 +2611,7 @@ func (client *ClusterClient) Unwatch(ctx context.Context) (string, error) {
 // Flushes all the previously watched keys for a transaction. Executing a transaction will
 // automatically flush all previously watched keys.
 //
-// See [valkey.io] and [Valkey Glide Wiki] for details.
+// See [valkey.io] and [Valkey GLIDE Documentation] for details.
 //
 // Parameters:
 //
@@ -2624,7 +2624,7 @@ func (client *ClusterClient) Unwatch(ctx context.Context) (string, error) {
 //	A simple "OK" response.
 //
 // [valkey.io]: https://valkey.io/commands/unwatch
-// [Valkey Glide Wiki]: https://valkey.io/topics/transactions/#cas
+// [Valkey GLIDE Documentation]: https://valkey.io/topics/transactions/#cas
 func (client *ClusterClient) UnwatchWithOptions(ctx context.Context, route options.RouteOption) (string, error) {
 	result, err := client.executeCommandWithRoute(ctx, C.UnWatch, []string{}, route.Route)
 	if err != nil {

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -24,7 +24,7 @@ import (
 // including the command name and subcommands, should be added as a separate value in args. The returning value depends on
 // the executed command.
 //
-// See [Valkey GLIDE Wiki] for details on the restrictions and limitations of the custom command API.
+// See [Valkey GLIDE Documentation] for details on the restrictions and limitations of the custom command API.
 //
 // This function should only be used for single-response commands. Commands that don't return complete response and awaits
 // (such as SUBSCRIBE), or that return potentially more than a single response (such as XREAD), or that change the client's
@@ -38,7 +38,7 @@ import (
 //
 //	The returned value for the custom command.
 //
-// [Valkey GLIDE Wiki]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command
+// [Valkey GLIDE Documentation]: https://glide.valkey.io/concepts/client-features/custom-commands/
 func (b *BaseBatch[T]) CustomCommand(args []string) *T {
 	return b.addCmd(C.CustomCommand, args)
 }
@@ -2079,7 +2079,7 @@ func (b *BaseBatch[T]) LInsert(key string, insertPosition constants.InsertPositi
 //	If no element could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BLPop(keys []string, timeout time.Duration) *T {
 	return b.addCmdAndConverter(
 		C.BLPop,
@@ -2112,7 +2112,7 @@ func (b *BaseBatch[T]) BLPop(keys []string, timeout time.Duration) *T {
 //	If no element could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/brpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BRPop(keys []string, timeout time.Duration) *T {
 	return b.addCmdAndConverter(
 		C.BRPop,
@@ -2263,7 +2263,7 @@ func (b *BaseBatch[T]) LMPopCount(keys []string, listDirection constants.ListDir
 //	If no member could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BLMPop(keys []string, listDirection constants.ListDirection, timeout time.Duration) *T {
 	listDirectionStr, err := listDirection.ToString()
 	if err != nil {
@@ -2309,7 +2309,7 @@ func (b *BaseBatch[T]) BLMPop(keys []string, listDirection constants.ListDirecti
 //	If no member could be popped and the timeout expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/blmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BLMPopCount(
 	keys []string,
 	listDirection constants.ListDirection,
@@ -2418,7 +2418,7 @@ func (b *BaseBatch[T]) LMove(
 //	The popped element or `nil` if source does not exist or if the operation timed-out.
 //
 // [valkey.io]: https://valkey.io/commands/blmove/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BLMove(
 	source string,
 	destination string,
@@ -3395,7 +3395,7 @@ func (b *BaseBatch[T]) ZCard(key string) *T {
 //
 // [valkey.io]: https://valkey.io/commands/bzpopmin/
 //
-// [Blocking commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BZPopMin(keys []string, timeout time.Duration) *T {
 	return b.addCmdAndConverter(
 		C.BZPopMin,
@@ -3436,7 +3436,7 @@ func (b *BaseBatch[T]) BZPopMin(keys []string, timeout time.Duration) *T {
 //	Returns `nil` if no member could be popped and the timeout expired.
 //
 // [valkey.io]: https://valkey.io/commands/bzmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BZMPop(keys []string, scoreFilter constants.ScoreFilter, timeout time.Duration) *T {
 	scoreFilterStr, err := scoreFilter.ToString()
 	if err != nil {
@@ -3486,7 +3486,7 @@ func (b *BaseBatch[T]) BZMPop(keys []string, scoreFilter constants.ScoreFilter, 
 //	Returns `nil` if no member could be popped and the timeout expired.
 //
 // [valkey.io]: https://valkey.io/commands/bzmpop/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BZMPopWithOptions(
 	keys []string,
 	scoreFilter constants.ScoreFilter,
@@ -5950,7 +5950,7 @@ func (b *BaseBatch[T]) ZLexCount(key string, rangeQuery options.RangeByLex) *T {
 //	If no member could be popped and the `timeout` expired, returns `nil`.
 //
 // [valkey.io]: https://valkey.io/commands/bzpopmax/
-// [Blocking Commands]: https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands
+// [Blocking Commands]: https://glide.valkey.io/how-to/connection-management/#blocking-commands
 func (b *BaseBatch[T]) BZPopMax(keys []string, timeout time.Duration) *T {
 	args := append(keys, utils.FloatToString(timeout.Seconds()))
 	return b.addCmdAndConverter(C.BZPopMax, args, reflect.Slice, true, internal.ConvertKeyWithMemberAndScore)

--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -73,8 +73,7 @@ import org.apache.commons.lang3.ArrayUtils;
  * Use {@link #createClient} to request a client.
  *
  * @see For full documentation refer to <a
- *     href="https://github.com/valkey-io/valkey-glide/wiki/Java-Wrapper#standalone">Valkey Glide
- *     Wiki</a>.
+ *     href="https://glide.valkey.io/how-to/client-initialization/">Valkey GLIDE Documentation</a>.
  */
 public class GlideClient extends BaseClient
         implements GenericCommands,

--- a/java/client/src/main/java/glide/api/GlideClusterClient.java
+++ b/java/client/src/main/java/glide/api/GlideClusterClient.java
@@ -103,8 +103,8 @@ import response.ResponseOuterClass.Response;
  * Use {@link #createClient} to request a client.
  *
  * @see For full documentation refer to <a
- *     href="https://github.com/valkey-io/valkey-glide/wiki/Java-Wrapper#cluster">Valkey Glide
- *     Wiki</a>.
+ *     href="https://glide.valkey.io/how-to/client-initialization/#cluster">Valkey GLIDE
+ *     Documentation</a>.
  */
 public class GlideClusterClient extends BaseClient
         implements ConnectionManagementClusterCommands,

--- a/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
@@ -20,9 +20,8 @@ public interface GenericClusterCommands {
      * subcommands, should be added as a separate value in <code>args</code>.<br>
      * The command will be routed automatically based on the passed command's default request policy.
      *
-     * @see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Valkey
-     *     GLIDE Wiki</a> for details on the restrictions and limitations of the custom command API.
+     * @see <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Valkey GLIDE
+     *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command including the command name.
      * @return The returned value for the custom command.
      * @example
@@ -38,9 +37,8 @@ public interface GenericClusterCommands {
      * subcommands, should be added as a separate value in <code>args</code>.<br>
      * The command will be routed automatically based on the passed command's default request policy.
      *
-     * @see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Valkey
-     *     GLIDE Wiki</a> for details on the restrictions and limitations of the custom command API.
+     * @see <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Valkey GLIDE
+     *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command including the command name.
      * @return The returned value for the custom command.
      * @example
@@ -55,9 +53,8 @@ public interface GenericClusterCommands {
      * Executes a single command, without checking inputs. Every part of the command, including
      * subcommands, should be added as a separate value in <code>args</code>.
      *
-     * @see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Valkey
-     *     GLIDE Wiki</a> for details on the restrictions and limitations of the custom command API.
+     * @see <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Valkey GLIDE
+     *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command including the command name
      * @param route Specifies the routing configuration for the command. The client will route the
      *     command to the nodes defined by <code>route</code>.
@@ -76,9 +73,8 @@ public interface GenericClusterCommands {
      * Executes a single command, without checking inputs. Every part of the command, including
      * subcommands, should be added as a separate value in <code>args</code>.
      *
-     * @see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Valkey
-     *     GLIDE Wiki</a> for details on the restrictions and limitations of the custom command API.
+     * @see <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Valkey GLIDE
+     *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command including the command name
      * @param route Specifies the routing configuration for the command. The client will route the
      *     command to the nodes defined by <code>route</code>.
@@ -171,8 +167,7 @@ public interface GenericClusterCommands {
      * <p>This command is similar to the <code>SCAN</code> command, but it is designed to work in a
      * Cluster environment. The main difference is that this command uses a {@link ClusterScanCursor}
      * object to manage iterations. For more information about the Cluster Scan implementation, see <a
-     * href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan">Cluster
-     * Scan</a>.
+     * href="https://glide.valkey.io/concepts/client-features/cluster-scan/">Cluster Scan</a>.
      *
      * <p>As with the <code>SCAN</code> command, this command is a cursor-based iterator. This means
      * that at every call of the command, the server returns an updated cursor ({@link
@@ -230,8 +225,7 @@ public interface GenericClusterCommands {
      * <p>This command is similar to the <code>SCAN</code> command, but it is designed to work in a
      * Cluster environment. The main difference is that this command uses a {@link ClusterScanCursor}
      * object to manage iterations. For more information about the Cluster Scan implementation, see <a
-     * href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan">Cluster
-     * Scan</a>.
+     * href="https://glide.valkey.io/concepts/client-features/cluster-scan/">Cluster Scan</a>.
      *
      * <p>As with the <code>SCAN</code> command, this command is a cursor-based iterator. This means
      * that at every call of the command, the server returns an updated cursor ({@link
@@ -288,8 +282,7 @@ public interface GenericClusterCommands {
      * <p>This command is similar to the <code>SCAN</code> command, but it is designed to work in a
      * Cluster environment. The main difference is that this command uses a {@link ClusterScanCursor}
      * object to manage iterations. For more information about the Cluster Scan implementation, see <a
-     * href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan">Cluster
-     * Scan</a>.
+     * href="https://glide.valkey.io/concepts/client-features/cluster-scan/">Cluster Scan</a>.
      *
      * <p>As with the <code>SCAN</code> command, this command is a cursor-based iterator. This means
      * that at every call of the command, the server returns an updated cursor ({@link
@@ -349,8 +342,7 @@ public interface GenericClusterCommands {
      * <p>This command is similar to the <code>SCAN</code> command, but it is designed to work in a
      * Cluster environment. The main difference is that this command uses a {@link ClusterScanCursor}
      * object to manage iterations. For more information about the Cluster Scan implementation, see <a
-     * href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan">Cluster
-     * Scan</a>.
+     * href="https://glide.valkey.io/concepts/client-features/cluster-scan/">Cluster Scan</a>.
      *
      * <p>As with the <code>SCAN</code> command, this command is a cursor-based iterator. This means
      * that at every call of the command, the server returns an updated cursor ({@link

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -16,9 +16,8 @@ public interface GenericCommands {
      * Executes a single command, without checking inputs. Every part of the command, including
      * subcommands, should be added as a separate value in <code>args</code>.
      *
-     * @see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Valkey
-     *     GLIDE Wiki</a> for details on the restrictions and limitations of the custom command API.
+     * @see <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Valkey GLIDE
+     *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command.
      * @return The returned value for the custom command.
      * @example
@@ -35,9 +34,8 @@ public interface GenericCommands {
      * Executes a single command, without checking inputs. Every part of the command, including
      * subcommands, should be added as a separate value in <code>args</code>.
      *
-     * @see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Valkey
-     *     GLIDE Wiki</a> for details on the restrictions and limitations of the custom command API.
+     * @see <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Valkey GLIDE
+     *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command.
      * @return The returned value for the custom command.
      * @example

--- a/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ListBaseCommands.java
@@ -751,7 +751,7 @@ public interface ListBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BLPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -781,7 +781,7 @@ public interface ListBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BLPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -811,7 +811,7 @@ public interface ListBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BRPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -841,7 +841,7 @@ public interface ListBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BRPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -1030,7 +1030,7 @@ public interface ListBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BLMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -1064,7 +1064,7 @@ public interface ListBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BLMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -1098,7 +1098,7 @@ public interface ListBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BLMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -1131,7 +1131,7 @@ public interface ListBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BLMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -1265,7 +1265,7 @@ public interface ListBaseCommands {
      *       <li>When in cluster mode, all <code>source</code> and <code>destination</code> must map
      *           to the same hash slot.
      *       <li><code>BLMove</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -1311,7 +1311,7 @@ public interface ListBaseCommands {
      *       <li>When in cluster mode, all <code>source</code> and <code>destination</code> must map
      *           to the same hash slot.
      *       <li><code>BLMove</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *

--- a/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SortedSetBaseCommands.java
@@ -493,7 +493,7 @@ public interface SortedSetBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZPOPMIN</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -523,7 +523,7 @@ public interface SortedSetBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZPOPMIN</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -629,7 +629,7 @@ public interface SortedSetBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZPOPMAX</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -659,7 +659,7 @@ public interface SortedSetBaseCommands {
      *     <ul>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZPOPMAX</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ul>
      *
@@ -2025,7 +2025,7 @@ public interface SortedSetBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -2059,7 +2059,7 @@ public interface SortedSetBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -2094,7 +2094,7 @@ public interface SortedSetBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *
@@ -2131,7 +2131,7 @@ public interface SortedSetBaseCommands {
      *     <ol>
      *       <li>When in cluster mode, all <code>keys</code> must map to the same hash slot.
      *       <li><code>BZMPOP</code> is a client blocking command, see <a
-     *           href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *           href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *           Commands</a> for more details and best practices.
      *     </ol>
      *

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -375,8 +375,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *
      * @implNote {@link ArgType} is limited to {@link String} or {@link GlideString}, any other type
      *     will throw {@link IllegalArgumentException}.
-     * @apiNote See <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command">Glide
+     * @apiNote See <a href="https://glide.valkey.io/concepts/client-features/custom-commands/">Glide
      *     Wiki</a> for details on the restrictions and limitations of the custom command API.
      * @param args Arguments for the custom command.
      * @return Command Response - The returned value for the custom command.
@@ -2816,7 +2815,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/bzpopmin/">valkey.io</a> for more details.
      * @apiNote <code>BZPOPMIN</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @param keys The keys of the sorted sets.
      * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
@@ -2882,7 +2881,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/bzpopmax/">valkey.io</a> for more details.
      * @apiNote <code>BZPOPMAX</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @param keys The keys of the sorted sets.
      * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
@@ -5186,7 +5185,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/brpop/">valkey.io</a> for details.
      * @apiNote <code>BRPOP</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @param keys The <code>keys</code> of the lists to pop from.
      * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
@@ -5247,7 +5246,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/blpop/">valkey.io</a> for details.
      * @apiNote <code>BLPOP</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @param keys The <code>keys</code> of the lists to pop from.
      * @param timeout The number of seconds to wait for a blocking operation to complete. A value of
@@ -5440,7 +5439,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
      * @apiNote <code>BZMPOP</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @param keys The keys of the sorted sets.
      * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
@@ -5472,7 +5471,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     will throw {@link IllegalArgumentException}.
      * @see <a href="https://valkey.io/commands/bzmpop/">valkey.io</a> for more details.
      * @apiNote <code>BZMPOP</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @param keys The keys of the sorted sets.
      * @param modifier The element pop criteria - either {@link ScoreFilter#MIN} or {@link
@@ -6283,7 +6282,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @implNote {@link ArgType} is limited to {@link String} or {@link GlideString}, any other type
      *     will throw {@link IllegalArgumentException}.
      * @apiNote <code>BLMPOP</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @since Valkey 7.0 and above.
      * @see <a href="https://valkey.io/commands/blmpop/">valkey.io</a> for details.
@@ -6324,7 +6323,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @implNote {@link ArgType} is limited to {@link String} or {@link GlideString}, any other type
      *     will throw {@link IllegalArgumentException}.
      * @apiNote <code>BLMPOP</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @since Valkey 7.0 and above.
      * @see <a href="https://valkey.io/commands/lmpop/">valkey.io</a> for details.
@@ -6578,7 +6577,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @implNote {@link ArgType} is limited to {@link String} or {@link GlideString}, any other type
      *     will throw {@link IllegalArgumentException}.
      * @apiNote <code>BLMove</code> is a client blocking command, see <a
-     *     href="https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands">Blocking
+     *     href="https://glide.valkey.io/how-to/connection-management/#blocking-commands">Blocking
      *     Commands</a> for more details and best practices.
      * @see <a href="https://valkey.io/commands/blmove/">valkey.io</a> for details.
      * @param source The key to the source list.

--- a/node/AGENTS.md
+++ b/node/AGENTS.md
@@ -229,7 +229,7 @@ node/
 - **Development Setup:** [DEVELOPER.md](./DEVELOPER.md)
 - **Examples:** [../examples/node/](../examples/node/)
 - **API Documentation:** [Valkey GLIDE Node.js docs](https://valkey.io/valkey-glide/node/)
-- **Wiki:** [NodeJS wrapper wiki](https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper)
+- **Documentation:** [GLIDE Docs](https://glide.valkey.io/)
 - **Test Suites:** [tests/](./tests/) directory
 - **Package Manager Tests:** [pm-and-types-tests/](./pm-and-types-tests/)
 - **Rust Client:** [rust-client/](./rust-client/) directory

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -3861,7 +3861,7 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
      * @remarks When in cluster mode, both `source` and `destination` must map to the same hash slot.
-     * @remarks `BLMOVE` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Valkey Glide Wiki} for more details and best practices.
+     * @remarks `BLMOVE` is a client blocking command, see {@link https://glide.valkey.io/how-to/connection-management/#blocking-commands|Valkey GLIDE Documentation} for more details and best practices.
      * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source list.
@@ -7676,7 +7676,7 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/brpop/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
-     * @remarks `BRPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @remarks `BRPOP` is a blocking command, see [Blocking Commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -7708,7 +7708,7 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/blpop/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
-     * @remarks `BLPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @remarks `BLPOP` is a blocking command, see [Blocking Commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -8327,7 +8327,7 @@ export class BaseClient {
      *
      * @see {@link https://valkey.io/commands/bzmpop/|valkey.io} for more details.
      * @remarks When in cluster mode, all `keys` must map to the same hash slot.
-     * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | Valkey Glide Wiki} for more details and best practices.
+     * @remarks `BZMPOP` is a client blocking command, see {@link https://glide.valkey.io/how-to/connection-management/#blocking-commands | Valkey GLIDE Documentation} for more details and best practices.
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets.
@@ -8703,7 +8703,7 @@ export class BaseClient {
      * will only execute commands if the watched keys are not modified before execution of the
      * transaction. Executing a transaction will automatically flush all previously watched keys.
      *
-     * @see {@link https://valkey.io/commands/watch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
+     * @see {@link https://valkey.io/commands/watch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey GLIDE Documentation} for more details.
      *
      * @remarks In cluster mode, if keys in `keys` map to different hash slots,
      * the command will be split across these slots and executed separately for each.

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -1492,7 +1492,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      *
      * @see {@link https://valkey.io/commands/blmove/|valkey.io} for details.
      * @remarks When in cluster mode, both `source` and `destination` must map to the same hash slot.
-     * @remarks `BLMOVE` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands|Valkey Glide Wiki} for more details and best practices.
+     * @remarks `BLMOVE` is a client blocking command, see {@link https://glide.valkey.io/how-to/connection-management/#blocking-commands|Valkey GLIDE Documentation} for more details and best practices.
      * @remarks Since Valkey version 6.2.0.
      *
      * @param source - The key to the source list.
@@ -2836,7 +2836,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
     /** Executes a single command, without checking inputs. Every part of the command, including subcommands,
      *  should be added as a separate value in args.
      *
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.
+     * @see {@link https://glide.valkey.io/concepts/client-features/custom-commands/|Valkey GLIDE Documentation} for details on the restrictions and limitations of the custom command API.
      *
      * Command Response - A response from Valkey with an `Object`.
      */
@@ -3456,7 +3456,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * Blocks the connection when there are no elements to pop from any of the given lists.
      *
      * @see {@link https://valkey.io/commands/brpop/|valkey.io} for details.
-     * @remarks `BRPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @remarks `BRPOP` is a blocking command, see [Blocking Commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -3474,7 +3474,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * Blocks the connection when there are no elements to pop from any of the given lists.
      *
      * @see {@link https://valkey.io/commands/blpop/|valkey.io} for details.
-     * @remarks `BLPOP` is a blocking command, see [Blocking Commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands) for more details and best practices.
+     * @remarks `BLPOP` is a blocking command, see [Blocking Commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands) for more details and best practices.
      *
      * @param keys - The `keys` of the lists to pop from.
      * @param timeout - The `timeout` in seconds.
@@ -3988,7 +3988,7 @@ export class BaseBatch<T extends BaseBatch<T>> {
      * to pop from any of the given sorted sets. `BZMPOP` is the blocking variant of {@link zmpop}.
      *
      * @see {@link https://valkey.io/commands/bzmpop/|valkey.io} for details.
-     * @remarks `BZMPOP` is a client blocking command, see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands | Valkey Glide Wiki} for more details and best practices.
+     * @remarks `BZMPOP` is a client blocking command, see {@link https://glide.valkey.io/how-to/connection-management/#blocking-commands | Valkey GLIDE Documentation} for more details and best practices.
      * @remarks Since Valkey version 7.0.0.
      *
      * @param keys - The keys of the sorted sets.

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -158,7 +158,7 @@ export type AdvancedGlideClientConfiguration =
  * Client used for connection to standalone servers.
  * Use {@link createClient} to request a client.
  *
- * @see For full documentation refer to {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#standalone | Valkey Glide Wiki}.
+ * @see For full documentation refer to {@link https://glide.valkey.io/how-to/client-initialization/#standalone | Valkey GLIDE Documentation}.
  */
 export class GlideClient extends BaseClient {
     /**
@@ -261,7 +261,7 @@ export class GlideClient extends BaseClient {
      * **Notes:**
      * - **Atomic Batches - Transactions:** If the transaction fails due to a `WATCH` command, `EXEC` will return `null`.
      *
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey Glide Wiki} for details on Valkey Transactions.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey GLIDE Documentation} for details on Valkey Transactions.
      *
      * @param batch - A {@link Batch} object containing a list of commands to be executed.
      * @param raiseOnError - Determines how errors are handled within the batch response.
@@ -322,7 +322,7 @@ export class GlideClient extends BaseClient {
      *
      * Note: An error will occur if the string decoder is used with commands that return only bytes as a response.
      *
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Valkey Glide Wiki} for details on the restrictions and limitations of the custom command API.
+     * @see {@link https://glide.valkey.io/concepts/client-features/custom-commands/|Valkey GLIDE Documentation} for details on the restrictions and limitations of the custom command API.
      *
      * @param args - A list including the command name and arguments for the custom command.
      * @param options - (Optional) See {@link DecoderOption}.
@@ -947,7 +947,7 @@ export class GlideClient extends BaseClient {
      * Flushes all the previously watched keys for a transaction. Executing a transaction will
      * automatically flush all previously watched keys.
      *
-     * @see {@link https://valkey.io/commands/unwatch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
+     * @see {@link https://valkey.io/commands/unwatch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey GLIDE Documentation} for more details.
      *
      * @returns A simple `"OK"` response.
      *

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -518,7 +518,7 @@ export type SingleNodeRoute =
  * Client used for connection to cluster servers.
  * Use {@link createClient} to request a client.
  *
- * @see For full documentation refer to {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#cluster | Valkey Glide Wiki}.
+ * @see For full documentation refer to {@link https://glide.valkey.io/how-to/client-initialization/#cluster | Valkey GLIDE Documentation}.
  */
 export class GlideClusterClient extends BaseClient {
     /**
@@ -730,7 +730,7 @@ export class GlideClusterClient extends BaseClient {
      * Using the same cursor object for multiple iterations may result in unexpected behavior.
      *
      * For more information about the Cluster Scan implementation, see
-     * {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan | Cluster Scan}.
+     * {@link https://glide.valkey.io/concepts/client-features/cluster-scan/ | Cluster Scan}.
      *
      * This method can iterate over all keys in the database from the start of the scan until it ends.
      * The same key may be returned in multiple scan iterations.
@@ -795,7 +795,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * Note: An error will occur if the string decoder is used with commands that return only bytes as a response.
      *
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command|Glide for Valkey Wiki} for details on the restrictions and limitations of the custom command API.
+     * @see {@link https://glide.valkey.io/concepts/client-features/custom-commands/|Glide for Valkey Wiki} for details on the restrictions and limitations of the custom command API.
      *
      * @param args - A list including the command name and arguments for the custom command.
      * @param options - (Optional) See {@link RouteOption} and {@link DecoderOption}
@@ -830,7 +830,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * - **Atomic Batches (Transactions):** All key-based commands must map to the same hash slot. If keys span different slots, the transaction will fail. If the transaction fails due to a `WATCH` command, `exec` will return `null`.
      *
-     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey Glide Wiki} for details on Valkey Transactions.
+     * @see {@link https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction|Valkey GLIDE Documentation} for details on Valkey Transactions.
      *
      * **Retry and Redirection:**
      *
@@ -1812,7 +1812,7 @@ export class GlideClusterClient extends BaseClient {
      *
      * The command will be routed to all primary nodes, unless `route` is provided
      *
-     * @see {@link https://valkey.io/commands/unwatch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey Glide Wiki} for more details.
+     * @see {@link https://valkey.io/commands/unwatch/|valkey.io} and {@link https://valkey.io/topics/transactions/#cas|Valkey GLIDE Documentation} for more details.
      *
      * @param options - (Optional) See {@link RouteOption}.
      * @returns A simple `"OK"` response.

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -239,7 +239,7 @@ python/
 - **Development Setup:** [DEVELOPER.md](./DEVELOPER.md)
 - **Examples:** [../examples/python/](../examples/python/)
 - **API Documentation:** [Valkey GLIDE Python docs](https://valkey.io/valkey-glide/)
-- **Wiki:** [Python wrapper wiki](https://github.com/valkey-io/valkey-glide/wiki/Python-wrapper)
+- **Documentation:** [GLIDE Documentation](https://glide.valkey.io/)
 - **Test Suites:** [tests/](./tests/) directory
 - **Async Client:** [glide-async/](./glide-async/) directory
 - **Sync Client:** [glide-sync/](./glide-sync/) directory

--- a/python/glide-async/python/glide/async_commands/cluster_commands.py
+++ b/python/glide-async/python/glide/async_commands/cluster_commands.py
@@ -34,7 +34,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[TResult]:
         """
         Executes a single command, without checking inputs.
-        See the [Valkey GLIDE Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
+        See the [Valkey GLIDE Documentation](https://glide.valkey.io/concepts/client-features/custom-commands/)
         for details on the restrictions and limitations of the custom command API.
 
         This function should only be used for single-response commands. Commands that don't return complete response and awaits
@@ -1256,7 +1256,7 @@ class ClusterCommands(CoreCommands):
         For each iteration, the new cursor object should be used to continue the scan.
         Using the same cursor object for multiple iterations will result in the same keys or unexpected behavior.
         For more information about the Cluster Scan implementation, see
-        [Cluster Scan](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan).
+        [Cluster Scan](https://glide.valkey.io/concepts/client-features/cluster-scan/).
 
         Like the SCAN command, the method can be used to iterate over the keys in the database,
         returning all keys the database has from when the scan started until the scan ends.

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -1797,7 +1797,7 @@ class CoreCommands(Protocol):
         Note:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BLPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         Args:
@@ -1876,7 +1876,7 @@ class CoreCommands(Protocol):
         Note:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BLMPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/blmpop/) for details.
@@ -2123,7 +2123,7 @@ class CoreCommands(Protocol):
         Notes:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BRPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         Args:
@@ -2249,7 +2249,7 @@ class CoreCommands(Protocol):
         Notes:
             1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
             2. `BLMOVE` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/blmove/) for details.
@@ -5005,7 +5005,7 @@ class CoreCommands(Protocol):
             1. When in cluster mode, all keys must map to the same hash slot.
             2. `BZPOPMAX` is the blocking variant of `ZPOPMAX`.
             3. `BZPOPMAX` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/bzpopmax) for more details.
@@ -5078,7 +5078,7 @@ class CoreCommands(Protocol):
             1. When in cluster mode, all keys must map to the same hash slot.
             2. `BZPOPMIN` is the blocking variant of `ZPOPMIN`.
             3. `BZPOPMIN` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/bzpopmin) for more details.
@@ -6160,7 +6160,7 @@ class CoreCommands(Protocol):
         Notes:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BZMPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         Args:

--- a/python/glide-async/python/glide/async_commands/standalone_commands.py
+++ b/python/glide-async/python/glide/async_commands/standalone_commands.py
@@ -29,7 +29,7 @@ class StandaloneCommands(CoreCommands):
     async def custom_command(self, command_args: List[TEncodable]) -> TResult:
         """
         Executes a single command, without checking inputs.
-        See the [Valkey GLIDE Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
+        See the [Valkey GLIDE Documentation](https://glide.valkey.io/concepts/client-features/custom-commands/)
         for details on the restrictions and limitations of the custom command API.
 
         This function should only be used for single-response commands. Commands that don't return complete response and awaits

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -845,7 +845,7 @@ class GlideClusterClient(BaseClient, ClusterCommands):
     Client used for connection to cluster servers.
     Use :func:`~BaseClient.create` to request a client.
     For full documentation, see
-    [Valkey GLIDE Wiki](https://github.com/valkey-io/valkey-glide/wiki/Python-wrapper#cluster)
+    [Valkey GLIDE Documentation](https://glide.valkey.io/how-to/client-initialization/#cluster)
     """
 
     async def _cluster_scan(
@@ -932,7 +932,7 @@ class GlideClient(BaseClient, StandaloneCommands):
     Client used for connection to standalone servers.
     Use :func:`~BaseClient.create` to request a client.
     For full documentation, see
-    [Valkey GLIDE Wiki](https://github.com/valkey-io/valkey-glide/wiki/Python-wrapper#standalone)
+    [Valkey GLIDE Documentation](https://glide.valkey.io/how-to/client-initialization/#standalone)
     """
 
     async def get_subscriptions(

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -276,8 +276,8 @@ class BaseBatch:
         """
         Executes a single command, without checking inputs.
 
-        See the Valkey GLIDE Wiki
-        [custom command](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
+        See the Valkey GLIDE Documentation
+        [custom command](https://glide.valkey.io/concepts/client-features/custom-commands/)
         for details on the restrictions and limitations of the custom command API.
 
         This function should only be used for single-response commands. Commands that don't return complete response and awaits
@@ -1439,7 +1439,7 @@ class BaseBatch:
 
         Note:
             BLPOP is a client blocking command, see
-            [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+            [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
             for more details and best practices.
 
         Args:
@@ -1674,7 +1674,7 @@ class BaseBatch:
 
         Note:
             BRPOP is a client blocking command, see
-            [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+            [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
             for more details and best practices.
 
         Args:
@@ -3821,7 +3821,7 @@ class BaseBatch:
 
         Note:
             `BZPOPMAX` is a client blocking command, see
-            [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+            [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
             for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/bzpopmax) for more details.
@@ -3872,7 +3872,7 @@ class BaseBatch:
 
         Note:
             `BZPOPMIN` is a client blocking command, see
-            [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+            [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
             for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/bzpopmin) for more details.
@@ -4614,7 +4614,7 @@ class BaseBatch:
 
         Note:
             `BZMPOP` is a client blocking command, see
-            [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+            [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
             for more details and best practices.
 
         Args:

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -913,7 +913,7 @@ class GlideClusterClient(BaseClient, ClusterCommands):
     """
     Client used for connection to cluster servers.
     For full documentation, see
-    https://github.com/valkey-io/valkey-glide/wiki/Python-wrapper#cluster
+    https://glide.valkey.io/how-to/client-initialization/#cluster
     """
 
     def _build_cluster_scan_args(self, match, count, type, allow_non_covered_slots):
@@ -1001,7 +1001,7 @@ class GlideClient(BaseClient, StandaloneCommands):
     """
     Client used for connection to standalone servers.
     For full documentation, see
-    https://github.com/valkey-io/valkey-glide/wiki/Python-wrapper#standalone
+    https://glide.valkey.io/how-to/client-initialization/#standalone
     """
 
 

--- a/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
@@ -35,7 +35,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[TResult]:
         """
         Executes a single command, without checking inputs.
-        See the [Valkey GLIDE Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
+        See the [Valkey GLIDE Documentation](https://glide.valkey.io/concepts/client-features/custom-commands/)
         for details on the restrictions and limitations of the custom command API.
 
         This function should only be used for single-response commands. Commands that don't return complete response and awaits
@@ -1384,7 +1384,7 @@ class ClusterCommands(CoreCommands):
         For each iteration, the new cursor object should be used to continue the scan.
         Using the same cursor object for multiple iterations will result in the same keys or unexpected behavior.
         For more information about the Cluster Scan implementation, see
-        [Cluster Scan](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#cluster-scan).
+        [Cluster Scan](https://glide.valkey.io/concepts/client-features/cluster-scan/).
 
         Like the SCAN command, the method can be used to iterate over the keys in the database,
         returning all keys the database has from when the scan started until the scan ends.

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -1765,7 +1765,7 @@ class CoreCommands(Protocol):
         Note:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BLPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         Args:
@@ -1844,7 +1844,7 @@ class CoreCommands(Protocol):
         Note:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BLMPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/blmpop/) for details.
@@ -2083,7 +2083,7 @@ class CoreCommands(Protocol):
         Notes:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BRPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         Args:
@@ -2209,7 +2209,7 @@ class CoreCommands(Protocol):
         Notes:
             1. When in cluster mode, both `source` and `destination` must map to the same hash slot.
             2. `BLMOVE` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/blmove/) for details.
@@ -4947,7 +4947,7 @@ class CoreCommands(Protocol):
             1. When in cluster mode, all keys must map to the same hash slot.
             2. `BZPOPMAX` is the blocking variant of `ZPOPMAX`.
             3. `BZPOPMAX` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/bzpopmax) for more details.
@@ -5020,7 +5020,7 @@ class CoreCommands(Protocol):
             1. When in cluster mode, all keys must map to the same hash slot.
             2. `BZPOPMIN` is the blocking variant of `ZPOPMIN`.
             3. `BZPOPMIN` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         See [valkey.io](https://valkey.io/commands/bzpopmin) for more details.
@@ -6100,7 +6100,7 @@ class CoreCommands(Protocol):
         Notes:
             1. When in cluster mode, all `keys` must map to the same hash slot.
             2. `BZMPOP` is a client blocking command, see
-               [blocking commands](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#blocking-commands)
+               [blocking commands](https://glide.valkey.io/how-to/connection-management/#blocking-commands)
                for more details and best practices.
 
         Args:

--- a/python/glide-sync/glide_sync/sync_commands/standalone_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/standalone_commands.py
@@ -30,7 +30,7 @@ class StandaloneCommands(CoreCommands):
     def custom_command(self, command_args: List[TEncodable]) -> TResult:
         """
         Executes a single command, without checking inputs.
-        See the [Valkey GLIDE Wiki](https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#custom-command)
+        See the [Valkey GLIDE Documentation](https://glide.valkey.io/concepts/client-features/custom-commands/)
         for details on the restrictions and limitations of the custom command API.
 
         This function should only be used for single-response commands. Commands that don't return complete response and awaits


### PR DESCRIPTION
### Summary

This PR updates links within the repo that points to our wiki at `https://github.com/valkey-io/valkey-glide/wiki/`.

A few links are omited in this PR:
- https://github.com/valkey-io/valkey-glide/wiki/Migration-Guide-StackExchange.Redis: C# docs not yet added.
- https://github.com/valkey-io/valkey-glide/wiki/General-Concepts#best-practices-for-refreshing-iam-tokens-and-re-authentication: Missing on doc site, will be added.
- https://github.com/valkey-io/valkey-glide/wiki/NodeJS-wrapper#transaction: Missing on doc site, will be added.

### Related Issues

#4361

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   ~~[ ] Tests are added or updated.~~
-   ~~[ ] CHANGELOG.md and documentation files are updated.~~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
