### PR TITLE
Fixed PermissionDenied error to fail fast

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2111,9 +2111,12 @@ where
                 Self::refresh_slots(inner.clone(), curr_retry, trigger)
                     .await
                     .map_err(|err| {
-                        if err.kind() == ErrorKind::AllConnectionsUnavailable
-                            || err.kind() == ErrorKind::PermissionDenied
-                        {
+                        if matches!(
+                            err.kind(),
+                            ErrorKind::AllConnectionsUnavailable
+                                | ErrorKind::PermissionDenied
+                                | ErrorKind::AuthenticationFailed
+                        ) {
                             RetryError::permanent(err)
                         } else {
                             RetryError::transient(err)
@@ -3750,10 +3753,9 @@ where
             }),
     );
 
-    // Check for NOPERM errors early and return immediately if found
+    // Check for PermissionDenied errors (NOPERM) and return early if found
     // Note: NOPERM is an ACL error. ACL permissions are expected to be applied cluster wide.
-    // If NOPERM is found it should be surfaced first.
-    // Other errors are passed to the existing flow.
+    // If NOPERM is found it should be surfaced first, otherwise we continue.
     if let Some(noperm_err) = topology_join_results.iter().find_map(|(_, res)| {
         res.as_ref()
             .err()

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -802,7 +802,7 @@ mod cluster_client_tests {
                 create_connection_request(&addresses, &restricted_configuration);
 
             // Increase connection timeout to 10 seconds to allow retries to complete
-            connection_request.connection_timeout = 10000;
+            connection_request.connection_timeout = 10_000;
 
             // Reconnect with the restricted user.
             let result = Client::new(connection_request.into(), None).await;


### PR DESCRIPTION
### Summary

This PR fixes an issue where PermissionDenied error during cluster topology calculation would trigger topology calculation retries. 

This also fixes the flaky test `test_cluster_connection_fails_with_permission_denied`. Because of the retries, sometimes it would take longer than the default `connection_timeout` duration. 

### Issue link

Closes #5505 
Related #4629 

### Features / Behaviour Changes

- Cluster topology calculation flow now catch `PermissionDenied` error and fail fast; no more retries.
- Re-enabled `test_cluster_connection_fails_with_permission_denied`
- Refactored `test_cluster_connection_fails_with_permission_denied` to simplify test code.

### Testing

`test_cluster_connection_fails_with_permission_denied` passed successfully for 100 iterations. Previously this would fail consistently within 10 iterations.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   ~~[ ] Tests are added or updated.~~
-   ~~[ ] CHANGELOG.md and documentation files are updated.~~
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
