### PR TITLE
Cherry pick/java cd deployment fixes to release 2.3

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -56,7 +56,7 @@ jobs:
               id: release-version
               shell: bash
               run: |
-                  if ${{ github.event_name == 'workflow_dispatch' }}; then
+                  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
                       R_VERSION="${{ env.INPUT_VERSION }}"
                   else
                       R_VERSION=${GITHUB_REF:11}
@@ -169,7 +169,7 @@ jobs:
                     # Build and publish client first
                     $GRADLE_CMD --build-cache :client:publishToMavenLocal -Psigning.secretKeyRingFile=secring.gpg \
                     -Psigning.password="${{ secrets.GPG_PASSWORD }}" -Psigning.keyId=${{ secrets.GPG_KEY_ID }} \
-                    -Ptarget=${{ matrix.host.TARGET }}
+                    -Ptarget=${{ matrix.host.TARGET }} $EXTRA_ARGS
 
                     # Then build jedis-compatibility
                     $GRADLE_CMD --build-cache :jedis-compatibility:publishToMavenLocal -Psigning.secretKeyRingFile=secring.gpg \
@@ -178,7 +178,7 @@ jobs:
                   else
                     # Build and publish client first
                     $GRADLE_CMD --build-cache :client:publishToMavenLocal -Psigning.secretKeyRingFile=secring.gpg \
-                    -Psigning.password="${{ secrets.GPG_PASSWORD }}" -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
+                    -Psigning.password="${{ secrets.GPG_PASSWORD }}" -Psigning.keyId=${{ secrets.GPG_KEY_ID }} $EXTRA_ARGS
 
                     # Then build jedis-compatibility
                     $GRADLE_CMD --build-cache :jedis-compatibility:publishToMavenLocal -Psigning.secretKeyRingFile=secring.gpg \
@@ -392,10 +392,10 @@ jobs:
               id: maven-deployment
               shell: bash
               run: |
-                  export DEPLOYMENT_ID=`curl --request POST \
+                  export DEPLOYMENT_ID=$(curl --fail --request POST \
                   -u "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" \
                   --form bundle=@build.zip \
-                  https://central.sonatype.com/api/v1/publisher/upload | tail -n 1`
+                  https://central.sonatype.com/api/v1/publisher/upload | tail -n 1)
                   echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_ENV
                   echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
                   echo Uploaded to Maven deployment with deployment ID $DEPLOYMENT_ID. Will be released if smoke tests pass and approved for release.
@@ -405,12 +405,12 @@ jobs:
               run: |
                   for ((retries = 0; retries < 20; retries++)); do
                       sleep 5
-                      export DEPLOYMENT_STATUS=`curl --request POST \
+                      export DEPLOYMENT_STATUS=$(curl --request POST \
                       -u "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" \
                       "https://central.sonatype.com/api/v1/publisher/status?id=${{ env.DEPLOYMENT_ID }}" \
-                      | jq '.deploymentState'`
+                      | jq -r '.deploymentState')
 
-                      if [[ $DEPLOYMENT_STATUS == ""\"VALIDATED"\"" ]]; then exit 0; fi
+                      if [[ $DEPLOYMENT_STATUS == "VALIDATED" ]]; then exit 0; fi
                   done
 
                   curl --request POST \
@@ -501,18 +501,18 @@ jobs:
             - name: Wait for deployment artifacts to be available
               shell: bash
               run: |
-                  AUTH_HEADER="Bearer $(echo "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"
+                  AUTH_HEADER="Bearer $(echo -n "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"
                   ARTIFACT_URL="https://central.sonatype.com/api/v1/publisher/deployments/download/io/valkey/valkey-glide/${{ env.RELEASE_VERSION }}/valkey-glide-${{ env.RELEASE_VERSION }}.pom"
-                  for ((retries = 0; retries < 20; retries++)); do
-                      sleep 10
+                  for ((retries = 0; retries < 6; retries++)); do
                       HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $AUTH_HEADER" "$ARTIFACT_URL")
                       if [ "$HTTP_STATUS" = "200" ]; then
-                          echo "Artifact available after $((retries * 10))s"
+                          echo "Artifact available"
                           exit 0
                       fi
