### PR TITLE
Cherry pick: Fix #5517 for Python: client is unusable after asyncio.CancelledError #5442 to release 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Java: Fix hanging issue in AWS Lambda when response exceeds 16KB ([#5081](https://github.com/valkey-io/valkey-glide/issues/5081))
 * Core: Fixed a bug where permission errors for CLUSTER SLOTS command is not surfaced during initial connection ([#5486](https://github.com/valkey-io/valkey-glide/pull/5486))
 * Core: Move credential fetching to token generation time ([#5508](https://github.com/valkey-io/valkey-glide/pull/5508))
+* Python: Fix async client becoming permanently unusable after cancelled commands due to callback index collisions ([#5442](https://github.com/valkey-io/valkey-glide/issues/5442))
 
 #### Operational Enhancements
 * Docs: Add missing references to windows-x86_64 classifier ([#5028](https://github.com/valkey-io/valkey-glide/pull/5028))

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -132,6 +132,7 @@ class BaseClient(CoreCommands):
         self.config: BaseClientConfiguration = config
         self._available_futures: Dict[int, "TFuture"] = {}
         self._available_callback_indexes: List[int] = list()
+        self._next_callback_index: int = 1  # 0 is reserved for connection setup
         self._buffered_requests: List[TRequest] = list()
         self._writer_lock = threading.Lock()
         self.socket_path: Optional[str] = None
@@ -644,14 +645,17 @@ class BaseClient(CoreCommands):
         try:
             return self._available_callback_indexes.pop()
         except IndexError:
-            # The list is empty
-            return len(self._available_futures)
+            # Use monotonic counter to avoid index collisions with cancelled futures
+            idx = self._next_callback_index
+            self._next_callback_index += 1
+            return idx
 
     async def _process_response(self, response: Response) -> None:
         res_future = self._available_futures.pop(response.callback_idx, None)
         if res_future is not None and res_future.done():
             # Future is already completed (e.g. request was cancelled while awaiting).
-            # Do not error to keep client in a valid state.
+            # Recycle the callback index to prevent index leaks.
+            self._available_callback_indexes.append(response.callback_idx)
             ClientLogger.log(
                 LogLevel.DEBUG,
                 "completed response",

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -595,6 +595,24 @@ class TestGlideClients:
         await assert_connected(glide_client)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_client_usable_after_cancelled_commands(
+        self, glide_client: TGlideClient
+    ):
+        """Verify the client remains usable after repeated command cancellations (issue #5442)."""
+
+        for _ in range(50):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(glide_client.exists, ["cancel_test_key"])
+                # Yield to let the command dispatch to the server
+                await anyio.sleep(0)
+                tg.cancel_scope.cancel()
+
+        # Wait for in-flight server responses to arrive and be processed
+        await anyio.sleep(1)
+        await assert_connected(glide_client)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("ip_address", [HOST_ADDRESS_IPV4, HOST_ADDRESS_IPV6])
     async def test_connect_with_ip_address_succeeds(
         self, cluster_mode: bool, ip_address: str

--- a/python/tests/test_api_consistency.py
+++ b/python/tests/test_api_consistency.py
@@ -51,6 +51,7 @@ EXCLUDED_TESTS = {
         "test_statistics",
         "test_UDS_socket_connection_failure",
         "test_cancelled_request_handled_gracefully",
+        "test_client_usable_after_cancelled_commands",
         "test_connection_timeout_on_unavailable_host",
         "test_invalid_tls_config_fails_fast",
         # Dynamic PubSub tests helper functions


### PR DESCRIPTION
This is a Cherry-pick from `main` to `release-2.3`. Reference PR: [Python: Recycle callback indices for cancelled futures and use monotonic counter to prevent index collisions that permanently closed the client #5517](https://github.com/valkey-io/valkey-glide/pull/5517)

### Summary

The Python async client would become permanently unusable (`ClosingError`) after `asyncio.CancelledError` during command execution.

The root cause was a callback index collision in `BaseClient`. When a cancelled future's response arrived, `_process_response` returned early without recycling the callback index. Combined with `_get_callback_index` using `len(self._available_futures)` as a fallback (which could produce duplicate indices when cancelled futures created gaps), this caused index collisions that crashed the reader loop and closed the client.

### Issue link

This Pull Request is linked to issue: [Python: client is unusable after asyncio.CancelledError #5442](https://github.com/valkey-io/valkey-glide/issues/5442)
Closes #5442

### Features / Behaviour Changes

The async client no longer permanently closes after cancelled commands. Previously, cancelling in-flight async operations (e.g. via `task.cancel()` or `anyio` scope cancellation) would eventually crash the client's reader loop, making it unusable.

### Implementation

Two changes in the base python client `glide_client.py`:

1. **`_process_response`**: When a response arrives for an already-cancelled future, the callback index is now appended back to `_available_callback_indexes` before returning. Previously it was leaked.

2. **`_get_callback_index`**: The fallback when `_available_callback_indexes` is empty now uses a monotonic counter (`_next_callback_index`) instead of `len(self._available_futures)`. The old approach could return an index that already existed as a key when cancelled futures created holes in the dict, causing a collision that overwrote a pending future.

### Limitations

The fix addresses the `asyncio` and `uvloop` backends. The trio backend uses `_CompatFuture` which doesn't mark futures as done on cancellation, so it doesn't trigger this specific collision — but the index leak was still present and is now fixed for all backends.

### Testing

- Added `test_client_usable_after_cancelled_commands` integration test — cancels 50 in-flight `exists` commands via `anyio` task group scope cancellation, then asserts the client is still connected.
- Verified across all 4 parametrized variants (`RESP2/RESP3` × `cluster/standalone`): 4/4 FAIL without fix, 4/4 PASS with fix.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
