### PR TITLE
Python: Downgrade protobuf dependency to >=3.20

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -188,9 +188,55 @@ jobs:
                   publish: "true"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
+            - name: Install protoc 3.20.0
+              run: |
+                  PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+
+                  OS=$(uname -s)
+                  ARCH=$(uname -m)
+
+                  # Determine OS prefix
+                  if [[ "$OS" == "Linux" ]]; then
+                    OS_PREFIX="linux"
+                  elif [[ "$OS" == "Darwin" ]]; then
+                    OS_PREFIX="osx"
+                  else
+                    echo "Unsupported OS: $OS"
+                    exit 1
+                  fi
+
+                  # Determine architecture
+                  if [[ "$ARCH" == "x86_64" ]]; then
+                    PROTOC_ARCH="x86_64"
+                  elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+                    PROTOC_ARCH="aarch_64"
+                  else
+                    echo "Unsupported architecture: $ARCH"
+                    exit 1
+                  fi
+
+                  # Use 3.20.0 (has all platform binaries including osx-aarch_64)
+                  PROTOC_ZIP="protoc-3.20.0-${OS_PREFIX}-${PROTOC_ARCH}.zip"
+                  echo "Downloading: $PROTOC_ZIP"
+
+                  curl -LO "$PB_REL/download/v3.20.0/$PROTOC_ZIP"
+
+                  # Install to a custom directory, not /usr/local
+                  sudo mkdir -p /opt/protoc
+                  sudo unzip -o "$PROTOC_ZIP" -d /opt/protoc
+
+                  # Add only the protoc bin directory to PATH
+                  echo "/opt/protoc/bin" >> $GITHUB_PATH
+
+                  /opt/protoc/bin/protoc --version
+
             - name: Generate protobuf files
               working-directory: ./python
               run: |
+                  # Verify correct protoc is used
+                  which protoc
+                  protoc --version
+
                   python3 dev.py protobuf
 
             - name: Include protobuf files in the package

--- a/python/glide-async/pyproject.toml
+++ b/python/glide-async/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     # Note: If you add a dependency here, make sure to also add it to glide-async/requirements.txt
     # Once issue https://github.com/aboutcode-org/python-inspector/issues/197 is resolved, the requirements.txt file can be removed.
     "anyio>=4.9.0",
-    "protobuf>=6.20",
+    "protobuf>=3.20",
     "sniffio",
     "typing-extensions>=4.8.0; python_version < '3.11'",
 ]

--- a/python/glide-shared/pyproject.toml
+++ b/python/glide-shared/pyproject.toml
@@ -5,7 +5,7 @@ description = "Shared code for GLIDE Python clients"
 dependencies = [
     # ⚠️  Note: If you add a dependency here, make sure to also add it to the requirements.txt files under glide-async and glide-sync.
     # Once issue https://github.com/aboutcode-org/python-inspector/issues/197 is resolved, the requirements.txt file can be removed.
-    "protobuf>=6.20",
+    "protobuf>=3.20",
     "typing-extensions>=4.8.0; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
## Summary

- Lowers the minimum protobuf Python dependency from `>=6.20` to `>=3.20` for `glide-async` and `glide-shared`
- Installs `protoc 3.20.0` in the PyPI CD workflow to generate backward-compatible protobuf files
- Broadens compatibility for users pinned to older protobuf versions

issue -  https://github.com/valkey-io/valkey-glide/issues/5221

## Tested Compatibility Matrix

Validated on the [PyPI CD workflow](https://github.com/valkey-io/valkey-glide/actions/runs/22435539064/) across **4 platforms** (Linux x86_64, Linux aarch64, macOS arm64, macOS x86_64) with both async and sync clients.

### CPython

| Python | 3.20.0 | 3.20.3 | 4.21.12 | 4.25.8 | 5.26.1 | 5.29.6 | 6.30.2 | 6.33.5 |
|--------|--------|--------|---------|--------|--------|--------|--------|--------|
| 3.9    | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.10   | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.11   | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.12   | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.13   | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.14   | ⏭️     | ⏭️     | ⏭️      | ⏭️     | ⏭️     | ✅     | ✅     | ✅     |

### PyPy

| PyPy   | 3.20.0 | 3.20.3 | 4.21.12 | 4.25.8 | 5.26.1 | 5.29.6 | 6.30.2 | 6.33.5 |
|--------|--------|--------|---------|--------|--------|--------|--------|--------|
| 3.9    | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.10   | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |
| 3.11   | ✅     | ✅     | ✅      | ✅     | ✅     | ✅     | ✅     | ✅     |

⏭️ = Skipped (Python 3.14 + protobuf < 5.29 — known incompatibility with metaclass `tp_new` removal)