### PR TITLE
Java: uber jar aarch64 native library was in the wrong path 

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -253,7 +253,7 @@ jobs:
               shell: bash
               run: |
                   # Create staging directory for native libraries
-                  mkdir -p java/client/build/native-libs-staging
+                  mkdir -p java/client/build/native-libs-staging/natives
 
                   # Copy all native libraries from downloaded artifacts
                   # Structure: native-libs-downloaded/native-lib-{TARGET}/{platform}/{arch}/*.{so,dylib,dll}
@@ -261,8 +261,16 @@ jobs:
                   for artifact_dir in native-libs-downloaded/native-lib-*; do
                       if [ -d "$artifact_dir" ]; then
                           echo "Processing $artifact_dir"
-                          # Copy preserving the platform/arch structure under a 'natives' directory
-                          cp -r "$artifact_dir"/* java/client/build/native-libs-staging/natives/ 2>/dev/null || true
+                          # Find all native library files and copy them preserving the platform/arch structure
+                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
+                              # Extract the relative path from the artifact directory
+                              rel_path="${lib_file#$artifact_dir/}"
+                              target_path="java/client/build/native-libs-staging/natives/$rel_path"
+                              # Create target directory if it doesn't exist
+                              mkdir -p "$(dirname "$target_path")"
+                              # Copy the file
+                              cp "$lib_file" "$target_path"
+                          done
                       fi
                   done
 


### PR DESCRIPTION
### Summary

- Update staging directory structure to include 'natives' subdirectory in initial mkdir
- Replace recursive directory copy with selective find-based approach for native libraries
- Filter copied files by extension (.so, .dylib, .dll) to exclude non-library artifacts
- Preserve platform/arch directory structure during file copy operations
- Add explicit directory creation for each target path to ensure proper hierarchy



### Issue link

This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)
Closes <Issue #>

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
