### PR TITLE
fix(java): optimize convertMapToKeyValueStringArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Python Sync: Add response buffer support to get() to improve performance by reducing copies ([#5493](https://github.com/valkey-io/valkey-glide/pull/5493))
 
 #### Fixes
+* Java: optimize `convertMapToKeyValueStringArray` and `convertMapToKeyValueGlideStringArray` to fix performance bottleneck and ArrayStoreException ([#5602](https://github.com/valkey-io/valkey-glide/issues/5602))
 * CORE: Fix empty hostname in CLUSTER SLOTS metadata causing AllConnectionsUnavailable ([#5367](https://github.com/valkey-io/valkey-glide/issues/5367)). AWS ElastiCache (plaintext, cluster mode) returns `hostname: ""` in node metadata, which was used as the connection address instead of falling back to the IP.
 * Node: Fix to handle non-string types in toBuffersArray ([#4842](https://github.com/valkey-io/valkey-glide/issues/4842))
 * CORE: Enforce connection_timeout for initial standalone connection failures  ([#4991](https://github.com/valkey-io/valkey-glide/issues/4991))

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -27,22 +27,31 @@ public class ArrayTransformUtils {
      * @return Array of strings [key1, value1.toString(), key2, value2.toString(), ...].
      */
     public static String[] convertMapToKeyValueStringArray(Map<String, ?> args) {
-        return args.entrySet().stream()
-                .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
-                .toArray(String[]::new);
+        final String[] result = new String[args.size() * 2];
+        int i = 0;
+        for (Map.Entry<String, ?> entry : args.entrySet()) {
+            result[i++] = entry.getKey();
+            Object value = entry.getValue();
+            result[i++] = value == null ? null : String.valueOf(value);
+        }
+        return result;
     }
 
     /**
      * Converts a map of GlideString keys and values to an array of GlideStrings.
      *
      * @param args Map of GlideString keys to values of GlideString.
-     * @return Array of strings [key1, gs(value1.toString()), key2, gs(value2.toString()), ...].
+     * @return Array of GlideStrings [key1, value1, key2, value2, ...].
      */
     public static GlideString[] convertMapToKeyValueGlideStringArray(
             Map<GlideString, GlideString> args) {
-        return args.entrySet().stream()
-                .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
-                .toArray(GlideString[]::new);
+        final GlideString[] result = new GlideString[args.size() * 2];
+        int i = 0;
+        for (Map.Entry<GlideString, GlideString> entry : args.entrySet()) {
+            result[i++] = entry.getKey();
+            result[i++] = entry.getValue();
+        }
+        return result;
     }
 
     /**

--- a/java/client/src/test/java/glide/utils/ArrayTransformUtilsTest.java
+++ b/java/client/src/test/java/glide/utils/ArrayTransformUtilsTest.java
@@ -1,0 +1,88 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.utils;
+
+import static glide.api.models.GlideString.gs;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import glide.api.models.GlideString;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ArrayTransformUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("provideMapsForConversion")
+    void testConvertMapToKeyValueStringArray(Map<String, ?> inputMap, String[] expectedArray) {
+        // When
+        String[] result = ArrayTransformUtils.convertMapToKeyValueStringArray(inputMap);
+
+        // Then
+        assertArrayEquals(expectedArray, result);
+    }
+
+    private static Stream<Arguments> provideMapsForConversion() {
+        // Given 1: Empty map
+        Map<String, Object> emptyMap = new LinkedHashMap<>();
+
+        // Given 2: Map with only String values
+        Map<String, Object> stringMap = new LinkedHashMap<>();
+        stringMap.put("key1", "value1");
+        stringMap.put("key2", "value2");
+
+        // Given 3: Map with mixed value types (Integer, Double, Boolean)
+        Map<String, Object> mixedTypeMap = new LinkedHashMap<>();
+        mixedTypeMap.put("stringKey", "str");
+        mixedTypeMap.put("intKey", 42);
+        mixedTypeMap.put("doubleKey", 3.14);
+        mixedTypeMap.put("boolKey", true);
+
+        // Given 4: Map with null value
+        Map<String, Object> nullValueMap = new LinkedHashMap<>();
+        nullValueMap.put("nullKey", null);
+
+        return Stream.of(
+                Arguments.of(emptyMap, new String[] {}),
+                Arguments.of(stringMap, new String[] {"key1", "value1", "key2", "value2"}),
+                Arguments.of(
+                        mixedTypeMap,
+                        new String[] {
+                            "stringKey", "str", "intKey", "42", "doubleKey", "3.14", "boolKey", "true"
+                        }),
+                Arguments.of(nullValueMap, new String[] {"nullKey", null}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGlideStringMapsForConversion")
+    void testConvertMapToKeyValueGlideStringArray(
+            Map<GlideString, GlideString> inputMap, GlideString[] expectedArray) {
+        // When
+        GlideString[] result = ArrayTransformUtils.convertMapToKeyValueGlideStringArray(inputMap);
+
+        // Then
+        assertArrayEquals(expectedArray, result);
+    }
+
+    private static Stream<Arguments> provideGlideStringMapsForConversion() {
+        // Given 1: Empty map
+        Map<GlideString, GlideString> emptyMap = new LinkedHashMap<>();
+
+        // Given 2: Map with values
+        Map<GlideString, GlideString> stringMap = new LinkedHashMap<>();
+        stringMap.put(gs("key1"), gs("value1"));
+        stringMap.put(gs("key2"), gs("value2"));
+
+        // Given 3: Map with null value
+        Map<GlideString, GlideString> nullValueMap = new LinkedHashMap<>();
+        nullValueMap.put(gs("nullKey"), null);
+
+        return Stream.of(
+                Arguments.of(emptyMap, new GlideString[] {}),
+                Arguments.of(
+                        stringMap, new GlideString[] {gs("key1"), gs("value1"), gs("key2"), gs("value2")}),
+                Arguments.of(nullValueMap, new GlideString[] {gs("nullKey"), null}));
+    }
+}


### PR DESCRIPTION
### Summary

The `convertMapToKeyValueStringArray` and `convertMapToKeyValueGlideStringArray` method in `glide.utils.ArrayTransformUtils (Java client)` is causing significant CPU and memory overhead when converting maps with a large number of entries. Additionally, it has a runtime bug that throws an ArrayStoreException if the map contains values that are not explicitly of type String.

### Issue link

This Pull Request is linked to issue: [[Java][Task] Performance bottleneck in ArrayTransformUtils.convertMapToKeyValueStringArray #5602](https://github.com/valkey-io/valkey-glide/issues/5602)
Closes #5602


### Features / Behaviour Changes

- Replace the Java Stream API approach with a simple, pre-allocated array and a for-each loop.
- We can avoid unnecessary object allocations and use `String.valueOf()` to safely convert any object type to a string.

### Testing
<img width="957" height="305" alt="Screenshot 2026-03-15 at 5 18 44 AM" src="https://github.com/user-attachments/assets/a0dc2b63-81e8-4345-99bd-0527ffb8023c" />

After fix(100,000 iteration):
- 93% reduction in memory consumption
- 80% reduction in Garbage Collection (GC) count
<img width="1811" height="504" alt="Image" src="https://github.com/user-attachments/assets/919b192d-fe73-4d2d-894c-2777074b3ff3" />

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
