### PR TITLE
Forward-port to release-2.3: Invalidate JNI method cache on callback failure for client recovery (#5666)

### DIFF
--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -55,6 +55,22 @@ pub extern "system" fn JNI_OnUnload(_vm: *const JavaVM, _reserved: *const c_void
     crate::cleanup_global_caches();
 }
 
+/// Invalidate cached JNI method IDs so the next call re-initializes them.
+/// Called when callback completion fails — stale method IDs (e.g. from classloader
+/// changes) would cause every subsequent callback to fail permanently. Clearing the
+/// cache lets the fallback `find_class` path re-discover the correct method IDs.
+///
+/// Safe to call at any time: the Mutex<Option<...>> pattern means the next caller
+/// will re-populate the cache from the current JNIEnv.
+fn invalidate_jni_caches() {
+    if let Some(cache_mutex) = METHOD_CACHE.get() {
+        *cache_mutex.lock() = None;
+    }
+    if let Some(cache_mutex) = GLIDE_CORE_CLIENT_CACHE.get() {
+        *cache_mutex.lock() = None;
+    }
+}
+
 // Type aliases for complex types
 type PushMessageTuple = (Vec<u8>, Vec<u8>, Option<Vec<u8>>);
 type CallbackResult = Result<ServerValue, ServerError>;
@@ -432,6 +448,11 @@ fn process_callback_job_with_env(
                     if let Err(e) = complete_java_callback(env, callback_id, &java_result) {
                         log::error!("JNI completion failed for callback {callback_id}: {e}");
                         let _ = env.exception_clear();
+                        invalidate_jni_caches();
+                        fail_all_pending_futures(
+                            env,
+                            "JNI callback completion failed — cached method IDs may be stale",
+                        );
                     }
                 }
                 Err(e) => {
@@ -445,6 +466,11 @@ fn process_callback_job_with_env(
                     ) {
                         log::error!("JNI error completion failed for callback {callback_id}: {e2}");
                         let _ = env.exception_clear();
+                        invalidate_jni_caches();
+                        fail_all_pending_futures(
+                            env,
+                            "JNI error callback completion failed — cached method IDs may be stale",
+                        );
                     }
                 }
             }
@@ -462,6 +488,11 @@ fn process_callback_job_with_env(
             {
                 log::error!("JNI error completion failed for callback {callback_id}: {e}");
                 let _ = env.exception_clear();
+                invalidate_jni_caches();
+                fail_all_pending_futures(
+                    env,
+                    "JNI error callback completion failed — cached method IDs may be stale",
+                );
             }
         }
     }


### PR DESCRIPTION
### Summary

Forward-port of `invalidate_jni_caches()` from `release-2.2` to `release-2.3`.

PR #5536 fixed swallowed errors in the JNI async bridge on `main`, and was cherry-picked to `release-2.3` via #5683. However, the `release-2.2` backport (#5664) included an additional fix — `invalidate_jni_caches()` — that was not part of the original PR or the `release-2.3` cherry-pick. This function clears stale `METHOD_CACHE` and `GLIDE_CORE_CLIENT_CACHE` when JNI callback completion fails, allowing the client to recover by re-initializing fresh method IDs on the next call instead of being permanently broken until JVM restart.

Without this fix, if cached `JStaticMethodID`s become invalid (e.g. classloader GC, Spring Boot context refresh, Lettuce coexistence), every subsequent callback fails permanently — the `OnceLock<Mutex<Option<...>>>` holds stale `Some(...)` forever.

### Implementation

Single file change in `java/src/jni_client.rs` (31 lines added):

1. **`invalidate_jni_caches()` function** — clears both `METHOD_CACHE` and `GLIDE_CORE_CLIENT_CACHE` to `None`, forcing re-initialization via `find_class` on the next access.

2. **3 call sites in `process_callback_job_with_env()`** — on each JNI callback completion error path, after `exception_clear()`, calls `invalidate_jni_caches()` then `fail_all_pending_futures()` to sweep all pending futures with `ClosingException`.

This matches the behavior already shipping in `release-2.2` since #5664.
