### PR TITLE
Fix python pubsub test

### DIFF
--- a/python/tests/sync_tests/test_sync_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pubsub.py
@@ -1907,6 +1907,13 @@ class TestSyncPubSub:
             context=context,
             timeout=10000,
         ) as (listening_client, publishing_client):
+            # Wait for subscription to be established before publishing
+            sync_wait_for_subscription_state_if_needed(
+                listening_client,
+                subscription_method,
+                expected_channels={channel},
+            )
+
             result = publishing_client.publish(message, channel)
             if cluster_mode:
                 assert result == 1
@@ -1961,6 +1968,13 @@ class TestSyncPubSub:
             context=context,
             timeout=10000,
         ) as (listening_client, publishing_client):
+            # Wait for subscription to be established before publishing
+            sync_wait_for_subscription_state_if_needed(
+                listening_client,
+                subscription_method,
+                expected_sharded={channel},
+            )
+
             assert (
                 cast(GlideClusterClient, publishing_client).publish(
                     message, channel, sharded=True


### PR DESCRIPTION
### Summary

Small fix for a python pubsub test that was missing sync_wait_for_subscription_state_if_needed

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
