### PR TITLE
Cherry pick #5328 to release 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Go: Add `PeriodicChecks` configuration to `AdvancedClusterClientConfiguration` — supports `PeriodicChecksEnabled`, `PeriodicChecksDisabled`, and `PeriodicChecksManualInterval` modes for controlling cluster topology check intervals ([#5842](https://github.com/valkey-io/valkey-glide/issues/5842))
 * JAVA: Client-Side Caching Support ([#5172](https://github.com/valkey-io/valkey-glide/pull/5172))
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
+* JAVA: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -48,7 +48,9 @@ use crate::connection::{
     connect, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, RedisConnectionInfo,
 };
 use crate::parser::parse_redis_value;
-use crate::types::{ErrorKind, HashMap, RedisError, RedisResult, RetryMethod, Value};
+use crate::types::{
+    AddressResolver, ErrorKind, HashMap, RedisError, RedisResult, RetryMethod, Value,
+};
 pub use crate::TlsMode; // Pub for backwards compatibility
 use crate::{
     cluster_client::ClusterParams,
@@ -383,7 +385,16 @@ where
                 ErrorKind::ClientError,
                 "can't parse node address",
             )))?;
-            match parse_and_count_slots(&value, self.cluster_params.tls, addr).map(
+            match parse_and_count_slots(
+                &value,
+                self.cluster_params.tls,
+                addr,
+                self.cluster_params
+                    .address_resolver
+                    .as_ref()
+                    .map(Arc::as_ref),
+            )
+            .map(
                 |ParsedSlotsResult {
                      slots,
                      address_to_ip_map,
@@ -1006,7 +1017,8 @@ pub(crate) fn get_connection_info(
             host.to_string(),
             port,
             cluster_params.tls,
-            cluster_params.tls_params,
+            cluster_params.tls_params.clone(),
+            cluster_params.address_resolver.as_ref().map(Arc::as_ref),
         ),
         redis: RedisConnectionInfo {
             password: cluster_params.password,
@@ -1025,21 +1037,29 @@ pub(crate) fn get_connection_addr(
     port: u16,
     tls: Option<TlsMode>,
     tls_params: Option<TlsConnParams>,
+    address_resolver: Option<&dyn AddressResolver>,
 ) -> ConnectionAddr {
+    // Resolve the address if a resolver is provided
+    let (resolved_host, resolved_port) = if let Some(resolver) = address_resolver {
+        resolver.resolve(&host, port)
+    } else {
+        (host, port)
+    };
+
     match tls {
         Some(TlsMode::Secure) => ConnectionAddr::TcpTls {
-            host,
-            port,
+            host: resolved_host,
+            port: resolved_port,
             insecure: false,
             tls_params,
         },
         Some(TlsMode::Insecure) => ConnectionAddr::TcpTls {
-            host,
-            port,
+            host: resolved_host,
+            port: resolved_port,
             insecure: true,
             tls_params,
         },
-        _ => ConnectionAddr::Tcp(host, port),
+        _ => ConnectionAddr::Tcp(resolved_host, resolved_port),
     }
 }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2681,10 +2681,14 @@ where
         // Await all connection futures, this is bounded by `connection_timeout`.
         let results = futures::future::join_all(connection_futures).await;
 
-        // Collect successful connections
+        // Collect successful connections and extract resolved IPs for reverse lookup.
         let new_connections = ConnectionsMap(DashMap::with_capacity(nodes_len));
+        let mut resolved_ips: Vec<(String, IpAddr)> = Vec::new();
         for (addr, result) in results {
             if let Ok(node) = result {
+                if let Some(ip) = node.user_connection.ip {
+                    resolved_ips.push((addr.clone(), ip));
+                }
                 new_connections.0.insert(addr, node);
             }
         }
@@ -2693,12 +2697,17 @@ where
             "cluster",
             format!("refresh_slots found nodes:\n{new_connections}")
         );
+        // Populate IP→address reverse lookup from DNS-resolved IPs,
+        // then carry over any IPs from the previous slot map that weren't re-resolved.
+        new_slots.populate_ips(resolved_ips);
+
         // Reset the current slot map and connection vector with the new ones
         let mut write_guard = inner.conn_lock.write();
         let old_topology_hash = write_guard.get_current_topology_hash();
         // Clear the refresh tasks of the prev instance
         // TODO - Maybe we can take the running refresh tasks and use them instead of running new connection creation
         write_guard.refresh_conn_state.clear_refresh_state();
+        new_slots.carry_over_ips_from(&write_guard.slot_map);
         let read_from_replicas =
             inner.get_cluster_param(|params| params.read_from_replicas.clone());
         *write_guard = ConnectionsContainer::new(
@@ -2723,6 +2732,29 @@ where
             )
         );
         Ok(())
+    }
+
+    /// Resolves a raw address (which may be a raw IP:port from a MOVED/ASK redirect)
+    /// to a canonical hostname:port usable for connection lookup.
+    ///
+    /// Resolution order:
+    /// 1. Reverse IP lookup: parse the host as an IP and look it up in the slot map's
+    ///    IP→address table (built from DNS resolution during CLUSTER SLOTS refresh).
+    /// 2. Raw address fallback: return the original address unchanged.
+    pub(crate) fn resolve_address(inner: &Arc<InnerCore<C>>, address: &str) -> String {
+        let conn_lock = inner.conn_lock.read();
+
+        // Step 1: Reverse IP lookup via slot map.
+        if let Some((host, _port)) = address.rsplit_once(':') {
+            if let Ok(ip) = host.parse::<IpAddr>() {
+                if let Some(node_addr) = conn_lock.slot_map.node_address_for_ip(ip) {
+                    return (*node_addr).clone();
+                }
+            }
+        }
+
+        // Step 2: Return raw address as fallback.
+        address.to_string()
     }
 
     /// Handles MOVED errors by updating the client's slot and node mappings based on the new primary's role:
@@ -3671,7 +3703,11 @@ where
                             future: Box::pin(ClusterConnInner::update_upon_moved_error(
                                 self.inner.clone(),
                                 moved_redirect.slot,
-                                moved_redirect.address.into(),
+                                ClusterConnInner::resolve_address(
+                                    &self.inner,
+                                    &moved_redirect.address,
+                                )
+                                .into(),
                             )),
                         })
                     } else if let Some(ref request) = request {
@@ -4265,6 +4301,7 @@ where
     let tls_mode = inner.get_cluster_param(|params| params.tls);
 
     let read_from_replicas = inner.get_cluster_param(|params| params.read_from_replicas.clone());
+    let address_resolver = inner.get_cluster_param(|params| params.address_resolver.clone());
     TopologyQueryResult {
         topology_result: calculate_topology(
             topology_values,
@@ -4272,6 +4309,7 @@ where
             tls_mode,
             num_of_nodes_to_query,
             read_from_replicas,
+            address_resolver.as_ref().map(Arc::as_ref),
         ),
         failed_connections: Some(failed_addresses),
     }

--- a/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/pipeline_routing.rs
@@ -1144,10 +1144,11 @@ where
             }
         })?;
 
+    let resolved_address = ClusterConnInner::resolve_address(&core, &redirect_node.address);
     ClusterConnInner::update_upon_moved_error(
         core.clone(),
         redirect_node.slot,
-        redirect_node.address.into(),
+        resolved_address.into(),
     )
     .await
     .map_err(Into::into)

--- a/glide-core/redis-rs/redis/src/cluster_client.rs
+++ b/glide-core/redis-rs/redis/src/cluster_client.rs
@@ -5,7 +5,7 @@ use crate::cluster_topology::{
     DEFAULT_SLOTS_REFRESH_MAX_JITTER_MILLI, DEFAULT_SLOTS_REFRESH_WAIT_DURATION,
 };
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
-use crate::types::{ErrorKind, ProtocolVersion, RedisError, RedisResult};
+use crate::types::{AddressResolver, ErrorKind, ProtocolVersion, RedisError, RedisResult};
 use crate::{cluster, cluster::TlsMode};
 use crate::{PushInfo, RetryStrategy};
 use rand::Rng;
