### PR TITLE
Cherry pick #5874 to release 2.4

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -255,6 +255,23 @@ jobs:
               env:
                   JEST_HTML_REPORTER_OUTPUT_PATH: test-report-ecma.html
 
+            # Test pnpm pubsub pointer handling
+            - name: Install pnpm
+              run: npm install -g pnpm
+
+            - name: Test pointer handling with npm (util.Long=null simulation)
+              run: |
+                  npm install
+                  npm run test
+              working-directory: ./node/hybrid-node-tests/pnpm-pubsub-test
+
+            - name: Test pointer handling with pnpm (util.Long=null simulation)
+              run: |
+                  rm -rf node_modules
+                  pnpm install
+                  pnpm run test
+              working-directory: ./node/hybrid-node-tests/pnpm-pubsub-test
+
             - name: Run benchmarks
               uses: ./.github/workflows/test-benchmark
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Fixes
 * CORE: Fall back to existing cluster connections when initial nodes are unavailable during topology refresh. When `refreshTopologyFromInitialNodes=true` and the initial/seed node is unreachable (e.g., dead primary during failover), the topology refresh now queries healthy existing connections instead of failing silently. This complements #5812 to enable failover recovery when the seed node itself is the failed node. ([#5814](https://github.com/valkey-io/valkey-glide/pull/5814))
