### PR TITLE
Core: Refactored IAM token refresh removing the circle client reference

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -805,6 +805,33 @@ impl Client {
         routing: Option<RoutingInfo>,
     ) -> redis::RedisFuture<'a, Value> {
         Box::pin(async move {
+            // Check for IAM token changes and update the password without authentication if needed (pull model)
+            if let Some(iam_manager) = &self.iam_token_manager
+                && iam_manager.token_changed()
+            {
+                // Token has changed, retrieve it and update the password without authentication
+                let current_token = iam_manager.get_token().await;
+
+                // Check if token is empty (edge case during initialization)
+                if current_token.is_empty() {
+                    return Err(RedisError::from((
+                        ErrorKind::ClientError,
+                        "IAM token not available",
+                    )));
+                }
+
+                // Clear the flag BEFORE calling update_connection_password
+                iam_manager.clear_token_changed();
+
+                // Authenticate with new token using immediate_auth=false
+                log_debug(
+                    "update_connection_password",
+                    "Updating connection password with IAM token",
+                );
+                self.update_connection_password(Some(current_token), false)
+                    .await?;
+            }
+
             let client = self.get_or_initialize_client().await?;
 
             if let Some(result) = self.pubsub_synchronizer.intercept_pubsub_command(cmd).await {
@@ -1275,10 +1302,7 @@ impl Client {
     /// Send AUTH command using IAM token (preferred) or the provided password
     async fn send_immediate_auth(&mut self, password: Option<String>) -> RedisResult<Value> {
         // Determine the password to use for authentication
-        let pass = if let Some(iam_manager) = &self.iam_token_manager {
-            log_debug("send_immediate_auth", "Using IAM token for authentication");
-            iam_manager.get_token().await
-        } else if let Some(ref password) = password {
+        let pass = if let Some(ref password) = password {
             if password.is_empty() {
                 return Err(RedisError::from((
                     ErrorKind::UserOperationError,
@@ -1333,53 +1357,20 @@ impl Client {
         }
     }
 
-    /// IAM token refresh callback function
-    ///
-    /// On new token, spawns a task that write-locks the `Client` and calls
-    /// `update_connection_password(Some(new_token), true)`. Uses a strong `Arc<RwLock<Client>>`.
-    /// Note: this can form a retain cycle; call `stop_refresh_task()` and drop the manager to tear down.
-    fn iam_callback(
-        client_arc: Arc<tokio::sync::RwLock<Client>>,
-    ) -> impl Fn(String) + Send + 'static {
-        move |new_token: String| {
-            let client_arc = Arc::clone(&client_arc);
-            tokio::spawn(async move {
-                let mut client = client_arc.write().await;
-                let result = client
-                    .update_connection_password(Some(new_token.clone()), true)
-                    .await;
-
-                if let Err(e) = result {
-                    log_error(
-                        "IAM token refresh",
-                        format!("Failed to update connection password with immediate auth: {e}"),
-                    );
-                }
-            });
-        }
-    }
-
     /// Create an `IAMTokenManager` when IAM auth is configured.
     ///
-    /// Uses a **strong** `Arc<RwLock<Client>>` in the refresh callback so the callback
-    /// can always reach the client. (Note: this can create a retain cycle unless you
-    /// stop the refresh task and drop the manager explicitly.)
+    /// Client retrieves tokens on-demand during command execution.
     async fn create_iam_token_manager(
         auth_info: &crate::client::types::AuthenticationInfo,
-        client_arc: std::sync::Arc<tokio::sync::RwLock<Client>>,
     ) -> Option<std::sync::Arc<crate::iam::IAMTokenManager>> {
         if let Some(iam_config) = &auth_info.iam_config {
             if let Some(username) = &auth_info.username {
-                // Set up callback to update connection password when token refreshes
-                let iam_callback = Self::iam_callback(std::sync::Arc::clone(&client_arc));
-
                 match crate::iam::IAMTokenManager::new(
                     iam_config.cluster_name.clone(),
                     username.clone(),
                     iam_config.region.clone(),
                     iam_config.service_type,
                     iam_config.refresh_interval_seconds,
-                    Some(std::sync::Arc::new(iam_callback)),
                 )
                 .await
                 {
@@ -1913,9 +1904,9 @@ impl Client {
 
             let client_arc = Arc::new(RwLock::new(client));
 
-            // Create IAM token manager if needed, passing a strong Arc to the callback
+            // Create IAM token manager if needed
             let iam_token_manager = if let Some(auth_info) = &request.authentication_info {
-                Self::create_iam_token_manager(auth_info, Arc::clone(&client_arc)).await
+                Self::create_iam_token_manager(auth_info).await
             } else {
                 None
             };

--- a/glide-core/src/iam/mod.rs
+++ b/glide-core/src/iam/mod.rs
@@ -7,6 +7,7 @@ use aws_sigv4::sign::v4;
 use logger_core::{log_debug, log_error, log_info, log_warn};
 use rand::Rng;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::time::SystemTime;
 use strum_macros::IntoStaticStr;
@@ -156,7 +157,7 @@ struct IamTokenState {
 /// - Tokens: valid 15m, refreshed every 5m by default.
 /// - Refresh: periodic, uses exponential backoff with ±20% jitter on failures.
 /// - Failures: logged only; cached token stays valid until expiry.
-/// - Thread-safe via `Arc<RwLock<...
+/// - Thread-safe via `Arc<RwLock<...>>` for token cache and `Arc<AtomicBool>` for change notification.
 pub struct IAMTokenManager {
     /// Cached auth token, stored in an `Arc<RwLock<String>>` to allow many concurrent readers,
     /// safe exclusive writes on refresh, and shared access across async tasks.
@@ -167,11 +168,11 @@ pub struct IAMTokenManager {
     refresh_task: Option<JoinHandle<()>>,
     /// Shutdown signal for graceful task termination
     shutdown_notify: Arc<Notify>,
-    /// Optional callback for when token is refreshed - used to update connection passwords
-    token_refresh_callback: Option<Arc<dyn Fn(String) + Send + Sync>>,
+    /// Atomic flag to signal when token has changed (for efficient change detection)
+    token_changed: Arc<AtomicBool>,
 }
 
-/// Custom Debug implementation because of the callback function doesn't implement Debug
+/// Custom Debug implementation for IAMTokenManager
 impl std::fmt::Debug for IAMTokenManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IAMTokenManager")
@@ -179,10 +180,7 @@ impl std::fmt::Debug for IAMTokenManager {
             .field("iam_token_state", &self.iam_token_state)
             .field("refresh_task", &self.refresh_task.is_some())
             .field("shutdown_notify", &"<Notify>")
-            .field(
-                "token_refresh_callback",
-                &self.token_refresh_callback.is_some(),
-            )
+            .field("token_changed", &self.token_changed.load(Ordering::Relaxed))
             .finish()
     }
 }
@@ -198,14 +196,12 @@ impl IAMTokenManager {
     /// * `refresh_interval_seconds` - Optional refresh interval in seconds. Defaults to 5 minutes (300 seconds).
     ///   Maximum allowed is 12 hours (43200 seconds). Values above 15 minutes (900 seconds) will log a warning
     ///   about potential performance consequences.
-    /// * `token_refresh_callback` - Optional callback to be called when the token is refreshed
     pub async fn new(
         cluster_name: String,
         username: String,
         region: String,
         service_type: ServiceType,
         refresh_interval_seconds: Option<u32>,
-        token_refresh_callback: Option<Arc<dyn Fn(String) + Send + Sync>>,
     ) -> Result<Self, GlideIAMError> {
         let validated_refresh_interval = validate_refresh_interval(refresh_interval_seconds)?;
 
@@ -226,7 +222,7 @@ impl IAMTokenManager {
             iam_token_state: state,
             refresh_task: None,
             shutdown_notify: Arc::new(Notify::new()),
-            token_refresh_callback,
+            token_changed: Arc::new(AtomicBool::new(true)), // Initially true to trigger first AUTH
         })
     }
 
@@ -239,13 +235,13 @@ impl IAMTokenManager {
         let iam_token_state = self.iam_token_state.clone();
         let cached_token = Arc::clone(&self.cached_token);
         let shutdown_notify = Arc::clone(&self.shutdown_notify);
-        let token_refresh_callback = self.token_refresh_callback.clone();
+        let token_changed = Arc::clone(&self.token_changed);
 
         let task = tokio::spawn(Self::token_refresh_task(
             iam_token_state,
             cached_token,
             shutdown_notify,
-            token_refresh_callback,
+            token_changed,
         ));
 
         self.refresh_task = Some(task);
@@ -256,7 +252,7 @@ impl IAMTokenManager {
         iam_token_state: IamTokenState,
         cached_token: Arc<RwLock<String>>,
         shutdown_notify: Arc<Notify>,
-        token_refresh_callback: Option<Arc<dyn Fn(String) + Send + Sync>>,
+        token_changed: Arc<AtomicBool>,
     ) {
         let refresh_interval = Duration::from_secs(iam_token_state.refresh_interval_seconds as u64);
 
@@ -269,7 +265,7 @@ impl IAMTokenManager {
         loop {
             tokio::select! {
                 _ = interval_timer.tick() => {
-                    Self::handle_token_refresh(&iam_token_state, &cached_token, &token_refresh_callback).await;
+                    Self::handle_token_refresh(&iam_token_state, &cached_token, &token_changed).await;
                 }
                 _ = shutdown_notify.notified() => {
                     log_info("IAM token refresh task shutting down", "");
@@ -280,25 +276,17 @@ impl IAMTokenManager {
     }
 
     /// Refresh cached token with backoff + jitter.
-    /// On success: update token + run callback.
+    /// On success: update token + set atomic flag.
     /// On failure: log error, keep old token.
     async fn handle_token_refresh(
         iam_token_state: &IamTokenState,
         cached_token: &Arc<RwLock<String>>,
-        token_refresh_callback: &Option<Arc<dyn Fn(String) + Send + Sync>>,
+        token_changed: &Arc<AtomicBool>,
     ) {
         match Self::generate_token_with_backoff(iam_token_state).await {
             Ok(new_token) => {
                 Self::set_cached_token_static(cached_token, new_token.clone()).await;
-
-                if let Some(callback) = token_refresh_callback {
-                    callback(new_token);
-                } else {
-                    log_error(
-                        "IAM token refresh warning",
-                        "No callback set for connection password update",
-                    );
-                }
+                token_changed.store(true, Ordering::Release);
             }
             Err(err) => {
                 // Leave cached token unchanged; logs already emitted in backoff routine
@@ -365,7 +353,7 @@ impl IAMTokenManager {
         Self::handle_token_refresh(
             &self.iam_token_state,
             &self.cached_token,
-            &self.token_refresh_callback,
+            &self.token_changed,
         )
         .await;
     }
@@ -389,6 +377,16 @@ impl IAMTokenManager {
     pub async fn get_token(&self) -> String {
         let token_guard = self.cached_token.read().await;
         token_guard.clone()
+    }
+
+    /// Check if token has changed since last check
+    pub fn token_changed(&self) -> bool {
+        self.token_changed.load(Ordering::Acquire)
+    }
+
+    /// Clear the token changed flag after handling the change
+    pub fn clear_token_changed(&self) {
+        self.token_changed.store(false, Ordering::Release)
     }
 
     /// Generate IAM authentication token using SigV4 signing (valid for 15 minutes)
@@ -489,7 +487,6 @@ mod tests {
     use std::env;
     use std::fs;
     use std::sync::Once;
-    use std::sync::{Arc, Mutex};
     use tokio::time::{Duration, sleep};
 
     const IAM_TOKENS_JSON: &str = "/tmp/iam_tokens.json";
@@ -560,16 +557,9 @@ mod tests {
         }
     }
 
-    /// Helper function to create a test callback that logs when invoked
-    fn create_test_callback() -> Arc<dyn Fn(String) + Send + Sync> {
-        Arc::new(move |_token: String| {
-            log_info("Refresh callback invoked!", "");
-        })
-    }
-
     #[tokio::test]
     #[serial]
-    async fn test_iam_token_manager_with_callback_in_constructor() {
+    async fn test_iam_token_manager_with_atomic_flag() {
         initialize_test_environment();
         setup_test_credentials();
 
@@ -577,55 +567,54 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        // Create a shared counter to track callback invocations
-        let callback_counter = Arc::new(Mutex::new(0));
-        let callback_counter_clone = callback_counter.clone();
-
-        // Create a callback that increments the counter
-        let callback = Arc::new(move |_token: String| {
-            let mut counter = callback_counter_clone.lock().unwrap();
-            *counter += 1;
-            log_info("Callback invoked! ", format!("Count: {}", *counter));
-        });
-
-        // Create IAM token manager with callback provided in constructor
+        // Create IAM token manager
         let mut manager = IAMTokenManager::new(
             cluster_name,
             username,
             region,
             ServiceType::ElastiCache,
             Some(2), // 2 second refresh interval for fast testing
-            Some(callback),
         )
         .await
         .unwrap();
 
+        // Initially, token_changed should be true (to trigger first AUTH)
+        assert!(
+            manager.token_changed(),
+            "Initial token_changed should be true"
+        );
+
+        // Clear the flag
+        manager.clear_token_changed();
+        assert!(
+            !manager.token_changed(),
+            "After clear, token_changed should be false"
+        );
+
         // Start the refresh task
         manager.start_refresh_task();
 
-        // Wait for a few refresh cycles
+        // Wait for a refresh cycle
         sleep(Duration::from_secs(3)).await;
+
+        // After refresh, flag should be true again
+        assert!(
+            manager.token_changed(),
+            "After refresh, token_changed should be true"
+        );
 
         // Stop the refresh task
         manager.stop_refresh_task().await;
 
-        // Verify that the callback was invoked at least once
-        let final_count = *callback_counter.lock().unwrap();
-        assert!(
-            final_count > 0,
-            "Callback should have been invoked at least once, got: {}",
-            final_count
-        );
-
         log_info(
             "Test completed successfully!",
-            format!("Callback was invoked {} times", final_count),
+            "Atomic flag working as expected",
         );
     }
 
     #[tokio::test]
     #[serial]
-    async fn test_iam_token_manager_manual_refresh_with_callback() {
+    async fn test_iam_token_manager_manual_refresh_sets_flag() {
         initialize_test_environment();
         setup_test_credentials();
 
@@ -633,37 +622,28 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        // Create a shared flag to track callback invocation
-        let callback_invoked = Arc::new(Mutex::new(false));
-        let callback_invoked_clone = callback_invoked.clone();
-
-        // Create a callback that sets the flag
-        let callback = Arc::new(move |_token: String| {
-            let mut invoked = callback_invoked_clone.lock().unwrap();
-            *invoked = true;
-            log_info("Manual refresh callback invoked!", "");
-        });
-
-        // Create IAM token manager with callback provided in constructor
+        // Create IAM token manager
         let manager = IAMTokenManager::new(
             cluster_name,
             username,
             region,
             ServiceType::ElastiCache,
             None,
-            Some(callback),
         )
         .await
         .unwrap();
 
+        // Clear the initial flag
+        manager.clear_token_changed();
+        assert!(!manager.token_changed(), "Flag should be false after clear");
+
         // Manually refresh the token
         manager.refresh_token().await;
 
-        // Verify that the callback was invoked
-        let was_invoked = *callback_invoked.lock().unwrap();
+        // Verify that the flag was set
         assert!(
-            was_invoked,
-            "Callback should have been invoked during manual refresh"
+            manager.token_changed(),
+            "Flag should be true after manual refresh"
         );
 
         log_info("Manual refresh test completed successfully!", "");
@@ -679,17 +659,12 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        let callback = Arc::new(move |_token: String| {
-            log_info("Manual refresh callback invoked!", "");
-        });
-
         let result = IAMTokenManager::new(
             cluster_name.clone(),
             username.clone(),
             region.clone(),
             ServiceType::ElastiCache,
             None,
-            Some(callback),
         )
         .await;
 
@@ -723,17 +698,12 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        let callback = Arc::new(move |_token: String| {
-            log_info("Manual refresh callback invoked!", "");
-        });
-
         let manager = IAMTokenManager::new(
             cluster_name,
             username,
             region,
             ServiceType::ElastiCache,
             None,
-            Some(callback),
         )
         .await
         .unwrap();
@@ -757,17 +727,12 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        let callback = Arc::new(move |_token: String| {
-            log_info("Manual refresh callback invoked!", "");
-        });
-
         let manager = IAMTokenManager::new(
             cluster_name.clone(),
             username.clone(),
             region.clone(),
             ServiceType::ElastiCache,
             None,
-            Some(callback),
         )
         .await
         .unwrap();
@@ -818,17 +783,12 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        let callback = Arc::new(move |_token: String| {
-            log_info("Manual refresh callback invoked!", "");
-        });
-
         let mut manager = IAMTokenManager::new(
             cluster_name,
             username,
             region,
             ServiceType::ElastiCache,
             Some(1), // 1 minute refresh interval for faster testing
-            Some(callback),
         )
         .await
         .unwrap();
@@ -866,7 +826,7 @@ mod tests {
         let region = "us-east-1".to_string();
 
         // Test valid refresh intervals in seconds
-        let valid_intervals = [60, 900, 21600, 43199]; // 0 seconds, 1 minute, 15 minutes, 6 hours, 12 hours
+        let valid_intervals = [60, 900, 21600, 43199]; // 1 minute, 15 minutes, 6 hours, 12 hours - 1 sec
         for interval in valid_intervals {
             let result = IAMTokenManager::new(
                 cluster_name.clone(),
@@ -874,7 +834,6 @@ mod tests {
                 region.clone(),
                 ServiceType::ElastiCache,
                 Some(interval),
-                Some(create_test_callback()),
             )
             .await;
 
@@ -885,7 +844,7 @@ mod tests {
         }
 
         // Test invalid refresh intervals (greater than 43200 seconds / 12 hours)
-        let invalid_intervals = [0, 43200, 86400, 172800]; // 12 hours, 24 hours, 48 hours
+        let invalid_intervals = [0, 43200, 86400, 172800]; // 0, 12 hours, 24 hours, 48 hours
         for interval in invalid_intervals {
             let result = IAMTokenManager::new(
                 cluster_name.clone(),
@@ -893,7 +852,6 @@ mod tests {
                 region.clone(),
                 ServiceType::ElastiCache,
                 Some(interval),
-                Some(create_test_callback()),
             )
             .await;
 
@@ -929,14 +887,13 @@ mod tests {
         let username = "test-user".to_string();
         let region = "us-east-1".to_string();
 
-        // Create IAMTokenManager with 5-second refresh interval
+        // Create IAMTokenManager with 2-second refresh interval
         let mut manager = IAMTokenManager::new(
             cluster_name.clone(),
             username.clone(),
             region.clone(),
             ServiceType::ElastiCache,
             Some(REFRESH_TIME_SECONDS),
-            Some(create_test_callback()),
         )
         .await
         .unwrap();


### PR DESCRIPTION
### Summary

IAM Token Manager had a circle reference to the client, which it was leading to a memory leak. Additionally, in some cases when the client were dropped, the token manager was still using the old stale client/connection to update the password. This PR restructure the IAM Token Manager removing the iam_callback. Now in every send_command a extra check will be made, this will check if the toke was updated and if it is, it will update the connection password with the token.

### Issue link

This Pull Request is linked to issue: #5561 
Closes <Issue #>

### Features / Behaviour Changes

- Replace token refresh callback mechanism with on-demand token retrieval during command execution
- Remove `iam_callback` function and callback-based password update logic
- Implement `token_changed` atomic flag for efficient change detection in pull model
- Update `IAMTokenManager` to use `Arc<AtomicBool>` instead of callback function
- Add token change check at start of command execution to retrieve and apply new tokens
- Remove strong `Arc<RwLock<Client>>` from IAM manager to eliminate retain cycle risk
- Simplify `create_iam_token_manager` signature by removing client arc parameter
- Improves resource management and eliminates potential memory leaks from circular references

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

- Java/Node/Go/Python clients were tested with the new refactored code
- Running Java client for more than 12 hours to check if it is working 

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
