### PR TITLE
test: fix cluster cleanup to handle TLS cluster prefixes

### DIFF
--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -69,6 +69,7 @@ func (suite *GlideTestSuite) SetupSuite() {
 	// Stop cluster in case previous test run was interrupted or crashed and didn't stop.
 	// If an error occurs, we ignore it in case the servers actually were stopped before running this.
 	runClusterManager(suite, []string{"stop", "--prefix", "cluster"}, true)
+	runClusterManager(suite, []string{"--tls", "stop", "--prefix", "cluster"}, true)
 
 	// Delete dirs if stop failed due to https://github.com/valkey-io/valkey-glide/issues/849
 	err := os.RemoveAll("../../utils/clusters")
@@ -303,6 +304,7 @@ func TestGlideTestSuite(t *testing.T) {
 
 func (suite *GlideTestSuite) TearDownSuite() {
 	runClusterManager(suite, []string{"stop", "--prefix", "cluster", "--keep-folder"}, true)
+	runClusterManager(suite, []string{"--tls", "stop", "--prefix", "cluster", "--keep-folder"}, true)
 }
 
 func (suite *GlideTestSuite) TearDownTest() {

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -84,7 +84,7 @@ tasks.register('stopAllAfterTests') {
         }
         exec {
             workingDir "${project.rootDir}/../utils"
-            commandLine getClusterCommand(['python3', 'cluster_manager.py', '--tls', 'stop', '--prefix', 'tls-cluster', '--keep-folder'])
+            commandLine getClusterCommand(['python3', 'cluster_manager.py', '--tls', 'stop', '--prefix', 'cluster', '--keep-folder'])
             ignoreExitValue true
         }
     }
@@ -102,7 +102,7 @@ tasks.register('stopAllBeforeTests') {
         }
         exec {
             workingDir "${project.rootDir}/../utils"
-            commandLine getClusterCommand(['python3', 'cluster_manager.py', '--tls', 'stop', '--prefix', 'tls-cluster'])
+            commandLine getClusterCommand(['python3', 'cluster_manager.py', '--tls', 'stop', '--prefix', 'cluster'])
             ignoreExitValue true
         }
     }

--- a/utils/TestUtils.ts
+++ b/utils/TestUtils.ts
@@ -182,12 +182,17 @@ export class ValkeyCluster {
     public async close(keepFolder = false): Promise<void> {
         if (this.clusterFolder) {
             await new Promise<void>((resolve, reject) => {
-                const commandArgs = [
-                    PY_SCRIPT_PATH,
+                const commandArgs = [PY_SCRIPT_PATH];
+
+                if (this.tls) {
+                    commandArgs.push(`--tls`);
+                }
+
+                commandArgs.push(
                     `stop`,
                     `--cluster-folder`,
                     `${this.clusterFolder}`,
-                ];
+                );
 
                 if (keepFolder) {
                     commandArgs.push(`--keep-folder`);

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -1337,14 +1337,15 @@ def main():
                 "One of following arguments is required: --cluster-folder or --prefix"
             )
         tic = time.perf_counter()
+        stop_prefix = f"tls-{args.prefix}" if args.tls and args.prefix else args.prefix
         logging.info(
-            f"{datetime.now(timezone.utc)} Stopping script for cluster/s {args.cluster_folder or f'{args.prefix}*'} in {args.folder_path}"
+            f"{datetime.now(timezone.utc)} Stopping script for cluster/s {args.cluster_folder or f'{stop_prefix}*'} in {args.folder_path}"
         )
 
         stop_clusters(
             args.host,
             args.folder_path,
-            args.prefix,
+            stop_prefix,
             args.cluster_folder,
             args.tls,
             args.auth,


### PR DESCRIPTION
### Summary

- Add TLS cluster cleanup in Go test suite SetupSuite and TearDownSuite
- Update Java integration tests to use consistent 'cluster' prefix for TLS cleanup
- Refactor TypeScript TestUtils to conditionally add --tls flag before stop command
- Fix cluster_manager.py to prepend 'tls-' prefix when both --tls and --prefix are specified

### Issue link

This Pull Request is linked to issue: #5494
Closes #5494

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
