### PR TITLE
Fix to allow auto-detect npm tag to handle RC and backport releases

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -124,8 +124,9 @@ jobs:
                     CURRENT_LATEST=$(npm view @valkey/valkey-glide dist-tags.latest 2>/dev/null || echo "0.0.0")
                     LOWER=$(printf '%s\n%s' "$RELEASE" "$CURRENT_LATEST" | sort -V | head -n1)
                     if [[ "$LOWER" == "$RELEASE" && "$RELEASE" != "$CURRENT_LATEST" ]]; then
-                      # RELEASE is older than current latest - this is a backport
-                      TAG="previous"
+                      # RELEASE is older than current latest - tag as latest-MAJOR.MINOR
+                      MINOR=$(echo "$RELEASE" | cut -d. -f1-2)
+                      TAG="latest-${MINOR}"
                     else
                       TAG="latest"
                     fi


### PR DESCRIPTION
### Summary
Fix npm publish failure when releasing a patch version lower than the current `latest` tag on npm. The workflow now checks the currently published `latest` version before assigning the npm dist-tag, using `previous` instead of `latest` when the release version is not strictly greater.

### Issue link
This Pull Request is linked to issue: N/A

### Features / Behaviour Changes
Publishing a version lower than the current npm `latest` (e.g. a backport patch like `2.2.9` when `2.3.0` is already `latest`) no longer fails. It publishes successfully under the `previous` dist-tag instead. RC versions continue to publish under the `next` tag, unchanged.

The `determine-npm-tag` step in `npm-cd.yml` previously assigned `latest` to all non-RC versions unconditionally. It now:
1. Queries npm for the current `latest` version via `npm view @valkey/valkey-glide dist-tags.latest`
2. Uses `semver.gt()` via an inline `node -e` call to compare the release version against the current latest
3. Assigns `latest` only if the new version is strictly greater; otherwise assigns `previous`

### Limitations
The `previous` tag is a fixed fallback label. If more granular tagging per minor line is needed (e.g. `v2.2.x`), that would require additional logic to derive the tag from the version string.

### Testing
We will see if release `2.2.9` will work since `2.3.0` already exist. It currently blocks from being released because it will always try to label any release that does not have `-rc` as the `latest` release.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [z] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
