### PR TITLE
fix(java): remove Java-side inflight counter, let Rust be sole authority

### DIFF
--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -22,30 +21,25 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <ul>
  *   <li>Maintain a thread-safe mapping from correlation id to the original future
- *   <li>Enforce per-client max inflight requests in Java (0 = defer to core default)
  *   <li>Schedule optional Java-side timeouts with cancellable tasks
  *   <li>Perform atomic cleanup on completion to avoid races and leaks
  * </ul>
  *
+ * <p>Inflight request limits are enforced exclusively by the Rust core via {@code
+ * InflightRequestTracker}. Java does not maintain its own counter — this avoids desync between
+ * Java-side and Rust-side counters that previously allowed zombie sub-command accumulation.
+ *
  * <p>Timeouts can be enforced at the Java layer (for immediate user feedback) or deferred to the
- * Rust core (when timeoutMillis = 0). Backpressure defaults and concurrency tuning are handled by
- * the Rust core.
+ * Rust core (when timeoutMillis = 0).
  */
 public final class AsyncRegistry {
 
     /** Thread-safe storage for active futures. Using ConcurrentHashMap for lock-free operations. */
     private static final ConcurrentHashMap<Long, CompletableFuture<Object>> activeFutures =
-            new ConcurrentHashMap<>(estimateInitialCapacity());
+            new ConcurrentHashMap<>();
 
     /** Scheduled timeout tasks mapped by correlation ID for cancellation on completion. */
     private static final ConcurrentHashMap<Long, ScheduledFuture<?>> timeoutTasks =
-            new ConcurrentHashMap<>();
-
-    /**
-     * Per-client inflight request counters. Maps client handle to the number of active requests for
-     * that client.
-     */
-    private static final ConcurrentHashMap<Long, AtomicInteger> clientInflightCounts =
             new ConcurrentHashMap<>();
 
     /** Thread-safe ID generator for correlation IDs. */
@@ -78,45 +72,20 @@ public final class AsyncRegistry {
         }
     }
 
