### PR TITLE
fix(glide-core): fall back to existing connections when initial nodes are unavailable during toplogy refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Pending 2.4
 
+#### Fixes
+* CORE: Fall back to existing cluster connections when initial nodes are unavailable during topology refresh. When `refreshTopologyFromInitialNodes=true` and the initial/seed node is unreachable (e.g., dead primary during failover), the topology refresh now queries healthy existing connections instead of failing silently. This complements #5812 to enable failover recovery when the seed node itself is the failed node. ([#5814](https://github.com/valkey-io/valkey-glide/pull/5814))
+
 #### Changes
 * CORE, Python, Java, Node, Go: Add `NodeDiscoveryMode` configuration for standalone clients — `STATIC` mode skips role detection for proxy compatibility (e.g., Envoy), `DISCOVER_ALL` mode discovers full topology (primary + all replicas) from any starting node ([#5724](https://github.com/valkey-io/valkey-glide/pull/5724))
 * Go: Add Valkey Search (FT) command support — FT.CREATE, FT.SEARCH, FT.AGGREGATE, FT.DROPINDEX, FT.LIST, FT.INFO, FT.EXPLAIN, FT.EXPLAINCLI, FT.ALIASADD, FT.ALIASDEL, FT.ALIASUPDATE, FT.ALIASLIST with full Valkey Search 1.2 options for both standalone and cluster clients ([#5590](https://github.com/valkey-io/valkey-glide/pull/5590))

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -4211,12 +4211,38 @@ where
             Ok(InitialNodeConnectionsResult {
                 connections,
                 addresses_needing_refresh,
-            }) => (connections, addresses_needing_refresh),
+            }) => {
+                if connections.is_empty() {
+                    log_info_lazy!("slot_refresh",
+                        "Initial nodes returned no connections, falling back to existing cluster connections");
+                    if let Some(random_conns) = inner
+                        .conn_lock
+                        .read()
+                        .random_connections(num_of_nodes_to_query, ConnectionType::PreferManagement)
+                    {
+                        (random_conns, addresses_needing_refresh)
+                    } else {
+                        (connections, addresses_needing_refresh)
+                    }
+                } else {
+                    (connections, addresses_needing_refresh)
+                }
+            }
             Err(err) => {
-                return TopologyQueryResult {
-                    topology_result: Err(err),
-                    failed_connections: None,
-                };
+                log_info_lazy!("slot_refresh",
+                    format!("Initial nodes query failed ({}), falling back to existing cluster connections", err));
+                if let Some(random_conns) = inner
+                    .conn_lock
+                    .read()
+                    .random_connections(num_of_nodes_to_query, ConnectionType::PreferManagement)
+                {
+                    (random_conns, HashSet::new())
+                } else {
+                    return TopologyQueryResult {
+                        topology_result: Err(err),
+                        failed_connections: None,
+                    };
+                }
             }
         }
     } else if let Some(random_conns) = inner

