### PR TITLE
feat(node): support mTLS client certificate and key TLS config

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -9,6 +9,7 @@
 
 import Long from "long";
 import * as net from "net";
+import * as fs from "fs";
 import { Buffer, BufferWriter, Reader, Writer } from "protobufjs/minimal";
 import {
     AggregationType,
@@ -329,6 +330,65 @@ export type GlideReturnType =
  * Union type that can store either a valid UTF-8 string or array of bytes.
  */
 export type GlideString = string | Buffer;
+
+function loadTlsPemFile(path: string, certType: string): Buffer {
+    let data: Buffer;
+
+    try {
+        data = fs.readFileSync(path);
+    } catch (error) {
+        const fsError = error as NodeJS.ErrnoException;
+
+        if (fsError.code === "ENOENT") {
+            throw new ConfigurationError(`${certType} file not found: ${path}`);
+        }
+
+        const message =
+            error instanceof Error ? error.message : String(error);
+        throw new ConfigurationError(
+            `Failed to read ${certType.toLowerCase()} file: ${message}`,
+        );
+    }
+
+    if (data.length === 0) {
+        throw new ConfigurationError(`${certType} file is empty: ${path}`);
+    }
+
+    return data;
+}
+
+/**
+ * Loads PEM-encoded root certificates from a file for TLS server verification.
+ *
+ * @param path - File path to a PEM root certificate or bundle.
+ * @returns Certificate data as a `Buffer`.
+ * @throws ConfigurationError If the file is missing, unreadable, or empty.
+ */
+export function loadRootCertificatesFromFile(path: string): Buffer {
+    return loadTlsPemFile(path, "Root certificate");
+}
+
+/**
+ * Loads a PEM-encoded client certificate from a file for mTLS authentication.
+ *
+ * @param path - File path to a PEM client certificate.
+ * @returns Certificate data as a `Buffer`.
+ * @throws ConfigurationError If the file is missing, unreadable, or empty.
+ */
+export function loadClientCertificateFromFile(path: string): Buffer {
+    return loadTlsPemFile(path, "Client certificate");
+}
+
+/**
+ * Loads a PEM-encoded client private key from a file for mTLS authentication.
+ *
+ * @param path - File path to a PEM client private key.
+ * @returns Private key data as a `Buffer`.
+ * @throws ConfigurationError If the file is missing, unreadable, or empty.
+ */
+export function loadClientPrivateKeyFromFile(path: string): Buffer {
+    return loadTlsPemFile(path, "Client private key");
+}
 
 /**
  * Enum representing the different types of decoders.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1058,6 +1058,29 @@ export interface AdvancedBaseClientConfiguration {
          * - This is useful when connecting to servers with self-signed certificates or custom certificate authorities.
          */
         rootCertificates?: string | Buffer;
+
+        /**
+         * Client certificate data for mutual TLS (mTLS) authentication.
+         *
+         * - When provided together with `clientPrivateKey`, the client presents this certificate
+         *   to the server during TLS handshake.
+         *
+         * - The certificate data should be in PEM format as a string or Buffer.
+         *
+         * - Must be used together with `clientPrivateKey`.
+         */
+        clientCertificate?: string | Buffer;
+
+        /**
+         * Client private key data for mutual TLS (mTLS) authentication.
+         *
+         * - When provided together with `clientCertificate`, enables client certificate authentication.
+         *
+         * - The private key data should be in PEM format as a string or Buffer.
+         *
+         * - Must be used together with `clientCertificate`.
+         */
+        clientPrivateKey?: string | Buffer;
     };
 
     /**
@@ -9555,6 +9578,8 @@ export class BaseClient {
 
         // Apply TLS configuration if present
         if (options.tlsAdvancedConfiguration) {
+            const tlsConfig = options.tlsAdvancedConfiguration;
+
             // request.tlsMode is either SecureTls or InsecureTls here
             if (request.tlsMode === connection_request.TlsMode.NoTls) {
                 throw new ConfigurationError(
@@ -9563,20 +9588,63 @@ export class BaseClient {
             }
 
             // If options.tlsAdvancedConfiguration.insecure is true then use InsecureTls mode
-            if (options.tlsAdvancedConfiguration.insecure) {
+            if (tlsConfig.insecure) {
                 request.tlsMode = connection_request.TlsMode.InsecureTls;
             }
 
-            if (options.tlsAdvancedConfiguration.rootCertificates) {
-                const certData =
-                    typeof options.tlsAdvancedConfiguration.rootCertificates ===
-                    "string"
-                        ? Buffer.from(
-                              options.tlsAdvancedConfiguration.rootCertificates,
-                              "utf-8",
-                          )
-                        : options.tlsAdvancedConfiguration.rootCertificates;
-                request.rootCerts = [new Uint8Array(certData)];
+            const getTlsBytes = (
+                data: string | Buffer,
+                fieldName: string,
+            ): Uint8Array => {
+                const bytes =
+                    typeof data === "string"
+                        ? Buffer.from(data, "utf-8")
+                        : data;
+
+                if (bytes.length === 0) {
+                    throw new ConfigurationError(
+                        `${fieldName} cannot be empty; use undefined to omit it.`,
+                    );
+                }
+
+                return new Uint8Array(bytes);
+            };
+
+            const clientCertificate = tlsConfig.clientCertificate;
+            const clientPrivateKey = tlsConfig.clientPrivateKey;
+            const clientCertificateProvided = clientCertificate != null;
+            const clientPrivateKeyProvided = clientPrivateKey != null;
+
+            if (clientCertificateProvided && !clientPrivateKeyProvided) {
+                throw new ConfigurationError(
+                    "clientCertificate is provided but clientPrivateKey is missing. mTLS requires both.",
+                );
+            }
+
+            if (!clientCertificateProvided && clientPrivateKeyProvided) {
+                throw new ConfigurationError(
+                    "clientPrivateKey is provided but clientCertificate is missing. mTLS requires both.",
+                );
+            }
+
+            if (tlsConfig.rootCertificates != null) {
+                request.rootCerts = [
+                    getTlsBytes(
+                        tlsConfig.rootCertificates,
+                        "rootCertificates",
+                    ),
+                ];
+            }
+
+            if (clientCertificateProvided && clientPrivateKeyProvided) {
+                request.clientCert = getTlsBytes(
+                    clientCertificate,
+                    "clientCertificate",
+                );
+                request.clientKey = getTlsBytes(
+                    clientPrivateKey,
+                    "clientPrivateKey",
+                );
             }
         }
     }

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -343,8 +343,7 @@ function loadTlsPemFile(path: string, certType: string): Buffer {
             throw new ConfigurationError(`${certType} file not found: ${path}`);
         }
 
-        const message =
-            error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         throw new ConfigurationError(
             `Failed to read ${certType.toLowerCase()} file: ${message}`,
         );
@@ -9689,10 +9688,7 @@ export class BaseClient {
 
             if (tlsConfig.rootCertificates != null) {
                 request.rootCerts = [
-                    getTlsBytes(
-                        tlsConfig.rootCertificates,
-                        "rootCertificates",
-                    ),
+                    getTlsBytes(tlsConfig.rootCertificates, "rootCertificates"),
                 ];
             }
 

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -900,7 +900,9 @@ describe("SocketConnectionInternals", () => {
 
             try {
                 fs.writeFileSync(certPath, certData);
-                expect(loadRootCertificatesFromFile(certPath)).toEqual(certData);
+                expect(loadRootCertificatesFromFile(certPath)).toEqual(
+                    certData,
+                );
             } finally {
                 fs.rmSync(tempDir, { recursive: true, force: true });
             }
@@ -940,7 +942,9 @@ describe("SocketConnectionInternals", () => {
         });
 
         it("should fail when client private key file is empty", () => {
-            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tls-empty-"));
+            const tempDir = fs.mkdtempSync(
+                path.join(os.tmpdir(), "tls-empty-"),
+            );
             const keyPath = path.join(tempDir, "client.key");
 
             try {

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -25,6 +25,9 @@ import {
     GlideReturnType,
     InfoOptions,
     isGlideRecord,
+    loadClientCertificateFromFile,
+    loadClientPrivateKeyFromFile,
+    loadRootCertificatesFromFile,
     MAX_REQUEST_ARGS_LEN,
     RequestError,
     SlotKeyTypes,
@@ -882,6 +885,71 @@ describe("SocketConnectionInternals", () => {
                 );
             } finally {
                 client.close();
+            }
+        });
+    });
+
+    describe("TLS certificate file loaders", () => {
+        it("should load root certificates from a file", () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tls-root-"));
+            const certPath = path.join(tempDir, "ca.pem");
+            const certData = Buffer.from(
+                "-----BEGIN CERTIFICATE-----\nROOT\n-----END CERTIFICATE-----\n",
+                "utf-8",
+            );
+
+            try {
+                fs.writeFileSync(certPath, certData);
+                expect(loadRootCertificatesFromFile(certPath)).toEqual(certData);
+            } finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
+            }
+        });
+
+        it("should load client certificate and private key from files", () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tls-mtls-"));
+            const certPath = path.join(tempDir, "client.crt");
+            const keyPath = path.join(tempDir, "client.key");
+            const certData = Buffer.from(
+                "-----BEGIN CERTIFICATE-----\nCLIENT\n-----END CERTIFICATE-----\n",
+                "utf-8",
+            );
+            const keyData = Buffer.from(
+                "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----\n",
+                "utf-8",
+            );
+
+            try {
+                fs.writeFileSync(certPath, certData);
+                fs.writeFileSync(keyPath, keyData);
+                expect(loadClientCertificateFromFile(certPath)).toEqual(
+                    certData,
+                );
+                expect(loadClientPrivateKeyFromFile(keyPath)).toEqual(keyData);
+            } finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
+            }
+        });
+
+        it("should fail when client certificate file does not exist", () => {
+            expect(() =>
+                loadClientCertificateFromFile(
+                    "/tmp/does-not-exist/client-cert.pem",
+                ),
+            ).toThrow("Client certificate file not found");
+        });
+
+        it("should fail when client private key file is empty", () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tls-empty-"));
+            const keyPath = path.join(tempDir, "client.key");
+
+            try {
+                fs.writeFileSync(keyPath, Buffer.alloc(0));
+                expect(() => loadClientPrivateKeyFromFile(keyPath)).toThrow(
+                    "Client private key file is empty",
+                );
+            } finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
             }
         });
     });

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -268,6 +268,18 @@ async function testSentValueMatches(config: {
     });
 }
 
+class TestGlideClient extends GlideClient {
+    public constructor() {
+        super(new net.Socket());
+    }
+
+    public buildConnectionRequest(
+        options: GlideClientConfiguration,
+    ): connection_request.IConnectionRequest {
+        return this.createClientRequest(options);
+    }
+}
+
 describe("SocketConnectionInternals", () => {
     it("Test setup returns values", async () => {
         await testWithResources((connection, socket) => {
@@ -725,6 +737,153 @@ describe("SocketConnectionInternals", () => {
             true,
         );
         closeTestResources(connection, server, socket);
+    });
+
+    describe("advanced TLS configuration", () => {
+        it("should set mTLS client certificate and private key as buffers", () => {
+            const client = new TestGlideClient();
+            const rootCert = Buffer.from("ROOT_CERT_DATA", "utf-8");
+            const clientCert = Buffer.from("CLIENT_CERT_DATA", "utf-8");
+            const clientKey = Buffer.from("CLIENT_KEY_DATA", "utf-8");
+
+            try {
+                const request = client.buildConnectionRequest({
+                    addresses: [{ host: "foo" }],
+                    useTLS: true,
+                    advancedConfiguration: {
+                        tlsAdvancedConfiguration: {
+                            rootCertificates: rootCert,
+                            clientCertificate: clientCert,
+                            clientPrivateKey: clientKey,
+                        },
+                    },
+                });
+
+                expect(request.rootCerts).toEqual([new Uint8Array(rootCert)]);
+                expect(request.clientCert).toEqual(new Uint8Array(clientCert));
+                expect(request.clientKey).toEqual(new Uint8Array(clientKey));
+            } finally {
+                client.close();
+            }
+        });
+
+        it("should set mTLS client certificate and private key from strings", () => {
+            const client = new TestGlideClient();
+            const clientCert = "CLIENT_CERT_DATA";
+            const clientKey = "CLIENT_KEY_DATA";
+
+            try {
+                const request = client.buildConnectionRequest({
+                    addresses: [{ host: "foo" }],
+                    useTLS: true,
+                    advancedConfiguration: {
+                        tlsAdvancedConfiguration: {
+                            clientCertificate: clientCert,
+                            clientPrivateKey: clientKey,
+                        },
+                    },
+                });
+
+                expect(request.clientCert).toEqual(
+                    new Uint8Array(Buffer.from(clientCert, "utf-8")),
+                );
+                expect(request.clientKey).toEqual(
+                    new Uint8Array(Buffer.from(clientKey, "utf-8")),
+                );
+            } finally {
+                client.close();
+            }
+        });
+
+        it("should fail when client certificate is provided without private key", () => {
+            const client = new TestGlideClient();
+
+            try {
+                expect(() =>
+                    client.buildConnectionRequest({
+                        addresses: [{ host: "foo" }],
+                        useTLS: true,
+                        advancedConfiguration: {
+                            tlsAdvancedConfiguration: {
+                                clientCertificate: "CLIENT_CERT_DATA",
+                            },
+                        },
+                    }),
+                ).toThrow(
+                    "clientCertificate is provided but clientPrivateKey is missing. mTLS requires both.",
+                );
+            } finally {
+                client.close();
+            }
+        });
+
+        it("should fail when client private key is provided without certificate", () => {
+            const client = new TestGlideClient();
+
+            try {
+                expect(() =>
+                    client.buildConnectionRequest({
+                        addresses: [{ host: "foo" }],
+                        useTLS: true,
+                        advancedConfiguration: {
+                            tlsAdvancedConfiguration: {
+                                clientPrivateKey: "CLIENT_KEY_DATA",
+                            },
+                        },
+                    }),
+                ).toThrow(
+                    "clientPrivateKey is provided but clientCertificate is missing. mTLS requires both.",
+                );
+            } finally {
+                client.close();
+            }
+        });
+
+        it("should fail when client certificate is empty", () => {
+            const client = new TestGlideClient();
+
+            try {
+                expect(() =>
+                    client.buildConnectionRequest({
+                        addresses: [{ host: "foo" }],
+                        useTLS: true,
+                        advancedConfiguration: {
+                            tlsAdvancedConfiguration: {
+                                clientCertificate: "",
+                                clientPrivateKey: "CLIENT_KEY_DATA",
+                            },
+                        },
+                    }),
+                ).toThrow(
+                    "clientCertificate cannot be empty; use undefined to omit it.",
+                );
+            } finally {
+                client.close();
+            }
+        });
+
+        it("should fail when client private key is empty", () => {
+            const client = new TestGlideClient();
+
+            try {
+                expect(() =>
+                    client.buildConnectionRequest({
+                        addresses: [{ host: "foo" }],
+                        useTLS: true,
+                        advancedConfiguration: {
+                            tlsAdvancedConfiguration: {
+                                clientCertificate: "CLIENT_CERT_DATA",
+                                clientPrivateKey: Buffer.alloc(0),
+                            },
+                        },
+                    }),
+                ).toThrow(
+                    "clientPrivateKey cannot be empty; use undefined to omit it.",
+                );
+            } finally {
+                client.close();
+            }
+        });
     });
 
     it("should pass routing information from user", async () => {

--- a/node/tests/TlsCertificateTest.test.ts
+++ b/node/tests/TlsCertificateTest.test.ts
@@ -15,6 +15,9 @@ import {
     GlideClient,
     GlideClusterClient,
     Logger,
+    loadClientCertificateFromFile,
+    loadClientPrivateKeyFromFile,
+    loadRootCertificatesFromFile,
     ProtocolVersion,
 } from "../build-ts";
 import { IP_ADDRESS_V4, IP_ADDRESS_V6 } from "./Constants";
@@ -43,6 +46,9 @@ describe.skip("TLS with custom certificates", () => {
     let standaloneClient: GlideClient | undefined;
     let clusterClient: GlideClusterClient | undefined;
     let caCertData: Buffer;
+    let caCertPath: string;
+    let serverCertPath: string;
+    let serverKeyPath: string;
 
     beforeAll(async () => {
         // Use insecure TLS only for getServerVersion during startup
@@ -79,6 +85,11 @@ describe.skip("TLS with custom certificates", () => {
         );
 
         // Read CA certificate after servers start (certificates now exist)
+        const glideHomeDir =
+            process.env.GLIDE_HOME_DIR || process.cwd() + "/..";
+        caCertPath = `${glideHomeDir}/utils/tls_crts/ca.crt`;
+        serverCertPath = `${glideHomeDir}/utils/tls_crts/server.crt`;
+        serverKeyPath = `${glideHomeDir}/utils/tls_crts/server.key`;
         caCertData = getCaCertificateData();
 
         // Small delay to ensure cluster is fully ready after TLS setup
@@ -191,6 +202,29 @@ describe.skip("TLS with custom certificates", () => {
                     advancedConfiguration: {
                         tlsAdvancedConfiguration: {
                             rootCertificates: certString,
+                        },
+                    },
+                });
+
+                const result = await standaloneClient.ping();
+                expect(result).toBe("PONG");
+            },
+            TIMEOUT,
+        );
+
+        it(
+            "should connect with certificate loaded from file helper",
+            async () => {
+                const certData = loadRootCertificatesFromFile(caCertPath);
+
+                standaloneClient = await GlideClient.createClient({
+                    ...getTlsClientConfigurationOption(
+                        standaloneCluster.getAddresses(),
+                    ),
+                    useTLS: true,
+                    advancedConfiguration: {
+                        tlsAdvancedConfiguration: {
+                            rootCertificates: certData,
                         },
                     },
                 });
@@ -325,6 +359,34 @@ describe.skip("TLS with custom certificates", () => {
                     advancedConfiguration: {
                         tlsAdvancedConfiguration: {
                             insecure: true,
+                        },
+                    },
+                });
+
+                const result = await clusterClient.ping();
+                expect(result).toBe("PONG");
+            },
+            TIMEOUT,
+        );
+
+        it(
+            "should connect with all TLS materials loaded from file helpers",
+            async () => {
+                const rootCert = loadRootCertificatesFromFile(caCertPath);
+                const clientCert =
+                    loadClientCertificateFromFile(serverCertPath);
+                const clientKey = loadClientPrivateKeyFromFile(serverKeyPath);
+
+                clusterClient = await GlideClusterClient.createClient({
+                    ...getTlsClientConfigurationOption(
+                        clusterModeCluster.getAddresses(),
+                    ),
+                    useTLS: true,
+                    advancedConfiguration: {
+                        tlsAdvancedConfiguration: {
+                            rootCertificates: rootCert,
+                            clientCertificate: clientCert,
+                            clientPrivateKey: clientKey,
                         },
                     },
                 });


### PR DESCRIPTION
## Summary
- add `tlsAdvancedConfiguration.clientCertificate` and `tlsAdvancedConfiguration.clientPrivateKey` to the Node client advanced TLS API
- map mTLS certificate and private key to protobuf connection request fields (`clientCert` and `clientKey`)
- validate TLS mTLS inputs:
  - require cert+key together
  - reject empty `rootCertificates`, `clientCertificate`, and `clientPrivateKey` payloads
- add TLS PEM file loader helpers:
  - `loadRootCertificatesFromFile(path)`
  - `loadClientCertificateFromFile(path)`
  - `loadClientPrivateKeyFromFile(path)`
- add test coverage:
  - unit coverage for loader success/error cases
  - integration coverage in TLS client tests using loader-returned materials in real client connections

Closes #5336

## Validation
- `npm run build:ts` (in `node/`)
- `npx eslint -c ../eslint.config.mjs src/BaseClient.ts tests/GlideClientInternals.test.ts tests/TlsCertificateTest.test.ts` (in `node/`)
- `npx jest --runInBand tests/TlsCertificateTest.test.ts --testNamePattern="loaded from file"` (pass: 2 tests)
- runtime smoke: exercised loader helpers for valid/missing/empty files via `node` against `build-ts` exports
- Note: `npx jest --runInBand tests/GlideClientInternals.test.ts` is currently blocked in this workspace by an existing ts-jest typing mismatch in imports from `build-ts/native` (missing `createLeaked*` exports).