### PR TITLE
Java: Make jedis-compatibility a pure-Java JAR with no-classifier support

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -249,33 +249,56 @@ jobs:
                   echo "Downloaded native library artifacts:"
                   find native-libs-downloaded -type f
 
-            - name: Organize native libraries for uber JARs
+            - name: Organize native libraries for uber JAR
               shell: bash
               run: |
-                  # Stage native libraries into both client and jedis-compatibility modules.
-                  # Structure: native-libs-downloaded/native-lib-{TARGET}/{platform}/{arch}/*.{so,dylib,dll}
-                  # Target:    java/<module>/build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
-                  STAGING_DIRS=(
-                      "java/client/build/native-libs-staging/natives"
-                      "java/jedis-compatibility/build/native-libs-staging/natives"
-                  )
+                  # Create staging directory for native libraries
+                  mkdir -p java/client/build/native-libs-staging/natives
 
-                  for staging_dir in "${STAGING_DIRS[@]}"; do
-                      mkdir -p "$staging_dir"
-                      for artifact_dir in native-libs-downloaded/native-lib-*; do
-                          if [ -d "$artifact_dir" ]; then
-                              echo "Processing $artifact_dir -> $staging_dir"
-                              find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
-                                  rel_path="${lib_file#$artifact_dir/}"
-                                  target_path="$staging_dir/$rel_path"
-                                  mkdir -p "$(dirname "$target_path")"
-                                  cp "$lib_file" "$target_path"
-                              done
-                          fi
-                      done
-                      echo "Native libraries staged in $staging_dir:"
-                      find "$staging_dir" -type f
+                  # Copy all native libraries from downloaded artifacts
+                  # Structure: native-libs-downloaded/native-lib-{TARGET}/{platform}/{arch}/*.{so,dylib,dll}
+                  # Target structure: java/client/build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
+                  for artifact_dir in native-libs-downloaded/native-lib-*; do
+                      if [ -d "$artifact_dir" ]; then
+                          echo "Processing $artifact_dir"
+                          # Find all native library files and copy them preserving the platform/arch structure
+                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
+                              # Extract the relative path from the artifact directory
+                              rel_path="${lib_file#$artifact_dir/}"
+                              target_path="java/client/build/native-libs-staging/natives/$rel_path"
+                              # Create target directory if it doesn't exist
+                              mkdir -p "$(dirname "$target_path")"
+                              # Copy the file
+                              cp "$lib_file" "$target_path"
+                          done
+                      fi
                   done
+
+                  echo "Native libraries staged:"
+                  find java/client/build/native-libs-staging -type f
+
+            - name: Organize jedis native libraries for uber JAR
+              shell: bash
+              run: |
+                  # Create staging directory for jedis native libraries
+                  # Reuse the same native-libs-downloaded artifacts, preserving the
+                  # natives/{platform}/{arch}/ directory structure
+                  mkdir -p java/jedis-compatibility/build/native-libs-staging/natives
+
+                  for artifact_dir in native-libs-downloaded/native-lib-*; do
+                      if [ -d "$artifact_dir" ]; then
+                          echo "Processing $artifact_dir"
+                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
+                              rel_path="${lib_file#$artifact_dir/}"
+                              target_path="java/jedis-compatibility/build/native-libs-staging/natives/$rel_path"
+                              mkdir -p "$(dirname "$target_path")"
+                              cp "$lib_file" "$target_path"
+                          done
+                      fi
+                  done
+
+                  echo "Jedis native libraries staged:"
+                  find java/jedis-compatibility/build/native-libs-staging -type f
 
             - name: Install protoc (protobuf)
               uses: arduino/setup-protoc@v3

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -331,11 +331,41 @@ jobs:
                   cd -
                   cp $src_folder/bundle.jar bundle-uber-jar.jar
 