-                      echo "Attempt $retries: HTTP $HTTP_STATUS, waiting 10s..."
+                      echo "Attempt $((retries + 1))/6: HTTP $HTTP_STATUS, waiting 5s..."
+                      sleep 5
                   done
-                  echo "Artifact not available after 200s, proceeding anyway"
+                  echo "::warning::Artifact not available after 30s, proceeding anyway (deployment already validated)"
 
             - name: Start standalone Valkey server
               working-directory: utils
@@ -520,6 +520,10 @@ jobs:
               shell: bash
               run: |
                   PORT=$(python3 ./cluster_manager.py start -r 0 2>&1 | grep CLUSTER_NODES | cut -d = -f 2 | cut -d , -f 1 | cut -d : -f 2)
+                  if [ -z "$PORT" ]; then
+                      echo "Failed to extract PORT from cluster_manager.py output"
+                      exit 1
+                  fi
                   echo "PORT=$PORT" >> $GITHUB_OUTPUT
 
             - name: Test deployment
@@ -530,7 +534,7 @@ jobs:
                   GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=120000 -Dorg.gradle.internal.http.socketTimeout=120000"
               run: |
                   export ORG_GRADLE_PROJECT_centralManualTestingAuthHeaderName="Authorization"
-                  export ORG_GRADLE_PROJECT_centralManualTestingAuthHeaderValue="Bearer $(echo "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"
+                  export ORG_GRADLE_PROJECT_centralManualTestingAuthHeaderValue="Bearer $(echo -n "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"
                   export GLIDE_RELEASE_VERSION=${{ env.RELEASE_VERSION }}
                   ./gradlew --build-cache :benchmarks:run --args="--minimal --clients glide --port ${{ env.PORT }}"
 
@@ -548,7 +552,7 @@ jobs:
         steps:
             - name: Publish to Maven
               run: |
-                  curl --request POST \
+                  curl --fail --request POST \
                   -u "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" \
                   "https://central.sonatype.com/api/v1/publisher/deployment/${{ env.DEPLOYMENT_ID }}"
 

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -463,7 +463,7 @@ jobs:
               run: |
                   # Set environment variable to indicate container environment for Gradle
                   echo "GLIDE_CONTAINER_BUILD=true" >> $GITHUB_ENV
-                  apk add openjdk11 git bash
+                  apk add openjdk11 git bash curl
                   export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
                   # Create gradle user home and disable auto-download
                   mkdir -p ~/.gradle
@@ -502,7 +502,7 @@ jobs:
               shell: bash
               run: |
                   AUTH_HEADER="Bearer $(echo "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"
-                  ARTIFACT_URL="https://central.sonatype.com/api/v1/publisher/deployments/download/${{ needs.publish-to-maven-central-deployment.outputs.DEPLOYMENT_ID }}/io/valkey/valkey-glide/${{ env.RELEASE_VERSION }}/valkey-glide-${{ env.RELEASE_VERSION }}.pom"
+                  ARTIFACT_URL="https://central.sonatype.com/api/v1/publisher/deployments/download/io/valkey/valkey-glide/${{ env.RELEASE_VERSION }}/valkey-glide-${{ env.RELEASE_VERSION }}.pom"
                   for ((retries = 0; retries < 20; retries++)); do
                       sleep 10
                       HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $AUTH_HEADER" "$ARTIFACT_URL")

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -498,6 +498,22 @@ jobs:
                       ${{ runner.os }}-gradle-cd-
                       ${{ runner.os }}-gradle-
 
+            - name: Wait for deployment artifacts to be available
+              shell: bash
+              run: |
+                  AUTH_HEADER="Bearer $(echo "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"
+                  ARTIFACT_URL="https://central.sonatype.com/api/v1/publisher/deployments/download/${{ needs.publish-to-maven-central-deployment.outputs.DEPLOYMENT_ID }}/io/valkey/valkey-glide/${{ env.RELEASE_VERSION }}/valkey-glide-${{ env.RELEASE_VERSION }}.pom"
+                  for ((retries = 0; retries < 20; retries++)); do
+                      sleep 10
+                      HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $AUTH_HEADER" "$ARTIFACT_URL")
+                      if [ "$HTTP_STATUS" = "200" ]; then
+                          echo "Artifact available after $((retries * 10))s"
+                          exit 0
+                      fi
+                      echo "Attempt $retries: HTTP $HTTP_STATUS, waiting 10s..."
+                  done
+                  echo "Artifact not available after 200s, proceeding anyway"
+
             - name: Start standalone Valkey server
               working-directory: utils
               id: port
