### PR TITLE
Cherry-pick/Pypi-CD: fix test-the-release step for linux-arm ephemera…

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -587,6 +587,12 @@ jobs:
 
                   echo "/opt/${PYPY_VERSION_3_10}/bin" >> ${GITHUB_PATH}
 
+            - name: Install engine build dependencies (ephemeral runners)
+              if: ${{ contains(matrix.build.RUNNER, 'ephemeral') }}
+              run: |
+                  sudo apt update -y
+                  sudo apt install -y pkg-config libssl-dev
+
             - name: Install engine
               uses: ./.github/workflows/install-engine
               with:


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

This is a CHERRY-PICK of [Pypi-CD: fix test-the-release step for linux-arm ephemeral runner #5566](https://github.com/valkey-io/valkey-glide/pull/5566)

The "Test the release" job in pypi-cd.yml calls install-engine directly (not through install-shared-dependencies), so OpenSSL headers were never explicitly installed. This was probably masked by the Valkey build cache previously — once Valkey 8.0 didn't have an available cached build, the build failed on the ARM64 ephemeral self-hosted runner with `openssl/ssl.h: No such file or directory.`                 
Failure run: https://github.com/valkey-io/valkey-glide/actions/runs/22911960509/job/66534752089
Install engine step:
```
sentinel.c:34:10: fatal error: openssl/ssl.h: No such file or directory
   34 | #include "openssl/ssl.h"
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile:534: sentinel.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/ubuntu/actions-runner/_work/valkey-glide/valkey-glide/valkey/src'
make: *** [Makefile:6: all] Error 2
Error: Process completed with exit code 2.
```
GitHub-hosted runners have libssl-dev pre-installed so they weren't affected. 

This was tested in this workflow run (testing an existing release instead of a new one)- https://github.com/valkey-io/valkey-glide/actions/runs/22967185544/job/66692227010 
