### PR TITLE
Update Compression Supported Commands and Block Unsupported Commands

### DIFF
--- a/ffi/miri-tests/mock-glide-core/src/request_type.rs
+++ b/ffi/miri-tests/mock-glide-core/src/request_type.rs
@@ -8,6 +8,9 @@ pub enum RequestType {
     /// Invalid request type
     InvalidRequest = 0,
 
+    // Custom command
+    CustomCommand = 1,
+
     // Basic string commands for testing
     Get = 1504,
     Set = 1517,
@@ -28,6 +31,41 @@ pub enum RequestType {
     // Other common commands
     Expire = 405,
     TTL = 428,
+
+    // Commands that support compression
+    MSet = 1508,
+    MSetNX = 1509,
+    SetEx = 1518,
+    PSetEx = 1512,
+    SetNX = 1519,
+    MGet = 1507,
+    GetEx = 1503,
+    GetDel = 1502,
+    GetSet = 1505,
+
+    // Incompatible commands - string manipulation
+    Append = 1501,
+    GetRange = 1506,
+    SetRange = 1520,
+    Strlen = 1521,
+    LCS = 1522,
+    Substr = 1523,
+
+    // Incompatible commands - numeric operations
+    Incr = 1510,
+    IncrBy = 1511,
+    IncrByFloat = 1513,
+    Decr = 1514,
+    DecrBy = 1515,
+
+    // Incompatible commands - bit operations
+    GetBit = 1524,
+    SetBit = 1525,
+    BitCount = 1526,
+    BitPos = 1527,
+    BitField = 1528,
+    BitFieldReadOnly = 1529,
+    BitOp = 1530,
 }
 
 impl RequestType {
@@ -35,6 +73,84 @@ impl RequestType {
         match self {
             RequestType::InvalidRequest => None,
             _ => Some(Cmd::default()),
+        }
+    }
+
+    /// Returns the reason why this command is incompatible with compression, if any.
+    /// Returns `None` if the command is compatible with compression.
+    pub fn compression_incompatibility_reason(self) -> Option<&'static str> {
+        match self {
+            // String manipulation commands
+            RequestType::Append => Some("APPEND modifies string data on the server"),
+            RequestType::GetRange => Some("GETRANGE returns a substring of raw bytes"),
+            RequestType::SetRange => Some("SETRANGE modifies bytes at a specific offset"),
+            RequestType::Strlen => Some("STRLEN returns the length of raw bytes"),
+            RequestType::LCS => Some("LCS compares raw bytes between strings"),
+            RequestType::Substr => Some("SUBSTR returns a substring of raw bytes"),
+            // Numeric operations
+            RequestType::Incr => Some("INCR expects a numeric string value"),
+            RequestType::IncrBy => Some("INCRBY expects a numeric string value"),
+            RequestType::IncrByFloat => Some("INCRBYFLOAT expects a numeric string value"),
+            RequestType::Decr => Some("DECR expects a numeric string value"),
+            RequestType::DecrBy => Some("DECRBY expects a numeric string value"),
+            // Bit operations
+            RequestType::GetBit => Some("GETBIT reads bits from raw bytes"),
+            RequestType::SetBit => Some("SETBIT modifies bits in raw bytes"),
+            RequestType::BitCount => Some("BITCOUNT counts bits in raw bytes"),
+            RequestType::BitPos => Some("BITPOS finds bit positions in raw bytes"),
+            RequestType::BitField => Some("BITFIELD performs bit operations on raw bytes"),
+            RequestType::BitFieldReadOnly => Some("BITFIELD_RO reads bits from raw bytes"),
+            RequestType::BitOp => Some("BITOP performs bitwise operations between strings"),
+            // All other commands are compatible
+            _ => None,
+        }
+    }
+
+    /// Returns the command name as a string, if available.
+    pub fn command_name(self) -> Option<&'static str> {
+        match self {
+            RequestType::InvalidRequest => None,
+            RequestType::CustomCommand => Some("CUSTOM"),
+            RequestType::Get => Some("GET"),
+            RequestType::Set => Some("SET"),
+            RequestType::Del => Some("DEL"),
+            RequestType::Exists => Some("EXISTS"),
+            RequestType::HGet => Some("HGET"),
+            RequestType::HSet => Some("HSET"),
+            RequestType::HDel => Some("HDEL"),
+            RequestType::LPush => Some("LPUSH"),
+            RequestType::RPush => Some("RPUSH"),
+            RequestType::LPop => Some("LPOP"),
+            RequestType::RPop => Some("RPOP"),
+            RequestType::Expire => Some("EXPIRE"),
+            RequestType::TTL => Some("TTL"),
+            RequestType::MSet => Some("MSET"),
+            RequestType::MSetNX => Some("MSETNX"),
+            RequestType::SetEx => Some("SETEX"),
+            RequestType::PSetEx => Some("PSETEX"),
+            RequestType::SetNX => Some("SETNX"),
+            RequestType::MGet => Some("MGET"),
+            RequestType::GetEx => Some("GETEX"),
+            RequestType::GetDel => Some("GETDEL"),
+            RequestType::GetSet => Some("GETSET"),
+            RequestType::Append => Some("APPEND"),
+            RequestType::GetRange => Some("GETRANGE"),
+            RequestType::SetRange => Some("SETRANGE"),
+            RequestType::Strlen => Some("STRLEN"),
+            RequestType::LCS => Some("LCS"),
+            RequestType::Substr => Some("SUBSTR"),
+            RequestType::Incr => Some("INCR"),
+            RequestType::IncrBy => Some("INCRBY"),
+            RequestType::IncrByFloat => Some("INCRBYFLOAT"),
+            RequestType::Decr => Some("DECR"),
+            RequestType::DecrBy => Some("DECRBY"),
+            RequestType::GetBit => Some("GETBIT"),
+            RequestType::SetBit => Some("SETBIT"),
+            RequestType::BitCount => Some("BITCOUNT"),
+            RequestType::BitPos => Some("BITPOS"),
+            RequestType::BitField => Some("BITFIELD"),
+            RequestType::BitFieldReadOnly => Some("BITFIELD_RO"),
+            RequestType::BitOp => Some("BITOP"),
         }
     }
 }

--- a/ffi/miri-tests/mock-glide-core/src/request_type.rs
+++ b/ffi/miri-tests/mock-glide-core/src/request_type.rs
@@ -106,6 +106,51 @@ impl RequestType {
         }
     }
 