-    /** Estimate initial capacity for the active futures map using inflight limit with margin. */
-    private static int estimateInitialCapacity() {
-        String env = System.getenv("GLIDE_MAX_INFLIGHT_REQUESTS");
-        if (env != null) {
-            try {
-                int v = Integer.parseInt(env.trim());
-                if (v > 0) return Math.max(16, v * 2);
-            } catch (NumberFormatException ignored) {
-            }
-        }
-
-        String prop = System.getProperty("glide.maxInflightRequests");
-        if (prop != null) {
-            try {
-                int v = Integer.parseInt(prop.trim());
-                if (v > 0) return Math.max(16, v * 2);
-            } catch (NumberFormatException ignored) {
-            }
-        }
-
-        return 2000; // Default with margin over core's 1000
-    }
-
     /**
-     * Register future with client-specific inflight limit, client handle for per-client tracking, and
-     * optional Java-side timeout.
+     * Register a future for native callback correlation with optional Java-side timeout.
      *
      * <p>If the registry is shutting down, the future will be completed exceptionally with a
      * ClosingException and a special correlation ID (0) will be returned to indicate the registration
      * failed.
      *
      * @param future the future to register
-     * @param maxInflightRequests per-client limit (0 = no Java-side limit, defer to core)
-     * @param clientHandle native client handle for tracking
+     * @param clientHandle native client handle (reserved for future per-client tracking)
      * @param timeoutMillis Java-side timeout in milliseconds (0 = use Rust default timeout)
      * @return correlation ID for native callback, or 0 if shutdown is in progress
      */
     public static <T> long register(
-            CompletableFuture<T> future, int maxInflightRequests, long clientHandle, long timeoutMillis) {
+            CompletableFuture<T> future, long clientHandle, long timeoutMillis) {
         if (future == null) {
             throw new IllegalArgumentException("Future cannot be null");
         }
@@ -127,12 +96,6 @@ public final class AsyncRegistry {
             future.completeExceptionally(
                     new ClosingException("Client is shutting down, cannot register new requests"));
             return 0L; // Special ID indicating registration failed
-        }
-
-        // Client-specific inflight limit check
-        // 0 means "use native/core defaults" - no limit enforcement in Java layer
-        if (maxInflightRequests > 0) {
-            enforceInflightLimit(clientHandle, maxInflightRequests);
         }
 
         long correlationId = nextId.getAndIncrement();
@@ -148,9 +111,6 @@ public final class AsyncRegistry {
         // If shutdown started between our first check and the put(), clean up and fail
         if (isShutdown.get()) {
             activeFutures.remove(correlationId);
-            if (maxInflightRequests > 0) {
-                decrementInflightCount(clientHandle);
-            }
             future.completeExceptionally(
                     new ClosingException("Client is shutting down, cannot register new requests"));
             return 0L;
@@ -163,23 +123,9 @@ public final class AsyncRegistry {
 
         // Set up cleanup on the original future
         // This ensures proper resource cleanup when completed
-        setupCleanup(correlationId, originalFuture, maxInflightRequests, clientHandle);
+        setupCleanup(correlationId, originalFuture);
 
         return correlationId;
-    }
-
-    /** Enforce per-client inflight limit, throwing RequestException if exceeded. */
-    private static void enforceInflightLimit(long clientHandle, int maxInflightRequests) {
-        clientInflightCounts.compute(
-                clientHandle,
-                (key, counter) -> {
-                    AtomicInteger value = counter != null ? counter : new AtomicInteger(0);
-                    if (value.incrementAndGet() > maxInflightRequests) {
-                        value.decrementAndGet();
-                        throw new RequestException("Client reached maximum inflight requests");
-                    }
-                    return value;
-                });
     }
 
     /**
@@ -205,11 +151,7 @@ public final class AsyncRegistry {
      * Set up cleanup handler for when the future completes (success, error, or timeout). Performs
      * atomic cleanup to avoid races and leaks.
      */
-    private static void setupCleanup(
-            long correlationId,
-            CompletableFuture<Object> future,
-            int maxInflightRequests,
-            long clientHandle) {
+    private static void setupCleanup(long correlationId, CompletableFuture<Object> future) {
         future.whenComplete(
                 (result, error) -> {
                     // Atomic cleanup - no race conditions
@@ -221,23 +163,6 @@ public final class AsyncRegistry {
                     if (timeoutTask != null) {
                         timeoutTask.cancel(false);
                     }
-
-                    // Decrement per-client counter if applicable
-                    if (maxInflightRequests > 0) {
-                        decrementInflightCount(clientHandle);
-                    }
-                });
-    }
-
-    /** Decrement inflight count for client, removing the entry when it reaches zero. */
-    private static void decrementInflightCount(long clientHandle) {
-        clientInflightCounts.computeIfPresent(
-                clientHandle,
-                (key, counter) -> {
-                    int remaining = counter.decrementAndGet();
-                    // Clean up the entry when no more inflight requests
-                    // to avoid leaking counters for inactive clients
-                    return remaining <= 0 ? null : counter;
                 });
     }
 
@@ -315,7 +240,6 @@ public final class AsyncRegistry {
         // Cancel user futures with interrupt (may be blocked waiting)
         activeFutures.values().forEach(future -> future.cancel(true));
         activeFutures.clear();
-        clientInflightCounts.clear();
 
         // Shutdown the timeout scheduler
         timeoutScheduler.shutdownNow();
@@ -342,12 +266,6 @@ public final class AsyncRegistry {
 
         timeoutTasks.values().forEach(task -> task.cancel(false));
         timeoutTasks.clear();
-        clientInflightCounts.clear();
-    }
-
-    /** Clean up per-client tracking when a client is closed. */
-    public static void cleanupClient(long clientHandle) {
-        clientInflightCounts.remove(clientHandle);
     }
 
     /** Reset all internal state. Intended for test isolation and client shutdown cleanup. */
@@ -359,7 +277,6 @@ public final class AsyncRegistry {
         timeoutTasks.values().forEach(task -> task.cancel(false));
         timeoutTasks.clear();
         activeFutures.clear();
-        clientInflightCounts.clear();
         nextId.set(1);
     }
 

--- a/java/client/src/main/java/glide/internal/GlideCoreClient.java
+++ b/java/client/src/main/java/glide/internal/GlideCoreClient.java
@@ -213,7 +213,7 @@ public class GlideCoreClient implements AutoCloseable {
             CompletableFuture<Object> future = new CompletableFuture<>();
             long correlationId;
             try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle, timeoutMs);
+                correlationId = AsyncRegistry.register(future, handle, timeoutMs);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -261,7 +261,7 @@ public class GlideCoreClient implements AutoCloseable {
             CompletableFuture<Object> future = new CompletableFuture<>();
             long correlationId;
             try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle, timeoutMs);
+                correlationId = AsyncRegistry.register(future, handle, timeoutMs);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -299,7 +299,7 @@ public class GlideCoreClient implements AutoCloseable {
                             ? timeoutOverrideMs
                             : this.requestTimeoutMillis;
             try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle, timeoutMs);
+                correlationId = AsyncRegistry.register(future, handle, timeoutMs);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -339,8 +339,7 @@ public class GlideCoreClient implements AutoCloseable {
             long correlationId;
             try {
                 correlationId =
-                        AsyncRegistry.register(
-                                future, this.maxInflightRequests, handle, this.requestTimeoutMillis);
+                        AsyncRegistry.register(future, handle, this.requestTimeoutMillis);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -373,8 +372,7 @@ public class GlideCoreClient implements AutoCloseable {
         long correlationId;
         try {
             correlationId =
-                    AsyncRegistry.register(
-                            future, this.maxInflightRequests, handle, this.requestTimeoutMillis);
+                    AsyncRegistry.register(future, handle, this.requestTimeoutMillis);
         } catch (glide.api.models.exceptions.RequestException e) {
             future.completeExceptionally(e);
             return future;
@@ -398,8 +396,7 @@ public class GlideCoreClient implements AutoCloseable {
         long correlationId;
         try {
             correlationId =
-                    AsyncRegistry.register(
-                            future, this.maxInflightRequests, handle, this.requestTimeoutMillis);
+                    AsyncRegistry.register(future, handle, this.requestTimeoutMillis);
         } catch (glide.api.models.exceptions.RequestException e) {
             future.completeExceptionally(e);
             return future;
@@ -431,8 +428,7 @@ public class GlideCoreClient implements AutoCloseable {
             long correlationId;
             try {
                 correlationId =
-                        AsyncRegistry.register(
-                                future, this.maxInflightRequests, handle, this.requestTimeoutMillis);
+                        AsyncRegistry.register(future, handle, this.requestTimeoutMillis);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -503,7 +499,6 @@ public class GlideCoreClient implements AutoCloseable {
             }
             try {
                 // Clean up per-client inflight tracking
-                AsyncRegistry.cleanupClient(handle);
                 GlideNativeBridge.closeClient(handle);
             } finally {
                 // Reset AsyncRegistry only when no clients remain (test isolation / full shutdown)
@@ -544,7 +539,6 @@ public class GlideCoreClient implements AutoCloseable {
             if (ptr != 0) {
                 nativeState.nativePtr = 0;
                 // Clean up per-client inflight tracking
-                AsyncRegistry.cleanupClient(ptr);
                 GlideNativeBridge.closeClient(ptr);
             }
         }

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -420,8 +420,6 @@ public class ConnectionManager {
                 () -> {
                     if (!isClosed && nativeClientHandle != 0) {
                         try {
-                            // Clean up any pending async operations for this client
-                            AsyncRegistry.cleanupClient(nativeClientHandle);
                             GlideNativeBridge.closeClient(nativeClientHandle);
                         } finally {
                             isClosed = true;
@@ -441,9 +439,6 @@ public class ConnectionManager {
         try {
             // Mark as closed immediately to prevent new commands
             isClosed = true;
-
-            // Clean up any pending async operations for this client
-            AsyncRegistry.cleanupClient(nativeClientHandle);
 
             // Close the native client handle
             if (nativeClientHandle != 0) {

--- a/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
+++ b/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
@@ -27,9 +27,9 @@ public class AsyncRegistryTest {
         CompletableFuture<Object> f3 = new CompletableFuture<>();
 
         // timeoutMillis=0 avoids native call to markTimedOut
-        AsyncRegistry.register(f1, 0, 1L, 0);
-        AsyncRegistry.register(f2, 0, 1L, 0);
-        AsyncRegistry.register(f3, 0, 1L, 0);
+        AsyncRegistry.register(f1, 1L, 0);
+        AsyncRegistry.register(f2, 1L, 0);
+        AsyncRegistry.register(f3, 1L, 0);
 
         assertEquals(3, AsyncRegistry.getActiveFutureCount());
 
@@ -49,7 +49,7 @@ public class AsyncRegistryTest {
     @Test
     void failAllWithError_withNullMessage_usesDefault() {
         CompletableFuture<Object> f = new CompletableFuture<>();
-        AsyncRegistry.register(f, 0, 1L, 0);
+        AsyncRegistry.register(f, 1L, 0);
 
         AsyncRegistry.failAllWithError(null);
 
@@ -60,7 +60,7 @@ public class AsyncRegistryTest {
     @Test
     void failAllWithError_withEmptyMessage_usesDefault() {
         CompletableFuture<Object> f = new CompletableFuture<>();
-        AsyncRegistry.register(f, 0, 1L, 0);
+        AsyncRegistry.register(f, 1L, 0);
 
         AsyncRegistry.failAllWithError("");
 
@@ -78,7 +78,7 @@ public class AsyncRegistryTest {
     @Test
     void failAllWithError_raceWithNormalCompletion() {
         CompletableFuture<Object> f = new CompletableFuture<>();
-        long id = AsyncRegistry.register(f, 0, 1L, 0);
+        long id = AsyncRegistry.register(f, 1L, 0);
 
         // Complete normally first
         AsyncRegistry.completeCallback(id, "normal result");
@@ -91,20 +91,6 @@ public class AsyncRegistryTest {
         assertEquals("normal result", f.getNow(null));
     }
 
-    @Test
-    void failAllWithError_clearsInflightCounters() {
-        CompletableFuture<Object> f1 = new CompletableFuture<>();
-        // Register with inflight limit of 1
-        AsyncRegistry.register(f1, 1, 42L, 0);
-
-        // Sweep clears counters
-        AsyncRegistry.failAllWithError("msg");
-
-        // Should be able to register again on the same client (counter was reset)
-        CompletableFuture<Object> f2 = new CompletableFuture<>();
-        assertDoesNotThrow(() -> AsyncRegistry.register(f2, 1, 42L, 0));
-    }
-
     // ==================== Shutdown Race Condition Tests ====================
 
     @Test
@@ -115,7 +101,7 @@ public class AsyncRegistryTest {
 
         // Now try to register a new future
         CompletableFuture<Object> f = new CompletableFuture<>();
-        long id = AsyncRegistry.register(f, 0, 1L, 0);
+        long id = AsyncRegistry.register(f, 1L, 0);
 
         // Should return 0 (special ID indicating registration failed)
         assertEquals(0L, id);
@@ -150,31 +136,10 @@ public class AsyncRegistryTest {
 
         // Should be able to register again
         CompletableFuture<Object> f = new CompletableFuture<>();
-        long id = AsyncRegistry.register(f, 0, 1L, 0);
+        long id = AsyncRegistry.register(f, 1L, 0);
 
         assertTrue(id > 0);
         assertEquals(1, AsyncRegistry.getActiveFutureCount());
-    }
-
-    @Test
-    void register_afterShutdown_doesNotIncrementInflightCounter() {
-        // Trigger shutdown
-        AsyncRegistry.failAllWithError("shutdown");
-
-        // Try to register with inflight limit
-        CompletableFuture<Object> f = new CompletableFuture<>();
-        long id = AsyncRegistry.register(f, 10, 42L, 0);
-
-        assertEquals(0L, id);
-
-        // Reset and verify we can register the full limit (counter wasn't incremented)
-        AsyncRegistry.reset();
-
-        for (int i = 0; i < 10; i++) {
-            CompletableFuture<Object> fi = new CompletableFuture<>();
-            long regId = AsyncRegistry.register(fi, 10, 42L, 0);
-            assertTrue(regId > 0, "Registration " + i + " should succeed");
-        }
     }
 
     @Test


### PR DESCRIPTION
## Remove Java-side inflight counter, let Rust be sole authority

Follow-up to #5632 (InflightRequestTracker). Cherry-pick version in #5642.

### The Problem

Both Rust and Java had independent inflight counters that released on timeout -- while zombie sub-commands were still alive in the event loop:

```
         Java counter          Rust counter
Send:       0 -> 1              1000 -> 999
Timeout:    1 -> 0  (freed!)    999 (held -- zombies alive)
Send:       0 -> 1  (allowed!)  999 -> 998  <-- new zombie
Timeout:    1 -> 0  (freed!)    998 (held)
  ...60 threads doing this...
  ...180 new zombies/second...
  ...54K zombies after 5 min -> permanent freeze
```

PR #5632 fixed Rust: `InflightRequestTracker` RAII guard holds the slot until the zombie actually finishes. But Java's `AsyncRegistry` counter still recycled on timeout (`whenComplete` callback), defeating the fix. Default config (`maxInflightRequests=1000`) meant this was active for all users.

### The Fix

Remove Java's counter entirely (-129 lines). Rust is the sole inflight authority.

- `AsyncRegistry.java`: removed `clientInflightCounts`, `enforceInflightLimit()`, `decrementInflightCount()`, `cleanupClient()`. Simplified `register()` signature.
- `GlideCoreClient.java`: updated `register()` calls
- `ConnectionManager.java`: removed `cleanupClient()` calls

### Chaos Test A/B (4-core pods, 60 threads, 5s netem)

| | Old v2.2 | Fix |
|---|---------|-----|
| Under chaos | Freeze within 5min | Stable at 60/s |
| After chaos removed | **Permanent freeze** (9+ min) | **Recovered in 15s** |

### Test plan
- [x] `AsyncRegistryTest` passes
- [x] 15-min sustained chaos test -- stable, instant recovery
- [x] A/B comparison with old v2.2 -- old freezes permanently, fix recovers
