### PR TITLE
Fix/add --skip-existing to twine upload for sync client PyPI publish

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -62,9 +62,9 @@ jobs:
                   # For building and publishing, replace "ephemeral" with "persistent" in RUNNER
                   export PLATFORM_MATRIX=$(echo "${TESTS_PLATFORM_MATRIX}" | jq 'map(
                       .RUNNER = (
-                          if (.RUNNER | type == "array") 
-                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
+                          if (.RUNNER | type == "array")
+                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end))
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end)
                           end
                       )
                   )' | jq -c .)
@@ -228,34 +228,34 @@ jobs:
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
                     PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_arm64
                     PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_arm64
-                    
+
                     echo "Downloading PyPy 3.9 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.10 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.11 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                   elif [[ "$ARCH" == "x86_64" ]]; then
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
                     PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
                     PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_x86_64
-                    
+
                     echo "Downloading PyPy 3.9 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.10 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.11 for x86_64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2" 
+                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                   fi
 
@@ -510,7 +510,7 @@ jobs:
                   TWINE_USERNAME: __token__
                   TWINE_PASSWORD: ${{ secrets.LIVEPYPI_API_TOKEN }}
               run: |
-                  twine upload python/glide-sync/wheels/* python/glide-sync/dist/*
+                  twine upload --skip-existing python/glide-sync/wheels/* python/glide-sync/dist/*
 
             - name: Sync client - Upload built wheels and sdist as GitHub artifacts
               uses: actions/upload-artifact@v4
@@ -557,7 +557,7 @@ jobs:
                       echo "Downloading PyPy 3.10 for x86_64"
                       curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                       sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                      
+
                     elif [[ "$ARCH" == "aarch64" ]]; then
                       PYPY_VERSION_3_10=pypy3.10-v7.3.19-aarch64
                       echo "Downloading PyPy 3.10 for aarch64"
@@ -573,7 +573,7 @@ jobs:
                       echo "Downloading PyPy 3.10 for arm64"
                       curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                       sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                      
+
                     else
                       PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
                       echo "Downloading PyPy 3.10 for x86_64"


### PR DESCRIPTION
### Summary
Add `--skip-existing` flag to the `twine upload` command for the sync client PyPI publish step. This prevents the workflow from failing with a `400 Bad Request` when a wheel or sdist for the same version was already uploaded (e.g. on a retry or partial run). The async client already handles this via maturin's built-in `--skip-existing` flag; this change brings the sync client to parity.

Link to deployment failure: https://github.com/valkey-io/valkey-glide/actions/runs/23655926302/job/68956271194
```
Run twine upload python/glide-sync/wheels/* python/glide-sync/dist/*
  twine upload python/glide-sync/wheels/* python/glide-sync/dist/*
  shell: /usr/bin/bash -e {0}
  env:
    RELEASE_VERSION: 2.2.9
    CARGO_INCREMENTAL: 0
    CARGO_TERM_COLOR: always
    TWINE_USERNAME: __token__
    TWINE_PASSWORD: ***
  
Uploading distributions to https://upload.pypi.org/legacy/
Uploading valkey_glide_sync-2.2.9-cp310-cp310-macosx_10_12_x86_64.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/4.9 MB • --:-- • ?
  6% ━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.3/4.9 MB • 00:01 • 8.5 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.9/4.9 MB • 00:00 • 37.7 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.9/4.9 MB • 00:00 • 37.7 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.9/4.9 MB • 00:00 • 37.7 MB/s
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Bad Request                                                            
Error: Process completed with exit code 1.
```

### Issue link
This Pull Request is linked to issue: N/A

Closes N/A

### Features / Behaviour Changes
- PyPI CD workflow no longer fails with `400 Bad Request` when re-uploading already-existing sync client artifacts.

### Implementation
Changed the `twine upload` invocation in the `build-source-dist-and-publish-to-pypi` job from:
```bash
twine upload python/glide-sync/wheels/* python/glide-sync/dist/*
```
to:
```bash
twine upload --skip-existing python/glide-sync/wheels/* python/glide-sync/dist/*
```

### Limitations
None.

### Testing


### Checklist
Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] ~Tests are added or updated.~
- [ ] ~CHANGELOG.md and documentation files are updated.~
- [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.