### PR TITLE
fix(node): allow protobufjs build scripts in pnpm test

### DIFF
--- a/node/hybrid-node-tests/pnpm-pubsub-test/pnpm-workspace.yaml
+++ b/node/hybrid-node-tests/pnpm-pubsub-test/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+    protobufjs: true


### PR DESCRIPTION
### Summary

Fix CI failure in the `test-node-extras` job caused by pnpm v11 blocking protobufjs build scripts by default. CI installs the latest pnpm (`npm install -g pnpm`), which is now v11.0.8. pnpm v11 replaced `onlyBuiltDependencies` with `allowBuilds` in `pnpm-workspace.yaml` and errors on unreviewed build scripts via `strictDepBuilds: true` (default).

### Issue link

This Pull Request fixes a CI regression where `pnpm install` fails with:
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: protobufjs@7.5.6
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

### Features / Behaviour Changes

No feature or behaviour changes. This is a CI-only fix.

### Implementation

Added `node/hybrid-node-tests/pnpm-pubsub-test/pnpm-workspace.yaml` with:
```yaml
allowBuilds:
    protobufjs: true
```

This is the pnpm v11 way to explicitly permit a dependency's postinstall scripts. pnpm v11 no longer reads build settings from `.npmrc`, `package.json` `pnpm` field, or the old `onlyBuiltDependencies` syntax.

### Limitations

None.

### Testing

- The fix targets the CI pipeline itself. Once merged, both `pnpm install` and `pnpm run test` (which triggers `verifyDepsBeforeRun` check) should pass without the `ERR_PNPM_IGNORED_BUILDS` error.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.