### PR TITLE
Add pipeline send timeout and fail pending requests during recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * FFI: Add OpenTelemetry DB semantic convention attributes to FFI path ([#5596](https://github.com/valkey-io/valkey-glide/issues/5596))
 
 #### Fixes
+* CORE: Add adaptive timeout on pipeline send to detect dead connections during half-open TCP scenarios, replace `now_or_never()` with proper `poll()` in recovery to fix busy-spin, remove `loop{}` from `poll_flush`, and fail pending requests immediately during recovery to prevent OOM under sustained partition ([#5715](https://github.com/valkey-io/valkey-glide/issues/5715), [#5716](https://github.com/valkey-io/valkey-glide/issues/5716))
 * CORE: Skip compression/decompression code paths when compression is not configured to eliminate per-command overhead ([#5644](https://github.com/valkey-io/valkey-glide/pull/5644))
 
 #### Operational Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))
+* CORE: Add adaptive timeout on pipeline send to detect dead connections during half-open TCP scenarios, replace `now_or_never()` with proper `poll()` in recovery to fix busy-spin, remove `loop{}` from `poll_flush`, and fail pending requests immediately during recovery to prevent OOM under sustained partition ([#5715](https://github.com/valkey-io/valkey-glide/issues/5715), [#5716](https://github.com/valkey-io/valkey-glide/issues/5716))
 * CORE: Skip compression/decompression code paths when compression is not configured to eliminate per-command overhead ([#5644](https://github.com/valkey-io/valkey-glide/pull/5644))
 
 #### Operational Enhancements

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -521,25 +521,41 @@ where
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
-        self.sender
-            .send(PipelineMessage {
+        // Timeout on pipeline send to detect dead connections. The pipeline channel
+        // is bounded (50 slots). Under normal operation, a slot frees in microseconds.
+        // Defaults to 100ms unless request_timeout is shorter, in which case will be 1/4
+        // request_timeout with a minimum of 1ms.
+        let send_timeout = std::cmp::max(
+            std::cmp::min(timeout / 4, std::time::Duration::from_millis(100)),
+            std::time::Duration::from_millis(1),
+        );
+        match tokio::time::timeout(
+            send_timeout,
+            self.sender.send(PipelineMessage {
                 input,
                 pipeline_response_count,
                 output: sender,
                 is_transaction: is_atomic,
                 is_fenced,
-            })
-            .await
-            .map_err(|err| {
-                // If an error occurs here, it means the request never reached the server, as guaranteed
-                // by the 'send' function. Since the server did not receive the data, it is safe to retry
-                // the request.
-                RedisError::from((
+            }),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                return Err(RedisError::from((
                     crate::ErrorKind::FatalSendError,
                     "Failed to send the request to the server",
                     err.to_string(),
-                ))
-            })?;
+                )));
+            }
+            Err(_elapsed) => {
+                return Err(RedisError::from((
+                    crate::ErrorKind::FatalSendError,
+                    "Pipeline channel full — connection likely dead",
+                )));
+            }
+        }
         match Runtime::locate().timeout(timeout, receiver).await {
             Ok(Ok(result)) => result,
             Ok(Err(err)) => {

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -522,25 +522,40 @@ where
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
-        self.sender
-            .send(PipelineMessage {
+        // Timeout on pipeline send to detect dead connections. The pipeline channel
+        // is bounded (50 slots). Under normal operation, a slot frees in microseconds.
+        // Defaults to 100ms unless request_timeout is shorter, with a minimum of 1ms.
+        let send_timeout = std::cmp::max(
+            std::cmp::min(timeout, std::time::Duration::from_millis(100)),
+            std::time::Duration::from_millis(1),
+        );
+        match tokio::time::timeout(
+            send_timeout,
+            self.sender.send(PipelineMessage {
                 input,
                 pipeline_response_count,
                 output: sender,
                 is_transaction: is_atomic,
                 is_fenced,
-            })
-            .await
-            .map_err(|err| {
-                // If an error occurs here, it means the request never reached the server, as guaranteed
-                // by the 'send' function. Since the server did not receive the data, it is safe to retry
-                // the request.
-                RedisError::from((
+            }),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                return Err(RedisError::from((
                     crate::ErrorKind::FatalSendError,
                     "Failed to send the request to the server",
                     err.to_string(),
-                ))
-            })?;
+                )));
+            }
+            Err(_elapsed) => {
+                return Err(RedisError::from((
+                    crate::ErrorKind::FatalSendError,
+                    "Pipeline channel full — connection likely dead",
+                )));
+            }
+        }
         match Runtime::locate().timeout(timeout, receiver).await {
             Ok(Ok(result)) => result,
             Ok(Err(err)) => {
@@ -987,5 +1002,141 @@ impl MultiplexedConnection {
     /// Returns `PushManager` of Connection, this method is used to subscribe/unsubscribe from Push types
     pub fn get_push_manager(&self) -> PushManager {
         self.push_manager.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::channel::mpsc as futures_mpsc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    /// A Sink+Stream where poll_ready/poll_flush return Pending when stall flag is set,
+    /// simulating a dead TCP connection where the send buffer is full.
+    struct StallingSink {
+        stall: Arc<AtomicBool>,
+        inner_tx: futures_mpsc::Sender<Vec<u8>>,
+        inner_rx: futures_mpsc::Receiver<RedisResult<Value>>,
+    }
+
+    impl Stream for StallingSink {
+        type Item = RedisResult<Value>;
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Pin::new(&mut self.inner_rx).poll_next(cx)
+        }
+    }
+
+    impl Sink<Vec<u8>> for StallingSink {
+        type Error = RedisError;
+
+        fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if self.stall.load(Ordering::Relaxed) {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            Pin::new(&mut self.get_mut().inner_tx)
+                .poll_ready(cx)
+                .map_err(|e| {
+                    RedisError::from((crate::ErrorKind::IoError, "sink error", e.to_string()))
+                })
+        }
+
+        fn start_send(mut self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
+            Pin::new(&mut self.inner_tx).start_send(item).map_err(|e| {
+                RedisError::from((crate::ErrorKind::IoError, "sink error", e.to_string()))
+            })
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            if self.stall.load(Ordering::Relaxed) {
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            Pin::new(&mut self.inner_tx).poll_flush(cx).map_err(|e| {
+                RedisError::from((crate::ErrorKind::IoError, "sink error", e.to_string()))
+            })
+        }
+
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Pin::new(&mut self.inner_tx).poll_close(cx).map_err(|e| {
+                RedisError::from((crate::ErrorKind::IoError, "sink error", e.to_string()))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_send_timeout_when_sink_stalls() {
+        // Test for #5715: Pipeline send blocks forever on dead shard
+        // See: https://github.com/valkey-io/valkey-glide/issues/5715
+        //
+        // When a TCP connection becomes half-open (e.g., network partition without RST),
+        // the send buffer fills and AsyncWrite::poll_write blocks indefinitely. This
+        // causes the pipeline's internal 50-slot channel to fill, and any subsequent
+        // send() call blocks forever waiting for a slot.
+        //
+        // The adaptive send timeout (min(timeout, 100ms), floor 1ms) wraps the channel
+        // send, so it fails with FatalSendError instead of hanging. This test verifies
+        // that behavior by creating a pipeline with no driver (never drains), filling
+        // the channel, and asserting the next send completes within the timeout.
+
+        let stall_flag = Arc::new(AtomicBool::new(false));
+        let (sink_tx, _sink_rx) = futures_mpsc::channel(100);
+        let (_resp_tx, resp_rx) = futures_mpsc::channel(100);
+
+        let stalling_sink = StallingSink {
+            stall: stall_flag.clone(),
+            inner_tx: sink_tx,
+            inner_rx: resp_rx,
+        };
+
+        // Create pipeline but don't drive it, the channel will fill and send() will block
+        let (mut pipeline, driver) = Pipeline::new(stalling_sink, None);
+        std::mem::forget(driver);
+
+        // Fill the 50-slot pipeline channel
+        for _ in 0..50 {
+            let mut pipeline_clone = pipeline.clone();
+            tokio::spawn(async move {
+                let _ = pipeline_clone
+                    .send_single(
+                        crate::cmd("PING").get_packed_command(),
+                        Duration::from_secs(60),
+                        false,
+                    )
+                    .await;
+            });
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Next send should hit the send timeout  instead of blocking forever
+        let timeout = Duration::from_millis(200);
+        let start = std::time::Instant::now();
+        let result = pipeline
+            .send_single(crate::cmd("PING").get_packed_command(), timeout, false)
+            .await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "Expected error when sink is stalled");
+        let err = result.unwrap_err();
+        assert!(
+            err.kind() == crate::ErrorKind::FatalSendError
+                || err.kind() == crate::ErrorKind::IoError,
+            "Expected FatalSendError or IoError, got: {:?}",
+            err.kind()
+        );
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "Send took {:?}, expected < 200ms (send_timeout = 100ms). \
+             Without the fix, this hangs forever.",
+            elapsed,
+        );
     }
 }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3270,7 +3270,28 @@ where
         Ok((address, conn))
     }
 
-    fn poll_recover(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), RedisError>> {
+    /// Fail all pending requests immediately with ClientError.
+    /// Called when entering recovery to prevent requests from waiting for slow
+    /// reconnection cycles.
+    fn fail_pending_requests(inner: &Core<C>) {
+        let mut rx_guard = inner
+            .pending_requests_rx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut requests = Vec::new();
+        while let Ok(request) = rx_guard.try_recv() {
+            requests.push(request);
+        }
+        drop(rx_guard);
+        for request in requests {
+            let _ = request.sender.send(Err(RedisError::from((
+                ErrorKind::ClientError,
+                "Connection in recovery",
+            ))));
+        }
+    }
+
+    fn poll_recover(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), RedisError>> {
         trace!("entered poll_recover");
 
         let recover_future = match &mut self.state {
@@ -3280,15 +3301,17 @@ where
 
         match recover_future {
             RecoverFuture::RefreshingSlots(handle) => {
-                // Check if the task has completed
-                match handle.now_or_never() {
-                    Some(Ok(Ok(()))) => {
+                // Use poll() instead of now_or_never() to properly register the waker.
+                // now_or_never() returns None without waking, causing poll_flush to busy-spin.
+                match Pin::new(handle).poll(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(Ok(Ok(()))) => {
                         // Task succeeded
                         trace!("Slot refresh completed successfully!");
                         self.state = ConnectionState::PollComplete;
-                        return Poll::Ready(Ok(()));
+                        Poll::Ready(Ok(()))
                     }
-                    Some(Ok(Err(e))) => {
+                    Poll::Ready(Ok(Err(e))) => {
                         // Task completed but returned an engine error
                         trace!("Slot refresh failed: {:?}", e);
 
@@ -3301,7 +3324,7 @@ where
                             self.state = ConnectionState::Recover(
                                 RecoverFuture::ReconnectToInitialNodes(handle),
                             );
-                            return Poll::Ready(Err(e));
+                            Poll::Ready(Err(e))
                         } else {
                             // Retry refresh
                             let new_handle = Self::spawn_refresh_slots_task(
@@ -3311,15 +3334,15 @@ where
                             self.state = ConnectionState::Recover(RecoverFuture::RefreshingSlots(
                                 new_handle,
                             ));
-                            return Poll::Ready(Ok(()));
+                            Poll::Ready(Ok(()))
                         }
                     }
-                    Some(Err(join_err)) => {
+                    Poll::Ready(Err(join_err)) => {
                         if join_err.is_cancelled() {
                             // Task was intentionally aborted - don't treat as an error
                             trace!("Slot refresh task was aborted");
                             self.state = ConnectionState::PollComplete;
-                            return Poll::Ready(Ok(()));
+                            Poll::Ready(Ok(()))
                         } else {
                             // Task panicked - try reconnecting to initial nodes as a recovery strategy
                             warn!("Slot refresh task panicked: {:?} - attempting recovery by reconnecting to initial nodes", join_err);
@@ -3341,69 +3364,50 @@ where
                                 "Slot refresh task panicked",
                                 format!("{join_err:?}"),
                             ));
-                            return Poll::Ready(Err(err));
+                            Poll::Ready(Err(err))
                         }
                     }
-                    None => {
-                        // Task is still running
-                        // Just continue and return Ok to not block poll_flush
-                    }
                 }
-
-                // Always return Ready to not block poll_flush
-                Poll::Ready(Ok(()))
             }
             RecoverFuture::ReconnectToInitialNodes(ref mut handle) => {
-                // Check if the task has completed
-                match handle.now_or_never() {
-                    Some(Ok(())) => {
+                match Pin::new(handle).poll(cx) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(Ok(())) => {
                         trace!("Reconnected to initial nodes");
                         self.state = ConnectionState::PollComplete;
+                        Poll::Ready(Ok(()))
                     }
-                    Some(Err(join_err)) => {
+                    Poll::Ready(Err(join_err)) => {
                         if join_err.is_cancelled() {
                             trace!("Reconnect to initial nodes task was aborted");
                         } else {
                             warn!("Reconnect to initial nodes task panicked: {:?} - marking recovery as complete", join_err);
                         }
                         self.state = ConnectionState::PollComplete;
-                    }
-                    None => {
-                        // Task is still running
-                        // Just continue and return Ok to not block poll_flush
+                        Poll::Ready(Ok(()))
                     }
                 }
-
-                // Always return Ready to not block poll_flush
-                Poll::Ready(Ok(()))
             }
-            RecoverFuture::Reconnect(ref mut handle) => {
-                // Check if the task has completed
-                match handle.now_or_never() {
-                    Some(Ok(())) => {
-                        trace!("Reconnected connections");
-                        self.state = ConnectionState::PollComplete;
-                    }
-                    Some(Err(join_err)) => {
-                        if join_err.is_cancelled() {
-                            trace!("Reconnect task was aborted");
-                        } else {
-                            warn!(
-                                "Reconnect task panicked: {:?} - marking recovery as complete",
-                                join_err
-                            );
-                        }
-                        self.state = ConnectionState::PollComplete;
-                    }
-                    None => {
-                        // Task is still running
-                        // Just continue and return Ok to not block poll_flush
-                    }
+            RecoverFuture::Reconnect(ref mut handle) => match Pin::new(handle).poll(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Ok(())) => {
+                    trace!("Reconnected connections");
+                    self.state = ConnectionState::PollComplete;
+                    Poll::Ready(Ok(()))
                 }
-
-                // Always return Ready to not block poll_flush
-                Poll::Ready(Ok(()))
-            }
+                Poll::Ready(Err(join_err)) => {
+                    if join_err.is_cancelled() {
+                        trace!("Reconnect task was aborted");
+                    } else {
+                        warn!(
+                            "Reconnect task panicked: {:?} - marking recovery as complete",
+                            join_err
+                        );
+                    }
+                    self.state = ConnectionState::PollComplete;
+                    Poll::Ready(Ok(()))
+                }
+            },
         }
     }
 
@@ -3651,56 +3655,57 @@ where
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::Error>> {
         trace!("poll_flush: {:?}", self.state);
-        loop {
-            self.send_refresh_error();
+        self.send_refresh_error();
 
-            if let Err(err) = ready!(self.as_mut().poll_recover(cx)) {
-                // We failed to reconnect, while we will try again we will report the
-                // error if we can to avoid getting trapped in an infinite loop of
-                // trying to reconnect
+        match self.as_mut().poll_recover(cx) {
+            Poll::Pending => {
+                // Fail any requests queued while in recovery
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                return Poll::Pending;
+            }
+            Poll::Ready(Err(err)) => {
                 self.refresh_error = Some(err);
-
-                // Give other tasks a chance to progress before we try to recover
-                // again. Since the future may not have registered a wake up we do so
-                // now so the task is not forgotten
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
+            Poll::Ready(Ok(())) => {}
+        }
 
-            match ready!(self.poll_complete(cx)) {
-                PollFlushAction::None => return Poll::Ready(Ok(())),
-                PollFlushAction::RebuildSlots => {
-                    // Spawn refresh task
-                    let task_handle = ClusterConnInner::spawn_refresh_slots_task(
-                        self.inner.clone(),
-                        &RefreshPolicy::Throttable,
-                    );
-
-                    // Update state
-                    self.state =
-                        ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
-                }
-                PollFlushAction::ReconnectFromInitialConnections => {
-                    let inner = self.inner.clone();
-                    let handle = tokio::spawn(async move {
-                        ClusterConnInner::reconnect_to_initial_nodes(inner).await
-                    });
-                    self.state =
-                        ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(handle));
-                }
-                PollFlushAction::Reconnect(addresses) => {
-                    let inner = self.inner.clone();
-                    let handle = tokio::spawn(async move {
-                        ClusterConnInner::trigger_refresh_connection_tasks(
-                            inner,
-                            addresses,
-                            RefreshConnectionType::OnlyUserConnection,
-                            true,
-                        )
-                        .await;
-                    });
-                    self.state = ConnectionState::Recover(RecoverFuture::Reconnect(handle));
-                }
+        match ready!(self.poll_complete(cx)) {
+            PollFlushAction::None => Poll::Ready(Ok(())),
+            PollFlushAction::RebuildSlots => {
+                let task_handle = ClusterConnInner::spawn_refresh_slots_task(
+                    self.inner.clone(),
+                    &RefreshPolicy::Throttable,
+                );
+                self.state = ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            PollFlushAction::ReconnectFromInitialConnections => {
+                let inner = self.inner.clone();
+                let handle = tokio::spawn(async move {
+                    ClusterConnInner::reconnect_to_initial_nodes(inner).await
+                });
+                self.state =
+                    ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(handle));
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            PollFlushAction::Reconnect(addresses) => {
+                let inner = self.inner.clone();
+                let handle = tokio::spawn(async move {
+                    ClusterConnInner::trigger_refresh_connection_tasks(
+                        inner,
+                        addresses,
+                        RefreshConnectionType::OnlyUserConnection,
+                        true,
+                    )
+                    .await;
+                });
+                self.state = ConnectionState::Recover(RecoverFuture::Reconnect(handle));
+                cx.waker().wake_by_ref();
+                Poll::Pending
             }
         }
     }

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -395,7 +395,7 @@ where
     }
 
     // Wait for all receivers to complete and collect the responses
-    let responses: Vec<_> = futures::future::join_all(receivers.into_iter())
+    let responses: Vec<_> = futures::future::join_all(receivers)
         .await
         .into_iter()
         .collect();

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -2614,10 +2614,23 @@ mod cluster_async {
                 )
                 .await;
 
-                // Assert that the GET succeeded (no timeout or error)
-                assert!(get_result.is_ok());
-                let result = get_result.unwrap().unwrap();
-                assert_eq!(result, "value2");
+                // Assert that the GET succeeded (no timeout or error) - may transiently fail during recovery
+                let get_value: String = match get_result {
+                    Ok(Ok(val)) => val,
+                    _ => {
+                        let mut val = None;
+                        for _ in 0..600 {
+                            tokio::time::sleep(Duration::from_millis(5)).await;
+                            if let Ok(v) = client1.get::<_, String>(other_shard_key).await {
+                                val = Some(v);
+                                break;
+                            }
+                        }
+                        val.expect("GET failed after retries")
+                    }
+                };
+                assert_eq!(get_value, "value2");
+                assert_eq!(get_value, "value2");
 
                 true
             });
@@ -6409,11 +6422,16 @@ mod cluster_async {
                 .move_specific_slot(channel_slot, slot_distribution)
                 .await;
 
-            // Push value to unblock BLPOP
-            let _: () = push_connection
-                .rpush(blpop_key, expected_value)
-                .await
-                .unwrap();
+            // Push value to unblock BLPOP — may transiently fail during recovery
+            for _ in 0..600 {
+                match push_connection
+                    .rpush::<_, _, ()>(blpop_key, expected_value)
+                    .await
+                {
+                    Ok(_) => break,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(5)).await,
+                }
+            }
 
             // Verify BLPOP received correct value
             let blpop_result = blpop_handle.await.unwrap();

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -2614,10 +2614,22 @@ mod cluster_async {
                 )
                 .await;
 
-                // Assert that the GET succeeded (no timeout or error)
-                assert!(get_result.is_ok());
-                let result = get_result.unwrap().unwrap();
-                assert_eq!(result, "value2");
+                // Assert that the GET succeeded (no timeout or error) - may transiently fail during recovery
+                let get_value: String = match get_result {
+                    Ok(Ok(val)) => val,
+                    _ => {
+                        let mut val = None;
+                        for _ in 0..600 {
+                            tokio::time::sleep(Duration::from_millis(5)).await;
+                            if let Ok(v) = client1.get::<_, String>(other_shard_key).await {
+                                val = Some(v);
+                                break;
+                            }
+                        }
+                        val.expect("GET failed after retries")
+                    }
+                };
+                assert_eq!(get_value, "value2");
 
                 true
             });
@@ -6409,11 +6421,16 @@ mod cluster_async {
                 .move_specific_slot(channel_slot, slot_distribution)
                 .await;
 
-            // Push value to unblock BLPOP
-            let _: () = push_connection
-                .rpush(blpop_key, expected_value)
-                .await
-                .unwrap();
+            // Push value to unblock BLPOP — may transiently fail during recovery
+            for _ in 0..600 {
+                match push_connection
+                    .rpush::<_, _, ()>(blpop_key, expected_value)
+                    .await
+                {
+                    Ok(_) => break,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(5)).await,
+                }
+            }
 
             // Verify BLPOP received correct value
             let blpop_result = blpop_handle.await.unwrap();

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -443,8 +443,9 @@ mod cluster_client_tests {
                     assert!(
                         err.is_connection_dropped()
                             || err.is_timeout()
-                            || err.kind() == redis::ErrorKind::AllConnectionsUnavailable,
-                        "Expected connection dropped, timeout, or unavailable error, got: {err:?}",
+                            || err.kind() == redis::ErrorKind::AllConnectionsUnavailable
+                            || err.kind() == redis::ErrorKind::ClientError,
+                        "Expected connection dropped, timeout, unavailable, or recovery error, got: {err:?}",
                     );
                     let client_info = retry(|| async {
                         let mut client = test_basics.client.clone();

--- a/java/e2e/dns-failover-test/src/main/java/com/company/glide/dnsfailover/DnsFailoverTest.java
+++ b/java/e2e/dns-failover-test/src/main/java/com/company/glide/dnsfailover/DnsFailoverTest.java
@@ -95,7 +95,8 @@ public class DnsFailoverTest {
                 break;
             } catch (Exception e) {
                 if (e.getMessage() != null
-                        && e.getMessage().contains("AllConnectionsUnavailable")
+                        && (e.getMessage().contains("AllConnectionsUnavailable")
+                                || e.getMessage().contains("Connection in recovery"))
                         && i < maxRetries - 1) {
                     Thread.sleep(500);
                     continue;

--- a/java/integTest/src/test/java/glide/cluster/ClusterClientTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterClientTests.java
@@ -409,7 +409,8 @@ public class ClusterClientTests {
                     break;
                 } catch (Exception e) {
                     if (e.getMessage() != null
-                            && e.getMessage().contains("AllConnectionsUnavailable")
+                            && (e.getMessage().contains("AllConnectionsUnavailable")
+                                    || e.getMessage().contains("Connection in recovery"))
                             && i < maxRetries - 1) {
                         Thread.sleep(500);
                         continue;
@@ -425,7 +426,8 @@ public class ClusterClientTests {
                     break;
                 } catch (Exception e) {
                     if (e.getMessage() != null
-                            && e.getMessage().contains("AllConnectionsUnavailable")
+                            && (e.getMessage().contains("AllConnectionsUnavailable")
+                                    || e.getMessage().contains("Connection in recovery"))
                             && i < maxRetries - 1) {
                         Thread.sleep(500);
                         continue;

--- a/java/integTest/src/test/java/glide/cluster/ClusterClientTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterClientTests.java
@@ -410,7 +410,8 @@ public class ClusterClientTests {
                     break;
                 } catch (Exception e) {
                     if (e.getMessage() != null
-                            && e.getMessage().contains("AllConnectionsUnavailable")
+                            && (e.getMessage().contains("AllConnectionsUnavailable")
+                                    || e.getMessage().contains("Connection in recovery"))
                             && i < maxRetries - 1) {
                         Thread.sleep(500);
                         continue;
@@ -426,7 +427,8 @@ public class ClusterClientTests {
                     break;
                 } catch (Exception e) {
                     if (e.getMessage() != null
-                            && e.getMessage().contains("AllConnectionsUnavailable")
+                            && (e.getMessage().contains("AllConnectionsUnavailable")
+                                    || e.getMessage().contains("Connection in recovery"))
                             && i < maxRetries - 1) {
                         Thread.sleep(500);
                         continue;

--- a/python/tests/async_tests/test_auth.py
+++ b/python/tests/async_tests/test_auth.py
@@ -306,7 +306,10 @@ class TestAuthCommands:
                 assert result == OK
                 break
             except Exception as e:
-                if "AllConnectionsUnavailable" in str(e) and i < max_retries - 1:
+                if (
+                    "AllConnectionsUnavailable" in str(e)
+                    or "Connection in recovery" in str(e)
+                ) and i < max_retries - 1:
                     await anyio.sleep(0.5)
                     continue
                 raise
@@ -317,7 +320,10 @@ class TestAuthCommands:
                 assert await acl_glide_client.set("test_key", "test_value") == OK
                 break
             except Exception as e:
-                if "AllConnectionsUnavailable" in str(e) and i < max_retries - 1:
+                if (
+                    "AllConnectionsUnavailable" in str(e)
+                    or "Connection in recovery" in str(e)
+                ) and i < max_retries - 1:
                     await anyio.sleep(0.5)
                     continue
                 raise

--- a/python/tests/sync_tests/test_sync_auth.py
+++ b/python/tests/sync_tests/test_sync_auth.py
@@ -306,7 +306,10 @@ class TestSyncAuthCommands:
                 assert result == OK
                 break
             except Exception as e:
-                if "AllConnectionsUnavailable" in str(e) and i < max_retries - 1:
+                if (
+                    "AllConnectionsUnavailable" in str(e)
+                    or "Connection in recovery" in str(e)
+                ) and i < max_retries - 1:
                     time.sleep(0.5)
                     continue
                 raise
@@ -317,7 +320,10 @@ class TestSyncAuthCommands:
                 assert acl_glide_sync_client.set("test_key", "test_value") == OK
                 break
             except Exception as e:
-                if "AllConnectionsUnavailable" in str(e) and i < max_retries - 1:
+                if (
+                    "AllConnectionsUnavailable" in str(e)
+                    or "Connection in recovery" in str(e)
+                ) and i < max_retries - 1:
                     time.sleep(0.5)
                     continue
                 raise


### PR DESCRIPTION
### Summary

Add a 100ms timeout on `pipeline.send()` to detect dead connections (half-open TCP) and fail pending requests immediately when entering recovery. Without this, `pipeline.send()` blocks indefinitely when the bounded channel (50 slots) is full due to a dead connection, preventing recovery from ever triggering and causing OOM under sustained partition.

### Issue link

Closes #5715
Closes #5716

### Features / Behaviour Changes

- `pipeline.send()` now times out after 100ms with `FatalSendError` instead of blocking forever
- `poll_recover()` uses proper `poll(cx)` instead of `now_or_never()`, fixing waker registration and preventing busy-spin
- `poll_flush()` no longer uses `loop{}` — returns `Pending` during recovery instead of spinning
- New `fail_pending_requests()` drains pending request queue with `ClientError("Connection in recovery")` when recovery is in progress

### Implementation

- `multiplexed_connection.rs`:
  - Wrapped `self.sender.send()` with `tokio::time::timeout()` in `pipeline.send()`. Defaults to 100ms; scales down to match `request_timeout` when below 100ms, with a minimum of 1ms. Timeout returns `FatalSendError` which maps to `ReconnectAndRetry`, triggering cluster recovery.
  - Added unit test `test_pipeline_send_timeout_when_sink_stalls` that verifies send times out instead of blocking forever when the pipeline channel is full.

- `cluster_async/mod.rs`:
  - Replaced `handle.now_or_never()` with `Pin::new(handle).poll(cx)` in `poll_recover()`. Returns `Poll::Pending` when recovery is in progress instead of `Poll::Ready(Ok(()))`.
  - Removed `loop{}` in `poll_flush()`. Now a single pass to check recovery, check completions, and enter recovery if needed. Returns `Pending` with waker registered when entering recovery.
  - Added new method, `fail_pending_requests`, that drains the `pending_requests_rx` channel and completes all senders with `ClientError`.

### Limitations

- The internal cluster connection layer does not enforce `request_timeout` (defaults to `Duration::MAX`). User-facing timeouts are still honored via GLIDE's outer timeout.

### Testing

- All unit tests pass
- New `test_pipeline_send_timeout_when_sink_stalls` hangs forever on main, passes with fix
- Tested locally with an example app while simulating half-open TCP (via `iptables` rules). Before, the queue grows linearly to OOM. After, the queue oscillates 0-40K in stable sawtooth, app stays alive indefinitely.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
