### PR TITLE
fix(java): preserve scalar types in large array direct-buffer path

### DIFF
--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -32,6 +32,7 @@ import glide.api.models.exceptions.RequestException;
 import glide.ffi.resolvers.OpenTelemetryResolver;
 import glide.internal.GlideCoreClient;
 import glide.utils.BufferUtils;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
@@ -1003,6 +1004,20 @@ public class CommandManager {
                 case ':': // Integer
                     long intValue = buffer.getLong();
                     result[i] = intValue;
+                    break;
+
+                case ',': // Double
+                    result[i] = buffer.getDouble();
+                    break;
+
+                case '?': // Boolean
+                    result[i] = buffer.get() != 0;
+                    break;
+
+                case '(': // BigNumber
+                    int bigNumberLen = buffer.getInt();
+                    String bigNumberStr = BufferUtils.decodeUtf8(buffer, bigNumberLen);
+                    result[i] = new BigInteger(bigNumberStr);
                     break;
 
                 case '#': // Complex type (serialized as string)

--- a/java/client/src/test/java/glide/managers/CommandManagerDirectBufferTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerDirectBufferTest.java
@@ -1,0 +1,78 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.managers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import glide.internal.GlideCoreClient;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CommandManagerDirectBufferTest {
+
+    private CommandManager commandManager;
+
+    @BeforeEach
+    void setUp() {
+        commandManager = new CommandManager(mock(GlideCoreClient.class));
+    }
+
+    @Test
+    void deserializeByteBufferArray_handlesBooleanDoubleAndBigNumberMarkers() throws Exception {
+        String bigNumberText = "1234567890123456789012345678901234567890";
+        byte[] bigNumberBytes = bigNumberText.getBytes(StandardCharsets.UTF_8);
+
+        ByteBuffer buffer =
+                ByteBuffer.allocate(
+                                1
+                                        + 4
+                                        + (1 + 1)
+                                        + (1 + 8)
+                                        + (1 + 4 + bigNumberBytes.length)
+                                        + (1 + 4))
+                        .order(ByteOrder.BIG_ENDIAN);
+
+        buffer.put((byte) '*');
+        buffer.putInt(4);
+
+        buffer.put((byte) '?');
+        buffer.put((byte) 1);
+
+        buffer.put((byte) ',');
+        buffer.putDouble(42.25d);
+
+        buffer.put((byte) '(');
+        buffer.putInt(bigNumberBytes.length);
+        buffer.put(bigNumberBytes);
+
+        buffer.put((byte) '$');
+        buffer.putInt(-1);
+
+        buffer.flip();
+
+        Object[] decoded = deserializeByteBufferArray(buffer, false);
+
+        assertEquals(4, decoded.length);
+        assertEquals(Boolean.TRUE, decoded[0]);
+        assertTrue(decoded[1] instanceof Double);
+        assertEquals(42.25d, (Double) decoded[1]);
+        assertEquals(new BigInteger(bigNumberText), decoded[2]);
+        assertNull(decoded[3]);
+    }
+
+    private Object[] deserializeByteBufferArray(ByteBuffer buffer, boolean expectUtf8Response)
+            throws Exception {
+        Method method =
+                CommandManager.class.getDeclaredMethod(
+                        "deserializeByteBufferArray", ByteBuffer.class, boolean.class);
+        method.setAccessible(true);
+        return (Object[]) method.invoke(commandManager, buffer, expectUtf8Response);
+    }
+}

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -4746,6 +4746,35 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
+    public void smismember_binary_with_large_response_preserves_boolean_array_values(BaseClient client) {
+        GlideString key = gs(UUID.randomUUID().toString());
+        final int memberCount = 1900; // >16KB in DirectByteBuffer array fast-path
+
+        GlideString[] queryMembers = new GlideString[memberCount];
+        List<GlideString> existingMembers = new ArrayList<>();
+        for (int i = 0; i < memberCount; i++) {
+            GlideString member = gs("m-" + i);
+            queryMembers[i] = member;
+            if (i % 3 == 0) {
+                existingMembers.add(member);
+            }
+        }
+
+        assertEquals(
+                existingMembers.size(), client.sadd(key, existingMembers.toArray(new GlideString[0])).get());
+
+        Boolean[] result = client.smismember(key, queryMembers).get();
+
+        assertEquals(memberCount, result.length);
+        for (int i = 0; i < memberCount; i++) {
+            assertNotNull(result[i], "SMISMEMBER should return booleans, never nil");
+            assertEquals(i % 3 == 0, result[i]);
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
     public void sdiffstore(BaseClient client) {
         String key1 = "{key}-1-" + UUID.randomUUID();
         String key2 = "{key}-2-" + UUID.randomUUID();
@@ -6298,6 +6327,38 @@ public class SharedCommandTests {
                 assertThrows(
                         ExecutionException.class, () -> client.zmscore(key2, new String[] {"one"}).get());
         assertInstanceOf(RequestException.class, executionException.getCause());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void zmscore_binary_with_large_response_preserves_double_and_null_values(BaseClient client) {
+        GlideString key = gs(UUID.randomUUID().toString());
+        final int memberCount = 2200; // >16KB in DirectByteBuffer array fast-path
+
+        GlideString[] members = new GlideString[memberCount];
+        Map<GlideString, Double> membersScores = new LinkedHashMap<>();
+        for (int i = 0; i < memberCount; i++) {
+            GlideString member = gs("member-" + i);
+            members[i] = member;
+            if (i % 4 == 0) {
+                membersScores.put(member, i + 0.5);
+            }
+        }
+
+        assertEquals(membersScores.size(), client.zadd(key, membersScores).get());
+
+        Double[] result = client.zmscore(key, members).get();
+
+        assertEquals(memberCount, result.length);
+        for (int i = 0; i < memberCount; i++) {
+            if (i % 4 == 0) {
+                assertNotNull(result[i], "Existing member score should not be nil");
+                assertEquals(i + 0.5, result[i]);
+            } else {
+                assertNull(result[i], "Missing member should stay null");
+            }
+        }
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Summary
Fixes large-array DirectByteBuffer serialization/deserialization for additional scalar RESP3 types in Java JNI path.

### What changed
- Added explicit serialization markers in `java/src/jni_client.rs` for:
  - `Boolean` (`?` + 1 byte)
  - `Double` (`,` + 8-byte float)
  - `BigNumber` (`(` + len + utf8 digits)
- Extended `deserializeByteBufferArray` in `java/client/src/main/java/glide/managers/CommandManager.java` to reconstruct:
  - `Boolean`
  - `Double`
  - `java.math.BigInteger`
- Added integration tests in `java/integTest/src/test/java/glide/SharedCommandTests.java` to validate large (>16KB) array behavior for:
  - `smismember` binary path (`Boolean[]`)
  - `zmscore` binary path (`Double[]` with nulls)
- Added unit test in `java/client/src/test/java/glide/managers/CommandManagerDirectBufferTest.java` validating decoder markers for bool/double/bignumber/null.
- Added Rust unit test in `java/src/jni_client.rs` validating serializer output for bool/double/bignumber/nil.

### Validation
- `GLIDE_VERSION=0.0.0 cargo test --manifest-path java/Cargo.toml --lib jni_client::tests::serialize_array_to_bytes_encodes_bool_double_bignumber_and_nil`
- `cd java && ./gradlew :client:test --tests glide.managers.CommandManagerDirectBufferTest`
- `cd java && ./gradlew :integTest:test --tests glide.SharedCommandTests.smismember_binary_with_large_response_preserves_boolean_array_values --tests glide.SharedCommandTests.zmscore_binary_with_large_response_preserves_double_and_null_values`

Fixes #5342