+* Node: Fix SIGSEGV in pubsub under pnpm strict hoisting — replace `value_from_split_pointer(high_u32, low_u32)` with `value_from_pointer(i64)` in the Node.js Rust client to accept response pointers as a single integer, eliminating the high/low split that caused upper 32-bit truncation when `protobufjs.util.Long` was null ([#5851](https://github.com/valkey-io/valkey-glide/issues/5851))
 
 #### Changes
 * Go: Expose client interfaces (`BaseClientCommands`, `GlideClientCommands`, `GlideClusterClientCommands`, etc.) as a public package for testing and abstraction ([#4900](https://github.com/valkey-io/valkey-glide/issues/4900))

--- a/node/hybrid-node-tests/pnpm-pubsub-test/package.json
+++ b/node/hybrid-node-tests/pnpm-pubsub-test/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "pnpm-pubsub-test",
+    "version": "1.0.0",
+    "description": "Test that command responses and pubsub work when protobufjs util.Long is null",
+    "main": "pnpm-pubsub-test.cjs",
+    "type": "commonjs",
+    "scripts": {
+        "test": "node pnpm-pubsub-test.cjs"
+    },
+    "author": "Amazon Web Services",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@valkey/valkey-glide": "file:../..",
+        "find-free-port": "^2.0.0"
+    }
+}

--- a/node/hybrid-node-tests/pnpm-pubsub-test/pnpm-pubsub-test.cjs
+++ b/node/hybrid-node-tests/pnpm-pubsub-test/pnpm-pubsub-test.cjs
@@ -1,0 +1,153 @@
+/* eslint no-undef: off */
+/* eslint @typescript-eslint/no-require-imports: off */
+"use strict";
+
+// Patch Module._resolveFilename to block 'long' resolution from
+// @protobufjs/inquire, simulating pnpm strict hoisting where inquire's
+// eval-wrapped require("long") fails. This forces protobufjs to return
+// JS numbers instead of Long objects for uint64 fields, exercising the
+// code path that requires correct 64-bit pointer handling.
+const Module = require("module");
+const origResolve = Module._resolveFilename;
+
+Module._resolveFilename = function (request, parent, ...rest) {
+    if (
+        request === "long" &&
+        parent &&
+        parent.filename &&
+        parent.filename.includes("@protobufjs")
+    ) {
+        throw new Error(
+            "Simulated pnpm strict hoisting: long not found from @protobufjs/inquire",
+        );
+    }
+
+    return origResolve.call(this, request, parent, ...rest);
+};
+
+const { GlideClient } = require("@valkey/valkey-glide");
+const FreePort = require("find-free-port");
+const { startServer, checkWhichCommandAvailable } = require("../utils.js");
+
+const PORT_NUMBER = 4001;
+
+/**
+ * Test the processResponse code path (normal commands) under simulated
+ * pnpm strict hoisting where respPointer arrives as a JS number.
+ */
+async function testProcessResponse(port) {
+    const client = await GlideClient.createClient({
+        addresses: [{ host: "localhost", port }],
+    });
+
+    try {
+        const key = "pnpm-test-key";
+        const value = "pnpm-test-value";
+
+        const setResult = await client.set(key, value);
+
+        if (setResult !== "OK") {
+            throw new Error(`set returned '${setResult}', expected 'OK'`);
+        }
+
+        const getResult = await client.get(key);
+
+        if (getResult !== value) {
+            throw new Error(`get returned '${getResult}', expected '${value}'`);
+        }
+
+        console.log("processResponse test passed: set/get round-trip OK");
+    } finally {
+        client.close();
+    }
+}
+
+/**
+ * Test the notificationToPubSubMessageSafe code path (pubsub) under
+ * simulated pnpm strict hoisting where respPointer arrives as a JS number.
+ */
+async function testPubSub(port) {
+    const receivedMessages = [];
+    const client = await GlideClient.createClient({
+        addresses: [{ host: "localhost", port }],
+        pubsubSubscriptions: {
+            channelsAndPatterns: {},
+            callback: (msg) => {
+                receivedMessages.push(msg);
+            },
+        },
+    });
+
+    const publisher = await GlideClient.createClient({
+        addresses: [{ host: "localhost", port }],
+    });
+
+    try {
+        const channel = "test-channel-pnpm";
+        const message = "hello-from-pnpm-test";
+
+        await client.subscribeLazy([channel]);
+
+        // Wait for subscription to be established
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        await publisher.publish(message, channel);
+
+        // Wait for message delivery
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        if (receivedMessages.length !== 1) {
+            throw new Error(
+                `Expected 1 message, got ${receivedMessages.length}`,
+            );
+        }
+
+        const received = receivedMessages[0];
+
+        if (received.message !== message) {
+            throw new Error(
+                `Expected message '${message}', got '${received.message}'`,
+            );
+        }
+
+        if (received.channel !== channel) {
+            throw new Error(
+                `Expected channel '${channel}', got '${received.channel}'`,
+            );
+        }
+
+        console.log(
+            `pubsub test passed: received '${received.message}' on '${received.channel}'`,
+        );
+    } finally {
+        client.close();
+        publisher.close();
+    }
+}
+
+async function main() {
+    let serverProcess;
+
+    try {
+        const port = await FreePort(PORT_NUMBER);
+        const serverCmd = await checkWhichCommandAvailable();
+        serverProcess = await startServer(serverCmd, port);
+
+        await testProcessResponse(port);
+        await testPubSub(port);
+
+        console.log("All pnpm pointer tests passed");
+        process.exit(0);
+    } catch (error) {
+        console.error("Error:", error.message);
+        process.exit(1);
+    } finally {
+        if (serverProcess) {
+            serverProcess.kill();
+        }
+    }
+}
+
+if (require.main === module) {
+    main();
+}

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -17,7 +17,6 @@ tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
 napi = { version = "2", default-features = false, features = ["napi8"] }
 napi-derive = "2"
 logger_core = { path = "../../logger_core" }
-byteorder = "1"
 bytes = "1"
 num-traits = "0.2"
 

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -14,7 +14,6 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 pub const FINISHED_SCAN_CURSOR: &str = "finished";
-use byteorder::{LittleEndian, WriteBytesExt};
 use bytes::Bytes;
 use glide_core::MAX_REQUEST_ARGS_LENGTH;
 use glide_core::client::ConnectionError;
@@ -419,29 +418,27 @@ fn resp_value_to_js(val: Value, js_env: Env, string_decoder: bool) -> Result<JsU
     }
 }
 
