### PR TITLE
Bump protobufjs dependency

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "long": "5",
-        "protobufjs": "7"
+        "protobufjs": "8"
     },
     "keywords": [
         "valkey",


### PR DESCRIPTION
protobufjs has a new major version, this add support for it.
https://github.com/protobufjs/protobuf.js/releases/tag/protobufjs-v8.0.0