### PR TITLE
fix(java): fix thread safety issue in NativeClusterScanCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Python Sync: Add response buffer support to get() to improve performance by reducing copies ([#5493](https://github.com/valkey-io/valkey-glide/pull/5493))
 
 #### Fixes
+* Java: Fix thread safety issue in NativeClusterScanCursor causing potential JVM crash ([#5527](https://github.com/valkey-io/valkey-glide/issues/5527))
 * Java: optimize `convertMapToKeyValueStringArray` and `convertMapToKeyValueGlideStringArray` to fix performance bottleneck and ArrayStoreException ([#5602](https://github.com/valkey-io/valkey-glide/issues/5602))
 * CORE: Fix empty hostname in CLUSTER SLOTS metadata causing AllConnectionsUnavailable ([#5367](https://github.com/valkey-io/valkey-glide/issues/5367)). AWS ElastiCache (plaintext, cluster mode) returns `hostname: ""` in node metadata, which was used as the connection address instead of falling back to the IP.
 * Node: Fix to handle non-string types in toBuffersArray ([#4842](https://github.com/valkey-io/valkey-glide/issues/4842))

--- a/java/client/src/main/java/glide/api/GlideClusterClient.java
+++ b/java/client/src/main/java/glide/api/GlideClusterClient.java
@@ -100,6 +100,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
@@ -1426,7 +1427,7 @@ public class GlideClusterClient extends BaseClient
 
         private final String cursorHandle;
         private final boolean isFinished;
-        private boolean isClosed = false;
+        private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
         // This is for internal use only.
         public NativeClusterScanCursor(@NonNull String cursorHandle) {
@@ -1465,7 +1466,7 @@ public class GlideClusterClient extends BaseClient
         }
 
         private void internalClose() {
-            if (!isClosed) {
+            if (isClosed.compareAndSet(false, true)) {
                 try {
                     ClusterScanCursorResolver.releaseNativeCursor(cursorHandle);
                 } catch (Exception ex) {
@@ -1474,9 +1475,6 @@ public class GlideClusterClient extends BaseClient
                             "ClusterScanCursor",
                             () -> "Error releasing cursor " + cursorHandle,
                             ex);
-                } finally {
-                    // Mark the cursor as closed to avoid double-free (if close() gets called more than once).
-                    isClosed = true;
                 }
             }
         }


### PR DESCRIPTION
### Summary

Fix a thread safety issue in the Java client's `NativeClusterScanCursor` where a race condition could lead to a double-free of the native cursor handle, potentially causing the JVM to crash.

### Issue link
- https://github.com/valkey-io/valkey-glide/issues/5527
- Closes #5527

### Features / Behaviour Changes

- Fixed a concurrency issue in the Java client's `NativeClusterScanCursor` that could occur when multiple threads (or an application thread and the Finalizer thread) concurrently closed the cursor.
- Ensures the native cursor handle is released exactly once, preventing double-free errors.

### Implementation

- Replaced the simple `boolean isClosed` flag in `NativeClusterScanCursor` with an `AtomicBoolean`.
- Updated the `internalClose()` method to use `compareAndSet(false, true)` to ensure thread-safe, atomic updates to the closed state.

### Limitations

None.

### Testing

- Verified the code compiles successfully.
- Manual verification of thread safety principles applied to `NativeClusterScanCursor.internalClose()`.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.__