### PR TITLE
Make python scan return type more friendly

### DIFF
--- a/python/glide-async/python/glide/async_commands/cluster_commands.py
+++ b/python/glide-async/python/glide/async_commands/cluster_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Set, Union, cast
+from typing import Dict, List, Mapping, Optional, Set, Tuple, cast
 
 from glide.glide import ClusterScanCursor, Script
 from glide_shared.commands.batch import ClusterBatch
@@ -1247,7 +1247,7 @@ class ClusterCommands(CoreCommands):
         count: Optional[int] = None,
         type: Optional[ObjectType] = None,
         allow_non_covered_slots: bool = False,
-    ) -> List[Union[ClusterScanCursor, List[bytes]]]:
+    ) -> Tuple[ClusterScanCursor, List[bytes]]:
         """
         Incrementally iterates over the keys in the cluster.
         The method returns a list containing the next cursor and a list of keys.
@@ -1279,8 +1279,8 @@ class ClusterCommands(CoreCommands):
                 and the method loses its way to validate the progress of the scan. Defaults to False.
 
         Returns:
-            List[Union[ClusterScanCursor, List[TEncodable]]]: A list containing the next cursor and a list of keys,
-            formatted as [ClusterScanCursor, [key1, key2, ...]].
+            Tuple[ClusterScanCursor, List[TEncodable]]: A tuple containing the next cursor and a list of keys,
+            formatted as (ClusterScanCursor, [key1, key2, ...]).
 
         Examples:
             >>> # Iterate over all keys in the cluster.
@@ -1319,14 +1319,14 @@ class ClusterCommands(CoreCommands):
             >>> print(all_keys)  # [b'key1', b'key2', b'key3']
         """
         return cast(
-            List[Union[ClusterScanCursor, List[bytes]]],
-            await self._cluster_scan(
+            Tuple[ClusterScanCursor, List[bytes]],
+            tuple(await self._cluster_scan(
                 cursor=cursor,
                 match=match,
                 count=count,
                 type=type,
                 allow_non_covered_slots=allow_non_covered_slots,
-            ),
+            )),
         )
 
     async def script_exists(

--- a/python/glide-async/python/glide/async_commands/standalone_commands.py
+++ b/python/glide-async/python/glide/async_commands/standalone_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Union, cast
+from typing import Dict, List, Mapping, Optional, Tuple, cast
 
 from glide.glide import Script
 from glide_shared.commands.batch import Batch
@@ -846,7 +846,7 @@ class StandaloneCommands(CoreCommands):
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
         type: Optional[ObjectType] = None,
-    ) -> List[Union[bytes, List[bytes]]]:
+    ) -> Tuple[bytes, List[bytes]]:
         """
         Incrementally iterate over a collection of keys.
         SCAN is a cursor based iterator. This means that at every call of the command,
@@ -878,8 +878,8 @@ class StandaloneCommands(CoreCommands):
             type (ObjectType): The type of object to scan for.
 
         Returns:
-            List[Union[bytes, List[bytes]]]: A List containing the next cursor value and a list of keys,
-            formatted as [cursor, [key1, key2, ...]]
+            Tuple[bytes, List[bytes]]: A List containing the next cursor value and a list of keys,
+            formatted as (cursor, [key1, key2, ...])
 
         Examples:
             >>> result = await client.scan(b'0')
@@ -903,8 +903,8 @@ class StandaloneCommands(CoreCommands):
         if type:
             args.extend(["TYPE", type.value])
         return cast(
-            List[Union[bytes, List[bytes]]],
-            await self._execute_command(RequestType.Scan, args),
+            Tuple[bytes, List[bytes]],
+            tuple(await self._execute_command(RequestType.Scan, args)),
         )
 
     async def script_exists(self, sha1s: List[TEncodable]) -> List[bool]:

--- a/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Set, Union, cast
+from typing import Dict, List, Mapping, Optional, Set, Tuple, Union, cast
 
 from glide_shared.commands.batch import ClusterBatch
 from glide_shared.commands.batch_options import ClusterBatchOptions
@@ -1375,7 +1375,7 @@ class ClusterCommands(CoreCommands):
         count: Optional[int] = None,
         type: Optional[ObjectType] = None,
         allow_non_covered_slots: bool = False,
-    ) -> List[Union[ClusterScanCursor, List[bytes]]]:
+    ) -> Tuple[ClusterScanCursor, List[bytes]]:
         """
         Incrementally iterates over the keys in the cluster.
         The method returns a list containing the next cursor and a list of keys.
