### PR TITLE
Java: Suppress Gradle module metadata

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -265,9 +265,6 @@ publishing {
             artifactId = 'valkey-glide'
             version = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion
             pom {
-                // Shadow plugin sets packaging to 'pom' by default; override to 'jar'
-                // so Maven and Gradle (without .module metadata) resolve the artifact correctly.
-                packaging = 'jar'
                 name = 'valkey-glide'
                 description = 'General Language Independent Driver for the Enterprise (GLIDE) for Valkey'
                 url = 'https://github.com/valkey-io/valkey-glide.git'
@@ -304,13 +301,7 @@ java {
 
 tasks.withType(GenerateModuleMetadata) {
     dependsOn shadowJar
-    // Only suppress .module for release builds. During local dev / CI builds,
-    // the single-platform .module is correct and needed for classifier resolution.
-    // For release publishes, each platform CI job generates its own .module and
-    // the last one wins the race during bundling, pointing to the wrong jar.
-    def releaseVersion = System.getenv("GLIDE_RELEASE_VERSION") ?: defaultReleaseVersion
-    def isReleaseBuild = releaseVersion != defaultReleaseVersion
-    enabled = !isReleaseBuild
+    enabled = false
 }
 
 tasks.withType(Sign) {


### PR DESCRIPTION

### Summary

- Disable .module metadata generation to prevent incorrect classifier resolution
- Ensure Maven and Gradle consumers resolve the correct artifact without metadata
- Fixes issue where Gradle could resolve wrong classifier jar due to incomplete per-platform variant declarations


### Issue link

This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)
Closes <Issue #>

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
