### PR TITLE
Go: fix PubSub config check for message handler creation (#5534)

### DIFF
--- a/go/base_client.go
+++ b/go/base_client.go
@@ -71,14 +71,9 @@ func (client *baseClient) getMessageHandler() *MessageHandler {
 }
 
 // GetQueue returns the pub/sub queue for the client.
-// This method is only available for clients that have a subscription,
-// and returns an error if the client does not have a subscription.
+// GetQueue returns the pub/sub queue for the client.
+// Returns an error if the client is configured with a callback.
 func (client *baseClient) GetQueue() (*PubSubMessageQueue, error) {
-	// Create MessageHandler lazily if not already created (for dynamic subscriptions)
-	if client.getMessageHandler() == nil {
-		client.setMessageHandler(NewMessageHandler(nil, nil))
-	}
-	// If a callback is configured, the queue should not be used
 	if client.getMessageHandler().callback != nil {
 		return nil, errors.New("cannot get queue for callback-only client")
 	}

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -62,6 +62,8 @@ func NewClient(config *config.ClientConfiguration) (*Client, error) {
 	if config.HasSubscription() {
 		subConfig := config.GetSubscription()
 		client.setMessageHandler(NewMessageHandler(subConfig.GetCallback(), subConfig.GetContext()))
+	} else {
+		client.setMessageHandler(NewMessageHandler(nil, nil))
 	}
 
 	return &Client{*client}, nil

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -69,6 +69,8 @@ func NewClusterClient(config *config.ClusterClientConfiguration) (*ClusterClient
 	if config.HasSubscription() {
 		subConfig := config.GetSubscription()
 		client.setMessageHandler(NewMessageHandler(subConfig.GetCallback(), subConfig.GetContext()))
+	} else {
+		client.setMessageHandler(NewMessageHandler(nil, nil))
 	}
 
 	return &ClusterClient{*client}, nil

--- a/go/integTest/pubsub_subscribe_test.go
+++ b/go/integTest/pubsub_subscribe_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/internal/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 )
 
@@ -290,6 +291,53 @@ func (suite *GlideTestSuite) TestBlockingSubscribeUnsubscribe() {
 	case <-time.After(2 * time.Second):
 		suite.T().Fatal("Initial subscription failed")
 	}
+}
+
+// Verifies that a client created without any subscription config can subscribe
+// dynamically and receive messages via polling.
+func (suite *GlideTestSuite) TestDynamicSubscribeWithoutConfig() {
+	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
+		channel := "no_config_channel"
+
+		clientType := StandaloneClient
+		if _, ok := client.(*glide.ClusterClient); ok {
+			clientType = ClusterClient
+		}
+
+		var standaloneClient *glide.Client
+		var clusterClient *glide.ClusterClient
+		if c, ok := client.(*glide.Client); ok {
+			standaloneClient = c
+		} else if c, ok := client.(*glide.ClusterClient); ok {
+			clusterClient = c
+		}
+		suite.subscribeByMethod(
+			standaloneClient,
+			clusterClient,
+			[]ChannelDefn{{Channel: channel, Mode: ExactMode}},
+			BlockingMethod,
+			suite.T(),
+		)
+
+		publisher := suite.createAnyClient(clientType, nil)
+		defer publisher.Close()
+
+		err := suite.PublishMessage(publisher, clientType, channel, "no_config_msg", false)
+		assert.NoError(suite.T(), err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		queue, err := client.(PubSubQueuer).GetQueue()
+		assert.NoError(suite.T(), err)
+
+		select {
+		case msg := <-queue.WaitForMessage():
+			assert.Equal(suite.T(), "no_config_msg", msg.Message)
+			assert.Equal(suite.T(), channel, msg.Channel)
+		case <-time.After(5 * time.Second):
+			suite.T().Fatal("Message not received on client created without subscription config")
+		}
+	})
 }
 
 func (suite *GlideTestSuite) TestGetSubscriptions() {


### PR DESCRIPTION
This is a cherry-pick of: https://github.com/valkey-io/valkey-glide/commit/c4c18e11230713b78e0ecca423a83066fa2c0179
Issue: https://github.com/valkey-io/valkey-glide/pull/5534 

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

The Go client currently drops Pub/Sub messages when it is initialized without a Pub/Sub configuration, even though dynamic Pub/Sub should allow subscribing and receiving messages later.

This happens because the message handler is only initialized when a Pub/Sub configuration is present:
```

if config.HasSubscription() {
    subConfig := config.GetSubscription()
    client.setMessageHandler(NewMessageHandler(subConfig.GetCallback(), subConfig.GetContext()))
}
```

If the client is created without a Pub/Sub configuration, the message handler is never set, causing incoming messages to be silently dropped. 

This was missed in a previous PR - https://github.com/valkey-io/valkey-glide/pull/5327#discussion_r2783416160

### Fix

Initialize the message handler even when the client is created without a Pub/Sub configuration so that asynchronous message delivery works correctly for dynamic Pub/Sub.

### Issue link

https://github.com/valkey-io/valkey-glide/issues/5533

### Testing

Added TestDynamicSubscribeWithoutConfig

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