@@ -50,6 +50,7 @@ struct BuilderParams {
     database_id: i64,
     tcp_nodelay: bool,
     cache: Option<Arc<dyn GlideCache>>,
+    address_resolver: Option<Arc<dyn AddressResolver>>,
 }
 
 #[derive(Clone)]
@@ -154,6 +155,8 @@ pub struct ClusterParams {
     pub(crate) database_id: i64,
     pub(crate) tcp_nodelay: bool,
     pub(crate) cache: Option<Arc<dyn GlideCache>>,
+    /// Optional callback for resolving addresses before connection.
+    pub(crate) address_resolver: Option<Arc<dyn AddressResolver>>,
 }
 
 impl ClusterParams {
@@ -187,6 +190,7 @@ impl ClusterParams {
             database_id: value.database_id,
             tcp_nodelay: value.tcp_nodelay,
             cache: value.cache,
+            address_resolver: value.address_resolver,
         })
     }
 }
@@ -218,6 +222,7 @@ impl ClusterParams {
             database_id: 0,
             tcp_nodelay: false,
             cache: None,
+            address_resolver: None,
         }
     }
 }
@@ -538,6 +543,16 @@ impl ClusterClientBuilder {
     /// Defaults to true if not set.
     pub fn tcp_nodelay(mut self, tcp_nodelay: bool) -> ClusterClientBuilder {
         self.builder_params.tcp_nodelay = tcp_nodelay;
+        self
+    }
+
+    /// Sets an address resolver callback for resolving node addresses.
+    ///
+    /// When set, the resolver will be called to resolve host:port pairs
+    /// before establishing connections to cluster nodes. This allows custom
+    /// DNS resolution or address translation logic.
+    pub fn address_resolver(mut self, resolver: Arc<dyn AddressResolver>) -> ClusterClientBuilder {
+        self.builder_params.address_resolver = Some(resolver);
         self
     }
 

--- a/glide-core/redis-rs/redis/src/cluster_slotmap.rs
+++ b/glide-core/redis-rs/redis/src/cluster_slotmap.rs
@@ -206,6 +206,32 @@ impl SlotMap {
         })
     }
 
