### PR TITLE
Fix lint errors due to new Rust version

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2169,17 +2169,13 @@ impl ResponseArena {
         let base = self.nodes.as_ptr() as usize;
         for node in &mut self.nodes {
             match node.response_type {
-                ResponseType::Array | ResponseType::Map => {
-                    if node.array_value_len > 0 {
-                        let offset = node.array_value as usize;
-                        node.array_value = unsafe { (base as *mut CommandResponse).add(offset) };
-                    }
+                ResponseType::Array | ResponseType::Map if node.array_value_len > 0 => {
+                    let offset = node.array_value as usize;
+                    node.array_value = unsafe { (base as *mut CommandResponse).add(offset) };
                 }
-                ResponseType::Sets => {
-                    if node.sets_value_len > 0 {
-                        let offset = node.sets_value as usize;
-                        node.sets_value = unsafe { (base as *mut CommandResponse).add(offset) };
-                    }
+                ResponseType::Sets if node.sets_value_len > 0 => {
+                    let offset = node.sets_value as usize;
+                    node.sets_value = unsafe { (base as *mut CommandResponse).add(offset) };
                 }
                 _ => {}
             }

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -229,7 +229,7 @@ impl StandaloneClient {
 
         let iam_token_handle = iam_token_manager.map(|m| m.get_token_handle());
 
-        let mut stream = stream::iter(addresses.into_iter())
+        let mut stream = stream::iter(addresses)
             .map(move |address| {
                 let info = valkey_connection_info.clone();
                 let retry = retry_strategy;

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -345,7 +345,7 @@ fn resp_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<JsU
             // because `Record` does not support `GlideString` as a key.
             // The result is in format `GlideRecord<T>`.
             let mut js_array = js_env.create_array_with_length(map.len())?;
-            for (idx, (key, value)) in (0_u32..).zip(map.into_iter()) {
+            for (idx, (key, value)) in (0_u32..).zip(map) {
                 let mut obj = js_env.create_object()?;
                 obj.set_named_property("key", resp_value_to_js(key, js_env, string_decoder)?)?;
                 obj.set_named_property("value", resp_value_to_js(value, js_env, string_decoder)?)?;


### PR DESCRIPTION
### Summary

Fix clippy lint errors introduced by Rust 1.95.

### Implementation

- Removed redundant `.into_iter()` calls where the receiving function already accepts `IntoIterator`
- Collapsed nested `if` blocks into match guards

### Testing

All builds, including lints, now pass locally and in CI.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] ~This Pull Request is related to one issue.~
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
