### PR TITLE
Add debug-mode safety guards for FFI stack response and arena allocator

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -596,6 +596,18 @@ impl ClientAdapter {
                                     _ => unreachable!(),
                                 }
                                 unsafe { (success_callback)(request_id, &resp as *const _) };
+                                // Debug canary: poison the stack response after the
+                                // callback returns so that any binding that stashed the
+                                // pointer instead of copying will read obvious garbage
+                                // and trip sanitizers / debug assertions.
+                                #[cfg(debug_assertions)]
+                                unsafe {
+                                    std::ptr::write_bytes(
+                                        &mut resp as *mut CommandResponse as *mut u8,
+                                        0xDE,
+                                        std::mem::size_of::<CommandResponse>(),
+                                    );
+                                }
                                 return std::ptr::null_mut();
                             }
                             _ => {}
@@ -2006,6 +2018,14 @@ impl ResponseArena {
 
     /// Allocate a node in the arena, returning its index.
     fn alloc_node(&mut self) -> usize {
+        debug_assert!(
+            self.nodes.len() < self.nodes.capacity(),
+            "Arena node Vec would reallocate ({} nodes, capacity {}). \
+             This means count_nodes() underestimated — all previously handed-out \
+             pointers would be invalidated after finalize().",
+            self.nodes.len(),
+            self.nodes.capacity(),
+        );
         let idx = self.nodes.len();
         self.nodes.push(CommandResponse::default());
         idx


### PR DESCRIPTION
### Summary

Add debug-only safety guards for two low-severity security findings in `ffi/src/lib.rs`. Both guards are gated behind `debug_assertions` with zero runtime cost in release builds.

### Issue link

This Pull Request addresses security findings 3 and 4 from the Python sync optimizations security audit (PR #5635).

### Features / Behaviour Changes

No behaviour changes in release builds. In debug builds only:
- Stack-allocated `CommandResponse` is poisoned with `0xDE` after the callback returns, making use-after-free immediately visible to sanitizers.
- `ResponseArena::alloc_node()` asserts that the node `Vec` has remaining capacity, catching `count_nodes()` underestimates before silent memory corruption.

### Implementation

**Stack Response Use-After-Free Canary:**
After the stack fast-path success callback returns, the stack `CommandResponse` is overwritten with `0xDE` bytes via `std::ptr::write_bytes` under `#[cfg(debug_assertions)]`. Any binding that stashes the pointer instead of copying synchronously will read obvious garbage and trip sanitizers.

**Arena Allocator Node Undercount Guard:**
`debug_assert!(self.nodes.len() < self.nodes.capacity())` added in `alloc_node()`. If `count_nodes()` 
underestimates for a new `Value` variant, this fires before `Vec` reallocation invalidates all pointers that
`finalize()` would hand out.

### Limitations

These guards only fire in debug/test builds. Release builds are unaffected by design — the existing mitigations
(opt-in flag, correct `count_nodes` implementation, miri tests) remain the primary defense.

### Testing
Validated that the assertions trigger when using the debug_assertions configuration.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