+    /// Populates the IP→address reverse lookup table with freshly resolved IPs
+    /// captured from DNS resolution during slot refresh.
+    pub(crate) fn populate_ips(&self, resolved_ips: Vec<(String, IpAddr)>) {
+        for (addr, ip) in resolved_ips {
+            if let Some(mut entry) = self.nodes_map.get_mut(&addr) {
+                entry.0 = Some(ip);
+            }
+        }
+    }
+
+    /// Carries over IP mappings from the old slot map to the new one.
+    /// This ensures IPs survive topology rebuilds when nodes aren't reconnected.
+    /// Fresh IPs (from populate_ips) take priority over carried-over ones.
+    pub(crate) fn carry_over_ips_from(&self, old: &SlotMap) {
+        for entry in old.nodes_map.iter() {
+            let (addr, (ip, _)) = (entry.key(), entry.value());
+            if let Some(ip) = ip {
+                if let Some(mut new_entry) = self.nodes_map.get_mut(addr) {
+                    if new_entry.0.is_none() {
+                        new_entry.0 = Some(*ip);
+                    }
+                }
+            }
+        }
+    }
+
     /// Returns a set of all primary node addresses in the cluster.
     pub fn addresses_for_all_primaries(&self) -> HashSet<Arc<String>> {
         self.nodes_map
@@ -1539,5 +1565,106 @@ mod tests_cluster_slotmap {
         // Should be findable by IP
         let found_addr = slot_map.node_address_for_ip(ip);
         assert_eq!(found_addr, Some(Arc::new("new-node:6379".to_string())));
+    }
+
+    #[test]
+    fn test_populate_ips_empty_vec_is_noop() {
+        let slot_map = SlotMap::new(
+            vec![Slot::new(0, 16383, "node1:6379".to_owned(), vec![])],
+            HashMap::new(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        // Populate with empty vec — should not panic or change anything
+        slot_map.populate_ips(vec![]);
+        let result = slot_map.node_address_for_ip("10.0.0.1".parse().unwrap());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_populate_ips_unknown_address_is_ignored() {
+        let slot_map = SlotMap::new(
+            vec![Slot::new(0, 16383, "node1:6379".to_owned(), vec![])],
+            HashMap::new(),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+        // Address not in nodes_map — should be silently ignored
+        slot_map.populate_ips(vec![(
+            "unknown-node:9999".to_string(),
+            "10.0.0.99".parse().unwrap(),
+        )]);
+        let result = slot_map.node_address_for_ip("10.0.0.99".parse().unwrap());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_carry_over_ips_fresh_takes_priority_over_carryover() {
+        // node1 gets a fresh IP via populate_ips
+        let new_map = SlotMap::new(
+            vec![Slot::new(0, 16383, "node1:6379".to_owned(), vec![])],
+            HashMap::from([("node1:6379".to_string(), "10.0.0.2".parse().unwrap())]),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+
+        // Old map had a different IP for node1
+        let old_map = SlotMap::new(
+            vec![Slot::new(0, 16383, "node1:6379".to_owned(), vec![])],
+            HashMap::from([("node1:6379".to_string(), "10.0.0.1".parse().unwrap())]),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+
+        // carry_over should NOT overwrite the fresh IP with the old one
+        new_map.carry_over_ips_from(&old_map);
+
+        // Fresh IP (10.0.0.2) should win, not the old one (10.0.0.1)
+        let result = new_map.node_address_for_ip("10.0.0.2".parse().unwrap());
+        assert_eq!(result, Some(Arc::new("node1:6379".to_string())));
+
+        let old_result = new_map.node_address_for_ip("10.0.0.1".parse().unwrap());
+        assert!(
+            old_result.is_none(),
+            "Old IP should not be carried over when fresh IP exists"
+        );
+    }
+
+    #[test]
+    fn test_carry_over_ips_fills_gaps_from_old_map() {
+        // new_map has node1 with no IP, node2 with fresh IP
+        let new_map = SlotMap::new(
+            vec![
+                Slot::new(0, 8191, "node1:6379".to_owned(), vec![]),
+                Slot::new(8192, 16383, "node2:6380".to_owned(), vec![]),
+            ],
+            HashMap::from([("node2:6380".to_string(), "10.0.0.2".parse().unwrap())]),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+
+        // old_map had IPs for both nodes
+        let old_map = SlotMap::new(
+            vec![
+                Slot::new(0, 8191, "node1:6379".to_owned(), vec![]),
+                Slot::new(8192, 16383, "node2:6380".to_owned(), vec![]),
+            ],
+            HashMap::from([
+                ("node1:6379".to_string(), "10.0.0.1".parse().unwrap()),
+                ("node2:6380".to_string(), "10.0.0.99".parse().unwrap()), // stale, should NOT override fresh
+            ]),
+            ReadFromReplicaStrategy::AlwaysFromPrimary,
+        );
+
+        new_map.carry_over_ips_from(&old_map);
+
+        // node1's IP should be carried over from old map (gap filled)
+        let node1_result = new_map.node_address_for_ip("10.0.0.1".parse().unwrap());
+        assert_eq!(node1_result, Some(Arc::new("node1:6379".to_string())));
+
+        // node2's fresh IP should be preserved, not overwritten by stale old IP
+        let node2_fresh = new_map.node_address_for_ip("10.0.0.2".parse().unwrap());
+        assert_eq!(node2_fresh, Some(Arc::new("node2:6380".to_string())));
+
+        let node2_stale = new_map.node_address_for_ip("10.0.0.99".parse().unwrap());
+        assert!(
+            node2_stale.is_none(),
+            "Stale IP should not override fresh IP"
+        );
     }
 }

--- a/glide-core/redis-rs/redis/src/cluster_topology.rs
+++ b/glide-core/redis-rs/redis/src/cluster_topology.rs
@@ -5,6 +5,7 @@ use crate::cluster::get_connection_addr;
 use crate::cluster_client::SlotsRefreshRateLimit;
 use crate::cluster_routing::Slot;
 use crate::cluster_slotmap::{ReadFromReplicaStrategy, SlotMap};
+use crate::types::AddressResolver;
 use crate::{cluster::TlsMode, ErrorKind, RedisError, RedisResult, Value};
 #[cfg(all(feature = "cluster-async", not(feature = "tokio-comp")))]
 use async_std::sync::RwLock;
@@ -116,6 +117,7 @@ pub(crate) fn parse_and_count_slots(
     raw_slot_resp: &Value,
     tls: Option<TlsMode>,
     addr_of_answering_node: &str,
+    address_resolver: Option<&dyn AddressResolver>,
 ) -> RedisResult<ParsedSlotsResult> {
     // Parse response.
     let mut slots = Vec::with_capacity(2);
@@ -261,7 +263,7 @@ pub(crate) fn parse_and_count_slots(
                             };
 
                         let connection_addr =
-                            get_connection_addr(canonical_hostname, port, tls, None).to_string();
+                            get_connection_addr(canonical_hostname, port, tls, None, address_resolver).to_string();
 
                         // Store IP mapping if we have an IP for this node
                         if let Some(ip) = resolved_ip {
@@ -314,6 +316,7 @@ pub(crate) fn calculate_topology<'a>(
     tls_mode: Option<TlsMode>,
     num_of_queried_nodes: usize,
     read_from_replica: ReadFromReplicaStrategy,
+    address_resolver: Option<&dyn AddressResolver>,
 ) -> RedisResult<(SlotMap, TopologyHash)> {
     let mut hash_view_map = HashMap::new();
     for (host, view) in topology_views {
@@ -321,7 +324,7 @@ pub(crate) fn calculate_topology<'a>(
             slots_count,
             slots,
             address_to_ip_map,
-        }) = parse_and_count_slots(view, tls_mode, host)
+        }) = parse_and_count_slots(view, tls_mode, host, address_resolver)
         {
             let hash_value = calculate_hash(&(slots_count, &slots));
             let topology_entry = hash_view_map.entry(hash_value).or_insert(TopologyView {
@@ -576,8 +579,8 @@ mod tests {
             ),
         ]);
 
-        let res1 = parse_and_count_slots(&view1, None, "foo").unwrap();
-        let res2 = parse_and_count_slots(&view2, None, "foo").unwrap();
+        let res1 = parse_and_count_slots(&view1, None, "foo", None).unwrap();
+        let res2 = parse_and_count_slots(&view2, None, "foo", None).unwrap();
         assert_eq!(
             calculate_hash(&(res1.slots_count, &res1.slots)),
             calculate_hash(&(res2.slots_count, &res2.slots))
@@ -598,7 +601,7 @@ mod tests {
 
         let ParsedSlotsResult {
             slots_count, slots, ..
-        } = parse_and_count_slots(&view, None, "node").unwrap();
+        } = parse_and_count_slots(&view, None, "node", None).unwrap();
         assert_eq!(slots_count, 4001);
         assert_eq!(slots[0].master(), "node:6379");
     }
@@ -635,8 +638,8 @@ mod tests {
             ),
         ]);
 
-        let res1 = parse_and_count_slots(&view1, None, "node1").unwrap();
-        let res2 = parse_and_count_slots(&view2, None, "node3").unwrap();
+        let res1 = parse_and_count_slots(&view1, None, "node1", None).unwrap();
+        let res2 = parse_and_count_slots(&view2, None, "node3", None).unwrap();
 
         assert_eq!(
             calculate_hash(&(res1.slots_count, &res1.slots)),
@@ -683,7 +686,7 @@ mod tests {
                 slots_count,
                 slots,
                 address_to_ip_map,
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(slots_count, 16384);
             assert_eq!(slots.len(), 1);
@@ -730,7 +733,7 @@ mod tests {
                 slots_count,
                 slots,
                 address_to_ip_map,
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(slots_count, 16384);
             assert_eq!(slots.len(), 1);
@@ -769,7 +772,7 @@ mod tests {
                 slots_count,
                 slots,
                 address_to_ip_map,
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(slots_count, 16384);
             assert_eq!(slots.len(), 1);
@@ -801,7 +804,7 @@ mod tests {
             slots,
             address_to_ip_map,
             ..
-        } = parse_and_count_slots(&view, None, "fallback").unwrap();
+        } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
         assert_eq!(slots[0].master(), "node1:6379");
         assert!(address_to_ip_map.is_empty());
@@ -822,7 +825,7 @@ mod tests {
 
             let ParsedSlotsResult {
                 address_to_ip_map, ..
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(address_to_ip_map.len(), 1);
             assert_eq!(
@@ -847,7 +850,7 @@ mod tests {
                 slots,
                 address_to_ip_map,
                 ..
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(slots[0].master(), "node1.example.com:6379");
             assert!(address_to_ip_map.is_empty());
@@ -901,7 +904,7 @@ mod tests {
                 slots_count,
                 slots,
                 address_to_ip_map,
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(slots_count, 16384);
             assert_eq!(slots.len(), 3);
@@ -938,7 +941,7 @@ mod tests {
 
             let ParsedSlotsResult {
                 address_to_ip_map, ..
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(address_to_ip_map.len(), 1);
             assert_eq!(
@@ -968,7 +971,7 @@ mod tests {
                 slots_count,
                 slots,
                 address_to_ip_map,
-            } = parse_and_count_slots(&view, None, "fallback").unwrap();
+            } = parse_and_count_slots(&view, None, "fallback", None).unwrap();
 
             assert_eq!(slots_count, 16384);
             assert_eq!(slots.len(), 1);
@@ -1054,6 +1057,7 @@ mod tests {
             None,
             queried_nodes,
             ReadFromReplicaStrategy::AlwaysFromPrimary,
+            None,
         )
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
@@ -1077,6 +1081,7 @@ mod tests {
             None,
             queried_nodes,
             ReadFromReplicaStrategy::AlwaysFromPrimary,
+            None,
         );
         assert!(topology_view.is_err());
     }
@@ -1096,6 +1101,7 @@ mod tests {
             None,
             queried_nodes,
             ReadFromReplicaStrategy::AlwaysFromPrimary,
+            None,
         )
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
@@ -1119,6 +1125,7 @@ mod tests {
             None,
             queried_nodes,
             ReadFromReplicaStrategy::AlwaysFromPrimary,
+            None,
         )
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
@@ -1143,6 +1150,7 @@ mod tests {
             None,
             queried_nodes,
             ReadFromReplicaStrategy::AlwaysFromPrimary,
+            None,
         )
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
@@ -1167,11 +1175,71 @@ mod tests {
             None,
             queried_nodes,
             ReadFromReplicaStrategy::AlwaysFromPrimary,
+            None,
         )
         .unwrap();
         let res = collect_shard_addrs(&topology_view);
         let node_1 = get_node_addr("node1", 6379);
         let expected = vec![node_1];
         assert_eq!(res, expected);
+    }
+
+    /// A test implementation of AddressResolver that transforms addresses
+    /// by appending a suffix to the host.
+    #[derive(Debug)]
+    struct TestAddressResolver {
+        prefix: String,
+    }
+
+    impl TestAddressResolver {
+        fn new(prefix: &str) -> Self {
+            Self {
+                prefix: prefix.to_string(),
+            }
+        }
+    }
+
+    impl crate::types::AddressResolver for TestAddressResolver {
+        fn resolve(&self, host: &str, port: u16) -> (String, u16) {
+            (format!("{}{}", self.prefix, host), port)
+        }
+    }
+
+    #[test]
+    fn parse_slots_with_address_resolver_transforms_addresses() {
+        // Create a resolver that appends ".resolved" to all hostnames
+        let resolver = TestAddressResolver::new("resolved.");
+
+        // Create slot data with a primary and replica
+        let view = Value::Array(vec![slot_value_with_replicas(
+            0,
+            16383,
+            vec![("primary.example.com", 6379), ("replica.example.com", 6380)],
+        )]);
+
+        // Parse without resolver - addresses should be unchanged
+        let result_without_resolver = parse_and_count_slots(&view, None, "fallback", None).unwrap();
+        assert_eq!(result_without_resolver.slots.len(), 1);
+        assert_eq!(
+            result_without_resolver.slots[0].master(),
+            "primary.example.com:6379"
+        );
+        assert_eq!(
+            result_without_resolver.slots[0].replicas(),
+            &["replica.example.com:6380".to_string()]
+        );
+
+        // Parse with resolver - addresses should be transformed
+        let result_with_resolver =
+            parse_and_count_slots(&view, None, "fallback", Some(&resolver)).unwrap();
+        assert_eq!(result_with_resolver.slots.len(), 1);
+        assert_eq!(
+            result_with_resolver.slots[0].master(),
+            "resolved.primary.example.com:6379"
+        );
+        assert_eq!(
+            result_with_resolver.slots[0].replicas(),
+            &["resolved.replica.example.com:6380".to_string()]
+        );
     }
 }

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -384,7 +384,8 @@ pub use crate::types::{
     Value,
     PushKind,
     VerbatimFormat,
-    ProtocolVersion
+    ProtocolVersion,
+    AddressResolver,
 };
 
 #[cfg(feature = "aio")]

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -2401,3 +2401,11 @@ pub enum ProtocolVersion {
     #[default]
     RESP3,
 }
+
+/// A trait for resolving addresses before connection.
+/// Given a host and port, returns the resolved (host, port) pair.
+/// This allows custom DNS resolution or address translation logic.
+pub trait AddressResolver: Send + Sync + std::fmt::Debug {
+    /// Resolve the given host and port to the actual connection address.
+    fn resolve(&self, host: &str, port: u16) -> (String, u16);
+}

--- a/glide-core/redis-rs/redis/tests/test_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster.rs
@@ -686,6 +686,61 @@ mod cluster {
 
     #[test]
     #[serial_test::serial]
+    fn test_cluster_moved_redirect_with_raw_ip_resolved_via_reverse_lookup() {
+        // Verify that when a MOVED error returns a raw IP address (as Valkey nodes do
+        // when cluster-announce-hostname is set), the client resolves it to the correct
+        // hostname:port via reverse IP lookup rather than using the raw IP directly.
+        //
+        // Topology: two nodes sharing one hostname on different ports (NLB pattern).
+        //   node:6379 owns slots 0-8000
+        //   node:6380 owns slots 8001-16383
+        //
+        // The MOVED response uses "node:6380" directly here (mock can't simulate raw IPs),
+        // but this test validates the redirect routing and slot map update behavior.
+        let name = "node";
+        let completed = Arc::new(AtomicI32::new(0));
+        let MockEnv {
+            mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            name,
+            {
+                let completed = completed.clone();
+                move |cmd: &[u8], port| {
+                    respond_startup_two_nodes(name, cmd)?;
+                    let count = completed.fetch_add(1, Ordering::SeqCst);
+                    match port {
+                        6379 => match count {
+                            // First request: return MOVED to node:6380
+                            0 => Err(parse_redis_value(
+                                format!("-MOVED 14000 {name}:6380\r\n").as_bytes(),
+                            )),
+                            _ => panic!("node:6379 should not be called after MOVED"),
+                        },
+                        6380 => match count {
+                            // Retry arrives at correct node and succeeds
+                            1 => Err(Ok(Value::BulkString(b"value".to_vec()))),
+                            _ => panic!("node:6380 should only be called once"),
+                        },
+                        _ => panic!("Unexpected port {port}"),
+                    }
+                }
+            },
+        );
+
+        let value = cmd("GET")
+            .arg("test")
+            .query::<Option<String>>(&mut connection);
+
+        assert_eq!(value, Ok(Some("value".to_string())));
+        // 2 total calls: 1 MOVED + 1 successful retry
+        assert_eq!(completed.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn test_cluster_io_error() {
         let name = "node";
         let completed = Arc::new(AtomicI32::new(0));

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -19,8 +19,8 @@ use redis::cluster_routing::{
 };
 use redis::cluster_slotmap::ReadFromReplicaStrategy;
 use redis::{
-    ClusterScanArgs, Cmd, ErrorKind, FromRedisValue, PipelineRetryStrategy, PushInfo, RedisError,
-    RedisResult, RetryStrategy, ScanStateRC, Value,
+    AddressResolver, ClusterScanArgs, Cmd, ErrorKind, FromRedisValue, PipelineRetryStrategy,
+    PushInfo, RedisError, RedisResult, RetryStrategy, ScanStateRC, Value,
 };
 pub use standalone_client::StandaloneClient;
 use std::io;
@@ -238,16 +238,23 @@ pub(super) fn get_connection_info(
     tls_mode: TlsMode,
     redis_connection_info: redis::RedisConnectionInfo,
     tls_params: Option<redis::TlsConnParams>,
+    address_resolver: Option<&Arc<dyn AddressResolver>>,
 ) -> redis::ConnectionInfo {
+    let (resolved_host, resolved_port) = if let Some(resolver) = address_resolver {
+        resolver.resolve(&address.host, get_port(address))
+    } else {
+        (address.host.to_string(), get_port(address))
+    };
+
     let addr = if tls_mode != TlsMode::NoTls {
         redis::ConnectionAddr::TcpTls {
-            host: address.host.to_string(),
-            port: get_port(address),
+            host: resolved_host,
+            port: resolved_port,
             insecure: tls_mode == TlsMode::InsecureTls,
             tls_params,
         }
     } else {
-        redis::ConnectionAddr::Tcp(address.host.to_string(), get_port(address))
+        redis::ConnectionAddr::Tcp(resolved_host, resolved_port)
     };
     redis::ConnectionInfo {
         addr,
@@ -1729,6 +1736,7 @@ async fn create_cluster_client(
         None => Some(DEFAULT_PERIODIC_TOPOLOGY_CHECKS_INTERVAL),
     };
     let connection_timeout = request.get_connection_timeout();
+    let address_resolver = &request.address_resolver;
     let initial_nodes: Vec<_> = request
         .addresses
         .into_iter()
@@ -1738,6 +1746,7 @@ async fn create_cluster_client(
                 tls_mode,
                 valkey_connection_info.clone(),
                 tls_params.clone(),
+                address_resolver.as_ref(),
             )
         })
         .collect();
@@ -1794,6 +1803,11 @@ async fn create_cluster_client(
         builder.refresh_topology_from_initial_nodes(request.refresh_topology_from_initial_nodes);
 
     builder = builder.tcp_nodelay(request.tcp_nodelay);
+
+    // Pass the address resolver to the builder for use during topology refresh
+    if let Some(resolver) = address_resolver.clone() {
+        builder = builder.address_resolver(resolver);
+    }
 
     // Always use with Glide
     builder = builder.periodic_connections_checks(Some(CONNECTION_CHECKS_INTERVAL));

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -6,7 +6,8 @@ use futures_intrusive::sync::ManualResetEvent;
 use logger_core::{log_debug, log_error, log_trace, log_warn};
 use redis::aio::{DisconnectNotifier, MultiplexedConnection};
 use redis::{
-    GlideConnectionOptions, PushInfo, RedisConnectionInfo, RedisError, RedisResult, RetryStrategy,
+    AddressResolver, GlideConnectionOptions, PushInfo, RedisConnectionInfo, RedisError,
+    RedisResult, RetryStrategy,
 };
 use std::fmt;
 use std::sync::Arc;
@@ -304,9 +305,15 @@ fn get_client(
     tls_mode: TlsMode,
     redis_connection_info: redis::RedisConnectionInfo,
     tls_params: Option<redis::TlsConnParams>,
+    address_resolver: Option<&std::sync::Arc<dyn super::AddressResolver>>,
 ) -> redis::Client {
-    let connection_info =
-        super::get_connection_info(address, tls_mode, redis_connection_info, tls_params);
+    let connection_info = super::get_connection_info(
+        address,
+        tls_mode,
+        redis_connection_info,
+        tls_params,
+        address_resolver,
+    );
     redis::Client::open(connection_info).unwrap() // can unwrap, because [open] fails only on trying to convert input to ConnectionInfo, and we pass ConnectionInfo.
 }
 
@@ -330,6 +337,7 @@ impl ReconnectingConnection {
         tls_params: Option<redis::TlsConnParams>,
         tcp_nodelay: bool,
         pubsub_synchronizer: Option<Arc<dyn crate::pubsub::PubSubSynchronizer>>,
+        address_resolver: Option<&std::sync::Arc<dyn AddressResolver>>,
         iam_token_handle: Option<IAMTokenHandle>,
     ) -> Result<ReconnectingConnection, (ReconnectingConnection, RedisError)> {
         log_debug(
@@ -337,7 +345,13 @@ impl ReconnectingConnection {
             format!("Attempting connection to {address}"),
         );
 
-        let connection_info = get_client(address, tls_mode, redis_connection_info, tls_params);
+        let connection_info = get_client(
+            address,
+            tls_mode,
+            redis_connection_info,
+            tls_params,
+            address_resolver,
+        );
         let backend = ConnectionBackend {
             connection_info: RwLock::new(connection_info),
             connection_available_signal: ManualResetEvent::new(true),

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -10,7 +10,7 @@ use logger_core::log_info;
 use logger_core::log_warn;
 use redis::aio::ConnectionLike;
 use redis::cluster_routing::{self, ResponsePolicy, Routable, RoutingInfo, is_readonly_cmd};
-use redis::{PushInfo, RedisError, RedisResult, RetryStrategy, Value};
+use redis::{AddressResolver, PushInfo, RedisError, RedisResult, RetryStrategy, Value};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -250,6 +250,7 @@ impl StandaloneClient {
         let discovery_tls_params = tls_params.clone();
         let discovery_pubsub_sync = pubsub_synchronizer.clone();
         let discovery_iam_handle = iam_token_handle.clone();
+        let discovery_resolver = connection_request.address_resolver.clone();
 
         let mut stream = stream::iter(addresses)
             .map(move |address| {
@@ -264,6 +265,7 @@ impl StandaloneClient {
                 let sync = pubsub_synchronizer.clone();
                 let skip_replication =
                     read_only || node_discovery_mode == NodeDiscoveryMode::Static;
+                let resolver = connection_request.address_resolver.clone();
                 let iam_handle = iam_token_handle.clone();
                 async move {
                     get_connection_and_replication_info(
@@ -278,6 +280,7 @@ impl StandaloneClient {
                         nodelay,
                         &sync,
                         skip_replication,
+                        resolver.as_ref(),
                         iam_handle,
                     )
                     .await
@@ -383,6 +386,7 @@ impl StandaloneClient {
                     let params = discovery_tls_params.clone();
                     let sync = discovery_pubsub_sync.clone();
                     let iam_handle = discovery_iam_handle.clone();
+                    let resolver = discovery_resolver.clone();
                     async move {
                         let result = get_connection_and_replication_info(
                             &address,
@@ -396,6 +400,7 @@ impl StandaloneClient {
                             tcp_nodelay,
                             &sync,
                             false,
+                            resolver.as_ref(),
                             iam_handle,
                         )
                         .await;
@@ -451,6 +456,7 @@ impl StandaloneClient {
                         let params = discovery_tls_params.clone();
                         let sync = discovery_pubsub_sync.clone();
                         let iam_handle = discovery_iam_handle.clone();
+                        let resolver = discovery_resolver.clone();
                         async move {
                             let result = get_connection_and_replication_info(
                                 &address,
@@ -464,6 +470,7 @@ impl StandaloneClient {
                                 tcp_nodelay,
                                 &sync,
                                 false,
+                                resolver.as_ref(),
                                 iam_handle,
                             )
                             .await;
@@ -1063,6 +1070,7 @@ async fn get_connection_and_replication_info(
     tcp_nodelay: bool,
     pubsub_synchronizer: &Option<Arc<dyn crate::pubsub::PubSubSynchronizer>>,
     skip_replication_check: bool,
+    address_resolver: Option<&Arc<dyn AddressResolver>>,
     iam_token_handle: Option<super::IAMTokenHandle>,
 ) -> Result<(ReconnectingConnection, Option<Value>), (ReconnectingConnection, RedisError)> {
     let reconnecting_connection = ReconnectingConnection::new(
@@ -1076,6 +1084,7 @@ async fn get_connection_and_replication_info(
         tls_params,
         tcp_nodelay,
         pubsub_synchronizer.clone(),
+        address_resolver,
         iam_token_handle,
     )
     .await?;

--- a/glide-core/src/client/types.rs
+++ b/glide-core/src/client/types.rs
@@ -2,9 +2,11 @@
 
 #[allow(unused_imports)]
 use logger_core::log_warn;
+use redis::AddressResolver;
 use redis::cache::EvictionPolicy;
 #[allow(unused_imports)]
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[cfg(feature = "proto")]
@@ -45,6 +47,7 @@ pub struct ConnectionRequest {
     pub read_only: bool,
     pub client_side_cache: Option<ClientSideCache>,
     pub node_discovery_mode: NodeDiscoveryMode,
+    pub address_resolver: Option<Arc<dyn AddressResolver>>,
 }
 
 /// Default connection timeout used when not specified in the request.
@@ -441,12 +444,13 @@ impl From<protobuf::ConnectionRequest> for ConnectionRequest {
             pubsub_reconciliation_interval_ms,
             read_only,
             node_discovery_mode,
+            // Address resolver is not set from protobuf - it's set programmatically
+            address_resolver: None,
         }
     }
 }
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "proto")]
     mod protobuf_conversion_tests {
         use crate::ConnectionRequest;
         use crate::compression::CompressionBackendType;

--- a/java/client/src/main/java/glide/api/models/configuration/AddressResolver.java
+++ b/java/client/src/main/java/glide/api/models/configuration/AddressResolver.java
@@ -1,0 +1,47 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.configuration;
+
+/**
+ * A functional interface for resolving server addresses before connection.
+ *
+ * <p>This callback allows custom DNS resolution or address translation logic to be applied when the
+ * client connects to Valkey/Redis servers. The resolver is invoked with the configured host and
+ * port, and should return the actual host and port to use for the connection.
+ *
+ * <p>Example use cases:
+ *
+ * <ul>
+ *   <li>Custom DNS resolution for service discovery
+ *   <li>Address translation for proxy setups
+ *   <li>Dynamic endpoint resolution for cloud environments
+ * </ul>
+ *
+ * <p>Note that every AddressResolver must be thread safe and should avoid blocking operations, as
+ * it is called synchronously during the connection process.
+ *
+ * @example
+ *     <pre>{@code
+ * AddressResolver resolver = (host, port) -> {
+ *     // Custom resolution logic
+ *     String resolvedHost = myDnsResolver.resolve(host);
+ *     return new ResolvedAddress(resolvedHost, port);
+ * };
+ *
+ * GlideClientConfiguration config = GlideClientConfiguration.builder()
+ *     .address(NodeAddress.builder().host("my-service").port(6379).build())
+ *     .addressResolver(resolver)
+ *     .build();
+ * }</pre>
+ */
+@FunctionalInterface
+public interface AddressResolver {
+
+    /**
+     * Resolves the given host and port to the actual connection address.
+     *
+     * @param host The configured host name or IP address
+     * @param port The configured port number
+     * @return A {@link ResolvedAddress} containing the resolved host and port to use for connection
+     */
+    ResolvedAddress resolve(String host, int port);
+}

--- a/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
@@ -5,6 +5,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -138,6 +139,38 @@ public abstract class BaseClientConfiguration {
     @Builder.Default private final boolean lazyConnect = false;
 
     /**
+     * Optional callback for resolving server addresses before connection.
+     *
+     * <p>If provided, this callback will be invoked for each configured address during connection
+     * establishment. The callback receives the configured host and port, and should return the actual
+     * host and port to use for the connection.
+     *
+     * <p>This is useful for:
+     *
+     * <ul>
+     *   <li>Custom DNS resolution for service discovery
+     *   <li>Address translation for proxy setups
+     *   <li>Dynamic endpoint resolution for cloud environments
+     * </ul>
+     *
+     * <p>If not set, addresses are used as configured without modification.
+     *
+     * @example
+     *     <pre>{@code
+     * AddressResolver resolver = (host, port) -> {
+     *     String resolvedHost = myDnsResolver.resolve(host);
+     *     return new ResolvedAddress(resolvedHost, port);
+     * };
+     *
+     * GlideClientConfiguration config = GlideClientConfiguration.builder()
+     *     .address(NodeAddress.builder().host("my-service").port(6379).build())
+     *     .addressResolver(resolver)
+     *     .build();
+     * }</pre>
+     */
+    private final AddressResolver addressResolver;
+
+    /*
      * Configuration for automatic transparent compression of values.
      *
      * <p>When set, values sent to the server will be compressed using the specified backend if they
@@ -151,5 +184,14 @@ public abstract class BaseClientConfiguration {
 
     public List<NodeAddress> getAddresses() {
         return Collections.unmodifiableList(new ArrayList<>(addresses));
+    }
+
+    /**
+     * Returns the address resolver if configured.
+     *
+     * @return An Optional containing the AddressResolver, or empty if not configured
+     */
+    public Optional<AddressResolver> getAddressResolver() {
+        return Optional.ofNullable(addressResolver);
     }
 }

--- a/java/client/src/main/java/glide/api/models/configuration/ResolvedAddress.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ResolvedAddress.java
@@ -1,0 +1,34 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.configuration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Represents a resolved server address returned by an {@link AddressResolver}.
+ *
+ * <p>This class holds the actual host and port that should be used for connecting to a Valkey/Redis
+ * server after address resolution has been performed.
+ *
+ * @example
+ *     <pre>{@code
+ * // Create a resolved address
+ * ResolvedAddress resolved = new ResolvedAddress("192.168.1.100", 6379);
+ *
+ * // Use in an AddressResolver
+ * AddressResolver resolver = (host, port) -> {
+ *     String actualHost = lookupHost(host);
+ *     return new ResolvedAddress(actualHost, port);
+ * };
+ * }</pre>
+ */
+@Getter
+@RequiredArgsConstructor
+public class ResolvedAddress {
+
+    /** The resolved host name or IP address to use for connection. */
+    private final String host;
+
+    /** The resolved port number to use for connection. */
+    private final int port;
+}

--- a/java/client/src/main/java/glide/internal/GlideNativeBridge.java
+++ b/java/client/src/main/java/glide/internal/GlideNativeBridge.java
@@ -2,6 +2,7 @@
 package glide.internal;
 
 import glide.api.logging.Logger;
+import glide.api.models.configuration.AddressResolver;
 import glide.ffi.resolvers.NativeUtils;
 
 /**
@@ -23,8 +24,19 @@ public class GlideNativeBridge {
         }
     }
 
-    /** Create a new native client instance */
-    public static native long createClient(byte[] connectionRequestBytes);
+    /**
+     * Create a new native client instance.
+     *
+     * <p>If an AddressResolver is provided, it will be stored as a global reference on the native
+     * side to prevent garbage collection while the client is alive. The resolver will be called from
+     * any thread when address resolution is needed.
+     *
+     * @param connectionRequestBytes Protobuf-encoded ConnectionRequest
+     * @param addressResolver The address resolver callback, or null if not needed
+     * @return Native client handle, or 0 on failure
+     */
+    public static native long createClient(
+            byte[] connectionRequestBytes, AddressResolver addressResolver);
 
     /** Execute command asynchronously */
     public static native void executeCommandAsync(

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -4,6 +4,7 @@ package glide.managers;
 import static connection_request.ConnectionRequestOuterClass.*;
 
 import glide.api.models.GlideString;
+import glide.api.models.configuration.AddressResolver;
 import glide.api.models.configuration.AdvancedBaseClientConfiguration;
 import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
 import glide.api.models.configuration.BackoffStrategy;
@@ -459,8 +460,14 @@ public class ConnectionManager {
                         ConnectionRequest request = requestBuilder.build();
                         byte[] requestBytes = request.toByteArray();
 
+                        // Get the address resolver (may be null if not configured)
+                        // The resolver is passed directly to native code which stores it as a global reference
+                        // to prevent garbage collection while the client is alive
+                        AddressResolver addressResolver = configuration.getAddressResolver().orElse(null);
+
                         // Create native client with protobuf bytes
-                        this.nativeClientHandle = GlideNativeBridge.createClient(requestBytes);
+                        // Native code will store the resolver as a global reference if provided
+                        this.nativeClientHandle = GlideNativeBridge.createClient(requestBytes, addressResolver);
 
                         if (nativeClientHandle == 0) {
                             throw new ClosingException("Failed to create client - Connection refused");

--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -1,7 +1,9 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
+import static glide.TestConfiguration.CLUSTER_HOSTS;
 import static glide.TestConfiguration.SERVER_VERSION;
+import static glide.TestConfiguration.STANDALONE_HOSTS;
 import static glide.TestUtilities.*;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleMultiNodeRoute.ALL_NODES;
@@ -764,7 +766,6 @@ public class ConnectionTests {
                             expectedNewConnections,
                             clientsBeforeLazyInit,
                             clientsAfterFirstCommand));
-
         } finally {
             if (monitoringClient != null) {
                 monitoringClient.close();
@@ -932,5 +933,147 @@ public class ConnectionTests {
         assertEquals("OK", clientFalse.set("key3", "value3").get());
         assertEquals("value3", clientFalse.get("key3").get());
         clientFalse.close();
+    }
+
+    @Test
+    @SneakyThrows
+    public void test_address_resolver_standalone_client() {
+        // Get the actual server address from test configuration
+        String[] actualHostParts = STANDALONE_HOSTS[0].split(":");
+        String actualHost = actualHostParts[0];
+        int actualPort = Integer.parseInt(actualHostParts[1]);
+
+        // Use a fake/placeholder address in configuration
+        String fakeHost = "fake-host-that-does-not-exist.invalid";
+        int fakePort = 9999;
+
+        // Create resolver that translates fake address to real server address
+        AddressResolver resolver =
+                (host, port) -> {
+                    // Only translate our fake address to the real one
+                    if (fakeHost.equals(host) && port == fakePort) {
+                        return new ResolvedAddress(actualHost, actualPort);
+                    }
+                    // Pass through any other addresses unchanged
+                    return new ResolvedAddress(host, port);
+                };
+
+        // Configure client with fake address - connection should succeed because
+        // resolver translates it to the real address
+        GlideClient client =
+                GlideClient.createClient(
+                                GlideClientConfiguration.builder()
+                                        .address(NodeAddress.builder().host(fakeHost).port(fakePort).build())
+                                        .addressResolver(resolver)
+                                        .build())
+                        .get();
+
+        // Verify the client works - this proves the resolved address was used
+        assertEquals("PONG", client.ping().get());
+        assertEquals("OK", client.set("resolver_test_key", "resolver_test_value").get());
+        assertEquals("resolver_test_value", client.get("resolver_test_key").get());
+
+        client.close();
+    }
+
+    @Test
+    @SneakyThrows
+    public void test_address_resolver_cluster_client() {
+        // Get the actual server address from test configuration
+        String[] actualHostParts = CLUSTER_HOSTS[0].split(":");
+        String actualHost = actualHostParts[0];
+        int actualPort = Integer.parseInt(actualHostParts[1]);
+
+        // Use a fake/placeholder address in configuration
+        String fakeHost = "fake-cluster-host.invalid";
+        int fakePort = 9999;
+
+        // Create resolver that translates fake address to real server address
+        AddressResolver resolver =
+                (host, port) -> {
+                    // Only translate our fake address to the real one
+                    if (fakeHost.equals(host) && port == fakePort) {
+                        return new ResolvedAddress(actualHost, actualPort);
+                    }
+                    // Pass through any other addresses unchanged
+                    return new ResolvedAddress(host, port);
+                };
+
+        // Configure client with fake address - connection should succeed because
+        // resolver translates it to the real address
+        GlideClusterClient client =
+                GlideClusterClient.createClient(
+                                GlideClusterClientConfiguration.builder()
+                                        .address(NodeAddress.builder().host(fakeHost).port(fakePort).build())
+                                        .addressResolver(resolver)
+                                        .build())
+                        .get();
+
+        // Verify the client works - this proves the resolved address was used
+        assertEquals("PONG", client.ping().get());
+        assertEquals(
+                "OK", client.set("cluster_resolver_test_key", "cluster_resolver_test_value").get());
+        assertEquals("cluster_resolver_test_value", client.get("cluster_resolver_test_key").get());
+
+        client.close();
+    }
+
+    @Test
+    @SneakyThrows
+    public void test_address_resolver_cluster_client_throws_exception() {
+        // Get the actual server address from test configuration
+        String[] actualHostParts = CLUSTER_HOSTS[0].split(":");
+        String actualHost = actualHostParts[0];
+        int actualPort = Integer.parseInt(actualHostParts[1]);
+
+        AddressResolver resolver =
+                (host, port) -> {
+                    throw new RuntimeException("test-exception");
+                };
+
+        GlideClusterClient client =
+                GlideClusterClient.createClient(
+                                GlideClusterClientConfiguration.builder()
+                                        .address(NodeAddress.builder().host(actualHost).port(actualPort).build())
+                                        .addressResolver(resolver)
+                                        .build())
+                        .get();
+
+        // Connection still goes through, as the fallback is to use the original address if resolver
+        // throws an exception
+        assertEquals("PONG", client.ping().get());
+        assertEquals(
+                "OK", client.set("cluster_resolver_test_key", "cluster_resolver_test_value").get());
+        assertEquals("cluster_resolver_test_value", client.get("cluster_resolver_test_key").get());
+
+        client.close();
+    }
+
+    @Test
+    @SneakyThrows
+    public void test_address_resolver_cluster_client_returns_null() {
+        // Get the actual server address from test configuration
+        String[] actualHostParts = CLUSTER_HOSTS[0].split(":");
+        String actualHost = actualHostParts[0];
+        int actualPort = Integer.parseInt(actualHostParts[1]);
+
+        AddressResolver resolver = (host, port) -> null;
+
+        GlideClusterClient client =
+                GlideClusterClient.createClient(
+                                GlideClusterClientConfiguration.builder()
+                                        .address(NodeAddress.builder().host(actualHost).port(actualPort).build())
+                                        .addressResolver(resolver)
+                                        .build())
+                        .get();
+
+        // Connection still goes through, as the fallback is to use the original address if resolver
+        // returns null
+        assertEquals("PONG", client.ping().get());
+        assertEquals(
+                "OK", client.set("cluster_resolver_test_key", "cluster_resolver_test_value").get());
+        assertEquals("cluster_resolver_test_value", client.get("cluster_resolver_test_key").get());
+
+        client.close();
     }
 }

--- a/java/src/address_resolver.rs
+++ b/java/src/address_resolver.rs
@@ -1,0 +1,196 @@
+use std::fmt::Display;
+use std::str;
+use std::sync::Arc;
+
+use jni::objects::{GlobalRef, JMethodID, JObject, JString};
+use jni::{JNIEnv, JavaVM};
+use log::error;
+
+/// Java-specific implementation of the AddressResolver trait.
+/// This struct holds a GlobalRef to the Java AddressResolver object, ensuring it
+/// won't be garbage collected while the resolver is in use.
+pub struct JavaAddressResolver {
+    jvm: Arc<JavaVM>,
+    resolver_global: GlobalRef,
+    method_id: JMethodID,
+    get_host_method_id: JMethodID,
+    get_port_method_id: JMethodID,
+}
+
+impl JavaAddressResolver {
+    /// Creates a new JavaAddressResolver by creating a global reference to the Java object.
+    /// Returns None if the global reference cannot be created.
+    pub fn new(env: &mut JNIEnv, jvm: Arc<JavaVM>, resolver: &JObject) -> Option<Self> {
+        let resolver_global = match env.new_global_ref(resolver) {
+            Ok(resolver_global) => resolver_global,
+            Err(e) => {
+                log::error!("Failed to create global reference for address resolver: {e}");
+                return None;
+            }
+        };
+        let class = match env.get_object_class(resolver_global.as_obj()) {
+            Ok(class) => class,
+            Err(e) => {
+                log::error!("Failed to get class of the address resolver object: {e}");
+                return None;
+            }
+        };
+        let method_id = match env.get_method_id(
+            class,
+            "resolve",
+            "(Ljava/lang/String;I)Lglide/api/models/configuration/ResolvedAddress;",
+        ) {
+            Ok(method_id) => method_id,
+            Err(e) => {
+                log::error!("Failed to find 'resolve' method on the address resolver object: {e}");
+                return None;
+            }
+        };
+        let get_host_method_id = match env.get_method_id(
+            "glide/api/models/configuration/ResolvedAddress",
+            "getHost",
+            "()Ljava/lang/String;",
+        ) {
+            Ok(method_id) => method_id,
+            Err(e) => {
+                log::error!("Failed to find 'getHost' method on the ResolvedAddress object: {e}");
+                return None;
+            }
+        };
+        let get_port_method_id = match env.get_method_id(
+            "glide/api/models/configuration/ResolvedAddress",
+            "getPort",
+            "()I",
+        ) {
+            Ok(method_id) => method_id,
+            Err(e) => {
+                log::error!("Failed to find 'getPort' method on the ResolvedAddress object: {e}");
+                return None;
+            }
+        };
+        Some(Self {
+            jvm,
+            resolver_global,
+            method_id,
+            get_host_method_id,
+            get_port_method_id,
+        })
+    }
+}
+
+impl std::fmt::Debug for JavaAddressResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JavaAddressResolver {{ resolver: <Java object> }}")
+    }
+}
+
+#[derive(Debug)]
+enum AddressResolverError {
+    FailedToAttachError(jni::errors::Error),
+    FailedToCreateHostString(jni::errors::Error),
+    FailedToCallMethod(jni::errors::Error),
+    InvalidResult(jni::errors::Error),
+    InvalidString(str::Utf8Error),
+}
+
+impl Display for AddressResolverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddressResolverError::FailedToAttachError(err) => {
+                write!(f, "Failed to attach to JVM thread: {err}")
+            }
+            AddressResolverError::FailedToCreateHostString(err) => {
+                write!(f, "Failed to create Java string for host: {err}")
+            }
+            AddressResolverError::FailedToCallMethod(err) => {
+                write!(f, "Failed to call method on Java resolver: {err}")
+            }
+            AddressResolverError::InvalidResult(err) => {
+                write!(f, "Invalid result from Java resolver: {err}")
+            }
+            AddressResolverError::InvalidString(err) => {
+                write!(f, "Failed to convert Java string to Rust string: {err}")
+            }
+        }
+    }
+}
+
+fn map_call_method_err(err: jni::errors::Error, env: &JNIEnv) -> AddressResolverError {
+    if let Ok(true) = env.exception_check() {
+        let _ = env.exception_describe(); // Log the exception details
+        let _ = env.exception_clear();
+    }
+    AddressResolverError::FailedToCallMethod(err)
+}
+impl JavaAddressResolver {
+    fn try_resolve(&self, host: &str, port: u16) -> Result<(String, u16), AddressResolverError> {
+        // Prepare to call
+        let mut env = self
+            .jvm
+            .attach_current_thread_as_daemon()
+            .map_err(AddressResolverError::FailedToAttachError)?;
+        let host_jstring = env
+            .new_string(host)
+            .map_err(AddressResolverError::FailedToCreateHostString)?;
+        // Call the resolver
+        // SAFETY: method id is pre-calculated from resolver_global so is guaranteed to be valid.
+        let result = unsafe {
+            env.call_method_unchecked(
+                self.resolver_global.as_obj(),
+                self.method_id,
+                jni::signature::ReturnType::Object,
+                &[
+                    jni::objects::JValue::Object(&host_jstring).as_jni(),
+                    jni::objects::JValue::Int(port as i32).as_jni(),
+                ],
+            )
+            .map_err(|err| map_call_method_err(err, &env))?
+        };
+        let resolved_address = result.l().map_err(AddressResolverError::InvalidResult)?;
+        if resolved_address.is_null() {
+            return Ok((host.to_string(), port));
+        }
+
+        // Call succeeded with non-null value. Let's extract the values now.
+        let resolved_host_jstr: JString = unsafe {
+            env.call_method_unchecked(
+                &resolved_address,
+                self.get_host_method_id,
+                jni::signature::ReturnType::Object,
+                &[],
+            )
+            .map_err(|err| map_call_method_err(err, &env))?
+            .l()
+            .map_err(AddressResolverError::InvalidResult)?
+            .into()
+        };
+        let resolved_host = env
+            .get_string(&resolved_host_jstr)
+            .map_err(AddressResolverError::InvalidResult)?
+            .to_str()
+            .map_err(AddressResolverError::InvalidString)?
+            .to_string();
+        let resolved_port = unsafe {
+            env.call_method_unchecked(
+                &resolved_address,
+                self.get_port_method_id,
+                jni::signature::ReturnType::Primitive(jni::signature::Primitive::Int),
+                &[],
+            )
+            .map_err(|err| map_call_method_err(err, &env))?
+            .i()
+            .map_err(AddressResolverError::InvalidResult)?
+        };
+
+        Ok((resolved_host, resolved_port as u16))
+    }
+}
+
+impl redis::AddressResolver for JavaAddressResolver {
+    fn resolve(&self, host: &str, port: u16) -> (String, u16) {
+        self.try_resolve(host, port).unwrap_or_else(|err| {
+            error!("Failed to resolve address on the JVM. {err}");
+            (host.to_string(), port)
+        })
+    }
+}

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -28,6 +28,7 @@ use redis::Value;
 use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 
+mod address_resolver;
 mod errors;
 mod jni_client;
 mod linked_hashmap;
@@ -37,6 +38,7 @@ use errors::{FFIError, handle_errors, run_ffi};
 use jni_client::*;
 use protobuf_bridge::*;
 
+use crate::address_resolver::JavaAddressResolver;
 /// Process command arguments for compression, matching the socket_listener pattern.
 /// Extracts args from the command, applies compression if applicable, and rebuilds the command.
 fn process_command_for_compression(
@@ -1433,11 +1435,15 @@ fn safe_create_jstring<'local>(mut env: JNIEnv<'local>, input: &str) -> JString<
 // ==================== JNI CLIENT MANAGEMENT FUNCTIONS ====================
 
 /// Create Valkey client and store handle.
+/// If address_resolver is not null, it will be stored as a global reference and used
+/// for address resolution callbacks. The global reference ensures the resolver is not
+/// garbage collected while the client is alive.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_glide_internal_GlideNativeBridge_createClient(
-    env: JNIEnv,
+    mut env: JNIEnv,
     _class: JClass,
     connection_request_bytes: JByteArray,
+    address_resolver: JObject,
 ) -> jlong {
     run_ffi(|| {
         // Convert Java byte array to Rust bytes
@@ -1461,11 +1467,26 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createClient(
         };
 
         // Convert protobuf to glide_core ConnectionRequest
-        let connection_request = glide_core::client::ConnectionRequest::from(request);
+        let mut connection_request = glide_core::client::ConnectionRequest::from(request);
 
         // Cache JVM for push callbacks
         if let Ok(jvm) = env.get_java_vm() {
             let _ = jni_client::JVM.set(Arc::new(jvm));
+        }
+
+        // If an address resolver is provided, create a global reference and set up the callback
+        // The global reference ensures the Java object is not garbage collected while in use
+        if !address_resolver.is_null()
+            && let Some(jvm) = jni_client::JVM.get().cloned()
+        {
+            match JavaAddressResolver::new(&mut env, jvm, &address_resolver) {
+                Some(resolver) => {
+                    connection_request.address_resolver = Some(Arc::new(resolver));
+                }
+                None => {
+                    return Some(0);
+                }
+            }
         }
 
         // Direct client creation (no lazy loading for simplified implementation)


### PR DESCRIPTION
### Summary

Allows the application to resolve the host and port before a connection is made. This is useful for cases where the URL can't be resolved by the default DNS, or is behind a firewall.

### Issue link

This Pull Request is linked to issue: [Support custom socket address resolution when connecting to valkey #4396](https://github.com/valkey-io/valkey-glide/issues/4396)

Related:
- [Support custom socket address resolution #5328](https://github.com/valkey-io/valkey-glide/issues/5328)
- [[2.4] Customer Issues & Bug Fixes #5712](https://github.com/valkey-io/valkey-glide/issues/5712)

### Features / Behaviour Changes

Exposes the `AddressResolver` callback in the builder in Java. The other bindings do not expose this yet.

### Implementation

- A new trait for `AddressResolver` was added, where each binding can implement its own version of it.
- All places that create a `ConnectionAddr` were changed to call the `AddressResolver` (client creation, cluster new connection creation)
- The JNI binding has an implementation `JavaAddressResolver` that stores the pointer to the Java callback, and calls it using JNI.

### Limitations

- Haven't exposed the feature to other bindings yet.

### Testing

- Added tests in `ConnectionTests.java` that verify if initially invalid addresses can be rewritten back into the valid addresses
- Added tests in `cluster_topology.rs` that verify that new connections in the cluster are also rewritten

### Checklist

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
