### PR TITLE
Backport: Security hardening — shutdown race + registry leak (#5583)

### DIFF
--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -3,6 +3,7 @@ package glide.internal;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -35,6 +36,12 @@ public final class AsyncRegistry {
 
     /** Thread-safe ID generator */
     private static final AtomicLong nextId = new AtomicLong(1);
+
+    /**
+     * Shutdown flag to prevent race conditions between register() and shutdown()/failAllWithError().
+     * Once set to true, register() will return pre-failed futures instead of adding to the registry.
+     */
+    private static final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
     // ==================== CONFIGURABLE CONSTANTS ====================
 
@@ -71,6 +78,14 @@ public final class AsyncRegistry {
             throw new IllegalArgumentException("Future cannot be null");
         }
 
+        // Check shutdown flag before registering to prevent race conditions
+        if (isShutdown.get()) {
+            future.completeExceptionally(
+                    new glide.api.models.exceptions.ClosingException(
+                            "Client is shutting down, cannot register new requests"));
+            return 0L;
+        }
+
         // Client-specific inflight limit check
         // 0 means "use native/core defaults" - no limit enforcement in Java layer
         if (maxInflightRequests > 0) {
@@ -99,6 +114,23 @@ public final class AsyncRegistry {
 
         // Store original future for completion by native code
         activeFutures.put(correlationId, originalFuture);
+
+        // Double-check shutdown flag after insertion to handle race with shutdown()
+        if (isShutdown.get()) {
+            activeFutures.remove(correlationId);
+            if (maxInflightRequests > 0) {
+                clientInflightCounts.computeIfPresent(
+                        clientHandle,
+                        (key, counter) -> {
+                            int remaining = counter.decrementAndGet();
+                            return remaining <= 0 ? null : counter;
+                        });
+            }
+            future.completeExceptionally(
+                    new glide.api.models.exceptions.ClosingException(
+                            "Client is shutting down, cannot register new requests"));
+            return 0L;
+        }
 
         // Set up cleanup on the original future
         // This ensures proper resource cleanup when completed
@@ -194,6 +226,8 @@ public final class AsyncRegistry {
 
     /** Shutdown cleanup - cancel all pending operations during client shutdown */
     public static void shutdown() {
+        isShutdown.set(true);
+
         // Complete all pending futures with cancellation
         activeFutures
                 .values()
@@ -219,6 +253,8 @@ public final class AsyncRegistry {
     public static void failAllWithError(String errorMessage) {
         // Best-effort sweep: only called when callback infrastructure is dead,
         // so any future registered concurrently would also fail to complete.
+        isShutdown.set(true);
+
         String msg =
                 (errorMessage == null || errorMessage.isEmpty())
                         ? "Native callback infrastructure failed"
@@ -237,6 +273,7 @@ public final class AsyncRegistry {
 
     /** Reset all internal state. Intended for test isolation and client shutdown cleanup. */
     public static void reset() {
+        isShutdown.set(false);
         activeFutures.clear();
         clientInflightCounts.clear();
         nextId.set(1);
@@ -251,6 +288,15 @@ public final class AsyncRegistry {
         if (!"false".equalsIgnoreCase(System.getProperty("glide.autoShutdownHook", "true"))) {
             Runtime.getRuntime().addShutdownHook(shutdownHook);
         }
+    }
+
+    /**
+     * Returns whether the registry is in shutdown state. Intended for testing and diagnostics.
+     *
+     * @return true if shutdown() or failAllWithError() has been called
+     */
+    public static boolean isShutdown() {
+        return isShutdown.get();
     }
 
     /**

--- a/java/client/src/main/java/glide/managers/JniResponseRegistry.java
+++ b/java/client/src/main/java/glide/managers/JniResponseRegistry.java
@@ -1,17 +1,29 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
+import glide.api.logging.Logger;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Registry for storing Java objects returned from JNI calls. This allows us to pass object IDs
  * through the Response protobuf instead of trying to pass Rust pointers that would become invalid.
  *
- * <p>The registry uses weak references to allow garbage collection when objects are no longer
- * needed.
+ * <p>Objects are stored temporarily and must be retrieved via {@link #retrieveAndRemove(long)} or
+ * cleaned up via {@link #remove(long)} to prevent memory leaks. The registry includes monitoring to
+ * detect potential leaks by periodically checking registry size.
  */
 public class JniResponseRegistry {
+
+    /** Log identifier for this class. */
+    private static final String LOG_IDENTIFIER = "JniResponseRegistry";
+
+    /** Minimum interval between warning checks in nanoseconds. */
+    private static final long CHECK_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(60); // 1 minute
+
+    /** Size threshold that triggers a warning. */
+    private static final int SIZE_WARNING_THRESHOLD = 10000;
 
     // Thread-safe storage for JNI response objects
     private static final ConcurrentHashMap<Long, Object> responseObjects = new ConcurrentHashMap<>();
@@ -19,12 +31,22 @@ public class JniResponseRegistry {
     // ID generator for object references
     private static final AtomicLong nextId = new AtomicLong(1);
 
+    // Last time we checked for warnings (to avoid overhead on every call)
+    private static volatile long lastCheckTimeNanos = System.nanoTime();
+
+    /** Private constructor - this class will never be instantiated */
+    private JniResponseRegistry() {}
+
     /**
      * Store a Java object and return its ID. This is used when JNI returns a converted Java object
      * that needs to be passed through the Response protobuf.
      *
+     * <p>IMPORTANT: The caller is responsible for ensuring the object is eventually removed via
+     * {@link #retrieveAndRemove(long)} or {@link #remove(long)}. Failure to do so will cause memory
+     * leaks.
+     *
      * @param object The Java object to store
-     * @return The ID that can be used to retrieve the object
+     * @return The ID that can be used to retrieve the object, or 0L if object is null
      */
     public static long storeObject(Object object) {
         if (object == null) {
@@ -33,6 +55,9 @@ public class JniResponseRegistry {
 
         long id = nextId.getAndIncrement();
         responseObjects.put(id, object);
+
+        checkForPotentialLeak();
+
         return id;
     }
 
@@ -41,7 +66,7 @@ public class JniResponseRegistry {
      * actual Java object. The object is removed after retrieval to prevent memory leaks.
      *
      * @param id The ID of the object to retrieve
-     * @return The Java object, or null if not found
+     * @return The Java object, or null if not found or id is 0
      */
     public static Object retrieveAndRemove(long id) {
         if (id == 0L) {
@@ -50,13 +75,61 @@ public class JniResponseRegistry {
         return responseObjects.remove(id);
     }
 
+    /**
+     * Remove an object from the registry without returning it. This is used for cleanup when an
+     * exception occurs after storing an object but before it can be retrieved normally.
+     *
+     * @param id The ID of the object to remove
+     * @return true if an object was removed, false if no object existed with that ID
+     */
+    public static boolean remove(long id) {
+        if (id == 0L) {
+            return false;
+        }
+        return responseObjects.remove(id) != null;
+    }
+
     /** Clear all stored objects. Called during client cleanup. */
     public static void clear() {
         responseObjects.clear();
     }
 
-    /** Get the current number of stored objects. Useful for debugging and monitoring. */
+    /**
+     * Get the current number of stored objects. Useful for debugging, monitoring, and detecting
+     * potential memory leaks.
+     *
+     * @return The number of objects currently stored in the registry
+     */
     public static int size() {
         return responseObjects.size();
+    }
+
+    /**
+     * Periodically check if registry size indicates a potential memory leak. This check is
+     * rate-limited to minimize performance overhead.
+     */
+    private static void checkForPotentialLeak() {
+        long now = System.nanoTime();
+        long lastCheck = lastCheckTimeNanos;
+
+        // Only check once per minute to minimize overhead
+        if ((now - lastCheck) < CHECK_INTERVAL_NANOS) {
+            return;
+        }
+
+        // Update last check time (benign race - multiple threads may update, that's fine)
+        lastCheckTimeNanos = now;
+
+        int currentSize = responseObjects.size();
+        if (currentSize >= SIZE_WARNING_THRESHOLD) {
+            Logger.log(
+                    Logger.Level.WARN,
+                    LOG_IDENTIFIER,
+                    "JniResponseRegistry size ("
+                            + currentSize
+                            + ") exceeds threshold ("
+                            + SIZE_WARNING_THRESHOLD
+                            + "). This may indicate a memory leak in response handling.");
+        }
     }
 }

--- a/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
+++ b/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
@@ -3,6 +3,7 @@ package glide.internal;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -101,6 +102,83 @@ public class AsyncRegistryTest {
         // Should be able to register again on the same client (counter was reset)
         CompletableFuture<Object> f2 = new CompletableFuture<>();
         assertDoesNotThrow(() -> AsyncRegistry.register(f2, 1, 42L));
+    }
+
+    // ==================== Shutdown Race Condition Tests ====================
+
+    @Test
+    void register_afterShutdown_returnsZeroAndFailsFuture() {
+        // First, trigger shutdown
+        AsyncRegistry.failAllWithError("shutdown");
+        assertTrue(AsyncRegistry.isShutdown());
+
+        // Now try to register a new future
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        long id = AsyncRegistry.register(f, 0, 1L);
+
+        // Should return 0 (special ID indicating registration failed)
+        assertEquals(0L, id);
+
+        // Future should be completed exceptionally
+        assertTrue(f.isCompletedExceptionally());
+        assertClosingException(f, "Client is shutting down, cannot register new requests");
+
+        // Should not be added to active futures
+        assertEquals(0, AsyncRegistry.getPendingCount());
+    }
+
+    @Test
+    void failAllWithError_setsShutdownFlag() {
+        assertFalse(AsyncRegistry.isShutdown());
+
+        AsyncRegistry.failAllWithError("test");
+
+        assertTrue(AsyncRegistry.isShutdown());
+    }
+
+    @Test
+    void reset_clearsShutdownFlag() {
+        // Trigger shutdown
+        AsyncRegistry.failAllWithError("test");
+        assertTrue(AsyncRegistry.isShutdown());
+
+        // Reset should clear the flag
+        AsyncRegistry.reset();
+
+        assertFalse(AsyncRegistry.isShutdown());
+
+        // Should be able to register again
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        long id = AsyncRegistry.register(f, 0, 1L);
+
+        assertTrue(id > 0);
+        assertEquals(1, AsyncRegistry.getPendingCount());
+    }
+
+    @Test
+    void register_afterShutdown_doesNotIncrementInflightCounter() {
+        // Trigger shutdown
+        AsyncRegistry.failAllWithError("shutdown");
+
+        // Try to register with inflight limit
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        long id = AsyncRegistry.register(f, 10, 42L);
+
+        assertEquals(0L, id);
+
+        // Reset and verify we can register the full limit (counter wasn't incremented)
+        AsyncRegistry.reset();
+
+        for (int i = 0; i < 10; i++) {
+            CompletableFuture<Object> fi = new CompletableFuture<>();
+            long regId = AsyncRegistry.register(fi, 10, 42L);
+            assertTrue(regId > 0, "Registration " + i + " should succeed");
+        }
+    }
+
+    @Test
+    void isShutdown_initiallyFalse() {
+        assertFalse(AsyncRegistry.isShutdown());
     }
 
     private static void assertClosingException(CompletableFuture<?> future, String expectedMessage) {


### PR DESCRIPTION
## Backport of security-relevant parts of #5583 to release-2.2

Depends on: PR #5664 (dangling futures fix)

### Shutdown race fix (AsyncRegistry)
- `isShutdown` AtomicBoolean flag prevents registering futures after shutdown starts
- Double-check pattern: check before inflight counter, check after `activeFutures.put()`
- `shutdown()` and `failAllWithError()` set flag before clearing maps
- `reset()` clears flag for test isolation

### Registry leak detection (JniResponseRegistry)
- Size monitoring with 10K warning threshold
- Periodic check (1 min interval) to avoid overhead
- Documents caller responsibility for cleanup

### Not backported (not applicable to 2.2)
- Temp dir security (NativeUtils) — different code path on 2.2
- Buffer bounds (CommandManager) — different deserialization on 2.2
- MUSL detection — unchanged on 2.2

### Tests
- AsyncRegistryTest: all tests pass (including new shutdown race tests)
- Spotless: clean