+            - name: Build jedis-compatibility (no classifier, no natives)
+              working-directory: java
+              shell: bash
+              env:
+                  GLIDE_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+                  JEDIS_NO_CLASSIFIER_BUILD: "true"
+              run: |
+                  ./gradlew --build-cache :jedis-compatibility:publishToMavenLocal \
+                  -x buildRust \
+                  -Psigning.secretKeyRingFile=jedis-compatibility/secring.gpg \
+                  -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
+                  -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
+
+            - name: Bundle jedis-compatibility no-classifier JAR
+              working-directory: java
+              shell: bash
+              run: |
+                  src_folder=~/.m2/repository/io/valkey/valkey-glide-jedis-compatibility/${{ env.RELEASE_VERSION }}
+                  cd $src_folder
+                  jar -cvf jedis-bundle.jar *
+                  ls -ltr
+                  cd -
+                  cp $src_folder/jedis-bundle.jar jedis-bundle-no-classifier.jar
+
             - name: Upload uber JAR artifact
               uses: actions/upload-artifact@v4
               with:
                   name: java-uber-jar
                   path: java/bundle-uber-jar.jar
+
+            - name: Upload jedis no-classifier artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: jedis-no-classifier
+                  path: java/jedis-bundle-no-classifier.jar
 
     publish-to-maven-central-deployment:
         if: ${{ inputs.maven_publish == true || github.event_name == 'push' }}

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -340,7 +340,7 @@ jobs:
               run: |
                   ./gradlew --build-cache :jedis-compatibility:publishToMavenLocal \
                   -x buildRust \
-                  -Psigning.secretKeyRingFile=jedis-compatibility/secring.gpg \
+                  -Psigning.secretKeyRingFile=secring.gpg \
                   -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
                   -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
 

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -277,6 +277,29 @@ jobs:
                   echo "Native libraries staged:"
                   find java/client/build/native-libs-staging -type f
 
+            - name: Organize jedis native libraries for uber JAR
+              shell: bash
+              run: |
+                  # Create staging directory for jedis native libraries
+                  # Reuse the same native-libs-downloaded artifacts, preserving the
+                  # natives/{platform}/{arch}/ directory structure
+                  mkdir -p java/jedis-compatibility/build/native-libs-staging/natives
+
+                  for artifact_dir in native-libs-downloaded/native-lib-*; do
+                      if [ -d "$artifact_dir" ]; then
+                          echo "Processing $artifact_dir"
+                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
+                              rel_path="${lib_file#$artifact_dir/}"
+                              target_path="java/jedis-compatibility/build/native-libs-staging/natives/$rel_path"
+                              mkdir -p "$(dirname "$target_path")"
+                              cp "$lib_file" "$target_path"
+                          done
+                      fi
+                  done
+
+                  echo "Jedis native libraries staged:"
+                  find java/jedis-compatibility/build/native-libs-staging -type f
+
             - name: Install protoc (protobuf)
               uses: arduino/setup-protoc@v3
               with:
@@ -312,9 +335,19 @@ jobs:
                   GLIDE_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
                   UBER_JAR_BUILD: "true"
               run: |
-                  # Build uber JAR and publish to Maven local in one step
+                  # Build client uber JAR and publish to Maven local first.
                   # UBER_JAR_BUILD env var signals build.gradle to use copyAllNativeLibs
                   ./gradlew --build-cache :client:publishToMavenLocal \
+                  -x buildRust -x copyNativeLib \
+                  -Psigning.secretKeyRingFile=secring.gpg \
+                  -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
+                  -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
+
+                  # Build jedis-compatibility uber JAR. With UBER_JAR_BUILD=true it will:
+                  # - Depend on the published uber valkey-glide Maven artifact (from mavenLocal above)
+                  # - Use copyAllNativeLibs to bundle all platform native libraries
+                  # - Produce a classifier-less, platform-independent JAR
+                  ./gradlew --build-cache :jedis-compatibility:publishToMavenLocal \
                   -x buildRust -x copyNativeLib \
                   -Psigning.secretKeyRingFile=secring.gpg \
                   -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
