### PR TITLE
Fix error log credentials potentially leaking sensitive information

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1243,8 +1243,8 @@ fn create_client_from_uri_internal(
             .map_err(|e| format!("Invalid UTF-8 in URI: {}", e))?
     };
 
-    let url = parse_connection_url(uri_string)
-        .ok_or_else(|| format!("Invalid connection URI: {}", uri_string))?;
+    let url =
+        parse_connection_url(uri_string).ok_or_else(|| "Invalid connection URI".to_string())?;
 
     // Build base ConnectionRequest from URI
     let mut request = connection_request::ConnectionRequest::new();
@@ -1362,8 +1362,14 @@ fn apply_json_options(
     request: &mut connection_request::ConnectionRequest,
     json_str: &str,
 ) -> Result<(), String> {
-    let json_value: serde_json::Value =
-        serde_json::from_str(json_str).map_err(|e| format!("Invalid JSON: {}", e))?;
+    let json_value: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
+        format!(
+            "Invalid JSON in connection options: {:?} at line {}, column {}",
+            e.classify(),
+            e.line(),
+            e.column()
+        )
+    })?;
 
     if !json_value.is_object() {
         return Err("JSON options must be an object".to_string());


### PR DESCRIPTION
### Summary

Prevent credential and secret leakage in error messages produced by the `create_client_from_uri` FFI function. Previously, URI parse failures included the full URI string — including embedded passwords — in the error message. Additionally, JSON parse failures could leak fragments of sensitive fields like `client_key` (TLS private key material) via `serde_json` error output.

### Issue link

This Pull Request is linked to issue: n/a

### Features / Behaviour Changes

- URI parse error no longer includes the input URI. The message is now simply `"Invalid connection URI"` — the caller already knows what URI was passed.
- JSON parse error no longer uses the raw `serde_json::Error` display (which can echo input fragments). The message now reports only the error category, line, and column: e.g., `"Invalid JSON in connection options: Syntax at line 1, column 12"`.

### Implementation

Two changes in `ffi/src/lib.rs`:

1. `create_client_from_uri_internal`: Replaced `format!("Invalid connection URI: {}", uri_string)` with a static `"Invalid connection URI"` string. No redaction helper needed — omitting the input entirely is simpler and safer.

2. `apply_json_options`: Replaced `format!("Invalid JSON: {}", e)` with `format!("Invalid JSON in connection options: {:?} at line {}, column {}", e.classify(), e.line(), e.column())`. This uses `serde_json::Error::classify()` (returns an enum like `Syntax`, `Data`, `Eof`) plus positional info, which provides sufficient diagnostic value without echoing any input content.

### Limitations

- Error messages are now less specific about *what* was wrong with the URI. This is an intentional tradeoff — the caller has the original input and can inspect it directly.

### Testing

- Verified `cargo check` passes with no errors or warnings in the `glide-ffi` crate.
- Existing tests remain unaffected as the change only modifies error message content, not control flow.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] ~Tests are added or updated.~
- [ ] ~CHANGELOG.md and documentation files are updated.~
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
