### PR TITLE
Scope Sonatype deployment repo to io.valkey group

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -46,6 +46,9 @@ subprojects {
                 authentication {
                     header(HttpHeaderAuthentication)
                 }
+                content {
+                    includeGroup "io.valkey"
+                }
             }
         }
         mavenCentral()


### PR DESCRIPTION
## Summary

The Sonatype deployments/download endpoint is registered as a Maven repository for all subprojects during CD test-deployment. Without filtering, Gradle tries to resolve all dependencies (guava, jedis, lettuce, etc) from it, not just valkey-glide. This endpoint is only meant for staged deployment artifacts and now times out for missing ones, failing the build.

Adds `content { includeGroup "io.valkey" }` so only valkey-glide is resolved from this repo. Everything else goes straight to Maven Central.