### PR TITLE
FFI: Enable client-side caching support on the URI API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Pending 2.5
 
-#### Changes
+### Changes
 * Go: Add RESET command support ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
 * Java: Add RESET command support ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))
 * CORE/FFI: Add `MonitorClient` for the MONITOR command ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
@@ -14,6 +14,7 @@
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
 * CORE: Avoid panic on cluster `SCAN` when a read-from-replica AZ affinity strategy is configured. The slot map carries no AZ metadata, so these strategies now fall back to their documented round-robin behavior (replicas for `AZAffinity`, replicas plus primary for `AZAffinityReplicasAndPrimary`) instead of hitting `todo!()` ([#5909](https://github.com/valkey-io/valkey-glide/issues/5909))
+* FFI: Add `client_side_cache` configuration to the URI-based client creation API (`create_client_from_uri`) — supports `max_cache_kb`, `entry_ttl_ms`, `eviction_policy` (LRU/LFU), and `enable_metrics` via JSON options; `cache_id` is auto-generated internally ([]())
 
 ## 2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
 * CORE: Avoid panic on cluster `SCAN` when a read-from-replica AZ affinity strategy is configured. The slot map carries no AZ metadata, so these strategies now fall back to their documented round-robin behavior (replicas for `AZAffinity`, replicas plus primary for `AZAffinityReplicasAndPrimary`) instead of hitting `todo!()` ([#5909](https://github.com/valkey-io/valkey-glide/issues/5909))
-* FFI: Add `client_side_cache` configuration to the URI-based client creation API (`create_client_from_uri`) — supports `max_cache_kb`, `entry_ttl_ms`, `eviction_policy` (LRU/LFU), and `enable_metrics` via JSON options; `cache_id` is auto-generated internally ([]())
+* FFI: Add `client_side_cache` configuration to the URI-based client creation API (`create_client_from_uri`) — supports `max_cache_kb`, `entry_ttl_ms`, `eviction_policy` (LRU/LFU), and `enable_metrics` via JSON options; `cache_id` is auto-generated internally ([#5860](https://github.com/valkey-io/valkey-glide/pull/5860))
 
 ## 2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Pending 2.5
 
-### Changes
+#### Changes
 * Go: Add RESET command support ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
 * Java: Add RESET command support ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))
 * CORE/FFI: Add `MonitorClient` for the MONITOR command ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,6 +17,7 @@ logger_core = { path = "../logger_core" }
 tracing = "0.1"
 serde_json = "1.0"
 url = "2"
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 rstest = "^0.23"

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "protobuf",
  "serde_json",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1668,6 +1669,7 @@ dependencies = [
  "glide-core",
  "mock-redis",
  "mock-telemetry",
+ "protobuf",
  "tokio",
 ]
 

--- a/ffi/miri-tests/Cargo.toml
+++ b/ffi/miri-tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 protobuf = { version = "3", features = [] }
 serde_json = "1.0"
 url = "2"
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 # Mock crates that can be used as drop-in replacements for the real crates
 redis = { path = "./mock-redis", package = "mock-redis" }
 glide-core = { path = "./mock-glide-core",  package = "mock-glide-core" }

--- a/ffi/miri-tests/mock-glide-core/src/connection_request.rs
+++ b/ffi/miri-tests/mock-glide-core/src/connection_request.rs
@@ -4,10 +4,12 @@
 // The FFI code accesses protobuf types via `glide_core::connection_request::*`.
 pub use glide_core::connection_request::{
     AuthenticationInfo,
+    ClientSideCache,
     CompressionBackend,
     CompressionConfig,
     ConnectionRequest,
     ConnectionRetryStrategy,
+    EvictionPolicy,
     IamCredentials,
     NodeAddress,
     NodeDiscoveryMode,

--- a/ffi/miri-tests/mock-glide-core/src/lib.rs
+++ b/ffi/miri-tests/mock-glide-core/src/lib.rs
@@ -22,10 +22,10 @@ pub use scripts_container::*;
 // (which is the protobuf type). The crate-root `ConnectionRequest` is the internal
 // type defined below, matching the real glide-core's `pub use client::ConnectionRequest`.
 pub use connection_request::{
-    AuthenticationInfo, CompressionBackend, CompressionConfig, ConnectionRetryStrategy,
-    IamCredentials, NodeDiscoveryMode, PeriodicChecksDisabled, PeriodicChecksManualInterval,
-    ProtocolVersion, PubSubChannelType, PubSubChannelsOrPatterns, PubSubSubscriptions, ReadFrom,
-    ServiceType,
+    AuthenticationInfo, ClientSideCache, CompressionBackend, CompressionConfig,
+    ConnectionRetryStrategy, EvictionPolicy, IamCredentials, NodeAddress, NodeDiscoveryMode,
+    PeriodicChecksDisabled, PeriodicChecksManualInterval, ProtocolVersion, PubSubChannelType,
+    PubSubChannelsOrPatterns, PubSubSubscriptions, ReadFrom, ServiceType, TlsMode,
 };
 
 pub use telemetrylib::*;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -39,7 +39,7 @@ use std::slice::from_raw_parts;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use uuid::Uuid;
 use std::{
     ffi::{CString, c_void},
     mem,
@@ -47,9 +47,6 @@ use std::{
 };
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;
-
-/// Atomic counter for auto-generating unique `cache_id` values for client-side cache configurations.
-static CLIENT_SIDE_CACHE_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[repr(C)]
 pub struct ScriptHashBuffer {
@@ -1942,10 +1939,6 @@ fn apply_json_options(
 
         let mut config = connection_request::ClientSideCache::new();
 
-        // Auto-generate cache_id (not accepted from JSON input)
-        let id = CLIENT_SIDE_CACHE_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-        config.cache_id = id.to_string().into();
-
         // max_cache_kb (required)
         let max_cache_kb = cache_obj
             .get("max_cache_kb")
@@ -1953,6 +1946,9 @@ fn apply_json_options(
         config.max_cache_kb = max_cache_kb.as_u64().ok_or_else(|| {
             "client_side_cache.max_cache_kb must be a positive integer".to_string()
         })?;
+        if config.max_cache_kb == 0 {
+            return Err("client_side_cache.max_cache_kb must be greater than 0".to_string());
+        }
 
         // entry_ttl_ms (required)
         let entry_ttl_ms = cache_obj
@@ -1987,6 +1983,8 @@ fn apply_json_options(
                 .ok_or_else(|| "client_side_cache.enable_metrics must be a boolean".to_string())?;
         }
 
+        // Auto-generate cache_id after all validation passes (not accepted from JSON input)
+        config.cache_id = Uuid::new_v4().to_string().into();
         request.client_side_cache = ::protobuf::MessageField::some(config);
     }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -39,6 +39,7 @@ use std::slice::from_raw_parts;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     ffi::{CString, c_void},
     mem,
@@ -46,6 +47,9 @@ use std::{
 };
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;
+
+/// Atomic counter for auto-generating unique `cache_id` values for client-side cache configurations.
+static CLIENT_SIDE_CACHE_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[repr(C)]
 pub struct ScriptHashBuffer {
@@ -1196,6 +1200,7 @@ pub unsafe extern "C-unwind" fn create_client(
 ///   - `periodic_checks`: Health check configuration with either `manual_interval` (object with `duration_in_sec`) or `disabled` (bool) (object)
 ///   - `iam_credentials`: AWS IAM authentication with `cluster_name`, `region`, `service_type` ("ELASTICACHE" or "MEMORYDB"), and optional `refresh_interval_seconds` (object)
 ///   - `pubsub_subscriptions`: Pre-subscribe to channels on connection - map of channel type (0=Exact, 1=Pattern, 2=Sharded) to array of channel names (object)
+///   - `client_side_cache`: Client-side caching configuration with `max_cache_kb` (u64, required), `entry_ttl_ms` (u64, required, 0 = no expiration), optional `eviction_policy` ("LRU" or "LFU", defaults to LRU), and optional `enable_metrics` (bool, defaults to false). The `cache_id` is auto-generated internally. (object)
 ///
 /// * `client_type`: Type of client to create (sync/async).
 ///
@@ -1271,6 +1276,17 @@ pub unsafe extern "C-unwind" fn create_client(
 ///     "}"
 /// "}";
 /// create_client_from_uri("valkey://localhost:6379", pubsub_opts, &client_type, 0);
+///
+/// // Client-side caching
+/// const char* cache_opts = "{"
+///     "\"client_side_cache\": {"
+///         "\"max_cache_kb\": 2048,"
+///         "\"entry_ttl_ms\": 60000,"
+///         "\"eviction_policy\": \"LRU\","
+///         "\"enable_metrics\": true"
+///     "}"
+/// "}";
+/// create_client_from_uri("valkey://localhost:6379", cache_opts, &client_type, 0);
 /// ```
 ///
 /// # Safety
@@ -1464,6 +1480,7 @@ fn is_known_connection_options_json_key(key: &str) -> bool {
             | "periodic_checks"
             | "iam_credentials"
             | "pubsub_subscriptions"
+            | "client_side_cache"
     )
 }
 
@@ -1908,6 +1925,62 @@ fn apply_json_options(
         }
 
         request.pubsub_subscriptions = ::protobuf::MessageField::some(subscriptions);
+    }
+
+    // Handle client_side_cache
+    if let Some(cache) = obj.get("client_side_cache") {
+        let cache_obj = cache
+            .as_object()
+            .ok_or_else(|| "client_side_cache must be an object".to_string())?;
+
+        let mut config = connection_request::ClientSideCache::new();
+
+        // Auto-generate cache_id (not accepted from JSON input)
+        let id = CLIENT_SIDE_CACHE_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        config.cache_id = id.to_string().into();
+
+        // max_cache_kb (required)
+        let max_cache_kb = cache_obj
+            .get("max_cache_kb")
+            .ok_or_else(|| "client_side_cache.max_cache_kb is required".to_string())?;
+        config.max_cache_kb = max_cache_kb.as_u64().ok_or_else(|| {
+            "client_side_cache.max_cache_kb must be a positive integer".to_string()
+        })?;
+
+        // entry_ttl_ms (required)
+        let entry_ttl_ms = cache_obj
+            .get("entry_ttl_ms")
+            .ok_or_else(|| "client_side_cache.entry_ttl_ms is required".to_string())?;
+        config.entry_ttl_ms = entry_ttl_ms.as_u64().ok_or_else(|| {
+            "client_side_cache.entry_ttl_ms must be a non-negative integer".to_string()
+        })?;
+
+        // eviction_policy (optional, defaults to LRU)
+        if let Some(policy) = cache_obj.get("eviction_policy") {
+            let policy_str = policy
+                .as_str()
+                .ok_or_else(|| "client_side_cache.eviction_policy must be a string".to_string())?;
+            let policy_enum = match policy_str.to_uppercase().as_str() {
+                "LRU" => connection_request::EvictionPolicy::LRU,
+                "LFU" => connection_request::EvictionPolicy::LFU,
+                _ => {
+                    return Err(format!(
+                        "Unknown eviction_policy: {}. Valid values are: LRU, LFU",
+                        policy_str
+                    ));
+                }
+            };
+            config.eviction_policy = Some(::protobuf::EnumOrUnknown::new(policy_enum));
+        }
+
+        // enable_metrics (optional, defaults to false)
+        if let Some(metrics) = cache_obj.get("enable_metrics") {
+            config.enable_metrics = metrics
+                .as_bool()
+                .ok_or_else(|| "client_side_cache.enable_metrics must be a boolean".to_string())?;
+        }
+
+        request.client_side_cache = ::protobuf::MessageField::some(config);
     }
 
     Ok(())

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -39,7 +39,6 @@ use std::slice::from_raw_parts;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
-use uuid::Uuid;
 use std::{
     ffi::{CString, c_void},
     mem,
@@ -47,6 +46,7 @@ use std::{
 };
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;
+use uuid::Uuid;
 
 #[repr(C)]
 pub struct ScriptHashBuffer {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1933,6 +1933,13 @@ fn apply_json_options(
             .as_object()
             .ok_or_else(|| "client_side_cache must be an object".to_string())?;
 
+        if cache_obj.contains_key("cache_id") {
+            return Err(
+                "client_side_cache.cache_id is not accepted; it is generated internally"
+                    .to_string(),
+            );
+        }
+
         let mut config = connection_request::ClientSideCache::new();
 
         // Auto-generate cache_id (not accepted from JSON input)

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -1544,3 +1544,32 @@ fn test_create_client_from_uri_client_side_cache_rejects_cache_id() {
         drop(Box::from_raw(client_type));
     }
 }
+
+#[test]
+fn test_create_client_from_uri_client_side_cache_zero_max_cache_kb() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{"client_side_cache": {"max_cache_kb": 0, "entry_ttl_ms": 1000}}"#,
+    )
+    .unwrap();
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+    let response = unsafe {
+        create_client_from_uri(uri.as_ptr(), options.as_ptr(), client_type, null_pubsub_callback())
+    };
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+    assert!(
+        !conn_response.connection_error_message.is_null(),
+        "Expected error for max_cache_kb=0"
+    );
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("max_cache_kb"),
+        "Expected max_cache_kb error, got: {error}"
+    );
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -1567,6 +1567,7 @@ fn test_create_client_from_uri_client_side_cache_zero_max_cache_kb() {
         !conn_response.connection_error_message.is_null(),
         "Expected error for max_cache_kb=0"
     );
+    assert!(conn_response.conn_ptr.is_null());
     let error = parse_error_msg(conn_response.connection_error_message);
     assert!(
         error.contains("max_cache_kb"),

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -1549,13 +1549,17 @@ fn test_create_client_from_uri_client_side_cache_rejects_cache_id() {
 fn test_create_client_from_uri_client_side_cache_zero_max_cache_kb() {
     let server = Server::new();
     let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
-    let options = CString::new(
-        r#"{"client_side_cache": {"max_cache_kb": 0, "entry_ttl_ms": 1000}}"#,
-    )
-    .unwrap();
+    let options =
+        CString::new(r#"{"client_side_cache": {"max_cache_kb": 0, "entry_ttl_ms": 1000}}"#)
+            .unwrap();
     let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
     let response = unsafe {
-        create_client_from_uri(uri.as_ptr(), options.as_ptr(), client_type, null_pubsub_callback())
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
     };
     assert!(!response.is_null());
     let conn_response = unsafe { &*response };

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -1118,3 +1118,347 @@ fn test_create_client_from_uri_invalid_service_type() {
         drop(Box::from_raw(client_type));
     }
 }
+
+#[test]
+fn test_create_client_from_uri_with_client_side_cache_all_fields() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "max_cache_kb": 2048,
+            "entry_ttl_ms": 60000,
+            "eviction_policy": "LRU",
+            "enable_metrics": true
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    if conn_response.connection_error_message.is_null() {
+        assert!(!conn_response.conn_ptr.is_null());
+
+        unsafe {
+            close_client(conn_response.conn_ptr);
+            free_connection_response(response as *mut ConnectionResponse);
+            drop(Box::from_raw(client_type));
+        }
+    } else {
+        let error = parse_error_msg(conn_response.connection_error_message);
+        panic!(
+            "Failed to create client with client_side_cache (all fields): {}",
+            error
+        );
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_with_client_side_cache_required_fields_only() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "max_cache_kb": 1024,
+            "entry_ttl_ms": 0
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    if conn_response.connection_error_message.is_null() {
+        assert!(!conn_response.conn_ptr.is_null());
+
+        unsafe {
+            close_client(conn_response.conn_ptr);
+            free_connection_response(response as *mut ConnectionResponse);
+            drop(Box::from_raw(client_type));
+        }
+    } else {
+        let error = parse_error_msg(conn_response.connection_error_message);
+        panic!(
+            "Failed to create client with client_side_cache (required fields only): {}",
+            error
+        );
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_with_client_side_cache_lfu_policy() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "max_cache_kb": 512,
+            "entry_ttl_ms": 30000,
+            "eviction_policy": "LFU"
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    if conn_response.connection_error_message.is_null() {
+        assert!(!conn_response.conn_ptr.is_null());
+
+        unsafe {
+            close_client(conn_response.conn_ptr);
+            free_connection_response(response as *mut ConnectionResponse);
+            drop(Box::from_raw(client_type));
+        }
+    } else {
+        let error = parse_error_msg(conn_response.connection_error_message);
+        panic!(
+            "Failed to create client with client_side_cache (LFU policy): {}",
+            error
+        );
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_invalid_eviction_policy() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "max_cache_kb": 1024,
+            "entry_ttl_ms": 60000,
+            "eviction_policy": "INVALID"
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    assert!(!conn_response.connection_error_message.is_null());
+    assert!(conn_response.conn_ptr.is_null());
+
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("Unknown eviction_policy") || error.contains("INVALID"),
+        "expected eviction_policy error, got: {error}"
+    );
+
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_client_side_cache_missing_max_cache_kb() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "entry_ttl_ms": 60000
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    assert!(!conn_response.connection_error_message.is_null());
+    assert!(conn_response.conn_ptr.is_null());
+
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("max_cache_kb is required"),
+        "expected missing max_cache_kb error, got: {error}"
+    );
+
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_client_side_cache_missing_entry_ttl_ms() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "max_cache_kb": 1024
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    assert!(!conn_response.connection_error_message.is_null());
+    assert!(conn_response.conn_ptr.is_null());
+
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("entry_ttl_ms is required"),
+        "expected missing entry_ttl_ms error, got: {error}"
+    );
+
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_client_side_cache_invalid_max_cache_kb_type() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{
+        "client_side_cache": {
+            "max_cache_kb": "not_a_number",
+            "entry_ttl_ms": 60000
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    assert!(!conn_response.connection_error_message.is_null());
+    assert!(conn_response.conn_ptr.is_null());
+
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("max_cache_kb must be a positive integer"),
+        "expected type error for max_cache_kb, got: {error}"
+    );
+
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_client_side_cache_not_an_object() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(r#"{"client_side_cache": "not_an_object"}"#).unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    assert!(!conn_response.connection_error_message.is_null());
+    assert!(conn_response.conn_ptr.is_null());
+
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("client_side_cache must be an object"),
+        "expected object type error, got: {error}"
+    );
+
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -1462,3 +1462,85 @@ fn test_create_client_from_uri_client_side_cache_not_an_object() {
         drop(Box::from_raw(client_type));
     }
 }
+
+#[rstest]
+#[case("lru")]
+#[case("lfu")]
+#[case("LrU")]
+#[case("lFu")]
+fn test_create_client_from_uri_client_side_cache_case_insensitive_eviction_policy(
+    #[case] eviction_policy: &str,
+) {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(format!(
+        r#"{{"client_side_cache": {{"max_cache_kb": 256, "entry_ttl_ms": 5000, "eviction_policy": "{}"}}}}"#,
+        eviction_policy
+    ))
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    if conn_response.connection_error_message.is_null() {
+        assert!(!conn_response.conn_ptr.is_null());
+
+        unsafe {
+            close_client(conn_response.conn_ptr);
+            free_connection_response(response as *mut ConnectionResponse);
+            drop(Box::from_raw(client_type));
+        }
+    } else {
+        let error = parse_error_msg(conn_response.connection_error_message);
+        panic!("Expected success for eviction_policy={eviction_policy:?}, got: {error}");
+    }
+}
+
+#[test]
+fn test_create_client_from_uri_client_side_cache_rejects_cache_id() {
+    let server = Server::new();
+    let uri = CString::new(format!("redis://127.0.0.1:{}", server.port)).unwrap();
+    let options = CString::new(
+        r#"{"client_side_cache": {"max_cache_kb": 256, "entry_ttl_ms": 5000, "cache_id": "user-supplied-id"}}"#,
+    )
+    .unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            options.as_ptr(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    assert!(!conn_response.connection_error_message.is_null());
+    assert!(conn_response.conn_ptr.is_null());
+
+    let error = parse_error_msg(conn_response.connection_error_message);
+    assert!(
+        error.contains("cache_id"),
+        "Error should mention cache_id, got: {error}"
+    );
+
+    unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}


### PR DESCRIPTION
### Summary

Add `client_side_cache` configuration support to the `create_client_from_uri` FFI function, allowing users of the URI-based API to enable and configure client-side caching through the `extra_options_json` parameter.

### Issue link

This Pull Request is linked to issue: [Add client-side cache configuration to the connection URI API](https://github.com/valkey-io/valkey-glide/issues/5807)
Closes #5807

### Features / Behaviour Changes

Users can now pass a `client_side_cache` object in the JSON options when creating a client via URI:

```json
{
  "client_side_cache": {
    "max_cache_kb": 2048,
    "entry_ttl_ms": 60000,
    "eviction_policy": "LRU",
    "enable_metrics": true
  }
}
```

**Fields:**

| Field | Type | Required | Default | Description |
|---|---|---|---|---|
| `max_cache_kb` | u64 | Yes | — | Maximum cache size in kilobytes |
| `entry_ttl_ms` | u64 | Yes | — | TTL for cache entries in ms (`0` = no expiration) |
| `eviction_policy` | string | No | `"LRU"` | `"LRU"` or `"LFU"` (case-insensitive) |
| `enable_metrics` | bool | No | `false` | Enable cache hit/miss metrics collection |

The `cache_id` is auto-generated internally using an atomic counter, consistent with the Java and Python bindings. It is not exposed in the JSON API.

### Implementation

All changes are in the `ffi/` crate:

**`ffi/src/lib.rs`**
- Added a `CLIENT_SIDE_CACHE_ID_COUNTER` static `AtomicU64` for auto-generating unique cache IDs.
- Added `"client_side_cache"` to `is_known_connection_options_json_key()`.
- Added parsing logic in `apply_json_options()` that deserializes the JSON object into a `ClientSideCache` protobuf message and sets it on the `ConnectionRequest`.
- Updated the `create_client_from_uri` doc comment to document the new option and include a usage example.

**`ffi/tests/test_create_client_from_uri.rs`**
- Added 8 new tests (see Testing section below).

### Limitations

- No changes to language bindings are needed — once a binding adopts the URI API, client-side cache config flows through automatically via the existing protobuf path.
- The `cache_id` counter is process-scoped (not persisted), which is the same behavior as the Java and Python bindings.

### Testing

8 new tests added to `ffi/tests/test_create_client_from_uri.rs`:

- `test_create_client_from_uri_with_client_side_cache_all_fields` — all fields specified
- `test_create_client_from_uri_with_client_side_cache_required_fields_only` — only required fields, defaults applied
- `test_create_client_from_uri_with_client_side_cache_lfu_policy` — LFU eviction policy
- `test_create_client_from_uri_invalid_eviction_policy` — unknown eviction policy string
- `test_create_client_from_uri_client_side_cache_missing_max_cache_kb` — missing required field
- `test_create_client_from_uri_client_side_cache_missing_entry_ttl_ms` — missing required field
- `test_create_client_from_uri_client_side_cache_invalid_max_cache_kb_type` — wrong type for numeric field
- `test_create_client_from_uri_client_side_cache_not_an_object` — value is not an object

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `create_client_from_uri` accepts a client-side cache JSON with required size/TTL, optional eviction policy (LRU/LFU) and metrics; cache IDs are auto-generated and user-supplied IDs are rejected.

* **Tests**
  * Added integration tests covering valid/invalid cache configs, eviction-policy handling, and error validation.

* **Documentation**
  * Changelog updated with Unreleased entry describing the new client-side cache options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-glide/pull/5860)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->