### PR TITLE
Fix/fcall_readonly_function flaky test by using WAIT command to ensure function replication to replicas before asserting for errors

### DIFF
--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -145,8 +144,7 @@ public class ConnectionTests {
         // Get Replica Count for current cluster
         long nReplicas =
                 getReplicaCount(
-                        configSetClient,
-                        new RequestRoutingConfiguration.SlotKeyRoute("key", PRIMARY));
+                        configSetClient, new RequestRoutingConfiguration.SlotKeyRoute("key", PRIMARY));
         long nGetCalls = 3 * nReplicas;
         String getCmdstat = String.format("cmdstat_get:calls=%d", 3);
 

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -7,10 +7,9 @@ import static glide.TestConfiguration.STANDALONE_HOSTS;
 import static glide.TestConfiguration.TLS;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.GlideString.gs;
-import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleSingleNodeRoute.RANDOM;
 import static glide.api.models.configuration.RequestRoutingConfiguration.Route;
+import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleSingleNodeRoute.RANDOM;
 import static glide.utils.Java8Utils.createMap;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,6 +26,7 @@ import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.GlideClusterClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import glide.api.models.configuration.TlsAdvancedConfiguration;
 import glide.cluster.ValkeyCluster;
 import java.nio.file.Files;
@@ -713,20 +713,15 @@ public class TestUtilities {
      */
     @SneakyThrows
     public static long getReplicaCount(GlideClusterClient client, Route primaryRoute) {
-        var replicationInfo =
+        ClusterValue<Object> replicationInfo =
                 client.customCommand(new String[] {"INFO", "REPLICATION"}, primaryRoute).get();
         return Long.parseLong(
                 Stream.of(((String) replicationInfo.getSingleValue()).split("\\R"))
                         .map(line -> line.split(":", 2))
-                        .filter(
-                                parts ->
-                                        parts.length == 2
-                                                && parts[0].trim().equals("connected_slaves"))
+                        .filter(parts -> parts.length == 2 && parts[0].trim().equals("connected_slaves"))
                         .map(parts -> parts[1].trim())
                         .findFirst()
                         .orElseThrow(
-                                () ->
-                                        new RuntimeException(
-                                                "connected_slaves not found in INFO REPLICATION")));
+                                () -> new RuntimeException("connected_slaves not found in INFO REPLICATION")));
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1930,8 +1930,7 @@ public class CommandTests {
         // function has been replicated before we attempt to call it on the replica.
         long replicaCount = getReplicaCount(clusterClient, primaryRoute);
         clusterClient
-                .customCommand(
-                        new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
+                .customCommand(new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
                 .get();
 
         // fcall on a replica should fail with a readonly error, because the function
@@ -1970,8 +1969,7 @@ public class CommandTests {
 
         // Wait for the updated function to replicate to the replica
         clusterClient
-                .customCommand(
-                        new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
+                .customCommand(new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
                 .get();
 
         // fcall should succeed now
@@ -2008,8 +2006,7 @@ public class CommandTests {
         // function has been replicated before we attempt to call it on the replica.
         long replicaCount = getReplicaCount(clusterClient, primaryRoute);
         clusterClient
-                .customCommand(
-                        new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
+                .customCommand(new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
                 .get();
 
         // fcall on a replica should fail with a readonly error, because the function
@@ -2048,8 +2045,7 @@ public class CommandTests {
 
         // Wait for the updated function to replicate to the replica
         clusterClient
-                .customCommand(
-                        new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
+                .customCommand(new String[] {"WAIT", String.valueOf(replicaCount), "5000"}, primaryRoute)
                 .get();
 
         // fcall should succeed now


### PR DESCRIPTION
### Summary

The `fcall_readonly_function` and `fcall_readonly_binary_function` tests were flaky because FUNCTION LOAD propagates to all primaries but replication to replicas is async. Java is fast enough to hit the replica before replication completes, causing "Function not found" instead of the expected "readonly" error. The original polling loop also had a bug where Thread.sleep only ran on the success path, so "Function not found" retries had no delay.

Replaced the polling loops with `WAIT <replicaCount> 5000` via `customCommand` routed to the specific primary (`primaryRoute`), which deterministically blocks until all connected replicas have acknowledged writes. The replica count is obtained dynamically via a new `getReplicaCount` helper that sends `INFO REPLICATION` and parses `connected_slaves`. Also refactored `ConnectionTests.java` to use the same helper, replacing its inline `INFO REPLICATION` parsing.

### Issue link

This Pull Request resolves [[Java][Flaky Test] CommandTests > fcall_readonly_function (GlideClusterClient) #5218](https://github.com/valkey-io/valkey-glide/issues/5218)


### Features / Behaviour Changes

No feature or behaviour changes. This is a test-only fix addressing flakiness in `fcall_readonly_function` and `fcall_readonly_binary_function` in the Java integration tests.

### Implementation

The original code used a polling loop with `Thread.sleep(100)` to wait for replication, but it had two problems:

1. The sleep was only in the try block (success path), so "Function not found" exceptions caused rapid-fire retries with no delay between them.
2. The approach is inherently non-deterministic — any fixed timeout can still be too short under load.

Replaced the polling loops with WAIT 1 5000 sent via customCommand to the specific primary (primaryRoute) whose replica we subsequently query. The WAIT command blocks until at least 1 replica has acknowledged all writes, guaranteeing the function has replicated before we assert against the replica. This is applied after both functionLoad calls in each test variant (the initial non-RO load and the RO replacement), since both are followed by fcall routed to the replica.

The equivalent Python test doesn't exhibit this flakiness because Python's runtime overhead provides enough implicit delay for replication to complete.

Changes:

- Added `getReplicaCount(GlideClusterClient, Route)` to `TestUtilities.java`. Sends `INFO REPLICATION` to the given primary and parses `connected_slaves` to return the actual replica count. Uses `@SneakyThrows` and throws `RuntimeException` if the field is missing.
- In `CommandTests.java`:
   - replaced the polling loops in both `fcall_readonly_function` and `fcall_readonly_binary_function` with `WAIT <replicaCount> 5000` sent via `customCommand` to `primaryRoute`. The replica assertion now uses `assertThrows` directly instead of a manual loop. A second `WAIT` is added after the read-only `functionLoad` replacement to ensure the updated function replicates before the subsequent `fcall` on the replica.
   - Also removed an unused `flist` variable in the `functionDump` test.
- In `ConnectionTests.java`:
   - replaced the inline `INFO REPLICATION` stream-parsing with a call to `getReplicaCount`.


### Limitations

The `WAIT` command is sent via `customCommand` because the `GlideClusterClient.wait()` method doesn't accept a `Route` parameter — it always routes to a random node. If a routed `wait(numreplicas, timeout, route)` variant is added to the cluster client API in the future, these calls could be migrated to use it instead.

### Testing

CICD

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