@@ -511,6 +527,7 @@ jobs:
               shell: bash
               env:
                   PORT: ${{ steps.port.outputs.PORT }}
+                  GRADLE_OPTS: "-Dorg.gradle.internal.http.connectionTimeout=120000 -Dorg.gradle.internal.http.socketTimeout=120000"
               run: |
                   export ORG_GRADLE_PROJECT_centralManualTestingAuthHeaderName="Authorization"
                   export ORG_GRADLE_PROJECT_centralManualTestingAuthHeaderValue="Bearer $(echo "${{ secrets.CENTRAL_TOKEN_USERNAME }}:${{ secrets.CENTRAL_TOKEN_PASSWORD }}" | base64)"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -46,6 +46,9 @@ subprojects {
                 authentication {
                     header(HttpHeaderAuthentication)
                 }
+                content {
+                    includeGroup "io.valkey"
+                }
             }
         }
         mavenCentral()


### PR DESCRIPTION
### Summary

Cherry-pick the PRs needed to fix and clean up the Java deployment workflow
- [Scope Sonatype deployment repo to io.valkey group #5770](https://github.com/valkey-io/valkey-glide/pull/5770)
- [Wait for artifact test deployment #5784](https://github.com/valkey-io/valkey-glide/pull/5784)
- [Correct URL for artifact wait #5785](https://github.com/valkey-io/valkey-glide/pull/5785)
- [Misc upgrades to Java deployment workflow #5786](https://github.com/valkey-io/valkey-glide/pull/5786)

### Issue link
n/a

### Features / Behaviour Changes
- Sonatype deployment repository is now scoped to the `io.valkey` group via `includeGroup`, preventing Gradle from attempting to resolve unrelated dependencies (guava, jedis, lettuce, etc.) from the staged deployment endpoint, which was causing timeout failures.
- A retry loop waits for deployment artifacts to become available before running test-deployment, with `curl` added to the Alpine container's package list.
- The artifact download URL is corrected to remove the erroneous `deployments/download/$DEPLOYMENT_ID/` path segment.
- `curl --fail` is added to all Maven Central API calls (upload, status check, publish) so HTTP 4xx/5xx responses are no longer silently treated as success.
- `echo -n` is used for base64-encoded auth tokens to prevent a trailing newline from being encoded into the credential.
- Deployment status comparison uses `jq -r` with a clean `"VALIDATED"` string match instead of the fragile escaped-quote pattern.
- The artifact availability retry loop tolerates transient curl failures (`|| true`) instead of aborting under `set -eo pipefail`.
- PORT validation is added after `cluster_manager.py` output parsing, failing fast with a clear message if empty.
- The `set-release-version` event name check uses `[[ ]]` string comparison instead of bare `${{ }}` interpolation to prevent potential script injection.

### Implementation
These are direct cherry-picks from `release-2.2` into this branch. The auto-generated attribution commit (#5748) was skipped as it is specific to the `release-2.2` dependency tree. One merge conflict in `.github/workflows/java-cd.yml` was resolved by accepting the incoming `$EXTRA_ARGS` addition to the Gradle publish commands.

### Limitations
- The `drop-deployment-if-validation-fails` job's `curl --request DELETE` intentionally does not include `--fail` — a failure to drop a deployment during cleanup should not mask the original error.
- The `echo -n` fix only applies to the `test-deployment-on-all-architectures` job. The `publish-to-maven-central-deployment` job runs on `ubuntu-latest` (not Alpine) where the existing behavior has been working, so it was left unchanged.

### Testing
No runtime tests — these are CI/CD workflow changes that can only be validated by triggering the deployment pipeline. See the original PRs for detailed validation notes.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~
-   [ ] ~CHANGELOG.md and documentation files are updated.~
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
