### PR TITLE
Fix Python client side cache test to use anyio

### DIFF
--- a/python/tests/async_tests/test_client_side_cache.py
+++ b/python/tests/async_tests/test_client_side_cache.py
@@ -1,6 +1,5 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-import asyncio
-
+import anyio
 import pytest
 from glide_shared import RequestError
 from glide_shared.cache import ClientSideCache, EvictionPolicy
@@ -162,7 +161,7 @@ class TestClientSideCache:
         assert await client.get("ttl_key") == b"ttl_value"
 
         # Wait for TTL to expire
-        await asyncio.sleep(3)
+        await anyio.sleep(3)
 
         # GET after expiration - should fetch from server again
         assert await client.get("ttl_key") == b"ttl_value"
@@ -468,7 +467,7 @@ class TestClientSideCache:
         assert await client.get_cache_entry_count() == 1, "Expected 1 entry in cache"
 
         # Wait a bit and verify entry is still cached (no TTL expiration)
-        await asyncio.sleep(3)
+        await anyio.sleep(3)
 
         # GET should still be a cache hit (no expiration)
         assert await client.get("no_ttl_key") == b"no_ttl_value"


### PR DESCRIPTION
### Summary

This PR fixes `test_client_side_cache.py` to use `anyio` instead of `asyncio`. This allows it to not break when `--async-backend=trio` is specified.

### Context
Recent FMT tests found python tests consistently failed for `trio` backend. Issue was traced to usage of asyncio in the code which would break when `trio` is used.

This error was introduced in #5127. PR check did not catch this because it only run against `asyncio`

### Changes

Tests now use `aynio` which is the backend-agnostic async API.

### Testing

Test verified locally to pass with `trio`

```
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[asyncio-ProtocolVersion.RESP2-True] SKIPPED (asyncio is excluded)                                                                                                              [  4%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[asyncio-ProtocolVersion.RESP2-False] SKIPPED (asyncio is excluded)                                                                                                             [  8%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[asyncio-ProtocolVersion.RESP3-True] SKIPPED (asyncio is excluded)                                                                                                              [ 12%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[asyncio-ProtocolVersion.RESP3-False] SKIPPED (asyncio is excluded)                                                                                                             [ 16%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[uvloop-ProtocolVersion.RESP2-True] SKIPPED (uvloop is excluded)                                                                                                                [ 20%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[uvloop-ProtocolVersion.RESP2-False] SKIPPED (uvloop is excluded)                                                                                                               [ 25%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[uvloop-ProtocolVersion.RESP3-True] SKIPPED (uvloop is excluded)                                                                                                                [ 29%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[uvloop-ProtocolVersion.RESP3-False] SKIPPED (uvloop is excluded)                                                                                                               [ 33%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[trio-ProtocolVersion.RESP2-True] PASSED                                                                                                                                        [ 37%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[trio-ProtocolVersion.RESP2-False] PASSED                                                                                                                                       [ 41%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[trio-ProtocolVersion.RESP3-True] PASSED                                                                                                                                        [ 45%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_ttl_expiration[trio-ProtocolVersion.RESP3-False] PASSED                                                                                                                                       [ 50%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[asyncio-ProtocolVersion.RESP2-True] SKIPPED (asyncio is excluded)                                                                                                           [ 54%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[asyncio-ProtocolVersion.RESP2-False] SKIPPED (asyncio is excluded)                                                                                                          [ 58%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[asyncio-ProtocolVersion.RESP3-True] SKIPPED (asyncio is excluded)                                                                                                           [ 62%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[asyncio-ProtocolVersion.RESP3-False] SKIPPED (asyncio is excluded)                                                                                                          [ 66%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[uvloop-ProtocolVersion.RESP2-True] SKIPPED (uvloop is excluded)                                                                                                             [ 70%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[uvloop-ProtocolVersion.RESP2-False] SKIPPED (uvloop is excluded)                                                                                                            [ 75%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[uvloop-ProtocolVersion.RESP3-True] SKIPPED (uvloop is excluded)                                                                                                             [ 79%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[uvloop-ProtocolVersion.RESP3-False] SKIPPED (uvloop is excluded)                                                                                                            [ 83%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[trio-ProtocolVersion.RESP2-True] PASSED                                                                                                                                     [ 87%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[trio-ProtocolVersion.RESP2-False] PASSED                                                                                                                                    [ 91%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[trio-ProtocolVersion.RESP3-True] PASSED                                                                                                                                     [ 95%]
tests/async_tests/test_client_side_cache.py::TestClientSideCache::test_cache_no_ttl_expiration[trio-ProtocolVersion.RESP3-False] PASSED                                                                                                                                    [100%]
```

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
