### PR TITLE
Fixed standalone client read strategies incorrect behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))
 * CORE: Add adaptive timeout on pipeline send to detect dead connections during half-open TCP scenarios, replace `now_or_never()` with proper `poll()` in recovery to fix busy-spin, remove `loop{}` from `poll_flush`, and fail pending requests immediately during recovery to prevent OOM under sustained partition ([#5715](https://github.com/valkey-io/valkey-glide/issues/5715), [#5716](https://github.com/valkey-io/valkey-glide/issues/5716))
 * CORE: Skip compression/decompression code paths when compression is not configured to eliminate per-command overhead ([#5644](https://github.com/valkey-io/valkey-glide/pull/5644))
-
+* CORE: Fixed standalone client read strategy AZAffinity including the primary in the read list when it is in the same az as the client.
+* CORE: Fixed standalone client read strategy AZAffinityAndPrimary not falling back to primary when there are no local replicas.
 #### Operational Enhancements
 
 

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -373,6 +373,8 @@ impl StandaloneClient {
         self.inner.nodes.get(self.inner.primary_index).unwrap()
     }
 
+    /// Round-robins through replicas (skipping the primary) and returns the first connected one.
+    /// Falls back to the primary if no replica is connected.
     fn round_robin_read_from_replica(
         &self,
         latest_read_replica_index: &Arc<AtomicUsize>,
@@ -434,11 +436,13 @@ impl StandaloneClient {
         }
     }
 
-    async fn round_robin_read_from_replica_az_awareness(
+    /// Round-robins through replicas (skipping the primary) and returns the first one
+    /// whose availability zone matches `client_az`. Returns `None` if no match is found.
+    async fn get_next_local_replica(
         &self,
         latest_read_replica_index: &Arc<AtomicUsize>,
-        client_az: String,
-    ) -> &ReconnectingConnection {
+        client_az: &str,
+    ) -> Option<&ReconnectingConnection> {
         let initial_index = latest_read_replica_index.load(Ordering::Relaxed);
         let mut retries = 0usize;
 
@@ -446,12 +450,14 @@ impl StandaloneClient {
             retries = retries.saturating_add(1);
             // Looped through all replicas; no connected replica found in the same AZ.
             if retries > self.inner.nodes.len() {
-                // Attempt a fallback to any available replica in other AZs or primary.
-                return self.round_robin_read_from_replica(latest_read_replica_index);
+                return None;
             }
 
             // Calculate index based on initial index and check count.
             let index = (initial_index + retries) % self.inner.nodes.len();
+            if index == self.inner.primary_index {
+                continue;
+            }
             let replica = &self.inner.nodes[index];
 
             // Attempt to get a connection and retrieve the replica's AZ.
@@ -466,45 +472,37 @@ impl StandaloneClient {
                     Ordering::Relaxed,
                     Ordering::Relaxed,
                 );
-                return replica;
+                return Some(replica);
             }
         }
     }
 
+    /// AZAffinity strategy: same-AZ replica → any replica (round-robin) → primary (last resort).
+    async fn round_robin_read_from_replica_az_awareness(
+        &self,
+        latest_read_replica_index: &Arc<AtomicUsize>,
+        client_az: &str,
+    ) -> &ReconnectingConnection {
+        if let Some(replica) = self
+            .get_next_local_replica(latest_read_replica_index, client_az)
+            .await
+        {
+            return replica;
+        }
+        self.round_robin_read_from_replica(latest_read_replica_index)
+    }
+
+    /// AZAffinityReplicasAndPrimary strategy: same-AZ replica → same-AZ primary → any node (round-robin).
     async fn round_robin_read_from_replica_az_awareness_replicas_and_primary(
         &self,
         latest_read_replica_index: &Arc<AtomicUsize>,
-        client_az: String,
+        client_az: &str,
     ) -> &ReconnectingConnection {
-        let initial_index = latest_read_replica_index.load(Ordering::Relaxed);
-        let mut retries = 0usize;
-
-        // Step 1: Try to find a replica in the same AZ
-        loop {
-            retries = retries.saturating_add(1);
-            // Looped through all replicas; no connected replica found in the same AZ.
-            if retries >= self.inner.nodes.len() {
-                break;
-            }
-
-            // Calculate index based on initial index and check count.
-            let index = (initial_index + retries) % self.inner.nodes.len();
-            let replica = &self.inner.nodes[index];
-
-            // Attempt to get a connection and retrieve the replica's AZ.
-            if let Ok(connection) = replica.get_connection().await
-                && let Some(replica_az) = connection.get_az().as_deref()
-                && replica_az == client_az
-            {
-                // Update `latest_used_replica` with the index of this replica.
-                let _ = latest_read_replica_index.compare_exchange_weak(
-                    initial_index,
-                    index,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                );
-                return replica;
-            }
+        if let Some(replica) = self
+            .get_next_local_replica(latest_read_replica_index, client_az)
+            .await
+        {
+            return replica;
         }
 
         // Step 2: Check if primary is in the same AZ
@@ -516,8 +514,8 @@ impl StandaloneClient {
             return primary;
         }
 
-        // Step 3: Fall back to any available replica using round-robin
-        self.round_robin_read_from_replica(latest_read_replica_index)
+        // Step 3: Fall back to any available node using round-robin
+        self.round_robin_read_from_all_nodes(latest_read_replica_index)
     }
 
     async fn get_connection(&self, readonly: bool) -> &ReconnectingConnection {
@@ -537,11 +535,8 @@ impl StandaloneClient {
                 client_az,
                 last_read_replica_index,
             } => {
-                self.round_robin_read_from_replica_az_awareness(
-                    last_read_replica_index,
-                    client_az.to_string(),
-                )
-                .await
+                self.round_robin_read_from_replica_az_awareness(last_read_replica_index, client_az)
+                    .await
             }
             ReadFrom::AZAffinityReplicasAndPrimary {
                 client_az,
@@ -549,7 +544,7 @@ impl StandaloneClient {
             } => {
                 self.round_robin_read_from_replica_az_awareness_replicas_and_primary(
                     last_read_replica_index,
-                    client_az.to_string(),
+                    client_az,
                 )
                 .await
             }

--- a/glide-core/tests/test_standalone_client.rs
+++ b/glide-core/tests/test_standalone_client.rs
@@ -186,19 +186,46 @@ mod standalone_client_tests {
         vec![primary_1, primary_2, replica]
     }
 
+    fn create_response_with_az(base: HashMap<String, Value>, az: &str) -> HashMap<String, Value> {
+        let mut responses = base;
+        responses.insert(
+            "*1\r\n$4\r\nINFO\r\n".to_string(),
+            Value::BulkString(format!("availability_zone:{az}\r\n").into_bytes()),
+        );
+        responses
+    }
+
     fn create_primary_mock_with_replicas(replica_count: usize) -> Vec<ServerMock> {
+        create_primary_mock_with_replicas_az(replica_count, None, &[])
+    }
+
+    /// Creates a primary and `replica_count` replica mock servers.
+    /// Returns `[primary, replica_0, replica_1, ...]`.
+    /// When `primary_az` is set, the primary's INFO response includes that AZ.
+    /// `replica_azs` maps each replica index to an AZ; replicas without an entry get no AZ.
+    fn create_primary_mock_with_replicas_az(
+        replica_count: usize,
+        primary_az: Option<&str>,
+        replica_azs: &[&str],
+    ) -> Vec<ServerMock> {
         let mut listeners: Vec<std::net::TcpListener> = (0..replica_count + 1)
             .map(|_| get_listener_on_available_port())
             .collect();
-        let primary =
-            ServerMock::new_with_listener(create_primary_responses(), listeners.pop().unwrap());
+
+        let primary_responses = match primary_az {
+            Some(az) => create_response_with_az(create_primary_responses(), az),
+            None => create_primary_responses(),
+        };
+        let primary = ServerMock::new_with_listener(primary_responses, listeners.pop().unwrap());
         let mut mocks = vec![primary];
 
-        mocks.extend(
-            listeners
-                .into_iter()
-                .map(|listener| ServerMock::new_with_listener(create_replica_response(), listener)),
-        );
+        for (i, listener) in listeners.into_iter().enumerate() {
+            let responses = match replica_azs.get(i) {
+                Some(az) => create_response_with_az(create_replica_response(), az),
+                None => create_replica_response(),
+            };
+            mocks.push(ServerMock::new_with_listener(responses, listener));
+        }
         mocks
     }
 
@@ -210,6 +237,9 @@ mod standalone_client_tests {
         number_of_missing_replicas: usize,
         number_of_replicas_dropped_after_connection: usize,
         number_of_requests_sent: usize,
+        client_az: Option<String>,
+        primary_az: Option<String>,
+        replica_azs: Vec<String>,
     }
 
     impl Default for ReadFromReplicaTestConfig {
@@ -222,19 +252,25 @@ mod standalone_client_tests {
                 number_of_missing_replicas: 0,
                 number_of_replicas_dropped_after_connection: 0,
                 number_of_requests_sent: 3,
+                client_az: None,
+                primary_az: None,
+                replica_azs: vec![],
             }
         }
     }
 
     fn test_read_from_replica(config: ReadFromReplicaTestConfig) {
-        let mut servers = create_primary_mock_with_replicas(
+        let replica_az_refs: Vec<&str> = config.replica_azs.iter().map(|s| s.as_str()).collect();
+        let mut servers = create_primary_mock_with_replicas_az(
             config.number_of_initial_replicas - config.number_of_missing_replicas,
+            config.primary_az.as_deref(),
+            &replica_az_refs,
         );
         let mut cmd = redis::cmd("GET");
         cmd.arg("foo");
 
         for server in servers.iter() {
-            for _ in 0..3 {
+            for _ in 0..config.number_of_requests_sent {
                 server.add_response(&cmd, "$-1\r\n".to_string());
             }
         }
@@ -249,6 +285,9 @@ mod standalone_client_tests {
         let mut connection_request =
             create_connection_request(addresses.as_slice(), &Default::default());
         connection_request.read_from = config.read_from.into();
+        if let Some(ref az) = config.client_az {
+            connection_request.client_az = az.clone().into();
+        }
 
         block_on_all(async {
             let mut client =
@@ -276,17 +315,27 @@ mod standalone_client_tests {
             }
         });
 
+        let primary_reads = servers[0].get_number_of_received_commands();
         assert_eq!(
-            servers[0].get_number_of_received_commands(),
-            config.expected_primary_reads
+            primary_reads, config.expected_primary_reads,
+            "Primary reads: expected {}, got {}",
+            config.expected_primary_reads, primary_reads
         );
+
         let mut replica_reads: Vec<_> = servers
             .iter()
             .skip(1)
             .map(|mock| mock.get_number_of_received_commands())
             .collect();
+
         replica_reads.sort();
-        assert!(config.expected_replica_reads <= replica_reads);
+
+        assert!(
+            config.expected_replica_reads <= replica_reads,
+            "Replica reads: expected {:?}, got {:?}",
+            config.expected_replica_reads,
+            replica_reads
+        );
     }
 
     #[rstest]
@@ -308,7 +357,7 @@ mod standalone_client_tests {
         });
     }
 
-    // TODO - Current test falls back to PreferReplica when run, need to integrate the az here also
+    // At least one replica matches client AZ.
     #[rstest]
     #[serial_test::serial]
     #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
@@ -316,19 +365,156 @@ mod standalone_client_tests {
         test_read_from_replica(ReadFromReplicaTestConfig {
             read_from: ReadFrom::AZAffinity,
             expected_primary_reads: 0,
-            expected_replica_reads: vec![1, 1, 1],
+            expected_replica_reads: vec![0, 0, 3],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1b".to_string()),
+            replica_azs: vec![
+                "us-east-1a".to_string(),
+                "us-east-1b".to_string(),
+                "us-east-1b".to_string(),
+            ],
             ..Default::default()
         });
     }
-    // TODO - Needs changes in the struct and the create_primary_mock
+
+    // AZAffinity: no replica matches client AZ, falls back to round-robin across replicas
     #[rstest]
     #[serial_test::serial]
     #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
-    fn test_read_from_replica_az_affinity_replicas_and_primary() {
+    fn test_read_from_replica_az_affinity_primary_az_match() {
+        test_read_from_replica(ReadFromReplicaTestConfig {
+            read_from: ReadFrom::AZAffinity,
+            expected_primary_reads: 0,
+            expected_replica_reads: vec![1, 1, 1],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1a".to_string()),
+            replica_azs: vec![
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+            ],
+            ..Default::default()
+        });
+    }
+
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_read_from_replica_az_affinity_no_az_match() {
+        test_read_from_replica(ReadFromReplicaTestConfig {
+            read_from: ReadFrom::AZAffinity,
+            expected_primary_reads: 0,
+            expected_replica_reads: vec![1, 1, 1],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1c".to_string()),
+            replica_azs: vec![
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+            ],
+            ..Default::default()
+        });
+    }
+
+    // AZAffinity: client reads from local replicas first. Fallback to other replicas or primary.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_read_from_replica_az_affinity_all_az_match() {
+        test_read_from_replica(ReadFromReplicaTestConfig {
+            read_from: ReadFrom::AZAffinity,
+            number_of_requests_sent: 4,
+            expected_primary_reads: 0,
+            expected_replica_reads: vec![1, 1, 2],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1a".to_string()),
+            replica_azs: vec![
+                "us-east-1a".to_string(),
+                "us-east-1a".to_string(),
+                "us-east-1a".to_string(),
+            ],
+            ..Default::default()
+        });
+    }
+
+    // AZAffinityReplicasAndPrimary: same-AZ replica preferred over primary
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_read_from_replica_az_affinity_replicas_and_primary_az_match_replica() {
+        test_read_from_replica(ReadFromReplicaTestConfig {
+            read_from: ReadFrom::AZAffinityReplicasAndPrimary,
+            number_of_requests_sent: 4,
+            expected_primary_reads: 0,
+            expected_replica_reads: vec![1, 1, 2],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1b".to_string()),
+            replica_azs: vec![
+                "us-east-1a".to_string(),
+                "us-east-1a".to_string(),
+                "us-east-1a".to_string(),
+            ],
+            ..Default::default()
+        });
+    }
+
+    // AZAffinityReplicasAndPrimary: same-AZ replica preferred over primary
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_read_from_replica_az_affinity_replicas_and_primary_az_match_primary() {
+        test_read_from_replica(ReadFromReplicaTestConfig {
+            read_from: ReadFrom::AZAffinityReplicasAndPrimary,
+            expected_primary_reads: 3,
+            expected_replica_reads: vec![0, 0, 0],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1a".to_string()),
+            replica_azs: vec![
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+            ],
+            ..Default::default()
+        });
+    }
+
+    // AZAffinityReplicasAndPrimary: When there are no local nodes, distribute read evenly starting with replicas.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_read_from_replica_az_affinity_replicas_and_primary_no_az_match() {
+        test_read_from_replica(ReadFromReplicaTestConfig {
+            read_from: ReadFrom::AZAffinityReplicasAndPrimary,
+            number_of_requests_sent: 4,
+            expected_primary_reads: 1,
+            expected_replica_reads: vec![1, 1, 1],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1c".to_string()),
+            replica_azs: vec![
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+                "us-east-1c".to_string(),
+            ],
+            ..Default::default()
+        });
+    }
+
+    // AZAffinityReplicasAndPrimary: When all nodes local, distribute read to all replicas first then primary.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_STANDALONE_TEST_TIMEOUT)]
+    fn test_read_from_replica_az_affinity_replicas_and_primary_all_az_match_prioritize_replicas() {
         test_read_from_replica(ReadFromReplicaTestConfig {
             read_from: ReadFrom::AZAffinityReplicasAndPrimary,
             expected_primary_reads: 0,
             expected_replica_reads: vec![1, 1, 1],
+            client_az: Some("us-east-1a".to_string()),
+            primary_az: Some("us-east-1a".to_string()),
+            replica_azs: vec![
+                "us-east-1a".to_string(),
+                "us-east-1a".to_string(),
+                "us-east-1a".to_string(),
+            ],
             ..Default::default()
         });
     }


### PR DESCRIPTION
## Summary

The following read strategy bugs were discovered in the standalone clients and fixed:
- AZAffinity: The local primary were not excluded in the read list
- AZAffinityReplicasAndPrimary: Did not correctly fall back to the primary.

This PR implemented fixes for the bugs above, as well updating the existing standalone client tests to increase read strategy coverage.

## Reviewing

Since this PR contains refactoring, suggestion is to review from the commits changes as they have been reordered to isolate the changes.

### Bug: AZAffinity

It was found that when all replicas and primary are in the same az as the client, the primary was given a read. 

Per the [documentations](https://glide.valkey.io/how-to/connections/read-strategy/#available-read-strategies) reads should only be given to replicas in the same az; Reads to primary is only be done as a last resort.

### Bug: AZAffinityReplicasAndPrimary

It was found that when there are no local nodes, the primary was not given a read.

Per the [documentations](https://glide.valkey.io/how-to/connections/read-strategy/#available-read-strategies), when no local nodes are available it should fall back to other nodes including the primary.

It was also found that the replica priority was not respected.

### Issue link

Closes #3048 

### Changes

- Refactored read strategy common code paths into `get_next_local_replica`.
- Applied bug fixes. 
- Added support for read strategy in tests.
- Added support for specifying replicas and primary az in tests.
- Added more comprehensive read strategy testing.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.