### PR TITLE
feat: add diagnostic logging for failover, topology refresh, and pipeline issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Pending 2.2
+
+#### Operational Enhancements
+* CORE, Java: Add diagnostic logging for failover, topology refresh, and pipeline issues — lazy and rate-limited logging macros in logger_core, MOVED error scenario identification, topology refresh throttle/overwrite tracking, pipeline send/response timing, inflight slot exhaustion, recovery state transitions, adaptive health snapshots, and Java-side timeout elapsed time. Fix Java Logger Supplier overloads to check level before evaluating. ([#5756](https://github.com/valkey-io/valkey-glide/pull/5756))
+
 ## 2.2.8
 
 ### Fixes

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,11 @@ ignore = [
     # via iai-callgrind for benchmarking. No security impact.
     # https://rustsec.org/advisories/RUSTSEC-2025-0141
     "RUSTSEC-2025-0141",
+    # rand 0.8.5 unsound with custom logger using rand::rng(). We don't use
+    # rand::rng() in custom loggers. Pinned by transitive dependencies
+    # (nanoid, opentelemetry_sdk, tower). Safe to ignore until deps upgrade.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097
+    "RUSTSEC-2026-0097",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -380,6 +380,7 @@ where
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
+        let send_start = std::time::Instant::now();
         self.sender
             .send(PipelineMessage {
                 input,
@@ -398,7 +399,33 @@ where
                     err.to_string(),
                 ))
             })?;
-        match Runtime::locate().timeout(timeout, receiver).await {
+        let send_elapsed = send_start.elapsed();
+        let send_warn_threshold = std::cmp::min(timeout / 4, std::time::Duration::from_millis(500));
+        if send_elapsed > send_warn_threshold {
+            logger_core::log_warn_rate_limited!(
+                "pipeline",
+                5,
+                format!(
+                    "pipeline.send() blocked for {:?} (threshold={:?}, response_timeout={:?}, channel capacity=50)",
+                    send_elapsed, send_warn_threshold, timeout
+                )
+            );
+        }
+        let recv_start = std::time::Instant::now();
+        let recv_result = Runtime::locate().timeout(timeout, receiver).await;
+        let recv_elapsed = recv_start.elapsed();
+        let recv_warn_threshold = std::cmp::min(timeout / 2, std::time::Duration::from_secs(5));
+        if recv_elapsed > recv_warn_threshold {
+            logger_core::log_warn_rate_limited!(
+                "pipeline",
+                5,
+                format!(
+                    "Response wait took {:?} (threshold={:?}, response_timeout={:?})",
+                    recv_elapsed, recv_warn_threshold, timeout
+                )
+            );
+        }
+        match recv_result {
             Ok(Ok(result)) => result,
             Ok(Err(err)) => {
                 // The `sender` was dropped, likely indicating a failure in the stream.

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -51,7 +51,9 @@ use pipeline_routing::{
     route_for_pipeline, PipelineResponses, ResponsePoliciesMap,
 };
 
-use logger_core::log_error;
+use logger_core::log_info_rate_limited;
+use logger_core::log_warn_rate_limited;
+use logger_core::{log_debug_lazy, log_error_lazy, log_info_lazy, log_trace_lazy, log_warn_lazy};
 use rand::seq::IteratorRandom;
 
 use std::{
@@ -115,7 +117,7 @@ use tokio::sync::{
     oneshot::{self, Receiver},
     RwLock as TokioRwLock,
 };
-use tracing::{debug, info, trace, warn};
+// tracing macros replaced by logger_core lazy macros
 
 use self::{
     connections_container::{ConnectionAndAddress, ConnectionType, ConnectionsMap},
@@ -252,7 +254,7 @@ where
         cmd: &Cmd,
         routing: cluster_routing::RoutingInfo,
     ) -> RedisResult<Value> {
-        trace!("route_command");
+        log_trace_lazy!("cluster", "route_command");
         let (sender, receiver) = oneshot::channel();
         self.0
             .send(Message {
@@ -1014,9 +1016,12 @@ impl<C> Future for Request<C> {
                     // Updating the slot map based on the MOVED error is an optimization.
                     // If it fails, proceed by retrying the request with the redirected node,
                     // and allow the slot refresh task to correct the slot map.
-                    info!(
-                        "Failed to update the slot map based on the received MOVED error.
+                    log_info_lazy!(
+                        "cluster",
+                        format!(
+                            "Failed to update the slot map based on the received MOVED error.
                         Error: {err:?}"
+                        )
                     );
                 }
                 if let Some(request) = self.project().request.take() {
@@ -1071,9 +1076,9 @@ impl<C> Future for Request<C> {
                 request.retry = request.retry.saturating_add(1);
                 // Record retry attempts metric if telemetry is initialized
                 if let Err(e) = GlideOpenTelemetry::record_retry_attempt() {
-                    log_error(
+                    log_error_lazy!(
                         "OpenTelemetry:retry_error",
-                        format!("Failed to record retry attempt: {e}"),
+                        format!("Failed to record retry attempt: {e}")
                     );
                 }
 
@@ -1089,7 +1094,10 @@ impl<C> Future for Request<C> {
                 let address = match target {
                     OperationTarget::Node { address } => address,
                     OperationTarget::FanOut => {
-                        trace!("Request error `{}` multi-node request", err);
+                        log_trace_lazy!(
+                            "cluster",
+                            format!("Request error `{}` multi-node request", err)
+                        );
 
                         // Fanout operation are retried per internal request, and don't need additional retries.
                         self.respond(Err(err));
@@ -1107,13 +1115,17 @@ impl<C> Future for Request<C> {
                         .into();
                     }
                     OperationTarget::FatalError => {
-                        trace!("Fatal error encountered: {:?}", err);
+                        log_trace_lazy!("cluster", format!("Fatal error encountered: {:?}", err));
                         self.respond(Err(err));
                         return Next::Done.into();
                     }
                 };
 
-                warn!("Received request error {} on node {:?}.", err, address);
+                log_warn_rate_limited!(
+                    "cluster",
+                    5,
+                    format!("Received request error {} on node {:?}.", err, address)
+                );
 
                 match err.retry_method() {
                     RetryMethod::AskRedirect => {
@@ -1160,7 +1172,11 @@ impl<C> Future for Request<C> {
                         let mut request = this.request.take().unwrap();
                         // TODO should we reset the redirect here?
                         request.info.reset_routing();
-                        warn!("disconnected from {:?}", address);
+                        log_warn_rate_limited!(
+                            "cluster",
+                            5,
+                            format!("disconnected from {:?}", address)
+                        );
                         let should_retry =
                             matches!(err.retry_method(), RetryMethod::ReconnectAndRetry);
                         Next::Reconnect {
@@ -1413,7 +1429,10 @@ where
                 connections.1.unwrap_or("".to_string()),
             )));
         }
-        info!("Connected to initial nodes:\n{}", connections.0);
+        log_info_lazy!(
+            "cluster",
+            format!("Connected to initial nodes:\n{}", connections.0)
+        );
         Ok(connections.0)
     }
 
@@ -1425,7 +1444,7 @@ where
         let cluster_params = match inner.get_cluster_param(|params| params.clone()) {
             Ok(params) => params,
             Err(err) => {
-                warn!("Failed to get cluster params: {}", err);
+                log_warn_lazy!("cluster", format!("Failed to get cluster params: {}", err));
                 return async {}.boxed();
             }
         };
@@ -1439,7 +1458,10 @@ where
             {
                 Ok(map) => map,
                 Err(err) => {
-                    warn!("Can't reconnect to initial nodes: `{err}`");
+                    log_warn_lazy!(
+                        "cluster",
+                        format!("Can't reconnect to initial nodes: `{err}`")
+                    );
                     return;
                 }
             };
@@ -1455,7 +1477,10 @@ where
             )
             .await
             {
-                warn!("Can't refresh slots with initial nodes: `{err}`");
+                log_warn_lazy!(
+                    "cluster",
+                    format!("Can't refresh slots with initial nodes: `{err}`")
+                );
             };
         })
     }
@@ -1542,7 +1567,10 @@ where
         conn_type: RefreshConnectionType,
         check_existing_conn: bool,
     ) {
-        trace!("refresh_and_update_connections: calling trigger_refresh_connection_tasks");
+        log_trace_lazy!(
+            "cluster",
+            "refresh_and_update_connections: calling trigger_refresh_connection_tasks"
+        );
         let refresh_task_notifiers = Self::trigger_refresh_connection_tasks(
             inner.clone(),
             addresses,
@@ -1551,7 +1579,10 @@ where
         )
         .await;
 
-        trace!("refresh_and_update_connections: Await on all tasks' refresh notifier");
+        log_trace_lazy!(
+            "cluster",
+            "refresh_and_update_connections: Await on all tasks' refresh notifier"
+        );
         futures::future::join_all(
             refresh_task_notifiers
                 .iter()
@@ -1570,7 +1601,10 @@ where
         conn_type: RefreshConnectionType,
         check_existing_conn: bool,
     ) -> Vec<Arc<Notify>> {
-        debug!("Triggering refresh connections tasks to {:?} ", addresses);
+        log_debug_lazy!(
+            "cluster",
+            format!("Triggering refresh connections tasks to {:?} ", addresses)
+        );
 
         let mut notifiers = Vec::<Arc<Notify>>::new();
 
@@ -1587,7 +1621,10 @@ where
                     // Store the notifier
                     notifiers.push(notifier.get_notifier());
                 }
-                debug!("Skipping refresh for {}: already in progress", address);
+                log_debug_lazy!(
+                    "cluster",
+                    format!("Skipping refresh for {}: already in progress", address)
+                );
                 continue; // Skip creating a new refresh task
             }
 
@@ -1605,9 +1642,12 @@ where
             }
 
             let handle = tokio::spawn(async move {
-                info!(
-                    "refreshing connection task to {:?} started",
-                    address_clone_for_task
+                log_info_lazy!(
+                    "cluster",
+                    format!(
+                        "refreshing connection task to {:?} started",
+                        address_clone_for_task
+                    )
                 );
 
                 // We run infinite retries to reconnect until it succeeds or it's aborted from outside.
@@ -1661,10 +1701,8 @@ where
 
                                 first_attempt = false;
                             }
-                            debug!(
-                                "Failed to refresh connection for node {}. Error: `{:?}`. Retrying in {:?}",
-                                address_clone_for_task, err, backoff_duration
-                            );
+                            log_debug_lazy!("cluster", format!("Failed to refresh connection for node {}. Error: `{:?}`. Retrying in {:?}",
+                                address_clone_for_task, err, backoff_duration));
                             tokio::time::sleep(backoff_duration).await;
                         }
                     }
@@ -1672,9 +1710,12 @@ where
 
                 match node_result {
                     Ok(node) => {
-                        info!(
-                            "Succeeded to refresh connection for node {}.",
-                            address_clone_for_task
+                        log_info_lazy!(
+                            "cluster",
+                            format!(
+                                "Succeeded to refresh connection for node {}.",
+                                address_clone_for_task
+                            )
                         );
                         inner_clone
                             .conn_lock
@@ -1683,9 +1724,12 @@ where
                             .replace_or_add_connection_for_address(&address_clone_for_task, node);
                     }
                     Err(err) => {
-                        warn!(
-                            "Failed to refresh connection for node {}. Error: `{:?}`",
-                            address_clone_for_task, err
+                        log_warn_lazy!(
+                            "cluster",
+                            format!(
+                                "Failed to refresh connection for node {}. Error: `{:?}`",
+                                address_clone_for_task, err
+                            )
                         );
                     }
                 }
@@ -1698,9 +1742,12 @@ where
                     .refresh_address_in_progress
                     .remove(&address_clone_for_task);
 
-                debug!(
-                    "Refreshing connection task to {:?} is done",
-                    address_clone_for_task
+                log_debug_lazy!(
+                    "cluster",
+                    format!(
+                        "Refreshing connection task to {:?} is done",
+                        address_clone_for_task
+                    )
                 );
             });
 
@@ -1718,7 +1765,7 @@ where
                 .refresh_address_in_progress
                 .insert(address.clone(), refresh_task_state);
         }
-        debug!("trigger_refresh_connection_tasks: Done");
+        log_debug_lazy!("cluster", "trigger_refresh_connection_tasks: Done");
         notifiers
     }
 
@@ -2103,12 +2150,27 @@ where
             rate_limiter,
         } = &inner.slot_refresh_state;
         // Ensure only a single slot refresh operation occurs at a time
+        // Time the acquisition attempt for diagnostic visibility
+        let acquire_start = std::time::Instant::now();
         if in_progress
             .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
             .is_err()
         {
+            log_warn_lazy!("topology_refresh", format!(
+                "Concurrent slot refresh rejected by compare_exchange (another refresh is already in progress)"));
             return Ok(());
         }
+        let acquire_elapsed = acquire_start.elapsed();
+        if acquire_elapsed > Duration::from_millis(100) {
+            log_warn_lazy!(
+                "topology_refresh",
+                format!(
+                    "in_progress lock acquisition took {:?} (>100ms threshold)",
+                    acquire_elapsed
+                )
+            );
+        }
+
         let mut should_refresh_slots = true;
         if *policy == RefreshPolicy::Throttable {
             // Check if the current slot refresh is triggered before the wait duration has passed
@@ -2117,17 +2179,16 @@ where
                 let passed_time = SystemTime::now()
                     .duration_since(last_run_time)
                     .unwrap_or_else(|err| {
-                        warn!(
-                            "Failed to get the duration since the last slot refresh, received error: {:?}",
-                            err
-                        );
+                        log_warn_lazy!("cluster", format!("Failed to get the duration since the last slot refresh, received error: {:?}",
+                            err));
                         // Setting the passed time to 0 will force the current refresh to continue and reset the stored last_run timestamp with the current one
                         Duration::from_secs(0)
                     });
                 let wait_duration = rate_limiter.wait_duration();
                 if passed_time <= wait_duration {
-                    debug!("Skipping slot refresh as the wait duration hasn't yet passed. Passed time = {:?},
-                            Wait duration = {:?}", passed_time, wait_duration);
+                    log_debug_lazy!("topology_refresh", format!(
+                        "Throttle: skipping slot refresh. passed_time={:?}, wait_duration={:?}, policy={:?}",
+                        passed_time, wait_duration, policy));
                     should_refresh_slots = false;
                 }
             }
@@ -2147,6 +2208,10 @@ where
                 Self::refresh_slots(inner.clone(), curr_retry, trigger)
                     .await
                     .map_err(|err| {
+                        log_warn_lazy!(
+                            "topology_refresh",
+                            format!("Slot refresh retry {} failed: {:?}", curr_retry, err)
+                        );
                         if err.kind() == ErrorKind::AllConnectionsUnavailable {
                             RetryError::permanent(err)
                         } else {
@@ -2194,9 +2259,12 @@ where
             {
                 Ok(topology_changed) => !topology_changed,
                 Err(err) => {
-                    warn!(
-                        "Failed to refresh slots during periodic topology checks:\n{:?}",
-                        err
+                    log_warn_lazy!(
+                        "cluster",
+                        format!(
+                            "Failed to refresh slots during periodic topology checks:\n{:?}",
+                            err
+                        )
                     );
                     true
                 }
@@ -2347,7 +2415,10 @@ where
 
         if let Some(failed) = failed_connections {
             if !failed.is_empty() {
-                trace!("check_for_topology_diff: calling trigger_refresh_connection_tasks");
+                log_trace_lazy!(
+                    "cluster",
+                    "check_for_topology_diff: calling trigger_refresh_connection_tasks"
+                );
                 Self::trigger_refresh_connection_tasks(
                     inner,
                     failed,
@@ -2474,9 +2545,13 @@ where
             }
         }
 
-        info!("refresh_slots found nodes:\n{new_connections}");
+        log_info_lazy!(
+            "cluster",
+            format!("refresh_slots found nodes:\n{new_connections}")
+        );
         // Reset the current slot map and connection vector with the new ones
         let mut write_guard = inner.conn_lock.write().expect(MUTEX_WRITE_ERR);
+        let old_topology_hash = write_guard.get_current_topology_hash();
         // Clear the refresh tasks of the prev instance
         // TODO - Maybe we can take the running refresh tasks and use them instead of running new connection creation
         write_guard.refresh_conn_state.clear_refresh_state();
@@ -2488,6 +2563,13 @@ where
             new_connections,
             read_from_replicas,
             topology_hash,
+        );
+        log_info_lazy!(
+            "slot_refresh",
+            format!(
+                "ConnectionsContainer replaced: old_topology_hash={:?}, new_topology_hash={:?}",
+                old_topology_hash, topology_hash
+            )
         );
         Ok(())
     }
@@ -2529,7 +2611,18 @@ where
             match curr_shard_addrs.attempt_shard_role_update(new_primary.clone()) {
                 // Scenario 1: No changes needed as the new primary is already the current slot owner.
                 // Scenario 2: Failover occurred and the new primary was promoted from a replica.
-                ShardUpdateResult::AlreadyPrimary | ShardUpdateResult::Promoted => return Ok(()),
+                ShardUpdateResult::AlreadyPrimary => {
+                    log_info_rate_limited!("moved_error", 10, format!(
+                        "Scenario 1 (No Change): slot={}, new_primary={} is already the current slot owner",
+                        slot, new_primary));
+                    return Ok(());
+                }
+                ShardUpdateResult::Promoted => {
+                    log_info_rate_limited!("moved_error", 10, format!(
+                        "Scenario 2 (Failover): slot={}, new_primary={} promoted from replica within same shard",
+                        slot, new_primary));
+                    return Ok(());
+                }
                 // The node was not found in this shard, proceed with further scenarios.
                 ShardUpdateResult::NodeNotFound => {}
             }
@@ -2545,6 +2638,9 @@ where
                 if is_existing_primary {
                     // Scenario 3: Slot Migration - The new primary is an existing primary in another shard
                     // Update the associated addresses for `slot` to `shard_addrs`.
+                    log_info_rate_limited!("moved_error", 10, format!(
+                        "Scenario 3 (Slot Migration): slot={}, new_primary={} is an existing primary in another shard",
+                        slot, new_primary));
                     drop(nodes_iter);
                     return wlock_conn_container
                         .slot_map
@@ -2552,6 +2648,9 @@ where
                 } else {
                     // Scenario 4: The MOVED error redirects to `new_primary` which is known as a replica in a shard that doesn’t own `slot`.
                     // Remove the replica from its existing shard and treat it as a new node in a new shard.
+                    log_info_rate_limited!("moved_error", 10, format!(
+                        "Scenario 4 (Replica Moved to Different Shard): slot={}, new_primary={} was a replica in a different shard",
+                        slot, new_primary));
                     shard_addrs_arc.remove_replica(new_primary.clone())?;
                     drop(nodes_iter);
                     return wlock_conn_container.slot_map.add_new_primary(
@@ -2565,6 +2664,9 @@ where
 
         drop(nodes_iter);
         // Scenario 5: New Node - The new primary is not present in the current slots map, add it as a primary of a new shard.
+        log_info_rate_limited!("moved_error", 10, format!(
+            "Scenario 5 (New Node): slot={}, new_primary={} is unknown, adding as new shard primary",
+            slot, new_primary));
         wlock_conn_container
             .slot_map
             .add_new_primary(slot, new_primary, None)
@@ -2576,7 +2678,7 @@ where
         core: Core<C>,
         response_policy: Option<ResponsePolicy>,
     ) -> OperationResult {
-        trace!("execute_on_multiple_nodes");
+        log_trace_lazy!("cluster", "execute_on_multiple_nodes");
 
         #[allow(clippy::type_complexity)]
         fn into_channels<C>(
@@ -2691,7 +2793,7 @@ where
 
             InternalRoutingInfo::SingleNode(routing) => routing,
         };
-        trace!("route request to single node");
+        log_trace_lazy!("cluster", "route request to single node");
 
         let (address, mut conn) = Self::get_connection(routing, core, Some(cmd.clone()))
             .await
@@ -2708,7 +2810,7 @@ where
         count: usize,
         conn: impl Future<Output = RedisResult<(String, C)>>,
     ) -> OperationResult {
-        trace!("try_pipeline_request");
+        log_trace_lazy!("cluster", "try_pipeline_request");
         let (address, mut conn) = conn.await.map_err(|err| (OperationTarget::NotFound, err))?;
         conn.req_packed_commands(&pipeline, offset, count, None)
             .await
@@ -3001,9 +3103,12 @@ where
                             .into());
                     }
 
-                    debug!(
-                        "SpecificNode: No connection found for route `{route:?}`.
+                    log_debug_lazy!(
+                        "cluster",
+                        format!(
+                            "SpecificNode: No connection found for route `{route:?}`.
                         Checking for reconnect tasks before redirecting to a random node."
+                        )
                     );
 
                     // Step 3: Obtain the reconnect notifier, ensuring the lock is released immediately after.
@@ -3014,15 +3119,11 @@ where
 
                     // Step 4: If a notifier exists, wait for it to signal completion.
                     if let Some(notifier) = reconnect_notifier {
-                        debug!(
-                            "SpecificNode: Waiting on reconnect notifier for route `{route:?}`."
-                        );
+                        log_debug_lazy!("cluster", format!("SpecificNode: Waiting on reconnect notifier for route `{route:?}`."));
 
                         notifier.notified().await;
 
-                        debug!(
-                            "SpecificNode: Finished waiting on notifier for route `{route:?}`. Retrying connection lookup."
-                        );
+                        log_debug_lazy!("cluster", format!("SpecificNode: Finished waiting on notifier for route `{route:?}`. Retrying connection lookup."));
 
                         // Step 5: Retry the connection lookup after waiting for the reconnect task.
                         if let Some((conn, address)) = core
@@ -3033,14 +3134,10 @@ where
                         {
                             conn_check = ConnectionCheck::Found((conn, address));
                         } else {
-                            debug!(
-                                "SpecificNode: No connection found for route `{route:?}` after waiting on reconnect notifier. Proceeding to random node."
-                            );
+                            log_debug_lazy!("cluster", format!("SpecificNode: No connection found for route `{route:?}` after waiting on reconnect notifier. Proceeding to random node."));
                         }
                     } else {
-                        debug!(
-                            "SpecificNode: No active reconnect task for route `{route:?}`. Proceeding to random node."
-                        );
+                        log_debug_lazy!("cluster", format!("SpecificNode: No active reconnect task for route `{route:?}`. Proceeding to random node."));
                     }
 
                     conn_check
@@ -3072,6 +3169,9 @@ where
         let (address, mut conn) = match conn_check {
             ConnectionCheck::Found((address, connection)) => (address, connection.await),
             ConnectionCheck::OnlyAddress(address) => {
+                log_warn_rate_limited!("moved_error", 10, format!(
+                    "MOVED target address {} not found in current connection map, triggering refresh",
+                    address));
                 // Trigger refresh task and get the single notifier
                 let mut notifiers = Self::trigger_refresh_connection_tasks(
                     core.clone(),
@@ -3083,20 +3183,29 @@ where
 
                 // Extract the single notifier (if any)
                 if let Some(refresh_notifier) = notifiers.pop() {
-                    debug!(
-                        "get_connection: Waiting on the refresh notifier for address: {}",
-                        address
+                    log_debug_lazy!(
+                        "cluster",
+                        format!(
+                            "get_connection: Waiting on the refresh notifier for address: {}",
+                            address
+                        )
                     );
                     // Wait for the refresh task to notify that it's done reconnecting (or transitioning).
                     refresh_notifier.notified().await;
-                    debug!(
-                        "get_connection: After waiting on the refresh notifier for address: {}",
-                        address
+                    log_debug_lazy!(
+                        "cluster",
+                        format!(
+                            "get_connection: After waiting on the refresh notifier for address: {}",
+                            address
+                        )
                     );
                 } else {
-                    debug!(
-                        "get_connection: No notifier to wait on for address: {}",
-                        address
+                    log_debug_lazy!(
+                        "cluster",
+                        format!(
+                            "get_connection: No notifier to wait on for address: {}",
+                            address
+                        )
                     );
                 }
 
@@ -3108,7 +3217,10 @@ where
                     .connection_for_address(&address);
 
                 if let Some((address, conn)) = conn_option {
-                    debug!("get_connection: Connection found for address: {}", address);
+                    log_debug_lazy!(
+                        "cluster",
+                        format!("get_connection: Connection found for address: {}", address)
+                    );
                     (address, conn.await)
                 } else {
                     return Err((
@@ -3147,7 +3259,7 @@ where
     }
 
     fn poll_recover(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), RedisError>> {
-        trace!("entered poll_recover");
+        log_trace_lazy!("cluster", "entered poll_recover");
 
         let recover_future = match &mut self.state {
             ConnectionState::PollComplete => return Poll::Ready(Ok(())),
@@ -3160,13 +3272,16 @@ where
                 match handle.now_or_never() {
                     Some(Ok(Ok(()))) => {
                         // Task succeeded
-                        trace!("Slot refresh completed successfully!");
+                        log_info_lazy!(
+                            "slot_refresh",
+                            "poll_recover: slot refresh completed successfully, recovery complete"
+                        );
                         self.state = ConnectionState::PollComplete;
                         return Poll::Ready(Ok(()));
                     }
                     Some(Ok(Err(e))) => {
                         // Task completed but returned an engine error
-                        trace!("Slot refresh failed: {:?}", e);
+                        log_trace_lazy!("cluster", format!("Slot refresh failed: {:?}", e));
 
                         if e.kind() == ErrorKind::AllConnectionsUnavailable {
                             // If all connections unavailable, try reconnect
@@ -3192,12 +3307,12 @@ where
                     Some(Err(join_err)) => {
                         if join_err.is_cancelled() {
                             // Task was intentionally aborted - don't treat as an error
-                            trace!("Slot refresh task was aborted");
+                            log_trace_lazy!("cluster", "Slot refresh task was aborted");
                             self.state = ConnectionState::PollComplete;
                             return Poll::Ready(Ok(()));
                         } else {
                             // Task panicked - try reconnecting to initial nodes as a recovery strategy
-                            warn!("Slot refresh task panicked: {:?} - attempting recovery by reconnecting to initial nodes", join_err);
+                            log_warn_lazy!("cluster", format!("Slot refresh task panicked: {:?} - attempting recovery by reconnecting to initial nodes", join_err));
 
                             // TODO - consider a gracefully closing of the client
                             // Since a panic indicates a bug in the refresh logic,
@@ -3221,6 +3336,10 @@ where
                     None => {
                         // Task is still running
                         // Just continue and return Ok to not block poll_flush
+                        // NOTE: now_or_never() does not register a waker, so the task
+                        // completion will not wake this future. The next poll_flush call
+                        // (triggered by a new request or cx.waker()) will re-check.
+                        log_debug_lazy!("cluster", "poll_recover: RefreshingSlots task still running (now_or_never returned None, no waker registered)");
                     }
                 }
 
@@ -3230,13 +3349,13 @@ where
             // Other cases remain unchanged
             RecoverFuture::ReconnectToInitialNodes(ref mut future) => {
                 ready!(future.as_mut().poll(cx));
-                trace!("Reconnected to initial nodes");
+                log_trace_lazy!("cluster", "Reconnected to initial nodes");
                 self.state = ConnectionState::PollComplete;
                 Poll::Ready(Ok(()))
             }
             RecoverFuture::Reconnect(ref mut future) => {
                 ready!(future.as_mut().poll(cx));
-                trace!("Reconnected connections");
+                log_trace_lazy!("cluster", "Reconnected connections");
                 self.state = ConnectionState::PollComplete;
                 Poll::Ready(Ok(()))
             }
@@ -3487,8 +3606,13 @@ where
         mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::Error>> {
-        trace!("poll_flush: {:?}", self.state);
+        log_trace_lazy!("cluster", format!("poll_flush: {:?}", self.state));
+        // Busy-spin detection: count loop iterations per call
+        let mut loop_iterations: u64 = 0;
+        // Adaptive health snapshot: healthy=5min, recovery=10s
+        static LAST_HEALTH_LOG: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         loop {
+            loop_iterations += 1;
             self.send_refresh_error();
 
             if let Err(err) = ready!(self.as_mut().poll_recover(cx)) {
@@ -3505,8 +3629,50 @@ where
             }
 
             match ready!(self.poll_complete(cx)) {
-                PollFlushAction::None => return Poll::Ready(Ok(())),
+                PollFlushAction::None => {
+                    if loop_iterations > 100 {
+                        log_warn_rate_limited!(
+                            "cluster",
+                            5,
+                            format!(
+                                "poll_flush busy-spin detected: {} loop iterations in single call",
+                                loop_iterations
+                            )
+                        );
+                    }
+                    // Adaptive health snapshot
+                    let now_secs = SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    let last_health = LAST_HEALTH_LOG.load(Ordering::Relaxed);
+                    let in_recovery = matches!(self.state, ConnectionState::Recover(_));
+                    let interval = if in_recovery { 10 } else { 300 };
+                    if now_secs >= last_health + interval {
+                        LAST_HEALTH_LOG.store(now_secs, Ordering::Relaxed);
+                        let in_flight = self.in_flight_requests.len();
+                        let pending = self.inner.pending_requests.lock().unwrap().len();
+                        if in_recovery {
+                            log_info_lazy!("cluster", format!(
+                                "poll_flush health (recovery): in_flight_requests={}, pending_requests={}, loop_iterations={}",
+                                in_flight, pending, loop_iterations));
+                        } else {
+                            log_debug_lazy!("cluster", format!(
+                                "poll_flush health (healthy): in_flight_requests={}, pending_requests={}, loop_iterations={}",
+                                in_flight, pending, loop_iterations));
+                        }
+                    }
+                    return Poll::Ready(Ok(()));
+                }
                 PollFlushAction::RebuildSlots => {
+                    let in_flight = self.in_flight_requests.len();
+                    log_info_lazy!(
+                        "cluster",
+                        format!(
+                            "poll_flush: transitioning to RebuildSlots, in_flight_requests={}",
+                            in_flight
+                        )
+                    );
                     // Spawn refresh task
                     let task_handle = ClusterConnInner::spawn_refresh_slots_task(
                         self.inner.clone(),
@@ -3518,12 +3684,20 @@ where
                         ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
                 }
                 PollFlushAction::ReconnectFromInitialConnections => {
+                    let in_flight = self.in_flight_requests.len();
+                    log_info_lazy!("cluster", format!(
+                        "poll_flush: transitioning to ReconnectFromInitialConnections, in_flight_requests={}",
+                        in_flight));
                     self.state =
                         ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
                             ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
                         )));
                 }
                 PollFlushAction::Reconnect(addresses) => {
+                    let in_flight = self.in_flight_requests.len();
+                    log_info_lazy!("cluster", format!(
+                        "poll_flush: transitioning to Reconnect(addresses={:?}), in_flight_requests={}",
+                        addresses, in_flight));
                     self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
                         ClusterConnInner::trigger_refresh_connection_tasks(
                             self.inner.clone(),
@@ -3789,6 +3963,10 @@ where
     // During initial connection, use existing connections to avoid double DNS lookup
     let use_initial_nodes_lookup = refresh_topology_from_initial_nodes
         && !matches!(trigger, SlotRefreshTrigger::InitialConnection);
+
+    log_info_lazy!("slot_refresh", format!(
+        "calculate_topology_from_random_nodes: use_initial_nodes={}, num_to_query={}, trigger={:?}, retry={}",
+        use_initial_nodes_lookup, num_of_nodes_to_query, trigger, curr_retry));
 
     // Get connections either from seed nodes or random existing connections.
     let (requested_nodes, mut failed_addresses) = if use_initial_nodes_lookup {

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -394,10 +394,10 @@ where
     core.pending_requests
         .lock()
         .unwrap()
-        .extend(pending_requests.into_iter());
+        .extend(pending_requests);
 
     // Wait for all receivers to complete and collect the responses
-    let responses: Vec<_> = futures::future::join_all(receivers.into_iter())
+    let responses: Vec<_> = futures::future::join_all(receivers)
         .await
         .into_iter()
         .collect();

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -5,7 +5,7 @@ mod types;
 use crate::cluster_scan_container::insert_cluster_scan_cursor;
 use crate::scripts_container::get_script;
 use futures::FutureExt;
-use logger_core::{log_debug, log_error, log_info, log_warn};
+use logger_core::{log_debug, log_error, log_info, log_warn, log_warn_rate_limited};
 use once_cell::sync::OnceCell;
 use redis::aio::ConnectionLike;
 use redis::cluster_async::ClusterConnection;
@@ -622,6 +622,16 @@ impl Client {
             let tracker = match self.reserve_inflight_request() {
                 Some(t) => t,
                 None => {
+                    let available = self.inflight_requests_allowed.load(Ordering::Relaxed);
+                    log_warn_rate_limited!(
+                        "inflight",
+                        10,
+                        format!(
+                            "Inflight request limit exhausted. limit={}, available={}",
+                            self.inflight_requests_limit, available
+                        )
+                    );
+
                     return Err(RedisError::from((
                         ErrorKind::ClientError,
                         "Reached maximum inflight requests",

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -181,7 +181,7 @@ impl StandaloneClient {
             None
         };
 
-        let mut stream = stream::iter(connection_request.addresses.into_iter())
+        let mut stream = stream::iter(connection_request.addresses)
             .map(move |address| {
                 let info = if address.host != pubsub_addr.host || address.port != pubsub_addr.port {
                     valkey_connection_info.clone()

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -130,7 +130,13 @@ public final class Logger {
             @NonNull Level level,
             @NonNull String logIdentifier,
             @NonNull Supplier<String> messageSupplier) {
-        log(level, logIdentifier, messageSupplier.get());
+        if (loggerLevel == null) {
+            initLogger(Level.DEFAULT, null);
+        }
+        if (level == Level.OFF || !(level.getLevel() <= loggerLevel.getLevel())) {
+            return;
+        }
+        logInternal(level.getLevel(), logIdentifier, messageSupplier.get());
     }
 
     /**
@@ -186,7 +192,16 @@ public final class Logger {
             @NonNull String logIdentifier,
             @NonNull Supplier<String> messageSupplier,
             @NonNull Throwable throwable) {
-        log(level, logIdentifier, messageSupplier.get() + ": " + prettyPrintException(throwable));
+        if (loggerLevel == null) {
+            initLogger(Level.DEFAULT, null);
+        }
+        if (level == Level.OFF || !(level.getLevel() <= loggerLevel.getLevel())) {
+            return;
+        }
+        logInternal(
+                level.getLevel(),
+                logIdentifier,
+                messageSupplier.get() + ": " + prettyPrintException(throwable));
     }
 
     private static String prettyPrintException(@NonNull Throwable throwable) {

--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -1,6 +1,7 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.internal;
 
+import glide.api.logging.Logger;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -36,6 +37,10 @@ public final class AsyncRegistry {
 
     /** Thread-safe ID generator */
     private static final AtomicLong nextId = new AtomicLong(1);
+
+    /** Registration timestamps for measuring elapsed time on errors. */
+    private static final ConcurrentHashMap<Long, Long> registrationTimestamps =
+            new ConcurrentHashMap<>();
 
     /**
      * Shutdown flag to prevent race conditions between register() and shutdown()/failAllWithError().
@@ -114,10 +119,12 @@ public final class AsyncRegistry {
 
         // Store original future for completion by native code
         activeFutures.put(correlationId, originalFuture);
+        registrationTimestamps.put(correlationId, System.nanoTime());
 
         // Double-check shutdown flag after insertion to handle race with shutdown()
         if (isShutdown.get()) {
             activeFutures.remove(correlationId);
+            registrationTimestamps.remove(correlationId);
             if (maxInflightRequests > 0) {
                 clientInflightCounts.computeIfPresent(
                         clientHandle,
@@ -138,6 +145,7 @@ public final class AsyncRegistry {
                 (result, throwable) -> {
                     // Atomic cleanup - no race conditions
                     activeFutures.remove(correlationId);
+                    registrationTimestamps.remove(correlationId);
 
                     // Decrement per-client counter if applicable
                     if (maxInflightRequests > 0) {
@@ -198,6 +206,19 @@ public final class AsyncRegistry {
                         ? "Unknown error from native code"
                         : errorMessage;
 
+        // Log elapsed time for timeout and disconnect errors
+        if (errorTypeCode == 2 || errorTypeCode == 3) {
+            Long registeredAt = registrationTimestamps.get(correlationId);
+            if (registeredAt != null) {
+                long elapsedMs = (System.nanoTime() - registeredAt) / 1_000_000;
+                String errorTypeName = errorTypeCode == 2 ? "Timeout" : "Disconnect";
+                Logger.log(
+                        Logger.Level.WARN,
+                        "AsyncRegistry",
+                        errorTypeName + " after " + elapsedMs + "ms: " + msg);
+            }
+        }
+
         // Map error codes directly to exception types
         RuntimeException ex;
         switch (errorTypeCode) {
@@ -240,6 +261,7 @@ public final class AsyncRegistry {
 
         // Clear the map
         activeFutures.clear();
+        registrationTimestamps.clear();
         clientInflightCounts.clear();
     }
 
@@ -263,6 +285,7 @@ public final class AsyncRegistry {
                 (id, future) ->
                         future.completeExceptionally(new glide.api.models.exceptions.ClosingException(msg)));
         activeFutures.clear();
+        registrationTimestamps.clear();
         clientInflightCounts.clear();
     }
 
@@ -275,6 +298,7 @@ public final class AsyncRegistry {
     public static void reset() {
         isShutdown.set(false);
         activeFutures.clear();
+        registrationTimestamps.clear();
         clientInflightCounts.clear();
         nextId.set(1);
     }

--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -426,6 +426,14 @@ fn process_callback_job_with_env(
     binary_mode: bool,
 ) {
     if take_timed_out_callback(callback_id) {
+        logger_core::log_warn_rate_limited!(
+            "jni_callback",
+            5,
+            format!(
+                "Rust task completed for callback_id={} but Java already timed out. Task was leaked.",
+                callback_id
+            )
+        );
         return;
     }
 

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -137,7 +137,19 @@ async fn execute_command_request_and_complete(
                     None
                 };
 
+                let send_start = std::time::Instant::now();
                 let exec = client.send_command(&cmd, routing).await;
+                let send_elapsed = send_start.elapsed();
+                if send_elapsed > std::time::Duration::from_secs(1) {
+                    logger_core::log_warn_rate_limited!(
+                        "jni_command",
+                        5,
+                        format!(
+                            "send_command took {:?} for callback_id={}",
+                            send_elapsed, callback_id
+                        )
+                    );
+                }
 
                 if let Some(root_span_ptr) = root_span_ptr_opt
                     && root_span_ptr != 0

--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -252,6 +252,98 @@ create_log!(log_info, INFO);
 create_log!(log_warn, WARN);
 create_log!(log_error, ERROR);
 
+/// Lazy logging macros that only evaluate the message expression if the log level is enabled.
+/// This avoids the cost of `format!(...)` when the level is disabled.
+///
+/// Usage:
+/// ```ignore
+/// log_trace_lazy!("identifier", format!("expensive computation: {}", value));
+/// log_warn_lazy!("identifier", format!("something happened: {:?}", err));
+/// ```
+#[macro_export]
+macro_rules! log_trace_lazy {
+    ($identifier:expr, $message:expr) => {
+        if tracing::event_enabled!(tracing::Level::TRACE) {
+            $crate::log_trace($identifier, $message);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! log_debug_lazy {
+    ($identifier:expr, $message:expr) => {
+        if tracing::event_enabled!(tracing::Level::DEBUG) {
+            $crate::log_debug($identifier, $message);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! log_info_lazy {
+    ($identifier:expr, $message:expr) => {
+        if tracing::event_enabled!(tracing::Level::INFO) {
+            $crate::log_info($identifier, $message);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! log_warn_lazy {
+    ($identifier:expr, $message:expr) => {
+        if tracing::event_enabled!(tracing::Level::WARN) {
+            $crate::log_warn($identifier, $message);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! log_error_lazy {
+    ($identifier:expr, $message:expr) => {
+        if tracing::event_enabled!(tracing::Level::ERROR) {
+            $crate::log_error($identifier, $message);
+        }
+    };
+}
+
+/// Rate-limited logging macro. Logs at most once per `interval_secs` seconds.
+/// Uses a static AtomicU64 per call site to track the last log time.
+///
+/// Usage:
+/// ```ignore
+/// log_warn_rate_limited!("identifier", 10, format!("something happened: {}", val));
+/// ```
+#[macro_export]
+macro_rules! log_warn_rate_limited {
+    ($identifier:expr, $interval_secs:expr, $message:expr) => {{
+        static LAST_LOG: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let last = LAST_LOG.load(std::sync::atomic::Ordering::Relaxed);
+        if now >= last + $interval_secs {
+            LAST_LOG.store(now, std::sync::atomic::Ordering::Relaxed);
+            $crate::log_warn($identifier, $message);
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! log_info_rate_limited {
+    ($identifier:expr, $interval_secs:expr, $message:expr) => {{
+        static LAST_LOG: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let last = LAST_LOG.load(std::sync::atomic::Ordering::Relaxed);
+        if now >= last + $interval_secs {
+            LAST_LOG.store(now, std::sync::atomic::Ordering::Relaxed);
+            $crate::log_info($identifier, $message);
+        }
+    }};
+}
+
 // Logs the given log, with log_identifier and log level prefixed. If the given log level is below the threshold of given when the logger was initialized, the log will be ignored.
 // log_identifier should be used to add context to a log, and make it easier to connect it to other relevant logs. For example, it can be used to pass a task identifier.
 // If this is called before a logger was initialized the log will not be registered.

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -345,7 +345,7 @@ fn resp_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<JsU
             // because `Record` does not support `GlideString` as a key.
             // The result is in format `GlideRecord<T>`.
             let mut js_array = js_env.create_array_with_length(map.len())?;
-            for (idx, (key, value)) in (0_u32..).zip(map.into_iter()) {
+            for (idx, (key, value)) in (0_u32..).zip(map) {
                 let mut obj = js_env.create_object()?;
                 obj.set_named_property("key", resp_value_to_js(key, js_env, string_decoder)?)?;
                 obj.set_named_property("value", resp_value_to_js(value, js_env, string_decoder)?)?;


### PR DESCRIPTION
- Add lazy and rate-limited logging macros to logger_core
- Convert tracing calls to logger_core lazy macros in cluster_async/mod.rs
- Fix Java Logger Supplier overloads to check level before evaluating
- Add MOVED error scenario identification and topology refresh logging
- Add pipeline send/response timing with adaptive thresholds
- Add inflight slot exhaustion, task leak, and recovery state logging
- Add adaptive health snapshot (5min DEBUG healthy, 10s INFO recovery)
- Add Java-side timeout/disconnect elapsed time logging

### Summary

Add comprehensive diagnostic logging across the Rust core, Java JNI layer, and Java client to help diagnose failover, topology refresh, and pipeline blocking issues. Also adds lazy and rate-limited logging macros to logger_core and fixes a bug in the Java Logger Supplier overloads.

### Issue link

n/a

### Features / Behaviour Changes

- Fixed Java lazy logging to properly check logging level before running the message supplier.
- Added lazy logging macros to Rust logger.
- Changed tracing crate calls in core to use lazy logging macros to make messages controlled using the log level.
- Add rate-limited logging macros

### Implementation

#### MOVED Error / Topology Refresh:

- topology_refresh_lock acquisition timing (WARN if >100ms)
- Concurrent refresh rejection and throttle skip with timing (WARN)
- Refresh retry failures with error details (WARN)
- Topology hash comparison on ConnectionsContainer replacement (INFO)
- update_upon_moved_error scenario identification 1-5 (INFO)
- MOVED redirect to unknown address (WARN, rate-limited 10s)
- Topology query source: initial nodes vs existing connections (INFO)

#### Thread-Stuck / Fail-Fast:

- Pipeline send blocking with adaptive threshold min(response_timeout/4, 500ms) (WARN, rate-limited 5s)
- Response wait with adaptive threshold min(response_timeout/2, 5s) (WARN, rate-limited 5s)
- Inflight request limit exhaustion (WARN, rate-limited 10s)
- send_command duration >1s in Java JNI path (WARN)
- Timed-out task leak detection (WARN, rate-limited 5s)
- Java-side timeout/disconnect elapsed time (WARN)

#### poll_flush / Recovery:

- Busy-spin detection: >100 loop iterations per poll_flush call (WARN, every 5s)
- now_or_never waker bug documentation (DEBUG)
- Recovery state transitions with in_flight_requests count (INFO)
- Recovery completion (INFO)
- Adaptive health snapshot: 5min at DEBUG when healthy, 10s at INFO during recovery

### Limitations

n/a

### Testing

Manually verified that the new logging works

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
