### PR TITLE
Core: trigger topology refresh on ConnectionNotFoundForRoute in fanout operations

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -1283,7 +1283,19 @@ impl<C> Future for Request<C> {
                     OperationTarget::FanOut => {
                         trace!("Request error `{}` multi-node request", err);
 
-                        // Fanout operation are retried per internal request, and don't need additional retries.
+                        // Fanout operations are retried per internal request, and don't need additional retries.
+                        // If the error is ConnectionNotFoundForRoute, trigger a slot refresh
+                        // to discover potential topology changes (e.g., failover).
+                        if err.kind() == ErrorKind::ConnectionNotFoundForRoute {
+                            let mut request = this.request.take().unwrap();
+                            request.info.reset_routing();
+                            return Next::RefreshSlots {
+                                request: Some(request),
+                                sleep_duration: Some(sleep_duration),
+                                moved_redirect: None,
+                            }
+                            .into();
+                        }
                         self.respond(Err(err));
                         return Next::Done.into();
                     }


### PR DESCRIPTION
## Summary

During cluster failover with periodic topology checks disabled, multi-key commands (e.g., DEL with multiple keys) that are split into per-node sub-requests via fanout fail silently when a node connection is unavailable. The error goes through `OperationTarget::FanOut` which returns `Next::Done` — no slot refresh, no topology discovery.

This causes the client to be stuck for 5+ minutes because the fanout path never triggers topology re-discovery. Recovery only happens when the dead node is replaced and returns a MOVED error.

### Root Cause

When a multi-key command is fanned out, sub-requests for unreachable nodes get `ConnectionNotFoundForRoute` injected directly into their channel. The aggregate error returns `OperationTarget::FanOut`, which previously returned `Next::Done` — a dead end with no recovery action. With periodic topology checks disabled, the client has no mechanism to discover the new primary.

### Fix

When a fanout operation fails with `ConnectionNotFoundForRoute`, trigger `Next::RefreshSlots` (same as `OperationTarget::NotFound`) to discover topology changes via slot refresh. The request is retried after the refresh.

