### PR TITLE
Node: Support custom socket address resolution when connecting to valkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Pending 2.5
+
+#### Changes
+* Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+
 ## Pending 2.4
 
 #### Fixes
@@ -31,7 +36,6 @@
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 * JAVA: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 * Python: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
-* Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 #### Changes
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
-## Pending 2.4
+## 2.4
 
 #### Fixes
 * CORE: Add dedicated timeout watchdog thread independent of the Tokio runtime. Under memory pressure or Tokio starvation, `tokio::time::sleep` may not fire on time. The watchdog uses a separate OS thread to guarantee timeout delivery, preventing commands from hanging indefinitely when the async runtime is overloaded. ([#5752](https://github.com/valkey-io/valkey-glide/issues/5752))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 * JAVA: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 * Python: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+* Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -20,6 +20,7 @@ logger_core = { path = "../../logger_core" }
 bytes = "1"
 num-traits = "0.2"
 uuid = { version = "1", features = ["v4"] }
+tracing = "0.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -19,6 +19,7 @@ napi-derive = "2"
 logger_core = { path = "../../logger_core" }
 bytes = "1"
 num-traits = "0.2"
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1,11 +1,11 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 use glide_core::errors::error_message;
-use logger_core::log_warn_lazy;
 use glide_core::{
     DEFAULT_FLUSH_SIGNAL_INTERVAL_MS, GlideOpenTelemetry, GlideOpenTelemetryConfigBuilder,
     GlideOpenTelemetrySignalsExporter, GlideSpan, Telemetry,
 };
+use logger_core::log_warn_lazy;
 use redis::GlideConnectionOptions;
 
 #[cfg(not(target_env = "msvc"))]

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 use glide_core::errors::error_message;
+use logger_core::log_warn_lazy;
 use glide_core::{
     DEFAULT_FLUSH_SIGNAL_INTERVAL_MS, GlideOpenTelemetry, GlideOpenTelemetryConfigBuilder,
     GlideOpenTelemetrySignalsExporter, GlideSpan, Telemetry,
@@ -811,11 +812,21 @@ impl redis::AddressResolver for NodeAddressResolver {
         );
 
         if status != napi::Status::Ok {
+            log_warn_lazy!(
+                "address_resolver",
+                format!("Address resolver failed, falling back to original address: {status:?}")
+            );
             return (host.to_string(), port);
         }
 
         // Wait for the JS callback to send back the resolved address
-        rx.recv().unwrap_or_else(|_| (host.to_string(), port))
+        rx.recv().unwrap_or_else(|e| {
+            log_warn_lazy!(
+                "address_resolver",
+                format!("Address resolver failed, falling back to original address: {e}")
+            );
+            (host.to_string(), port)
+        })
     }
 }
 
@@ -865,7 +876,13 @@ pub fn register_address_resolver(
                     Ok((h.into_utf8()?.into_owned()?, p.get_uint32()? as u16))
                 })()
                 .unwrap_or((request.host.clone(), request.port)),
-                Err(_) => (request.host.clone(), request.port),
+                Err(e) => {
+                    log_warn_lazy!(
+                        "address_resolver",
+                        format!("Address resolver failed, falling back to original address: {e}")
+                    );
+                    (request.host.clone(), request.port)
+                }
             };
 
             // Send the result back to the waiting Rust thread

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -764,6 +764,26 @@ struct ResolveRequest {
     tx: std::sync::mpsc::SyncSender<(String, u16)>,
 }
 
+/// A Send+Sync wrapper around napi::Ref<()> for use in TSFN closures.
+/// napi::Ref<()> is !Send, but we only access it from the JS thread via the TSFN resolve closure.
+/// On drop, we use std::mem::forget to avoid napi-rs's assertion that ref count == 0.
+/// The reference is cleaned up when removeAddressResolver is called (which drops the TSFN,
+/// causing N-API to release the closure and its captured data).
+struct CallbackRef(Option<napi::Ref<()>>);
+
+unsafe impl Send for CallbackRef {}
+unsafe impl Sync for CallbackRef {}
+
+impl Drop for CallbackRef {
+    fn drop(&mut self) {
+        // Use mem::forget to avoid napi-rs's panic assertion on Ref drop.
+        // The N-API reference will be cleaned up by the runtime at process exit.
+        if let Some(r) = self.0.take() {
+            std::mem::forget(r);
+        }
+    }
+}
+
 impl std::fmt::Debug for NodeAddressResolver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "NodeAddressResolver {{ callback: <JS function> }}")
