### PR TITLE
fix: java workflow correctly skips container tests on windows only and moved start time

### DIFF
--- a/.github/workflows/fmt-go.yml
+++ b/.github/workflows/fmt-go.yml
@@ -9,9 +9,9 @@ permissions:
     actions: write
 
 on:
-    # Nightly at 01:30 UTC.
+    # Nightly at 04:30 UTC (9:30 PM PDT).
     schedule:
-        - cron: "30 1 * * *"
+        - cron: "30 4 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fmt-java-windows.yml
+++ b/.github/workflows/fmt-java-windows.yml
@@ -10,9 +10,9 @@ permissions:
     actions: write
 
 on:
-    # Nightly at 03:00 UTC.
+    # Nightly at 06:00 UTC (11:00 PM PDT).
     schedule:
-        - cron: "0 3 * * *"
+        - cron: "0 6 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fmt-java.yml
+++ b/.github/workflows/fmt-java.yml
@@ -10,9 +10,9 @@ permissions:
     actions: write
 
 on:
-    # Nightly at 01:00 UTC.
+    # Nightly at 04:00 UTC (9:00 PM PDT).
     schedule:
-        - cron: "0 1 * * *"
+        - cron: "0 4 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fmt-node.yml
+++ b/.github/workflows/fmt-node.yml
@@ -9,9 +9,9 @@ permissions:
     actions: write
 
 on:
-    # Nightly at 00:30 UTC.
+    # Nightly at 03:30 UTC (8:30 PM PDT).
     schedule:
-        - cron: "30 0 * * *"
+        - cron: "30 3 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fmt-python.yml
+++ b/.github/workflows/fmt-python.yml
@@ -7,11 +7,12 @@ name: FMT Python
 permissions:
     contents: read
     actions: write
+    id-token: write
 
 on:
-    # Nightly at 00:00 UTC.
+    # Nightly at 03:00 UTC (8:00 PM PDT).
     schedule:
-        - cron: "0 0 * * *"
+        - cron: "0 3 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fmt-redis-rs.yml
+++ b/.github/workflows/fmt-redis-rs.yml
@@ -9,9 +9,9 @@ permissions:
     actions: write
 
 on:
-    # Nightly at 02:30 UTC.
+    # Nightly at 05:30 UTC (10:30 PM PDT).
     schedule:
-        - cron: "30 2 * * *"
+        - cron: "30 5 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/fmt-rust.yml
+++ b/.github/workflows/fmt-rust.yml
@@ -9,9 +9,9 @@ permissions:
     actions: write
 
 on:
-    # Nightly at 02:00 UTC.
+    # Nightly at 05:00 UTC (10:00 PM PDT).
     schedule:
-        - cron: "0 2 * * *"
+        - cron: "0 5 * * *"
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -426,7 +426,7 @@ jobs:
 
     get-containers:
         runs-on: ubuntu-latest
-        if: ${{ github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule' }}
+        if: ${{ inputs.windows-only != true && (github.event.inputs.full-matrix == 'true' || github.event_name == 'schedule') }}
         outputs:
             engine-matrix-output: ${{ steps.get-matrices.outputs.engine-matrix-output }}
             host-matrix-output: ${{ steps.get-matrices.outputs.host-matrix-output }}


### PR DESCRIPTION
### Summary

This PR fixes java workflow to skip container tests when windows-only is specified.

Also moved start time to 8pm PDT to avoid contentions.

### Related
Follow-up of: #5808 

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [ ] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
