### PR TITLE
Fix flaky scan_with_options and scan_binary_with_options tests

### DIFF
--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1421,7 +1421,6 @@ public class CommandTests {
         // Empty return - match a random UUID
         ScanOptions options = ScanOptions.builder().matchPattern("*" + UUID.randomUUID()).build();
         Object[] emptyResult = regularClient.scan(initialCursor, options).get();
-        assertNotEquals(initialCursor, emptyResult[resultCursorIndex]);
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor
@@ -1509,7 +1508,6 @@ public class CommandTests {
         // Empty return - match a random UUID
         ScanOptions options = ScanOptions.builder().matchPattern("*" + UUID.randomUUID()).build();
         Object[] emptyResult = regularClient.scan(initialCursor, options).get();
-        assertNotEquals(initialCursor, emptyResult[resultCursorIndex]);
         assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
 
         // Negative cursor


### PR DESCRIPTION
### Summary
Fix flaky `scan_with_options` and `scan_binary_with_options` tests by removing incorrect cursor value assertions.

### Issue link
This Pull Request is linked to issue: [[Java][Flaky Test] glide.standalone.CommandTests.scan_with_options](https://github.com/valkey-io/valkey-glide/issues/5545)
Closes #5545

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The tests assert that after scanning with a non-matching pattern, the returned cursor must not be "0". This assumption is incorrect — the SCAN command can return cursor "0" on the very first call when the keyspace is small enough to be scanned in a single iteration. This happens frequently in CI where the test database has few keys.

**Fix:** Remove the `assertNotEquals(initialCursor, emptyResult[resultCursorIndex])` assertion from both `scan_with_options` and `scan_binary_with_options`. The meaningful assertion — that no keys matched the random UUID pattern (empty result set) — is retained.

### Limitations
None

### Testing
The fix removes an incorrect assertion. The remaining assertions still validate that SCAN with a non-matching pattern returns no keys.

This fix was tested repeatedly over 250 cycles without any occurrence of flakiness.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release