### PR TITLE
Install pkg-config and libssl-dev before building Valkey with TLS in the Python CD pipeline

### DIFF
--- a/.github/workflows/install-engine/action.yml
+++ b/.github/workflows/install-engine/action.yml
@@ -87,6 +87,15 @@ runs:
               fi
               echo 'export PATH=/usr/local/bin:$PATH' >>~/.bash_profile
 
+        - name: Install build dependencies
+          if: ${{ steps.cache-valkey.outputs.cache-hit != 'true' }}
+          shell: bash
+          run: |
+              if command -v apt-get &> /dev/null; then
+                  sudo apt-get update -q
+                  sudo apt-get install -y pkg-config libssl-dev
+              fi
+
         - name: Build and install engine
           if: ${{ steps.cache-valkey.outputs.cache-hit != 'true'}}
           shell: ${{ contains(inputs.target, 'windows') && 'wsl-bash {0}' || 'bash' }}
@@ -112,7 +121,7 @@ runs:
               echo 'Configuring system for cluster mode...'
               sudo sysctl vm.overcommit_memory=1 || echo 'Cannot set overcommit'
               sudo bash -c 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' || echo 'Cannot disable hugepage'
-                
+
               echo 'WSL Configuration complete'
 
         - name: Verify Valkey installation and symlinks


### PR DESCRIPTION
### Summary
The `install-engine` action failed to build Valkey with `BUILD_TLS=yes` on Ubuntu self-hosted runners because `pkg-config` and `libssl-dev` were not present. Other workflows avoid this by going through `install-shared-dependencies` first, but the Python CD pipeline calls `install-engine` directly, bypassing that setup.

### Issue link
This Pull Request is linked to issue: N/A

Example of run failure: https://github.com/valkey-io/valkey-glide/actions/runs/23808386909/job/69412435972

### Features / Behaviour Changes
No functional changes. The engine install now succeeds on Ubuntu runners when called directly without `install-shared-dependencies`.

### Implementation
Added a step in `.github/workflows/install-engine/action.yml` that runs `apt-get install -y pkg-config libssl-dev` before the build step, conditioned only on cache miss. The step guards with `command -v apt-get` internally, making it a no-op on non-apt systems (Amazon Linux, musl), so no platform-specific conditionals are needed.

### Limitations
None.

### Testing
The fix addresses the exact error seen in CI: `fatal error: openssl/ssl.h: No such file or directory` followed by `fatal error: jemalloc/jemalloc.h: No such file or directory` (a downstream consequence of the same deps build failure).


### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