--- a/java/integTest/src/test/java/glide/cluster/FailoverRecoveryTests.java
+++ b/java/integTest/src/test/java/glide/cluster/FailoverRecoveryTests.java
@@ -1,0 +1,238 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import glide.api.GlideClusterClient;
+import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.PeriodicChecksStatus;
+import glide.api.models.configuration.RequestRoutingConfiguration.ByAddressRoute;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Integration test for failover recovery with multi-key fan-out operations.
+ *
+ * <p>Verifies that cross-slot DEL operations recover after a primary node crash when using
+ * refreshTopologyFromInitialNodes=true and periodic checks disabled. The client connects directly
+ * to the first cluster node as its sole initial node. Killing the node with SIGKILL leaves TCP
+ * connections in half-open state, matching real crash behavior.
+ *
+ * <p>Without the fallback in calculate_topology_from_random_nodes, the topology refresh tries to
+ * reconnect to the dead initial node and hangs, preventing recovery. With the fallback, it queries
+ * existing healthy connections and discovers the updated topology from the promoted replica.
+ *
+ * <p>Requires: valkey-server (or redis-server), python3, cluster_manager.py
+ */
+@Tag("failover")
+@Timeout(180)
+public class FailoverRecoveryTests {
+
+    @SneakyThrows
+    @Test
+    public void test_fanout_del_recovers_when_initial_node_unreachable() {
+        try (ValkeyCluster cluster = new ValkeyCluster(false, true, 3, 1, null, null)) {
+            List<NodeAddress> nodes = cluster.getNodesAddr();
+            assertTrue(nodes.size() >= 6, "Need at least 6 nodes (3 primaries + 3 replicas)");
+
+            NodeAddress firstNode = nodes.get(0);
+            int targetPort = firstNode.getPort();
+            String targetHost = firstNode.getHost();
+
+            GlideClusterClientConfiguration config =
+                    GlideClusterClientConfiguration.builder()
+                            .address(NodeAddress.builder().host(targetHost).port(targetPort).build())
+                            .advancedConfiguration(
+                                    AdvancedGlideClusterClientConfiguration.builder()
+                                            .refreshTopologyFromInitialNodes(true)
+                                            .periodicChecks(PeriodicChecksStatus.DISABLED)
+                                            .build())
+                            .requestTimeout(5000)
+                            .build();
+
+            GlideClusterClient client = GlideClusterClient.createClient(config).get(30, TimeUnit.SECONDS);
+
+            try {
+                // Populate keys across slots
+                for (int i = 0; i < 100; i++) {
+                    client.set("key:" + i, "value:" + i).get(5, TimeUnit.SECONDS);
+                }
+                client.del(new String[] {"key:0", "key:1", "key:2"}).get(5, TimeUnit.SECONDS);
+
+                // Get the primary's node ID and PID before killing it
+                String info =
+                        (String)
+                                client
+                                        .customCommand(
+                                                new String[] {"INFO", "server"}, new ByAddressRoute(targetHost, targetPort))
+                                        .get(5, TimeUnit.SECONDS)
+                                        .getSingleValue();
+                String pid = null;
+                for (String line : info.split("\n")) {
+                    if (line.startsWith("process_id:")) {
+                        pid = line.split(":")[1].trim().replace("\r", "");
+                        break;
+                    }
+                }
+                assertTrue(pid != null && !pid.isEmpty(), "Should find server PID");
+
+                String nodeId =
+                        ((String)
+                                        client
+                                                .customCommand(
+                                                        new String[] {"CLUSTER", "MYID"},
+                                                        new ByAddressRoute(targetHost, targetPort))
+                                                .get(5, TimeUnit.SECONDS)
+                                                .getSingleValue())
+                                .trim();
+
+                // Find the replica port by querying a different node
+                String replicaPort = findReplicaPort(client, nodes, targetHost, targetPort, nodeId);
+
+                // Start continuous cross-slot DELs
+                AtomicInteger successCount = new AtomicInteger(0);
+                AtomicInteger errorCount = new AtomicInteger(0);
+                AtomicBoolean running = new AtomicBoolean(true);
+
+                Thread delThread =
+                        new Thread(
+                                () -> {
+                                    int round = 0;
+                                    while (running.get() && round < 800) {
+                                        String[] keys = {
+                                            "key:" + (round % 30),
+                                            "key:" + ((round + 10) % 30),
+                                            "key:" + ((round + 20) % 30)
+                                        };
+                                        try {
+                                            client.del(keys).get(5, TimeUnit.SECONDS);
+                                            successCount.incrementAndGet();
+                                        } catch (Exception e) {
+                                            errorCount.incrementAndGet();
+                                        }
+                                        round++;
+                                        try {
+                                            Thread.sleep(100);
+                                        } catch (InterruptedException ie) {
+                                            break;
+                                        }
+                                    }
+                                });
+                delThread.start();
+                Thread.sleep(3000); // steady state
+
+                // Kill the initial node with SIGKILL via cluster_manager.py
+                killNodeByPid(pid);
+                Thread.sleep(2000);
+
+                // Promote the replica using a separate client
+                if (replicaPort != null) {
+                    promoteReplica(targetHost, Integer.parseInt(replicaPort));
+                }
+
+                // Wait 55s, then verify no new errors in the last 10s.
+                // Without the fallback, errors keep accumulating (client never recovers).
+                // With the fallback, the client recovers and errors stop.
+                Thread.sleep(55000);
+                int errorsAtSnapshot = errorCount.get();
+                Thread.sleep(10000);
+                running.set(false);
+                delThread.join(10000);
+
+                int successes = successCount.get();
+                int errors = errorCount.get();
+                int errorsInLast10s = errors - errorsAtSnapshot;
+                System.out.printf(
+                        "Failover test: successes=%d, errors=%d, errorsInLast10s=%d%n",
+                        successes, errors, errorsInLast10s);
+
+                assertTrue(
+                        successes > errors,
+                        String.format("Client should recover. Successes: %d, Errors: %d", successes, errors));
+                assertTrue(
+                        errorsInLast10s == 0,
+                        String.format(
+                                "Errors still accumulating after 55s (got %d in last 10s, total %d)."
+                                        + " Client did not recover.",
+                                errorsInLast10s, errors));
+            } finally {
+                client.close();
+            }
+        }
+    }
+
+    /** Find the replica port for the given primary by querying a different cluster node. */
+    private String findReplicaPort(
+            GlideClusterClient client,
+            List<NodeAddress> nodes,
+            String primaryHost,
+            int primaryPort,
+            String primaryNodeId)
+            throws Exception {
+        for (NodeAddress node : nodes) {
+            if (node.getPort() == primaryPort) continue;
+            try {
+                String clusterNodes =
+                        (String)
+                                client
+                                        .customCommand(
+                                                new String[] {"CLUSTER", "NODES"},
+                                                new ByAddressRoute(node.getHost(), node.getPort()))
+                                        .get(5, TimeUnit.SECONDS)
+                                        .getSingleValue();
+                for (String line : clusterNodes.split("\n")) {
+                    if (line.contains("slave") && line.contains(primaryNodeId)) {
+                        String addr = line.split("\\s+")[1].split("@")[0];
+                        return addr.split(":")[1];
+                    }
+                }
+            } catch (Exception e) {
+                continue;
+            }
+        }
+        return null;
+    }
+
+    /** Kill a node by PID using cluster_manager.py (cross-platform, handles WSL on Windows). */
+    private void killNodeByPid(String pid) throws Exception {
+        Path scriptFile =
+                java.nio.file.Paths.get(System.getProperty("user.dir"))
+                        .getParent()
+                        .getParent()
+                        .resolve("utils")
+                        .resolve("cluster_manager.py");
+        new ProcessBuilder(
+                        "python3", scriptFile.toString(), "stop", "--prefix", "none-will-match", "--pids", pid)
+                .redirectErrorStream(true)
+                .start()
+                .waitFor(10, TimeUnit.SECONDS);
+    }
+
+    /** Promote a replica by issuing CLUSTER FAILOVER FORCE via a short-lived client. */
+    private void promoteReplica(String host, int port) throws Exception {
+        GlideClusterClientConfiguration replicaConfig =
+                GlideClusterClientConfiguration.builder()
+                        .address(NodeAddress.builder().host(host).port(port).build())
+                        .requestTimeout(5000)
+                        .build();
+        GlideClusterClient replicaClient =
+                GlideClusterClient.createClient(replicaConfig).get(10, TimeUnit.SECONDS);
+        try {
+            replicaClient
+                    .customCommand(
+                            new String[] {"CLUSTER", "FAILOVER", "FORCE"}, new ByAddressRoute(host, port))
+                    .get(5, TimeUnit.SECONDS);
+        } finally {
+            replicaClient.close();
+        }
+    }
+}


