### PR TITLE
Address issues with tests in CI (#5625)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -335,6 +335,9 @@ jobs:
               env:
                   RC_VERSION: ${{ github.event.inputs.rc-version }}
                   VALKEY_GLIDE_DNS_TESTS_ENABLED: "1"
+                  AWS_ACCESS_KEY_ID: test_access_key
+                  AWS_SECRET_ACCESS_KEY: test_secret_key
+                  AWS_SESSION_TOKEN: test_session_token
               run: |
                   if [[ -n "$RC_VERSION" ]]; then
                     make install-tools

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -152,9 +152,9 @@ jobs:
               shell: bash
               run: |
                   npm run build
-                  export AWS_ACCESS_KEY_ID=test_access_key 
-                  export AWS_SECRET_ACCESS_KEY=test_secret_key 
-                  export AWS_SESSION_TOKEN=test_session_token 
+                  export AWS_ACCESS_KEY_ID=test_access_key
+                  export AWS_SECRET_ACCESS_KEY=test_secret_key
+                  export AWS_SESSION_TOKEN=test_session_token
                   npm run test
               working-directory: ./node
               env:
@@ -308,7 +308,7 @@ jobs:
     test-node-container:
         runs-on: ${{ matrix.host.RUNNER }}
         needs: [get-containers]
-        timeout-minutes: 25
+        timeout-minutes: 35
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,6 +73,10 @@ on:
                 description: "Build with mock pubsub and run dynamic pubsub tests"
                 type: boolean
                 default: false
+            containers-only:
+                description: "Run only container tests (skip regular test-python job)"
+                type: boolean
+                default: false
 
     workflow_call:
         inputs:
@@ -121,6 +125,7 @@ jobs:
         name: Python Tests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: get-matrices
+        if: ${{ github.event.inputs.containers-only != 'true' }}
         timeout-minutes: 120
         strategy:
             fail-fast: false
@@ -233,6 +238,7 @@ jobs:
         name: Python PubSubTests - ${{ matrix.python }}, EngineVersion - ${{ matrix.engine.version }}, Target - ${{ matrix.host.TARGET }}
         runs-on: ${{ matrix.host.RUNNER }}
         needs: get-matrices
+        if: ${{ github.event.inputs.containers-only != 'true' }}
         timeout-minutes: 120
         strategy:
             fail-fast: false
@@ -334,6 +340,7 @@ jobs:
 
     lint:
         runs-on: ubuntu-latest
+        if: ${{ github.event.inputs.containers-only != 'true' }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v4
@@ -358,6 +365,7 @@ jobs:
 
     docs-test:
         runs-on: ubuntu-latest
+        if: ${{ github.event.inputs.containers-only != 'true' }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v4
@@ -379,7 +387,7 @@ jobs:
 
     get-containers:
         runs-on: ubuntu-latest
-        if: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
+        if: ${{ github.event.inputs.full-matrix == 'true' || github.event.inputs.containers-only == 'true' || github.event_name == 'schedule' }}
         outputs:
             engine-matrix-output: ${{ steps.get-matrices.outputs.engine-matrix-output }}
             host-matrix-output: ${{ steps.get-matrices.outputs.host-matrix-output }}
@@ -446,12 +454,20 @@ jobs:
             - name: Test with pytest (asyncio only)
               if: ${{ env.RUN_FULL_MATRIX != 'true' }}
               working-directory: ./python
+              env:
+                  AWS_ACCESS_KEY_ID: test_access_key
+                  AWS_SECRET_ACCESS_KEY: test_secret_key
+                  AWS_SESSION_TOKEN: test_session_token
               run: |
                   python3 dev.py test --args --html=pytest_report.html --self-contained-html
 
             - name: Test with pytest (full matrix)
               if: ${{ env.RUN_FULL_MATRIX == 'true' }}
               working-directory: ./python
+              env:
+                  AWS_ACCESS_KEY_ID: test_access_key
+                  AWS_SECRET_ACCESS_KEY: test_secret_key
+                  AWS_SESSION_TOKEN: test_session_token
               run: |
                   python3 dev.py test --args --async-backend=asyncio --async-backend=trio --html=pytest_report.html --self-contained-html
 

--- a/go/integTest/auth_test.go
+++ b/go/integTest/auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 )
@@ -28,7 +29,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationWithMockCredentials() {
 
 	// Create credentials with IAM config
 	credentials, err := config.NewServerCredentialsWithIam(TestIamUsername, iamConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 
 	// Create cluster client configuration
 	// Note: useTLS is set from suite.tls which respects the --tls flag
@@ -42,7 +43,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationWithMockCredentials() {
 
 	// Create client with IAM authentication
 	client, err := glide.NewClusterClient(clusterConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err, "Failed to create client - ensure AWS mock credentials are set")
 	defer client.Close()
 
 	// Verify connection works
@@ -88,7 +89,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationAutomaticTokenRefresh() {
 	).WithRefreshIntervalSeconds(2)
 
 	credentials, err := config.NewServerCredentialsWithIam(TestIamUsername, iamConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 
 	clusterConfig := config.NewClusterClientConfiguration().
 		WithAddress(&config.NodeAddress{
@@ -99,7 +100,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationAutomaticTokenRefresh() {
 		WithUseTLS(suite.tls)
 
 	client, err := glide.NewClusterClient(clusterConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err, "Failed to create client - ensure AWS mock credentials are set")
 	defer client.Close()
 
 	// Verify initial connection
@@ -131,7 +132,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationWithMockCredentialsStandalone(
 
 	// Create credentials with IAM config
 	credentials, err := config.NewServerCredentialsWithIam(TestIamUsername, iamConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 
 	// Create standalone client configuration
 	standaloneConfig := config.NewClientConfiguration().
@@ -144,7 +145,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationWithMockCredentialsStandalone(
 
 	// Create client with IAM authentication
 	client, err := glide.NewClient(standaloneConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err, "Failed to create client - ensure AWS mock credentials are set")
 	defer client.Close()
 
 	// Verify connection works
@@ -187,7 +188,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationAutomaticTokenRefreshStandalon
 	).WithRefreshIntervalSeconds(2)
 
 	credentials, err := config.NewServerCredentialsWithIam(TestIamUsername, iamConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
 
 	standaloneConfig := config.NewClientConfiguration().
 		WithAddress(&config.NodeAddress{
@@ -198,7 +199,7 @@ func (suite *GlideTestSuite) TestIamAuthenticationAutomaticTokenRefreshStandalon
 		WithUseTLS(suite.tls)
 
 	client, err := glide.NewClient(standaloneConfig)
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err, "Failed to create client - ensure AWS mock credentials are set")
 	defer client.Close()
 
 	// Verify initial connection

--- a/python/tests/sync_tests/test_sync_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pubsub.py
@@ -1926,6 +1926,10 @@ class TestSyncPubSub:
             assert callback_messages[0].channel == channel.encode()
             assert callback_messages[0].pattern is None
 
+    @pytest.mark.skip(
+        reason="This test requires special configuration for client-output-buffer-limit for valkey-server and timeouts seems "
+        + "to vary across platforms and server versions"
+    )
     @pytest.mark.skip_if_version_below("7.0.0")
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This addresses two issues with our current FMT tests in CI:

Skips a test in python sync tests which the async version of has been skipped longterm due to major flaky issues in different environments
Adds go configuration required for IAM tests to the go container CI job and python container CI job
It also modifies the go test to error out before corruption and segfaults can happen

Also increases timeout on node container CI job.

