### PR TITLE
Cherry Pick - refactor(java): rename unsubscribe methods to lazy variants (#5532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Python: Add inflight request limit support to sync client
 * Python Sync: Add OpenTelemetry support with traces and metrics configuration
 * Python: Move OpenTelemetry config classes to glide_shared for code reuse between async and sync clients
-* JAVA: Add dynamic PubSub methods (subscribe, psubscribe, unsubscribe, punsubscribe, ssubscribe, sunsubscribe), getSubscriptions() for subscription state tracking, pubsubReconciliationIntervalMs configuration option, and subscription_out_of_sync_count and subscription_last_sync_timestamp metrics ([#5267](https://github.com/valkey-io/valkey-glide/issues/5267))
+* JAVA: Add dynamic PubSub methods (subscribe, psubscribe, ssubscribe, unsubscribe, punsubscribe, sunsubscribe and their non-blocking "Lazy" variants), getSubscriptions() for subscription state tracking, pubsubReconciliationIntervalMs configuration option, and subscription_out_of_sync_count and subscription_last_sync_timestamp metrics ([#5267](https://github.com/valkey-io/valkey-glide/issues/5267))
 * Go: Add ALLOW_NON_COVERED_SLOTS flag support for cluster scan ([#4895](https://github.com/valkey-io/valkey-glide/issues/4895))
 * CORE: Track HELLO and AUTH state for reconnection ([#5145](https://github.com/valkey-io/valkey-glide/issues/5145))
 * CORE: Add support for ZRANGEBYLEX, ZRANGEBYSCORE, ZREVRANGE, ZREVRANGEBYLEX, and ZREVRANGEBYSCORE commands in request_type ([#5379](https://github.com/valkey-io/valkey-glide/pull/5379))

--- a/java/README.md
+++ b/java/README.md
@@ -371,7 +371,7 @@ GlideClientConfiguration config = GlideClientConfiguration.builder()
 
 try (GlideClient client = GlideClient.createClient(config).get()) {
     // Subscribe to channels dynamically
-    client.subscribe(Set.of("news", "updates")).get();
+    client.subscribeLazy(Set.of("news", "updates")).get();
 
     // Get subscription state
     var state = client.getSubscriptions().get();
@@ -379,7 +379,7 @@ try (GlideClient client = GlideClient.createClient(config).get()) {
     System.out.println("Actual subscriptions: " + state.actualSubscriptions);
 
     // Unsubscribe
-    client.unsubscribe(Set.of("news")).get();
+    client.unsubscribeLazy(Set.of("news")).get();
 }
 ```
 

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -6294,11 +6294,11 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(PSubscribeBlocking, args, response -> null);
     }
 
-    public CompletableFuture<Void> unsubscribe() {
+    public CompletableFuture<Void> unsubscribeLazy() {
         return commandManager.submitNewCommand(Unsubscribe, EMPTY_STRING_ARRAY, response -> null);
     }
 
-    public CompletableFuture<Void> unsubscribe(Set<String> channels) {
+    public CompletableFuture<Void> unsubscribeLazy(Set<String> channels) {
         return commandManager.submitNewCommand(
                 Unsubscribe, channels.toArray(EMPTY_STRING_ARRAY), response -> null);
     }
@@ -6324,11 +6324,11 @@ public abstract class BaseClient
                 UnsubscribeBlocking, new String[] {String.valueOf(timeoutMs)}, response -> null);
     }
 
-    public CompletableFuture<Void> punsubscribe() {
+    public CompletableFuture<Void> punsubscribeLazy() {
         return commandManager.submitNewCommand(PUnsubscribe, EMPTY_STRING_ARRAY, response -> null);
     }
 
-    public CompletableFuture<Void> punsubscribe(Set<String> patterns) {
+    public CompletableFuture<Void> punsubscribeLazy(Set<String> patterns) {
         return commandManager.submitNewCommand(
                 PUnsubscribe, patterns.toArray(EMPTY_STRING_ARRAY), response -> null);
     }

--- a/java/client/src/main/java/glide/api/GlideClusterClient.java
+++ b/java/client/src/main/java/glide/api/GlideClusterClient.java
@@ -1524,31 +1524,43 @@ public class GlideClusterClient extends BaseClient
     /**
      * Unsubscribes the client from all currently subscribed sharded channels.
      *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
+     *
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.sunsubscribe().get();
+     * client.sunsubscribeLazy().get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/sunsubscribe/">valkey.io</a> for details
      */
-    public CompletableFuture<Void> sunsubscribe() {
+    public CompletableFuture<Void> sunsubscribeLazy() {
         return commandManager.submitNewCommand(SUnsubscribe, EMPTY_STRING_ARRAY, response -> null);
     }
 
     /**
      * Unsubscribes the client from the specified sharded channels.
      *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
+     *
      * @param channels A set of sharded channel names to unsubscribe from
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.sunsubscribe(Set.of("shard-news", "shard-updates")).get();
+     * client.sunsubscribeLazy(Set.of("shard-news", "shard-updates")).get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/sunsubscribe/">valkey.io</a> for details
      */
-    public CompletableFuture<Void> sunsubscribe(Set<String> channels) {
+    public CompletableFuture<Void> sunsubscribeLazy(Set<String> channels) {
         return commandManager.submitNewCommand(
                 SUnsubscribe, channels.toArray(EMPTY_STRING_ARRAY), response -> null);
     }

--- a/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
@@ -15,25 +15,25 @@ import java.util.concurrent.CompletableFuture;
 public interface PubSubBaseCommands {
 
     /**
-     * Constant representing "unsubscribe from all channels". Pass this to {@link #unsubscribe(Set)}
-     * or {@link #unsubscribe(Set, int)} to unsubscribe from all channels.
+     * Constant representing "unsubscribe from all channels". Pass this to {@link
+     * #unsubscribeLazy(Set)} or {@link #unsubscribe(Set, int)} to unsubscribe from all channels.
      *
      * @example
      *     <pre>{@code
      * // Unsubscribe from all channels
-     * client.unsubscribe(PubSubBaseCommands.ALL_CHANNELS).get();
+     * client.unsubscribeLazy(PubSubBaseCommands.ALL_CHANNELS).get();
      * }</pre>
      */
     Set<String> ALL_CHANNELS = Collections.emptySet();
 
     /**
-     * Constant representing "unsubscribe from all patterns". Pass this to {@link #punsubscribe(Set)}
-     * or {@link #punsubscribe(Set, int)} to unsubscribe from all patterns.
+     * Constant representing "unsubscribe from all patterns". Pass this to {@link
+     * #punsubscribeLazy(Set)} or {@link #punsubscribe(Set, int)} to unsubscribe from all patterns.
      *
      * @example
      *     <pre>{@code
      * // Unsubscribe from all patterns
-     * client.punsubscribe(PubSubBaseCommands.ALL_PATTERNS).get();
+     * client.punsubscribeLazy(PubSubBaseCommands.ALL_PATTERNS).get();
      * }</pre>
      */
     Set<String> ALL_PATTERNS = Collections.emptySet();
@@ -279,29 +279,41 @@ public interface PubSubBaseCommands {
     /**
      * Unsubscribes the client from all currently subscribed channels.
      *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
+     *
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.unsubscribe().get();
+     * client.unsubscribeLazy().get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/unsubscribe/">valkey.io</a> for details
      */
-    CompletableFuture<Void> unsubscribe();
+    CompletableFuture<Void> unsubscribeLazy();
 
     /**
      * Unsubscribes the client from the specified channels.
+     *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
      *
      * @param channels A set of channel names to unsubscribe from
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.unsubscribe(Set.of("news", "updates")).get();
+     * client.unsubscribeLazy(Set.of("news", "updates")).get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/unsubscribe/">valkey.io</a> for details
      */
-    CompletableFuture<Void> unsubscribe(Set<String> channels);
+    CompletableFuture<Void> unsubscribeLazy(Set<String> channels);
 
     /**
      * Unsubscribes the client from the specified channels with a timeout.
@@ -341,29 +353,41 @@ public interface PubSubBaseCommands {
     /**
      * Unsubscribes the client from all currently subscribed patterns.
      *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
+     *
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.punsubscribe().get();
+     * client.punsubscribeLazy().get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/punsubscribe/">valkey.io</a> for details
      */
-    CompletableFuture<Void> punsubscribe();
+    CompletableFuture<Void> punsubscribeLazy();
 
     /**
      * Unsubscribes the client from the specified patterns.
+     *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
      *
      * @param patterns A set of glob patterns to unsubscribe from
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.punsubscribe(Set.of("news.*", "updates.*")).get();
+     * client.punsubscribeLazy(Set.of("news.*", "updates.*")).get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/punsubscribe/">valkey.io</a> for details
      */
-    CompletableFuture<Void> punsubscribe(Set<String> patterns);
+    CompletableFuture<Void> punsubscribeLazy(Set<String> patterns);
 
     /**
      * Unsubscribes the client from the specified patterns with a timeout.

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -16,13 +16,13 @@ public interface PubSubClusterCommands {
 
     /**
      * Constant representing "unsubscribe from all sharded channels". Pass this to {@link
-     * #sunsubscribe(Set)} or {@link #sunsubscribe(Set, int)} to unsubscribe from all sharded
+     * #sunsubscribeLazy(Set)} or {@link #sunsubscribe(Set, int)} to unsubscribe from all sharded
      * channels.
      *
      * @example
      *     <pre>{@code
      * // Unsubscribe from all sharded channels
-     * client.sunsubscribe(PubSubClusterCommands.ALL_SHARDED_CHANNELS).get();
+     * client.sunsubscribeLazy(PubSubClusterCommands.ALL_SHARDED_CHANNELS).get();
      * }</pre>
      */
     Set<String> ALL_SHARDED_CHANNELS = Collections.emptySet();
@@ -197,29 +197,41 @@ public interface PubSubClusterCommands {
     /**
      * Unsubscribes the client from all currently subscribed sharded channels.
      *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
+     *
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.sunsubscribe().get();
+     * client.sunsubscribeLazy().get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/sunsubscribe/">valkey.io</a> for details
      */
-    CompletableFuture<Void> sunsubscribe();
+    CompletableFuture<Void> sunsubscribeLazy();
 
     /**
      * Unsubscribes the client from the specified sharded channels.
+     *
+     * <p>This command updates the client's internal desired subscription state without waiting for
+     * server confirmation. It returns immediately after updating the local state. The client will
+     * attempt to unsubscribe asynchronously in the background.
+     *
+     * <p>Note: Use {@code getSubscriptions()} to verify the actual server-side subscription state.
      *
      * @param channels A set of sharded channel names to unsubscribe from
      * @return A {@link CompletableFuture} that completes when the unsubscription request is processed
      * @example
      *     <pre>{@code
-     * client.sunsubscribe(Set.of("shard-news", "shard-updates")).get();
+     * client.sunsubscribeLazy(Set.of("shard-news", "shard-updates")).get();
      * }</pre>
      *
      * @see <a href="https://valkey.io/commands/sunsubscribe/">valkey.io</a> for details
      */
-    CompletableFuture<Void> sunsubscribe(Set<String> channels);
+    CompletableFuture<Void> sunsubscribeLazy(Set<String> channels);
 
     /**
      * Unsubscribes the client from the specified sharded channels with a timeout.

--- a/java/client/src/test/java/glide/api/GlideClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClientTest.java
@@ -16178,7 +16178,7 @@ public class GlideClientTest {
 
     @SneakyThrows
     @Test
-    public void unsubscribe_returns_success() {
+    public void unsubscribe_blocking_returns_success() {
         // setup
         CompletableFuture<Void> testResponse = new CompletableFuture<>();
         testResponse.complete(null);
@@ -16214,7 +16214,7 @@ public class GlideClientTest {
 
     @SneakyThrows
     @Test
-    public void punsubscribe_returns_success() {
+    public void punsubscribe_blocking_returns_success() {
         // setup
         CompletableFuture<Void> testResponse = new CompletableFuture<>();
         testResponse.complete(null);
@@ -16226,6 +16226,48 @@ public class GlideClientTest {
 
         // exercise
         CompletableFuture<Void> response = service.punsubscribe(createSet("pattern*"), 2000);
+
+        // verify
+        assertNull(response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void unsubscribe_lazy_returns_success() {
+        // setup
+        CompletableFuture<Void> testResponse = new CompletableFuture<>();
+        testResponse.complete(null);
+
+        // match on protobuf request
+        when(commandManager.<Void>submitNewCommand(
+                        eq(command_request.CommandRequestOuterClass.RequestType.Unsubscribe),
+                        any(String[].class),
+                        any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Void> response = service.unsubscribeLazy(createSet("channel1"));
+
+        // verify
+        assertNull(response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void punsubscribe_lazy_returns_success() {
+        // setup
+        CompletableFuture<Void> testResponse = new CompletableFuture<>();
+        testResponse.complete(null);
+
+        // match on protobuf request
+        when(commandManager.<Void>submitNewCommand(
+                        eq(command_request.CommandRequestOuterClass.RequestType.PUnsubscribe),
+                        any(String[].class),
+                        any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Void> response = service.punsubscribeLazy(createSet("pattern*"));
 
         // verify
         assertNull(response.get());

--- a/java/client/src/test/java/glide/api/GlideClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClusterClientTest.java
@@ -3833,7 +3833,7 @@ public class GlideClusterClientTest {
 
     @SneakyThrows
     @Test
-    public void sunsubscribe_returns_success() {
+    public void sunsubscribe_blocking_returns_success() {
         // setup
         CompletableFuture<Void> testResponse = new CompletableFuture<>();
         testResponse.complete(null);
@@ -3845,6 +3845,27 @@ public class GlideClusterClientTest {
 
         // exercise
         CompletableFuture<Void> response = service.sunsubscribe(createSet("channel1"), 1000);
+
+        // verify
+        assertNull(response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void sunsubscribe_lazy_returns_success() {
+        // setup
+        CompletableFuture<Void> testResponse = new CompletableFuture<>();
+        testResponse.complete(null);
+
+        // match on protobuf request
+        when(commandManager.<Void>submitNewCommand(
+                        eq(command_request.CommandRequestOuterClass.RequestType.SUnsubscribe),
+                        any(String[].class),
+                        any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Void> response = service.sunsubscribeLazy(createSet("channel1"));
 
         // verify
         assertNull(response.get());

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -2155,24 +2155,65 @@ public class PubSubTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @SneakyThrows
+    public void dynamic_punsubscribe(boolean standalone) {
+        executeWithClients(
+                standalone,
+                (listener, sender) -> {
+                    String pattern1 = "test-pattern-1-*";
+                    String pattern2 = "test-pattern-2-*";
+                    String channel1 = "test-pattern-1-" + UUID.randomUUID();
+                    String channel2 = "test-pattern-2-" + UUID.randomUUID();
+                    String message = "test-message";
+
+                    // Subscribe
+                    listener.psubscribeLazy(createSet(pattern1, pattern2)).get();
+                    Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+                    // Unsubscribe (lazy)
+                    listener.punsubscribeLazy(createSet(pattern1)).get();
+                    Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+                    // Unsubscribe (blocking)
+                    listener.punsubscribe(createSet(pattern2), 5000).get();
+                    Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+                    // Publish message
+                    sender.publish(message, channel1).get();
+                    sender.publish(message, channel2).get();
+                    Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+                    // Should not receive message
+                    PubSubMessage msg = listener.tryGetPubSubMessage();
+                    assertNull(msg);
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @SneakyThrows
     public void dynamic_unsubscribe(boolean standalone) {
         executeWithClients(
                 standalone,
                 (listener, sender) -> {
-                    String channel = "test-channel-" + UUID.randomUUID();
+                    String channel1 = "test-channel-1-" + UUID.randomUUID();
+                    String channel2 = "test-channel-2-" + UUID.randomUUID();
                     String message = "test-message";
 
                     // Subscribe
-                    Set<String> channels = createSet(channel);
-                    listener.subscribeLazy(channels).get();
+                    listener.subscribeLazy(createSet(channel1, channel2)).get();
                     Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
-                    // Unsubscribe
-                    listener.unsubscribe(channels).get();
+                    // Unsubscribe (lazy)
+                    listener.unsubscribeLazy(createSet(channel1)).get();
+                    Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+                    // Unsubscribe (blocking)
+                    listener.unsubscribe(createSet(channel2), 5000).get();
                     Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
                     // Publish message
-                    sender.publish(message, channel).get();
+                    sender.publish(message, channel1).get();
+                    sender.publish(message, channel2).get();
                     Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
                     // Should not receive message
@@ -2214,20 +2255,25 @@ public class PubSubTests {
 
         executeWithClusterClients(
                 (listener, sender) -> {
-                    String channel = "test-shard-channel-" + UUID.randomUUID();
+                    String channel1 = "test-shard-channel-1-" + UUID.randomUUID();
+                    String channel2 = "test-shard-channel-2-" + UUID.randomUUID();
                     String message = "test-message";
 
                     // Subscribe
-                    Set<String> channels = createSet(channel);
-                    listener.ssubscribeLazy(channels).get();
+                    listener.ssubscribeLazy(createSet(channel1, channel2)).get();
                     Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
-                    // Unsubscribe
-                    listener.sunsubscribe(channels).get();
+                    // Unsubscribe (lazy)
+                    listener.sunsubscribeLazy(createSet(channel1)).get();
+                    Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+                    // Unsubscribe (blocking)
+                    listener.sunsubscribe(createSet(channel2), 5000).get();
                     Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
                     // Publish message
-                    sender.publish(message, channel, true).get();
+                    sender.publish(message, channel1, true).get();
+                    sender.publish(message, channel2, true).get();
                     Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
                     // Should not receive message
@@ -2266,7 +2312,8 @@ public class PubSubTests {
     @ValueSource(booleans = {true, false})
     @SneakyThrows
     public void dynamic_unsubscribe_from_preconfigured(boolean standalone) {
-        String channel = "preconfigured-channel-" + UUID.randomUUID();
+        String channel1 = "preconfigured-channel-1-" + UUID.randomUUID();
+        String channel2 = "preconfigured-channel-2-" + UUID.randomUUID();
         String message = "test-message";
 
         // Create client with pre-configured subscription
@@ -2274,7 +2321,8 @@ public class PubSubTests {
         if (standalone) {
             StandaloneSubscriptionConfiguration subConfig =
                     StandaloneSubscriptionConfiguration.builder()
-                            .subscription(PubSubChannelMode.EXACT, gs(channel))
+                            .subscription(PubSubChannelMode.EXACT, gs(channel1))
+                            .subscription(PubSubChannelMode.EXACT, gs(channel2))
                             .build();
             listener =
                     GlideClient.createClient(
@@ -2286,7 +2334,8 @@ public class PubSubTests {
         } else {
             ClusterSubscriptionConfiguration subConfig =
                     ClusterSubscriptionConfiguration.builder()
-                            .subscription(PubSubClusterChannelMode.EXACT, gs(channel))
+                            .subscription(PubSubClusterChannelMode.EXACT, gs(channel1))
+                            .subscription(PubSubClusterChannelMode.EXACT, gs(channel2))
                             .build();
             listener =
                     GlideClusterClient.createClient(
@@ -2301,18 +2350,22 @@ public class PubSubTests {
         Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
         // Verify subscription is active by receiving a message
-        sender.publish(message, channel).get();
+        sender.publish(message, channel1).get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY);
         PubSubMessage msg = listener.getPubSubMessage().get(5, TimeUnit.SECONDS);
         assertEquals(message, msg.getMessage().getString());
 
-        // Now unsubscribe dynamically from the pre-configured subscription
-        Set<String> channels = createSet(channel);
-        listener.unsubscribe(channels).get();
+        // Now unsubscribe dynamically from the pre-configured subscription (lazy)
+        listener.unsubscribeLazy(createSet(channel1)).get();
+        Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
+        // Now unsubscribe dynamically from the pre-configured subscription (blocking)
+        listener.unsubscribe(createSet(channel2), 5000).get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
         // Publish another message
-        sender.publish(message + "-2", channel).get();
+        sender.publish(message + "-2", channel1).get();
+        sender.publish(message + "-2", channel2).get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY);
 
         // Should not receive message
@@ -2358,7 +2411,7 @@ public class PubSubTests {
             assertTrue(updatedTimestamp >= initialTimestamp);
 
             // Cleanup subscription
-            client.unsubscribe().get();
+            client.unsubscribeLazy().get();
             Thread.sleep(100);
         }
     }
@@ -2394,8 +2447,17 @@ public class PubSubTests {
             Thread.sleep(500);
             Thread.sleep(500);
 
-            // Unsubscribe from all
-            client.unsubscribe().get();
+            // Unsubscribe from all (lazy)
+            client.unsubscribeLazy().get();
+            Thread.sleep(500);
+            Thread.sleep(500);
+
+            // Verify we can subscribe again (proves unsubscribe worked)
+            client.subscribeLazy(createSet(channel1, channel2)).get();
+            Thread.sleep(500);
+
+            // Unsubscribe from all (blocking)
+            client.unsubscribe(5000).get();
             Thread.sleep(500);
             Thread.sleep(500);
 
@@ -2428,13 +2490,27 @@ public class PubSubTests {
             assertNotNull(exact);
             assertEquals(2, exact.size());
 
-            // Unsubscribe from all
-            client.unsubscribe().get();
+            // Unsubscribe from all (lazy)
+            client.unsubscribeLazy().get();
             Thread.sleep(500);
 
             // Verify all unsubscribed
             state = client.getSubscriptions().get();
             Set<String> exactAfter = state.getActualSubscriptions().get(PubSubClusterChannelMode.EXACT);
+            assertTrue(exactAfter == null || exactAfter.isEmpty());
+
+            // Subscribe again
+            client.subscribeLazy(createSet(channel1, channel2)).get();
+            Thread.sleep(500);
+            Thread.sleep(500);
+
+            // Unsubscribe from all (blocking)
+            client.unsubscribe(5000).get();
+            Thread.sleep(500);
+
+            // Verify all unsubscribed
+            state = client.getSubscriptions().get();
+            exactAfter = state.getActualSubscriptions().get(PubSubClusterChannelMode.EXACT);
             assertTrue(exactAfter == null || exactAfter.isEmpty());
         } finally {
             client.close();
@@ -2461,13 +2537,26 @@ public class PubSubTests {
             assertNotNull(patterns);
             assertEquals(2, patterns.size());
 
-            // Unsubscribe from all patterns
-            client.punsubscribe().get();
+            // Unsubscribe from all patterns (lazy)
+            client.punsubscribeLazy().get();
             Thread.sleep(1000); // Wait longer to ensure unsubscribe completes
 
             // Verify all unsubscribed
             state = client.getSubscriptions().get();
             Set<String> patternsAfter = state.getActualSubscriptions().get(PubSubChannelMode.PATTERN);
+            assertTrue(patternsAfter == null || patternsAfter.isEmpty());
+
+            // Subscribe to multiple patterns again
+            client.psubscribeLazy(createSet(pattern1, pattern2)).get();
+            Thread.sleep(500);
+
+            // Unsubscribe from all patterns (blocking)
+            client.punsubscribe(5000).get();
+            Thread.sleep(1000); // Wait longer to ensure unsubscribe completes
+
+            // Verify all unsubscribed
+            state = client.getSubscriptions().get();
+            patternsAfter = state.getActualSubscriptions().get(PubSubChannelMode.PATTERN);
             assertTrue(patternsAfter == null || patternsAfter.isEmpty());
         } finally {
             // Extra wait before closing to ensure server processes unsubscribe
@@ -2499,14 +2588,27 @@ public class PubSubTests {
             assertNotNull(sharded);
             assertEquals(2, sharded.size());
 
-            // Unsubscribe from all sharded channels
-            client.sunsubscribe().get();
+            // Unsubscribe from all sharded channels (lazy)
+            client.sunsubscribeLazy().get();
             Thread.sleep(500);
 
             // Verify all unsubscribed
             state = client.getSubscriptions().get();
             Set<String> shardedAfter =
                     state.getActualSubscriptions().get(PubSubClusterChannelMode.SHARDED);
+            assertTrue(shardedAfter == null || shardedAfter.isEmpty());
+
+            // Subscribe again
+            client.ssubscribeLazy(createSet(channel1, channel2)).get();
+            Thread.sleep(500);
+
+            // Unsubscribe from all sharded channels (blocking)
+            client.sunsubscribe(5000).get();
+            Thread.sleep(500);
+
+            // Verify all unsubscribed
+            state = client.getSubscriptions().get();
+            shardedAfter = state.getActualSubscriptions().get(PubSubClusterChannelMode.SHARDED);
             assertTrue(shardedAfter == null || shardedAfter.isEmpty());
         } finally {
             client.close();
@@ -2594,7 +2696,7 @@ public class PubSubTests {
             publisher.publish(channel2, "message2", true).get();
             Thread.sleep(500);
         } finally {
-            client.sunsubscribe().get();
+            client.sunsubscribeLazy().get();
             Thread.sleep(100);
             client.close();
             listeners.remove(client);
@@ -2617,7 +2719,7 @@ public class PubSubTests {
         Thread.sleep(500);
 
         // Unsubscribe from one channel
-        client.sunsubscribe(createSet(channel1)).get();
+        client.sunsubscribeLazy(createSet(channel1)).get();
         Thread.sleep(500);
 
         // Verify only channel2 remains
@@ -2627,7 +2729,7 @@ public class PubSubTests {
         assertTrue(sharded.contains(channel2));
 
         // Cleanup remaining subscription
-        client.sunsubscribe().get();
+        client.sunsubscribeLazy().get();
         Thread.sleep(100);
         client.close();
         listeners.remove(client);
@@ -2653,7 +2755,7 @@ public class PubSubTests {
         assertNotNull(state.getActualSubscriptions().get(PubSubChannelMode.PATTERN));
 
         // Unsubscribe from all exact channels
-        client.unsubscribe().get();
+        client.unsubscribeLazy().get();
         Thread.sleep(500);
 
         // Verify exact unsubscribed but pattern remains
@@ -2665,7 +2767,7 @@ public class PubSubTests {
         assertFalse(patterns.isEmpty());
 
         // Unsubscribe from all patterns
-        client.punsubscribe().get();
+        client.punsubscribeLazy().get();
         Thread.sleep(500);
 
         // Verify all unsubscribed
@@ -2701,15 +2803,15 @@ public class PubSubTests {
         assertNotNull(state.getActualSubscriptions().get(PubSubClusterChannelMode.SHARDED));
 
         // Unsubscribe from all exact channels
-        client.unsubscribe().get();
+        client.unsubscribeLazy().get();
         Thread.sleep(500);
 
         // Unsubscribe from all patterns
-        client.punsubscribe().get();
+        client.punsubscribeLazy().get();
         Thread.sleep(500);
 
         // Unsubscribe from all sharded
-        client.sunsubscribe().get();
+        client.sunsubscribeLazy().get();
         Thread.sleep(500);
 
         // Verify all unsubscribed


### PR DESCRIPTION
### Summary

Renamed the non-blocking `unsubscribe` and `punsubscribe` methods in the Java client to `unsubscribeLazy` and `punsubscribeLazy` to align with the existing naming conventions of `subscribeLazy` and `psubscribeLazy`. Additionally, tests were expanded to cover both the non-blocking (`*Lazy`) and blocking variants of these commands inline.

This improves API consistency and developer experience by making the non-blocking nature of these operations explicit and testing both approaches thoroughly.

### Issue link

This Pull Request is linked to issue: [[Task] Add Lazy Unsubscribe to Java client](https://github.com/valkey-io/valkey-glide/issues/5525)

### Features / Behaviour Changes

- Renamed `unsubscribe()` to `unsubscribeLazy()`
- Renamed `unsubscribe(Set<String> channels)` to `unsubscribeLazy(Set<String> channels)`
- Renamed `punsubscribe()` to `punsubscribeLazy()`
- Renamed `punsubscribe(Set<String> patterns)` to `punsubscribeLazy(Set<String> patterns)`
- Renamed `sunsubscribe()` to `sunsubscribeLazy()`
- Renamed `sunsubscribe(Set<String> channels)` to `sunsubscribeLazy(Set<String> channels)`
- Updated `PubSubBaseCommands.java` Javadocs to reflect that these commands execute asynchronously without waiting for server confirmation.
- Updated `CHANGELOG.md` to reflect the addition of "Lazy" variants for dynamic PubSub methods.

### Implementation

- Refactored `PubSubBaseCommands` interface to rename the methods and updated JavaDoc.
- Updated `BaseClient` to implement the new method names, keeping the internal asynchronous routing identical (using `EMPTY_STRING_ARRAY` and simple parameter packing).
- Replaced occurrences in `java/README.md`.
- Updated test methods in `java/integTest/src/test/java/glide/PubSubTests.java` to test both the non-blocking (`*Lazy`) and blocking (e.g., `unsubscribe(..., 5000)`) variants within the same test functions. 

### Limitations

- This PR only addresses the Java language bindings as described in the issue. Other language bindings may require similar consistency passes in separate PRs.

### Testing

- Executed `gradlew testClasses` successfully.
- Integration tests in `PubSubTests.java` have been expanded to utilize and test both the new `unsubscribeLazy`, `punsubscribeLazy`, `sunsubscribeLazy` commands and their blocking counterparts inline.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.