@@ -1407,8 +1407,8 @@ class ClusterCommands(CoreCommands):
                 and the method loses its way to validate the progress of the scan. Defaults to False.
 
         Returns:
-            List[Union[ClusterScanCursor, List[TEncodable]]]: A list containing the next cursor and a list of keys,
-            formatted as [ClusterScanCursor, [key1, key2, ...]].
+            Tuple[ClusterScanCursor, List[TEncodable]]: A list containing the next cursor and a list of keys,
+            formatted as (ClusterScanCursor, [key1, key2, ...]).
 
         Examples:
             >>> # Iterate over all keys in the cluster.
@@ -1447,14 +1447,14 @@ class ClusterCommands(CoreCommands):
             >>> print(all_keys)  # [b'key1', b'key2', b'key3']
         """
         return cast(
-            List[Union[ClusterScanCursor, List[bytes]]],
-            self._cluster_scan(
+            Tuple[ClusterScanCursor, List[bytes]],
+            tuple(self._cluster_scan(
                 cursor=cursor,
                 match=match,
                 count=count,
                 type=type,
                 allow_non_covered_slots=allow_non_covered_slots,
-            ),
+            )),
         )
 
     def ssubscribe_lazy(self, channels: Set[str]) -> None:

--- a/python/glide-sync/glide_sync/sync_commands/standalone_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/standalone_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Union, cast
+from typing import Dict, List, Mapping, Optional, Tuple, cast
 
 from glide_shared.commands.batch import Batch
 from glide_shared.commands.batch_options import BatchOptions
@@ -933,7 +933,7 @@ class StandaloneCommands(CoreCommands):
         match: Optional[TEncodable] = None,
         count: Optional[int] = None,
         type: Optional[ObjectType] = None,
-    ) -> List[Union[bytes, List[bytes]]]:
+    ) -> Tuple[bytes, List[bytes]]:
         """
         Incrementally iterate over a collection of keys.
         SCAN is a cursor based iterator. This means that at every call of the command,
@@ -965,8 +965,8 @@ class StandaloneCommands(CoreCommands):
             type (ObjectType): The type of object to scan for.
 
         Returns:
-            List[Union[bytes, List[bytes]]]: A List containing the next cursor value and a list of keys,
-            formatted as [cursor, [key1, key2, ...]]
+            Tuple[bytes, List[bytes]]: A List containing the next cursor value and a list of keys,
+            formatted as (cursor, [key1, key2, ...])
 
         Examples:
             >>> result = client.scan(b'0')
@@ -990,6 +990,6 @@ class StandaloneCommands(CoreCommands):
         if type:
             args.extend(["TYPE", type.value])
         return cast(
-            List[Union[bytes, List[bytes]]],
-            self._execute_command(RequestType.Scan, args),
+            Tuple[bytes, List[bytes]],
+            tuple(self._execute_command(RequestType.Scan, args)),
         )


### PR DESCRIPTION
Currently `scan` is typed to return `List[Union[bytes, List[bytes]]]`. I think that's not correct, and can be vexing for clients using mypy and the like. 

`List[Union[bytes, List[bytes]]]` is closer to `-> [[b'1', b'2', b'3'], [b'1', b'2', b'3'], ...] | [b'1', b'2', b'3', ...]`; where as this function is actually shaped like `[b'0', [b'1', b'2', b'3', ...]]`. A tuple is more appropriate for communicating this shape (fixed size + heterogeneous types).


### Summary

Initial stab at changing the types, but I don't have any formatters set up so it's probably worth someone taking this over.


### Features / Behaviour Changes

Better typing. `List[Union[bytes, List[bytes]]]` doesn't actually match the return

### Implementation

Type signature changes + a tuple call

### Limitations

your imagination

### Testing

:eyes:

Closes #5617