@@ -804,48 +824,29 @@ impl redis::AddressResolver for NodeAddressResolver {
 /// `address_resolver_key` field so the socket listener can look it up.
 ///
 /// The JS callback signature is: `(host: string, port: number) => [string, number]`
-///
-/// Internally, we create a wrapper JS function that:
-/// 1. Calls the user's resolver
-/// 2. Extracts the result
-/// 3. Sends it back through a channel to the waiting Rust thread
 #[napi(js_name = "registerAddressResolver")]
 pub fn register_address_resolver(
     env: Env,
     #[napi(ts_arg_type = "(host: string, port: number) => [string, number]")]
     callback: napi::JsFunction,
 ) -> Result<String> {
-    // Create a persistent reference to the user's callback so it won't be GC'd
-    let callback_ref = env.create_reference(&callback)?;
+    // Create a persistent reference to the user's callback so it won't be GC'd.
+    // Wrap it in CallbackRef (which is Send+Sync) for use in the TSFN closure.
+    let callback_ref = CallbackRef(Some(env.create_reference(&callback)?));
 
-    // Create a wrapper function that will be called by the ThreadsafeFunction.
-    // This wrapper calls the user's resolver and sends the result through the channel
-    // embedded in the arguments.
-    //
-    // The ThreadsafeFunction mechanism:
-    // - `call(data, Blocking)` schedules the callback on the JS thread and blocks
-    // - The `resolve` closure converts `ResolveRequest` into JS args
-    // - The original JS function (our wrapper) is called with those args
-    // - But we can't get the return value through this mechanism...
-    //
-    // Alternative approach: We use the `resolve` closure to call the user's function
-    // directly (since it runs on the JS thread with access to `env`), capture the
-    // return value, send it through the channel, and return empty args.
-    //
-    // However, in napi-rs v2, the `resolve` closure's return value becomes the args
-    // passed to the original function. The original function IS called regardless.
-    //
-    // Solution: Create a no-op JS function as the "original" function, and do all
-    // the work in the resolve closure.
+    // Create a no-op JS function as the "original" function for the TSFN.
+    // All actual work happens in the resolve closure below.
     let noop_fn = env.create_function_from_closure("noop", |_ctx| Ok(()))?;
 
-    let tsfn = noop_fn.create_threadsafe_function(
+    let mut tsfn = noop_fn.create_threadsafe_function(
         0,
         move |ctx: napi::threadsafe_function::ThreadSafeCallContext<ResolveRequest>| {
             let request = ctx.value;
 
             // Get the user's callback from the reference
-            let user_callback: napi::JsFunction = ctx.env.get_reference_value(&callback_ref)?;
+            let user_callback: napi::JsFunction = ctx
+                .env
+                .get_reference_value(callback_ref.0.as_ref().unwrap())?;
 
             // Create JS arguments for the user's callback
             let js_host = ctx.env.create_string(&request.host)?;
@@ -874,6 +875,9 @@ pub fn register_address_resolver(
             Ok(Vec::<napi::JsUnknown>::new())
         },
     )?;
+
+    // Unref the TSFN so it doesn't prevent the Node.js event loop from exiting.
+    tsfn.unref(&env)?;
 
     let key = uuid::Uuid::new_v4().to_string();
     let resolver = Arc::new(NodeAddressResolver { tsfn });

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -746,3 +746,145 @@ pub fn get_statistics(env: Env) -> Result<JsObject> {
 
     Ok(stats)
 }
+
+/// A Node.js address resolver wrapper that implements the `AddressResolver` trait.
+/// It holds a `ThreadsafeFunction` reference to a wrapper JavaScript function that
+/// calls the user's resolver and sends the result through a channel.
+struct NodeAddressResolver {
+    tsfn: napi::threadsafe_function::ThreadsafeFunction<
+        ResolveRequest,
+        napi::threadsafe_function::ErrorStrategy::Fatal,
+    >,
+}
+
+/// Internal request type that carries both the input and a channel sender for the response.
+struct ResolveRequest {
+    host: String,
+    port: u16,
+    tx: std::sync::mpsc::SyncSender<(String, u16)>,
+}
+
+impl std::fmt::Debug for NodeAddressResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NodeAddressResolver {{ callback: <JS function> }}")
+    }
+}
+
+// SAFETY: ThreadsafeFunction is designed to be called from any thread.
+unsafe impl Send for NodeAddressResolver {}
+unsafe impl Sync for NodeAddressResolver {}
+
+impl redis::AddressResolver for NodeAddressResolver {
+    fn resolve(&self, host: &str, port: u16) -> (String, u16) {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
+        let request = ResolveRequest {
+            host: host.to_string(),
+            port,
+            tx,
+        };
+
+        // Schedule the JS callback on the main thread and block until it completes
+        let status = self.tsfn.call(
+            request,
+            napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
+        );
+
+        if status != napi::Status::Ok {
+            return (host.to_string(), port);
+        }
+
+        // Wait for the JS callback to send back the resolved address
+        rx.recv().unwrap_or_else(|_| (host.to_string(), port))
+    }
+}
+
+/// Register a JavaScript address resolver callback in the global registry.
+/// Returns the registry key (UUID) that must be set in the ConnectionRequest's
+/// `address_resolver_key` field so the socket listener can look it up.
+///
+/// The JS callback signature is: `(host: string, port: number) => [string, number]`
+///
+/// Internally, we create a wrapper JS function that:
+/// 1. Calls the user's resolver
+/// 2. Extracts the result
+/// 3. Sends it back through a channel to the waiting Rust thread
+#[napi(js_name = "registerAddressResolver")]
+pub fn register_address_resolver(
+    env: Env,
+    #[napi(ts_arg_type = "(host: string, port: number) => [string, number]")] callback: napi::JsFunction,
+) -> Result<String> {
+    // Create a persistent reference to the user's callback so it won't be GC'd
+    let callback_ref = env.create_reference(&callback)?;
+
+    // Create a wrapper function that will be called by the ThreadsafeFunction.
+    // This wrapper calls the user's resolver and sends the result through the channel
+    // embedded in the arguments.
+    //
+    // The ThreadsafeFunction mechanism:
+    // - `call(data, Blocking)` schedules the callback on the JS thread and blocks
+    // - The `resolve` closure converts `ResolveRequest` into JS args
+    // - The original JS function (our wrapper) is called with those args
+    // - But we can't get the return value through this mechanism...
+    //
+    // Alternative approach: We use the `resolve` closure to call the user's function
+    // directly (since it runs on the JS thread with access to `env`), capture the
+    // return value, send it through the channel, and return empty args.
+    //
+    // However, in napi-rs v2, the `resolve` closure's return value becomes the args
+    // passed to the original function. The original function IS called regardless.
+    //
+    // Solution: Create a no-op JS function as the "original" function, and do all
+    // the work in the resolve closure.
+    let noop_fn = env.create_function_from_closure("noop", |_ctx| {
+        Ok(())
+    })?;
+
+    let tsfn = noop_fn.create_threadsafe_function(
+        0,
+        move |ctx: napi::threadsafe_function::ThreadSafeCallContext<ResolveRequest>| {
+            let request = ctx.value;
+
+            // Get the user's callback from the reference
+            let user_callback: napi::JsFunction = ctx.env.get_reference_value(&callback_ref)?;
+
+            // Create JS arguments for the user's callback
+            let js_host = ctx.env.create_string(&request.host)?;
+            let js_port = ctx.env.create_uint32(request.port as u32)?;
+
+            // Call the user's resolver function
+            let result = user_callback.call(None, &[js_host.into_unknown(), js_port.into_unknown()]);
+
+            // Extract the resolved address from the return value
+            let resolved = match result {
+                Ok(value) => {
+                    (|| -> napi::Result<(String, u16)> {
+                        let obj = value.coerce_to_object()?;
+                        let h: napi::JsString = obj.get_element(0)?;
+                        let p: napi::JsNumber = obj.get_element(1)?;
+                        Ok((h.into_utf8()?.into_owned()?, p.get_uint32()? as u16))
+                    })()
+                    .unwrap_or((request.host.clone(), request.port))
+                }
+                Err(_) => (request.host.clone(), request.port),
+            };
+
+            // Send the result back to the waiting Rust thread
+            let _ = request.tx.send(resolved);
+
+            // Return empty args for the no-op function (it does nothing)
+            Ok(Vec::<napi::JsUnknown>::new())
+        },
+    )?;
+
+    let key = uuid::Uuid::new_v4().to_string();
+    let resolver = Arc::new(NodeAddressResolver { tsfn });
+    glide_core::address_resolver_registry::register(key.clone(), resolver);
+    Ok(key)
+}
+
+/// Remove an address resolver from the global registry by key.
+#[napi(js_name = "removeAddressResolver")]
+pub fn remove_address_resolver(key: String) {
+    glide_core::address_resolver_registry::remove(&key);
+}

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -812,7 +812,8 @@ impl redis::AddressResolver for NodeAddressResolver {
 #[napi(js_name = "registerAddressResolver")]
 pub fn register_address_resolver(
     env: Env,
-    #[napi(ts_arg_type = "(host: string, port: number) => [string, number]")] callback: napi::JsFunction,
+    #[napi(ts_arg_type = "(host: string, port: number) => [string, number]")]
+    callback: napi::JsFunction,
 ) -> Result<String> {
     // Create a persistent reference to the user's callback so it won't be GC'd
     let callback_ref = env.create_reference(&callback)?;
@@ -836,9 +837,7 @@ pub fn register_address_resolver(
     //
     // Solution: Create a no-op JS function as the "original" function, and do all
     // the work in the resolve closure.
-    let noop_fn = env.create_function_from_closure("noop", |_ctx| {
-        Ok(())
-    })?;
+    let noop_fn = env.create_function_from_closure("noop", |_ctx| Ok(()))?;
 
     let tsfn = noop_fn.create_threadsafe_function(
         0,
@@ -853,19 +852,18 @@ pub fn register_address_resolver(
             let js_port = ctx.env.create_uint32(request.port as u32)?;
 
             // Call the user's resolver function
-            let result = user_callback.call(None, &[js_host.into_unknown(), js_port.into_unknown()]);
+            let result =
+                user_callback.call(None, &[js_host.into_unknown(), js_port.into_unknown()]);
 
             // Extract the resolved address from the return value
             let resolved = match result {
-                Ok(value) => {
-                    (|| -> napi::Result<(String, u16)> {
-                        let obj = value.coerce_to_object()?;
-                        let h: napi::JsString = obj.get_element(0)?;
-                        let p: napi::JsNumber = obj.get_element(1)?;
-                        Ok((h.into_utf8()?.into_owned()?, p.get_uint32()? as u16))
-                    })()
-                    .unwrap_or((request.host.clone(), request.port))
-                }
+                Ok(value) => (|| -> napi::Result<(String, u16)> {
+                    let obj = value.coerce_to_object()?;
+                    let h: napi::JsString = obj.get_element(0)?;
+                    let p: napi::JsNumber = obj.get_element(1)?;
+                    Ok((h.into_utf8()?.into_owned()?, p.get_uint32()? as u16))
+                })()
+                .unwrap_or((request.host.clone(), request.port)),
                 Err(_) => (request.host.clone(), request.port),
             };
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -9513,6 +9513,13 @@ export class BaseClient {
         this.pubsubFutures.forEach(([, reject]) => {
             reject(new ClosingError(errorMessage || ""));
         });
+
+        // Clean up address resolver from the global registry
+        if (this.addressResolverKey) {
+            removeAddressResolver(this.addressResolverKey);
+            this.addressResolverKey = undefined;
+        }
+
         Logger.log("info", "Client lifetime", "disposing of client");
         this.socket.end();
     }

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -70,6 +70,8 @@ import {
     SetOptions,
     SortOptions,
     StartSocketConnection,
+    registerAddressResolver,
+    removeAddressResolver,
     StreamAddOptions,
     StreamClaimOptions,
     StreamGroupOptions,
@@ -931,6 +933,37 @@ export interface BaseClientConfiguration {
      * ```
      */
     clientSideCache?: ClientSideCache;
+
+    /**
+     * Optional callback for resolving server addresses before connection.
+     *
+     * When provided, this callback will be invoked for each configured address during connection
+     * establishment and during cluster topology refreshes. The callback receives the configured
+     * host and port, and should return a tuple `[resolvedHost, resolvedPort]` with the actual
+     * address to use for the connection.
+     *
+     * Use cases:
+     * - Custom DNS resolution for service discovery
+     * - Address translation for proxy setups
+     * - Dynamic endpoint resolution for cloud environments
+     *
+     * If the resolver throws an exception or returns an invalid value, the original address
+     * is used as a fallback.
+     *
+     * @example
+     * ```typescript
+     * const config: BaseClientConfiguration = {
+     *   addresses: [{ host: "internal-service", port: 9999 }],
+     *   addressResolver: (host, port) => {
+     *     if (host === "internal-service") {
+     *       return ["10.0.0.5", 6379];
+     *     }
+     *     return [host, port];
+     *   },
+     * };
+     * ```
+     */
+    addressResolver?: (host: string, port: number) => [string, number];
 }
 
 /**
@@ -1121,6 +1154,7 @@ export class BaseClient {
     private pendingPushNotification: response.Response[] = [];
     private readonly inflightRequestsLimit: number;
     private config: BaseClientConfiguration | undefined;
+    private addressResolverKey: string | undefined;
 
     protected configurePubsub(
         options: GlideClusterClientConfiguration | GlideClientConfiguration,
@@ -9417,15 +9451,37 @@ export class BaseClient {
      */
     protected connectToServer(options: BaseClientConfiguration): Promise<void> {
         return new Promise((resolve, reject) => {
+            // Register address resolver in the global registry before sending
+            // the connection request, so the socket listener can pick it up.
+            if (options.addressResolver) {
+                this.addressResolverKey = registerAddressResolver(
+                    options.addressResolver,
+                );
+            }
+
             this.promiseCallbackFunctions[0] = [
                 resolve,
-                reject,
+                (err: unknown) => {
+                    // Clean up the resolver from the registry if connection fails
+                    if (this.addressResolverKey) {
+                        removeAddressResolver(this.addressResolverKey);
+                        this.addressResolverKey = undefined;
+                    }
+
+                    reject(err);
+                },
                 options?.defaultDecoder,
             ];
 
-            const message = connection_request.ConnectionRequest.create(
-                this.createClientRequest(options),
-            );
+            const request = this.createClientRequest(options);
+
+            // Set the address resolver key in the protobuf request
+            if (this.addressResolverKey) {
+                request.addressResolverKey = this.addressResolverKey;
+            }
+
+            const message =
+                connection_request.ConnectionRequest.create(request);
 
             this.writeOrBufferRequest(
                 message,

--- a/node/tests/AddressResolver.test.ts
+++ b/node/tests/AddressResolver.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { ValkeyCluster } from "../../utils/TestUtils.js";
+import { GlideClient, GlideClusterClient, ProtocolVersion } from "../build-ts";
+import {
+    getClientConfigurationOption,
+    getServerVersion,
+    parseEndpoints,
+} from "./TestUtilities";
+
+const TIMEOUT = 50000;
+
+describe("AddressResolver", () => {
+    let standaloneCluster: ValkeyCluster;
+    let clusterCluster: ValkeyCluster;
+
+    beforeAll(async () => {
+        const standaloneAddresses: string =
+            global.STAND_ALONE_ENDPOINT as string;
+        standaloneCluster = standaloneAddresses
+            ? await ValkeyCluster.initFromExistingCluster(
+                  false,
+                  parseEndpoints(standaloneAddresses),
+                  getServerVersion,
+              )
+            : await ValkeyCluster.createCluster(false, 1, 1, getServerVersion);
+
+        const clusterAddresses: string = global.CLUSTER_ENDPOINTS as string;
+        clusterCluster = clusterAddresses
+            ? await ValkeyCluster.initFromExistingCluster(
+                  true,
+                  parseEndpoints(clusterAddresses),
+                  getServerVersion,
+              )
+            : await ValkeyCluster.createCluster(true, 3, 1, getServerVersion);
+    }, 120000);
+
+    afterAll(async () => {
+        if (standaloneCluster) {
+            await standaloneCluster.close();
+        }
+
+        if (clusterCluster) {
+            await clusterCluster.close();
+        }
+    });
+
+    it(
+        "address resolver with fake address - standalone",
+        async () => {
+            const addresses = standaloneCluster.getAddresses();
+            const [actualHost, actualPort] = addresses[0];
+
+            const fakeHost = "fake-host-that-does-not-exist.invalid";
+            const fakePort = 9999;
+
+            // Resolver translates fake address to real server address
+            const resolver = (host: string, port: number): [string, number] => {
+                if (host === fakeHost && port === fakePort) {
+                    return [actualHost, actualPort];
+                }
+
+                return [host, port];
+            };
+
+            const client = await GlideClient.createClient({
+                ...getClientConfigurationOption(
+                    [[fakeHost, fakePort]],
+                    ProtocolVersion.RESP3,
+                ),
+                addressResolver: resolver,
+            });
+
+            try {
+                const pingResult = await client.ping();
+                expect(pingResult).toBe("PONG");
+
+                const setResult = await client.set(
+                    "resolver_test_key",
+                    "resolver_test_value",
+                );
+                expect(setResult).toBe("OK");
+
+                const getResult = await client.get("resolver_test_key");
+                expect(getResult).toBe("resolver_test_value");
+            } finally {
+                client.close();
+            }
+        },
+        TIMEOUT,
+    );
+
+    it(
+        "address resolver with fake address - cluster",
+        async () => {
+            const addresses = clusterCluster.getAddresses();
+            const [actualHost, actualPort] = addresses[0];
+
+            const fakeHost = "fake-cluster-host.invalid";
+            const fakePort = 9999;
+
+            // Resolver translates fake address to real server address
+            const resolver = (host: string, port: number): [string, number] => {
+                if (host === fakeHost && port === fakePort) {
+                    return [actualHost, actualPort];
+                }
+
+                return [host, port];
+            };
+
+            const client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    [[fakeHost, fakePort]],
+                    ProtocolVersion.RESP3,
+                ),
+                addressResolver: resolver,
+            });
+
+            try {
+                const pingResult = await client.ping();
+                expect(pingResult).toBe("PONG");
+
+                const setResult = await client.set(
+                    "cluster_resolver_test_key",
+                    "cluster_resolver_test_value",
+                );
+                expect(setResult).toBe("OK");
+
+                const getResult = await client.get("cluster_resolver_test_key");
+                expect(getResult).toBe("cluster_resolver_test_value");
+            } finally {
+                client.close();
+            }
+        },
+        TIMEOUT,
+    );
+
+    it(
+        "address resolver exception falls back to original - standalone",
+        async () => {
+            const addresses = standaloneCluster.getAddresses();
+            const [actualHost, actualPort] = addresses[0];
+
+            // Resolver that always throws
+            const resolver = (_host: string, _port: number): [string, number] => {
+                throw new Error("test-exception");
+            };
+
+            // Client should still connect using the original (valid) address as fallback
+            const client = await GlideClient.createClient({
+                ...getClientConfigurationOption(
+                    [[actualHost, actualPort]],
+                    ProtocolVersion.RESP3,
+                ),
+                addressResolver: resolver,
+            });
+
+            try {
+                const pingResult = await client.ping();
+                expect(pingResult).toBe("PONG");
+            } finally {
+                client.close();
+            }
+        },
+        TIMEOUT,
+    );
+
+    it(
+        "address resolver exception falls back to original - cluster",
+        async () => {
+            const addresses = clusterCluster.getAddresses();
+            const [actualHost, actualPort] = addresses[0];
+
+            // Resolver that always throws
+            const resolver = (_host: string, _port: number): [string, number] => {
+                throw new Error("test-exception");
+            };
+
+            // Client should still connect using the original (valid) address as fallback
+            const client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    [[actualHost, actualPort]],
+                    ProtocolVersion.RESP3,
+                ),
+                addressResolver: resolver,
+            });
+
+            try {
+                const pingResult = await client.ping();
+                expect(pingResult).toBe("PONG");
+            } finally {
+                client.close();
+            }
+        },
+        TIMEOUT,
+    );
+});

--- a/node/tests/AddressResolver.test.ts
+++ b/node/tests/AddressResolver.test.ts
@@ -144,8 +144,10 @@ describe("AddressResolver", () => {
             const addresses = standaloneCluster.getAddresses();
             const [actualHost, actualPort] = addresses[0];
 
-            // Resolver that always throws
-            const resolver = (_host: string, _port: number): [string, number] => {
+            // Resolver that always throws - params are consumed to satisfy lint
+            const resolver = (host: string, port: number): [string, number] => {
+                void host;
+                void port;
                 throw new Error("test-exception");
             };
 
@@ -174,8 +176,13 @@ describe("AddressResolver", () => {
             const addresses = clusterCluster.getAddresses();
             const [actualHost, actualPort] = addresses[0];
 
-            // Resolver that always throws
-            const resolver = (_host: string, _port: number): [string, number] => {
+            // Resolver that always throws - params are consumed to satisfy lint
+            const clusterResolver = (
+                host: string,
+                port: number,
+            ): [string, number] => {
+                void host;
+                void port;
                 throw new Error("test-exception");
             };
 
@@ -185,7 +192,7 @@ describe("AddressResolver", () => {
                     [[actualHost, actualPort]],
                     ProtocolVersion.RESP3,
                 ),
-                addressResolver: resolver,
+                addressResolver: clusterResolver,
             });
 
             try {


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Adds custom socket address resolution support for the Node.js client, allowing users to provide a callback that translates configured addresses to actual connection endpoints. This enables use cases like custom DNS resolution, proxy address translation, and dynamic endpoint resolution for cloud environments.

### Issue link

This Pull Request is linked to issue: [Node: Support custom socket address resolution when connecting to valkey](https://github.com/valkey-io/valkey-glide/issues/5807)

### Features / Behaviour Changes

- Added `addressResolver` option to `BaseClientConfiguration` that accepts a synchronous callback `(host: string, port: number) => [string, number]`
- The resolver is invoked for each configured address during connection establishment and cluster topology refreshes
- If the resolver throws an exception or returns an invalid value, the original address is used as a fallback
- The resolver is automatically cleaned up from the global registry on client close or connection failure

### Implementation

- **`node/rust-client/src/lib.rs`**: Implements `NodeAddressResolver` struct that wraps a JS callback via N-API `ThreadsafeFunction`. Uses a `SyncChannel` to bridge the async Rust resolve call to the synchronous JS callback on the main thread. Registers/removes resolvers in `glide_core::address_resolver_registry` using UUID keys.
- **`node/src/BaseClient.ts`**: Registers the address resolver before sending the connection request, passes the registry key via `addressResolverKey` in the protobuf `ConnectionRequest`, and cleans up the resolver on close or connection failure.
- **`node/rust-client/Cargo.toml`**: Added `uuid` dependency for generating unique resolver registry keys.
- **`CHANGELOG.md`**: Added changelog entry under breaking features.

### Limitations

- The resolver callback must be **synchronous** — async resolvers are not supported.
- The resolver runs on the Node.js main thread; long-running resolution logic could block the event loop.

### Testing

- Added `node/tests/AddressResolver.test.ts` with integration tests covering:
  - Address resolution with fake addresses for standalone and cluster modes
  - Fallback behavior when the resolver throws an exception (standalone and cluster)

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
