### PR TITLE
Java: Make jedis-compatibility a pure-Java JAR with no-classifier support (Cherry-pick #5649)

### DIFF
--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -331,11 +331,41 @@ jobs:
                   cd -
                   cp $src_folder/bundle.jar bundle-uber-jar.jar
 
+            - name: Build jedis-compatibility (no classifier, no natives)
+              working-directory: java
+              shell: bash
+              env:
+                  GLIDE_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+                  JEDIS_NO_CLASSIFIER_BUILD: "true"
+              run: |
+                  ./gradlew --build-cache :jedis-compatibility:publishToMavenLocal \
+                  -x buildRust \
+                  -Psigning.secretKeyRingFile=secring.gpg \
+                  -Psigning.password="${{ secrets.GPG_PASSWORD }}" \
+                  -Psigning.keyId=${{ secrets.GPG_KEY_ID }}
+
+            - name: Bundle jedis-compatibility no-classifier JAR
+              working-directory: java
+              shell: bash
+              run: |
+                  src_folder=~/.m2/repository/io/valkey/valkey-glide-jedis-compatibility/${{ env.RELEASE_VERSION }}
+                  cd $src_folder
+                  jar -cvf jedis-bundle.jar *
+                  ls -ltr
+                  cd -
+                  cp $src_folder/jedis-bundle.jar jedis-bundle-no-classifier.jar
+
             - name: Upload uber JAR artifact
               uses: actions/upload-artifact@v4
               with:
                   name: java-uber-jar
                   path: java/bundle-uber-jar.jar
+
+            - name: Upload jedis no-classifier artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: jedis-no-classifier
+                  path: java/jedis-bundle-no-classifier.jar
 
     publish-to-maven-central-deployment:
         if: ${{ inputs.maven_publish == true || github.event_name == 'push' }}

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     // Use published GLIDE artifact
     implementation group: 'io.valkey', name: 'valkey-glide', version: project.ext.defaultReleaseVersion, classifier: classifier
 
-    // Use published jedis-compatibility artifact
-    testImplementation group: 'io.valkey', name: 'valkey-glide-jedis-compatibility', version: project.ext.defaultReleaseVersion, classifier: osdetector.classifier
+    // Use project dependency for jedis-compatibility (resolves directly, no Maven Local needed)
+    testImplementation project(':jedis-compatibility')
 
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
     implementation 'com.google.code.gson:gson:2.13.2'
@@ -279,10 +279,10 @@ gradle.buildFinished {
         println "Failed to clean up cluster folders: ${e.message}"
     }
 }
-compileTestJava.dependsOn ':client:publishToMavenLocal', ':jedis-compatibility:publishToMavenLocal'
+compileTestJava.dependsOn ':client:publishToMavenLocal'
 
 tasks.withType(Test) {
-    dependsOn ':client:publishToMavenLocal', ':jedis-compatibility:publishToMavenLocal'
+    dependsOn ':client:publishToMavenLocal'
     useJUnitPlatform()
     if (!project.gradle.startParameter.taskNames.contains(':integTest:modulesTest')) {
         dependsOn 'beforeTests'

--- a/java/jedis-compatibility/build.gradle
+++ b/java/jedis-compatibility/build.gradle
@@ -60,27 +60,7 @@ javadoc {
     failOnError = false // Disable javadoc errors for compatibility layer
 }
 
-tasks.register('copyNativeLib', Copy) {
-    def target
-    if (project.hasProperty('target')) {
-        target = project.target
-        from "${projectDir}/../target/${target}/release/"
-    } else if (osdetector.os == 'linux' && osdetector.release.id != 'alpine') {
-        from "${projectDir}/../target/${arch}-unknown-linux-gnu/release/"
-    } else if (osdetector.os == 'linux' && osdetector.release.id == 'alpine') {
-        from "${projectDir}/../target/${arch}-unknown-linux-musl/release/"
-    } else {
-        from "${projectDir}/../target/release/"
-    }
-    include "*.dylib", "*.so", "*.dll"
-    into sourceSets.main.output.resourcesDir
-}
-
-jar.dependsOn('copyNativeLib')
-javadoc.dependsOn('copyNativeLib')
-compileTestJava.dependsOn('copyNativeLib')
 delombok.dependsOn('compileJava')
-copyNativeLib.dependsOn(':client:buildRust')
 compileJava.dependsOn(':client:jar')
 
 tasks.withType(Test) {
@@ -99,7 +79,11 @@ tasks.withType(Test) {
 }
 
 jar {
-    if (project.hasProperty('target') && project.target.contains("musl")) {
+    def isNoClassifierBuild = System.getenv("JEDIS_NO_CLASSIFIER_BUILD") == "true"
+
+    if (isNoClassifierBuild) {
+        archiveClassifier = ''
+    } else if (project.hasProperty('target') && project.target.contains("musl")) {
         archiveClassifier = "linux_musl_${arch}"
     } else {
         archiveClassifier = osdetector.classifier
@@ -129,6 +113,7 @@ publishing {
             artifactId = 'valkey-glide-jedis-compatibility'
             version = System.getenv("GLIDE_RELEASE_VERSION") ?: project.ext.defaultReleaseVersion
             pom {
+                packaging = 'jar'
                 name = 'valkey-glide-jedis-compatibility'
                 description = 'Jedis compatibility layer for Valkey GLIDE'
                 url = 'https://github.com/valkey-io/valkey-glide.git'


### PR DESCRIPTION

### Summary

Java: Make jedis-compatibility a pure-Java JAR with no-classifier support (Cherry-pick #5649)

### Issue link

N/A

### Features / Behaviour Changes

N/A

### Implementation

N/A

### Limitations

N/A
### Testing

N/A

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