@@ -324,6 +357,7 @@ jobs:
               working-directory: java
               shell: bash
               run: |
+                  # Bundle client uber JAR
                   src_folder=~/.m2/repository/io/valkey/valkey-glide/${{ env.RELEASE_VERSION }}
                   cd $src_folder
                   jar -cvf bundle.jar *
@@ -331,11 +365,21 @@ jobs:
                   cd -
                   cp $src_folder/bundle.jar bundle-uber-jar.jar
 
+                  # Bundle jedis-compatibility uber JAR
+                  jedis_src_folder=~/.m2/repository/io/valkey/valkey-glide-jedis-compatibility/${{ env.RELEASE_VERSION }}
+                  cd $jedis_src_folder
+                  jar -cvf jedis-bundle.jar *
+                  ls -ltr
+                  cd -
+                  cp $jedis_src_folder/jedis-bundle.jar jedis-bundle-uber-jar.jar
+
             - name: Upload uber JAR artifact
               uses: actions/upload-artifact@v4
               with:
                   name: java-uber-jar
-                  path: java/bundle-uber-jar.jar
+                  path: |
+                      java/bundle-uber-jar.jar
+                      java/jedis-bundle-uber-jar.jar
 
     publish-to-maven-central-deployment:
         if: ${{ inputs.maven_publish == true || github.event_name == 'push' }}

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -249,56 +249,33 @@ jobs:
                   echo "Downloaded native library artifacts:"
                   find native-libs-downloaded -type f
 
-            - name: Organize native libraries for uber JAR
+            - name: Organize native libraries for uber JARs
               shell: bash
               run: |
-                  # Create staging directory for native libraries
-                  mkdir -p java/client/build/native-libs-staging/natives
-
-                  # Copy all native libraries from downloaded artifacts
+                  # Stage native libraries into both client and jedis-compatibility modules.
                   # Structure: native-libs-downloaded/native-lib-{TARGET}/{platform}/{arch}/*.{so,dylib,dll}
-                  # Target structure: java/client/build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
-                  for artifact_dir in native-libs-downloaded/native-lib-*; do
-                      if [ -d "$artifact_dir" ]; then
-                          echo "Processing $artifact_dir"
-                          # Find all native library files and copy them preserving the platform/arch structure
-                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
-                              # Extract the relative path from the artifact directory
-                              rel_path="${lib_file#$artifact_dir/}"
-                              target_path="java/client/build/native-libs-staging/natives/$rel_path"
-                              # Create target directory if it doesn't exist
-                              mkdir -p "$(dirname "$target_path")"
-                              # Copy the file
-                              cp "$lib_file" "$target_path"
-                          done
-                      fi
+                  # Target:    java/<module>/build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
+                  STAGING_DIRS=(
+                      "java/client/build/native-libs-staging/natives"
+                      "java/jedis-compatibility/build/native-libs-staging/natives"
+                  )
+
+                  for staging_dir in "${STAGING_DIRS[@]}"; do
+                      mkdir -p "$staging_dir"
+                      for artifact_dir in native-libs-downloaded/native-lib-*; do
+                          if [ -d "$artifact_dir" ]; then
+                              echo "Processing $artifact_dir -> $staging_dir"
+                              find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
+                                  rel_path="${lib_file#$artifact_dir/}"
+                                  target_path="$staging_dir/$rel_path"
+                                  mkdir -p "$(dirname "$target_path")"
+                                  cp "$lib_file" "$target_path"
+                              done
+                          fi
+                      done
+                      echo "Native libraries staged in $staging_dir:"
+                      find "$staging_dir" -type f
                   done
