### PR TITLE
Revert: core: break reference cycle in IAM token manager callback (#5431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 * Java: Fix mget large binary data issue and add test case ([#5341](https://github.com/valkey-io/valkey-glide/pull/5341))
 * Java: Fix resource leak in integration tests where clients created via @MethodSource were never closed ([#5347](https://github.com/valkey-io/valkey-glide/issues/5347))
 * Java: Fix hanging issue in AWS Lambda when response exceeds 16KB ([#5081](https://github.com/valkey-io/valkey-glide/issues/5081))
-* Core: break reference cycle in IAM token manager callback ([#5431](https://github.com/valkey-io/valkey-glide/pull/5431))
 * Core: Fixed a bug where permission errors for CLUSTER SLOTS command is not surfaced during initial connection ([#5486](https://github.com/valkey-io/valkey-glide/pull/5486))
 
 #### Operational Enhancements

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1336,39 +1336,23 @@ impl Client {
     /// IAM token refresh callback function
     ///
     /// On new token, spawns a task that write-locks the `Client` and calls
-    /// `update_connection_password(Some(new_token), true)`.
-    ///
-    /// Uses a **Weak** reference to break the reference cycle between Client and IAMTokenManager.
+    /// `update_connection_password(Some(new_token), true)`. Uses a strong `Arc<RwLock<Client>>`.
+    /// Note: this can form a retain cycle; call `stop_refresh_task()` and drop the manager to tear down.
     fn iam_callback(
-        client_weak: std::sync::Weak<tokio::sync::RwLock<Client>>,
+        client_arc: Arc<tokio::sync::RwLock<Client>>,
     ) -> impl Fn(String) + Send + 'static {
         move |new_token: String| {
-            let client_weak = client_weak.clone();
+            let client_arc = Arc::clone(&client_arc);
             tokio::spawn(async move {
-                // Try to upgrade Weak to Arc - this will fail if Client has been dropped
-                if let Some(client_arc) = client_weak.upgrade() {
-                    let mut client = client_arc.write().await;
-                    let result = client
-                        .update_connection_password(Some(new_token.clone()), true)
-                        .await;
+                let mut client = client_arc.write().await;
+                let result = client
+                    .update_connection_password(Some(new_token.clone()), true)
+                    .await;
 
-                    if let Err(e) = result {
-                        log_error(
-                            "IAM token refresh",
-                            format!(
-                                "Failed to update connection password with immediate auth: {e}"
-                            ),
-                        );
-                    } else {
-                        log_debug(
-                            "IAM token refresh",
-                            "Successfully updated connection password",
-                        );
-                    }
-                } else {
-                    log_debug(
+                if let Err(e) = result {
+                    log_error(
                         "IAM token refresh",
-                        "Client has been dropped, skipping password update",
+                        format!("Failed to update connection password with immediate auth: {e}"),
                     );
                 }
             });
@@ -1377,18 +1361,17 @@ impl Client {
 
     /// Create an `IAMTokenManager` when IAM auth is configured.
     ///
-    /// Uses a **Weak** reference to the client in the refresh callback to avoid reference cycles.
+    /// Uses a **strong** `Arc<RwLock<Client>>` in the refresh callback so the callback
+    /// can always reach the client. (Note: this can create a retain cycle unless you
+    /// stop the refresh task and drop the manager explicitly.)
     async fn create_iam_token_manager(
         auth_info: &crate::client::types::AuthenticationInfo,
         client_arc: std::sync::Arc<tokio::sync::RwLock<Client>>,
     ) -> Option<std::sync::Arc<crate::iam::IAMTokenManager>> {
         if let Some(iam_config) = &auth_info.iam_config {
             if let Some(username) = &auth_info.username {
-                log_debug("IAM", "Creating IAM token manager with Weak reference");
-
-                // Use Weak reference to break reference cycle
-                let client_weak = Arc::downgrade(&client_arc);
-                let iam_callback = Self::iam_callback(client_weak);
+                // Set up callback to update connection password when token refreshes
+                let iam_callback = Self::iam_callback(std::sync::Arc::clone(&client_arc));
 
                 match crate::iam::IAMTokenManager::new(
                     iam_config.cluster_name.clone(),
@@ -1402,7 +1385,6 @@ impl Client {
                 {
                     Ok(mut token_manager) => {
                         token_manager.start_refresh_task();
-                        log_info("IAM", "IAM token manager started successfully");
                         Some(std::sync::Arc::new(token_manager))
                     }
                     Err(e) => {


### PR DESCRIPTION
This reverts commit a04cff66709ae0205cb3ca126b65a5fbf07770e9.

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

<!--
Add a summary describing the changes
-->

### Issue link

This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)
Closes <Issue #>

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
