### PR TITLE
Enable PeriodicCheck parameter for Go Client in AdvancedClusterClient Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * FFI: Add OpenTelemetry DB semantic convention attributes to FFI path ([#5596](https://github.com/valkey-io/valkey-glide/issues/5596))
 * JAVA: Add cluster management commands (CLUSTER MEET, CLUSTER FORGET, CLUSTER REPLICATE, CLUSTER REPLICAS, CLUSTER COUNT-FAILURE-REPORTS, CLUSTER FAILOVER, CLUSTER SETSLOT, CLUSTER BUMPEPOCH, CLUSTER SET-CONFIG-EPOCH, CLUSTER FLUSHSLOTS, CLUSTER RESET, READONLY, READWRITE, ASKING, CLUSTER SAVECONFIG, CLUSTER GETKEYSINSLOT) ([#5503](https://github.com/valkey-io/valkey-glide/pull/5503))
 * Go: Client-Side Caching Support ([#5721](https://github.com/valkey-io/valkey-glide/pull/5721))
+* Go: Add `PeriodicChecks` configuration to `AdvancedClusterClientConfiguration` — supports `PeriodicChecksEnabled`, `PeriodicChecksDisabled`, and `PeriodicChecksManualInterval` modes for controlling cluster topology check intervals ([#5842](https://github.com/valkey-io/valkey-glide/issues/5842))
 * JAVA: Client-Side Caching Support ([#5172](https://github.com/valkey-io/valkey-glide/pull/5172))
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -618,6 +618,24 @@ func (config *ClusterClientConfiguration) ToProtobuf() (*protobuf.ConnectionRequ
 	}
 	request.RefreshTopologyFromInitialNodes = config.AdvancedClusterClientConfiguration.refreshTopologyFromInitialNodes
 
+	// Handle periodic topology checks configuration
+	if config.AdvancedClusterClientConfiguration.periodicChecks != nil {
+		switch v := config.AdvancedClusterClientConfiguration.periodicChecks.(type) {
+		case PeriodicChecksDisabled:
+			request.PeriodicChecks = &protobuf.ConnectionRequest_PeriodicChecksDisabled{
+				PeriodicChecksDisabled: &protobuf.PeriodicChecksDisabled{},
+			}
+		case PeriodicChecksManualInterval:
+			request.PeriodicChecks = &protobuf.ConnectionRequest_PeriodicChecksManualInterval{
+				PeriodicChecksManualInterval: &protobuf.PeriodicChecksManualInterval{
+					DurationInSec: v.DurationInSec,
+				},
+			}
+		case PeriodicChecksEnabled:
+			// Default behavior - no need to set anything in protobuf
+		}
+	}
+
 	// Handle TCP_NODELAY configuration
 	if config.AdvancedClusterClientConfiguration.tcpNoDelay != nil {
 		request.TcpNodelay = config.AdvancedClusterClientConfiguration.tcpNoDelay
@@ -935,11 +953,38 @@ func (config *AdvancedClientConfiguration) WithPubSubReconciliationIntervalMs(
 	return config
 }
 
+// PeriodicChecksConfig is an interface implemented by [PeriodicChecksEnabled],
+// [PeriodicChecksDisabled], and [PeriodicChecksManualInterval] to configure
+// periodic topology checks for cluster clients.
+type PeriodicChecksConfig interface {
+	isPeriodicChecksConfig()
+}
+
+// PeriodicChecksEnabled enables periodic topology checks with the default interval.
+// This is the default behavior when no periodic checks configuration is set.
+type PeriodicChecksEnabled struct{}
+
+func (PeriodicChecksEnabled) isPeriodicChecksConfig() {}
+
+// PeriodicChecksDisabled disables periodic topology checks.
+type PeriodicChecksDisabled struct{}
+
+func (PeriodicChecksDisabled) isPeriodicChecksConfig() {}
+
+// PeriodicChecksManualInterval configures periodic topology checks with a custom interval.
+type PeriodicChecksManualInterval struct {
+	// DurationInSec is the interval in seconds between periodic topology checks.
+	DurationInSec uint32
+}
+
+func (PeriodicChecksManualInterval) isPeriodicChecksConfig() {}
+
 // Represents advanced configuration settings for a Cluster client used in
 // [ClusterClientConfiguration].
 type AdvancedClusterClientConfiguration struct {
 	connectionTimeout               time.Duration
 	refreshTopologyFromInitialNodes bool
+	periodicChecks                  PeriodicChecksConfig
 	tlsConfig                       *TlsConfiguration
 	tcpNoDelay                      *bool
 	pubsubReconciliationIntervalMs  *int
@@ -972,6 +1017,23 @@ func (config *AdvancedClusterClientConfiguration) WithRefreshTopologyFromInitial
 	refreshTopologyFromInitialNodes bool,
 ) *AdvancedClusterClientConfiguration {
 	config.refreshTopologyFromInitialNodes = refreshTopologyFromInitialNodes
+	return config
+}
+
+// WithPeriodicChecks configures the periodic topology checks for the cluster client.
+// These checks evaluate changes in the cluster's topology, triggering a slot refresh when detected.
+// Periodic checks ensure a quick and efficient process by querying a limited number of nodes.
+//
+// Accepted values:
+//   - [PeriodicChecksEnabled]: Enables periodic checks with the default interval (this is the default).
+//   - [PeriodicChecksDisabled]: Disables periodic topology checks.
+//   - [PeriodicChecksManualInterval]: Enables periodic checks with a custom interval in seconds.
+//
+// If not set, defaults to enabled with the default interval.
+func (config *AdvancedClusterClientConfiguration) WithPeriodicChecks(
+	periodicChecks PeriodicChecksConfig,
+) *AdvancedClusterClientConfiguration {
+	config.periodicChecks = periodicChecks
 	return config
 }
 

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -1407,3 +1407,58 @@ func TestConfig_NodeDiscoveryMode_DiscoverAll(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, protobuf.NodeDiscoveryMode_DiscoverAll, result.NodeDiscoveryMode)
 }
+
+func TestClusterConfig_PeriodicChecks_DefaultNotSet(t *testing.T) {
+	// When no periodic checks config is set, the protobuf field should be nil (server uses default).
+	config := NewClusterClientConfiguration()
+	result, err := config.ToProtobuf()
+	if err != nil {
+		t.Fatalf("Failed to convert default cluster config to protobuf: %v", err)
+	}
+	assert.Nil(t, result.PeriodicChecks)
+}
+
+func TestClusterConfig_PeriodicChecks_Enabled(t *testing.T) {
+	// Explicitly setting PeriodicChecksEnabled should not set any protobuf field (default behavior).
+	config := NewClusterClientConfiguration().
+		WithAdvancedConfiguration(
+			NewAdvancedClusterClientConfiguration().
+				WithPeriodicChecks(PeriodicChecksEnabled{}),
+		)
+	result, err := config.ToProtobuf()
+	if err != nil {
+		t.Fatalf("Failed to convert cluster config to protobuf: %v", err)
+	}
+	assert.Nil(t, result.PeriodicChecks)
+}
+
+func TestClusterConfig_PeriodicChecks_Disabled(t *testing.T) {
+	config := NewClusterClientConfiguration().
+		WithAdvancedConfiguration(
+			NewAdvancedClusterClientConfiguration().
+				WithPeriodicChecks(PeriodicChecksDisabled{}),
+		)
+	result, err := config.ToProtobuf()
+	if err != nil {
+		t.Fatalf("Failed to convert cluster config to protobuf: %v", err)
+	}
+	assert.NotNil(t, result.PeriodicChecks)
+	_, ok := result.PeriodicChecks.(*protobuf.ConnectionRequest_PeriodicChecksDisabled)
+	assert.True(t, ok, "expected PeriodicChecksDisabled protobuf type")
+}
+
+func TestClusterConfig_PeriodicChecks_ManualInterval(t *testing.T) {
+	config := NewClusterClientConfiguration().
+		WithAdvancedConfiguration(
+			NewAdvancedClusterClientConfiguration().
+				WithPeriodicChecks(PeriodicChecksManualInterval{DurationInSec: 30}),
+		)
+	result, err := config.ToProtobuf()
+	if err != nil {
+		t.Fatalf("Failed to convert cluster config to protobuf: %v", err)
+	}
+	assert.NotNil(t, result.PeriodicChecks)
+	manual, ok := result.PeriodicChecks.(*protobuf.ConnectionRequest_PeriodicChecksManualInterval)
+	assert.True(t, ok, "expected PeriodicChecksManualInterval protobuf type")
+	assert.Equal(t, uint32(30), manual.PeriodicChecksManualInterval.DurationInSec)
+}


### PR DESCRIPTION
### Summary

Add support for the `PeriodicChecks` parameter in the Go client's `AdvancedClusterClientConfiguration`. This enables users to configure periodic topology checks for cluster clients, matching the functionality already available in other GLIDE language clients.

### Issue link

This Pull Request is linked to issue: [[Go][Task] Add PeriodicChecks configuration to AdvancedClusterClientConfiguration #5842](https://github.com/valkey-io/valkey-glide/issues/5842)
Closes #5842

### Features / Behaviour Changes
Introduces three periodic topology check modes for the Go cluster client:                                                                                                                                                                                                                                                                                                                                                                                                          

- `PeriodicChecksEnabled`: Enables periodic checks with the default interval (default behavior, no protobuf field set).
- `PeriodicChecksDisabled`: Disables periodic topology checks entirely.
- `PeriodicChecksManualInterval`: Enables periodic checks with a user-specified interval in seconds.

Users can configure this via `AdvancedClusterClientConfiguration.WithPeriodicChecks()`.

### Implementation

- Added a `PeriodicChecksConfig` sealed interface with three implementing types: `PeriodicChecksEnabled`, `PeriodicChecksDisabled`, and `PeriodicChecksManualInterval`.
- Added `periodicChecks` field to `AdvancedClusterClientConfiguration` and a `WithPeriodicChecks` builder method.
- Extended `ClusterClientConfiguration.ToProtobuf()` to serialize the periodic checks configuration into the appropriate protobuf oneof variant.
- `PeriodicChecksEnabled` is treated as the default and does not set any protobuf field, preserving existing behavior for clients that do not configure this option.

### Limitations

n/a

### Testing

Added four unit tests in `config_test.go`:
- `TestClusterConfig_PeriodicChecks_DefaultNotSet`: Verifies no protobuf field is set when periodic checks are not configured.
- `TestClusterConfig_PeriodicChecks_Enabled`: Verifies explicitly setting `PeriodicChecksEnabled` results in nil protobuf field (default behavior).
- `TestClusterConfig_PeriodicChecks_Disabled`: Verifies `PeriodicChecksDisabled` serializes to the correct protobuf type.
- `TestClusterConfig_PeriodicChecks_ManualInterval`: Verifies `PeriodicChecksManualInterval` serializes with the correct duration value.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