-
-                  echo "Native libraries staged:"
-                  find java/client/build/native-libs-staging -type f
-
-            - name: Organize jedis native libraries for uber JAR
-              shell: bash
-              run: |
-                  # Create staging directory for jedis native libraries
-                  # Reuse the same native-libs-downloaded artifacts, preserving the
-                  # natives/{platform}/{arch}/ directory structure
-                  mkdir -p java/jedis-compatibility/build/native-libs-staging/natives
-
-                  for artifact_dir in native-libs-downloaded/native-lib-*; do
-                      if [ -d "$artifact_dir" ]; then
-                          echo "Processing $artifact_dir"
-                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
-                              rel_path="${lib_file#$artifact_dir/}"
-                              target_path="java/jedis-compatibility/build/native-libs-staging/natives/$rel_path"
-                              mkdir -p "$(dirname "$target_path")"
-                              cp "$lib_file" "$target_path"
-                          done
-                      fi
-                  done
-
-                  echo "Jedis native libraries staged:"
-                  find java/jedis-compatibility/build/native-libs-staging -type f
 
             - name: Install protoc (protobuf)
               uses: arduino/setup-protoc@v3

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -277,29 +277,6 @@ jobs:
                   echo "Native libraries staged:"
                   find java/client/build/native-libs-staging -type f
 
-            - name: Organize jedis native libraries for uber JAR
-              shell: bash
-              run: |
-                  # Create staging directory for jedis native libraries
-                  # Reuse the same native-libs-downloaded artifacts, preserving the
-                  # natives/{platform}/{arch}/ directory structure
-                  mkdir -p java/jedis-compatibility/build/native-libs-staging/natives
-
-                  for artifact_dir in native-libs-downloaded/native-lib-*; do
-                      if [ -d "$artifact_dir" ]; then
-                          echo "Processing $artifact_dir"
-                          find "$artifact_dir" -type f \( -name "*.so" -o -name "*.dylib" -o -name "*.dll" \) | while read -r lib_file; do
-                              rel_path="${lib_file#$artifact_dir/}"
-                              target_path="java/jedis-compatibility/build/native-libs-staging/natives/$rel_path"
-                              mkdir -p "$(dirname "$target_path")"
-                              cp "$lib_file" "$target_path"
-                          done
-                      fi
-                  done
-
-                  echo "Jedis native libraries staged:"
-                  find java/jedis-compatibility/build/native-libs-staging -type f
-
             - name: Install protoc (protobuf)
               uses: arduino/setup-protoc@v3
               with:
@@ -335,19 +312,9 @@ jobs:
                   GLIDE_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
                   UBER_JAR_BUILD: "true"
               run: |
-                  # Build client uber JAR and publish to Maven local first.
+                  # Build uber JAR and publish to Maven local in one step
                   # UBER_JAR_BUILD env var signals build.gradle to use copyAllNativeLibs
                   ./gradlew --build-cache :client:publishToMavenLocal \
-                  -x buildRust -x copyNativeLib \
-                  -Psigning.secretKeyRingFile=secring.gpg \
-                  -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
-                  -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
-
-                  # Build jedis-compatibility uber JAR. With UBER_JAR_BUILD=true it will:
-                  # - Depend on the published uber valkey-glide Maven artifact (from mavenLocal above)
-                  # - Use copyAllNativeLibs to bundle all platform native libraries
-                  # - Produce a classifier-less, platform-independent JAR
-                  ./gradlew --build-cache :jedis-compatibility:publishToMavenLocal \
                   -x buildRust -x copyNativeLib \
                   -Psigning.secretKeyRingFile=secring.gpg \
                   -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
@@ -357,7 +324,6 @@ jobs:
               working-directory: java
               shell: bash
               run: |
-                  # Bundle client uber JAR
                   src_folder=~/.m2/repository/io/valkey/valkey-glide/${{ env.RELEASE_VERSION }}
                   cd $src_folder
                   jar -cvf bundle.jar *
@@ -365,21 +331,11 @@ jobs:
                   cd -
                   cp $src_folder/bundle.jar bundle-uber-jar.jar
 
