### PR TITLE
Update npm-cd.yml to install zig from direct binary

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -241,8 +241,12 @@ jobs:
                   # Install needed dependencies
                   if [[ "${{ matrix.TARGET }}" == *"linux"* ]]; then
                     sudo apt update
-                    sudo apt install -y snap gcc pkg-config openssl libssl-dev
-                    sudo snap install zig --classic --beta
+                    sudo apt install -y gcc pkg-config openssl libssl-dev
+                    # Install zig via direct binary download (works on all runners without snap/pip)
+                    ZIG_VERSION="0.13.0"
+                    ZIG_ARCH="$(uname -m)"
+                    curl -sSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}.tar.xz" | sudo tar -xJ -C /usr/local
+                    sudo ln -sf "/usr/local/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
                   else
                     brew update
                     brew install tree


### PR DESCRIPTION
### Summary

Replace the `snap install zig` method with a direct binary download from ziglang.org in the npm CD workflow. Snap is unreliable on GitHub Actions runners and can fail or hang, while the direct tarball download works consistently across all runner environments.

### Issue link

N/A

### Features / Behaviour Changes

- Removed `snap` from the apt install list and removed `sudo snap install zig --classic --beta`.
- Added a direct binary download of Zig 0.13.0 from ziglang.org, extracted to `/usr/local`, and symlinked to `/usr/local/bin/zig`.
- The installation method is architecture-aware via `uname -m`.

### Implementation

- Replaced the two-step snap-based installation (`apt install snap` + `snap install zig`) with a `curl | tar` download of the official Zig release tarball.
- Pinned Zig version to `0.13.0`.
- Detects architecture dynamically (`x86_64` or `aarch64`) to fetch the correct binary.
- Creates a symlink at `/usr/local/bin/zig` for PATH availability.

### Limitations

- Zig version is now pinned (`0.13.0`) rather than tracking a snap channel. Future Zig upgrades require a manual version bump in the workflow.

### Testing

- Verified the download URL pattern resolves correctly for both `x86_64` and `aarch64`.
- CI run of the workflow will validate the installation works end-to-end on Linux runners.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.