### PR TITLE
fix(java): reduce inflight_requests_limit test from 1000 to 100

### DIFF
--- a/java/integTest/src/test/java/glide/SharedClientTests.java
+++ b/java/integTest/src/test/java/glide/SharedClientTests.java
@@ -164,10 +164,8 @@ public class SharedClientTests {
         return Stream.of(
                 Arguments.of(false, 5),
                 Arguments.of(false, 100),
-                Arguments.of(false, 1000),
                 Arguments.of(true, 5),
-                Arguments.of(true, 100),
-                Arguments.of(true, 1000));
+                Arguments.of(true, 100));
     }
 
     @SneakyThrows


### PR DESCRIPTION
Follow-up to #5658. The `limit=1000` test case requires the single tokio worker to process 1001 BLPOP commands before the inflight rejection can be verified. On slower CI machines (aarch64), this exceeds the 10s timeout — causing full matrix failures.

Drop the 1000 case. `limit=100` still validates the Rust backpressure mechanism without stressing CI.

1 file, 1 line change.