### PR TITLE
fix(java): remove Java-side inflight counter, let Rust be sole authority

### DIFF
--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -12,83 +12,33 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <ul>
  *   <li>Maintain a thread-safe mapping from correlation id to the original future
- *   <li>Enforce per-client max inflight requests in Java (0 = defer to core default)
  *   <li>Perform atomic cleanup on completion to avoid races and leaks
  *   <li>Provide batched completion helpers to reduce native call overhead
  * </ul>
  *
- * <p>Timeouts, backpressure defaults, and concurrency tuning are handled by the Rust core.
+ * <p>Inflight request limits are enforced exclusively by the Rust core via {@code
+ * InflightRequestTracker}. Java does not maintain its own counter — this avoids desync between
+ * Java-side and Rust-side counters that previously allowed zombie sub-command accumulation.
  */
 public final class AsyncRegistry {
 
     /** Thread-safe storage for active futures Using ConcurrentHashMap for lock-free operations */
     private static final ConcurrentHashMap<Long, CompletableFuture<Object>> activeFutures =
-            // Size based on max inflight requests with a small margin
-            new ConcurrentHashMap<>(estimateInitialCapacity());
-
-    /**
-     * Per-client inflight request counters Maps client handle to the number of active requests for
-     * that client
-     */
-    private static final ConcurrentHashMap<Long, java.util.concurrent.atomic.AtomicInteger>
-            clientInflightCounts = new ConcurrentHashMap<>();
+            new ConcurrentHashMap<>();
 
     /** Thread-safe ID generator */
     private static final AtomicLong nextId = new AtomicLong(1);
 
-    // ==================== CONFIGURABLE CONSTANTS ====================
-
-    /** Estimate initial capacity for the active futures map using inflight limit with margin */
-    private static int estimateInitialCapacity() {
-        String env = System.getenv("GLIDE_MAX_INFLIGHT_REQUESTS");
-        if (env != null) {
-            try {
-                int v = Integer.parseInt(env.trim());
-                if (v > 0) return Math.max(16, v * 2);
-            } catch (NumberFormatException ignored) {
-            }
-        }
-
-        String prop = System.getProperty("glide.maxInflightRequests");
-        if (prop != null) {
-            try {
-                int v = Integer.parseInt(prop.trim());
-                if (v > 0) return Math.max(16, v * 2);
-            } catch (NumberFormatException ignored) {
-            }
-        }
-
-        // Fall back to Rust core default (1000) with margin
-        return 2000;
-    }
-
     /**
-     * Register future with client-specific inflight limit and client handle for per-client tracking
+     * Register future for native callback correlation.
+     *
+     * @param future the future to register
+     * @param clientHandle native client handle (reserved for future per-client tracking)
+     * @return correlation ID for native callback
      */
-    public static <T> long register(
-            CompletableFuture<T> future, int maxInflightRequests, long clientHandle) {
+    public static <T> long register(CompletableFuture<T> future, long clientHandle) {
         if (future == null) {
             throw new IllegalArgumentException("Future cannot be null");
-        }
-
-        // Client-specific inflight limit check
-        // 0 means "use native/core defaults" - no limit enforcement in Java layer
-        if (maxInflightRequests > 0) {
-            clientInflightCounts.compute(
-                    clientHandle,
-                    (key, counter) -> {
-                        java.util.concurrent.atomic.AtomicInteger value =
-                                counter != null ? counter : new java.util.concurrent.atomic.AtomicInteger(0);
-
-                        int updated = value.incrementAndGet();
-                        if (updated > maxInflightRequests) {
-                            value.decrementAndGet();
-                            throw new glide.api.models.exceptions.RequestException(
-                                    "Client reached maximum inflight requests");
-                        }
-
-                        return value;
-                    });
         }
 
         long correlationId = nextId.getAndIncrement();
@@ -106,23 +56,6 @@ public final class AsyncRegistry {
                 (result, throwable) -> {
                     // Atomic cleanup - no race conditions
                     activeFutures.remove(correlationId);
-
-                    // Decrement per-client counter if applicable
-                    if (maxInflightRequests > 0) {
-                        clientInflightCounts.compute(
-                                clientHandle,
-                                (key, counter) -> {
-                                    if (counter == null) {
-                                        return null;
-                                    }
-
-                                    int remaining = counter.decrementAndGet();
-
-                                    // Clean up the entry when no more inflight requests to avoid
-                                    // leaking counters for inactive clients.
-                                    return remaining <= 0 ? null : counter;
-                                });
-                    }
                 });
 
         return correlationId;
@@ -206,18 +139,11 @@ public final class AsyncRegistry {
 
         // Clear the map
         activeFutures.clear();
-        clientInflightCounts.clear();
-    }
-
-    /** Clean up per-client tracking when a client is closed */
-    public static void cleanupClient(long clientHandle) {
-        clientInflightCounts.remove(clientHandle);
     }
 
     /** Reset all internal state. Intended for test isolation and client shutdown cleanup. */
     public static void reset() {
         activeFutures.clear();
-        clientInflightCounts.clear();
         nextId.set(1);
     }
 

--- a/java/client/src/main/java/glide/internal/GlideCoreClient.java
+++ b/java/client/src/main/java/glide/internal/GlideCoreClient.java
@@ -88,7 +88,10 @@ public class GlideCoreClient implements AutoCloseable {
         return nativeClientHandle.get();
     }
 
-    /** Maximum number of inflight requests allowed for this client. */
+    /**
+     * Maximum inflight requests — passed to Rust core via protobuf ConnectionRequest. Not enforced on
+     * the Java side; Rust's InflightRequestTracker is the sole authority.
+     */
     private final int maxInflightRequests;
 
     public int getMaxInflightRequests() {
@@ -151,7 +154,7 @@ public class GlideCoreClient implements AutoCloseable {
             long correlationId;
             try {
                 // Rust handles all timeout logic - Java just waits for response
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+                correlationId = AsyncRegistry.register(future, handle);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -187,7 +190,7 @@ public class GlideCoreClient implements AutoCloseable {
             long correlationId;
             try {
                 // Rust handles all timeout logic - Java just waits for response
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+                correlationId = AsyncRegistry.register(future, handle);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -223,7 +226,7 @@ public class GlideCoreClient implements AutoCloseable {
             CompletableFuture<Object> future = new CompletableFuture<>();
             long correlationId;
             try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+                correlationId = AsyncRegistry.register(future, handle);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -262,7 +265,7 @@ public class GlideCoreClient implements AutoCloseable {
             CompletableFuture<Object> future = new CompletableFuture<>();
             long correlationId;
             try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+                correlationId = AsyncRegistry.register(future, handle);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -294,7 +297,7 @@ public class GlideCoreClient implements AutoCloseable {
         CompletableFuture<String> future = new CompletableFuture<>();
         long correlationId;
         try {
-            correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+            correlationId = AsyncRegistry.register(future, handle);
         } catch (glide.api.models.exceptions.RequestException e) {
             future.completeExceptionally(e);
             return future;
@@ -317,7 +320,7 @@ public class GlideCoreClient implements AutoCloseable {
 
         long correlationId;
         try {
-            correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+            correlationId = AsyncRegistry.register(future, handle);
         } catch (glide.api.models.exceptions.RequestException e) {
             future.completeExceptionally(e);
             return future;
@@ -348,7 +351,7 @@ public class GlideCoreClient implements AutoCloseable {
             CompletableFuture<Object> future = new CompletableFuture<>();
             long correlationId;
             try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle);
+                correlationId = AsyncRegistry.register(future, handle);
             } catch (glide.api.models.exceptions.RequestException e) {
                 future.completeExceptionally(e);
                 return future;
@@ -418,8 +421,6 @@ public class GlideCoreClient implements AutoCloseable {
             } catch (Throwable ignore) {
             }
             try {
-                // Clean up per-client inflight tracking
-                AsyncRegistry.cleanupClient(handle);
                 GlideNativeBridge.closeClient(handle);
             } finally {
                 // Reset AsyncRegistry only when no clients remain (test isolation / full shutdown)
@@ -455,8 +456,6 @@ public class GlideCoreClient implements AutoCloseable {
             long ptr = nativeState.nativePtr;
             if (ptr != 0) {
                 nativeState.nativePtr = 0;
-                // Clean up per-client inflight tracking
-                AsyncRegistry.cleanupClient(ptr);
                 GlideNativeBridge.closeClient(ptr);
             }
         }

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -16,7 +16,6 @@ import glide.api.models.configuration.ServerCredentials;
 import glide.api.models.configuration.TlsAdvancedConfiguration;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConfigurationError;
-import glide.internal.AsyncRegistry;
 import glide.internal.GlideNativeBridge;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -408,8 +407,6 @@ public class ConnectionManager {
                 () -> {
                     if (!isClosed && nativeClientHandle != 0) {
                         try {
-                            // Clean up any pending async operations for this client
-                            AsyncRegistry.cleanupClient(nativeClientHandle);
                             GlideNativeBridge.closeClient(nativeClientHandle);
                         } finally {
                             isClosed = true;
@@ -429,9 +426,6 @@ public class ConnectionManager {
         try {
             // Mark as closed immediately to prevent new commands
             isClosed = true;
-
-            // Clean up any pending async operations for this client
-            AsyncRegistry.cleanupClient(nativeClientHandle);
 
             // Close the native client handle
             if (nativeClientHandle != 0) {

--- a/java/integTest/src/test/java/glide/SharedClientTests.java
+++ b/java/integTest/src/test/java/glide/SharedClientTests.java
@@ -203,7 +203,7 @@ public class SharedClientTests {
 
         // The last request should complete exceptionally
         try {
-            responses.get(inflightRequestsLimit).get(100, TimeUnit.MILLISECONDS);
+            responses.get(inflightRequestsLimit).get(10, TimeUnit.SECONDS);
             fail("Expected the last request to throw an exception");
         } catch (ExecutionException e) {
             assertInstanceOf(RequestException.class, e.getCause());


### PR DESCRIPTION
## Remove Java-side inflight counter, let Rust be sole authority

Follow-up to #5642 (InflightRequestTracker cherry-pick). Separated into its own PR for clean review.

### The Problem

Both Rust and Java had independent inflight counters that released on timeout -- while zombie sub-commands were still alive in the event loop:

```
         Java counter          Rust counter
Send:       0 -> 1              1000 -> 999
Timeout:    1 -> 0  (freed!)    999 (held -- zombies alive)
Send:       0 -> 1  (allowed!)  999 -> 998  <-- new zombie
  ...60 threads doing this...
  ...180 new zombies/second...
  ...54K zombies after 5 min -> permanent freeze
```

#5642 fixed Rust (RAII tracker holds until zombie finishes). But Java's `AsyncRegistry` counter still recycled on timeout, defeating the fix. Default config (`maxInflightRequests=1000`) meant this was active for all users.

### The Fix

Remove Java's counter entirely (-95 lines, 3 files). Rust is the sole inflight authority.

### Chaos Test A/B (4-core pods, 60 threads, sustained 5s netem)

| | Old v2.2 | Fix |
|---|---------|-----|
| Under chaos | Freeze within 5min | Stable at 60/s |
| After chaos removed | **Permanent freeze** (9+ min) | **Recovered in 15s** |
