### PR TITLE
Pypi-CD: fix test-the-release step for linux-arm ephemeral runner

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -521,6 +521,7 @@ jobs:
                       python/glide-sync/dist/*.tar.gz
 
     test-release:
+        if: ${{ github.event_name == 'push' || inputs.publish_async== true || inputs.publish_sync == true }}
         name: Test the release
         runs-on: ${{ matrix.build.RUNNER }}
         needs:
@@ -598,44 +599,83 @@ jobs:
                   engine-version: "8.0"
                   target: ${{ matrix.build.target }}
 
+            - name: Check if RC and set a distribution tag for the package
+              shell: bash
+              env:
+                  RELEASE_VERSION: ${{ needs.publish-binaries.outputs.release_version }}
+              run: |
+                  if [[ "$RELEASE_VERSION" == *"rc"* ]]
+                  then
+                    echo "This is a release candidate"
+                    echo "PIP_PRE=true" >> $GITHUB_ENV
+                  else
+                    echo "This is a stable release"
+                    echo "PIP_PRE=false" >> $GITHUB_ENV
+                  fi
+
+                  # Format the version for PyPI (remove leading 'v' and convert '-rc' to 'rc')
+                  PYPI_VERSION="${RELEASE_VERSION#v}"
+                  PYPI_VERSION="${PYPI_VERSION//-rc/rc}"
+                  echo "PYPI_VERSION=${PYPI_VERSION}" >> $GITHUB_ENV
+
             - name: Run the Async Client tests
+              if: ${{ inputs.publish_async == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
                   python -m venv venv
                   source venv/bin/activate
                   pip install -U pip
-                  pip install valkey-glide
+                  if [[ "${{ env.PIP_PRE }}" == "true" ]]; then
+                    pip install "valkey-glide==${{ env.PYPI_VERSION }}"
+                  else
+                    pip install valkey-glide
+                  fi
                   python async_rc_test.py
 
             - name: Run the Async Clients tests with PyPy
+              if: ${{ inputs.publish_async == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
                   pypy3 -m venv pypy_venv
                   source pypy_venv/bin/activate
                   pip install -U pip
-                  pip install valkey-glide
+                  if [[ "${{ env.PIP_PRE }}" == "true" ]]; then
+                    pip install "valkey-glide==${{ env.PYPI_VERSION }}"
+                  else
+                    pip install valkey-glide
+                  fi
                   pypy3 async_rc_test.py
 
             - name: Run the Sync Client tests
+              if: ${{ inputs.publish_sync == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
-                  python -m venv venv_sync
-                  source venv_sync/bin/activate
+                  python -m venv venv
+                  source venv/bin/activate
                   pip install -U pip
-                  pip install valkey-glide-sync
+                  if [[ "${{ env.PIP_PRE }}" == "true" ]]; then
+                    pip install "valkey-glide-sync==${{ env.PYPI_VERSION }}"
+                  else
+                    pip install valkey-glide-sync
+                  fi
                   python sync_rc_test.py
 
             - name: Run the Sync Client tests with PyPy
+              if: ${{ inputs.publish_sync == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
-                  pypy3 -m venv pypy_venv_sync
-                  source pypy_venv_sync/bin/activate
+                  pypy3 -m venv pypy_venv
+                  source pypy_venv/bin/activate
                   pip install -U pip
-                  pip install valkey-glide-sync
+                  if [[ "${{ env.PIP_PRE }}" == "true" ]]; then
+                    pip install "valkey-glide-sync==${{ env.PYPI_VERSION }}"
+                  else
+                    pip install valkey-glide-sync
+                  fi
                   pypy3 sync_rc_test.py
 
             # Reset the repository to make sure we get the clean checkout of the action later in other actions.


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

The "Test the release" job in pypi-cd.yml calls install-engine directly (not through install-shared-dependencies), so OpenSSL headers were never explicitly installed. This was probably masked by the Valkey build cache previously — once Valkey 8.0 didn't have an available cached build, the build failed on the ARM64 ephemeral self-hosted runner with `openssl/ssl.h: No such file or directory.`                 
Failure run: https://github.com/valkey-io/valkey-glide/actions/runs/22911960509/job/66534752089
Install engine step:
```
sentinel.c:34:10: fatal error: openssl/ssl.h: No such file or directory
   34 | #include "openssl/ssl.h"
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:534: sentinel.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/ubuntu/actions-runner/_work/valkey-glide/valkey-glide/valkey/src'
make: *** [Makefile:6: all] Error 2
Error: Process completed with exit code 2.
```
GitHub-hosted runners have libssl-dev pre-installed so they weren't affected. 

This was tested in this workflow run (testing an existing release instead of a new one)- https://github.com/valkey-io/valkey-glide/actions/runs/22967185544/job/66692227010 
