### PR TITLE
fix(glide-core): prevent topology overwrite cycle during cross-region failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Pending 2.2
 
+#### Fixes
+* CORE: Fix 3+ minute MOVED error delay during cross-region failover with `refreshTopologyFromInitialNodes` by skipping topology overwrite when seed nodes return unchanged topology hash ([#5769](https://github.com/valkey-io/valkey-glide/pull/5769))
+
 #### Operational Enhancements
 * CORE, Java: Add diagnostic logging for failover, topology refresh, and pipeline issues — lazy and rate-limited logging macros in logger_core, MOVED error scenario identification, topology refresh throttle/overwrite tracking, pipeline send/response timing, inflight slot exhaustion, recovery state transitions, adaptive health snapshots, and Java-side timeout elapsed time. Fix Java Logger Supplier overloads to check level before evaluating. ([#5756](https://github.com/valkey-io/valkey-glide/pull/5756))
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2552,6 +2552,28 @@ where
         // Reset the current slot map and connection vector with the new ones
         let mut write_guard = inner.conn_lock.write().expect(MUTEX_WRITE_ERR);
         let old_topology_hash = write_guard.get_current_topology_hash();
+
+        // Skip overwrite when topology hash is unchanged during runtime refresh.
+        // This prevents the destructive cycle where stale seed nodes overwrite corrections
+        // made by update_upon_moved_error or error-driven routing fixes.
+        if old_topology_hash == topology_hash
+            && old_topology_hash != 0
+            && matches!(trigger, SlotRefreshTrigger::RuntimeRefresh)
+        {
+            log_info_lazy!(
+                "slot_refresh",
+                format!(
+                    "Topology unchanged (hash={}), skipping ConnectionsContainer replacement to preserve routing corrections. trigger={:?}",
+                    topology_hash, trigger
+                )
+            );
+            drop(write_guard);
+            return Err(RedisError::from((
+                ErrorKind::ResponseError,
+                "Topology unchanged from seed nodes — retrying to detect updates",
+            )));
+        }
+
         // Clear the refresh tasks of the prev instance
         // TODO - Maybe we can take the running refresh tasks and use them instead of running new connection creation
         write_guard.refresh_conn_state.clear_refresh_state();


### PR DESCRIPTION
### Summary

When refreshTopologyFromInitialNodes is enabled and a cross-region failover occurs (e.g., Global Datastore failover with Route53 DNS switch), the client experiences a 3+ minute error window caused by a destructive topology overwrite cycle:

1. MOVED/ReadOnly errors trigger update_upon_moved_error which correctly fixes the slot map
2. Full topology refresh queries seed nodes via CLUSTER SLOTS, gets an identical topology hash (seed nodes haven't updated yet)
3. The refresh unconditionally replaces the entire ConnectionsContainer, undoing the per-request fix
4. Throttle (15-30s) blocks the next refresh attempt
5. Cycle repeats until seed node DNS propagates (~3 minutes for ElastiCache config endpoints)

This PR adds a topology hash comparison before replacing the ConnectionsContainer during RuntimeRefresh. When the new topology hash matches the current one, the replacement is skipped, preserving routing corrections made by update_upon_moved_error. The check only applies to runtime refreshes (not initial connection) and only when the hash is non-zero (not the first topology load).

### Issue link

n/a

### Features / Behaviour Changes

Internal behaviour change only. Avoid rewriting the entire ConnectionsContainer if the topology is the same after a CLUSTER SLOTS request.

### Implementation

Skip unnecessary overwriting of ConnectionsContainer, losing correct updates to the slot map done in update_upon_moved_error.

### Limitations

n/a

### Testing

The scenario tested was to have two clusters, one operating as a primary and secondary. The client would connect
to an endpoint and that endpoint would resolve differently in a simulated failover scenario (achieved by editing the
hosts file during runtime). There would be a 3 minute window (this was the time it took for the topology changes to get propagated to the initial nodes) where Glide would continuously receive MOVED errors before
this PR and now gets a single MOVED error and correctly.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
