### PR TITLE
Exempt transitive rand 0.8.5 in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,12 @@ ignore = [
     # via iai-callgrind for benchmarking. No security impact.
     # https://rustsec.org/advisories/RUSTSEC-2025-0141
     "RUSTSEC-2025-0141",
+    # rand is unsound with custom logger using rand::rng(), but only used as
+    # a transitive dependency (nanoid, opentelemetry_sdk, tower). Glide doesn't
+    # use a custom logger that calls rand::thread_rng(). No 0.8.x patch exists
+    # and direct dependency bumped to 0.9.4, which is patched.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097
+    "RUSTSEC-2026-0097",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## Summary

Adds an exemption for [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097) (Rand is unsound with a custom logger using `rand::rng()`) to `deny.toml`. The advisory affects rand `>=0.7, <0.9.3`, and rand 0.8.5 is pulled in transitively by `nanoid`, `opentelemetry_sdk`, and `tower`, and no patch exists yet. The direct rand dependency has already been bumped to 0.9.4 via `cargo update` in CI.

This exemption is safe because glide does not use a custom logger that calls `rand::rng()`. Should be revisited once upstream crates drop their rand 0.8 dependency.

### Testing

Ran `cargo deny check --config ../deny.toml` locally, which now passes.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] ~This Pull Request is related to one issue.~
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
