### PR TITLE
Core: Add IAM token cache support for cluster reconnections (#5663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * CORE: Add OpenTelemetry DB semantic convention attributes to command spans ([#5416](https://github.com/valkey-io/valkey-glide/issues/5416))
 * CORE: Prevent zombie subcommand accumulation with InflightTracker ([#5632](https://github.com/valkey-io/valkey-glide/issues/5632))
 * JAVA: Fix swallowed errors in JNI async bridge that left CompletableFutures dangling ([#5536](https://github.com/valkey-io/valkey-glide/issues/5536))
+* CORE: Add IAM token cache support for cluster reconnections — switch from push to pull model for IAM token refresh, add `IAMTokenProvider` trait so the cluster reconnection loop fetches a fresh IAM token before each connection attempt, preventing AUTH failures when tokens expire during node downtime ([#5663](https://github.com/valkey-io/valkey-glide/pull/5663))
 
 ## 2.3.0
 

--- a/glide-core/benches/connections_benchmark.rs
+++ b/glide-core/benches/connections_benchmark.rs
@@ -125,7 +125,7 @@ fn cluster_connection_benchmark(
                     builder = builder.read_from_replicas();
                 }
                 let client = builder.build().unwrap();
-                client.get_async_connection(None, None).await
+                client.get_async_connection(None, None, None).await
             })
             .unwrap()
     });

--- a/glide-core/redis-rs/redis/src/client.rs
+++ b/glide-core/redis-rs/redis/src/client.rs
@@ -103,6 +103,20 @@ pub struct GlideConnectionOptions {
     pub tcp_nodelay: bool,
     /// Optional PubSub synchronizer for managing subscription state
     pub pubsub_synchronizer: Option<Arc<dyn PubSubSynchronizer>>,
+    /// Optional async callback that returns a valid IAM token for authentication.
+    /// When set, the cluster reconnection loop will invoke this callback before each
+    /// connection attempt to ensure the password uses fresh credentials.
+    /// The callback should return `Some(token)` if a valid token is available,
+    /// or `None` if token retrieval failed.
+    pub iam_token_provider: Option<Arc<dyn IAMTokenProvider>>,
+}
+
+/// Trait for providing IAM tokens to the reconnection path.
+/// Implemented by the IAM token handle in glide-core.
+#[async_trait::async_trait]
+pub trait IAMTokenProvider: Send + Sync {
+    /// Returns a valid token, refreshing it if expired.
+    async fn get_valid_token(&self) -> Option<String>;
 }
 
 /// To enable async support you need to enable the feature: `tokio-comp`

--- a/glide-core/redis-rs/redis/src/cluster_async/connections_logic.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/connections_logic.rs
@@ -195,6 +195,7 @@ where
             connection_retry_strategy: None,
             tcp_nodelay: params.tcp_nodelay,
             pubsub_synchronizer: None,
+            iam_token_provider: None,
         },
     )
     .await

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -15,7 +15,7 @@
 //! async fn fetch_an_integer() -> String {
 //!     let nodes = vec!["redis://127.0.0.1/"];
 //!     let client = ClusterClient::new(nodes).unwrap();
-//!     let mut connection = client.get_async_connection(None, None).await.unwrap();
+//!     let mut connection = client.get_async_connection(None, None, None).await.unwrap();
 //!     let _: () = connection.set("test", "test_data").await.unwrap();
 //!     let rv: String = connection.get("test").await.unwrap();
 //!     return rv;
@@ -155,12 +155,14 @@ where
         cluster_params: ClusterParams,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
         pubsub_synchronizer: Option<Arc<dyn crate::pubsub_synchronizer::PubSubSynchronizer>>,
+        iam_token_provider: Option<Arc<dyn crate::client::IAMTokenProvider>>,
     ) -> RedisResult<ClusterConnection<C>> {
         ClusterConnInner::new(
             initial_nodes,
             cluster_params,
             push_sender,
             pubsub_synchronizer,
+            iam_token_provider,
         )
         .await
         .map(|inner| {
@@ -206,7 +208,7 @@ where
     /// async fn scan_all_cluster() -> Vec<String> {
     ///     let nodes = vec!["redis://127.0.0.1/"];
     ///     let client = ClusterClient::new(nodes).unwrap();
-    ///     let mut connection = client.get_async_connection(None, None).await.unwrap();
+    ///     let mut connection = client.get_async_connection(None, None, None).await.unwrap();
     ///     let mut scan_state_rc = ScanStateRC::new();
     ///     let mut keys: Vec<String> = vec![];
     ///     let cluster_scan_args = ClusterScanArgs::builder().with_count(1000).with_object_type(ObjectType::String).build();
@@ -1008,6 +1010,146 @@ mod inflight_tracker_tests {
     }
 }
 
+#[cfg(test)]
+mod iam_token_refresh_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Mock IAM token provider that returns a configurable token and tracks call count.
+    struct MockTokenProvider {
+        token: std::sync::Mutex<String>,
+        call_count: AtomicUsize,
+    }
+
+    impl MockTokenProvider {
+        fn new(token: &str) -> Arc<Self> {
+            Arc::new(Self {
+                token: std::sync::Mutex::new(token.to_string()),
+                call_count: AtomicUsize::new(0),
+            })
+        }
+
+        fn set_token(&self, token: &str) {
+            *self.token.lock().unwrap() = token.to_string();
+        }
+
+        fn calls(&self) -> usize {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::client::IAMTokenProvider for MockTokenProvider {
+        async fn get_valid_token(&self) -> Option<String> {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            let token = self.token.lock().unwrap().clone();
+            if token.is_empty() {
+                None
+            } else {
+                Some(token)
+            }
+        }
+    }
+
+    /// Helper to build a minimal GlideConnectionOptions with an IAM provider.
+    fn options_with_provider(
+        provider: Option<Arc<dyn crate::client::IAMTokenProvider>>,
+    ) -> GlideConnectionOptions {
+        GlideConnectionOptions {
+            push_sender: None,
+            disconnect_notifier: None,
+            discover_az: false,
+            connection_timeout: None,
+            connection_retry_strategy: None,
+            tcp_nodelay: false,
+            pubsub_synchronizer: None,
+            iam_token_provider: provider,
+        }
+    }
+
+    /// Helper to build a minimal InnerCore with the given password and IAM provider.
+    fn build_inner(
+        initial_password: Option<String>,
+        provider: Option<Arc<dyn crate::client::IAMTokenProvider>>,
+    ) -> Arc<InnerCore<crate::aio::MultiplexedConnection>> {
+        use crate::cluster_client::ClusterParams;
+        use connections_container::ConnectionsContainer;
+
+        let params = ClusterParams::default_for_test(initial_password);
+
+        Arc::new(InnerCore {
+            conn_lock: StdRwLock::new(ConnectionsContainer::default()),
+            cluster_params: StdRwLock::new(params),
+            pending_requests: Mutex::new(Vec::new()),
+            slot_refresh_state: SlotRefreshState::new(
+                crate::cluster_client::SlotsRefreshRateLimit::default(),
+            ),
+            initial_nodes: Vec::new(),
+            glide_connection_options: options_with_provider(provider),
+            topology_refresh_lock: tokio::sync::Mutex::new(()),
+        })
+    }
+
+    fn read_password(inner: &Arc<InnerCore<crate::aio::MultiplexedConnection>>) -> Option<String> {
+        inner.cluster_params.read().unwrap().password.clone()
+    }
+
+    #[tokio::test]
+    async fn refresh_updates_password_when_provider_returns_token() {
+        let provider = MockTokenProvider::new("fresh-token-123");
+        let inner = build_inner(Some("old-token".into()), Some(provider.clone()));
+
+        ClusterConnInner::refresh_iam_token_in_cluster_params(&inner).await;
+
+        assert_eq!(read_password(&inner), Some("fresh-token-123".into()));
+        assert_eq!(provider.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_does_not_change_password_when_provider_returns_none() {
+        let provider = MockTokenProvider::new(""); // returns None
+        let inner = build_inner(Some("old-token".into()), Some(provider.clone()));
+
+        ClusterConnInner::refresh_iam_token_in_cluster_params(&inner).await;
+
+        assert_eq!(read_password(&inner), Some("old-token".into()));
+        assert_eq!(provider.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn refresh_is_noop_when_no_provider_configured() {
+        let inner = build_inner(Some("static-password".into()), None);
+
+        ClusterConnInner::refresh_iam_token_in_cluster_params(&inner).await;
+
+        assert_eq!(read_password(&inner), Some("static-password".into()));
+    }
+
+    #[tokio::test]
+    async fn refresh_sets_password_when_initially_none() {
+        let provider = MockTokenProvider::new("first-token");
+        let inner = build_inner(None, Some(provider.clone()));
+
+        ClusterConnInner::refresh_iam_token_in_cluster_params(&inner).await;
+
+        assert_eq!(read_password(&inner), Some("first-token".into()));
+    }
+
+    #[tokio::test]
+    async fn refresh_picks_up_new_token_on_second_call() {
+        let provider = MockTokenProvider::new("token-v1");
+        let inner = build_inner(None, Some(provider.clone()));
+
+        ClusterConnInner::refresh_iam_token_in_cluster_params(&inner).await;
+        assert_eq!(read_password(&inner), Some("token-v1".into()));
+
+        provider.set_token("token-v2");
+        ClusterConnInner::refresh_iam_token_in_cluster_params(&inner).await;
+        assert_eq!(read_password(&inner), Some("token-v2".into()));
+        assert_eq!(provider.calls(), 2);
+    }
+}
+
 struct PendingRequest<C> {
     retry: u32,
     sender: oneshot::Sender<RedisResult<Response>>,
@@ -1278,6 +1420,7 @@ where
         cluster_params: ClusterParams,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
         pubsub_synchronizer: Option<Arc<dyn crate::pubsub_synchronizer::PubSubSynchronizer>>,
+        iam_token_provider: Option<Arc<dyn crate::client::IAMTokenProvider>>,
     ) -> RedisResult<Disposable<Self>> {
         let disconnect_notifier = {
             #[cfg(feature = "tokio-comp")]
@@ -1304,6 +1447,7 @@ where
             connection_retry_strategy: Some(connection_retry_strategy),
             tcp_nodelay: cluster_params.tcp_nodelay,
             pubsub_synchronizer,
+            iam_token_provider,
         };
 
         let connections = Self::create_initial_connections(
@@ -1490,19 +1634,32 @@ where
         Ok(connections.0)
     }
 
+    /// If IAM authentication is configured, refresh the token in `cluster_params` so that
+    /// any subsequent connection attempts use a valid credential.
+    async fn refresh_iam_token_in_cluster_params(inner: &Arc<InnerCore<C>>) {
+        if let Some(ref token_provider) = inner.glide_connection_options.iam_token_provider {
+            if let Some(valid_token) = token_provider.get_valid_token().await {
+                if let Ok(mut params) = inner.cluster_params.write() {
+                    params.password = Some(valid_token);
+                }
+            }
+        }
+    }
+
     // Reconnect to the initial nodes provided by the user in the creation of the client,
     // and try to refresh the slots based on the initial connections.
     // Being used when all cluster connections are unavailable.
     fn reconnect_to_initial_nodes(inner: Arc<InnerCore<C>>) -> impl Future<Output = ()> {
         let inner = inner.clone();
-        let cluster_params = match inner.get_cluster_param(|params| params.clone()) {
-            Ok(params) => params,
-            Err(err) => {
-                warn!("Failed to get cluster params: {}", err);
-                return async {}.boxed();
-            }
-        };
         Box::pin(async move {
+            Self::refresh_iam_token_in_cluster_params(&inner).await;
+            let cluster_params = match inner.get_cluster_param(|params| params.clone()) {
+                Ok(params) => params,
+                Err(err) => {
+                    warn!("Failed to get cluster params: {}", err);
+                    return;
+                }
+            };
             let connection_map = match Self::create_initial_connections(
                 &inner.initial_nodes,
                 &cluster_params,
@@ -1693,6 +1850,8 @@ where
                 )));
                 let mut first_attempt = true;
                 for backoff_duration in infinite_backoff_iter {
+                    Self::refresh_iam_token_in_cluster_params(&inner_clone).await;
+
                     let cluster_params = inner_clone
                         .cluster_params
                         .read()
@@ -2387,6 +2546,8 @@ where
         let nodes = new_slots.all_node_addresses();
         let nodes_len = nodes.len();
 
+        // Ensure cluster_params has a fresh IAM token before creating connections
+        Self::refresh_iam_token_in_cluster_params(&inner).await;
         let cluster_params = inner
             .get_cluster_param(|params| params.clone())
             .expect(MUTEX_READ_ERR);

--- a/glide-core/redis-rs/redis/src/cluster_client.rs
+++ b/glide-core/redis-rs/redis/src/cluster_client.rs
@@ -187,6 +187,36 @@ impl ClusterParams {
     }
 }
 
+impl ClusterParams {
+    /// Create a `ClusterParams` with sensible defaults for unit tests.
+    #[cfg(test)]
+    pub(crate) fn default_for_test(password: Option<String>) -> Self {
+        Self {
+            password,
+            username: None,
+            read_from_replicas: ReadFromReplicaStrategy::AlwaysFromPrimary,
+            tls: None,
+            retry_params: Default::default(),
+            connection_timeout: Duration::from_secs(1),
+            #[cfg(feature = "cluster-async")]
+            topology_checks_interval: None,
+            #[cfg(feature = "cluster-async")]
+            slots_refresh_rate_limit: Default::default(),
+            #[cfg(feature = "cluster-async")]
+            connections_validation_interval: None,
+            tls_params: None,
+            client_name: None,
+            lib_name: None,
+            response_timeout: Duration::from_secs(1),
+            protocol: ProtocolVersion::RESP2,
+            reconnect_retry_strategy: None,
+            refresh_topology_from_initial_nodes: false,
+            database_id: 0,
+            tcp_nodelay: false,
+        }
+    }
+}
+
 /// Used to configure and build a [`ClusterClient`].
 pub struct ClusterClientBuilder {
     initial_nodes: RedisResult<Vec<ConnectionInfo>>,
@@ -613,12 +643,14 @@ impl ClusterClient {
         &self,
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
         pubsub_synchronizer: Option<Arc<dyn crate::pubsub_synchronizer::PubSubSynchronizer>>,
+        iam_token_provider: Option<Arc<dyn crate::client::IAMTokenProvider>>,
     ) -> RedisResult<cluster_async::ClusterConnection> {
         cluster_async::ClusterConnection::new(
             &self.initial_nodes,
             self.cluster_params.clone(),
             push_sender,
             pubsub_synchronizer,
+            iam_token_provider,
         )
         .await
     }
@@ -655,6 +687,7 @@ impl ClusterClient {
         cluster_async::ClusterConnection::new(
             &self.initial_nodes,
             self.cluster_params.clone(),
+            None,
             None,
             None,
         )

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -338,6 +338,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 // public api
 pub use crate::client::Client;
 pub use crate::client::GlideConnectionOptions;
+pub use crate::client::IAMTokenProvider;
 pub use crate::cmd::{cmd, fenced_cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
     Commands, ControlFlow, Direction, LposOptions, PubSubCommands, SetOptions,

--- a/glide-core/redis-rs/redis/tests/auth.rs
+++ b/glide-core/redis-rs/redis/tests/auth.rs
@@ -41,7 +41,10 @@ mod auth {
                 let cluster_context =
                     cluster_context.expect("ClusterContext is required for Cluster connection");
                 let builder = get_builder(cluster_context, password);
-                let connection = builder.build()?.get_async_connection(None, None).await?;
+                let connection = builder
+                    .build()?
+                    .get_async_connection(None, None, None)
+                    .await?;
                 Ok(Connection::Cluster(connection))
             }
             ConnectionType::Standalone => {

--- a/glide-core/redis-rs/redis/tests/support/cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/cluster.rs
@@ -414,7 +414,7 @@ impl TestClusterContext {
         push_sender: Option<mpsc::UnboundedSender<PushInfo>>,
     ) -> redis::cluster_async::ClusterConnection {
         self.client
-            .get_async_connection(push_sender, None)
+            .get_async_connection(push_sender, None, None)
             .await
             .unwrap()
     }

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -955,7 +955,7 @@ mod cluster_async {
             .read_from(strategy)
             .build()
             .unwrap()
-            .get_async_connection(None, None)
+            .get_async_connection(None, None, None)
             .await
             .unwrap();
 
@@ -1058,7 +1058,7 @@ mod cluster_async {
             .read_from(strategy)
             .build()
             .unwrap()
-            .get_async_connection(None, None)
+            .get_async_connection(None, None, None)
             .await
             .unwrap();
 
@@ -1163,7 +1163,7 @@ mod cluster_async {
             )
             .build()
             .unwrap()
-            .get_async_connection(None, None)
+            .get_async_connection(None, None, None)
             .await
             .unwrap();
 
@@ -1341,7 +1341,7 @@ mod cluster_async {
             let client = ClusterClient::builder(cluster_addresses.clone())
                 .read_from_replicas()
                 .build()?;
-            let mut connection = client.get_async_connection(None, None).await?;
+            let mut connection = client.get_async_connection(None, None, None).await?;
 
             let route_to_all_nodes = redis::cluster_routing::MultipleNodeRoutingInfo::AllNodes;
             let routing = RoutingInfo::MultiNode((route_to_all_nodes, None));
@@ -2378,7 +2378,7 @@ mod cluster_async {
                         .build()
                         .unwrap();
 
-                let mut conn = client.get_async_connection(None, None).await.unwrap();
+                let mut conn = client.get_async_connection(None, None, None).await.unwrap();
 
                 // Disable full coverage requirement
                 let _ = conn
@@ -6473,7 +6473,7 @@ mod cluster_async {
                 .unwrap();
 
             let mut connection = test_user_client
-                .get_async_connection(None, None)
+                .get_async_connection(None, None, None)
                 .await
                 .unwrap();
 
@@ -6537,7 +6537,7 @@ mod cluster_async {
             let cluster = TestClusterContext::new_with_mtls(3, 0);
             block_on_all(async move {
                 let client = create_cluster_client_from_cluster(&cluster, true).unwrap();
-                let mut connection = client.get_async_connection(None, None).await.unwrap();
+                let mut connection = client.get_async_connection(None, None, None).await.unwrap();
                 cmd("SET")
                     .arg("test")
                     .arg("test_data")
@@ -6560,7 +6560,7 @@ mod cluster_async {
             let cluster = TestClusterContext::new_with_mtls(3, 0);
             block_on_all(async move {
             let client = create_cluster_client_from_cluster(&cluster, false).unwrap();
-            let connection = client.get_async_connection(None, None).await;
+            let connection = client.get_async_connection(None, None, None).await;
             match cluster.cluster.servers.first().unwrap().connection_info() {
                 ConnectionInfo {
                     addr: redis::ConnectionAddr::TcpTls { .. },

--- a/glide-core/redis-rs/redis/tests/test_cluster_pipeline.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_pipeline.rs
@@ -1133,7 +1133,7 @@ mod test_cluster_pipeline {
             ))
             .build()
             .unwrap()
-            .get_async_connection(None, None)
+            .get_async_connection(None, None, None)
             .await
             .unwrap();
 

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -33,6 +33,7 @@ pub use types::*;
 
 use self::value_conversion::{convert_to_expected_type, expected_type_for_cmd, get_value_type};
 mod reconnecting_connection;
+pub use reconnecting_connection::IAMTokenHandle;
 mod standalone_client;
 mod value_conversion;
 use crate::pubsub::{PubSubSynchronizer, create_pubsub_synchronizer};
@@ -1676,8 +1677,11 @@ async fn create_cluster_client(
     builder = builder.periodic_connections_checks(Some(CONNECTION_CHECKS_INTERVAL));
 
     let client = builder.build()?;
+    let iam_token_provider: Option<Arc<dyn redis::IAMTokenProvider>> = iam_token_manager
+        .map(|manager| Arc::new(manager.get_token_handle()) as Arc<dyn redis::IAMTokenProvider>);
+
     let mut con = client
-        .get_async_connection(push_sender, Some(pubsub_synchronizer))
+        .get_async_connection(push_sender, Some(pubsub_synchronizer), iam_token_provider)
         .await?;
 
     // This validation ensures that sharded subscriptions are not applied to Redis engines older than version 7.0,

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -34,6 +34,81 @@ pub enum ReconnectReason {
     CreateError,
 }
 
+/// Token handle to the IAM token cache for use during reconnection.
+///
+/// Holds shared references to the cached token, its creation timestamp, and the
+/// IAM configuration needed to generate a fresh token on demand. On every
+/// reconnection attempt the handle returns the best available token — refreshing
+/// it via SigV4 signing when the current one has expired — so the AUTH command
+/// always uses valid credentials without requiring a reference back to the full
+/// `IAMTokenManager`.
+#[derive(Clone)]
+pub struct IAMTokenHandle {
+    /// Shared cached IAM token (same `Arc` owned by `IAMTokenManager`).
+    pub(crate) cached_token: Arc<tokio::sync::RwLock<String>>,
+    /// When the cached token was last generated or refreshed.
+    pub(crate) token_created_at: Arc<tokio::sync::RwLock<tokio::time::Instant>>,
+    /// IAM configuration (cluster name, region, etc.) for on-demand token generation.
+    pub(crate) iam_token_state: crate::iam::IamTokenState,
+}
+
+impl IAMTokenHandle {
+    /// Returns the best available token, refreshing it first if expired.
+    ///
+    /// If the token has expired, attempts to generate a fresh one via SigV4.
+    /// On refresh failure, falls back to the existing cached token so that
+    /// the password is always updated on every reconnection attempt.
+    /// Returns `None` only if the cache is completely empty.
+    pub(crate) async fn get_valid_token_inner(&self) -> Option<String> {
+        use crate::iam::TOKEN_TTL_SECONDS;
+
+        let is_expired = {
+            let ts = self.token_created_at.read().await;
+            ts.elapsed() >= std::time::Duration::from_secs(TOKEN_TTL_SECONDS)
+        };
+
+        if is_expired {
+            logger_core::log_info(
+                "IAM reconnect",
+                "Token expired, generating a fresh token before reconnection",
+            );
+            match crate::iam::IAMTokenManager::generate_token_with_backoff(&self.iam_token_state)
+                .await
+            {
+                Ok(new_token) => {
+                    {
+                        let mut guard = self.cached_token.write().await;
+                        *guard = new_token.clone();
+                    }
+                    {
+                        let mut ts = self.token_created_at.write().await;
+                        *ts = tokio::time::Instant::now();
+                    }
+                    return Some(new_token);
+                }
+                Err(err) => {
+                    logger_core::log_error(
+                        "IAM reconnect",
+                        format!("Failed to generate fresh IAM token, using cached token: {err}"),
+                    );
+                    // Fall through to return the cached (possibly expired) token
+                }
+            }
+        }
+
+        let guard = self.cached_token.read().await;
+        let token = guard.clone();
+        if token.is_empty() { None } else { Some(token) }
+    }
+}
+
+#[async_trait::async_trait]
+impl redis::IAMTokenProvider for IAMTokenHandle {
+    async fn get_valid_token(&self) -> Option<String> {
+        self.get_valid_token_inner().await
+    }
+}
+
 /// The object that is used in order to recreate a connection after a disconnect.
 struct ConnectionBackend {
     /// This signal is reset when a connection disconnects, and set when a new `ConnectionState` has been set with a `Connected` state.
@@ -42,6 +117,8 @@ struct ConnectionBackend {
     connection_info: RwLock<redis::Client>,
     /// Once this flag is set, the internal connection needs no longer try to reconnect to the server, because all the outer clients were dropped.
     client_dropped_flagged: AtomicBool,
+    /// Optional handle to the IAM token cache for refreshing the password before reconnection.
+    iam_token_handle: Option<IAMTokenHandle>,
 }
 
 /// State of the current connection. Allows the user to use a connection only when a reconnect isn't in progress or has failed.
@@ -144,6 +221,7 @@ async fn create_connection(
         connection_retry_strategy: Some(retry_strategy),
         tcp_nodelay,
         pubsub_synchronizer,
+        iam_token_provider: None,
     };
 
     // Wrap retry loop in timeout so total time respects connection_timeout
@@ -252,6 +330,7 @@ impl ReconnectingConnection {
         tls_params: Option<redis::TlsConnParams>,
         tcp_nodelay: bool,
         pubsub_synchronizer: Option<Arc<dyn crate::pubsub::PubSubSynchronizer>>,
+        iam_token_handle: Option<IAMTokenHandle>,
     ) -> Result<ReconnectingConnection, (ReconnectingConnection, RedisError)> {
         log_debug(
             "connection creation",
@@ -263,6 +342,7 @@ impl ReconnectingConnection {
             connection_info: RwLock::new(connection_info),
             connection_available_signal: ManualResetEvent::new(true),
             client_dropped_flagged: AtomicBool::new(false),
+            iam_token_handle,
         };
         create_connection(
             backend,
@@ -347,12 +427,19 @@ impl ReconnectingConnection {
         // The reconnect task is spawned instead of awaited here, so that the reconnect attempt will continue in the
         // background, regardless of whether the calling task is dropped or not.
         task::spawn(async move {
-            // Get a clone of the client with the current connection info
-            // updates made via update_connection_database(). This ensures reconnection uses the
-            // correct database as selected by previous SELECT commands.
-            let client = {
-                let guard = connection_clone.inner.backend.get_backend_client();
-                guard.clone()
+            let has_iam = connection_clone.inner.backend.iam_token_handle.is_some();
+
+            // For non-IAM connections, clone the client once before the loop to preserve
+            // the original reconnection behavior (password is fixed at reconnect start).
+            // For IAM connections, the client is cloned inside the loop so each retry
+            // picks up the freshest token written by the IAM handle.
+            let static_client = if !has_iam {
+                Some({
+                    let guard = connection_clone.inner.backend.get_backend_client();
+                    guard.clone()
+                })
+            } else {
+                None
             };
 
             let infinite_backoff_dur_iterator = connection_clone
@@ -369,6 +456,34 @@ impl ReconnectingConnection {
                     // Client was dropped, reconnection attempts can stop
                     return;
                 }
+
+                // If IAM authentication is configured, ensure the connection uses a
+                // valid token before attempting to reconnect.  If the cached token has
+                // expired, a fresh one is generated on demand via SigV4 signing.
+                if let Some(handle) = &connection_clone.inner.backend.iam_token_handle
+                    && let Some(valid_token) = handle.get_valid_token_inner().await
+                {
+                    let mut client = connection_clone
+                        .inner
+                        .backend
+                        .connection_info
+                        .write()
+                        .expect(WRITE_LOCK_ERR);
+                    client.update_password(Some(valid_token));
+                    log_debug(
+                        "reconnect",
+                        "Updated connection password with valid IAM token before reconnection attempt",
+                    );
+                }
+
+                let client = if let Some(ref c) = static_client {
+                    c.clone()
+                } else {
+                    // IAM path: re-read from backend to pick up the token update above
+                    let guard = connection_clone.inner.backend.get_backend_client();
+                    guard.clone()
+                };
+
                 match get_multiplexed_connection(&client, &connection_clone.connection_options)
                     .await
                 {

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -224,6 +224,8 @@ impl StandaloneClient {
         let addresses = connection_request.addresses.clone();
         let read_from_option = connection_request.read_from.clone();
 
+        let iam_token_handle = iam_token_manager.map(|m| m.get_token_handle());
+
         let mut stream = stream::iter(addresses.into_iter())
             .map(move |address| {
                 let info = valkey_connection_info.clone();
@@ -236,6 +238,7 @@ impl StandaloneClient {
                 let nodelay = tcp_nodelay;
                 let sync = pubsub_synchronizer.clone();
                 let skip_replication = read_only;
+                let iam_handle = iam_token_handle.clone();
                 async move {
                     get_connection_and_replication_info(
                         &address,
@@ -249,6 +252,7 @@ impl StandaloneClient {
                         nodelay,
                         &sync,
                         skip_replication,
+                        iam_handle,
                     )
                     .await
                     .map_err(|err| (format!("{}:{}", address.host, address.port), err))
@@ -831,6 +835,7 @@ async fn get_connection_and_replication_info(
     tcp_nodelay: bool,
     pubsub_synchronizer: &Option<Arc<dyn crate::pubsub::PubSubSynchronizer>>,
     skip_replication_check: bool,
+    iam_token_handle: Option<super::IAMTokenHandle>,
 ) -> Result<(ReconnectingConnection, Option<Value>), (ReconnectingConnection, RedisError)> {
     let reconnecting_connection = ReconnectingConnection::new(
         address,
@@ -843,6 +848,7 @@ async fn get_connection_and_replication_info(
         tls_params,
         tcp_nodelay,
         pubsub_synchronizer.clone(),
+        iam_token_handle,
     )
     .await?;
 

--- a/glide-core/src/iam/mod.rs
+++ b/glide-core/src/iam/mod.rs
@@ -24,7 +24,7 @@ const DEFAULT_REFRESH_INTERVAL_SECONDS: u32 = 300; // 300 seconds (5min)
 /// Setting refresh intervals above this value may have performance consequences
 const WARNING_REFRESH_INTERVAL_SECONDS: u32 = 15 * 60; // 900 seconds
 /// SigV4 presign expiration (15 minutes)
-const TOKEN_TTL_SECONDS: u64 = 15 * 60; // 900
+pub const TOKEN_TTL_SECONDS: u64 = 15 * 60; // 900
 
 /// Exponential backoff settings for token generation
 const TOKEN_GEN_MAX_ATTEMPTS: u32 = 8;
@@ -139,7 +139,7 @@ async fn get_signing_identity(
 
 /// Internal state structure for IAM token management
 #[derive(Clone, Debug)]
-struct IamTokenState {
+pub(crate) struct IamTokenState {
     /// AWS region for signing requests
     region: String,
     /// ElastiCache/MemoryDB cluster name
@@ -162,6 +162,8 @@ pub struct IAMTokenManager {
     /// Cached auth token, stored in an `Arc<RwLock<String>>` to allow many concurrent readers,
     /// safe exclusive writes on refresh, and shared access across async tasks.
     cached_token: Arc<RwLock<String>>,
+    /// Timestamp of when the cached token was last generated/refreshed.
+    token_created_at: Arc<RwLock<tokio::time::Instant>>,
     /// IAM token state containing all configuration
     iam_token_state: IamTokenState,
     /// Background refresh task handle
@@ -219,6 +221,7 @@ impl IAMTokenManager {
 
         Ok(Self {
             cached_token: Arc::new(RwLock::new(initial_token)),
+            token_created_at: Arc::new(RwLock::new(tokio::time::Instant::now())),
             iam_token_state: state,
             refresh_task: None,
             shutdown_notify: Arc::new(Notify::new()),
@@ -234,12 +237,14 @@ impl IAMTokenManager {
 
         let iam_token_state = self.iam_token_state.clone();
         let cached_token = Arc::clone(&self.cached_token);
+        let token_created_at = Arc::clone(&self.token_created_at);
         let shutdown_notify = Arc::clone(&self.shutdown_notify);
         let token_changed = Arc::clone(&self.token_changed);
 
         let task = tokio::spawn(Self::token_refresh_task(
             iam_token_state,
             cached_token,
+            token_created_at,
             shutdown_notify,
             token_changed,
         ));
@@ -251,6 +256,7 @@ impl IAMTokenManager {
     async fn token_refresh_task(
         iam_token_state: IamTokenState,
         cached_token: Arc<RwLock<String>>,
+        token_created_at: Arc<RwLock<tokio::time::Instant>>,
         shutdown_notify: Arc<Notify>,
         token_changed: Arc<AtomicBool>,
     ) {
@@ -265,7 +271,7 @@ impl IAMTokenManager {
         loop {
             tokio::select! {
                 _ = interval_timer.tick() => {
-                    Self::handle_token_refresh(&iam_token_state, &cached_token, &token_changed).await;
+                    Self::handle_token_refresh(&iam_token_state, &cached_token, &token_created_at, &token_changed).await;
                 }
                 _ = shutdown_notify.notified() => {
                     log_info("IAM token refresh task shutting down", "");
@@ -281,11 +287,16 @@ impl IAMTokenManager {
     async fn handle_token_refresh(
         iam_token_state: &IamTokenState,
         cached_token: &Arc<RwLock<String>>,
+        token_created_at: &Arc<RwLock<tokio::time::Instant>>,
         token_changed: &Arc<AtomicBool>,
     ) {
         match Self::generate_token_with_backoff(iam_token_state).await {
             Ok(new_token) => {
                 Self::set_cached_token_static(cached_token, new_token.clone()).await;
+                {
+                    let mut ts = token_created_at.write().await;
+                    *ts = tokio::time::Instant::now();
+                }
                 token_changed.store(true, Ordering::Release);
             }
             Err(err) => {
@@ -301,7 +312,9 @@ impl IAMTokenManager {
     /// Generate a token with exponential backoff + ±20% jitter.
     /// Retries up to `TOKEN_GEN_MAX_ATTEMPTS`, doubling backoff each time (capped).
     /// Returns token on success, last error on failure.
-    async fn generate_token_with_backoff(state: &IamTokenState) -> Result<String, GlideIAMError> {
+    pub(crate) async fn generate_token_with_backoff(
+        state: &IamTokenState,
+    ) -> Result<String, GlideIAMError> {
         let mut attempt: u32 = 0;
         let mut backoff_ms = TOKEN_GEN_INITIAL_BACKOFF_MS;
 
@@ -353,6 +366,7 @@ impl IAMTokenManager {
         Self::handle_token_refresh(
             &self.iam_token_state,
             &self.cached_token,
+            &self.token_created_at,
             &self.token_changed,
         )
         .await;
@@ -387,6 +401,19 @@ impl IAMTokenManager {
     /// Clear the token changed flag after handling the change
     pub fn clear_token_changed(&self) {
         self.token_changed.store(false, Ordering::Release)
+    }
+
+    /// Create a lightweight handle to the token cache for use by the reconnection path.
+    ///
+    /// The returned handle shares the same `Arc`s as this manager, so any token
+    /// refresh performed by the background task is immediately visible through
+    /// the handle without requiring a reference back to the full `IAMTokenManager`.
+    pub fn get_token_handle(&self) -> crate::client::IAMTokenHandle {
+        crate::client::IAMTokenHandle {
+            cached_token: Arc::clone(&self.cached_token),
+            token_created_at: Arc::clone(&self.token_created_at),
+            iam_token_state: self.iam_token_state.clone(),
+        }
     }
 
     /// Generate IAM authentication token using SigV4 signing (valid for 15 minutes)

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -480,7 +480,7 @@ impl PubSubTestSetup {
             .expect("Failed to build cluster client for topology test");
 
         let connection = client
-            .get_async_connection(None, Some(synchronizer.clone()))
+            .get_async_connection(None, Some(synchronizer.clone()), None)
             .await
             .expect("Failed to get async connection for topology test");
 


### PR DESCRIPTION
Cherry-picking https://github.com/valkey-io/valkey-glide/pull/5663 to `release-2.3`