### PR TITLE
fix(glide-core,java): rate-limit high-frequency diagnostic logs during failover

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -1642,8 +1642,9 @@ where
             }
 
             let handle = tokio::spawn(async move {
-                log_info_lazy!(
+                log_info_rate_limited!(
                     "cluster",
+                    10,
                     format!(
                         "refreshing connection task to {:?} started",
                         address_clone_for_task
@@ -1710,8 +1711,9 @@ where
 
                 match node_result {
                     Ok(node) => {
-                        log_info_lazy!(
+                        log_info_rate_limited!(
                             "cluster",
+                            10,
                             format!(
                                 "Succeeded to refresh connection for node {}.",
                                 address_clone_for_task
@@ -3272,8 +3274,9 @@ where
                 match handle.now_or_never() {
                     Some(Ok(Ok(()))) => {
                         // Task succeeded
-                        log_info_lazy!(
+                        log_info_rate_limited!(
                             "slot_refresh",
+                            10,
                             "poll_recover: slot refresh completed successfully, recovery complete"
                         );
                         self.state = ConnectionState::PollComplete;
@@ -3666,8 +3669,9 @@ where
                 }
                 PollFlushAction::RebuildSlots => {
                     let in_flight = self.in_flight_requests.len();
-                    log_info_lazy!(
+                    log_info_rate_limited!(
                         "cluster",
+                        10,
                         format!(
                             "poll_flush: transitioning to RebuildSlots, in_flight_requests={}",
                             in_flight
@@ -3685,7 +3689,7 @@ where
                 }
                 PollFlushAction::ReconnectFromInitialConnections => {
                     let in_flight = self.in_flight_requests.len();
-                    log_info_lazy!("cluster", format!(
+                    log_info_rate_limited!("cluster", 10, format!(
                         "poll_flush: transitioning to ReconnectFromInitialConnections, in_flight_requests={}",
                         in_flight));
                     self.state =
@@ -3695,7 +3699,7 @@ where
                 }
                 PollFlushAction::Reconnect(addresses) => {
                     let in_flight = self.in_flight_requests.len();
-                    log_info_lazy!("cluster", format!(
+                    log_info_rate_limited!("cluster", 10, format!(
                         "poll_flush: transitioning to Reconnect(addresses={:?}), in_flight_requests={}",
                         addresses, in_flight));
                     self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(

--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -23,6 +23,21 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class AsyncRegistry {
 
+    /** Rate-limit interval for timeout/disconnect log messages (in nanoseconds) */
+    private static final long LOG_RATE_LIMIT_NS = 5_000_000_000L; // 5 seconds
+
+    /** Last log timestamp for timeout errors */
+    private static final AtomicLong lastTimeoutLogNs = new AtomicLong(0);
+
+    /** Last log timestamp for disconnect errors */
+    private static final AtomicLong lastDisconnectLogNs = new AtomicLong(0);
+
+    /** Suppressed timeout log count since last emitted log */
+    private static final AtomicLong suppressedTimeoutLogs = new AtomicLong(0);
+
+    /** Suppressed disconnect log count since last emitted log */
+    private static final AtomicLong suppressedDisconnectLogs = new AtomicLong(0);
+
     /** Thread-safe storage for active futures Using ConcurrentHashMap for lock-free operations */
     private static final ConcurrentHashMap<Long, CompletableFuture<Object>> activeFutures =
             // Size based on max inflight requests with a small margin
@@ -206,16 +221,29 @@ public final class AsyncRegistry {
                         ? "Unknown error from native code"
                         : errorMessage;
 
-        // Log elapsed time for timeout and disconnect errors
+        // Log elapsed time for timeout and disconnect errors (rate-limited to avoid log spam during
+        // failover)
         if (errorTypeCode == 2 || errorTypeCode == 3) {
             Long registeredAt = registrationTimestamps.get(correlationId);
             if (registeredAt != null) {
                 long elapsedMs = (System.nanoTime() - registeredAt) / 1_000_000;
-                String errorTypeName = errorTypeCode == 2 ? "Timeout" : "Disconnect";
-                Logger.log(
-                        Logger.Level.WARN,
-                        "AsyncRegistry",
-                        errorTypeName + " after " + elapsedMs + "ms: " + msg);
+                boolean isTimeout = errorTypeCode == 2;
+                AtomicLong lastLogRef = isTimeout ? lastTimeoutLogNs : lastDisconnectLogNs;
+                AtomicLong suppressedRef = isTimeout ? suppressedTimeoutLogs : suppressedDisconnectLogs;
+                String errorTypeName = isTimeout ? "Timeout" : "Disconnect";
+
+                long now = System.nanoTime();
+                long lastLog = lastLogRef.get();
+                if (now - lastLog >= LOG_RATE_LIMIT_NS && lastLogRef.compareAndSet(lastLog, now)) {
+                    long suppressed = suppressedRef.getAndSet(0);
+                    String suffix = suppressed > 0 ? " (suppressed " + suppressed + " similar)" : "";
+                    Logger.log(
+                            Logger.Level.WARN,
+                            "AsyncRegistry",
+                            errorTypeName + " after " + elapsedMs + "ms: " + msg + suffix);
+                } else {
+                    suppressedRef.incrementAndGet();
+                }
             }
         }
 


### PR DESCRIPTION
### Summary
Rate-limit noisy log messages that fire on every request/connection during failover scenarios, reducing log spam while preserving diagnostic value:

Java (AsyncRegistry):
- Rate-limit Timeout/Disconnect WARN logs to once per 5 seconds per error type
- Include suppressed count in emitted messages for visibility

Rust (cluster_async):
- Rate-limit poll_flush transition logs (RebuildSlots, Reconnect) to 10s
- Rate-limit connection refresh task started/succeeded logs to 10s

These logs were firing thousands of times during failover (e.g., 7250 poll_flush, 6473 refreshing connection, 1875 AsyncRegistry messages in a 4-minute window).

### Issue link
n/a

### Features / Behaviour Changes
No changes other than rate-limiting particular logging messages.

### Implementation
Apply the rate-limitter logging macro to additional logs that occurred frequently during failover.

### Limitations
n/a

### Testing
Manually verified redundant logging is reduced.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
