### PR TITLE
chore: Clean up deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,13 +25,7 @@ ignore = [
     # bincode is unmaintained but only used as a transitive dev dependency
     # via iai-callgrind for benchmarking. No security impact.
     # https://rustsec.org/advisories/RUSTSEC-2025-0141
-    "RUSTSEC-2025-0141",
-    # rand is unsound with custom logger using rand::rng(), but only used as
-    # a transitive dependency (nanoid, opentelemetry_sdk, tower). Glide doesn't
-    # use a custom logger that calls rand::thread_rng(). No 0.8.x patch exists
-    # and direct dependency bumped to 0.9.4, which is patched.
-    # https://rustsec.org/advisories/RUSTSEC-2026-0097
-    "RUSTSEC-2026-0097",
+    "RUSTSEC-2025-0141"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -62,12 +56,9 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "ISC",
-    "OpenSSL",
     "MPL-2.0",
-    "Unicode-3.0",
     "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
### Changes

Cleanup `deny.toml`:

- Removed stale `RUSTSEC-2026-0097` advisory ignore. (Followup to #5739).
- Removed unused license allowances: `Unicode-DFS-2016`, `OpenSSL`, and duplicate `Unicode-3.0`