### PR TITLE
Java: Refactor native library staging for uber JAR builds

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -252,21 +252,22 @@ jobs:
             - name: Organize native libraries for uber JAR
               shell: bash
               run: |
-                  # Create the target directory
-                  mkdir -p java/client/build/resources/main/natives
+                  # Create staging directory for native libraries
+                  mkdir -p java/client/build/native-libs-staging
 
                   # Copy all native libraries from downloaded artifacts
                   # Structure: native-libs-downloaded/native-lib-{TARGET}/{platform}/{arch}/*.{so,dylib,dll}
-                  # Each artifact contains platform/arch subdirectories directly
+                  # Target structure: java/client/build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
                   for artifact_dir in native-libs-downloaded/native-lib-*; do
                       if [ -d "$artifact_dir" ]; then
                           echo "Processing $artifact_dir"
-                          cp -r "$artifact_dir"/* java/client/build/resources/main/natives/ 2>/dev/null || true
+                          # Copy preserving the platform/arch structure under a 'natives' directory
+                          cp -r "$artifact_dir"/* java/client/build/native-libs-staging/natives/ 2>/dev/null || true
                       fi
                   done
 
-                  echo "Native libraries organized:"
-                  find java/client/build/resources/main/natives -type f
+                  echo "Native libraries staged:"
+                  find java/client/build/native-libs-staging -type f
 
             - name: Install protoc (protobuf)
               uses: arduino/setup-protoc@v3
@@ -303,17 +304,10 @@ jobs:
                   GLIDE_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
                   UBER_JAR_BUILD: "true"
               run: |
-                  # Build uber JAR without platform classifier
-                  # We set UBER_JAR_BUILD env var to signal build.gradle to skip classifier
-                  ./gradlew --build-cache :client:shadowJar :client:javadocJar :client:sourcesJar \
-                  -x buildRust -x copyNativeLib \
-                  -Psigning.secretKeyRingFile=secring.gpg \
-                  -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
-                  -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
-
-                  # Manually publish to Maven local with correct structure
+                  # Build uber JAR and publish to Maven local in one step
+                  # UBER_JAR_BUILD env var signals build.gradle to use copyAllNativeLibs
                   ./gradlew --build-cache :client:publishToMavenLocal \
-                  -x buildRust -x copyNativeLib -x shadowJar -x javadocJar -x sourcesJar \
+                  -x buildRust -x copyNativeLib \
                   -Psigning.secretKeyRingFile=secring.gpg \
                   -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
                   -Psigning.keyId=${{ secrets.GPG_KEY_ID }}

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -188,11 +188,47 @@ tasks.register('copyNativeLib', Copy) {
     into "${sourceSets.main.output.resourcesDir}/${jarPath}"
 }
 
+// Task for uber JAR: copy all platform native libraries
+tasks.register('copyAllNativeLibs', Copy) {
+    description = 'Copy all platform native libraries for uber JAR build from downloaded artifacts'
+    
+    // This task expects native libraries to be pre-placed in a staging directory
+    // by the CI workflow after downloading artifacts from all platform builds
+    // Structure: build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
+    def stagingDir = file("${projectDir}/build/native-libs-staging/natives")
+    
+    from stagingDir
+    into "${sourceSets.main.output.resourcesDir}/natives"
+    include "**/*.dylib", "**/*.so", "**/*.dll"
+    
+    // Only run if staging directory exists and has content
+    onlyIf {
+        stagingDir.exists() && stagingDir.listFiles()?.length > 0
+    }
+    
+    // Run after processResources to avoid being deleted
+    mustRunAfter processResources
+    
+    doFirst {
+        println "Copying native libraries from staging: ${stagingDir}"
+        println "To resources dir: ${sourceSets.main.output.resourcesDir}/natives"
+    }
+}
+
 delombok.dependsOn('compileJava')
-shadowJar.dependsOn('copyNativeLib')
-javadoc.dependsOn('copyNativeLib')
-copyNativeLib.dependsOn('buildRust')
-compileTestJava.dependsOn('copyNativeLib')
+
+// For uber JAR builds, use copyAllNativeLibs instead of copyNativeLib
+if (System.getenv("UBER_JAR_BUILD") == "true") {
+    shadowJar.dependsOn('copyAllNativeLibs')
+    compileTestJava.dependsOn('copyAllNativeLibs')
+    javadoc.dependsOn('copyAllNativeLibs')
+} else {
+    shadowJar.dependsOn('copyNativeLib')
+    compileTestJava.dependsOn('copyNativeLib')
+    javadoc.dependsOn('copyNativeLib')
+    copyNativeLib.dependsOn('buildRust')
+}
+
 test.dependsOn('buildRust')
 
 sourceSets {


### PR DESCRIPTION

### Summary

- Create separate staging directory (build/native-libs-staging) for organizing downloaded native libraries from all platform builds
- Add new copyAllNativeLibs Gradle task to copy pre-staged native libraries into uber JAR resources
- Update CI workflow to stage native libraries in intermediate directory before Gradle build
- Conditionally use copyAllNativeLibs task when UBER_JAR_BUILD environment variable is set

### Issue link

This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)
Closes <Issue #>

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
