### PR TITLE
Go: Support custom socket address resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 * JAVA: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 * Python: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+* Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Changes
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+* Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
 ## 2.4
 
@@ -36,7 +37,6 @@
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 * JAVA: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 * Python: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
-* Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
 #### Fixes
 * Java: Populate actual `lib-ver` instead of `unknown` in `CLIENT INFO` responses ([#5634](https://github.com/valkey-io/valkey-glide/issues/5634))

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,6 +17,7 @@ logger_core = { path = "../logger_core" }
 tracing = "0.1"
 serde_json = "1.0"
 url = "2"
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 rstest = "^0.23"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,7 +17,6 @@ logger_core = { path = "../logger_core" }
 tracing = "0.1"
 serde_json = "1.0"
 url = "2"
-uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 rstest = "^0.23"

--- a/ffi/miri-tests/tests/ffi_miri_tests.rs
+++ b/ffi/miri-tests/tests/ffi_miri_tests.rs
@@ -40,6 +40,7 @@ unsafe extern "C-unwind" fn pubsub_callback(
 
 /// No-op address resolver that returns port 0 to signal "use original address".
 unsafe extern "C-unwind" fn noop_address_resolver(
+    _client_id: usize,
     _host: *const u8,
     _host_len: usize,
     _port: u16,
@@ -80,6 +81,7 @@ fn create_client_test() {
             client_type_ptr,
             pubsub_callback,
             noop_address_resolver,
+            0usize,
         );
         let conn_ptr = (*connection_response_ptr).conn_ptr;
         close_client(conn_ptr);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1317,7 +1317,8 @@ pub unsafe extern "C-unwind" fn create_client_from_uri(
                     ),
                 },
                 Ok(bytes) => {
-                    match create_client_internal(&bytes, client_type.clone(), callback_opt, None, 0) {
+                    match create_client_internal(&bytes, client_type.clone(), callback_opt, None, 0)
+                    {
                         Err(err) => ConnectionResponse {
                             conn_ptr: std::ptr::null(),
                             connection_error_message: CString::into_raw(

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -328,6 +328,7 @@ pub type PubSubCallback = unsafe extern "C-unwind" fn(
 /// * `resolved_host_len` must be a valid pointer to a writable `usize`.
 /// * The callback must write the resolved host into `resolved_host_buf` and set `resolved_host_len`.
 pub type AddressResolverCallback = unsafe extern "C-unwind" fn(
+    client_id: usize,
     host: *const u8,
     host_len: usize,
     port: u16,
@@ -339,6 +340,7 @@ pub type AddressResolverCallback = unsafe extern "C-unwind" fn(
 /// A wrapper around an FFI address resolver callback that implements the `AddressResolver` trait.
 struct FFIAddressResolver {
     callback: AddressResolverCallback,
+    client_id: usize,
 }
 
 // SAFETY: The callback is a C function pointer that is safe to send across threads.
@@ -359,6 +361,7 @@ impl redis::AddressResolver for FFIAddressResolver {
 
         let resolved_port = unsafe {
             (self.callback)(
+                self.client_id,
                 host.as_ptr(),
                 host.len(),
                 port,
@@ -970,6 +973,7 @@ fn create_client_internal(
     client_type: ClientType,
     pubsub_callback: Option<PubSubCallback>,
     address_resolver: Option<AddressResolverCallback>,
+    client_id: usize,
 ) -> Result<*const ClientAdapter, String> {
     let request = connection_request::ConnectionRequest::parse_from_bytes(connection_request_bytes)
         .map_err(|err| err.to_string())?;
@@ -1034,6 +1038,7 @@ fn create_client_internal(
         if let Some(resolver_callback) = address_resolver {
             connection_request.address_resolver = Some(Arc::new(FFIAddressResolver {
                 callback: resolver_callback,
+                client_id,
             }));
         }
 
@@ -1107,6 +1112,7 @@ pub unsafe extern "C-unwind" fn create_client(
     client_type: *const ClientType,
     pubsub_callback: PubSubCallback,
     address_resolver: AddressResolverCallback,
+    client_id: usize,
 ) -> *const ConnectionResponse {
     assert!(!connection_request_bytes.is_null());
     let request_bytes =
@@ -1132,6 +1138,7 @@ pub unsafe extern "C-unwind" fn create_client(
         client_type.clone(),
         callback_opt,
         resolver_opt,
+        client_id,
     ) {
         Err(err) => ConnectionResponse {
             conn_ptr: std::ptr::null(),
@@ -1310,7 +1317,7 @@ pub unsafe extern "C-unwind" fn create_client_from_uri(
                     ),
                 },
                 Ok(bytes) => {
-                    match create_client_internal(&bytes, client_type.clone(), callback_opt, None) {
+                    match create_client_internal(&bytes, client_type.clone(), callback_opt, None, 0) {
                         Err(err) => ConnectionResponse {
                             conn_ptr: std::ptr::null(),
                             connection_error_message: CString::into_raw(

--- a/ffi/tests/ffi_client_tests.rs
+++ b/ffi/tests/ffi_client_tests.rs
@@ -272,6 +272,7 @@ fn test_ffi_client_command_execution(#[values(false, true)] async_client: bool) 
             std::mem::transmute::<
                 *mut c_void,
                 unsafe extern "C-unwind" fn(
+                    client_ptr: usize,
                     host: *const u8,
                     host_len: usize,
                     port: u16,
@@ -280,6 +281,7 @@ fn test_ffi_client_command_execution(#[values(false, true)] async_client: bool) 
                     resolved_host_len: *mut usize,
                 ) -> u16,
             >(std::ptr::null_mut()),
+            0,
         );
 
         assert!(!response_ptr.is_null(), "Failed to create client");
@@ -479,6 +481,7 @@ fn test_inflight_request_limit_sync_client() {
             std::mem::transmute::<
                 *mut c_void,
                 unsafe extern "C-unwind" fn(
+                    client_ptr: usize,
                     host: *const u8,
                     host_len: usize,
                     port: u16,
@@ -487,6 +490,7 @@ fn test_inflight_request_limit_sync_client() {
                     resolved_host_len: *mut usize,
                 ) -> u16,
             >(std::ptr::null_mut()),
+            0,
         );
 
         assert!(!response_ptr.is_null(), "Failed to create client");

--- a/go/Makefile
+++ b/go/Makefile
@@ -115,6 +115,9 @@ build-glide-ffi: libglide_ffi gen-c-bindings
 gen-c-bindings:
 	cd $(GLIDE_FFI_PATH) && \
 	cbindgen --config cbindgen.toml --crate glide-ffi --output $(GO_DIR)/lib.h --lang c
+	@# Add include guard to prevent multiple inclusion errors with CGo
+	@sed -i.bak '1 a\
+	#pragma once' $(GO_DIR)/lib.h && rm -f $(GO_DIR)/lib.h.bak
 
 generate-protobuf:
 	rm -rf internal/protobuf

--- a/go/address_resolver.go
+++ b/go/address_resolver.go
@@ -1,4 +1,4 @@
-// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+// Copyright Valkey GLIDE Project Contributors - SPDX-Identifier: Apache-2.0
 
 package glide
 
@@ -13,36 +13,19 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/config"
 )
 
-// globalResolver holds the address resolver that is currently active.
-// Since the FFI callback signature does not carry a context pointer, only one
-// resolver can be active at a time. When multiple clients are created with
-// different resolvers, the last one set wins for all subsequent resolution calls.
-//
-// In practice this is acceptable because:
-//  1. Most applications use a single resolver for all clients.
-//  2. The resolver is called during client creation and topology refresh,
-//     both of which happen on the client's own runtime.
-var (
-	globalResolver   config.AddressResolver
-	globalResolverMu sync.RWMutex
-)
+var resolverRegistry sync.Map // map[uintptr]config.AddressResolver
 
-// setGlobalResolver sets the global address resolver.
-func setGlobalResolver(resolver config.AddressResolver) {
-	globalResolverMu.Lock()
-	defer globalResolverMu.Unlock()
-	globalResolver = resolver
+func registerResolver(clientID uintptr, resolver config.AddressResolver) {
+	resolverRegistry.Store(clientID, resolver)
 }
 
-// getGlobalResolver returns the current global address resolver.
-func getGlobalResolver() config.AddressResolver {
-	globalResolverMu.RLock()
-	defer globalResolverMu.RUnlock()
-	return globalResolver
+func unregisterResolver(clientID uintptr) {
+	resolverRegistry.Delete(clientID)
 }
 
 //export addressResolverCallback
 func addressResolverCallback(
+	clientID C.uintptr_t,
 	host *C.uint8_t,
 	hostLen C.uintptr_t,
 	port C.uint16_t,
@@ -50,23 +33,23 @@ func addressResolverCallback(
 	resolvedHostBufLen C.uintptr_t,
 	resolvedHostLen *C.uintptr_t,
 ) C.uint16_t {
-	resolver := getGlobalResolver()
-	if resolver == nil {
-		// No resolver configured, return 0 to signal fallback to original address
+	val, ok := resolverRegistry.Load(uintptr(clientID))
+	if !ok {
+		return 0
+	}
+	resolver, ok := val.(config.AddressResolver)
+	if !ok || resolver == nil {
 		return 0
 	}
 
-	// Convert C host to Go string
 	goHost := C.GoStringN((*C.char)(unsafe.Pointer(host)), C.int(hostLen))
 	goPort := int(port)
 
-	// Call the user's resolver (recover from panics)
 	var resolvedHost string
 	var resolvedPort int
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				// On panic, signal fallback by leaving resolvedPort as 0
 				resolvedHost = ""
 				resolvedPort = 0
 			}
@@ -74,19 +57,15 @@ func addressResolverCallback(
 		resolvedHost, resolvedPort = resolver(goHost, goPort)
 	}()
 
-	// If resolver returned port 0 or empty host, signal fallback
-	if resolvedPort == 0 || resolvedHost == "" {
+	if resolvedPort < 1 || resolvedPort > 65535 || resolvedHost == "" {
 		return 0
 	}
 
-	// Write resolved host into the buffer
 	hostBytes := []byte(resolvedHost)
 	if len(hostBytes) > int(resolvedHostBufLen) {
-		// Host too long for buffer, signal fallback
 		return 0
 	}
 
-	// Copy resolved host into the C buffer
 	C.memcpy(
 		unsafe.Pointer(resolvedHostBuf),
 		unsafe.Pointer(&hostBytes[0]),

--- a/go/address_resolver.go
+++ b/go/address_resolver.go
@@ -1,0 +1,98 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+// #include "lib.h"
+// #include <string.h>
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+)
+
+// globalResolver holds the address resolver that is currently active.
+// Since the FFI callback signature does not carry a context pointer, only one
+// resolver can be active at a time. When multiple clients are created with
+// different resolvers, the last one set wins for all subsequent resolution calls.
+//
+// In practice this is acceptable because:
+// 1. Most applications use a single resolver for all clients.
+// 2. The resolver is called during client creation and topology refresh,
+//    both of which happen on the client's own runtime.
+var (
+	globalResolver   config.AddressResolver
+	globalResolverMu sync.RWMutex
+)
+
+// setGlobalResolver sets the global address resolver.
+func setGlobalResolver(resolver config.AddressResolver) {
+	globalResolverMu.Lock()
+	defer globalResolverMu.Unlock()
+	globalResolver = resolver
+}
+
+// getGlobalResolver returns the current global address resolver.
+func getGlobalResolver() config.AddressResolver {
+	globalResolverMu.RLock()
+	defer globalResolverMu.RUnlock()
+	return globalResolver
+}
+
+//export addressResolverCallback
+func addressResolverCallback(
+	host *C.uint8_t,
+	hostLen C.size_t,
+	port C.uint16_t,
+	resolvedHostBuf *C.uint8_t,
+	resolvedHostBufLen C.size_t,
+	resolvedHostLen *C.size_t,
+) C.uint16_t {
+	resolver := getGlobalResolver()
+	if resolver == nil {
+		// No resolver configured, return 0 to signal fallback to original address
+		return 0
+	}
+
+	// Convert C host to Go string
+	goHost := C.GoStringN((*C.char)(unsafe.Pointer(host)), C.int(hostLen))
+	goPort := int(port)
+
+	// Call the user's resolver (recover from panics)
+	var resolvedHost string
+	var resolvedPort int
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// On panic, signal fallback by leaving resolvedPort as 0
+				resolvedHost = ""
+				resolvedPort = 0
+			}
+		}()
+		resolvedHost, resolvedPort = resolver(goHost, goPort)
+	}()
+
+	// If resolver returned port 0 or empty host, signal fallback
+	if resolvedPort == 0 || resolvedHost == "" {
+		return 0
+	}
+
+	// Write resolved host into the buffer
+	hostBytes := []byte(resolvedHost)
+	if len(hostBytes) > int(resolvedHostBufLen) {
+		// Host too long for buffer, signal fallback
+		return 0
+	}
+
+	// Copy resolved host into the C buffer
+	C.memcpy(
+		unsafe.Pointer(resolvedHostBuf),
+		unsafe.Pointer(&hostBytes[0]),
+		C.size_t(len(hostBytes)),
+	)
+	*resolvedHostLen = C.size_t(len(hostBytes))
+
+	return C.uint16_t(resolvedPort)
+}

--- a/go/address_resolver.go
+++ b/go/address_resolver.go
@@ -19,9 +19,9 @@ import (
 // different resolvers, the last one set wins for all subsequent resolution calls.
 //
 // In practice this is acceptable because:
-// 1. Most applications use a single resolver for all clients.
-// 2. The resolver is called during client creation and topology refresh,
-//    both of which happen on the client's own runtime.
+//  1. Most applications use a single resolver for all clients.
+//  2. The resolver is called during client creation and topology refresh,
+//     both of which happen on the client's own runtime.
 var (
 	globalResolver   config.AddressResolver
 	globalResolverMu sync.RWMutex
@@ -44,11 +44,11 @@ func getGlobalResolver() config.AddressResolver {
 //export addressResolverCallback
 func addressResolverCallback(
 	host *C.uint8_t,
-	hostLen C.size_t,
+	hostLen C.uintptr_t,
 	port C.uint16_t,
 	resolvedHostBuf *C.uint8_t,
-	resolvedHostBufLen C.size_t,
-	resolvedHostLen *C.size_t,
+	resolvedHostBufLen C.uintptr_t,
+	resolvedHostLen *C.uintptr_t,
 ) C.uint16_t {
 	resolver := getGlobalResolver()
 	if resolver == nil {
@@ -92,7 +92,7 @@ func addressResolverCallback(
 		unsafe.Pointer(&hostBytes[0]),
 		C.size_t(len(hostBytes)),
 	)
-	*resolvedHostLen = C.size_t(len(hostBytes))
+	*resolvedHostLen = C.uintptr_t(len(hostBytes))
 
 	return C.uint16_t(resolvedPort)
 }

--- a/go/address_resolver.go
+++ b/go/address_resolver.go
@@ -1,4 +1,4 @@
-// Copyright Valkey GLIDE Project Contributors - SPDX-Identifier: Apache-2.0
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 package glide
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -20,6 +20,10 @@ package glide
 //                     const uint8_t *message, int64_t message_len,
 //                     const uint8_t *channel, int64_t channel_len,
 //                     const uint8_t *pattern, int64_t pattern_len);
+// uint16_t addressResolverCallback(const uint8_t *host, size_t host_len,
+//                                  uint16_t port,
+//                                  uint8_t *resolved_host_buf, size_t resolved_host_buf_len,
+//                                  size_t *resolved_host_len);
 import "C"
 
 import (
@@ -51,6 +55,7 @@ type payload struct {
 
 type clientConfiguration interface {
 	ToProtobuf() (*protobuf.ConnectionRequest, error)
+	GetAddressResolver() config.AddressResolver
 }
 
 type baseClient struct {
@@ -156,15 +161,23 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 	}
 	client := &baseClient{pending: make(map[unsafe.Pointer]struct{}), mu: &sync.Mutex{}}
 
+	// Set up address resolver if configured
+	var resolverCallback C.AddressResolverCallback
+	if resolver := config.GetAddressResolver(); resolver != nil {
+		setGlobalResolver(resolver)
+		resolverCallback = (C.AddressResolverCallback)(unsafe.Pointer(C.addressResolverCallback))
+	}
+
 	cResponse := (*C.struct_ConnectionResponse)(
 		C.create_client(
 			(*C.uchar)(requestBytes),
 			C.uintptr_t(byteCount),
 			&clientType,
 			(C.PubSubCallback)(unsafe.Pointer(C.pubSubCallback)),
-			(C.AddressResolverCallback)(nil),
+			resolverCallback,
 		),
 	)
+
 	defer C.free_connection_response(cResponse)
 	cErr := cResponse.connection_error_message
 	if cErr != nil {

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -142,8 +142,8 @@ func buildAsyncClientType(successCb C.SuccessCallback, failureCb C.FailureCallba
 // Passes the pointers to callback functions which will be invoked when the command succeeds or fails.
 // Once the connection is established, this function invokes `free_connection_response` exposed by rust library to free the
 // connection_response to avoid any memory leaks.
-func createClient(config clientConfiguration) (*baseClient, error) {
-	request, err := config.ToProtobuf()
+func createClient(cfg clientConfiguration) (*baseClient, error) {
+	request, err := cfg.ToProtobuf()
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +168,8 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 	// Determine resolver callback and client ID
 	var resolverCallback C.AddressResolverCallback
 	var clientID uintptr
-	if cfg, ok := config.(interface{ GetAddressResolver() config.AddressResolver }); ok {
-		if resolver := cfg.GetAddressResolver(); resolver != nil {
+	if cfgWithResolver, ok := cfg.(interface{ GetAddressResolver() config.AddressResolver }); ok {
+		if resolver := cfgWithResolver.GetAddressResolver(); resolver != nil {
 			clientID = uintptr(clientIDCounter.Add(1))
 			registerResolver(clientID, resolver)
 			resolverCallback = (C.AddressResolverCallback)(unsafe.Pointer(C.addressResolverCallback))

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -33,6 +33,7 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -47,6 +48,8 @@ import (
 )
 
 const OK = "OK"
+
+var clientIDCounter atomic.Uintptr
 
 type payload struct {
 	value *C.struct_CommandResponse
@@ -63,6 +66,7 @@ type baseClient struct {
 	coreClient     unsafe.Pointer
 	mu             *sync.Mutex
 	messageHandler *MessageHandler
+	resolverID     uintptr
 }
 
 // setMessageHandler assigns a message handler to the client for processing pub/sub messages
@@ -161,11 +165,15 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 	}
 	client := &baseClient{pending: make(map[unsafe.Pointer]struct{}), mu: &sync.Mutex{}}
 
-	// Set up address resolver if configured
+	// Determine resolver callback and client ID
 	var resolverCallback C.AddressResolverCallback
-	if resolver := config.GetAddressResolver(); resolver != nil {
-		setGlobalResolver(resolver)
-		resolverCallback = (C.AddressResolverCallback)(unsafe.Pointer(C.addressResolverCallback))
+	var clientID uintptr
+	if cfg, ok := config.(interface{ GetAddressResolver() config.AddressResolver }); ok {
+		if resolver := cfg.GetAddressResolver(); resolver != nil {
+			clientID = uintptr(clientIDCounter.Add(1))
+			registerResolver(clientID, resolver)
+			resolverCallback = (C.AddressResolverCallback)(unsafe.Pointer(C.addressResolverCallback))
+		}
 	}
 
 	cResponse := (*C.struct_ConnectionResponse)(
@@ -175,6 +183,7 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 			&clientType,
 			(C.PubSubCallback)(unsafe.Pointer(C.pubSubCallback)),
 			resolverCallback,
+			C.uintptr_t(clientID),
 		),
 	)
 
@@ -182,10 +191,14 @@ func createClient(config clientConfiguration) (*baseClient, error) {
 	cErr := cResponse.connection_error_message
 	if cErr != nil {
 		message := C.GoString(cErr)
+		if clientID != 0 {
+			unregisterResolver(clientID)
+		}
 		return nil, NewConnectionError(message)
 	}
 
 	client.coreClient = cResponse.conn_ptr
+	client.resolverID = clientID
 
 	// Register the client in our registry using the pointer value from C
 	registerClient(client, uintptr(cResponse.conn_ptr))
@@ -206,6 +219,11 @@ func (client *baseClient) Close() {
 
 	C.close_client(client.coreClient)
 	client.coreClient = nil
+
+	if client.resolverID != 0 {
+		unregisterResolver(client.resolverID)
+		client.resolverID = 0
+	}
 
 	// iterating the channel map while holding the lock guarantees those unsafe.Pointers is still valid
 	// because holding the lock guarantees the owner of the unsafe.Pointer hasn't exit.

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -20,10 +20,10 @@ package glide
 //                     const uint8_t *message, int64_t message_len,
 //                     const uint8_t *channel, int64_t channel_len,
 //                     const uint8_t *pattern, int64_t pattern_len);
-// uint16_t addressResolverCallback(const uint8_t *host, size_t host_len,
+// uint16_t addressResolverCallback(const uint8_t *host, uintptr_t host_len,
 //                                  uint16_t port,
-//                                  uint8_t *resolved_host_buf, size_t resolved_host_buf_len,
-//                                  size_t *resolved_host_len);
+//                                  uint8_t *resolved_host_buf, uintptr_t resolved_host_buf_len,
+//                                  uintptr_t *resolved_host_len);
 import "C"
 
 import (

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -20,7 +20,7 @@ package glide
 //                     const uint8_t *message, int64_t message_len,
 //                     const uint8_t *channel, int64_t channel_len,
 //                     const uint8_t *pattern, int64_t pattern_len);
-// uint16_t addressResolverCallback(const uint8_t *host, uintptr_t host_len,
+// uint16_t addressResolverCallback(uintptr_t client_id, const uint8_t *host, uintptr_t host_len,
 //                                  uint16_t port,
 //                                  uint8_t *resolved_host_buf, uintptr_t resolved_host_buf_len,
 //                                  uintptr_t *resolved_host_len);

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -217,10 +217,9 @@ const (
 //   - Address translation for proxy setups
 //   - Dynamic endpoint resolution for cloud environments
 //
-// Note: The resolver must be safe for concurrent use, as it may be called from multiple goroutines
-// during connection and topology refresh. If the resolver returns an error or panics, the original
-// address will be used as a fallback.
-type AddressResolver func(host string, port int) (resolvedHost string, resolvedPort int)
+// The resolver must be safe for concurrent use, as it may be called from multiple goroutines
+// during connection and topology refresh.
+type AddressResolver func(host string, port int) (string, int)
 
 type baseClientConfiguration struct {
 	addresses         []NodeAddress
@@ -587,19 +586,16 @@ func (config *ClientConfiguration) WithNodeDiscoveryMode(mode NodeDiscoveryMode)
 	return config
 }
 
-// WithAddressResolver sets an address resolver callback for resolving node addresses before connection.
-//
-// When set, the resolver will be called to resolve host:port pairs before establishing connections
-// to server nodes. This allows custom DNS resolution or address translation logic.
-//
-// If the resolver is nil, addresses are used as configured without modification.
-//
-// Note: Due to FFI constraints, only one resolver can be active globally at a time. If multiple
-// clients are created with different resolvers, the last one set will be used for all clients.
-// In most applications this is not an issue since a single resolver is shared across all clients.
+// WithAddressResolver sets a custom address resolver for the standalone client.
+// The resolver is called during connection establishment and topology refresh to translate
+// addresses before connecting. Return the original host and port to use them unchanged.
 func (config *ClientConfiguration) WithAddressResolver(resolver AddressResolver) *ClientConfiguration {
 	config.addressResolver = resolver
 	return config
+}
+
+func (config *ClientConfiguration) GetAddressResolver() AddressResolver {
+	return config.addressResolver
 }
 
 func (config *ClientConfiguration) HasSubscription() bool {
@@ -611,11 +607,6 @@ func (config *ClientConfiguration) GetSubscription() *StandaloneSubscriptionConf
 		return config.subscriptionConfig
 	}
 	return nil
-}
-
-// GetAddressResolver returns the configured address resolver, or nil if none is set.
-func (config *ClientConfiguration) GetAddressResolver() AddressResolver {
-	return config.addressResolver
 }
 
 // ClusterClientConfiguration represents the configuration settings for a Cluster Glide client.
@@ -833,16 +824,9 @@ func (config *ClusterClientConfiguration) WithClientSideCache(
 	return config
 }
 
-// WithAddressResolver sets an address resolver callback for resolving node addresses before connection.
-//
-// When set, the resolver will be called to resolve host:port pairs before establishing connections
-// to cluster nodes. This allows custom DNS resolution or address translation logic.
-//
-// If the resolver is nil, addresses are used as configured without modification.
-//
-// Note: Due to FFI constraints, only one resolver can be active globally at a time. If multiple
-// clients are created with different resolvers, the last one set will be used for all clients.
-// In most applications this is not an issue since a single resolver is shared across all clients.
+// WithAddressResolver sets a custom address resolver for the cluster client.
+// The resolver is called during connection establishment and topology refresh to translate
+// addresses before connecting. Return the original host and port to use them unchanged.
 func (config *ClusterClientConfiguration) WithAddressResolver(resolver AddressResolver) *ClusterClientConfiguration {
 	config.addressResolver = resolver
 	return config
@@ -852,16 +836,15 @@ func (config *ClusterClientConfiguration) HasSubscription() bool {
 	return config.subscriptionConfig != nil
 }
 
+func (config *ClusterClientConfiguration) GetAddressResolver() AddressResolver {
+	return config.addressResolver
+}
+
 func (config *ClusterClientConfiguration) GetSubscription() *ClusterSubscriptionConfig {
 	if config.HasSubscription() {
 		return config.subscriptionConfig
 	}
 	return nil
-}
-
-// GetAddressResolver returns the configured address resolver, or nil if none is set.
-func (config *ClusterClientConfiguration) GetAddressResolver() AddressResolver {
-	return config.addressResolver
 }
 
 // TlsConfiguration represents TLS-specific configuration settings.

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -593,6 +593,10 @@ func (config *ClientConfiguration) WithNodeDiscoveryMode(mode NodeDiscoveryMode)
 // to server nodes. This allows custom DNS resolution or address translation logic.
 //
 // If the resolver is nil, addresses are used as configured without modification.
+//
+// Note: Due to FFI constraints, only one resolver can be active globally at a time. If multiple
+// clients are created with different resolvers, the last one set will be used for all clients.
+// In most applications this is not an issue since a single resolver is shared across all clients.
 func (config *ClientConfiguration) WithAddressResolver(resolver AddressResolver) *ClientConfiguration {
 	config.addressResolver = resolver
 	return config
@@ -835,6 +839,10 @@ func (config *ClusterClientConfiguration) WithClientSideCache(
 // to cluster nodes. This allows custom DNS resolution or address translation logic.
 //
 // If the resolver is nil, addresses are used as configured without modification.
+//
+// Note: Due to FFI constraints, only one resolver can be active globally at a time. If multiple
+// clients are created with different resolvers, the last one set will be used for all clients.
+// In most applications this is not an issue since a single resolver is shared across all clients.
 func (config *ClusterClientConfiguration) WithAddressResolver(resolver AddressResolver) *ClusterClientConfiguration {
 	config.addressResolver = resolver
 	return config

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -206,6 +206,22 @@ const (
 	NodeDiscoveryModeDiscoverAll NodeDiscoveryMode = 2
 )
 
+// AddressResolver is a callback interface for resolving server addresses before connection.
+//
+// When provided to a client configuration, this callback is invoked for each configured address
+// during connection establishment and during cluster topology refreshes. The callback receives
+// the configured host and port, and should return the actual host and port to use for the connection.
+//
+// Use cases:
+//   - Custom DNS resolution for service discovery
+//   - Address translation for proxy setups
+//   - Dynamic endpoint resolution for cloud environments
+//
+// Note: The resolver must be safe for concurrent use, as it may be called from multiple goroutines
+// during connection and topology refresh. If the resolver returns an error or panics, the original
+// address will be used as a fallback.
+type AddressResolver func(host string, port int) (resolvedHost string, resolvedPort int)
+
 type baseClientConfiguration struct {
 	addresses         []NodeAddress
 	useTLS            bool
@@ -219,6 +235,7 @@ type baseClientConfiguration struct {
 	DatabaseId        *int `json:"database_id,omitempty"`
 	compressionConfig *CompressionConfiguration
 	clientSideCache   *ClientSideCache
+	addressResolver   AddressResolver
 }
 
 func (config *baseClientConfiguration) toProtobuf() (*protobuf.ConnectionRequest, error) {
@@ -570,6 +587,17 @@ func (config *ClientConfiguration) WithNodeDiscoveryMode(mode NodeDiscoveryMode)
 	return config
 }
 
+// WithAddressResolver sets an address resolver callback for resolving node addresses before connection.
+//
+// When set, the resolver will be called to resolve host:port pairs before establishing connections
+// to server nodes. This allows custom DNS resolution or address translation logic.
+//
+// If the resolver is nil, addresses are used as configured without modification.
+func (config *ClientConfiguration) WithAddressResolver(resolver AddressResolver) *ClientConfiguration {
+	config.addressResolver = resolver
+	return config
+}
+
 func (config *ClientConfiguration) HasSubscription() bool {
 	return config.subscriptionConfig != nil
 }
@@ -579,6 +607,11 @@ func (config *ClientConfiguration) GetSubscription() *StandaloneSubscriptionConf
 		return config.subscriptionConfig
 	}
 	return nil
+}
+
+// GetAddressResolver returns the configured address resolver, or nil if none is set.
+func (config *ClientConfiguration) GetAddressResolver() AddressResolver {
+	return config.addressResolver
 }
 
 // ClusterClientConfiguration represents the configuration settings for a Cluster Glide client.
@@ -796,6 +829,17 @@ func (config *ClusterClientConfiguration) WithClientSideCache(
 	return config
 }
 
+// WithAddressResolver sets an address resolver callback for resolving node addresses before connection.
+//
+// When set, the resolver will be called to resolve host:port pairs before establishing connections
+// to cluster nodes. This allows custom DNS resolution or address translation logic.
+//
+// If the resolver is nil, addresses are used as configured without modification.
+func (config *ClusterClientConfiguration) WithAddressResolver(resolver AddressResolver) *ClusterClientConfiguration {
+	config.addressResolver = resolver
+	return config
+}
+
 func (config *ClusterClientConfiguration) HasSubscription() bool {
 	return config.subscriptionConfig != nil
 }
@@ -805,6 +849,11 @@ func (config *ClusterClientConfiguration) GetSubscription() *ClusterSubscription
 		return config.subscriptionConfig
 	}
 	return nil
+}
+
+// GetAddressResolver returns the configured address resolver, or nil if none is set.
+func (config *ClusterClientConfiguration) GetAddressResolver() AddressResolver {
+	return config.addressResolver
 }
 
 // TlsConfiguration represents TLS-specific configuration settings.

--- a/go/integTest/address_resolver_test.go
+++ b/go/integTest/address_resolver_test.go
@@ -1,0 +1,198 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"context"
+
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+)
+
+func (suite *GlideTestSuite) TestAddressResolverWithFakeAddress_Standalone() {
+	// Get the actual server address from test configuration
+	actualHost := suite.standaloneHosts[0].Host
+	actualPort := suite.standaloneHosts[0].Port
+
+	// Use a fake/placeholder address in configuration
+	fakeHost := "fake-host-that-does-not-exist.invalid"
+	fakePort := 9999
+
+	// Create resolver that translates fake address to real server address
+	resolver := func(host string, port int) (string, int) {
+		if host == fakeHost && port == fakePort {
+			return actualHost, actualPort
+		}
+		return host, port
+	}
+
+	// Configure client with fake address - connection should succeed because
+	// resolver translates it to the real address
+	clientConfig := defaultClientConfig().
+		WithAddress(&config.NodeAddress{Host: fakeHost, Port: fakePort}).
+		WithAddressResolver(resolver)
+
+	client, err := glide.NewClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	// Verify the client works - this proves the resolved address was used
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+
+	setResult, err := client.Set(ctx, "resolver_test_key", "resolver_test_value")
+	suite.Require().NoError(err)
+	suite.Equal("OK", setResult)
+
+	getResult, err := client.Get(ctx, "resolver_test_key")
+	suite.Require().NoError(err)
+	suite.Equal("resolver_test_value", getResult.Value())
+}
+
+func (suite *GlideTestSuite) TestAddressResolverWithFakeAddress_Cluster() {
+	// Get the actual server address from test configuration
+	actualHost := suite.clusterHosts[0].Host
+	actualPort := suite.clusterHosts[0].Port
+
+	// Use a fake/placeholder address in configuration
+	fakeHost := "fake-cluster-host.invalid"
+	fakePort := 9999
+
+	// Create resolver that translates fake address to real server address
+	resolver := func(host string, port int) (string, int) {
+		if host == fakeHost && port == fakePort {
+			return actualHost, actualPort
+		}
+		return host, port
+	}
+
+	// Configure client with fake address - connection should succeed because
+	// resolver translates it to the real address
+	clientConfig := defaultClusterClientConfig().
+		WithAddress(&config.NodeAddress{Host: fakeHost, Port: fakePort}).
+		WithAddressResolver(resolver)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	// Verify the client works - this proves the resolved address was used
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+
+	setResult, err := client.Set(ctx, "cluster_resolver_test_key", "cluster_resolver_test_value")
+	suite.Require().NoError(err)
+	suite.Equal("OK", setResult)
+
+	getResult, err := client.Get(ctx, "cluster_resolver_test_key")
+	suite.Require().NoError(err)
+	suite.Equal("cluster_resolver_test_value", getResult.Value())
+}
+
+func (suite *GlideTestSuite) TestAddressResolverExceptionFallsBackToOriginal_Standalone() {
+	// Get the actual server address from test configuration
+	actualHost := suite.standaloneHosts[0].Host
+	actualPort := suite.standaloneHosts[0].Port
+
+	// Create resolver that always panics
+	resolver := func(host string, port int) (string, int) {
+		panic("test-exception")
+	}
+
+	// Configure client with real address - connection should still succeed
+	// because the fallback uses the original address when resolver panics
+	clientConfig := defaultClientConfig().
+		WithAddress(&config.NodeAddress{Host: actualHost, Port: actualPort}).
+		WithAddressResolver(resolver)
+
+	client, err := glide.NewClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+}
+
+func (suite *GlideTestSuite) TestAddressResolverExceptionFallsBackToOriginal_Cluster() {
+	// Get the actual server address from test configuration
+	actualHost := suite.clusterHosts[0].Host
+	actualPort := suite.clusterHosts[0].Port
+
+	// Create resolver that always panics
+	resolver := func(host string, port int) (string, int) {
+		panic("test-exception")
+	}
+
+	// Configure client with real address - connection should still succeed
+	// because the fallback uses the original address when resolver panics
+	clientConfig := defaultClusterClientConfig().
+		WithAddress(&config.NodeAddress{Host: actualHost, Port: actualPort}).
+		WithAddressResolver(resolver)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+}
+
+func (suite *GlideTestSuite) TestAddressResolverReturnsEmptyFallsBackToOriginal_Standalone() {
+	// Get the actual server address from test configuration
+	actualHost := suite.standaloneHosts[0].Host
+	actualPort := suite.standaloneHosts[0].Port
+
+	// Create resolver that returns empty host (signals fallback)
+	resolver := func(host string, port int) (string, int) {
+		return "", 0
+	}
+
+	// Configure client with real address - connection should still succeed
+	// because returning empty/zero signals fallback to original address
+	clientConfig := defaultClientConfig().
+		WithAddress(&config.NodeAddress{Host: actualHost, Port: actualPort}).
+		WithAddressResolver(resolver)
+
+	client, err := glide.NewClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+}
+
+func (suite *GlideTestSuite) TestAddressResolverReturnsEmptyFallsBackToOriginal_Cluster() {
+	// Get the actual server address from test configuration
+	actualHost := suite.clusterHosts[0].Host
+	actualPort := suite.clusterHosts[0].Port
+
+	// Create resolver that returns empty host (signals fallback)
+	resolver := func(host string, port int) (string, int) {
+		return "", 0
+	}
+
+	// Configure client with real address - connection should still succeed
+	// because returning empty/zero signals fallback to original address
+	clientConfig := defaultClusterClientConfig().
+		WithAddress(&config.NodeAddress{Host: actualHost, Port: actualPort}).
+		WithAddressResolver(resolver)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+}

--- a/go/integTest/address_resolver_test.go
+++ b/go/integTest/address_resolver_test.go
@@ -196,3 +196,43 @@ func (suite *GlideTestSuite) TestAddressResolverReturnsEmptyFallsBackToOriginal_
 	suite.Require().NoError(err)
 	suite.Equal("PONG", result)
 }
+
+func (suite *GlideTestSuite) TestAddressResolverNil_Standalone() {
+	// Get the actual server address from test configuration
+	actualHost := suite.standaloneHosts[0].Host
+	actualPort := suite.standaloneHosts[0].Port
+
+	// Configure client with nil resolver - should work normally
+	clientConfig := defaultClientConfig().
+		WithAddress(&config.NodeAddress{Host: actualHost, Port: actualPort}).
+		WithAddressResolver(nil)
+
+	client, err := glide.NewClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+}
+
+func (suite *GlideTestSuite) TestAddressResolverNil_Cluster() {
+	// Get the actual server address from test configuration
+	actualHost := suite.clusterHosts[0].Host
+	actualPort := suite.clusterHosts[0].Port
+
+	// Configure client with nil resolver - should work normally
+	clientConfig := defaultClusterClientConfig().
+		WithAddress(&config.NodeAddress{Host: actualHost, Port: actualPort}).
+		WithAddressResolver(nil)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	suite.Require().NoError(err)
+	defer client.Close()
+
+	ctx := context.Background()
+	result, err := client.Ping(ctx)
+	suite.Require().NoError(err)
+	suite.Equal("PONG", result)
+}


### PR DESCRIPTION
### Summary

Add support for custom socket address resolution in the Go client, allowing applications to resolve host and port before a connection is made. This is useful for cases where the URL can't be resolved by default DNS, or is behind a firewall/proxy.

This is the Go port of the address resolver feature already available in Java ([#5328](https://github.com/valkey-io/valkey-glide/pull/5328)) and Python ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873)).

### Issue link

This Pull Request is linked to issue: [Support custom socket address resolution](https://github.com/valkey-io/valkey-glide/issues/5873)
Closes

### Features / Behaviour Changes

- Added `AddressResolver` type (`func(host string, port int) (resolvedHost string, resolvedPort int)`) in the `config` package.
- Added `WithAddressResolver` builder method to both `ClientConfiguration` and `ClusterClientConfiguration`.
- The resolver is invoked for each configured address during connection establishment and during cluster topology refreshes.
- Fallback behavior: if the resolver returns port 0, an empty host, or panics, the original address is used.

### Implementation

- **`go/address_resolver.go`**: New file implementing the FFI callback bridge. Uses a global resolver pattern (with RWMutex protection) since the C callback signature doesn't carry a context pointer. Includes panic recovery to ensure fallback behavior on resolver errors.
- **`go/base_client.go`**: Wires up the resolver callback during client creation, passing it to the Rust `create_client` FFI function.
- **`go/config/config.go`**: Adds the `AddressResolver` type definition and `WithAddressResolver`/`GetAddressResolver` methods for both standalone and cluster configurations.
- **`go/lib.h`**: Added `#pragma once` include guard to prevent multiple inclusion errors when CGo processes multiple files with `//export` directives.
- **`go/Makefile`**: Updated `gen-c-bindings` target to auto-insert `#pragma once` after cbindgen generates the header, ensuring the fix persists across rebuilds.

Key areas for review:
- The global resolver pattern and its "last one wins" limitation (documented in godoc)
- The `uintptr_t` types in the callback signature matching the C header exactly
- Panic recovery in the FFI callback

### Limitations


### Testing

- Integration tests added in `go/integTest/address_resolver_test.go` covering:
  - Fake address resolved to real server address (standalone + cluster)
  - Resolver that panics falls back to original address (standalone + cluster)
  - Resolver that returns empty/zero falls back to original address (standalone + cluster)
  - Nil resolver doesn't break anything (standalone + cluster)

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.