+    /// Parses a command name string and returns the corresponding `RequestType`.
+    /// This is used for CustomCommand handling where we need to determine the actual
+    /// command type from the command name for compression processing.
+    ///
+    /// Returns `None` if the command name is not recognized or not relevant for compression.
+    pub fn from_command_name(name: &str) -> Option<Self> {
+        match name.to_uppercase().as_str() {
+            // Commands that support compression
+            "SET" => Some(RequestType::Set),
+            "MSET" => Some(RequestType::MSet),
+            "MSETNX" => Some(RequestType::MSetNX),
+            "SETEX" => Some(RequestType::SetEx),
+            "PSETEX" => Some(RequestType::PSetEx),
+            "SETNX" => Some(RequestType::SetNX),
+            "GET" => Some(RequestType::Get),
+            "MGET" => Some(RequestType::MGet),
+            "GETEX" => Some(RequestType::GetEx),
+            "GETDEL" => Some(RequestType::GetDel),
+            "GETSET" => Some(RequestType::GetSet),
+            // Incompatible commands - string manipulation
+            "APPEND" => Some(RequestType::Append),
+            "GETRANGE" => Some(RequestType::GetRange),
+            "SETRANGE" => Some(RequestType::SetRange),
+            "STRLEN" => Some(RequestType::Strlen),
+            "LCS" => Some(RequestType::LCS),
+            "SUBSTR" => Some(RequestType::Substr),
+            // Incompatible commands - numeric operations
+            "INCR" => Some(RequestType::Incr),
+            "INCRBY" => Some(RequestType::IncrBy),
+            "INCRBYFLOAT" => Some(RequestType::IncrByFloat),
+            "DECR" => Some(RequestType::Decr),
+            "DECRBY" => Some(RequestType::DecrBy),
+            // Incompatible commands - bit operations
+            "GETBIT" => Some(RequestType::GetBit),
+            "SETBIT" => Some(RequestType::SetBit),
+            "BITCOUNT" => Some(RequestType::BitCount),
+            "BITPOS" => Some(RequestType::BitPos),
+            "BITFIELD" => Some(RequestType::BitField),
+            "BITFIELD_RO" => Some(RequestType::BitFieldReadOnly),
+            "BITOP" => Some(RequestType::BitOp),
+            // Unknown command - not relevant for compression
+            _ => None,
+        }
+    }
+
     /// Returns the command name as a string, if available.
     pub fn command_name(self) -> Option<&'static str> {
         match self {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2556,15 +2556,24 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
         let mut owned_args: Vec<Vec<u8>> = arg_vec.iter().map(|&arg| arg.to_vec()).collect();
 
         // For CustomCommand, we need to determine the actual command type from the first argument
-        let effective_command_type = if matches!(command_type, RequestType::CustomCommand) {
+        // and process compression on args[1..] since args[0] is the command name
+        let is_custom_command = matches!(command_type, RequestType::CustomCommand);
+        let effective_command_type = if is_custom_command {
             resolve_custom_command_type(&owned_args)
         } else {
             command_type
         };
 
         // Apply compression to command arguments
+        // For CustomCommand, skip the first argument (command name) when processing compression
+        let args_to_compress = if is_custom_command && !owned_args.is_empty() {
+            &mut owned_args[1..]
+        } else {
+            &mut owned_args[..]
+        };
+
         if let Err(err) = glide_core::compression::process_command_args_for_compression(
-            &mut owned_args,
+            args_to_compress,
             effective_command_type,
             compression_manager.as_deref(),
         ) {
@@ -3427,15 +3436,24 @@ pub(crate) unsafe fn create_cmd(
         let mut owned_args: Vec<Vec<u8>> = arg_vec.iter().map(|&arg| arg.to_vec()).collect();
 
         // For CustomCommand, we need to determine the actual command type from the first argument
-        let effective_command_type = if matches!(info.request_type, RequestType::CustomCommand) {
+        // and process compression on args[1..] since args[0] is the command name
+        let is_custom_command = matches!(info.request_type, RequestType::CustomCommand);
+        let effective_command_type = if is_custom_command {
             resolve_custom_command_type(&owned_args)
         } else {
             info.request_type
         };
 
         // Apply compression to command arguments
+        // For CustomCommand, skip the first argument (command name) when processing compression
+        let args_to_compress = if is_custom_command && !owned_args.is_empty() {
+            &mut owned_args[1..]
+        } else {
+            &mut owned_args[..]
+        };
+
         if let Err(err) = glide_core::compression::process_command_args_for_compression(
-            &mut owned_args,
+            args_to_compress,
             effective_command_type,
             compression_manager.map(|m| m.as_ref()),
         ) {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1907,6 +1907,55 @@ unsafe fn free_command_response_elements(command_response: CommandResponse) {
 }
 
 /// Converts a double pointer to a vec.
+/// Resolves the actual RequestType for a CustomCommand by parsing the command name from the first argument.
+/// This is needed for compression validation since CustomCommand doesn't carry the actual command type.
+fn resolve_custom_command_type(args: &[Vec<u8>]) -> RequestType {
+    if args.is_empty() {
+        return RequestType::CustomCommand;
+    }
+
+    let command_name = &args[0];
+    let command_str = String::from_utf8_lossy(command_name).to_uppercase();
+
+    match command_str.as_str() {
+        // Commands that support compression
+        "SET" => RequestType::Set,
+        "MSET" => RequestType::MSet,
+        "MSETNX" => RequestType::MSetNX,
+        "SETEX" => RequestType::SetEx,
+        "PSETEX" => RequestType::PSetEx,
+        "SETNX" => RequestType::SetNX,
+        "GET" => RequestType::Get,
+        "MGET" => RequestType::MGet,
+        "GETEX" => RequestType::GetEx,
+        "GETDEL" => RequestType::GetDel,
+        "GETSET" => RequestType::GetSet,
+        // Incompatible commands - string manipulation
+        "APPEND" => RequestType::Append,
+        "GETRANGE" => RequestType::GetRange,
+        "SETRANGE" => RequestType::SetRange,
+        "STRLEN" => RequestType::Strlen,
+        "LCS" => RequestType::LCS,
+        "SUBSTR" => RequestType::Substr,
+        // Incompatible commands - numeric operations
+        "INCR" => RequestType::Incr,
+        "INCRBY" => RequestType::IncrBy,
+        "INCRBYFLOAT" => RequestType::IncrByFloat,
+        "DECR" => RequestType::Decr,
+        "DECRBY" => RequestType::DecrBy,
+        // Incompatible commands - bit operations
+        "GETBIT" => RequestType::GetBit,
+        "SETBIT" => RequestType::SetBit,
+        "BITCOUNT" => RequestType::BitCount,
+        "BITPOS" => RequestType::BitPos,
+        "BITFIELD" => RequestType::BitField,
+        "BITFIELD_RO" => RequestType::BitFieldReadOnly,
+        "BITOP" => RequestType::BitOp,
+        // Unknown command - keep as CustomCommand (no compression processing)
+        _ => RequestType::CustomCommand,
+    }
+}
+
 ///
 /// # Safety
 ///
@@ -2506,10 +2555,17 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
         // Convert arg_vec to owned Vec<Vec<u8>> for compression processing
         let mut owned_args: Vec<Vec<u8>> = arg_vec.iter().map(|&arg| arg.to_vec()).collect();
 
+        // For CustomCommand, we need to determine the actual command type from the first argument
+        let effective_command_type = if matches!(command_type, RequestType::CustomCommand) {
+            resolve_custom_command_type(&owned_args)
+        } else {
+            command_type
+        };
+
         // Apply compression to command arguments
         if let Err(err) = glide_core::compression::process_command_args_for_compression(
             &mut owned_args,
-            command_type,
+            effective_command_type,
             compression_manager.as_deref(),
         ) {
             let err = RedisError::from((
@@ -3370,10 +3426,17 @@ pub(crate) unsafe fn create_cmd(
         // Convert arg_vec to owned Vec<Vec<u8>> for compression processing
         let mut owned_args: Vec<Vec<u8>> = arg_vec.iter().map(|&arg| arg.to_vec()).collect();
 
+        // For CustomCommand, we need to determine the actual command type from the first argument
+        let effective_command_type = if matches!(info.request_type, RequestType::CustomCommand) {
+            resolve_custom_command_type(&owned_args)
+        } else {
+            info.request_type
+        };
+
         // Apply compression to command arguments
         if let Err(err) = glide_core::compression::process_command_args_for_compression(
             &mut owned_args,
-            info.request_type,
+            effective_command_type,
             compression_manager.map(|m| m.as_ref()),
         ) {
             return Err(format!("Compression failed: {}", err));

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1915,45 +1915,10 @@ fn resolve_custom_command_type(args: &[Vec<u8>]) -> RequestType {
     }
 
     let command_name = &args[0];
-    let command_str = String::from_utf8_lossy(command_name).to_uppercase();
+    let command_str = String::from_utf8_lossy(command_name);
 
-    match command_str.as_str() {
-        // Commands that support compression
-        "SET" => RequestType::Set,
-        "MSET" => RequestType::MSet,
-        "MSETNX" => RequestType::MSetNX,
-        "SETEX" => RequestType::SetEx,
-        "PSETEX" => RequestType::PSetEx,
-        "SETNX" => RequestType::SetNX,
-        "GET" => RequestType::Get,
-        "MGET" => RequestType::MGet,
-        "GETEX" => RequestType::GetEx,
-        "GETDEL" => RequestType::GetDel,
-        "GETSET" => RequestType::GetSet,
-        // Incompatible commands - string manipulation
-        "APPEND" => RequestType::Append,
-        "GETRANGE" => RequestType::GetRange,
-        "SETRANGE" => RequestType::SetRange,
-        "STRLEN" => RequestType::Strlen,
-        "LCS" => RequestType::LCS,
-        "SUBSTR" => RequestType::Substr,
-        // Incompatible commands - numeric operations
-        "INCR" => RequestType::Incr,
-        "INCRBY" => RequestType::IncrBy,
-        "INCRBYFLOAT" => RequestType::IncrByFloat,
-        "DECR" => RequestType::Decr,
-        "DECRBY" => RequestType::DecrBy,
-        // Incompatible commands - bit operations
-        "GETBIT" => RequestType::GetBit,
-        "SETBIT" => RequestType::SetBit,
-        "BITCOUNT" => RequestType::BitCount,
-        "BITPOS" => RequestType::BitPos,
-        "BITFIELD" => RequestType::BitField,
-        "BITFIELD_RO" => RequestType::BitFieldReadOnly,
-        "BITOP" => RequestType::BitOp,
-        // Unknown command - keep as CustomCommand (no compression processing)
-        _ => RequestType::CustomCommand,
-    }
+    // Use the centralized from_command_name method in glide-core
+    RequestType::from_command_name(&command_str).unwrap_or(RequestType::CustomCommand)
 }
 
 ///

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1906,7 +1906,6 @@ unsafe fn free_command_response_elements(command_response: CommandResponse) {
     }
 }
 
-/// Converts a double pointer to a vec.
 /// Resolves the actual RequestType for a CustomCommand by parsing the command name from the first argument.
 /// This is needed for compression validation since CustomCommand doesn't carry the actual command type.
 fn resolve_custom_command_type(args: &[Vec<u8>]) -> RequestType {

--- a/glide-core/src/compression.rs
+++ b/glide-core/src/compression.rs
@@ -152,6 +152,12 @@ impl CompressionError {
             CompressionError::IncompatibleCommand { .. } => "",
         }
     }
+
+    /// Returns true if this error is an IncompatibleCommand error.
+    /// These errors should be propagated to the user rather than logged and ignored.
+    pub fn is_incompatible_command(&self) -> bool {
+        matches!(self, CompressionError::IncompatibleCommand { .. })
+    }
 }
 
 /// Format byte size in human-readable format

--- a/glide-core/src/compression.rs
+++ b/glide-core/src/compression.rs
@@ -29,6 +29,8 @@ pub enum CompressionError {
     UnsupportedBackend { backend_name: String },
     /// Invalid compression configuration
     InvalidConfiguration { backend: String, reason: String },
+    /// Command is incompatible with compression
+    IncompatibleCommand { command: String, reason: String },
 }
 
 impl std::fmt::Display for CompressionError {
@@ -80,6 +82,13 @@ impl std::fmt::Display for CompressionError {
                     backend, reason
                 )
             }
+            CompressionError::IncompatibleCommand { command, reason } => {
+                write!(
+                    f,
+                    "Command '{}' is incompatible with compression: {}",
+                    command, reason
+                )
+            }
         }
     }
 }
@@ -126,6 +135,13 @@ impl CompressionError {
         }
     }
 
+    pub fn incompatible_command(command: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::IncompatibleCommand {
+            command: command.into(),
+            reason: reason.into(),
+        }
+    }
+
     /// Returns the backend name associated with this error
     pub fn backend(&self) -> &str {
         match self {
@@ -133,6 +149,7 @@ impl CompressionError {
             CompressionError::DecompressionFailed { backend, .. } => backend,
             CompressionError::InvalidConfiguration { backend, .. } => backend,
             CompressionError::UnsupportedBackend { backend_name } => backend_name,
+            CompressionError::IncompatibleCommand { .. } => "",
         }
     }
 }
@@ -710,6 +727,14 @@ pub fn process_command_args_for_compression(
         return Ok(());
     }
 
+    // Check if the command is incompatible with compression
+    if let Some(reason) = request_type.compression_incompatibility_reason() {
+        return Err(CompressionError::incompatible_command(
+            request_type.command_name().unwrap_or("unknown"),
+            reason,
+        ));
+    }
+
     let behavior = request_type.compression_behavior();
     if behavior != CommandCompressionBehavior::CompressValues {
         return Ok(());
@@ -723,6 +748,31 @@ pub fn process_command_args_for_compression(
         RequestType::SetNX => compress_single_value_command(args, manager, 1),
         _ => Ok(()),
     }
+}
+
+/// Validates that a command is compatible with compression.
+/// Returns an error if the command is incompatible with compression when compression is enabled.
+pub fn validate_command_compression_compatibility(
+    request_type: RequestType,
+    compression_manager: Option<&CompressionManager>,
+) -> CompressionResult<()> {
+    let Some(manager) = compression_manager else {
+        return Ok(());
+    };
+
+    if !manager.is_enabled() {
+        return Ok(());
+    }
+
+    // Check if the command is incompatible with compression
+    if let Some(reason) = request_type.compression_incompatibility_reason() {
+        return Err(CompressionError::incompatible_command(
+            request_type.command_name().unwrap_or("unknown"),
+            reason,
+        ));
+    }
+
+    Ok(())
 }
 
 fn compress_single_value_command(

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -860,6 +860,118 @@ impl RequestType {
         }
     }
 
+    /// Returns the reason why this command is incompatible with compression, if any.
+    /// Returns `None` if the command is compatible with compression.
+    ///
+    /// Commands that are incompatible with compression are those that:
+    /// - Manipulate string data on the server side (APPEND, GETRANGE, SETRANGE, STRLEN, LCS)
+    /// - Perform numeric operations on string values (INCR, INCRBY, INCRBYFLOAT, DECR, DECRBY)
+    /// - Perform bit operations on string values (GETBIT, SETBIT, BITCOUNT, BITPOS, BITFIELD, BITFIELD_RO, BITOP)
+    pub fn compression_incompatibility_reason(self) -> Option<&'static str> {
+        match self {
+            // String manipulation commands - operate on raw bytes server-side
+            RequestType::Append => Some(
+                "APPEND modifies string data on the server, which would corrupt compressed values",
+            ),
+            RequestType::GetRange => Some(
+                "GETRANGE returns a substring of the raw bytes, which would return compressed data instead of the original value",
+            ),
+            RequestType::SetRange => Some(
+                "SETRANGE modifies bytes at a specific offset, which would corrupt compressed values",
+            ),
+            RequestType::Strlen => Some(
+                "STRLEN returns the length of the raw bytes, which would return the compressed size instead of the original size",
+            ),
+            RequestType::LCS => Some(
+                "LCS compares raw bytes between strings, which would compare compressed data instead of original values",
+            ),
+            RequestType::Substr => Some(
+                "SUBSTR (deprecated alias for GETRANGE) returns a substring of raw bytes, which would return compressed data",
+            ),
+
+            // Numeric operations - expect numeric string values
+            RequestType::Incr => Some(
+                "INCR expects a numeric string value, but would receive compressed bytes",
+            ),
+            RequestType::IncrBy => Some(
+                "INCRBY expects a numeric string value, but would receive compressed bytes",
+            ),
+            RequestType::IncrByFloat => Some(
+                "INCRBYFLOAT expects a numeric string value, but would receive compressed bytes",
+            ),
+            RequestType::Decr => Some(
+                "DECR expects a numeric string value, but would receive compressed bytes",
+            ),
+            RequestType::DecrBy => Some(
+                "DECRBY expects a numeric string value, but would receive compressed bytes",
+            ),
+
+            // Bit operations - operate on raw binary data
+            RequestType::GetBit => Some(
+                "GETBIT reads bits from raw bytes, which would read from compressed data instead of original value",
+            ),
+            RequestType::SetBit => Some(
+                "SETBIT modifies bits in raw bytes, which would corrupt compressed values",
+            ),
+            RequestType::BitCount => Some(
+                "BITCOUNT counts bits in raw bytes, which would count bits in compressed data instead of original value",
+            ),
+            RequestType::BitPos => Some(
+                "BITPOS finds bit positions in raw bytes, which would search in compressed data instead of original value",
+            ),
+            RequestType::BitField => Some(
+                "BITFIELD performs bit operations on raw bytes, which would operate on compressed data",
+            ),
+            RequestType::BitFieldReadOnly => Some(
+                "BITFIELD_RO reads bits from raw bytes, which would read from compressed data instead of original value",
+            ),
+            RequestType::BitOp => Some(
+                "BITOP performs bitwise operations between strings, which would operate on compressed data",
+            ),
+
+            // All other commands are compatible
+            _ => None,
+        }
+    }
+
+    /// Returns the command name as a string, if available.
+    pub fn command_name(self) -> Option<&'static str> {
+        match self {
+            RequestType::InvalidRequest => None,
+            RequestType::CustomCommand => Some("CUSTOM"),
+            RequestType::Get => Some("GET"),
+            RequestType::Set => Some("SET"),
+            RequestType::Append => Some("APPEND"),
+            RequestType::GetRange => Some("GETRANGE"),
+            RequestType::SetRange => Some("SETRANGE"),
+            RequestType::Strlen => Some("STRLEN"),
+            RequestType::LCS => Some("LCS"),
+            RequestType::Substr => Some("SUBSTR"),
+            RequestType::Incr => Some("INCR"),
+            RequestType::IncrBy => Some("INCRBY"),
+            RequestType::IncrByFloat => Some("INCRBYFLOAT"),
+            RequestType::Decr => Some("DECR"),
+            RequestType::DecrBy => Some("DECRBY"),
+            RequestType::GetBit => Some("GETBIT"),
+            RequestType::SetBit => Some("SETBIT"),
+            RequestType::BitCount => Some("BITCOUNT"),
+            RequestType::BitPos => Some("BITPOS"),
+            RequestType::BitField => Some("BITFIELD"),
+            RequestType::BitFieldReadOnly => Some("BITFIELD_RO"),
+            RequestType::BitOp => Some("BITOP"),
+            RequestType::MGet => Some("MGET"),
+            RequestType::MSet => Some("MSET"),
+            RequestType::MSetNX => Some("MSETNX"),
+            RequestType::SetEx => Some("SETEX"),
+            RequestType::PSetEx => Some("PSETEX"),
+            RequestType::SetNX => Some("SETNX"),
+            RequestType::GetEx => Some("GETEX"),
+            RequestType::GetDel => Some("GETDEL"),
+            RequestType::GetSet => Some("GETSET"),
+            _ => None, // For other commands, return None
+        }
+    }
+
     /// Returns a `Cmd` set with the command name matching the request.
     pub fn get_command(&self) -> Option<Cmd> {
         match self {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -972,6 +972,51 @@ impl RequestType {
         }
     }
 
+    /// Parses a command name string and returns the corresponding `RequestType`.
+    /// This is used for CustomCommand handling where we need to determine the actual
+    /// command type from the command name for compression processing.
+    ///
+    /// Returns `None` if the command name is not recognized or not relevant for compression.
+    pub fn from_command_name(name: &str) -> Option<Self> {
+        match name.to_uppercase().as_str() {
+            // Commands that support compression
+            "SET" => Some(RequestType::Set),
+            "MSET" => Some(RequestType::MSet),
+            "MSETNX" => Some(RequestType::MSetNX),
+            "SETEX" => Some(RequestType::SetEx),
+            "PSETEX" => Some(RequestType::PSetEx),
+            "SETNX" => Some(RequestType::SetNX),
+            "GET" => Some(RequestType::Get),
+            "MGET" => Some(RequestType::MGet),
+            "GETEX" => Some(RequestType::GetEx),
+            "GETDEL" => Some(RequestType::GetDel),
+            "GETSET" => Some(RequestType::GetSet),
+            // Incompatible commands - string manipulation
+            "APPEND" => Some(RequestType::Append),
+            "GETRANGE" => Some(RequestType::GetRange),
+            "SETRANGE" => Some(RequestType::SetRange),
+            "STRLEN" => Some(RequestType::Strlen),
+            "LCS" => Some(RequestType::LCS),
+            "SUBSTR" => Some(RequestType::Substr),
+            // Incompatible commands - numeric operations
+            "INCR" => Some(RequestType::Incr),
+            "INCRBY" => Some(RequestType::IncrBy),
+            "INCRBYFLOAT" => Some(RequestType::IncrByFloat),
+            "DECR" => Some(RequestType::Decr),
+            "DECRBY" => Some(RequestType::DecrBy),
+            // Incompatible commands - bit operations
+            "GETBIT" => Some(RequestType::GetBit),
+            "SETBIT" => Some(RequestType::SetBit),
+            "BITCOUNT" => Some(RequestType::BitCount),
+            "BITPOS" => Some(RequestType::BitPos),
+            "BITFIELD" => Some(RequestType::BitField),
+            "BITFIELD_RO" => Some(RequestType::BitFieldReadOnly),
+            "BITOP" => Some(RequestType::BitOp),
+            // Unknown command - not relevant for compression
+            _ => None,
+        }
+    }
+
     /// Returns a `Cmd` set with the command name matching the request.
     pub fn get_command(&self) -> Option<Cmd> {
         match self {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -890,29 +890,29 @@ impl RequestType {
             ),
 
             // Numeric operations - expect numeric string values
-            RequestType::Incr => Some(
-                "INCR expects a numeric string value, but would receive compressed bytes",
-            ),
-            RequestType::IncrBy => Some(
-                "INCRBY expects a numeric string value, but would receive compressed bytes",
-            ),
+            RequestType::Incr => {
+                Some("INCR expects a numeric string value, but would receive compressed bytes")
+            }
+            RequestType::IncrBy => {
+                Some("INCRBY expects a numeric string value, but would receive compressed bytes")
+            }
             RequestType::IncrByFloat => Some(
                 "INCRBYFLOAT expects a numeric string value, but would receive compressed bytes",
             ),
-            RequestType::Decr => Some(
-                "DECR expects a numeric string value, but would receive compressed bytes",
-            ),
-            RequestType::DecrBy => Some(
-                "DECRBY expects a numeric string value, but would receive compressed bytes",
-            ),
+            RequestType::Decr => {
+                Some("DECR expects a numeric string value, but would receive compressed bytes")
+            }
+            RequestType::DecrBy => {
+                Some("DECRBY expects a numeric string value, but would receive compressed bytes")
+            }
 
             // Bit operations - operate on raw binary data
             RequestType::GetBit => Some(
                 "GETBIT reads bits from raw bytes, which would read from compressed data instead of original value",
             ),
-            RequestType::SetBit => Some(
-                "SETBIT modifies bits in raw bytes, which would corrupt compressed values",
-            ),
+            RequestType::SetBit => {
+                Some("SETBIT modifies bits in raw bytes, which would corrupt compressed values")
+            }
             RequestType::BitCount => Some(
                 "BITCOUNT counts bits in raw bytes, which would count bits in compressed data instead of original value",
             ),

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -345,11 +345,8 @@ async fn send_command(
     #[allow(clippy::collapsible_if)]
     if client.is_compression_enabled() {
         if let Err(compression_error) = process_command_for_compression(&mut cmd, &client) {
-            // Check if this is an incompatible command error - these should be returned as errors
-            if matches!(
-                compression_error,
-                crate::compression::CompressionError::IncompatibleCommand { .. }
-            ) {
+            // Incompatible command errors should be returned to the user
+            if compression_error.is_incompatible_command() {
                 return Err(ClientUsageError::User(compression_error.to_string()));
             }
             // For other compression errors (e.g., compression failed), log and continue
@@ -594,11 +591,8 @@ async fn send_batch(
         // Apply compression to command arguments if needed
         // This also validates that the command is compatible with compression
         if let Err(e) = process_command_for_compression(&mut redis_cmd, client) {
-            // Check if this is an incompatible command error - these should be returned as errors
-            if matches!(
-                e,
-                crate::compression::CompressionError::IncompatibleCommand { .. }
-            ) {
+            // Incompatible command errors should be returned to the user
+            if e.is_incompatible_command() {
                 return Err(ClientUsageError::User(e.to_string()));
             }
             // Log other compression errors but continue with uncompressed command

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -337,16 +337,25 @@ async fn send_command(
     }
 
     // Process command arguments for compression if compression is enabled
-    if client.is_compression_enabled()
-        && let Err(compression_error) = process_command_for_compression(&mut cmd, &client)
-    {
-        log_warn(
-            "send_command",
-            format!(
-                "Compression processing failed: {}, continuing with original command",
-                compression_error
-            ),
-        );
+    // This also validates that the command is compatible with compression
+    if client.is_compression_enabled() {
+        if let Err(compression_error) = process_command_for_compression(&mut cmd, &client) {
+            // Check if this is an incompatible command error - these should be returned as errors
+            if matches!(
+                compression_error,
+                crate::compression::CompressionError::IncompatibleCommand { .. }
+            ) {
+                return Err(ClientUsageError::User(compression_error.to_string()));
+            }
+            // For other compression errors (e.g., compression failed), log and continue
+            log_warn(
+                "send_command",
+                format!(
+                    "Compression processing failed: {}, continuing with original command",
+                    compression_error
+                ),
+            );
+        }
     }
 
     client
@@ -419,6 +428,14 @@ fn process_command_for_compression(
     let compression_manager = client.compression_manager();
     let compression_manager_ref = compression_manager.as_deref();
 
+    // If compression is not enabled, skip all processing
+    if compression_manager_ref
+        .map(|m| !m.is_enabled())
+        .unwrap_or(true)
+    {
+        return Ok(());
+    }
+
     // Collect all arguments first to avoid borrowing issues
     let all_args: Vec<Vec<u8>> = cmd
         .args_iter()
@@ -444,8 +461,35 @@ fn process_command_for_compression(
         "SETEX" => crate::request_type::RequestType::SetEx,
         "PSETEX" => crate::request_type::RequestType::PSetEx,
         "SETNX" => crate::request_type::RequestType::SetNX,
-        _ => return Ok(()), // Unknown command, no compression needed
+        // Incompatible commands - string manipulation
+        "APPEND" => crate::request_type::RequestType::Append,
+        "GETRANGE" => crate::request_type::RequestType::GetRange,
+        "SETRANGE" => crate::request_type::RequestType::SetRange,
+        "STRLEN" => crate::request_type::RequestType::Strlen,
+        "LCS" => crate::request_type::RequestType::LCS,
+        "SUBSTR" => crate::request_type::RequestType::Substr,
+        // Incompatible commands - numeric operations
+        "INCR" => crate::request_type::RequestType::Incr,
+        "INCRBY" => crate::request_type::RequestType::IncrBy,
+        "INCRBYFLOAT" => crate::request_type::RequestType::IncrByFloat,
+        "DECR" => crate::request_type::RequestType::Decr,
+        "DECRBY" => crate::request_type::RequestType::DecrBy,
+        // Incompatible commands - bit operations
+        "GETBIT" => crate::request_type::RequestType::GetBit,
+        "SETBIT" => crate::request_type::RequestType::SetBit,
+        "BITCOUNT" => crate::request_type::RequestType::BitCount,
+        "BITPOS" => crate::request_type::RequestType::BitPos,
+        "BITFIELD" => crate::request_type::RequestType::BitField,
+        "BITFIELD_RO" => crate::request_type::RequestType::BitFieldReadOnly,
+        "BITOP" => crate::request_type::RequestType::BitOp,
+        _ => return Ok(()), // Unknown command, no compression processing needed
     };
+
+    // Check if the command is incompatible with compression - this should error out
+    crate::compression::validate_command_compression_compatibility(
+        request_type,
+        compression_manager_ref,
+    )?;
 
     // Get arguments excluding the command name
     let mut args: Vec<Vec<u8>> = all_args[1..].to_vec();
@@ -543,8 +587,16 @@ async fn send_batch(
         let mut redis_cmd = get_redis_command(&command)?;
 
         // Apply compression to command arguments if needed
+        // This also validates that the command is compatible with compression
         if let Err(e) = process_command_for_compression(&mut redis_cmd, client) {
-            // Log compression error but continue with uncompressed command
+            // Check if this is an incompatible command error - these should be returned as errors
+            if matches!(
+                e,
+                crate::compression::CompressionError::IncompatibleCommand { .. }
+            ) {
+                return Err(ClientUsageError::User(e.to_string()));
+            }
+            // Log other compression errors but continue with uncompressed command
             log_warn(
                 "batch_command_compression",
                 format!("Failed to compress batch command arguments: {}", e),

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -338,6 +338,11 @@ async fn send_command(
 
     // Process command arguments for compression if compression is enabled
     // This also validates that the command is compatible with compression
+    // Note: We intentionally keep these as separate if statements for clarity:
+    // - First check: is compression enabled?
+    // - Second check: did compression processing fail?
+    // - Third check: is it an incompatible command error?
+    #[allow(clippy::collapsible_if)]
     if client.is_compression_enabled() {
         if let Err(compression_error) = process_command_for_compression(&mut cmd, &client) {
             // Check if this is an incompatible command error - these should be returned as errors

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -551,7 +551,7 @@ mod compression_tests {
         use glide_core::compression::lz4_backend::Lz4Backend;
 
         let backend = Lz4Backend::new();
-        let original_data = b"Hello, World! This is a test of LZ4 compression. 
+        let original_data = b"Hello, World! This is a test of LZ4 compression.
             Here is a long string of repetitive dataaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
         // Test compression
@@ -759,5 +759,178 @@ mod compression_tests {
         // try_decompress_value should gracefully return the original compressed data
         let result = manager.try_decompress_value(&unsupported_data);
         assert_eq!(result, unsupported_data);
+    }
+
+    #[test]
+    fn test_incompatible_command_error() {
+        // Test IncompatibleCommand error creation and display
+        let err = CompressionError::incompatible_command(
+            "APPEND",
+            "APPEND modifies string data on the server",
+        );
+        assert!(matches!(
+            err,
+            CompressionError::IncompatibleCommand { .. }
+        ));
+        assert!(err.to_string().contains("APPEND"));
+        assert!(err.to_string().contains("incompatible with compression"));
+        assert!(err.to_string().contains("modifies string data"));
+        assert_eq!(err.backend(), ""); // IncompatibleCommand has no backend
+
+        // Test Clone and PartialEq
+        let err2 = err.clone();
+        assert_eq!(err, err2);
+
+        let err3 = CompressionError::incompatible_command("INCR", "expects numeric string");
+        assert_ne!(err, err3);
+    }
+
+    #[test]
+    fn test_compression_incompatibility_reason() {
+        // Test string manipulation commands
+        assert!(RequestType::Append.compression_incompatibility_reason().is_some());
+        assert!(RequestType::GetRange.compression_incompatibility_reason().is_some());
+        assert!(RequestType::SetRange.compression_incompatibility_reason().is_some());
+        assert!(RequestType::Strlen.compression_incompatibility_reason().is_some());
+        assert!(RequestType::LCS.compression_incompatibility_reason().is_some());
+        assert!(RequestType::Substr.compression_incompatibility_reason().is_some());
+
+        // Test numeric operations
+        assert!(RequestType::Incr.compression_incompatibility_reason().is_some());
+        assert!(RequestType::IncrBy.compression_incompatibility_reason().is_some());
+        assert!(RequestType::IncrByFloat.compression_incompatibility_reason().is_some());
+        assert!(RequestType::Decr.compression_incompatibility_reason().is_some());
+        assert!(RequestType::DecrBy.compression_incompatibility_reason().is_some());
+
+        // Test bit operations
+        assert!(RequestType::GetBit.compression_incompatibility_reason().is_some());
+        assert!(RequestType::SetBit.compression_incompatibility_reason().is_some());
+        assert!(RequestType::BitCount.compression_incompatibility_reason().is_some());
+        assert!(RequestType::BitPos.compression_incompatibility_reason().is_some());
+        assert!(RequestType::BitField.compression_incompatibility_reason().is_some());
+        assert!(RequestType::BitFieldReadOnly.compression_incompatibility_reason().is_some());
+        assert!(RequestType::BitOp.compression_incompatibility_reason().is_some());
+
+        // Test compatible commands
+        assert!(RequestType::Set.compression_incompatibility_reason().is_none());
+        assert!(RequestType::Get.compression_incompatibility_reason().is_none());
+        assert!(RequestType::MSet.compression_incompatibility_reason().is_none());
+        assert!(RequestType::MGet.compression_incompatibility_reason().is_none());
+        assert!(RequestType::SetEx.compression_incompatibility_reason().is_none());
+        assert!(RequestType::GetEx.compression_incompatibility_reason().is_none());
+        assert!(RequestType::Del.compression_incompatibility_reason().is_none());
+        assert!(RequestType::Ping.compression_incompatibility_reason().is_none());
+    }
+
+    #[test]
+    fn test_validate_command_compression_compatibility() {
+        use glide_core::compression::zstd_backend::ZstdBackend;
+
+        // Create an enabled compression manager
+        let backend = Box::new(ZstdBackend::new());
+        let config = CompressionConfig::new(CompressionBackendType::Zstd);
+        let manager = CompressionManager::new(backend, config).unwrap();
+
+        // Test incompatible commands return errors
+        let result = validate_command_compression_compatibility(
+            RequestType::Append,
+            Some(&manager),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
+        assert!(err.to_string().contains("APPEND"));
+
+        let result = validate_command_compression_compatibility(
+            RequestType::Incr,
+            Some(&manager),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
+        assert!(err.to_string().contains("INCR"));
+
+        let result = validate_command_compression_compatibility(
+            RequestType::BitCount,
+            Some(&manager),
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
+        assert!(err.to_string().contains("BITCOUNT"));
+
+        // Test compatible commands succeed
+        let result = validate_command_compression_compatibility(
+            RequestType::Set,
+            Some(&manager),
+        );
+        assert!(result.is_ok());
+
+        let result = validate_command_compression_compatibility(
+            RequestType::Get,
+            Some(&manager),
+        );
+        assert!(result.is_ok());
+
+        let result = validate_command_compression_compatibility(
+            RequestType::Del,
+            Some(&manager),
+        );
+        assert!(result.is_ok());
+
+        // Test with no compression manager (should always succeed)
+        let result = validate_command_compression_compatibility(
+            RequestType::Append,
+            None,
+        );
+        assert!(result.is_ok());
+
+        // Test with disabled compression manager (should always succeed)
+        let backend = Box::new(ZstdBackend::new());
+        // Need to create a manager with matching backend for disabled config
+        let disabled_config = CompressionConfig {
+            enabled: false,
+            backend: CompressionBackendType::Zstd,
+            compression_level: None,
+            min_compression_size: 64,
+        };
+        let disabled_manager = CompressionManager::new(backend, disabled_config).unwrap();
+        let result = validate_command_compression_compatibility(
+            RequestType::Append,
+            Some(&disabled_manager),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_command_name() {
+        // Test incompatible commands have names
+        assert_eq!(RequestType::Append.command_name(), Some("APPEND"));
+        assert_eq!(RequestType::GetRange.command_name(), Some("GETRANGE"));
+        assert_eq!(RequestType::SetRange.command_name(), Some("SETRANGE"));
+        assert_eq!(RequestType::Strlen.command_name(), Some("STRLEN"));
+        assert_eq!(RequestType::LCS.command_name(), Some("LCS"));
+        assert_eq!(RequestType::Substr.command_name(), Some("SUBSTR"));
+        assert_eq!(RequestType::Incr.command_name(), Some("INCR"));
+        assert_eq!(RequestType::IncrBy.command_name(), Some("INCRBY"));
+        assert_eq!(RequestType::IncrByFloat.command_name(), Some("INCRBYFLOAT"));
+        assert_eq!(RequestType::Decr.command_name(), Some("DECR"));
+        assert_eq!(RequestType::DecrBy.command_name(), Some("DECRBY"));
+        assert_eq!(RequestType::GetBit.command_name(), Some("GETBIT"));
+        assert_eq!(RequestType::SetBit.command_name(), Some("SETBIT"));
+        assert_eq!(RequestType::BitCount.command_name(), Some("BITCOUNT"));
+        assert_eq!(RequestType::BitPos.command_name(), Some("BITPOS"));
+        assert_eq!(RequestType::BitField.command_name(), Some("BITFIELD"));
+        assert_eq!(RequestType::BitFieldReadOnly.command_name(), Some("BITFIELD_RO"));
+        assert_eq!(RequestType::BitOp.command_name(), Some("BITOP"));
+
+        // Test compatible commands have names
+        assert_eq!(RequestType::Set.command_name(), Some("SET"));
+        assert_eq!(RequestType::Get.command_name(), Some("GET"));
+        assert_eq!(RequestType::MSet.command_name(), Some("MSET"));
+        assert_eq!(RequestType::MGet.command_name(), Some("MGET"));
+
+        // Test invalid request has no name
+        assert_eq!(RequestType::InvalidRequest.command_name(), None);
     }
 }

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -1018,4 +1018,160 @@ mod compression_tests {
         // Test invalid request has no name
         assert_eq!(RequestType::InvalidRequest.command_name(), None);
     }
+
+    #[test]
+    fn test_from_command_name() {
+        // Test commands that support compression
+        assert!(matches!(
+            RequestType::from_command_name("SET"),
+            Some(RequestType::Set)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("MSET"),
+            Some(RequestType::MSet)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("MSETNX"),
+            Some(RequestType::MSetNX)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("SETEX"),
+            Some(RequestType::SetEx)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("PSETEX"),
+            Some(RequestType::PSetEx)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("SETNX"),
+            Some(RequestType::SetNX)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("GET"),
+            Some(RequestType::Get)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("MGET"),
+            Some(RequestType::MGet)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("GETEX"),
+            Some(RequestType::GetEx)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("GETDEL"),
+            Some(RequestType::GetDel)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("GETSET"),
+            Some(RequestType::GetSet)
+        ));
+
+        // Test incompatible commands - string manipulation
+        assert!(matches!(
+            RequestType::from_command_name("APPEND"),
+            Some(RequestType::Append)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("GETRANGE"),
+            Some(RequestType::GetRange)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("SETRANGE"),
+            Some(RequestType::SetRange)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("STRLEN"),
+            Some(RequestType::Strlen)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("LCS"),
+            Some(RequestType::LCS)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("SUBSTR"),
+            Some(RequestType::Substr)
+        ));
+
+        // Test incompatible commands - numeric operations
+        assert!(matches!(
+            RequestType::from_command_name("INCR"),
+            Some(RequestType::Incr)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("INCRBY"),
+            Some(RequestType::IncrBy)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("INCRBYFLOAT"),
+            Some(RequestType::IncrByFloat)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("DECR"),
+            Some(RequestType::Decr)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("DECRBY"),
+            Some(RequestType::DecrBy)
+        ));
+
+        // Test incompatible commands - bit operations
+        assert!(matches!(
+            RequestType::from_command_name("GETBIT"),
+            Some(RequestType::GetBit)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("SETBIT"),
+            Some(RequestType::SetBit)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("BITCOUNT"),
+            Some(RequestType::BitCount)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("BITPOS"),
+            Some(RequestType::BitPos)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("BITFIELD"),
+            Some(RequestType::BitField)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("BITFIELD_RO"),
+            Some(RequestType::BitFieldReadOnly)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("BITOP"),
+            Some(RequestType::BitOp)
+        ));
+
+        // Test case insensitivity
+        assert!(matches!(
+            RequestType::from_command_name("set"),
+            Some(RequestType::Set)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("Set"),
+            Some(RequestType::Set)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("sEt"),
+            Some(RequestType::Set)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("append"),
+            Some(RequestType::Append)
+        ));
+        assert!(matches!(
+            RequestType::from_command_name("APPEND"),
+            Some(RequestType::Append)
+        ));
+
+        // Test unknown commands return None
+        assert!(RequestType::from_command_name("UNKNOWN").is_none());
+        assert!(RequestType::from_command_name("HSET").is_none());
+        assert!(RequestType::from_command_name("LPUSH").is_none());
+        assert!(RequestType::from_command_name("ZADD").is_none());
+        assert!(RequestType::from_command_name("").is_none());
+    }
 }

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -768,10 +768,7 @@ mod compression_tests {
             "APPEND",
             "APPEND modifies string data on the server",
         );
-        assert!(matches!(
-            err,
-            CompressionError::IncompatibleCommand { .. }
-        ));
+        assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
         assert!(err.to_string().contains("APPEND"));
         assert!(err.to_string().contains("incompatible with compression"));
         assert!(err.to_string().contains("modifies string data"));
@@ -788,38 +785,142 @@ mod compression_tests {
     #[test]
     fn test_compression_incompatibility_reason() {
         // Test string manipulation commands
-        assert!(RequestType::Append.compression_incompatibility_reason().is_some());
-        assert!(RequestType::GetRange.compression_incompatibility_reason().is_some());
-        assert!(RequestType::SetRange.compression_incompatibility_reason().is_some());
-        assert!(RequestType::Strlen.compression_incompatibility_reason().is_some());
-        assert!(RequestType::LCS.compression_incompatibility_reason().is_some());
-        assert!(RequestType::Substr.compression_incompatibility_reason().is_some());
+        assert!(
+            RequestType::Append
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::GetRange
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::SetRange
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::Strlen
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::LCS
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::Substr
+                .compression_incompatibility_reason()
+                .is_some()
+        );
 
         // Test numeric operations
-        assert!(RequestType::Incr.compression_incompatibility_reason().is_some());
-        assert!(RequestType::IncrBy.compression_incompatibility_reason().is_some());
-        assert!(RequestType::IncrByFloat.compression_incompatibility_reason().is_some());
-        assert!(RequestType::Decr.compression_incompatibility_reason().is_some());
-        assert!(RequestType::DecrBy.compression_incompatibility_reason().is_some());
+        assert!(
+            RequestType::Incr
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::IncrBy
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::IncrByFloat
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::Decr
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::DecrBy
+                .compression_incompatibility_reason()
+                .is_some()
+        );
 
         // Test bit operations
-        assert!(RequestType::GetBit.compression_incompatibility_reason().is_some());
-        assert!(RequestType::SetBit.compression_incompatibility_reason().is_some());
-        assert!(RequestType::BitCount.compression_incompatibility_reason().is_some());
-        assert!(RequestType::BitPos.compression_incompatibility_reason().is_some());
-        assert!(RequestType::BitField.compression_incompatibility_reason().is_some());
-        assert!(RequestType::BitFieldReadOnly.compression_incompatibility_reason().is_some());
-        assert!(RequestType::BitOp.compression_incompatibility_reason().is_some());
+        assert!(
+            RequestType::GetBit
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::SetBit
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::BitCount
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::BitPos
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::BitField
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::BitFieldReadOnly
+                .compression_incompatibility_reason()
+                .is_some()
+        );
+        assert!(
+            RequestType::BitOp
+                .compression_incompatibility_reason()
+                .is_some()
+        );
 
         // Test compatible commands
-        assert!(RequestType::Set.compression_incompatibility_reason().is_none());
-        assert!(RequestType::Get.compression_incompatibility_reason().is_none());
-        assert!(RequestType::MSet.compression_incompatibility_reason().is_none());
-        assert!(RequestType::MGet.compression_incompatibility_reason().is_none());
-        assert!(RequestType::SetEx.compression_incompatibility_reason().is_none());
-        assert!(RequestType::GetEx.compression_incompatibility_reason().is_none());
-        assert!(RequestType::Del.compression_incompatibility_reason().is_none());
-        assert!(RequestType::Ping.compression_incompatibility_reason().is_none());
+        assert!(
+            RequestType::Set
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::Get
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::MSet
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::MGet
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::SetEx
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::GetEx
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::Del
+                .compression_incompatibility_reason()
+                .is_none()
+        );
+        assert!(
+            RequestType::Ping
+                .compression_incompatibility_reason()
+                .is_none()
+        );
     }
 
     #[test]
@@ -832,57 +933,38 @@ mod compression_tests {
         let manager = CompressionManager::new(backend, config).unwrap();
 
         // Test incompatible commands return errors
-        let result = validate_command_compression_compatibility(
-            RequestType::Append,
-            Some(&manager),
-        );
+        let result =
+            validate_command_compression_compatibility(RequestType::Append, Some(&manager));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
         assert!(err.to_string().contains("APPEND"));
 
-        let result = validate_command_compression_compatibility(
-            RequestType::Incr,
-            Some(&manager),
-        );
+        let result = validate_command_compression_compatibility(RequestType::Incr, Some(&manager));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
         assert!(err.to_string().contains("INCR"));
 
-        let result = validate_command_compression_compatibility(
-            RequestType::BitCount,
-            Some(&manager),
-        );
+        let result =
+            validate_command_compression_compatibility(RequestType::BitCount, Some(&manager));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
         assert!(err.to_string().contains("BITCOUNT"));
 
         // Test compatible commands succeed
-        let result = validate_command_compression_compatibility(
-            RequestType::Set,
-            Some(&manager),
-        );
+        let result = validate_command_compression_compatibility(RequestType::Set, Some(&manager));
         assert!(result.is_ok());
 
-        let result = validate_command_compression_compatibility(
-            RequestType::Get,
-            Some(&manager),
-        );
+        let result = validate_command_compression_compatibility(RequestType::Get, Some(&manager));
         assert!(result.is_ok());
 
-        let result = validate_command_compression_compatibility(
-            RequestType::Del,
-            Some(&manager),
-        );
+        let result = validate_command_compression_compatibility(RequestType::Del, Some(&manager));
         assert!(result.is_ok());
 
         // Test with no compression manager (should always succeed)
-        let result = validate_command_compression_compatibility(
-            RequestType::Append,
-            None,
-        );
+        let result = validate_command_compression_compatibility(RequestType::Append, None);
         assert!(result.is_ok());
 
         // Test with disabled compression manager (should always succeed)
@@ -921,7 +1003,10 @@ mod compression_tests {
         assert_eq!(RequestType::BitCount.command_name(), Some("BITCOUNT"));
         assert_eq!(RequestType::BitPos.command_name(), Some("BITPOS"));
         assert_eq!(RequestType::BitField.command_name(), Some("BITFIELD"));
-        assert_eq!(RequestType::BitFieldReadOnly.command_name(), Some("BITFIELD_RO"));
+        assert_eq!(
+            RequestType::BitFieldReadOnly.command_name(),
+            Some("BITFIELD_RO")
+        );
         assert_eq!(RequestType::BitOp.command_name(), Some("BITOP"));
 
         // Test compatible commands have names

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -787,8 +787,7 @@ mod compression_tests {
             CompressionError::compression_failed("zstd", Some(3), 1000, "test error");
         assert!(!compression_err.is_incompatible_command());
 
-        let decompression_err =
-            CompressionError::decompression_failed("lz4", 500, "test error");
+        let decompression_err = CompressionError::decompression_failed("lz4", 500, "test error");
         assert!(!decompression_err.is_incompatible_command());
 
         let unsupported_err = CompressionError::unsupported_backend("brotli");

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -769,6 +769,7 @@ mod compression_tests {
             "APPEND modifies string data on the server",
         );
         assert!(matches!(err, CompressionError::IncompatibleCommand { .. }));
+        assert!(err.is_incompatible_command());
         assert!(err.to_string().contains("APPEND"));
         assert!(err.to_string().contains("incompatible with compression"));
         assert!(err.to_string().contains("modifies string data"));
@@ -780,6 +781,21 @@ mod compression_tests {
 
         let err3 = CompressionError::incompatible_command("INCR", "expects numeric string");
         assert_ne!(err, err3);
+
+        // Test is_incompatible_command returns false for other error types
+        let compression_err =
+            CompressionError::compression_failed("zstd", Some(3), 1000, "test error");
+        assert!(!compression_err.is_incompatible_command());
+
+        let decompression_err =
+            CompressionError::decompression_failed("lz4", 500, "test error");
+        assert!(!decompression_err.is_incompatible_command());
+
+        let unsupported_err = CompressionError::unsupported_backend("brotli");
+        assert!(!unsupported_err.is_incompatible_command());
+
+        let config_err = CompressionError::invalid_configuration("zstd", "invalid level");
+        assert!(!config_err.is_incompatible_command());
     }
 
     #[test]

--- a/go/integTest/compression_test.go
+++ b/go/integTest/compression_test.go
@@ -995,9 +995,9 @@ func (suite *GlideTestSuite) TestCompressionMSetMGet() {
 	retrieved, err := client.MGet(context.Background(), []string{key1, key2, key3})
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(retrieved))
-	assert.Equal(t, value, retrieved[key1].Value())
-	assert.Equal(t, value, retrieved[key2].Value())
-	assert.Equal(t, value, retrieved[key3].Value())
+	assert.Equal(t, value, retrieved[0].Value())
+	assert.Equal(t, value, retrieved[1].Value())
+	assert.Equal(t, value, retrieved[2].Value())
 
 	client.Del(context.Background(), []string{key1, key2, key3})
 }

--- a/go/integTest/compression_test.go
+++ b/go/integTest/compression_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/options"
 	"github.com/valkey-io/valkey-glide/go/v2/pipeline"
 )
 
@@ -954,6 +955,574 @@ func (suite *GlideTestSuite) TestCompressionStatistics() {
 	assert.Greater(t, afterStats["total_bytes_decompressed"],
 		initialStats["total_bytes_decompressed"],
 		"total_bytes_decompressed should increase after GET")
+
+	client.Del(context.Background(), []string{key})
+}
+
+// ============================================================================
+// Supported Commands Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionMSetMGet() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key1 := fmt.Sprintf("{mset_test}_1_%s", randomString(8))
+	key2 := fmt.Sprintf("{mset_test}_2_%s", randomString(8))
+	key3 := fmt.Sprintf("{mset_test}_3_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	// MSET should compress values
+	keyValueMap := map[string]string{
+		key1: value,
+		key2: value,
+		key3: value,
+	}
+	result, err := client.MSet(context.Background(), keyValueMap)
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	stats := client.GetStatistics()
+	assert.GreaterOrEqual(t, stats["total_values_compressed"], initialCompressed+3,
+		"MSET should compress all values")
+
+	// MGET should decompress values
+	retrieved, err := client.MGet(context.Background(), []string{key1, key2, key3})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(retrieved))
+	assert.Equal(t, value, retrieved[key1].Value())
+	assert.Equal(t, value, retrieved[key2].Value())
+	assert.Equal(t, value, retrieved[key3].Value())
+
+	client.Del(context.Background(), []string{key1, key2, key3})
+}
+
+func (suite *GlideTestSuite) TestCompressionMSetNX() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key1 := fmt.Sprintf("{msetnx_test}_1_%s", randomString(8))
+	key2 := fmt.Sprintf("{msetnx_test}_2_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	// MSETNX should compress values
+	keyValueMap := map[string]string{
+		key1: value,
+		key2: value,
+	}
+	result, err := client.MSetNX(context.Background(), keyValueMap)
+	assert.NoError(t, err)
+	assert.True(t, result, "MSETNX should succeed for new keys")
+
+	stats := client.GetStatistics()
+	assert.GreaterOrEqual(t, stats["total_values_compressed"], initialCompressed+2,
+		"MSETNX should compress all values")
+
+	// Verify values can be retrieved and decompressed
+	retrieved1, err := client.Get(context.Background(), key1)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved1.Value())
+
+	retrieved2, err := client.Get(context.Background(), key2)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved2.Value())
+
+	client.Del(context.Background(), []string{key1, key2})
+}
+
+func (suite *GlideTestSuite) TestCompressionGetEx() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("getex_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	// Set value (should be compressed)
+	_, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+
+	// GETEX should decompress value
+	opts := options.NewGetExOptions().SetExpiry(options.NewExpiryIn(10 * time.Second))
+	retrieved, err := client.GetExWithOptions(context.Background(), key, *opts)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	// Verify TTL was set
+	ttl, err := client.TTL(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Greater(t, ttl, int64(0))
+	assert.LessOrEqual(t, ttl, int64(10))
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionGetDel() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("getdel_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	// Set value (should be compressed)
+	_, err := client.Set(context.Background(), key, value)
+	assert.NoError(t, err)
+
+	// GETDEL should decompress value and delete key
+	retrieved, err := client.GetDel(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	// Verify key was deleted
+	getResult, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.True(t, getResult.IsNil())
+}
+
+func (suite *GlideTestSuite) TestCompressionSetExViaCustomCommand() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("setex_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	// SETEX via custom command should compress value
+	result, err := client.CustomCommand(context.Background(), []string{"SETEX", key, "10", value})
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+		"SETEX should compress value")
+
+	// Verify value can be retrieved and decompressed
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	// Verify TTL was set
+	ttl, err := client.TTL(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Greater(t, ttl, int64(0))
+	assert.LessOrEqual(t, ttl, int64(10))
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionPSetExViaCustomCommand() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("psetex_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	// PSETEX via custom command should compress value
+	result, err := client.CustomCommand(context.Background(), []string{"PSETEX", key, "10000", value})
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+		"PSETEX should compress value")
+
+	// Verify value can be retrieved and decompressed
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionSetNXViaCustomCommand() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("setnx_test_%s", randomString(8))
+	value := generateCompressibleText(1024)
+
+	// Ensure key doesn't exist
+	client.Del(context.Background(), []string{key})
+
+	initialStats := client.GetStatistics()
+	initialCompressed := initialStats["total_values_compressed"]
+
+	// SETNX via custom command should compress value
+	result, err := client.CustomCommand(context.Background(), []string{"SETNX", key, value})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), result)
+
+	stats := client.GetStatistics()
+	assert.Greater(t, stats["total_values_compressed"], initialCompressed,
+		"SETNX should compress value")
+
+	// Verify value can be retrieved and decompressed
+	retrieved, err := client.Get(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, value, retrieved.Value())
+
+	client.Del(context.Background(), []string{key})
+}
+
+// ============================================================================
+// Incompatible Commands Tests
+// ============================================================================
+
+func (suite *GlideTestSuite) TestCompressionAppendIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("append_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "initial_value")
+	assert.NoError(t, err)
+
+	// APPEND should fail with compression enabled
+	_, err = client.Append(context.Background(), key, "_appended")
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionGetRangeIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("getrange_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, generateCompressibleText(1024))
+	assert.NoError(t, err)
+
+	// GETRANGE should fail with compression enabled
+	_, err = client.GetRange(context.Background(), key, 0, 10)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionSetRangeIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("setrange_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, generateCompressibleText(1024))
+	assert.NoError(t, err)
+
+	// SETRANGE should fail with compression enabled
+	_, err = client.SetRange(context.Background(), key, 5, "replacement")
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionStrlenIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("strlen_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, generateCompressibleText(1024))
+	assert.NoError(t, err)
+
+	// STRLEN should fail with compression enabled
+	_, err = client.Strlen(context.Background(), key)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionIncrIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("incr_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "100")
+	assert.NoError(t, err)
+
+	// INCR should fail with compression enabled
+	_, err = client.Incr(context.Background(), key)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionIncrByIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("incrby_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "100")
+	assert.NoError(t, err)
+
+	// INCRBY should fail with compression enabled
+	_, err = client.IncrBy(context.Background(), key, 10)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionIncrByFloatIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("incrbyfloat_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "100.5")
+	assert.NoError(t, err)
+
+	// INCRBYFLOAT should fail with compression enabled
+	_, err = client.IncrByFloat(context.Background(), key, 0.5)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionDecrIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("decr_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "100")
+	assert.NoError(t, err)
+
+	// DECR should fail with compression enabled
+	_, err = client.Decr(context.Background(), key)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionDecrByIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("decrby_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "100")
+	assert.NoError(t, err)
+
+	// DECRBY should fail with compression enabled
+	_, err = client.DecrBy(context.Background(), key, 10)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionGetBitIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("getbit_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "test_value")
+	assert.NoError(t, err)
+
+	// GETBIT should fail with compression enabled
+	_, err = client.GetBit(context.Background(), key, 0)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionSetBitIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("setbit_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "test_value")
+	assert.NoError(t, err)
+
+	// SETBIT should fail with compression enabled
+	_, err = client.SetBit(context.Background(), key, 0, 1)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionBitCountIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("bitcount_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "test_value")
+	assert.NoError(t, err)
+
+	// BITCOUNT should fail with compression enabled
+	_, err = client.BitCount(context.Background(), key)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionBitPosIncompatible() {
+	client := suite.compressionClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("bitpos_test_%s", randomString(8))
+	_, err := client.Set(context.Background(), key, "test_value")
+	assert.NoError(t, err)
+
+	// BITPOS should fail with compression enabled
+	_, err = client.BitPos(context.Background(), key, 1)
+	assert.Error(t, err)
+	errMsg := strings.ToLower(err.Error())
+	assert.True(t, strings.Contains(errMsg, "incompatible") || strings.Contains(errMsg, "compression"),
+		"Error should mention incompatibility: %v", err)
+
+	client.Del(context.Background(), []string{key})
+}
+
+func (suite *GlideTestSuite) TestCompressionIncompatibleCommandsWorkWithoutCompression() {
+	client := suite.defaultClient()
+	defer client.Close()
+
+	t := suite.T()
+
+	key := fmt.Sprintf("no_compression_test_%s", randomString(8))
+
+	// Set initial value
+	_, err := client.Set(context.Background(), key, "100")
+	assert.NoError(t, err)
+
+	// All these commands should work without compression
+	// INCR
+	incrResult, err := client.Incr(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(101), incrResult)
+
+	// INCRBY
+	incrByResult, err := client.IncrBy(context.Background(), key, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(111), incrByResult)
+
+	// DECR
+	decrResult, err := client.Decr(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(110), decrResult)
+
+	// DECRBY
+	decrByResult, err := client.DecrBy(context.Background(), key, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(100), decrByResult)
+
+	// STRLEN
+	_, err = client.Set(context.Background(), key, "hello")
+	assert.NoError(t, err)
+	strlenResult, err := client.Strlen(context.Background(), key)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), strlenResult)
+
+	// APPEND
+	appendResult, err := client.Append(context.Background(), key, " world")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(11), appendResult)
+
+	// GETRANGE
+	getrangeResult, err := client.GetRange(context.Background(), key, 0, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", getrangeResult)
+
+	// SETRANGE
+	setrangeResult, err := client.SetRange(context.Background(), key, 6, "WORLD")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(11), setrangeResult)
+
+	// GETBIT
+	_, err = client.Set(context.Background(), key, "\x00")
+	assert.NoError(t, err)
+	getbitResult, err := client.GetBit(context.Background(), key, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), getbitResult)
+
+	// SETBIT
+	setbitResult, err := client.SetBit(context.Background(), key, 0, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), setbitResult)
+
+	// BITCOUNT
+	bitcountResult, err := client.BitCount(context.Background(), key)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, bitcountResult, int64(0))
 
 	client.Del(context.Background(), []string{key})
 }

--- a/go/integTest/compression_test.go
+++ b/go/integTest/compression_test.go
@@ -1050,14 +1050,20 @@ func (suite *GlideTestSuite) TestCompressionGetEx() {
 	value := generateCompressibleText(1024)
 
 	// Set value (should be compressed)
+	compressBefore := client.GetStatistics()["total_values_compressed"]
 	_, err := client.Set(context.Background(), key, value)
 	assert.NoError(t, err)
+	assert.Greater(t, client.GetStatistics()["total_values_compressed"], compressBefore,
+		"SET should compress value")
 
 	// GETEX should decompress value
+	decompressBefore := client.GetStatistics()["total_values_decompressed"]
 	opts := options.NewGetExOptions().SetExpiry(options.NewExpiryIn(10 * time.Second))
 	retrieved, err := client.GetExWithOptions(context.Background(), key, *opts)
 	assert.NoError(t, err)
 	assert.Equal(t, value, retrieved.Value())
+	assert.Greater(t, client.GetStatistics()["total_values_decompressed"], decompressBefore,
+		"GETEX should decompress value")
 
 	// Verify TTL was set
 	ttl, err := client.TTL(context.Background(), key)
@@ -1078,13 +1084,19 @@ func (suite *GlideTestSuite) TestCompressionGetDel() {
 	value := generateCompressibleText(1024)
 
 	// Set value (should be compressed)
+	compressBefore := client.GetStatistics()["total_values_compressed"]
 	_, err := client.Set(context.Background(), key, value)
 	assert.NoError(t, err)
+	assert.Greater(t, client.GetStatistics()["total_values_compressed"], compressBefore,
+		"SET should compress value")
 
 	// GETDEL should decompress value and delete key
+	decompressBefore := client.GetStatistics()["total_values_decompressed"]
 	retrieved, err := client.GetDel(context.Background(), key)
 	assert.NoError(t, err)
 	assert.Equal(t, value, retrieved.Value())
+	assert.Greater(t, client.GetStatistics()["total_values_decompressed"], decompressBefore,
+		"GETDEL should decompress value")
 
 	// Verify key was deleted
 	getResult, err := client.Get(context.Background(), key)

--- a/java/integTest/src/test/java/glide/CompressionTests.java
+++ b/java/integTest/src/test/java/glide/CompressionTests.java
@@ -403,11 +403,18 @@ public class CompressionTests {
             String value = generateCompressibleText(1024);
 
             // Set value (should be compressed)
+            long compressBefore = getStat(client, "total_values_compressed");
             assertEquals(OK, client.set(key, value).get());
+            assertTrue(
+                    getStat(client, "total_values_compressed") > compressBefore, "SET should compress value");
 
             // GETEX should decompress value
+            long decompressBefore = getStat(client, "total_values_decompressed");
             String retrieved = client.getex(key, GetExOptions.Seconds(10L)).get();
             assertEquals(value, retrieved);
+            assertTrue(
+                    getStat(client, "total_values_decompressed") > decompressBefore,
+                    "GETEX should decompress value");
 
             // Verify TTL was set
             long ttl = client.ttl(key).get();
@@ -428,11 +435,18 @@ public class CompressionTests {
             String value = generateCompressibleText(1024);
 
             // Set value (should be compressed)
+            long compressBefore = getStat(client, "total_values_compressed");
             assertEquals(OK, client.set(key, value).get());
+            assertTrue(
+                    getStat(client, "total_values_compressed") > compressBefore, "SET should compress value");
 
             // GETDEL should decompress value and delete key
+            long decompressBefore = getStat(client, "total_values_decompressed");
             String retrieved = client.getdel(key).get();
             assertEquals(value, retrieved);
+            assertTrue(
+                    getStat(client, "total_values_decompressed") > decompressBefore,
+                    "GETDEL should decompress value");
 
             // Verify key was deleted
             assertEquals(null, client.get(key).get());

--- a/java/integTest/src/test/java/glide/CompressionTests.java
+++ b/java/integTest/src/test/java/glide/CompressionTests.java
@@ -11,12 +11,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import glide.api.BaseClient;
 import glide.api.GlideClient;
 import glide.api.GlideClusterClient;
+import glide.api.models.commands.GetExOptions;
 import glide.api.models.configuration.CompressionBackend;
 import glide.api.models.configuration.CompressionConfiguration;
 import glide.api.models.exceptions.ConfigurationError;
+import glide.api.models.exceptions.RequestException;
 import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -316,5 +321,547 @@ public class CompressionTests {
         assertEquals(CompressionBackend.LZ4, config.getBackend());
         assertEquals(5, (int) config.getCompressionLevel());
         assertEquals(128, config.getMinCompressionSize());
+    }
+
+    // ============================================================================
+    // Supported Commands Tests
+    // ============================================================================
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_mset_mget(BaseClient client) {
+        try {
+            String key1 = randomKey("{mset_test}_1");
+            String key2 = randomKey("{mset_test}_2");
+            String key3 = randomKey("{mset_test}_3");
+            String value = generateCompressibleText(1024);
+
+            long before = getStat(client, "total_values_compressed");
+
+            // MSET should compress values
+            Map<String, String> keyValueMap = new LinkedHashMap<>();
+            keyValueMap.put(key1, value);
+            keyValueMap.put(key2, value);
+            keyValueMap.put(key3, value);
+            assertEquals(OK, client.mset(keyValueMap).get());
+
+            assertTrue(
+                    getStat(client, "total_values_compressed") >= before + 3,
+                    "MSET should compress all values");
+
+            // MGET should decompress values
+            String[] retrieved = client.mget(new String[] {key1, key2, key3}).get();
+            assertEquals(3, retrieved.length);
+            assertEquals(value, retrieved[0]);
+            assertEquals(value, retrieved[1]);
+            assertEquals(value, retrieved[2]);
+
+            client.del(new String[] {key1, key2, key3}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_msetnx(BaseClient client) {
+        try {
+            String key1 = randomKey("{msetnx_test}_1");
+            String key2 = randomKey("{msetnx_test}_2");
+            String value = generateCompressibleText(1024);
+
+            long before = getStat(client, "total_values_compressed");
+
+            // MSETNX should compress values
+            Map<String, String> keyValueMap = new LinkedHashMap<>();
+            keyValueMap.put(key1, value);
+            keyValueMap.put(key2, value);
+            assertTrue(client.msetnx(keyValueMap).get(), "MSETNX should succeed for new keys");
+
+            assertTrue(
+                    getStat(client, "total_values_compressed") >= before + 2,
+                    "MSETNX should compress all values");
+
+            // Verify values can be retrieved and decompressed
+            assertEquals(value, client.get(key1).get());
+            assertEquals(value, client.get(key2).get());
+
+            client.del(new String[] {key1, key2}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_getex(BaseClient client) {
+        try {
+            String key = randomKey("getex_test");
+            String value = generateCompressibleText(1024);
+
+            // Set value (should be compressed)
+            assertEquals(OK, client.set(key, value).get());
+
+            // GETEX should decompress value
+            String retrieved = client.getex(key, GetExOptions.Seconds(10L)).get();
+            assertEquals(value, retrieved);
+
+            // Verify TTL was set
+            long ttl = client.ttl(key).get();
+            assertTrue(ttl > 0 && ttl <= 10, "TTL should be set");
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_getdel(BaseClient client) {
+        try {
+            String key = randomKey("getdel_test");
+            String value = generateCompressibleText(1024);
+
+            // Set value (should be compressed)
+            assertEquals(OK, client.set(key, value).get());
+
+            // GETDEL should decompress value and delete key
+            String retrieved = client.getdel(key).get();
+            assertEquals(value, retrieved);
+
+            // Verify key was deleted
+            assertEquals(null, client.get(key).get());
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void compression_setex_via_custom_command() {
+        try (GlideClient client = compressionClient()) {
+            String key = randomKey("setex_test");
+            String value = generateCompressibleText(1024);
+
+            long before = getStat(client, "total_values_compressed");
+
+            // SETEX via custom command should compress value
+            assertEquals(OK, client.customCommand(new String[] {"SETEX", key, "10", value}).get());
+
+            assertTrue(
+                    getStat(client, "total_values_compressed") > before, "SETEX should compress value");
+
+            // Verify value can be retrieved and decompressed
+            assertEquals(value, client.get(key).get());
+
+            // Verify TTL was set
+            long ttl = client.ttl(key).get();
+            assertTrue(ttl > 0 && ttl <= 10, "TTL should be set");
+
+            client.del(new String[] {key}).get();
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void compression_psetex_via_custom_command() {
+        try (GlideClient client = compressionClient()) {
+            String key = randomKey("psetex_test");
+            String value = generateCompressibleText(1024);
+
+            long before = getStat(client, "total_values_compressed");
+
+            // PSETEX via custom command should compress value
+            assertEquals(OK, client.customCommand(new String[] {"PSETEX", key, "10000", value}).get());
+
+            assertTrue(
+                    getStat(client, "total_values_compressed") > before, "PSETEX should compress value");
+
+            // Verify value can be retrieved and decompressed
+            assertEquals(value, client.get(key).get());
+
+            client.del(new String[] {key}).get();
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void compression_setnx_via_custom_command() {
+        try (GlideClient client = compressionClient()) {
+            String key = randomKey("setnx_test");
+            String value = generateCompressibleText(1024);
+
+            // Ensure key doesn't exist
+            client.del(new String[] {key}).get();
+
+            long before = getStat(client, "total_values_compressed");
+
+            // SETNX via custom command should compress value
+            assertEquals(1L, client.customCommand(new String[] {"SETNX", key, value}).get());
+
+            assertTrue(
+                    getStat(client, "total_values_compressed") > before, "SETNX should compress value");
+
+            // Verify value can be retrieved and decompressed
+            assertEquals(value, client.get(key).get());
+
+            client.del(new String[] {key}).get();
+        }
+    }
+
+    // ============================================================================
+    // Incompatible Commands Tests
+    // ============================================================================
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_append_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("append_test");
+            assertEquals(OK, client.set(key, "initial_value").get());
+
+            // APPEND should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.append(key, "_appended").get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_getrange_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("getrange_test");
+            assertEquals(OK, client.set(key, generateCompressibleText(1024)).get());
+
+            // GETRANGE should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.getrange(key, 0, 10).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_setrange_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("setrange_test");
+            assertEquals(OK, client.set(key, generateCompressibleText(1024)).get());
+
+            // SETRANGE should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(
+                            ExecutionException.class, () -> client.setrange(key, 5, "replacement").get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_strlen_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("strlen_test");
+            assertEquals(OK, client.set(key, generateCompressibleText(1024)).get());
+
+            // STRLEN should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.strlen(key).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_incr_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("incr_test");
+            assertEquals(OK, client.set(key, "100").get());
+
+            // INCR should fail with compression enabled
+            ExecutionException ex = assertThrows(ExecutionException.class, () -> client.incr(key).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_incrby_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("incrby_test");
+            assertEquals(OK, client.set(key, "100").get());
+
+            // INCRBY should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.incrBy(key, 10).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_incrbyfloat_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("incrbyfloat_test");
+            assertEquals(OK, client.set(key, "100.5").get());
+
+            // INCRBYFLOAT should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.incrByFloat(key, 0.5).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_decr_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("decr_test");
+            assertEquals(OK, client.set(key, "100").get());
+
+            // DECR should fail with compression enabled
+            ExecutionException ex = assertThrows(ExecutionException.class, () -> client.decr(key).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_decrby_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("decrby_test");
+            assertEquals(OK, client.set(key, "100").get());
+
+            // DECRBY should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.decrBy(key, 10).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_getbit_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("getbit_test");
+            assertEquals(OK, client.set(key, "test_value").get());
+
+            // GETBIT should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.getbit(key, 0).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_setbit_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("setbit_test");
+            assertEquals(OK, client.set(key, "test_value").get());
+
+            // SETBIT should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.setbit(key, 0, 1).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_bitcount_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("bitcount_test");
+            assertEquals(OK, client.set(key, "test_value").get());
+
+            // BITCOUNT should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.bitcount(key).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getCompressionClients")
+    public void compression_bitpos_incompatible(BaseClient client) {
+        try {
+            String key = randomKey("bitpos_test");
+            assertEquals(OK, client.set(key, "test_value").get());
+
+            // BITPOS should fail with compression enabled
+            ExecutionException ex =
+                    assertThrows(ExecutionException.class, () -> client.bitpos(key, 1).get());
+            assertTrue(ex.getCause() instanceof RequestException, "Should throw RequestException");
+            String errorMsg = ex.getCause().getMessage().toLowerCase();
+            assertTrue(
+                    errorMsg.contains("incompatible") || errorMsg.contains("compression"),
+                    "Error should mention incompatibility: " + errorMsg);
+
+            client.del(new String[] {key}).get();
+        } finally {
+            client.close();
+        }
+    }
+
+    @SneakyThrows
+    @Test
+    public void compression_incompatible_commands_work_without_compression() {
+        try (GlideClient client = GlideClient.createClient(commonClientConfig().build()).get()) {
+            String key = randomKey("no_compression_test");
+
+            // Set initial value
+            assertEquals(OK, client.set(key, "100").get());
+
+            // All these commands should work without compression
+            // INCR
+            assertEquals(101L, client.incr(key).get());
+
+            // INCRBY
+            assertEquals(111L, client.incrBy(key, 10).get());
+
+            // DECR
+            assertEquals(110L, client.decr(key).get());
+
+            // DECRBY
+            assertEquals(100L, client.decrBy(key, 10).get());
+
+            // STRLEN
+            assertEquals(OK, client.set(key, "hello").get());
+            assertEquals(5L, client.strlen(key).get());
+
+            // APPEND
+            assertEquals(11L, client.append(key, " world").get());
+
+            // GETRANGE
+            assertEquals("hello", client.getrange(key, 0, 4).get());
+
+            // SETRANGE
+            assertEquals(11L, client.setrange(key, 6, "WORLD").get());
+
+            // GETBIT
+            assertEquals(OK, client.set(key, "\u0000").get());
+            assertEquals(0L, client.getbit(key, 0).get());
+
+            // SETBIT
+            assertEquals(0L, client.setbit(key, 0, 1).get());
+
+            // BITCOUNT
+            assertTrue(client.bitcount(key).get() >= 0);
+
+            client.del(new String[] {key}).get();
+        }
     }
 }

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -66,36 +66,12 @@ fn process_command_for_compression(
     }
 
     let command_name = &all_args[0];
-    let command_str = String::from_utf8_lossy(command_name).to_uppercase();
-    let request_type = match command_str.as_str() {
-        "SET" => glide_core::request_type::RequestType::Set,
-        "MSET" => glide_core::request_type::RequestType::MSet,
-        "MSETNX" => glide_core::request_type::RequestType::MSetNX,
-        "SETEX" => glide_core::request_type::RequestType::SetEx,
-        "PSETEX" => glide_core::request_type::RequestType::PSetEx,
-        "SETNX" => glide_core::request_type::RequestType::SetNX,
-        // Incompatible commands - string manipulation
-        "APPEND" => glide_core::request_type::RequestType::Append,
-        "GETRANGE" => glide_core::request_type::RequestType::GetRange,
-        "SETRANGE" => glide_core::request_type::RequestType::SetRange,
-        "STRLEN" => glide_core::request_type::RequestType::Strlen,
-        "LCS" => glide_core::request_type::RequestType::LCS,
-        "SUBSTR" => glide_core::request_type::RequestType::Substr,
-        // Incompatible commands - numeric operations
-        "INCR" => glide_core::request_type::RequestType::Incr,
-        "INCRBY" => glide_core::request_type::RequestType::IncrBy,
-        "INCRBYFLOAT" => glide_core::request_type::RequestType::IncrByFloat,
-        "DECR" => glide_core::request_type::RequestType::Decr,
-        "DECRBY" => glide_core::request_type::RequestType::DecrBy,
-        // Incompatible commands - bit operations
-        "GETBIT" => glide_core::request_type::RequestType::GetBit,
-        "SETBIT" => glide_core::request_type::RequestType::SetBit,
-        "BITCOUNT" => glide_core::request_type::RequestType::BitCount,
-        "BITPOS" => glide_core::request_type::RequestType::BitPos,
-        "BITFIELD" => glide_core::request_type::RequestType::BitField,
-        "BITFIELD_RO" => glide_core::request_type::RequestType::BitFieldReadOnly,
-        "BITOP" => glide_core::request_type::RequestType::BitOp,
-        _ => return Ok(()),
+    let command_str = String::from_utf8_lossy(command_name);
+
+    let request_type = match glide_core::request_type::RequestType::from_command_name(&command_str)
+    {
+        Some(rt) => rt,
+        None => return Ok(()), // Unknown command - no compression processing needed
     };
 
     // Check if the command is incompatible with compression - this should error out

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -253,11 +253,8 @@ async fn execute_command_request_and_complete(
                 #[allow(clippy::collapsible_if)]
                 if client.is_compression_enabled() {
                     if let Err(e) = process_command_for_compression(&mut cmd, &client) {
-                        // Check if this is an incompatible command error - these should be returned as errors
-                        if matches!(
-                            e,
-                            glide_core::compression::CompressionError::IncompatibleCommand { .. }
-                        ) {
+                        // Incompatible command errors should be returned to the user
+                        if e.is_incompatible_command() {
                             return Err(redis::RedisError::from((
                                 redis::ErrorKind::ClientError,
                                 "Incompatible command with compression",
@@ -331,11 +328,8 @@ async fn execute_command_request_and_complete(
                     #[allow(clippy::collapsible_if)]
                     if client.is_compression_enabled() {
                         if let Err(e) = process_command_for_compression(&mut valkey_cmd, &client) {
-                            // Check if this is an incompatible command error - these should be returned as errors
-                            if matches!(
-                                e,
-                                glide_core::compression::CompressionError::IncompatibleCommand { .. }
-                            ) {
+                            // Incompatible command errors should be returned to the user
+                            if e.is_incompatible_command() {
                                 return Err(redis::RedisError::from((
                                     redis::ErrorKind::ClientError,
                                     "Incompatible command with compression",

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -45,6 +45,14 @@ fn process_command_for_compression(
     let compression_manager = client.compression_manager();
     let compression_manager_ref = compression_manager.as_deref();
 
+    // If compression is not enabled, skip all processing
+    if compression_manager_ref
+        .map(|m| !m.is_enabled())
+        .unwrap_or(true)
+    {
+        return Ok(());
+    }
+
     let all_args: Vec<Vec<u8>> = cmd
         .args_iter()
         .filter_map(|arg| match arg {
@@ -61,8 +69,40 @@ fn process_command_for_compression(
     let command_str = String::from_utf8_lossy(command_name).to_uppercase();
     let request_type = match command_str.as_str() {
         "SET" => glide_core::request_type::RequestType::Set,
+        "MSET" => glide_core::request_type::RequestType::MSet,
+        "MSETNX" => glide_core::request_type::RequestType::MSetNX,
+        "SETEX" => glide_core::request_type::RequestType::SetEx,
+        "PSETEX" => glide_core::request_type::RequestType::PSetEx,
+        "SETNX" => glide_core::request_type::RequestType::SetNX,
+        // Incompatible commands - string manipulation
+        "APPEND" => glide_core::request_type::RequestType::Append,
+        "GETRANGE" => glide_core::request_type::RequestType::GetRange,
+        "SETRANGE" => glide_core::request_type::RequestType::SetRange,
+        "STRLEN" => glide_core::request_type::RequestType::Strlen,
+        "LCS" => glide_core::request_type::RequestType::LCS,
+        "SUBSTR" => glide_core::request_type::RequestType::Substr,
+        // Incompatible commands - numeric operations
+        "INCR" => glide_core::request_type::RequestType::Incr,
+        "INCRBY" => glide_core::request_type::RequestType::IncrBy,
+        "INCRBYFLOAT" => glide_core::request_type::RequestType::IncrByFloat,
+        "DECR" => glide_core::request_type::RequestType::Decr,
+        "DECRBY" => glide_core::request_type::RequestType::DecrBy,
+        // Incompatible commands - bit operations
+        "GETBIT" => glide_core::request_type::RequestType::GetBit,
+        "SETBIT" => glide_core::request_type::RequestType::SetBit,
+        "BITCOUNT" => glide_core::request_type::RequestType::BitCount,
+        "BITPOS" => glide_core::request_type::RequestType::BitPos,
+        "BITFIELD" => glide_core::request_type::RequestType::BitField,
+        "BITFIELD_RO" => glide_core::request_type::RequestType::BitFieldReadOnly,
+        "BITOP" => glide_core::request_type::RequestType::BitOp,
         _ => return Ok(()),
     };
+
+    // Check if the command is incompatible with compression - this should error out
+    glide_core::compression::validate_command_compression_compatibility(
+        request_type,
+        compression_manager_ref,
+    )?;
 
     let mut args: Vec<Vec<u8>> = all_args[1..].to_vec();
     glide_core::compression::process_command_args_for_compression(
@@ -229,10 +269,23 @@ async fn execute_command_request_and_complete(
                 })?;
 
                 // Apply compression to command arguments if compression is enabled
-                if client.is_compression_enabled()
-                    && let Err(e) = process_command_for_compression(&mut cmd, &client)
-                {
-                    log::warn!("Compression processing failed: {e}, continuing with original command");
+                // This also validates that the command is compatible with compression
+                if client.is_compression_enabled() {
+                    if let Err(e) = process_command_for_compression(&mut cmd, &client) {
+                        // Check if this is an incompatible command error - these should be returned as errors
+                        if matches!(
+                            e,
+                            glide_core::compression::CompressionError::IncompatibleCommand { .. }
+                        ) {
+                            return Err(redis::RedisError::from((
+                                redis::ErrorKind::ClientError,
+                                "Incompatible command with compression",
+                                e.to_string(),
+                            )));
+                        }
+                        // For other compression errors, log and continue
+                        log::warn!("Compression processing failed: {e}, continuing with original command");
+                    }
                 }
 
                 // Compute routing
@@ -291,10 +344,23 @@ async fn execute_command_request_and_complete(
                         ))
                     })?;
                     // Apply compression to each command in the batch
-                    if client.is_compression_enabled()
-                        && let Err(e) = process_command_for_compression(&mut valkey_cmd, &client)
-                    {
-                        log::warn!("Compression processing failed for batch command: {e}, continuing with original");
+                    // This also validates that the command is compatible with compression
+                    if client.is_compression_enabled() {
+                        if let Err(e) = process_command_for_compression(&mut valkey_cmd, &client) {
+                            // Check if this is an incompatible command error - these should be returned as errors
+                            if matches!(
+                                e,
+                                glide_core::compression::CompressionError::IncompatibleCommand { .. }
+                            ) {
+                                return Err(redis::RedisError::from((
+                                    redis::ErrorKind::ClientError,
+                                    "Incompatible command with compression",
+                                    e.to_string(),
+                                )));
+                            }
+                            // For other compression errors, log and continue
+                            log::warn!("Compression processing failed for batch command: {e}, continuing with original");
+                        }
                     }
                     pipeline.add_command(valkey_cmd);
                 }

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -270,6 +270,11 @@ async fn execute_command_request_and_complete(
 
                 // Apply compression to command arguments if compression is enabled
                 // This also validates that the command is compatible with compression
+                // Note: We intentionally keep these as separate if statements for clarity:
+                // - First check: is compression enabled?
+                // - Second check: did compression processing fail?
+                // - Third check: is it an incompatible command error?
+                #[allow(clippy::collapsible_if)]
                 if client.is_compression_enabled() {
                     if let Err(e) = process_command_for_compression(&mut cmd, &client) {
                         // Check if this is an incompatible command error - these should be returned as errors
@@ -284,7 +289,9 @@ async fn execute_command_request_and_complete(
                             )));
                         }
                         // For other compression errors, log and continue
-                        log::warn!("Compression processing failed: {e}, continuing with original command");
+                        log::warn!(
+                            "Compression processing failed: {e}, continuing with original command"
+                        );
                     }
                 }
 
@@ -345,6 +352,7 @@ async fn execute_command_request_and_complete(
                     })?;
                     // Apply compression to each command in the batch
                     // This also validates that the command is compatible with compression
+                    #[allow(clippy::collapsible_if)]
                     if client.is_compression_enabled() {
                         if let Err(e) = process_command_for_compression(&mut valkey_cmd, &client) {
                             // Check if this is an incompatible command error - these should be returned as errors

--- a/node/tests/Compression.test.ts
+++ b/node/tests/Compression.test.ts
@@ -377,13 +377,23 @@ describe("Compression", () => {
             const key = uniqueKey("getex_test");
 
             // Set value (should be compressed)
+            const compressBefore =
+                getNumericStats(client).total_values_compressed;
             await client.set(key, TEXT_1K);
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThan(compressBefore);
 
             // GETEX should decompress value
+            const decompressBefore =
+                getNumericStats(client).total_values_decompressed;
             const retrieved = await client.getex(key, {
                 expiry: { type: TimeUnit.Seconds, duration: 10 },
             });
             expect(retrieved).toBe(TEXT_1K);
+            expect(
+                getNumericStats(client).total_values_decompressed,
+            ).toBeGreaterThan(decompressBefore);
 
             // Verify TTL was set
             const ttl = await client.ttl(key);
@@ -402,11 +412,21 @@ describe("Compression", () => {
             const key = uniqueKey("getdel_test");
 
             // Set value (should be compressed)
+            const compressBefore =
+                getNumericStats(client).total_values_compressed;
             await client.set(key, TEXT_1K);
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThan(compressBefore);
 
             // GETDEL should decompress value and delete key
+            const decompressBefore =
+                getNumericStats(client).total_values_decompressed;
             const retrieved = await client.getdel(key);
             expect(retrieved).toBe(TEXT_1K);
+            expect(
+                getNumericStats(client).total_values_decompressed,
+            ).toBeGreaterThan(decompressBefore);
 
             // Verify key was deleted
             expect(await client.get(key)).toBeNull();

--- a/node/tests/Compression.test.ts
+++ b/node/tests/Compression.test.ts
@@ -20,6 +20,8 @@ import {
     GlideClient,
     GlideClusterClient,
     ProtocolVersion,
+    RequestError,
+    TimeUnit,
     validateCompressionConfiguration,
 } from "../build-ts";
 import {
@@ -301,6 +303,490 @@ describe("Compression", () => {
                 await setAndExpectCompression(client, key, patterns[i]);
                 expect(await client.get(key)).toBe(patterns[i]);
             }
+        },
+        TIMEOUT,
+    );
+
+    // --- Supported commands tests ---
+
+    it.each([false, true])(
+        "compression_mset_mget cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key1 = uniqueKey("{mset_test}_1");
+            const key2 = uniqueKey("{mset_test}_2");
+            const key3 = uniqueKey("{mset_test}_3");
+
+            const before = getNumericStats(client).total_values_compressed;
+
+            // MSET should compress values
+            await client.mset({
+                [key1]: TEXT_1K,
+                [key2]: TEXT_1K,
+                [key3]: TEXT_1K,
+            });
+
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThanOrEqual(before + 3);
+
+            // MGET should decompress values
+            const retrieved = await client.mget([key1, key2, key3]);
+            expect(retrieved).toEqual([TEXT_1K, TEXT_1K, TEXT_1K]);
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_msetnx cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key1 = uniqueKey("{msetnx_test}_1");
+            const key2 = uniqueKey("{msetnx_test}_2");
+
+            const before = getNumericStats(client).total_values_compressed;
+
+            // MSETNX should compress values
+            const result = await client.msetnx({
+                [key1]: TEXT_1K,
+                [key2]: TEXT_1K,
+            });
+            expect(result).toBe(true);
+
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThanOrEqual(before + 2);
+
+            // Verify values can be retrieved and decompressed
+            expect(await client.get(key1)).toBe(TEXT_1K);
+            expect(await client.get(key2)).toBe(TEXT_1K);
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_getex cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("getex_test");
+
+            // Set value (should be compressed)
+            await client.set(key, TEXT_1K);
+
+            // GETEX should decompress value
+            const retrieved = await client.getex(key, {
+                expiry: { type: TimeUnit.Seconds, duration: 10 },
+            });
+            expect(retrieved).toBe(TEXT_1K);
+
+            // Verify TTL was set
+            const ttl = await client.ttl(key);
+            expect(ttl).toBeGreaterThan(0);
+            expect(ttl).toBeLessThanOrEqual(10);
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_getdel cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("getdel_test");
+
+            // Set value (should be compressed)
+            await client.set(key, TEXT_1K);
+
+            // GETDEL should decompress value and delete key
+            const retrieved = await client.getdel(key);
+            expect(retrieved).toBe(TEXT_1K);
+
+            // Verify key was deleted
+            expect(await client.get(key)).toBeNull();
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_setex_via_custom_command cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("setex_test");
+
+            const before = getNumericStats(client).total_values_compressed;
+
+            // SETEX via custom command should compress value
+            await client.customCommand(["SETEX", key, "10", TEXT_1K]);
+
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThan(before);
+
+            // Verify value can be retrieved and decompressed
+            expect(await client.get(key)).toBe(TEXT_1K);
+
+            // Verify TTL was set
+            const ttl = await client.ttl(key);
+            expect(ttl).toBeGreaterThan(0);
+            expect(ttl).toBeLessThanOrEqual(10);
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_psetex_via_custom_command cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("psetex_test");
+
+            const before = getNumericStats(client).total_values_compressed;
+
+            // PSETEX via custom command should compress value
+            await client.customCommand(["PSETEX", key, "10000", TEXT_1K]);
+
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThan(before);
+
+            // Verify value can be retrieved and decompressed
+            expect(await client.get(key)).toBe(TEXT_1K);
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_setnx_via_custom_command cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("setnx_test");
+
+            // Ensure key doesn't exist
+            await client.del([key]);
+
+            const before = getNumericStats(client).total_values_compressed;
+
+            // SETNX via custom command should compress value
+            const result = await client.customCommand(["SETNX", key, TEXT_1K]);
+            expect(result).toBe(1);
+
+            expect(
+                getNumericStats(client).total_values_compressed,
+            ).toBeGreaterThan(before);
+
+            // Verify value can be retrieved and decompressed
+            expect(await client.get(key)).toBe(TEXT_1K);
+        },
+        TIMEOUT,
+    );
+
+    // --- Incompatible commands tests ---
+
+    it.each([false, true])(
+        "compression_append_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("append_test");
+            await client.set(key, "initial_value");
+
+            // APPEND should fail with compression enabled
+            await expect(client.append(key, "_appended")).rejects.toThrow(
+                RequestError,
+            );
+            await expect(client.append(key, "_appended")).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_getrange_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("getrange_test");
+            await client.set(key, TEXT_1K);
+
+            // GETRANGE should fail with compression enabled
+            await expect(client.getrange(key, 0, 10)).rejects.toThrow(
+                RequestError,
+            );
+            await expect(client.getrange(key, 0, 10)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_setrange_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("setrange_test");
+            await client.set(key, TEXT_1K);
+
+            // SETRANGE should fail with compression enabled
+            await expect(
+                client.setrange(key, 5, "replacement"),
+            ).rejects.toThrow(RequestError);
+            await expect(
+                client.setrange(key, 5, "replacement"),
+            ).rejects.toThrow(/incompatible|compression/i);
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_strlen_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("strlen_test");
+            await client.set(key, TEXT_1K);
+
+            // STRLEN should fail with compression enabled
+            await expect(client.strlen(key)).rejects.toThrow(RequestError);
+            await expect(client.strlen(key)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_incr_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("incr_test");
+            await client.set(key, "100");
+
+            // INCR should fail with compression enabled
+            await expect(client.incr(key)).rejects.toThrow(RequestError);
+            await expect(client.incr(key)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_incrby_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("incrby_test");
+            await client.set(key, "100");
+
+            // INCRBY should fail with compression enabled
+            await expect(client.incrBy(key, 10)).rejects.toThrow(RequestError);
+            await expect(client.incrBy(key, 10)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_incrbyfloat_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("incrbyfloat_test");
+            await client.set(key, "100.5");
+
+            // INCRBYFLOAT should fail with compression enabled
+            await expect(client.incrByFloat(key, 0.5)).rejects.toThrow(
+                RequestError,
+            );
+            await expect(client.incrByFloat(key, 0.5)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_decr_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("decr_test");
+            await client.set(key, "100");
+
+            // DECR should fail with compression enabled
+            await expect(client.decr(key)).rejects.toThrow(RequestError);
+            await expect(client.decr(key)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_decrby_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("decrby_test");
+            await client.set(key, "100");
+
+            // DECRBY should fail with compression enabled
+            await expect(client.decrBy(key, 10)).rejects.toThrow(RequestError);
+            await expect(client.decrBy(key, 10)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_getbit_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("getbit_test");
+            await client.set(key, "test_value");
+
+            // GETBIT should fail with compression enabled
+            await expect(client.getbit(key, 0)).rejects.toThrow(RequestError);
+            await expect(client.getbit(key, 0)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_setbit_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("setbit_test");
+            await client.set(key, "test_value");
+
+            // SETBIT should fail with compression enabled
+            await expect(client.setbit(key, 0, 1)).rejects.toThrow(
+                RequestError,
+            );
+            await expect(client.setbit(key, 0, 1)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_bitcount_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("bitcount_test");
+            await client.set(key, "test_value");
+
+            // BITCOUNT should fail with compression enabled
+            await expect(client.bitcount(key)).rejects.toThrow(RequestError);
+            await expect(client.bitcount(key)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it.each([false, true])(
+        "compression_bitpos_incompatible cluster_mode=%p",
+        async (clusterMode) => {
+            client = await createCompressedClient(clusterMode, {
+                enabled: true,
+            });
+            const key = uniqueKey("bitpos_test");
+            await client.set(key, "test_value");
+
+            // BITPOS should fail with compression enabled
+            await expect(client.bitpos(key, 1)).rejects.toThrow(RequestError);
+            await expect(client.bitpos(key, 1)).rejects.toThrow(
+                /incompatible|compression/i,
+            );
+        },
+        TIMEOUT,
+    );
+
+    it(
+        "compression_incompatible_commands_work_without_compression",
+        async () => {
+            client = await GlideClient.createClient(
+                getClientConfigurationOption(
+                    getAddresses(false),
+                    ProtocolVersion.RESP3,
+                ),
+            );
+            const key = uniqueKey("no_compression_test");
+
+            // Set initial value
+            await client.set(key, "100");
+
+            // All these commands should work without compression
+            // INCR
+            expect(await client.incr(key)).toBe(101);
+
+            // INCRBY
+            expect(await client.incrBy(key, 10)).toBe(111);
+
+            // DECR
+            expect(await client.decr(key)).toBe(110);
+
+            // DECRBY
+            expect(await client.decrBy(key, 10)).toBe(100);
+
+            // STRLEN
+            await client.set(key, "hello");
+            expect(await client.strlen(key)).toBe(5);
+
+            // APPEND
+            expect(await client.append(key, " world")).toBe(11);
+
+            // GETRANGE
+            expect(await client.getrange(key, 0, 4)).toBe("hello");
+
+            // SETRANGE
+            expect(await client.setrange(key, 6, "WORLD")).toBe(11);
+
+            // GETBIT
+            await client.set(key, "\x00");
+            expect(await client.getbit(key, 0)).toBe(0);
+
+            // SETBIT
+            expect(await client.setbit(key, 0, 1)).toBe(0);
+
+            // BITCOUNT
+            expect(await client.bitcount(key)).toBeGreaterThanOrEqual(0);
         },
         TIMEOUT,
     );

--- a/python/tests/async_tests/test_compression.py
+++ b/python/tests/async_tests/test_compression.py
@@ -1632,33 +1632,33 @@ class TestCompressionIncompatibleCommands:
 
         # STRLEN
         await no_compression_client.set(key, "hello")
-        result = await no_compression_client.strlen(key)
-        assert result == 5
+        strlen_result = await no_compression_client.strlen(key)
+        assert strlen_result == 5
 
         # APPEND
-        result = await no_compression_client.append(key, " world")
-        assert result == 11  # "hello world" = 11 chars
+        append_result = await no_compression_client.append(key, " world")
+        assert append_result == 11  # "hello world" = 11 chars
 
         # GETRANGE
-        result = await no_compression_client.getrange(key, 0, 4)
-        assert result == b"hello"
+        getrange_result = await no_compression_client.getrange(key, 0, 4)
+        assert getrange_result == b"hello"
 
         # SETRANGE
-        result = await no_compression_client.setrange(key, 6, "WORLD")
-        assert result == 11
+        setrange_result = await no_compression_client.setrange(key, 6, "WORLD")
+        assert setrange_result == 11
 
         # GETBIT
         await no_compression_client.set(key, "\x00")
-        result = await no_compression_client.getbit(key, 0)
-        assert result == 0
+        getbit_result = await no_compression_client.getbit(key, 0)
+        assert getbit_result == 0
 
         # SETBIT
-        result = await no_compression_client.setbit(key, 0, 1)
-        assert result == 0  # Previous value was 0
+        setbit_result = await no_compression_client.setbit(key, 0, 1)
+        assert setbit_result == 0  # Previous value was 0
 
         # BITCOUNT
-        result = await no_compression_client.bitcount(key)
-        assert result >= 0
+        bitcount_result = await no_compression_client.bitcount(key)
+        assert bitcount_result >= 0
 
         # Cleanup
         await no_compression_client.delete([key])

--- a/python/tests/async_tests/test_compression.py
+++ b/python/tests/async_tests/test_compression.py
@@ -1289,3 +1289,461 @@ class TestCompressionCompatibility:
 
         # Cleanup
         await compression_client.delete([key])
+
+
+@pytest.mark.anyio
+class TestCompressionIncompatibleCommands:
+    """Test that incompatible commands error out when compression is enabled.
+
+    These commands are incompatible with compression because they operate on
+    the raw bytes stored in the server, which would be compressed data instead
+    of the original values.
+    """
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_append_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that APPEND command errors out when compression is enabled."""
+        key = f"append_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "initial_value")
+
+        # APPEND should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.append(key, "_appended")
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_getrange_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that GETRANGE command errors out when compression is enabled."""
+        key = f"getrange_test_{get_random_string(8)}"
+        value = generate_compressible_text(1024)
+
+        # First set a value
+        await compression_client.set(key, value)
+
+        # GETRANGE should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.getrange(key, 0, 10)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_setrange_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that SETRANGE command errors out when compression is enabled."""
+        key = f"setrange_test_{get_random_string(8)}"
+        value = generate_compressible_text(1024)
+
+        # First set a value
+        await compression_client.set(key, value)
+
+        # SETRANGE should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.setrange(key, 5, "replacement")
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_strlen_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that STRLEN command errors out when compression is enabled."""
+        key = f"strlen_test_{get_random_string(8)}"
+        value = generate_compressible_text(1024)
+
+        # First set a value
+        await compression_client.set(key, value)
+
+        # STRLEN should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.strlen(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_incr_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that INCR command errors out when compression is enabled."""
+        key = f"incr_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        await compression_client.set(key, "100")
+
+        # INCR should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.incr(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_incrby_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that INCRBY command errors out when compression is enabled."""
+        key = f"incrby_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        await compression_client.set(key, "100")
+
+        # INCRBY should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.incrby(key, 10)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_incrbyfloat_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that INCRBYFLOAT command errors out when compression is enabled."""
+        key = f"incrbyfloat_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        await compression_client.set(key, "100.5")
+
+        # INCRBYFLOAT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.incrbyfloat(key, 0.5)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_decr_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that DECR command errors out when compression is enabled."""
+        key = f"decr_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        await compression_client.set(key, "100")
+
+        # DECR should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.decr(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_decrby_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that DECRBY command errors out when compression is enabled."""
+        key = f"decrby_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        await compression_client.set(key, "100")
+
+        # DECRBY should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.decrby(key, 10)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_getbit_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that GETBIT command errors out when compression is enabled."""
+        key = f"getbit_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "test_value")
+
+        # GETBIT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.getbit(key, 0)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_setbit_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that SETBIT command errors out when compression is enabled."""
+        key = f"setbit_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "test_value")
+
+        # SETBIT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.setbit(key, 0, 1)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_bitcount_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that BITCOUNT command errors out when compression is enabled."""
+        key = f"bitcount_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "test_value")
+
+        # BITCOUNT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.bitcount(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_bitpos_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that BITPOS command errors out when compression is enabled."""
+        key = f"bitpos_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "test_value")
+
+        # BITPOS should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.bitpos(key, 1)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_incompatible_commands_work_without_compression(
+        self, no_compression_client: TGlideClient
+    ):
+        """Test that incompatible commands work normally when compression is disabled."""
+        key = f"no_compression_test_{get_random_string(8)}"
+
+        # Set initial value
+        await no_compression_client.set(key, "100")
+
+        # All these commands should work without compression
+        # INCR
+        result = await no_compression_client.incr(key)
+        assert result == 101
+
+        # INCRBY
+        result = await no_compression_client.incrby(key, 10)
+        assert result == 111
+
+        # DECR
+        result = await no_compression_client.decr(key)
+        assert result == 110
+
+        # DECRBY
+        result = await no_compression_client.decrby(key, 10)
+        assert result == 100
+
+        # STRLEN
+        await no_compression_client.set(key, "hello")
+        result = await no_compression_client.strlen(key)
+        assert result == 5
+
+        # APPEND
+        result = await no_compression_client.append(key, " world")
+        assert result == 11  # "hello world" = 11 chars
+
+        # GETRANGE
+        result = await no_compression_client.getrange(key, 0, 4)
+        assert result == b"hello"
+
+        # SETRANGE
+        result = await no_compression_client.setrange(key, 6, "WORLD")
+        assert result == 11
+
+        # GETBIT
+        await no_compression_client.set(key, "\x00")
+        result = await no_compression_client.getbit(key, 0)
+        assert result == 0
+
+        # SETBIT
+        result = await no_compression_client.setbit(key, 0, 1)
+        assert result == 0  # Previous value was 0
+
+        # BITCOUNT
+        result = await no_compression_client.bitcount(key)
+        assert result >= 0
+
+        # Cleanup
+        await no_compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_incompatible_commands_via_custom_command(
+        self, compression_client: TGlideClient
+    ):
+        """Test that incompatible commands also error out when called via custom_command."""
+        key = f"custom_cmd_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "100")
+
+        # INCR via custom_command should fail
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.custom_command(
+                cast(List[Union[str, bytes]], ["INCR", key])
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # APPEND via custom_command should fail
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.custom_command(
+                cast(List[Union[str, bytes]], ["APPEND", key, "_suffix"])
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # STRLEN via custom_command should fail
+        with pytest.raises(Exception) as exc_info:
+            await compression_client.custom_command(
+                cast(List[Union[str, bytes]], ["STRLEN", key])
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_incompatible_commands_in_batch(
+        self, compression_client: TGlideClient, cluster_mode: bool
+    ):
+        """Test that incompatible commands in batch operations also error out."""
+        key = f"batch_incompatible_test_{get_random_string(8)}"
+
+        # First set a value
+        await compression_client.set(key, "100")
+
+        # Create batch with incompatible command
+        batch = (
+            Batch(is_atomic=False)
+            if isinstance(compression_client, GlideClient)
+            else ClusterBatch(is_atomic=False)
+        )
+        batch.incr(key)  # This should cause an error
+
+        # Execute batch - should fail due to incompatible command
+        with pytest.raises(Exception) as exc_info:
+            if isinstance(compression_client, GlideClient):
+                await cast(GlideClient, compression_client).exec(
+                    cast(Batch, batch), raise_on_error=True
+                )
+            else:
+                await cast(GlideClusterClient, compression_client).exec(
+                    cast(ClusterBatch, batch), raise_on_error=True
+                )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        await compression_client.delete([key])

--- a/python/tests/sync_tests/test_sync_compression.py
+++ b/python/tests/sync_tests/test_sync_compression.py
@@ -1436,9 +1436,7 @@ class TestCompressionIncompatibleCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    def test_incr_incompatible_with_compression(
-        self, compression_client: TGlideClient
-    ):
+    def test_incr_incompatible_with_compression(self, compression_client: TGlideClient):
         """Test that INCR command errors out when compression is enabled."""
         key = f"incr_test_{get_random_string(8)}"
 
@@ -1505,9 +1503,7 @@ class TestCompressionIncompatibleCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    def test_decr_incompatible_with_compression(
-        self, compression_client: TGlideClient
-    ):
+    def test_decr_incompatible_with_compression(self, compression_client: TGlideClient):
         """Test that DECR command errors out when compression is enabled."""
         key = f"decr_test_{get_random_string(8)}"
 

--- a/python/tests/sync_tests/test_sync_compression.py
+++ b/python/tests/sync_tests/test_sync_compression.py
@@ -1329,3 +1329,460 @@ class TestCompressionCompatibility:
 
         # Cleanup
         compression_client.delete([key])
+
+
+class TestCompressionIncompatibleCommands:
+    """Test that incompatible commands error out when compression is enabled.
+
+    These commands are incompatible with compression because they operate on
+    the raw bytes stored in the server, which would be compressed data instead
+    of the original values.
+    """
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_append_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that APPEND command errors out when compression is enabled."""
+        key = f"append_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "initial_value")
+
+        # APPEND should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.append(key, "_appended")
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_getrange_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that GETRANGE command errors out when compression is enabled."""
+        key = f"getrange_test_{get_random_string(8)}"
+        value = generate_compressible_text(1024)
+
+        # First set a value
+        compression_client.set(key, value)
+
+        # GETRANGE should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.getrange(key, 0, 10)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_setrange_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that SETRANGE command errors out when compression is enabled."""
+        key = f"setrange_test_{get_random_string(8)}"
+        value = generate_compressible_text(1024)
+
+        # First set a value
+        compression_client.set(key, value)
+
+        # SETRANGE should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.setrange(key, 5, "replacement")
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_strlen_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that STRLEN command errors out when compression is enabled."""
+        key = f"strlen_test_{get_random_string(8)}"
+        value = generate_compressible_text(1024)
+
+        # First set a value
+        compression_client.set(key, value)
+
+        # STRLEN should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.strlen(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_incr_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that INCR command errors out when compression is enabled."""
+        key = f"incr_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        compression_client.set(key, "100")
+
+        # INCR should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.incr(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_incrby_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that INCRBY command errors out when compression is enabled."""
+        key = f"incrby_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        compression_client.set(key, "100")
+
+        # INCRBY should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.incrby(key, 10)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_incrbyfloat_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that INCRBYFLOAT command errors out when compression is enabled."""
+        key = f"incrbyfloat_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        compression_client.set(key, "100.5")
+
+        # INCRBYFLOAT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.incrbyfloat(key, 0.5)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_decr_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that DECR command errors out when compression is enabled."""
+        key = f"decr_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        compression_client.set(key, "100")
+
+        # DECR should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.decr(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_decrby_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that DECRBY command errors out when compression is enabled."""
+        key = f"decrby_test_{get_random_string(8)}"
+
+        # First set a numeric value
+        compression_client.set(key, "100")
+
+        # DECRBY should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.decrby(key, 10)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_getbit_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that GETBIT command errors out when compression is enabled."""
+        key = f"getbit_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "test_value")
+
+        # GETBIT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.getbit(key, 0)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_setbit_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that SETBIT command errors out when compression is enabled."""
+        key = f"setbit_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "test_value")
+
+        # SETBIT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.setbit(key, 0, 1)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_bitcount_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that BITCOUNT command errors out when compression is enabled."""
+        key = f"bitcount_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "test_value")
+
+        # BITCOUNT should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.bitcount(key)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_bitpos_incompatible_with_compression(
+        self, compression_client: TGlideClient
+    ):
+        """Test that BITPOS command errors out when compression is enabled."""
+        key = f"bitpos_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "test_value")
+
+        # BITPOS should fail with compression enabled
+        with pytest.raises(Exception) as exc_info:
+            compression_client.bitpos(key, 1)
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_incompatible_commands_work_without_compression(
+        self, no_compression_client: TGlideClient
+    ):
+        """Test that incompatible commands work normally when compression is disabled."""
+        key = f"no_compression_test_{get_random_string(8)}"
+
+        # Set initial value
+        no_compression_client.set(key, "100")
+
+        # All these commands should work without compression
+        # INCR
+        result = no_compression_client.incr(key)
+        assert result == 101
+
+        # INCRBY
+        result = no_compression_client.incrby(key, 10)
+        assert result == 111
+
+        # DECR
+        result = no_compression_client.decr(key)
+        assert result == 110
+
+        # DECRBY
+        result = no_compression_client.decrby(key, 10)
+        assert result == 100
+
+        # STRLEN
+        no_compression_client.set(key, "hello")
+        result = no_compression_client.strlen(key)
+        assert result == 5
+
+        # APPEND
+        result = no_compression_client.append(key, " world")
+        assert result == 11  # "hello world" = 11 chars
+
+        # GETRANGE
+        result = no_compression_client.getrange(key, 0, 4)
+        assert result == b"hello"
+
+        # SETRANGE
+        result = no_compression_client.setrange(key, 6, "WORLD")
+        assert result == 11
+
+        # GETBIT
+        no_compression_client.set(key, "\x00")
+        result = no_compression_client.getbit(key, 0)
+        assert result == 0
+
+        # SETBIT
+        result = no_compression_client.setbit(key, 0, 1)
+        assert result == 0  # Previous value was 0
+
+        # BITCOUNT
+        result = no_compression_client.bitcount(key)
+        assert result >= 0
+
+        # Cleanup
+        no_compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_incompatible_commands_via_custom_command(
+        self, compression_client: TGlideClient
+    ):
+        """Test that incompatible commands also error out when called via custom_command."""
+        key = f"custom_cmd_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "100")
+
+        # INCR via custom_command should fail
+        with pytest.raises(Exception) as exc_info:
+            compression_client.custom_command(
+                cast(List[Union[str, bytes]], ["INCR", key])
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # APPEND via custom_command should fail
+        with pytest.raises(Exception) as exc_info:
+            compression_client.custom_command(
+                cast(List[Union[str, bytes]], ["APPEND", key, "_suffix"])
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # STRLEN via custom_command should fail
+        with pytest.raises(Exception) as exc_info:
+            compression_client.custom_command(
+                cast(List[Union[str, bytes]], ["STRLEN", key])
+            )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_incompatible_commands_in_batch(
+        self, compression_client: TGlideClient, cluster_mode: bool
+    ):
+        """Test that incompatible commands in batch operations also error out."""
+        key = f"batch_incompatible_test_{get_random_string(8)}"
+
+        # First set a value
+        compression_client.set(key, "100")
+
+        # Create batch with incompatible command
+        batch = (
+            Batch(is_atomic=False)
+            if isinstance(compression_client, GlideClient)
+            else ClusterBatch(is_atomic=False)
+        )
+        batch.incr(key)  # This should cause an error
+
+        # Execute batch - should fail due to incompatible command
+        with pytest.raises(Exception) as exc_info:
+            if isinstance(compression_client, GlideClient):
+                cast(GlideClient, compression_client).exec(
+                    cast(Batch, batch), raise_on_error=True
+                )
+            else:
+                cast(GlideClusterClient, compression_client).exec(
+                    cast(ClusterBatch, batch), raise_on_error=True
+                )
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "incompatible" in error_msg or "compression" in error_msg
+        ), f"Error should mention incompatibility with compression: {exc_info.value}"
+
+        # Cleanup
+        compression_client.delete([key])

--- a/python/tests/sync_tests/test_sync_compression.py
+++ b/python/tests/sync_tests/test_sync_compression.py
@@ -1667,33 +1667,33 @@ class TestCompressionIncompatibleCommands:
 
         # STRLEN
         no_compression_client.set(key, "hello")
-        result = no_compression_client.strlen(key)
-        assert result == 5
+        strlen_result = no_compression_client.strlen(key)
+        assert strlen_result == 5
 
         # APPEND
-        result = no_compression_client.append(key, " world")
-        assert result == 11  # "hello world" = 11 chars
+        append_result = no_compression_client.append(key, " world")
+        assert append_result == 11  # "hello world" = 11 chars
 
         # GETRANGE
-        result = no_compression_client.getrange(key, 0, 4)
-        assert result == b"hello"
+        getrange_result = no_compression_client.getrange(key, 0, 4)
+        assert getrange_result == b"hello"
 
         # SETRANGE
-        result = no_compression_client.setrange(key, 6, "WORLD")
-        assert result == 11
+        setrange_result = no_compression_client.setrange(key, 6, "WORLD")
+        assert setrange_result == 11
 
         # GETBIT
         no_compression_client.set(key, "\x00")
-        result = no_compression_client.getbit(key, 0)
-        assert result == 0
+        getbit_result = no_compression_client.getbit(key, 0)
+        assert getbit_result == 0
 
         # SETBIT
-        result = no_compression_client.setbit(key, 0, 1)
-        assert result == 0  # Previous value was 0
+        setbit_result = no_compression_client.setbit(key, 0, 1)
+        assert setbit_result == 0  # Previous value was 0
 
         # BITCOUNT
-        result = no_compression_client.bitcount(key)
-        assert result >= 0
+        bitcount_result = no_compression_client.bitcount(key)
+        assert bitcount_result >= 0
 
         # Cleanup
         no_compression_client.delete([key])


### PR DESCRIPTION
### Summary

This PR adds tests and support for all supported compression commands to Node, Go, Java.

It also blocks unsupported compression commands from being used when compression configuration is enabled.

### Issue link

This Pull Request is linked to issue: [5299](https://github.com/valkey-io/valkey-glide/issues/5299)

### Features / Behaviour Changes

This PR adds safety guardrails for the experimental compression feature by blocking string commands that are incompatible with client-side compression.

When compression is enabled, the following commands now return an `IncompatibleCommand` error with a descriptive message:

**String manipulation commands:**
- `APPEND` - modifies string data server-side, would corrupt compressed values
- `GETRANGE` - returns substring of raw bytes, would return compressed data
- `SETRANGE` - modifies bytes at offset, would corrupt compressed values
- `STRLEN` - returns raw byte length, would return compressed size
- `LCS` - compares raw bytes, would compare compressed data
- `SUBSTR` - deprecated alias for GETRANGE

**Numeric operations:**
- `INCR`, `INCRBY`, `INCRBYFLOAT`, `DECR`, `DECRBY` - expect numeric strings but would receive compressed bytes

**Bit operations:**
- `GETBIT`, `SETBIT`, `BITCOUNT`, `BITPOS`, `BITFIELD`, `BITFIELD_RO`, `BITOP` - operate on raw binary data

Commands that remain compatible with compression:
- **Write (compress):** `SET`, `MSET`, `MSETNX`, `SETEX`, `PSETEX`, `SETNX`
- **Read (decompress):** `GET`, `MGET`, `GETEX`, `GETDEL`, `GETSET`

### Implementation

**Core changes (`glide-core`):**
- Added `IncompatibleCommand` variant to `CompressionError` enum in `compression.rs`
- Added `compression_incompatibility_reason()` method to `RequestType` that returns a descriptive reason for incompatible commands
- Modified `socket_listener.rs` to check command compatibility before execution when compression is enabled
- The check happens early in the request pipeline to fail fast with a clear error message

**FFI layer:**
- Updated `ffi/src/lib.rs` to propagate `IncompatibleCommand` errors through the FFI boundary
- Updated `java/src/lib.rs` for Java bindings

**Key design decisions:**
- Errors are returned at request time rather than silently corrupting data
- Each incompatible command has a specific reason explaining why it's blocked
- The check is only performed when compression is enabled (no overhead when disabled)

### Limitations

- Commands executed via `customCommand()` are also checked for compatibility
- There is no way to bypass the check for advanced users who understand the risks
- The feature remains experimental

### Testing

Added comprehensive integration tests across all client languages:

**Python** (`test_compression.py`, `test_sync_compression.py`):
- Tests for all supported commands (SET, GET, MSET, MGET, MSETNX, GETEX, GETDEL, SETEX, PSETEX, SETNX)
- Tests for all incompatible commands verifying they raise `RequestError` with appropriate message
- Tests verify compression statistics (`total_values_compressed`, `total_values_decompressed`) to confirm compression is actually happening

**Java** (`CompressionTests.java`):
- Parameterized tests for both standalone and cluster modes
- Tests for supported commands with compression stat validation
- Tests for incompatible commands verifying `RequestException` is thrown

**Node.js** (`Compression.test.ts`):
- Parameterized tests with `cluster_mode` true/false
- Tests for supported commands with compression stat validation
- Tests for incompatible commands verifying error is thrown

**Go** (`compression_test.go`):
- Tests for supported commands with compression stat validation
- Tests for incompatible commands verifying error is returned

**Rust** (`test_compression.rs`):
- Unit tests for `compression_incompatibility_reason()` method
- Tests verifying all incompatible commands return appropriate reasons
### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