-                  # Bundle jedis-compatibility uber JAR
-                  jedis_src_folder=~/.m2/repository/io/valkey/valkey-glide-jedis-compatibility/${{ env.RELEASE_VERSION }}
-                  cd $jedis_src_folder
-                  jar -cvf jedis-bundle.jar *
-                  ls -ltr
-                  cd -
-                  cp $jedis_src_folder/jedis-bundle.jar jedis-bundle-uber-jar.jar
-
             - name: Upload uber JAR artifact
               uses: actions/upload-artifact@v4
               with:
                   name: java-uber-jar
-                  path: |
-                      java/bundle-uber-jar.jar
-                      java/jedis-bundle-uber-jar.jar
+                  path: java/bundle-uber-jar.jar
 
     publish-to-maven-central-deployment:
         if: ${{ inputs.maven_publish == true || github.event_name == 'push' }}

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     // Use published GLIDE artifact
     implementation group: 'io.valkey', name: 'valkey-glide', version: project.ext.defaultReleaseVersion, classifier: classifier
 
-    // Use published jedis-compatibility artifact
-    testImplementation group: 'io.valkey', name: 'valkey-glide-jedis-compatibility', version: project.ext.defaultReleaseVersion, classifier: osdetector.classifier
+    // Use project dependency for jedis-compatibility (resolves directly, no Maven Local needed)
+    testImplementation project(':jedis-compatibility')
 
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
     implementation 'com.google.code.gson:gson:2.13.2'
@@ -279,10 +279,10 @@ gradle.buildFinished {
         println "Failed to clean up cluster folders: ${e.message}"
     }
 }
