### PR TITLE
Fix/go/python cicd test-container tests

### DIFF
--- a/.github/actions/setup-dns-tests/action.yml
+++ b/.github/actions/setup-dns-tests/action.yml
@@ -26,6 +26,8 @@ runs:
               ::1 valkey.glide.test.no_tls.com"
               if [[ "$OS" == "windows" ]]; then
                   echo "$ENTRIES" >> /c/Windows/System32/drivers/etc/hosts
-              else
+              elif command -v sudo &> /dev/null; then
                   echo "$ENTRIES" | sudo tee -a /etc/hosts
+              else
+                  echo "$ENTRIES" | tee -a /etc/hosts
               fi


### PR DESCRIPTION
### Summary

Fix `setup-dns-tests` composite action failing on container-based jobs where `sudo` is not installed.

### Issue link

This Pull Request is linked to issue: [[Go/Python][Flaky Test] New DNS test broke test container tests #5559](https://github.com/valkey-io/valkey-glide/issues/5559)
Closes #5559

### Features / Behaviour Changes

No feature changes. The `setup-dns-tests` action now gracefully handles environments where `sudo` is not available (e.g., amazon-linux containers running as root).

### Implementation

In `.github/actions/setup-dns-tests/action.yml`, replaced the unconditional `sudo tee` with a check for `sudo` availability using `command -v sudo`. If `sudo` is not found (container environments already running as root), it falls back to plain `tee`. This preserves the existing sudo behavior for GitHub-hosted runners (Ubuntu, macOS) where it's still required.

### Limitations

None.

### Testing

- All green FMT for test-container Go CI test run: https://github.com/valkey-io/valkey-glide/actions/runs/22921356242
- All green FMT for test-container Python CI test run: https://github.com/valkey-io/valkey-glide/actions/runs/22963807308

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
