### PR TITLE
Fix false error logs in cluster_manager.py when stopping already-dead servers

### DIFF
--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -71,7 +71,7 @@ func (suite *GlideTestSuite) SetupSuite() {
 	runClusterManager(suite, []string{"stop", "--prefix", "cluster"}, true)
 	runClusterManager(suite, []string{"--tls", "stop", "--prefix", "cluster"}, true)
 
-	// Delete dirs if stop failed due to https://github.com/valkey-io/valkey-glide/issues/849
+	// Delete dirs to ensure clean state before starting new clusters
 	err := os.RemoveAll("../../utils/clusters")
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatal(err)

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -108,7 +108,7 @@ tasks.register('stopAllBeforeTests') {
     }
 }
 
-// delete dirs if stop failed due to https://github.com/valkey-io/valkey-glide/issues/849
+// delete dirs to ensure clean state before starting new clusters
 tasks.register('clearDirs', Delete) {
     delete "${project.rootDir}/../utils/clusters"
 }

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -919,6 +919,17 @@ def dir_path(path: str):
 
 def stop_server(server: Server, cluster_folder: str, use_tls: bool, auth: str):
     logging.debug(f"Stopping server {server}")
+    try:
+        ping = subprocess.run(
+            [get_cli_command(), "-h", server.host, "-p", str(server.port),
+             *get_cli_option_args(cluster_folder, use_tls, auth), "PING"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if ping.returncode != 0:
+            logging.info(f"Server {server} is already down, skipping shutdown")
+            return
+    except subprocess.TimeoutExpired:
+        logging.debug(f"Ping to {server} timed out, attempting shutdown anyway")
     cmd_args = [
         get_cli_command(),
         "-h",
@@ -941,6 +952,9 @@ def stop_server(server: Server, cluster_folder: str, use_tls: bool, auth: str):
                 text=True,
             )
             output, err = p.communicate(timeout=5)
+            if err and "Connection refused" in err:
+                logging.info(f"Server {server} is already down")
+                return
             if err and "Warning: Using a password with '-a'" not in err:
                 err_msg = (
                     f"Failed to shutdown host {server.host}:{server.port}:\n {err}"


### PR DESCRIPTION
### Summary

Adds a liveness pre-check to `stop_server()` so that already-stopped servers are handled gracefully with an `INFO` log instead of producing noisy `ERROR` messages.

### Issue link

Closes #849

### Features / Behaviour Changes

- `stop_server()` now pings the server before attempting shutdown. If the server is already down, it logs at `INFO` level and returns early.
- If a server goes down between the ping and the shutdown attempt, the "Connection refused" error is caught and treated as a successful no-op at `INFO` level instead of `ERROR`.

### Implementation

Two changes in `stop_server()` in `utils/cluster_manager.py`:
1. Pre-check ping at the top of the function — returns early if server is unreachable.
2. "Connection refused" check before the general error handler in the shutdown retry loop — handles the race condition gracefully.

### Testing

Tested manually locally:
1. Started a 6-node cluster with `cluster_manager.py start --cluster-mode`
2. Killed all servers with `pkill` to simulate a crash
3. Ran `cluster_manager.py stop --prefix cluster`
   - **main branch**: 6x `ERROR:root:Failed to shutdown host ... Connection refused`
   - **fix branch**: 6x `INFO:root:Server ... is already down, skipping shutdown`

Also verified that in CI it now logs at `INFO` instead of `ERROR`:
```
Finding and stopping all running Valkey processes...
INFO:root:## Executing cluster_manager.py with the following args:
  Namespace(host='127.0.0.1', tls=False, auth=None, log='info', logfile=None, action='stop', folder_path='/home/runner/work/valkey-glide/valkey-glide/utils/clusters', prefix='cluster', cluster_folder=None, keep_folder=True, pids='')
INFO:root:2026-04-10 18:22:55.920937+00:00 Stopping script for cluster/s cluster* in /home/runner/work/valkey-glide/valkey-glide/utils/clusters
INFO:root:Server 127.0.0.1:38176 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:50927 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:14452 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:22584 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:43090 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:21948 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:26766 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:29696 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:43236 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:55282 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:18938 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:34982 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:10619 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:16340 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:44717 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:23078 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:43325 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:24991 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:14515 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:14871 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:47289 is already down, skipping shutdown
INFO:root:Server 127.0.0.1:48911 is already down, skipping shutdown
LOG_FILE=/home/runner/work/valkey-glide/valkey-glide/utils/clusters/cluster-2026-04-10T18-14-34Z-ZcRloY/cluster_manager.log
LOG_FILE=/home/runner/work/valkey-glide/valkey-glide/utils/clusters/cluster-2026-04-10T18-14-47Z-sa2mLh/cluster_manager.log
LOG_FILE=/home/runner/work/valkey-glide/valkey-glide/utils/clusters/cluster-2026-04-10T18-15-07Z-mHxFDC/cluster_manager.log
```

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] ~Tests are added or updated.~
- [ ] ~CHANGELOG.md and documentation files are updated.~
- [x] Linters have been run.
- [x] Destination branch is correct - main.
- [x] Create merge commit if merging release branch into main, squash otherwise.