### PR DESCRIPTION
Cherry-pick of #5814 to main branch.

## Problem

During failover with `refreshTopologyFromInitialNodes=true` and periodic checks disabled, multi-key operations (DEL, MGET, etc.) that fan out across nodes fail for **5+ minutes** because the client never discovers the new primary.

### Root Cause

Multi-key DEL is split into per-node sub-requests via `execute_on_multiple_nodes` → `into_channels`. When the primary dies:

1. The dead node's connection is removed from the connection map by `trigger_refresh_connection_tasks`
2. Subsequent fan-out sub-requests fail with `ConnectionNotFoundForRoute` because the slot map still points to the dead node'\''s address
3. The FanOut error handler returns `Next::Done` — **no topology refresh is triggered**
4. Without periodic checks, the client never discovers the new primary

Even when a topology check does run (e.g., from the Reconnect handler), two additional issues prevent recovery:

- **Stale initial nodes**: With `refreshTopologyFromInitialNodes=true`, the topology check queries the config endpoint/seed node. If that node is dead or returns stale data, `get_random_connections_from_initial_nodes` returns `Ok` with **empty connections** (not `Err`), so the existing error fallback never triggers.


## Fix

One targeted changes, each addressing one link in the failure chain:

### Fall back to existing connections when initial nodes are unavailable