-compileTestJava.dependsOn ':client:publishToMavenLocal', ':jedis-compatibility:publishToMavenLocal'
+compileTestJava.dependsOn ':client:publishToMavenLocal'
 
 tasks.withType(Test) {
-    dependsOn ':client:publishToMavenLocal', ':jedis-compatibility:publishToMavenLocal'
+    dependsOn ':client:publishToMavenLocal'
     useJUnitPlatform()
     if (!project.gradle.startParameter.taskNames.contains(':integTest:modulesTest')) {
         dependsOn 'beforeTests'

--- a/java/jedis-compatibility/build.gradle
+++ b/java/jedis-compatibility/build.gradle
@@ -7,11 +7,6 @@ plugins {
 }
 
 repositories {
-    // For uber JAR builds, the client uber JAR is published to mavenLocal first,
-    // so we need to resolve it from there before it reaches Maven Central.
-    if (System.getenv("UBER_JAR_BUILD") == "true") {
-        mavenLocal()
-    }
     mavenCentral()
 }
 
@@ -28,19 +23,10 @@ tasks.withType(Javadoc) {
 ext {
     // osdetector returns 'aarch_64', but rust triplet has 'aarch64'
     arch = osdetector.arch == 'aarch_64' ? 'aarch64' : osdetector.arch;
-    isUberJarBuild = System.getenv("UBER_JAR_BUILD") == "true"
 }
 
 dependencies {
-    // For uber JAR CD builds, depend on the published Maven artifact so the POM
-    // declares the correct transitive dependency on the platform-independent uber JAR.
-    // For local dev / CI / per-platform CD builds, use the Gradle project dependency.
-    if (project.ext.isUberJarBuild) {
-        def releaseVersion = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion
-        api "io.valkey:valkey-glide:${releaseVersion}"
-    } else {
-        implementation project(':client')
-    }
+    implementation project(':client')
 
     // Apache Commons Pool 2 for connection pooling - part of public API
     api group: 'org.apache.commons', name: 'commons-pool2', version: '2.12.1'
@@ -90,45 +76,12 @@ tasks.register('copyNativeLib', Copy) {
     into sourceSets.main.output.resourcesDir
 }
 
-// Task for uber JAR: copy all platform native libraries from a staging directory
-// populated by the CI workflow after downloading artifacts from all platform builds.
-// Structure mirrors the client: build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
-tasks.register('copyAllNativeLibs', Copy) {
-    description = 'Copy all platform native libraries for uber JAR build from downloaded artifacts'
-
-    def stagingDir = file("${projectDir}/build/native-libs-staging/natives")
-
-    from stagingDir
-    into "${sourceSets.main.output.resourcesDir}/natives"
-    include "**/*.dylib", "**/*.so", "**/*.dll"
-
-    onlyIf {
-        stagingDir.exists() && stagingDir.listFiles()?.length > 0
-    }
-
-    mustRunAfter processResources
-
-    doFirst {
-        println "Copying native libraries from staging: ${stagingDir}"
-        println "To resources dir: ${sourceSets.main.output.resourcesDir}/natives"
-    }
-}
-
-// For uber JAR builds, skip per-platform native lib copy and Rust build — use
-// copyAllNativeLibs which pulls from the CI staging directory instead.
-if (project.ext.isUberJarBuild) {
-    jar.dependsOn('copyAllNativeLibs')
-    javadoc.dependsOn('copyAllNativeLibs')
-    compileTestJava.dependsOn('copyAllNativeLibs')
-    delombok.dependsOn('compileJava')
-} else {
-    jar.dependsOn('copyNativeLib')
-    javadoc.dependsOn('copyNativeLib')
-    compileTestJava.dependsOn('copyNativeLib')
-    delombok.dependsOn('compileJava')
-    copyNativeLib.dependsOn(':client:buildRust')
-    compileJava.dependsOn(':client:jar')
-}
+jar.dependsOn('copyNativeLib')
+javadoc.dependsOn('copyNativeLib')
+compileTestJava.dependsOn('copyNativeLib')
+delombok.dependsOn('compileJava')
+copyNativeLib.dependsOn(':client:buildRust')
+compileJava.dependsOn(':client:jar')
 
 tasks.withType(Test) {
     useJUnitPlatform()
@@ -145,12 +98,8 @@ tasks.withType(Test) {
     }
 }
 
-// For uber JAR builds, produce a platform-independent JAR (no classifier).
-// For per-platform builds, keep the platform classifier as before.
 jar {
-    if (project.ext.isUberJarBuild) {
-        archiveClassifier = ''
-    } else if (project.hasProperty('target') && project.target.contains("musl")) {
+    if (project.hasProperty('target') && project.target.contains("musl")) {
         archiveClassifier = "linux_musl_${arch}"
     } else {
         archiveClassifier = osdetector.classifier
@@ -211,13 +160,6 @@ publishing {
 }
 
 publishMavenJavaPublicationToMavenLocal.dependsOn jar
-
-// Suppress Gradle module metadata (.module file). Multiple platform-classified JARs
-// are published under the same Maven coordinate, and the .module file cannot correctly
-// represent this. The POM is the source of truth for dependency declarations.
-tasks.withType(GenerateModuleMetadata) {
-    enabled = false
-}
 
 tasks.withType(Sign) {
     def releaseVersion = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion;

--- a/java/jedis-compatibility/build.gradle
+++ b/java/jedis-compatibility/build.gradle
@@ -60,27 +60,7 @@ javadoc {
     failOnError = false // Disable javadoc errors for compatibility layer
 }
 
-tasks.register('copyNativeLib', Copy) {
-    def target
-    if (project.hasProperty('target')) {
-        target = project.target
-        from "${projectDir}/../target/${target}/release/"
-    } else if (osdetector.os == 'linux' && osdetector.release.id != 'alpine') {
-        from "${projectDir}/../target/${arch}-unknown-linux-gnu/release/"
-    } else if (osdetector.os == 'linux' && osdetector.release.id == 'alpine') {
-        from "${projectDir}/../target/${arch}-unknown-linux-musl/release/"
-    } else {
-        from "${projectDir}/../target/release/"
-    }
-    include "*.dylib", "*.so", "*.dll"
-    into sourceSets.main.output.resourcesDir
-}
-
-jar.dependsOn('copyNativeLib')
-javadoc.dependsOn('copyNativeLib')
-compileTestJava.dependsOn('copyNativeLib')
 delombok.dependsOn('compileJava')
-copyNativeLib.dependsOn(':client:buildRust')
 compileJava.dependsOn(':client:jar')
 
 tasks.withType(Test) {
@@ -99,7 +79,11 @@ tasks.withType(Test) {
 }
 
 jar {
-    if (project.hasProperty('target') && project.target.contains("musl")) {
+    def isNoClassifierBuild = System.getenv("JEDIS_NO_CLASSIFIER_BUILD") == "true"
+
+    if (isNoClassifierBuild) {
+        archiveClassifier = ''
+    } else if (project.hasProperty('target') && project.target.contains("musl")) {
         archiveClassifier = "linux_musl_${arch}"
     } else {
         archiveClassifier = osdetector.classifier

--- a/java/jedis-compatibility/build.gradle
+++ b/java/jedis-compatibility/build.gradle
@@ -7,6 +7,11 @@ plugins {
 }
 
 repositories {
+    // For uber JAR builds, the client uber JAR is published to mavenLocal first,
+    // so we need to resolve it from there before it reaches Maven Central.
+    if (System.getenv("UBER_JAR_BUILD") == "true") {
+        mavenLocal()
+    }
     mavenCentral()
 }
 
@@ -23,10 +28,19 @@ tasks.withType(Javadoc) {
 ext {
     // osdetector returns 'aarch_64', but rust triplet has 'aarch64'
     arch = osdetector.arch == 'aarch_64' ? 'aarch64' : osdetector.arch;
+    isUberJarBuild = System.getenv("UBER_JAR_BUILD") == "true"
 }
 
 dependencies {
-    implementation project(':client')
+    // For uber JAR CD builds, depend on the published Maven artifact so the POM
+    // declares the correct transitive dependency on the platform-independent uber JAR.
+    // For local dev / CI / per-platform CD builds, use the Gradle project dependency.
+    if (project.ext.isUberJarBuild) {
+        def releaseVersion = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion
+        api "io.valkey:valkey-glide:${releaseVersion}"
+    } else {
+        implementation project(':client')
+    }
 
     // Apache Commons Pool 2 for connection pooling - part of public API
     api group: 'org.apache.commons', name: 'commons-pool2', version: '2.12.1'
@@ -76,12 +90,45 @@ tasks.register('copyNativeLib', Copy) {
     into sourceSets.main.output.resourcesDir
 }
 
-jar.dependsOn('copyNativeLib')
-javadoc.dependsOn('copyNativeLib')
-compileTestJava.dependsOn('copyNativeLib')
-delombok.dependsOn('compileJava')
-copyNativeLib.dependsOn(':client:buildRust')
-compileJava.dependsOn(':client:jar')
+// Task for uber JAR: copy all platform native libraries from a staging directory
+// populated by the CI workflow after downloading artifacts from all platform builds.
+// Structure mirrors the client: build/native-libs-staging/natives/{platform}/{arch}/*.{so,dylib,dll}
+tasks.register('copyAllNativeLibs', Copy) {
+    description = 'Copy all platform native libraries for uber JAR build from downloaded artifacts'
+
+    def stagingDir = file("${projectDir}/build/native-libs-staging/natives")
+
+    from stagingDir
+    into "${sourceSets.main.output.resourcesDir}/natives"
+    include "**/*.dylib", "**/*.so", "**/*.dll"
+
+    onlyIf {
+        stagingDir.exists() && stagingDir.listFiles()?.length > 0
+    }
+
+    mustRunAfter processResources
+
+    doFirst {
+        println "Copying native libraries from staging: ${stagingDir}"
+        println "To resources dir: ${sourceSets.main.output.resourcesDir}/natives"
+    }
+}
+
+// For uber JAR builds, skip per-platform native lib copy and Rust build — use
+// copyAllNativeLibs which pulls from the CI staging directory instead.
+if (project.ext.isUberJarBuild) {
+    jar.dependsOn('copyAllNativeLibs')
+    javadoc.dependsOn('copyAllNativeLibs')
+    compileTestJava.dependsOn('copyAllNativeLibs')
+    delombok.dependsOn('compileJava')
+} else {
+    jar.dependsOn('copyNativeLib')
+    javadoc.dependsOn('copyNativeLib')
+    compileTestJava.dependsOn('copyNativeLib')
+    delombok.dependsOn('compileJava')
+    copyNativeLib.dependsOn(':client:buildRust')
+    compileJava.dependsOn(':client:jar')
+}
 
 tasks.withType(Test) {
     useJUnitPlatform()
@@ -98,8 +145,12 @@ tasks.withType(Test) {
     }
 }
 
+// For uber JAR builds, produce a platform-independent JAR (no classifier).
+// For per-platform builds, keep the platform classifier as before.
 jar {
-    if (project.hasProperty('target') && project.target.contains("musl")) {
+    if (project.ext.isUberJarBuild) {
+        archiveClassifier = ''
+    } else if (project.hasProperty('target') && project.target.contains("musl")) {
         archiveClassifier = "linux_musl_${arch}"
     } else {
         archiveClassifier = osdetector.classifier
@@ -160,6 +211,13 @@ publishing {
 }
 
 publishMavenJavaPublicationToMavenLocal.dependsOn jar
+
+// Suppress Gradle module metadata (.module file). Multiple platform-classified JARs
+// are published under the same Maven coordinate, and the .module file cannot correctly
+// represent this. The POM is the source of truth for dependency declarations.
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
 
 tasks.withType(Sign) {
     def releaseVersion = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion;

--- a/java/jedis-compatibility/build.gradle
+++ b/java/jedis-compatibility/build.gradle
@@ -113,6 +113,7 @@ publishing {
             artifactId = 'valkey-glide-jedis-compatibility'
             version = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion
             pom {
+                packaging = 'jar'
                 name = 'valkey-glide-jedis-compatibility'
                 description = 'Jedis compatibility layer for Valkey GLIDE'
                 url = 'https://github.com/valkey-io/valkey-glide.git'


### PR DESCRIPTION
### Summary

Make `valkey-glide-jedis-compatibility` a pure-Java JAR by removing native library bundling, and publish a no-classifier variant so users no longer need to specify a platform classifier.

### Issue link

This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)
Closes <Issue #>

### Features / Behaviour Changes

**Before:** Users had to specify a platform classifier when depending on `valkey-glide-jedis-compatibility`:
```xml
<classifier>linux-x86_64</classifier>
```

**After:** No classifier needed. The uber JAR is resolved transitively via the POM:
```xml
<dependency>
    <groupId>io.valkey</groupId>
    <artifactId>valkey-glide-jedis-compatibility</artifactId>
    <version>2.3.0</version>
</dependency>
```

### Implementation

**`java/jedis-compatibility/build.gradle`:**
- Removed the `copyNativeLib` task and all its `dependsOn` references — the JAR no longer bundles native libraries
- Added `JEDIS_NO_CLASSIFIER_BUILD` env var support to the `jar` block:
  - `"true"` → no classifier (for the new no-classifier JAR)
  - Otherwise → existing classifier logic (musl or osdetector)

**`.github/workflows/java-cd.yml`:**
- Added 3 steps to the `create-uber-jar` job:
  1. Build jedis-compatibility with `JEDIS_NO_CLASSIFIER_BUILD=true` (skips Rust, reuses already-compiled client)
  2. Bundle the Maven local output into `jedis-bundle-no-classifier.jar`
  3. Upload as `jedis-no-classifier` artifact
- The publish job needs no changes — existing glob patterns pick up the new artifact automatically

### Limitations

- Classifier JARs are still published during the transition period (they now contain pure Java, same as the no-classifier JAR)
- Users who exclude the transitive `valkey-glide` dependency will get `UnsatisfiedLinkError` at runtime

### Testing

- YAML syntax validated for `java-cd.yml`
- Verified publish job glob patterns handle the new artifact
- Verified POM consistency across classifier and no-classifier builds

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
