### PR TITLE
Backport: Fix swallowed errors in JNI async bridge (#5536)

### DIFF
--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -209,6 +209,27 @@ public final class AsyncRegistry {
         clientInflightCounts.clear();
     }
 
+    /**
+     * Fail all pending futures with a {@link glide.api.models.exceptions.ClosingException}. Called
+     * from the native layer when a fatal infrastructure failure is detected (e.g., callback worker
+     * threads terminated). This ensures no future is left dangling.
+     *
+     * @param errorMessage description of the failure cause
+     */
+    public static void failAllWithError(String errorMessage) {
+        // Best-effort sweep: only called when callback infrastructure is dead,
+        // so any future registered concurrently would also fail to complete.
+        String msg =
+                (errorMessage == null || errorMessage.isEmpty())
+                        ? "Native callback infrastructure failed"
+                        : errorMessage;
+        activeFutures.forEach(
+                (id, future) ->
+                        future.completeExceptionally(new glide.api.models.exceptions.ClosingException(msg)));
+        activeFutures.clear();
+        clientInflightCounts.clear();
+    }
+
     /** Clean up per-client tracking when a client is closed */
     public static void cleanupClient(long clientHandle) {
         clientInflightCounts.remove(clientHandle);

--- a/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
+++ b/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
@@ -1,0 +1,117 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.internal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import glide.api.models.exceptions.ClosingException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AsyncRegistryTest {
+
+    @BeforeEach
+    void setUp() {
+        AsyncRegistry.reset();
+    }
+
+    @Test
+    void failAllWithError_completesAllPendingFutures() {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        CompletableFuture<Object> f2 = new CompletableFuture<>();
+        CompletableFuture<Object> f3 = new CompletableFuture<>();
+
+        // timeoutMillis=0 avoids native call to markTimedOut
+        AsyncRegistry.register(f1, 0, 1L);
+        AsyncRegistry.register(f2, 0, 1L);
+        AsyncRegistry.register(f3, 0, 1L);
+
+        assertEquals(3, AsyncRegistry.getPendingCount());
+
+        AsyncRegistry.failAllWithError("test error");
+
+        assertTrue(f1.isCompletedExceptionally());
+        assertTrue(f2.isCompletedExceptionally());
+        assertTrue(f3.isCompletedExceptionally());
+        assertEquals(0, AsyncRegistry.getPendingCount());
+
+        assertClosingException(f1, "test error");
+        assertClosingException(f2, "test error");
+        assertClosingException(f3, "test error");
+    }
+
+    @Test
+    void failAllWithError_withNullMessage_usesDefault() {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        AsyncRegistry.register(f, 0, 1L);
+
+        AsyncRegistry.failAllWithError(null);
+
+        assertTrue(f.isCompletedExceptionally());
+        assertClosingException(f, "Native callback infrastructure failed");
+    }
+
+    @Test
+    void failAllWithError_withEmptyMessage_usesDefault() {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        AsyncRegistry.register(f, 0, 1L);
+
+        AsyncRegistry.failAllWithError("");
+
+        assertTrue(f.isCompletedExceptionally());
+        assertClosingException(f, "Native callback infrastructure failed");
+    }
+
+    @Test
+    void failAllWithError_withEmptyTable_isNoOp() {
+        assertEquals(0, AsyncRegistry.getPendingCount());
+        assertDoesNotThrow(() -> AsyncRegistry.failAllWithError("msg"));
+        assertEquals(0, AsyncRegistry.getPendingCount());
+    }
+
+    @Test
+    void failAllWithError_raceWithNormalCompletion() {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        long id = AsyncRegistry.register(f, 0, 1L);
+
+        // Complete normally first
+        AsyncRegistry.completeCallback(id, "normal result");
+
+        // Then sweep — should not override the normal result
+        AsyncRegistry.failAllWithError("late error");
+
+        assertTrue(f.isDone());
+        // First completion wins — should have normal result, not exception
+        assertEquals("normal result", f.getNow(null));
+    }
+
+    @Test
+    void failAllWithError_clearsInflightCounters() {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        // Register with inflight limit of 1
+        AsyncRegistry.register(f1, 1, 42L);
+
+        // Sweep clears counters
+        AsyncRegistry.failAllWithError("msg");
+
+        // Should be able to register again on the same client (counter was reset)
+        CompletableFuture<Object> f2 = new CompletableFuture<>();
+        assertDoesNotThrow(() -> AsyncRegistry.register(f2, 1, 42L));
+    }
+
+    private static void assertClosingException(CompletableFuture<?> future, String expectedMessage) {
+        try {
+            future.get();
+        } catch (ExecutionException e) {
+            assertInstanceOf(ClosingException.class, e.getCause());
+            assertEquals(expectedMessage, e.getCause().getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Unexpected interruption", e);
+        }
+    }
+}

--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -12,7 +12,7 @@ use jni::objects::{GlobalRef, JClass, JObject, JStaticMethodID, JValue};
 use jni::signature;
 use jni::sys::{JNI_VERSION_1_8, jint, jlong, jstring};
 use parking_lot::Mutex;
-use redis::{RedisError, Value as ServerValue};
+use redis::{RedisError as ServerError, Value as ServerValue};
 use std::ffi::c_void;
 use std::sync::Arc;
 use std::sync::mpsc::{Sender, channel};
@@ -55,9 +55,25 @@ pub extern "system" fn JNI_OnUnload(_vm: *const JavaVM, _reserved: *const c_void
     crate::cleanup_global_caches();
 }
 
+/// Invalidate cached JNI method IDs so the next call re-initializes them.
+/// Called when callback completion fails — stale method IDs (e.g. from classloader
+/// changes) would cause every subsequent callback to fail permanently. Clearing the
+/// cache lets the fallback `find_class` path re-discover the correct method IDs.
+///
+/// Safe to call at any time: the Mutex<Option<...>> pattern means the next caller
+/// will re-populate the cache from the current JNIEnv.
+fn invalidate_jni_caches() {
+    if let Some(cache_mutex) = METHOD_CACHE.get() {
+        *cache_mutex.lock() = None;
+    }
+    if let Some(cache_mutex) = GLIDE_CORE_CLIENT_CACHE.get() {
+        *cache_mutex.lock() = None;
+    }
+}
+
 // Type aliases for complex types
 type PushMessageTuple = (Vec<u8>, Vec<u8>, Option<Vec<u8>>);
-type CallbackResult = Result<ServerValue, RedisError>;
+type CallbackResult = Result<ServerValue, ServerError>;
 
 // Runtime and JVM statics
 pub static JVM: std::sync::OnceLock<Arc<JavaVM>> = std::sync::OnceLock::new();
@@ -73,6 +89,8 @@ const DEFAULT_CALLBACK_WORKER_THREADS: usize = 2;
 static NATIVE_BUFFER_REGISTRY: std::sync::OnceLock<dashmap::DashMap<u64, Vec<u8>>> =
     std::sync::OnceLock::new();
 static NEXT_NATIVE_BUFFER_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+static TIMED_OUT_CALLBACKS: std::sync::OnceLock<dashmap::DashMap<jlong, ()>> =
+    std::sync::OnceLock::new();
 
 fn get_native_buffer_registry() -> &'static dashmap::DashMap<u64, Vec<u8>> {
     NATIVE_BUFFER_REGISTRY.get_or_init(dashmap::DashMap::new)
@@ -92,6 +110,21 @@ pub fn register_native_buffer(bytes: Vec<u8>) -> (u64, *mut u8, usize) {
 pub fn free_native_buffer(id: u64) -> bool {
     let registry = get_native_buffer_registry();
     registry.remove(&id).is_some()
+}
+
+fn get_timed_out_callbacks() -> &'static dashmap::DashMap<jlong, ()> {
+    TIMED_OUT_CALLBACKS.get_or_init(dashmap::DashMap::new)
+}
+
+#[allow(dead_code)] // Used by Java-side timeout scheduling (PR #5264), not yet on release-2.2
+pub fn mark_callback_timed_out(callback_id: jlong) {
+    let registry = get_timed_out_callbacks();
+    registry.insert(callback_id, ());
+}
+
+fn take_timed_out_callback(callback_id: jlong) -> bool {
+    let registry = get_timed_out_callbacks();
+    registry.remove(&callback_id).is_some()
 }
 
 /// Initialize or return the shared Tokio runtime.
@@ -168,38 +201,27 @@ pub async fn ensure_client_for_handle(handle_id: u64) -> Result<GlideClient> {
     if let Some(mut cfg) = pending {
         cfg.lazy_connect = false;
 
-        // Setup push channel if subscriptions configured
-        let has_pubsub = cfg
-            .pubsub_subscriptions
-            .as_ref()
-            .map(|m| !m.is_empty())
-            .unwrap_or(false);
+        // Always setup push channel for push message support
+        // This enables dynamic subscriptions to work,
+        // even when no initial subscriptions are configured
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<redis::PushInfo>();
 
-        let (tx_opt, rx_opt) = if has_pubsub {
-            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<redis::PushInfo>();
-            (Some(tx), Some(rx))
-        } else {
-            (None, None)
-        };
-
-        let client = create_glide_client(cfg, tx_opt).await?;
+        let client = create_glide_client(cfg, Some(tx)).await?;
         table.insert(handle_id, client.clone());
 
-        // Handle push notifications if needed
-        if let Some(mut rx) = rx_opt {
-            let jvm_arc = JVM.get().cloned();
-            let handle_for_java = handle_id as jlong;
-            get_runtime().spawn(async move {
-                while let Some(push) = rx.recv().await {
-                    if let Some(jvm) = jvm_arc.as_ref()
-                        && let Ok(mut env) = jvm.attach_current_thread_as_daemon()
-                    {
-                        // Handle push notification callback to Java
-                        handle_push_notification(&mut env, handle_for_java, push);
-                    }
+        // Always spawn push notification handler
+        let jvm_arc = JVM.get().cloned();
+        let handle_for_java = handle_id as jlong;
+        get_runtime().spawn(async move {
+            while let Some(push) = rx.recv().await {
+                if let Some(jvm) = jvm_arc.as_ref()
+                    && let Ok(mut env) = jvm.attach_current_thread_as_daemon()
+                {
+                    // Handle push notification callback to Java
+                    handle_push_notification(&mut env, handle_for_java, push);
                 }
-            });
-        }
+            }
+        });
 
         return Ok(table.get(&handle_id).unwrap().value().clone());
     }
@@ -278,6 +300,7 @@ pub(crate) struct MethodCache {
     async_handle_table_class: GlobalRef,
     complete_callback_method: JStaticMethodID,
     complete_error_with_code_method: JStaticMethodID,
+    fail_all_method: JStaticMethodID,
 }
 
 static METHOD_CACHE: std::sync::OnceLock<Mutex<Option<MethodCache>>> = std::sync::OnceLock::new();
@@ -315,10 +338,15 @@ pub(crate) fn get_method_cache(env: &mut JNIEnv) -> Result<MethodCache> {
             anyhow::anyhow!("Failed to get completeCallbackWithErrorCode method ID: {e}")
         })?;
 
+    let fail_all_method = env
+        .get_static_method_id(&class, "failAllWithError", "(Ljava/lang/String;)V")
+        .map_err(|e| anyhow::anyhow!("Failed to get failAllWithError method ID: {e}"))?;
+
     let method_cache = MethodCache {
         async_handle_table_class: global_class,
         complete_callback_method,
         complete_error_with_code_method,
+        fail_all_method,
     };
 
     // Store in cache
@@ -357,17 +385,29 @@ pub fn init_callback_workers() -> &'static Sender<CallbackJob> {
             thread::Builder::new()
                 .name(format!("glide-jni-callback-{i}"))
                 .spawn(move || {
+                    // Pre-attach to JVM once at thread start. attach_current_thread_as_daemon
+                    // keeps the thread attached for its entire lifetime (no detach on drop).
+                    // This eliminates per-callback attach overhead and the attach failure window.
+                    let Some(jvm) = JVM.get() else {
+                        log::error!("Callback worker {i}: JVM not cached, cannot start");
+                        return;
+                    };
+                    let Ok(mut env) = jvm.attach_current_thread_as_daemon() else {
+                        log::error!("Callback worker {i}: failed to attach to JVM at startup");
+                        return;
+                    };
+
                     loop {
                         let job_opt = {
                             let guard = rx_clone.lock().unwrap();
                             guard.recv().ok()
                         };
-                        let Some((jvm, callback_id, result, binary_mode)) = job_opt else {
+                        let Some((_, callback_id, result, binary_mode)) = job_opt else {
                             break;
                         };
 
-                        // Process callback on this dedicated thread
-                        process_callback_job(jvm, callback_id, result, binary_mode);
+                        // Process callback with pre-attached env
+                        process_callback_job_with_env(&mut env, callback_id, result, binary_mode);
                     }
                 })
                 .expect("Failed to spawn callback worker thread");
@@ -377,63 +417,90 @@ pub fn init_callback_workers() -> &'static Sender<CallbackJob> {
     })
 }
 
-fn process_callback_job(
-    jvm: Arc<JavaVM>,
+/// Process a callback with an already-attached JNIEnv.
+/// Used by pre-attached callback worker threads.
+fn process_callback_job_with_env(
+    env: &mut JNIEnv,
     callback_id: jlong,
     result: CallbackResult,
     binary_mode: bool,
 ) {
-    match jvm.attach_current_thread_as_daemon() {
-        Ok(mut env) => match result {
-            Ok(server_value) => {
-                let _ = env.push_local_frame(16);
+    if take_timed_out_callback(callback_id) {
+        return;
+    }
 
-                // Direct conversion with size-based routing
-                let java_result = if should_use_direct_buffer(&server_value) {
-                    // For large data (>16KB): Use DirectByteBuffer
-                    create_direct_byte_buffer(&mut env, server_value, !binary_mode)
-                } else {
-                    // For small data (<16KB): Regular JNI objects
-                    crate::resp_value_to_java(&mut env, server_value, !binary_mode)
-                };
+    match result {
+        Ok(server_value) => {
+            let _ = env.push_local_frame(16);
 
-                match java_result {
-                    Ok(java_result) => {
-                        let _ = complete_java_callback(&mut env, callback_id, &java_result);
-                    }
-                    Err(e) => {
-                        // Use ClientError for conversion failures
-                        let error_code = 0; // UNSPECIFIED error type
-                        let error_msg = format!("Response conversion failed: {e}");
-                        let _ = complete_java_callback_with_error_code(
-                            &mut env,
-                            callback_id,
-                            error_code,
-                            &error_msg,
+            let java_result = if should_use_direct_buffer(&server_value) {
+                create_direct_byte_buffer(env, server_value, !binary_mode)
+            } else {
+                crate::resp_value_to_java(env, server_value, !binary_mode)
+            };
+
+            if take_timed_out_callback(callback_id) {
+                let _ = unsafe { env.pop_local_frame(&JObject::null()) };
+                return;
+            }
+
+            match java_result {
+                Ok(java_result) => {
+                    if let Err(e) = complete_java_callback(env, callback_id, &java_result) {
+                        log::error!("JNI completion failed for callback {callback_id}: {e}");
+                        let _ = env.exception_clear();
+                        invalidate_jni_caches();
+                        fail_all_pending_futures(
+                            env,
+                            "JNI callback completion failed — cached method IDs may be stale",
                         );
                     }
                 }
-                let _ = unsafe { env.pop_local_frame(&JObject::null()) };
+                Err(e) => {
+                    let error_code = 0;
+                    let error_msg = format!("Response conversion failed: {e}");
+                    if let Err(e2) = complete_java_callback_with_error_code(
+                        env,
+                        callback_id,
+                        error_code,
+                        &error_msg,
+                    ) {
+                        log::error!("JNI error completion failed for callback {callback_id}: {e2}");
+                        let _ = env.exception_clear();
+                        invalidate_jni_caches();
+                        fail_all_pending_futures(
+                            env,
+                            "JNI error callback completion failed — cached method IDs may be stale",
+                        );
+                    }
+                }
             }
-            Err(redis_err) => {
-                // Always use error codes for consistent error handling
-                let error_code = error_type(&redis_err) as i32;
-                let error_msg = error_message(&redis_err);
-                let _ = complete_java_callback_with_error_code(
-                    &mut env,
-                    callback_id,
-                    error_code,
-                    &error_msg,
+            let _ = unsafe { env.pop_local_frame(&JObject::null()) };
+        }
+        Err(server_err) => {
+            if take_timed_out_callback(callback_id) {
+                return;
+            }
+
+            let error_code = error_type(&server_err) as i32;
+            let error_msg = error_message(&server_err);
+            if let Err(e) =
+                complete_java_callback_with_error_code(env, callback_id, error_code, &error_msg)
+            {
+                log::error!("JNI error completion failed for callback {callback_id}: {e}");
+                let _ = env.exception_clear();
+                invalidate_jni_caches();
+                fail_all_pending_futures(
+                    env,
+                    "JNI error callback completion failed — cached method IDs may be stale",
                 );
             }
-        },
-        Err(e) => {
-            log::error!("JNI environment attachment failed: {e}");
         }
     }
 }
 
 /// Enqueue callback job to dedicated workers.
+/// If the channel is dead (all workers terminated), sweeps all pending futures with error.
 pub fn complete_callback(
     jvm: Arc<JavaVM>,
     callback_id: jlong,
@@ -441,9 +508,53 @@ pub fn complete_callback(
     binary_mode: bool,
 ) {
     let sender = init_callback_workers();
-    if let Err(e) = sender.send((jvm, callback_id, result, binary_mode)) {
-        log::error!("Callback queue send failed: {e}");
+    if let Err(e) = sender.send((jvm.clone(), callback_id, result, binary_mode)) {
+        log::error!("Callback channel dead, sweeping all pending futures: {e}");
+        // Workers are dead — sweep the entire AsyncRegistry table
+        if let Ok(mut env) = jvm.attach_current_thread_as_daemon() {
+            fail_all_pending_futures(
+                &mut env,
+                "Native callback workers terminated — all pending requests failed",
+            );
+        } else {
+            log::error!(
+                "FATAL: Cannot attach to JVM to sweep futures — all pending requests will hang"
+            );
+        }
     }
+}
+
+/// Fail all pending futures in AsyncRegistry by calling failAllWithError from Java.
+/// Used when fatal infrastructure failures are detected (channel dead, native panic).
+pub fn fail_all_pending_futures(env: &mut JNIEnv, error_msg: &str) {
+    let cache = match get_method_cache(env) {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("Cannot sweep futures — failed to get method cache: {e}");
+            return;
+        }
+    };
+    let _ = env.push_local_frame(4);
+    let msg = match env.new_string(error_msg) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Cannot sweep futures — failed to create error string: {e}");
+            let _ = unsafe { env.pop_local_frame(&JObject::null()) };
+            return;
+        }
+    };
+    if let Err(e) = unsafe {
+        env.call_static_method_unchecked(
+            &cache.async_handle_table_class,
+            cache.fail_all_method,
+            signature::ReturnType::Primitive(signature::Primitive::Void),
+            &[JValue::Object(&msg).as_jni()],
+        )
+    } {
+        log::error!("Failed to sweep pending futures via failAllWithError: {e}");
+        let _ = env.exception_clear();
+    }
+    let _ = unsafe { env.pop_local_frame(&JObject::null()) };
 }
 
 /// Complete Java CompletableFuture with success result using cached method IDs.
@@ -656,14 +767,22 @@ fn serialize_array_to_bytes(
     arr: Vec<ServerValue>,
     _encoding_utf8: bool,
 ) -> Result<Vec<u8>, crate::errors::FFIError> {
+    const NULL_VALUE: i32 = -1;
+    const FALSE_BOOL: u8 = 0;
+    const TRUE_BOOL: u8 = 1;
+
     let mut bytes = Vec::new();
 
     // Write array marker and length
-    bytes.push(b'*'); // Redis array prefix
+    bytes.push(b'*'); // RESP array prefix
     bytes.extend_from_slice(&(arr.len() as u32).to_be_bytes());
 
     for value in arr {
         match value {
+            redis::Value::Nil => {
+                bytes.push(b'$'); // Bulk string marker
+                bytes.extend_from_slice(&NULL_VALUE.to_be_bytes()); // -1 indicates null in binary format
+            }
             redis::Value::BulkString(data) => {
                 bytes.push(b'$'); // Bulk string marker
                 bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
@@ -696,6 +815,20 @@ fn serialize_array_to_bytes(
             redis::Value::Int(n) => {
                 bytes.push(b':'); // Integer marker
                 bytes.extend_from_slice(&n.to_be_bytes());
+            }
+            redis::Value::Double(n) => {
+                bytes.push(b','); // Double marker
+                bytes.extend_from_slice(&n.to_be_bytes());
+            }
+            redis::Value::Boolean(b) => {
+                bytes.push(b'?'); // Boolean marker
+                bytes.push(if b { TRUE_BOOL } else { FALSE_BOOL });
+            }
+            redis::Value::BigNumber(n) => {
+                let data = n.to_string().into_bytes();
+                bytes.push(b'('); // BigNumber marker
+                bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+                bytes.extend_from_slice(&data);
             }
             _ => {
                 // For complex nested types, store as serialized string representation
@@ -760,14 +893,46 @@ pub fn get_optional_string_param_raw(env: &mut JNIEnv, param: jstring) -> Option
     }
 }
 
-/// JNI init hook to ensure JVM cached for push callbacks
+/// JNI init hook to cache JVM and GlideCoreClient class/methods with correct classloader context.
+///
+/// This is called from `GlideCoreClient`'s static initializer in Java. We cache the class and
+/// method IDs here rather than in `JNI_OnLoad` because `GlideCoreClient` may not be findable
+/// via `env.find_class()` during `JNI_OnLoad` in environments with non-standard classloaders
+/// (AWS Lambda, Spring Boot with nested JARs). The `class` parameter passed by JNI is already
+/// loaded by the application classloader, bypassing `find_class` issues entirely.
+///
+/// Other caches (`MethodCache`, `JavaValueConversionCache`) are safe to initialize in
+/// `JNI_OnLoad` because they only reference standard Java classes (`java/lang/Long`,
+/// `java/util/HashMap`, etc.) which are always available from the bootstrap classloader.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_glide_internal_GlideCoreClient_onNativeInit(
-    env: JNIEnv,
-    _class: JClass,
+    mut env: JNIEnv,
+    class: JClass,
 ) {
+    // Cache JVM
     if let Ok(jvm) = env.get_java_vm() {
         let _ = JVM.set(Arc::new(jvm));
+    }
+
+    // Cache GlideCoreClient class and method IDs with correct classloader context.
+    // The 'class' parameter is GlideCoreClient, already loaded by the application classloader.
+    if let Ok(global) = env.new_global_ref(&class)
+        && let (Ok(on_native_push), Ok(register_cleaner)) = (
+            env.get_static_method_id(&class, "onNativePush", "(J[B[B[B)V"),
+            env.get_static_method_id(
+                &class,
+                "registerNativeBufferCleaner",
+                "(Ljava/nio/ByteBuffer;J)V",
+            ),
+        )
+    {
+        let cache = GlideCoreClientCache {
+            class: global,
+            on_native_push,
+            register_native_buffer_cleaner: register_cleaner,
+        };
+        let cache_mutex = GLIDE_CORE_CLIENT_CACHE.get_or_init(|| Mutex::new(None));
+        *cache_mutex.lock() = Some(cache);
     }
 }
 
@@ -792,42 +957,94 @@ struct GlideCoreClientCache {
 static GLIDE_CORE_CLIENT_CACHE: std::sync::OnceLock<Mutex<Option<GlideCoreClientCache>>> =
     std::sync::OnceLock::new();
 
-/// Get GLIDE core client cache using correct classloader context
-fn get_glide_core_client_cache_safe(fallback_env: &mut JNIEnv) -> Result<GlideCoreClientCache> {
-    // Try cached JVM env first
-    if let Some(cached_jvm) = JVM.get()
-        && let Ok(mut cached_env) = cached_jvm.get_env()
-    {
-        return get_glide_core_client_cache(&mut cached_env);
-    }
-    // Otherwise fallback to provided env
-    get_glide_core_client_cache(fallback_env)
-}
-
-fn get_glide_core_client_cache(env: &mut JNIEnv) -> Result<GlideCoreClientCache> {
+/// Get GlideCoreClient cache, with fallback dynamic initialization.
+///
+/// Preferred path: return the cache populated by `onNativeInit` (correct classloader context).
+/// Fallback: if `onNativeInit` wasn't called or failed, attempt `find_class` with the provided
+/// `env`. This may fail in non-standard classloader environments but keeps the client resilient
+/// in standard JVM setups.
+fn get_glide_core_client_cache_safe(env: &mut JNIEnv) -> Result<GlideCoreClientCache> {
     let cache_mutex = GLIDE_CORE_CLIENT_CACHE.get_or_init(|| Mutex::new(None));
     {
         let guard = cache_mutex.lock();
-        if let Some(c) = guard.as_ref() {
-            return Ok(c.clone());
+        if let Some(ref cache) = *guard {
+            return Ok(cache.clone());
         }
     }
+
+    // Fallback: try to initialize dynamically using the provided env
     let class = env.find_class("glide/internal/GlideCoreClient")?;
     let global = env.new_global_ref(&class)?;
     let on_native_push = env.get_static_method_id(&class, "onNativePush", "(J[B[B[B)V")?;
-    let register_native_buffer_cleaner = env.get_static_method_id(
+    let register_cleaner = env.get_static_method_id(
         &class,
         "registerNativeBufferCleaner",
         "(Ljava/nio/ByteBuffer;J)V",
     )?;
+
     let cache = GlideCoreClientCache {
         class: global,
         on_native_push,
-        register_native_buffer_cleaner,
+        register_native_buffer_cleaner: register_cleaner,
     };
-    {
-        let mut guard = cache_mutex.lock();
-        *guard = Some(cache.clone());
+
+    let mut guard = cache_mutex.lock();
+    if guard.is_none() {
+        *guard = Some(cache);
     }
-    Ok(cache)
+
+    Ok(guard.as_ref().cloned().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::serialize_array_to_bytes;
+    use redis::{Value, parse_redis_value};
+
+    #[test]
+    fn serialize_array_to_bytes_encodes_bool_double_bignumber_and_nil() {
+        let big_number_value = parse_redis_value(b"(123456789012345678901234567890\r\n").unwrap();
+        let Value::BigNumber(big_number) = big_number_value else {
+            panic!("expected big number from parser");
+        };
+
+        let payload = vec![
+            Value::Boolean(true),
+            Value::Double(42.25),
+            Value::BigNumber(big_number),
+            Value::Nil,
+        ];
+
+        let bytes = match serialize_array_to_bytes(payload, false) {
+            Ok(bytes) => bytes,
+            Err(err) => panic!("serialization failed: {err}"),
+        };
+
+        // Array header: '*' + 4-byte element count.
+        assert_eq!(bytes[0], b'*');
+        assert_eq!(u32::from_be_bytes(bytes[1..5].try_into().unwrap()), 4);
+
+        // Element 1: boolean true ('?'+1).
+        assert_eq!(bytes[5], b'?');
+        assert_eq!(bytes[6], 1);
+
+        // Element 2: double (',' + 8 bytes).
+        assert_eq!(bytes[7], b',');
+        let decoded_double = f64::from_be_bytes(bytes[8..16].try_into().unwrap());
+        assert_eq!(decoded_double, 42.25);
+
+        // Element 3: big number ('(' + len + utf8 digits).
+        assert_eq!(bytes[16], b'(');
+        let big_number_len = u32::from_be_bytes(bytes[17..21].try_into().unwrap()) as usize;
+        let big_number_text = std::str::from_utf8(&bytes[21..21 + big_number_len]).unwrap();
+        assert_eq!(big_number_text, "123456789012345678901234567890");
+
+        // Element 4: null bulk string ('$' + -1).
+        let null_offset = 21 + big_number_len;
+        assert_eq!(bytes[null_offset], b'$');
+        assert_eq!(
+            i32::from_be_bytes(bytes[null_offset + 1..null_offset + 5].try_into().unwrap()),
+            -1
+        );
+    }
 }


### PR DESCRIPTION
## Backport of #5536 to release-2.2

Cherry-pick of b5479f61e from main, adapted for release-2.2.

### The Problem

Customer production logs showed the root cause of their permanent freeze:
```
12:43:37.858 ERROR DIAG cb=68086611 response CONVERSION FAILED: JNIEnv null method pointer for GlideCoreClient cache
12:43:37.858 ERROR DIAG cb=68086611 complete_java_callback_with_error_code FAILED (future left dangling)
... 60 consecutive failures, then silence for 5 days
```

When JNI callback completion fails (method cache corruption, JNI exception), futures are left dangling — Java threads block on `.get()` forever.

### The Fix

- **Pre-attach callback workers to JVM at startup** — eliminates per-callback attach failure window
- **`AsyncRegistry.failAllWithError()`** — sweeps all pending futures with ClosingException when fatal infrastructure failures detected
- **Sweep on callback channel death** — if all workers terminate, sweep remaining futures
- **Log + clear JNI exceptions** — worker threads stay usable after transient failures

### Conflict Resolution

- `jni_client.rs`: took incoming (the fix) — core of the change
- `lib.rs`: kept release-2.2 version (uses `handle_panics` not `run_ffi`)
- `errors.rs`: kept release-2.2 version (preserves `handle_panics` signature)
- `AsyncRegistry.java`: merged — added `failAllWithError()` keeping existing inflight counter
- `AsyncRegistryTest.java`: adapted `register()` calls to 3-param signature

### Tests
- AsyncRegistryTest: 6 tests pass (failAllWithError behavior)
- Rust: compiles clean
- Spotless: clean