+/// Dereference a response pointer passed as a single JS number.
+///
+/// napi-rs marshals `i64` via `napi_get_value_int64`, which preserves all
+/// bits for values within the safe integer range. User-space heap addresses
+/// on current 64-bit platforms (48-bit on arm64 macOS, 47-bit on x86-64
+/// Linux) are well within this range. Using a single integer avoids the
+/// high/low u32 split and eliminates the class of bugs where the caller
+/// passes the wrong high bits.
 #[napi(
     ts_return_type = "null | string | Uint8Array | number | {} | Boolean | BigInt | Set<any> | any[] | Buffer"
 )]
-pub fn value_from_split_pointer(
+pub fn value_from_pointer(
     js_env: Env,
-    high_bits: u32,
-    low_bits: u32,
+    pointer_number: i64,
     string_decoder: bool,
 ) -> Result<JsUnknown> {
-    let mut bytes = [0_u8; 8];
-    (&mut bytes[..4])
-        .write_u32::<LittleEndian>(low_bits)
-        .unwrap();
-    (&mut bytes[4..])
-        .write_u32::<LittleEndian>(high_bits)
-        .unwrap();
-    let pointer = u64::from_le_bytes(bytes);
-    let value = unsafe { Box::from_raw(pointer as *mut Value) };
+    let value = unsafe { Box::from_raw(pointer_number as *mut Value) };
     resp_value_to_js(*value, js_env, string_decoder)
 }
 
-// Pointers are split because JS cannot represent a full usize using its `number` object.
-// The pointer is split into 2 `number`s, and then combined back in `value_from_split_pointer`.
+// Split a pointer into [low, high] u32 pair for testing utilities.
 fn split_pointer<T>(pointer: *mut T) -> [u32; 2] {
     let pointer = pointer as usize;
     let bytes = usize::to_le_bytes(pointer);

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -9,13 +9,7 @@
 
 import Long from "long";
 import * as net from "net";
-import {
-    Buffer,
-    BufferWriter,
-    Long as ProtoLong,
-    Reader,
-    Writer,
-} from "protobufjs/minimal";
+import { Buffer, BufferWriter, Reader, Writer } from "protobufjs/minimal";
 import {
     AggregationType,
     BaseScanOptions,
@@ -287,7 +281,7 @@ import {
     getStatistics,
     compressionConfigToProtobuf,
     validateCompressionConfiguration,
-    valueFromSplitPointer,
+    valueFromPointer,
 } from ".";
 import {
     command_request,
@@ -543,28 +537,6 @@ export function convertRecordToGlideRecord<T>(
     return Object.entries(data).map(([key, value]) => {
         return { key, value };
     });
-}
-
-/**
- * Our purpose in creating PointerResponse type is to mark when response is of number/long pointer response type.
- * Consequently, when the response is returned, we can check whether it is instanceof the PointerResponse type and pass it to the Rust core function with the proper parameters.
- */
-class PointerResponse {
-    pointer: number | ProtoLong | null;
-    // As Javascript does not support 64-bit integers,
-    // we split the Rust u64 pointer into two u32 integers (high and low) and build it again when we call value_from_split_pointer, the Rust function.
-    high: number | undefined;
-    low: number | undefined;
-
-    constructor(
-        pointer: number | ProtoLong | null,
-        high?: number | undefined,
-        low?: number | undefined,
-    ) {
-        this.pointer = pointer;
-        this.high = high;
-        this.low = low;
-    }
 }
 
 /** Represents the types of services that can be used for IAM authentication. */
@@ -1326,33 +1298,13 @@ export class BaseClient {
             const errorType = getRequestErrorClass(message.requestError.type);
             reject(new errorType(message.requestError.message ?? undefined));
         } else if (message.respPointer != null) {
-            let pointer;
-
-            if (typeof message.respPointer === "number") {
-                // Response from type number
-                const long = Long.fromNumber(message.respPointer);
-                pointer = new PointerResponse(
-                    message.respPointer,
-                    long.high,
-                    long.low,
-                );
-            } else {
-                // Response from type long
-                pointer = new PointerResponse(
-                    message.respPointer,
-                    message.respPointer.high,
-                    message.respPointer.low,
-                );
-            }
+            const ptrNum =
+                typeof message.respPointer === "number"
+                    ? message.respPointer
+                    : message.respPointer.toNumber();
 
             try {
-                resolve(
-                    valueFromSplitPointer(
-                        pointer.high!,
-                        pointer.low!,
-                        decoder === Decoder.String,
-                    ),
-                );
+                resolve(valueFromPointer(ptrNum, decoder === Decoder.String));
             } catch (err: unknown) {
                 Logger.log("error", "Decoder", `Decoding error: '${err}'`);
                 reject(
@@ -1853,19 +1805,14 @@ export class BaseClient {
             (decoder ?? this.defaultDecoder) === Decoder.String;
 
         if (responsePointer) {
-            if (typeof responsePointer !== "number") {
-                nextPushNotificationValue = valueFromSplitPointer(
-                    responsePointer.high,
-                    responsePointer.low,
-                    isStringDecoder,
-                ) as Record<string, unknown>;
-            } else {
-                nextPushNotificationValue = valueFromSplitPointer(
-                    0,
-                    responsePointer,
-                    isStringDecoder,
-                ) as Record<string, unknown>;
-            }
+            const ptrNum =
+                typeof responsePointer === "number"
+                    ? responsePointer
+                    : responsePointer.toNumber();
+            nextPushNotificationValue = valueFromPointer(
+                ptrNum,
+                isStringDecoder,
+            ) as Record<string, unknown>;
 
             const messageKind = nextPushNotificationValue["kind"];
 


### PR DESCRIPTION
### Summary

Fix SIGSEGV in Node.js pubsub (and potentially command responses) when protobufjs.util.Long is null, which occurs under pnpm strict hoisting. Replace the value_from_split_pointer(high_u32, low_u32) FFI function with value_from_pointer(i64) that accepts the response pointer as a single integer, making 64-bit truncation structurally impossible.

### Issue link

This Pull Request is linked to issue: [node: SIGSEGV in valueFromSplitPointer on first subscribeLazy under pnpm](https://github.com/valkey-io/valkey-glide/issues/5851)

Related:
#5851 
#5712 

### Features / Behaviour Changes

No user-facing behaviour change. The same pointer is passed to the same Rust deserialization logic — only the FFI marshalling changes from two u32 parameters to one i64 parameter.

### Implementation

When protobufjs.util.Long is null (common under pnpm strict hoisting where @protobufjs/inquire can't resolve the long package), protobufjs decodes uint64 fields as JS numbers instead of Long objects. The pubsub code path in notificationToPubSubMessageSafe passed (0, responsePointer) to valueFromSplitPointer, hardcoding high=0 and dropping the upper 32 bits of the pointer. The truncated pointer was then dereferenced via Box::from_raw, causing SIGSEGV.

Fix:
node/rust-client/src/lib.rs: Add value_from_pointer(i64) — napi-rs marshals i64 via napi_get_value_int64, preserving all bits. User-space heap addresses on all supported 64-bit platforms are under 2^47, well within

Update previous value_from_split_pointer() calls to use value_from_pointer().

### Limitations

None

### Testing

Added integration test (node/hybrid-node-tests/pnpm-pubsub-test/) that simulates pnpm strict hoisting by patching Module._resolveFilename to block long resolution from @protobufjs/inquire, then:
- Exercises processResponse path via set/get round-trip and validates the returned value
- Exercises notificationToPubSubMessageSafe path via publish/subscribeLazy and validates the received message
   content

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
