### PR TITLE
fix(glide-core): propagate cluster response timeout

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1586,8 +1586,10 @@ async fn create_cluster_client(
         })
         .collect();
 
+    let request_timeout = to_duration(request.request_timeout, DEFAULT_RESPONSE_TIMEOUT);
     let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes)
         .connection_timeout(connection_timeout)
+        .response_timeout(request_timeout)
         .retries(DEFAULT_RETRIES);
     let read_from_strategy = request.read_from.unwrap_or_default();
     builder = builder.read_from(match read_from_strategy {


### PR DESCRIPTION
## Summary
- propagate the configured request timeout to the cluster client's per-node response timeout
- prevent cluster sub-commands from defaulting to Duration::MAX while the top-level request times out earlier

## Scope
- this PR is intentionally separate from #5511
- it does not include the pipeline buffer sizing / inflight work from that PR
- the only code change here is the cluster builder wiring for `response_timeout`

## Test Plan
- GLIDE_VERSION=dev cargo test --manifest-path glide-core/Cargo.toml --test test_client test_request_timeout
- cargo fmt --manifest-path glide-core/Cargo.toml --check