### PR TITLE
Pypi-CD: fix test-the-release step for linux-arm ephemeral runner (#5566)

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -587,6 +587,12 @@ jobs:
 
                   echo "/opt/${PYPY_VERSION_3_10}/bin" >> ${GITHUB_PATH}
 
+            - name: Install engine build dependencies (ephemeral runners)
+              if: ${{ contains(matrix.build.RUNNER, 'ephemeral') }}
+              run: |
+                  sudo apt update -y
+                  sudo apt install -y pkg-config libssl-dev
+
             - name: Install engine
               uses: ./.github/workflows/install-engine
               with:


### PR DESCRIPTION
This is a cherry-pick of https://github.com/valkey-io/valkey-glide/commit/5327ebcaa6691ea20e4253171c5c6456f94fc61d