### PR TITLE
fix(go): use semantic version comparisons in integration tests

### DIFF
--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -322,14 +322,14 @@ func (suite *GlideTestSuite) TestBatchConvertersHandleServerError() {
 			XRevRange(key1, options.NewStreamBoundary("0-0", true), options.NewStreamBoundary("2-0", true)).
 			XRevRangeWithOptions(key1, options.NewStreamBoundary("0-0", true), options.NewStreamBoundary("2-0", true), *options.NewXRangeOptions().SetCount(2))
 
-		if suite.serverVersion >= "7.0.0" {
+		if suite.IsServerVersionAtLeast("7.0.0") {
 			transaction.
 				ZMPop([]string{key1}, constants.MAX).
 				ZMPopWithOptions([]string{key1}, constants.MAX, *options.NewZMPopOptions().SetCount(2)).
 				LMPop([]string{key1}, constants.Left).
 				LMPopCount([]string{key1}, constants.Left, 42)
 		}
-		if suite.serverVersion >= "7.2.0" {
+		if suite.IsServerVersionAtLeast("7.2.0") {
 			transaction.
 				ZRankWithScore(key1, "d").
 				ZRevRankWithScore(key1, "d")
@@ -341,7 +341,7 @@ func (suite *GlideTestSuite) TestBatchConvertersHandleServerError() {
 			suite.Equal("WRONGTYPE: Operation against a key holding the wrong kind of value", resp.(error).Error(), i)
 		}
 
-		if suite.serverVersion < "7.0.0" {
+		if suite.IsServerVersionLowerThan("7.0.0") {
 			return
 		}
 		// LCS has another error message
@@ -448,7 +448,7 @@ func (suite *GlideTestSuite) TestBatchStandaloneAndClusterPubSub() {
 			res, err := c.Exec(context.Background(), *batch, false)
 			suite.NoError(err)
 			suite.Equal(int64(0), res[0], "Publish")
-			if suite.serverVersion >= "7.0.0" {
+			if suite.IsServerVersionAtLeast("7.0.0") {
 				suite.Equal([]string{}, res[1], "PubSubShardChannels")
 				suite.Equal(map[string]int64{}, res[3], "PubSubShardNumSub")
 			} else {

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -103,7 +103,7 @@ func (suite *GlideTestSuite) TestInfoCluster() {
 
 	// info with option or with multiple options without route
 	sections := []constants.Section{constants.Cpu}
-	if suite.serverVersion >= "7.0.0" {
+	if suite.IsServerVersionAtLeast("7.0.0") {
 		sections = append(sections, constants.Memory)
 	}
 	opts := options.ClusterInfoOptions{
@@ -1226,7 +1226,7 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_WithRandomRoute() {
 func (suite *GlideTestSuite) TestLolwutWithOptions_Version9_AllNodes() {
 	client := suite.defaultClusterClient()
 	// Test LOLWUT version 9 (available in Valkey 9.0.0+)
-	if suite.serverVersion >= "9.0.0" {
+	if suite.IsServerVersionAtLeast("9.0.0") {
 		options := options.ClusterLolwutOptions{
 			LolwutOptions: &options.LolwutOptions{
 				Version: 9,
@@ -1250,7 +1250,7 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_Version9_AllNodes() {
 func (suite *GlideTestSuite) TestLolwutWithOptions_Version9_RandomNode() {
 	client := suite.defaultClusterClient()
 	// Test LOLWUT version 9 (available in Valkey 9.0.0+)
-	if suite.serverVersion >= "9.0.0" {
+	if suite.IsServerVersionAtLeast("9.0.0") {
 		options := options.ClusterLolwutOptions{
 			LolwutOptions: &options.LolwutOptions{
 				Version: 9,
@@ -3033,7 +3033,7 @@ func (suite *GlideTestSuite) TestClusterShards() {
 	t := suite.T()
 
 	// CLUSTER SHARDS requires Valkey 7.0+
-	if suite.serverVersion < "7.0.0" {
+	if suite.IsServerVersionLowerThan("7.0.0") {
 		t.Skip("CLUSTER SHARDS requires Valkey 7.0 or above")
 	}
 
@@ -3058,7 +3058,7 @@ func (suite *GlideTestSuite) TestClusterShardsWithRoute() {
 	t := suite.T()
 
 	// CLUSTER SHARDS requires Valkey 7.0+
-	if suite.serverVersion < "7.0.0" {
+	if suite.IsServerVersionLowerThan("7.0.0") {
 		t.Skip("CLUSTER SHARDS requires Valkey 7.0 or above")
 	}
 
@@ -3142,7 +3142,7 @@ func (suite *GlideTestSuite) TestClusterMyShardId() {
 	t := suite.T()
 
 	// CLUSTER MYSHARDID requires Valkey 7.2+
-	if suite.serverVersion < "7.2.0" {
+	if suite.IsServerVersionLowerThan("7.2.0") {
 		t.Skip("CLUSTER MYSHARDID requires Valkey 7.2 or above")
 	}
 
@@ -3220,7 +3220,7 @@ func (suite *GlideTestSuite) TestClusterLinks() {
 	t := suite.T()
 
 	// CLUSTER LINKS requires Valkey 7.0+
-	if suite.serverVersion < "7.0.0" {
+	if suite.IsServerVersionLowerThan("7.0.0") {
 		t.Skip("CLUSTER LINKS requires Valkey 7.0 or above")
 	}
 

--- a/go/integTest/server_version_compare_test.go
+++ b/go/integTest/server_version_compare_test.go
@@ -1,0 +1,215 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import "testing"
+
+func TestCompareSemanticVersions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		current  string
+		required string
+		expected int
+	}{
+		{
+			name:     "major version is higher",
+			current:  "10.0.0",
+			required: "7.2.0",
+			expected: 1,
+		},
+		{
+			name:     "minor version is higher",
+			current:  "7.10.0",
+			required: "7.2.0",
+			expected: 1,
+		},
+		{
+			name:     "patch version is lower",
+			current:  "7.2.3",
+			required: "7.2.4",
+			expected: -1,
+		},
+		{
+			name:     "versions are equal",
+			current:  "8.1.0",
+			required: "8.1.0",
+			expected: 0,
+		},
+		{
+			name:     "pre-release is lower than release",
+			current:  "9.0.0-rc1",
+			required: "9.0.0",
+			expected: -1,
+		},
+		{
+			name:     "release is higher than pre-release",
+			current:  "9.0.0",
+			required: "9.0.0-rc1",
+			expected: 1,
+		},
+		{
+			name:     "pre-release identifiers are compared semantically",
+			current:  "9.0.0-rc.2",
+			required: "9.0.0-rc.1",
+			expected: 1,
+		},
+		{
+			name:     "pre-release numeric identifiers compare as numbers not strings",
+			current:  "9.0.0-rc.10",
+			required: "9.0.0-rc.2",
+			expected: 1,
+		},
+		{
+			name:     "build metadata is ignored",
+			current:  "9.0.1+build42",
+			required: "9.0.1",
+			expected: 0,
+		},
+		{
+			name:     "numeric pre-release identifier is lower than alpha identifier",
+			current:  "9.0.0-1",
+			required: "9.0.0-alpha",
+			expected: -1,
+		},
+		{
+			name:     "alpha pre-release identifier is higher than numeric identifier",
+			current:  "9.0.0-alpha",
+			required: "9.0.0-1",
+			expected: 1,
+		},
+		{
+			name:     "shorter pre-release identifier list is lower",
+			current:  "9.0.0-rc.1",
+			required: "9.0.0-rc.1.1",
+			expected: -1,
+		},
+		{
+			name:     "longer pre-release identifier list is higher when prefix matches",
+			current:  "9.0.0-rc.1.1",
+			required: "9.0.0-rc.1",
+			expected: 1,
+		},
+		{
+			name:     "normalization trims spaces prefix and metadata",
+			current:  " v9.0.1+build42 ",
+			required: "9.0.1",
+			expected: 0,
+		},
+		{
+			name:     "required version normalization trims spaces prefix and metadata",
+			current:  "9.0.1",
+			required: " v9.0.1+meta ",
+			expected: 0,
+		},
+		{
+			name:     "two-segment version equals explicit patch zero",
+			current:  "7.2",
+			required: "7.2.0",
+			expected: 0,
+		},
+		{
+			name:     "two-segment version lower than next patch",
+			current:  "7.2",
+			required: "7.2.1",
+			expected: -1,
+		},
+		{
+			name:     "two-segment version compares larger minor correctly",
+			current:  "7.10",
+			required: "7.2.9",
+			expected: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			comparison, err := compareSemanticVersions(testCase.current, testCase.required)
+			if err != nil {
+				t.Fatalf("unexpected compare error: %s", err.Error())
+			}
+
+			if comparison != testCase.expected {
+				t.Fatalf(
+					"expected compare result %d, got %d (current=%s, required=%s)",
+					testCase.expected,
+					comparison,
+					testCase.current,
+					testCase.required,
+				)
+			}
+		})
+	}
+}
+
+func TestGlideTestSuite_ServerVersionPredicates(t *testing.T) {
+	preReleaseSuite := &GlideTestSuite{serverVersion: "9.0.0-rc1"}
+	preReleaseSuite.SetT(t)
+	if preReleaseSuite.IsServerVersionAtLeast("9.0.0") {
+		t.Fatalf("expected 9.0.0-rc1 to be lower than 9.0.0")
+	}
+	if !preReleaseSuite.IsServerVersionLowerThan("9.0.0") {
+		t.Fatalf("expected 9.0.0-rc1 to be lower than 9.0.0")
+	}
+
+	stableSuite := &GlideTestSuite{serverVersion: "7.2.0"}
+	stableSuite.SetT(t)
+	if !stableSuite.IsServerVersionAtLeast("7.2.0") {
+		t.Fatalf("expected 7.2.0 to satisfy at least 7.2.0")
+	}
+	if stableSuite.IsServerVersionGreaterThan("7.2.0") {
+		t.Fatalf("expected 7.2.0 not to be greater than 7.2.0")
+	}
+	if !stableSuite.IsServerVersionGreaterThan("7.1.9") {
+		t.Fatalf("expected 7.2.0 to be greater than 7.1.9")
+	}
+	if !stableSuite.IsServerVersionGreaterThan("7.2.0-rc1") {
+		t.Fatalf("expected stable release to be greater than its pre-release")
+	}
+}
+
+func TestCompareSemanticVersions_InvalidFormat(t *testing.T) {
+	testCases := []struct {
+		name     string
+		current  string
+		required string
+	}{
+		{
+			name:     "current version missing minor and patch",
+			current:  "7",
+			required: "7.0.0",
+		},
+		{
+			name:     "required version contains text segment",
+			current:  "7.2.0",
+			required: "7.x.0",
+		},
+		{
+			name:     "current version with empty pre-release identifier",
+			current:  "9.0.0-rc..1",
+			required: "9.0.0",
+		},
+		{
+			name:     "required version with dangling pre-release separator",
+			current:  "9.0.0",
+			required: "9.0.0-",
+		},
+		{
+			name:     "required version with too many core segments",
+			current:  "9.0.0",
+			required: "9.0.0.1",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := compareSemanticVersions(testCase.current, testCase.required)
+			if err == nil {
+				t.Fatalf(
+					"expected an error for versions current=%s required=%s",
+					testCase.current,
+					testCase.required,
+				)
+			}
+		})
+	}
+}

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -1266,7 +1266,7 @@ func (suite *GlideTestSuite) TestHScan() {
 		assert.Empty(t, result.Data)
 
 		// Negative cursor check.
-		if suite.serverVersion >= "8.0.0" {
+		if suite.IsServerVersionAtLeast("8.0.0") {
 			_, err = client.HScan(context.Background(), key1, models.NewCursorFromString("-1"))
 			assert.NotEmpty(t, err)
 		} else {
@@ -1371,7 +1371,7 @@ func (suite *GlideTestSuite) TestHScan() {
 		assert.True(t, resCursorInt >= 0)
 		assert.True(t, len(result.Data) >= 0)
 
-		if suite.serverVersion >= "8.0.0" {
+		if suite.IsServerVersionAtLeast("8.0.0") {
 			opts = options.NewHashScanOptions().SetNoValues(true)
 			result, _ = client.HScanWithOptions(context.Background(), key1, initialCursor, *opts)
 			resCursorInt, _ = strconv.Atoi(result.Cursor.String())
@@ -3123,7 +3123,7 @@ func (suite *GlideTestSuite) TestSScan() {
 		assert.Empty(t, result.Data)
 
 		// negative cursor
-		if suite.serverVersion < "8.0.0" {
+		if suite.IsServerVersionLowerThan("8.0.0") {
 			result, err = client.SScan(context.Background(), key1, models.NewCursorFromString("-1"))
 			assert.NoError(t, err)
 			assert.Equal(t, initialCursor.String(), result.Cursor.String())
@@ -3558,7 +3558,7 @@ func (suite *GlideTestSuite) TestLPushX() {
 }
 
 func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
-	if suite.serverVersion < "7.0.0" {
+	if suite.IsServerVersionLowerThan("7.0.0") {
 		suite.T().Skip("This feature is added in version 7")
 	}
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
@@ -3610,7 +3610,7 @@ func (suite *GlideTestSuite) TestLMPopAndLMPopCount() {
 }
 
 func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
-	if suite.serverVersion < "7.0.0" {
+	if suite.IsServerVersionLowerThan("7.0.0") {
 		suite.T().Skip("This feature is added in version 7")
 	}
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
@@ -3664,7 +3664,7 @@ func (suite *GlideTestSuite) TestBLMPopAndBLMPopCount() {
 }
 
 func (suite *GlideTestSuite) TestBZMPopAndBZMPopWithOptions() {
-	if suite.serverVersion < "7.0.0" {
+	if suite.IsServerVersionLowerThan("7.0.0") {
 		suite.T().Skip("This feature is added in version 7")
 	}
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
@@ -3778,7 +3778,7 @@ func (suite *GlideTestSuite) TestLSet() {
 }
 
 func (suite *GlideTestSuite) TestLMove() {
-	if suite.serverVersion < "6.2.0" {
+	if suite.IsServerVersionLowerThan("6.2.0") {
 		suite.T().Skip("This feature is added in version 6.2.0")
 	}
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
@@ -4892,7 +4892,7 @@ func (suite *GlideTestSuite) TestSortReadyOnlyWithOptions_DescendingOrder() {
 }
 
 func (suite *GlideTestSuite) TestBLMove() {
-	if suite.serverVersion < "6.2.0" {
+	if suite.IsServerVersionLowerThan("6.2.0") {
 		suite.T().Skip("This feature is added in version 6.2.0")
 	}
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
@@ -5254,7 +5254,7 @@ func (suite *GlideTestSuite) TestXAutoClaim() {
 		xautoclaim, err := client.XAutoClaimWithOptions(context.Background(), key, group, consumer, 0, "0-0", *opts)
 		assert.NoError(suite.T(), err)
 		var deletedEntries []string
-		if suite.serverVersion >= "7.0.0" {
+		if suite.IsServerVersionAtLeast("7.0.0") {
 			deletedEntries = []string{}
 		}
 		assert.Equal(
@@ -5697,7 +5697,7 @@ func (suite *GlideTestSuite) TestXGroupSetId() {
 		assert.Nil(suite.T(), xreadgroup)
 
 		// Reset the last delivered ID for the consumer group to "1-1"
-		if suite.serverVersion < "7.0.0" {
+		if suite.IsServerVersionLowerThan("7.0.0") {
 			suite.verifyOK(client.XGroupSetId(context.Background(), key, group, "1-1"))
 		} else {
 			opts := options.NewXGroupSetIdOptionsOptions().SetEntriesRead(42)
@@ -6413,7 +6413,7 @@ func (suite *GlideTestSuite) TestZRank() {
 		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res.Value())
 
-		if suite.serverVersion >= "7.2.0" {
+		if suite.IsServerVersionAtLeast("7.2.0") {
 			res2, err := client.ZRankWithScore(context.Background(), key, "one")
 			suite.NoError(err)
 			assert.Equal(suite.T(), int64(0), res2.Value().Rank)
@@ -6445,7 +6445,7 @@ func (suite *GlideTestSuite) TestZRevRank() {
 		suite.NoError(err)
 		assert.Equal(suite.T(), int64(1), res.Value())
 
-		if suite.serverVersion >= "7.2.0" {
+		if suite.IsServerVersionAtLeast("7.2.0") {
 			res2, err := client.ZRevRankWithScore(context.Background(), key, "one")
 			suite.NoError(err)
 			assert.Equal(suite.T(), int64(2), res2.Value().Rank)
@@ -6753,7 +6753,7 @@ func (suite *GlideTestSuite) TestZScan() {
 		assert.Empty(suite.T(), result.Data)
 
 		// Negative cursor
-		if suite.serverVersion >= "8.0.0" {
+		if suite.IsServerVersionAtLeast("8.0.0") {
 			_, err = client.ZScan(context.Background(), key1, models.NewCursorFromString("-1"))
 			suite.Error(err)
 		} else {
@@ -6845,7 +6845,7 @@ func (suite *GlideTestSuite) TestZScan() {
 		assert.GreaterOrEqual(suite.T(), len(result.Data), 0)
 
 		// Test NoScores option for Redis 8.0.0+
-		if suite.serverVersion >= "8.0.0" {
+		if suite.IsServerVersionAtLeast("8.0.0") {
 			// Use a fresh key for NoScores test to avoid interference from previous entries
 			noScoresKey := uuid.New().String()
 			// Create a smaller fresh map for NoScores test - we don't need 50K entries just to test the NoScores option
@@ -7426,7 +7426,7 @@ func (suite *GlideTestSuite) TestXGroupCreate_XGroupDestroy() {
 
 		// ENTRIESREAD option was added in valkey 7.0.0
 		opts = options.NewXGroupCreateOptions().SetEntriesRead(100)
-		if suite.serverVersion >= "7.0.0" {
+		if suite.IsServerVersionAtLeast("7.0.0") {
 			suite.verifyOK(client.XGroupCreateWithOptions(context.Background(), key, group, id, *opts))
 		} else {
 			_, err = client.XGroupCreateWithOptions(context.Background(), key, group, id, *opts)
@@ -8243,7 +8243,7 @@ func (suite *GlideTestSuite) TestXInfoStream() {
 		)
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(2), infoFull.Length)
-		if suite.serverVersion >= "7.0.0" {
+		if suite.IsServerVersionAtLeast("7.0.0") {
 			assert.Equal(suite.T(), "1-0", infoFull.RecordedFirstEntryId.Value())
 		} else {
 			assert.True(suite.T(), infoFull.RecordedFirstEntryId.IsNil())
@@ -8255,7 +8255,7 @@ func (suite *GlideTestSuite) TestXInfoStream() {
 		// first group
 		assert.Equal(suite.T(), len(infoFull.Groups), 1)
 		groupItem := infoFull.Groups[0]
-		if suite.serverVersion >= "7.0.0" {
+		if suite.IsServerVersionAtLeast("7.0.0") {
 			assert.Equal(suite.T(), groupItem.EntriesRead.Value(), int64(1))
 			assert.Equal(suite.T(), groupItem.Lag.Value(), int64(1))
 		}
@@ -8271,7 +8271,7 @@ func (suite *GlideTestSuite) TestXInfoStream() {
 		assert.Equal(suite.T(), len(cns.Pending), int(1))
 		assert.Equal(suite.T(), cns.Pending[0].Id, "1-0")
 		assert.Equal(suite.T(), cns.Pending[0].DeliveredCount, int64(1))
-		if suite.serverVersion >= "7.2.0" {
+		if suite.IsServerVersionAtLeast("7.2.0") {
 			assert.False(suite.T(), cns.ActiveTime.IsNil())
 		} else {
 			assert.True(suite.T(), cns.ActiveTime.IsNil())
@@ -8343,7 +8343,7 @@ func (suite *GlideTestSuite) TestXInfoConsumers() {
 		assert.Equal(suite.T(), consumer1, info[0].Name)
 		assert.Equal(suite.T(), int64(1), info[0].Pending)
 		assert.Greater(suite.T(), info[0].Idle, int64(0))
-		if suite.serverVersion > "7.2.0" {
+		if suite.IsServerVersionGreaterThan("7.2.0") {
 			assert.False(suite.T(), info[0].Inactive.IsNil())
 			assert.Greater(suite.T(), info[0].Inactive.Value(), int64(0))
 		} else {
@@ -8449,7 +8449,7 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 		// one empty group exists
 		xinfo, err := client.XInfoGroups(context.Background(), key)
 		suite.NoError(err)
-		if suite.serverVersion < "7.0.0" {
+		if suite.IsServerVersionLowerThan("7.0.0") {
 			suite.Equal([]models.XInfoGroupInfo{
 				{
 					Name:            group,
@@ -8499,7 +8499,7 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 		// same as previous check, bug lag = 3, there are 3 messages unread
 		xinfo, err = client.XInfoGroups(context.Background(), key)
 		suite.NoError(err)
-		if suite.serverVersion < "7.0.0" {
+		if suite.IsServerVersionLowerThan("7.0.0") {
 			suite.Equal([]models.XInfoGroupInfo{
 				{
 					Name:            group,
@@ -8580,7 +8580,7 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 		// after reading, `lag` is reset, and `pending`, consumer count and last ID are set
 		xinfo, err = client.XInfoGroups(context.Background(), key)
 		assert.NoError(suite.T(), err)
-		if suite.serverVersion < "7.0.0" {
+		if suite.IsServerVersionLowerThan("7.0.0") {
 			assert.Equal(suite.T(), []models.XInfoGroupInfo{
 				{
 					Name:            group,
@@ -8611,7 +8611,7 @@ func (suite *GlideTestSuite) TestXInfoGroups() {
 		// once message ack'ed, pending counter decreased
 		xinfo, err = client.XInfoGroups(context.Background(), key)
 		assert.NoError(suite.T(), err)
-		if suite.serverVersion < "7.0.0" {
+		if suite.IsServerVersionLowerThan("7.0.0") {
 			assert.Equal(suite.T(), []models.XInfoGroupInfo{
 				{
 					Name:            group,
@@ -9495,7 +9495,7 @@ func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 		assert.NotNil(suite.T(), streamId3)
 
 		// Exclusive ranges are added in 6.2.0
-		if suite.serverVersion >= "6.2.0" {
+		if suite.IsServerVersionAtLeast("6.2.0") {
 			// get the newest stream entry
 			xrangeResult, err = client.XRangeWithOptions(
 				context.Background(),

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -408,7 +408,7 @@ func (suite *GlideTestSuite) TestInfoStandalone() {
 
 	// info with option or with multiple options
 	sections := []constants.Section{constants.Cpu}
-	if suite.serverVersion >= "7.0.0" {
+	if suite.IsServerVersionAtLeast("7.0.0") {
 		sections = append(sections, constants.Memory)
 	}
 	info, err = client.InfoWithOptions(context.Background(), options.InfoOptions{Sections: sections})
@@ -817,7 +817,7 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_EmptyArgs() {
 func (suite *GlideTestSuite) TestLolwutWithOptions_Version9_TwoParams() {
 	client := suite.defaultClient()
 	// Test LOLWUT version 9 (available in Valkey 9.0.0+)
-	if suite.serverVersion >= "9.0.0" {
+	if suite.IsServerVersionAtLeast("9.0.0") {
 		opts := options.NewLolwutOptions(9).SetArgs([]int{30, 4})
 		res, err := client.LolwutWithOptions(context.Background(), *opts)
 		assert.NoError(suite.T(), err)
@@ -831,7 +831,7 @@ func (suite *GlideTestSuite) TestLolwutWithOptions_Version9_TwoParams() {
 func (suite *GlideTestSuite) TestLolwutWithOptions_Version9_FourParams() {
 	client := suite.defaultClient()
 	// Test LOLWUT version 9 (available in Valkey 9.0.0+)
-	if suite.serverVersion >= "9.0.0" {
+	if suite.IsServerVersionAtLeast("9.0.0") {
 		opts := options.NewLolwutOptions(9).SetArgs([]int{40, 20, 1, 2})
 		res, err := client.LolwutWithOptions(context.Background(), *opts)
 		assert.NoError(suite.T(), err)


### PR DESCRIPTION
## Summary
- replace direct string-based version comparisons in Go integration tests with semantic comparison helpers
- add semantic version parsing/comparison support (including pre-release precedence and metadata normalization)
- add focused tests for semantic comparison behavior and predicate boundaries

Fixes #5368

## Testing
- attempted: `cd go && make build`
- attempted: `cd go && go test ./integTest -run 'TestCompareSemanticVersions' -count=1`

Both are currently blocked in this environment by existing FFI header/C symbol generation errors (`C.store_script`, `C.drop_script`, etc.) during Go package build.