In `calculate_topology_from_random_nodes`, when `get_random_connections_from_initial_nodes` returns `Ok` with empty connections or returns `Err`, fall back to querying random existing cluster connections.

**Why this works**: During failover, healthy nodes (including the promoted replica) report the new topology immediately in `CLUSTER SLOTS`. The config endpoint may take minutes to update, but existing connections to healthy nodes have the correct topology right away.

**Why this is safe**: The fallback only activates when the initial nodes query returns empty results or fails. In normal operation, the initial nodes query succeeds and the fallback is never reached.

## Performance Impact

**None expected.** All three changes are narrowly scoped to failover conditions:

- The existing connections fallback only activates when the initial nodes query returns empty results

## Test Results

## Failover Scenario Test Results

All tests: `refreshTopologyFromInitialNodes=true`, `periodicChecks=DISABLED` (unless noted), TLS enabled, 400 TPS DEL, 1 client, 1 concurrent task, 5s request timeout.

| # | Scenario | release-2.2 branch | With Fallback (#5814) | Notes |
|---|---|---|---|---|
| 1 | Network latency (200ms added) | 0 errors, 0 timeouts, 400 TPS | Same | Latency well within 5s timeout |
| 2 | AZ failure (test-failover) | 21 timeouts, 1 error, recovers ~60s | Same | Same mechanism as master node failure |
| 3a | Master node failure (test-failover, config endpoint) | 21 timeouts, 1 error, recovers ~60s | 4 errors, recovers ~8s | Config endpoint stays reachable |
| 3b | Master node failure + config endpoint unreachable | **274+ timeouts, TPS 0, never recovers** | **21 timeouts, 1 error, recovers to 400 TPS** | Config endpoint blocked via /etc/hosts |
| 3c | Master node failure, direct node connection (reachable) | 35 timeouts, 1 error, recovers ~60s | Same | Node stays reachable as replica after test-failover |
| 3d | Master node failure, direct node connection (unreachable) | **154 timeouts, 1 error, TPS 0, never recovers** | **37 timeouts, 1 error, recovers to 400 TPS** | Node hostname blocked via /etc/hosts |
| 4a | GDS failover, no DNS switch, periodic checks off | 367 timeouts, 303 errors, never recovers | Same | Config endpoint returns stale topology; not fixable client-side |
| 4b | GDS failover + DNS switch, periodic checks on | 1-4s recovery, 268-403 errors | Same | Periodic check discovers new topology after DNS switch |
| 4c | GDS failover + DNS switch, periodic checks off | 62 timeouts, 57 errors, recovers to 18 TPS | 60 timeouts, 41 errors, recovers to 18 TPS | 18 TPS due to cross-region latency (~55ms); error-triggered RefreshSlots re-resolves DNS |
| 5 | Add shard (3→4) | 0 errors, 0 timeouts, 400 TPS | Same | Online resharding is transparent |
| 6 | Add replica (1→2) | 0 errors, 0 timeouts, 400 TPS | Same | Adding replica doesn't affect slot routing |
| 7 | Delete shard (4→3) | 0 errors, 0 timeouts, 400 TPS | Same | Online resharding is transparent |
| 8 | Delete replica (2→1) | 0 errors, 0 timeouts, 400 TPS | Same | Removing replica doesn't affect slot routing |
| 9 | Node type upgrade (r7g.large→xlarge) | 0 errors, 0 timeouts during 20 min | Same | Rolling upgrade; completed after benchmark ended |
| **SM** | **Self-managed kill -9 + FAILOVER FORCE** | **50+ errors in 4 min, never recovers** | **7 errors, recovers ~15s** | **Fallback is critical here: dead initial node blocks topology refresh without it** |


### Self-managed cluster (kill primary + CLUSTER FAILOVER FORCE)

| Scenario | Baseline | This PR |
|---|---|---|
| Failover before DEL loop | N/A | **0 errors** (topology discovered during wait) |
| Failover during DEL loop | ~350 errors, never recovers | **64 errors, ~15s recovery** |

Base alone did not help on self-managed because: (a) the initial node was dead so the topology check queried a dead node. This PR's fallback addresses the issue.
