### PR TITLE
Core: Propagate per-command response timeout to multiplexed connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Pending 2.4
 
 #### Fixes
+* CORE: Propagate per-command response timeout to the multiplexed connection layer. The configured `request_timeout` (including blocking command timeouts) is now enforced at the connection level, ensuring commands time out reliably instead of waiting indefinitely with `Duration::MAX`. ([#5581](https://github.com/valkey-io/valkey-glide/issues/5581))
 * CORE: Fall back to existing cluster connections when initial nodes are unavailable during topology refresh. When `refreshTopologyFromInitialNodes=true` and the initial/seed node is unreachable (e.g., dead primary during failover), the topology refresh now queries healthy existing connections instead of failing silently. This complements #5812 to enable failover recovery when the seed node itself is the failed node. ([#5814](https://github.com/valkey-io/valkey-glide/pull/5814))
 * Node: Fix SIGSEGV in pubsub under pnpm strict hoisting — replace `value_from_split_pointer(high_u32, low_u32)` with `value_from_pointer(i64)` in the Node.js Rust client to accept response pointers as a single integer, eliminating the high/low split that caused upper 32-bit truncation when `protobufjs.util.Long` was null ([#5851](https://github.com/valkey-io/valkey-glide/issues/5851))
 

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -729,13 +729,10 @@ impl MultiplexedConnection {
                 return Ok(value);
             }
         }
+        let timeout = cmd.response_timeout().unwrap_or(self.response_timeout);
         let result = self
             .pipeline
-            .send_single(
-                cmd.get_packed_command(),
-                self.response_timeout,
-                cmd.is_fenced(),
-            )
+            .send_single(cmd.get_packed_command(), timeout, cmd.is_fenced())
             .await;
         if self.protocol != ProtocolVersion::RESP2 {
             if let Err(e) = &result {

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -35,6 +35,10 @@ pub struct Cmd {
     span: Option<GlideSpan>,
     //  A flag indicating whether this is a fenced command  (will have PING appended to ensure ordering)
     is_fenced: bool,
+    /// Per-command response timeout. When set, overrides the connection-level
+    /// response_timeout for this specific command. Used to propagate the
+    /// caller's request_timeout into the multiplexed connection layer.
+    response_timeout: Option<std::time::Duration>,
     /// Inflight slot tracker. When set, the slot is released when the last
     /// clone of this Cmd (or its Arc) is dropped. Used to decouple user-facing
     /// timeout from internal pipeline cleanup.
@@ -360,6 +364,7 @@ impl Cmd {
             no_response: false,
             span: None,
             is_fenced: false,
+            response_timeout: None,
             #[cfg(feature = "cluster-async")]
             inflight_tracker: None,
         }
@@ -373,9 +378,10 @@ impl Cmd {
             cursor: None,
             no_response: false,
             span: None,
+            is_fenced: false,
+            response_timeout: None,
             #[cfg(feature = "cluster-async")]
             inflight_tracker: None,
-            is_fenced: false,
         }
     }
 
@@ -669,6 +675,18 @@ impl Cmd {
         self.is_fenced
     }
 
+    /// Set a per-command response timeout that overrides the connection default.
+    #[inline]
+    pub fn set_response_timeout(&mut self, timeout: Option<std::time::Duration>) {
+        self.response_timeout = timeout;
+    }
+
+    /// Get the per-command response timeout, if set.
+    #[inline]
+    pub fn response_timeout(&self) -> Option<std::time::Duration> {
+        self.response_timeout
+    }
+
     /// Attach an inflight slot tracker. The slot is released when the last
     /// clone of this Cmd (or its `Arc<Cmd>`) is dropped.
     #[cfg(feature = "cluster-async")]
@@ -750,6 +768,7 @@ pub fn pipe() -> Pipeline {
 #[cfg(feature = "cluster")]
 mod tests {
     use super::Cmd;
+    use std::time::Duration;
 
     #[test]
     fn test_cmd_arg_idx() {
@@ -765,5 +784,23 @@ mod tests {
         assert_eq!(c.arg_idx(2), Some(&b"42"[..]));
         assert_eq!(c.arg_idx(3), None);
         assert_eq!(c.arg_idx(4), None);
+    }
+
+    #[test]
+    fn test_response_timeout_defaults_to_none() {
+        let cmd = Cmd::new();
+        assert_eq!(cmd.response_timeout(), None);
+    }
+
+    #[test]
+    fn test_response_timeout_override() {
+        let mut cmd = Cmd::new();
+        cmd.arg("GET").arg("key");
+
+        cmd.set_response_timeout(Some(Duration::from_millis(100)));
+        assert_eq!(cmd.response_timeout(), Some(Duration::from_millis(100)));
+
+        cmd.set_response_timeout(None);
+        assert_eq!(cmd.response_timeout(), None);
     }
 }

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1001,6 +1001,7 @@ impl Client {
             }
 
             cmd.set_inflight_tracker(tracker);
+            cmd.set_response_timeout(request_timeout);
 
             // Clone compression_manager reference only if compression is enabled
             let compression_manager = if self.is_compression_enabled() {


### PR DESCRIPTION
### Summary

Propagates the per-command timeout from glide-core's `send_command` to the redis-rs multiplexed connection layer. This ensures each command in the connection layer times out with the correct duration (including blocking commands), rather than relying solely on the connection-level default.

Without this, commands to unresponsive nodes wait indefinitely (`Duration::MAX` at connection layer), permanently consuming inflight slots and preventing the client from detecting node failures.

### Issue link

Closes #5581

### Features / Behaviour Changes

- Per-command response timeout at the connection layer, ensuring commands to unresponsive nodes timeout correctly
- Blocking commands retain their extended timeout semantics (blocking duration + buffer)
- Infinite-block commands (timeout=0) remain unaffected

### Implementation

- `Cmd` struct gains `response_timeout: Option<Duration>` with getter/setter
- `MultiplexedConnection::send_packed_command` resolves timeout as `cmd.response_timeout().unwrap_or(self.response_timeout)`
- `glide-core/src/client/mod.rs`: `send_command` calls `cmd.set_response_timeout(request_timeout)` where `request_timeout` is the value from `get_request_timeout()` (already handles blocking command extensions)

This differs from the closed #5580 which set `response_timeout` on the cluster builder (connection-level default), breaking blocking commands. This approach is per-command, respecting the existing `get_request_timeout()` logic.

Note: The per-command timeout only affects when the caller receives the error. The command remains in the multiplexed connection's internal pipeline until the server responds or the connection drops, so pipeline ordering and protocol integrity are preserved.

### Limitations

- Pipeline/transaction commands are not affected, they use their own timeout wrapper at the glide-core level

### Testing

- All core and Java unit tests pass, including new unit tests (`test_response_timeout_defaults_to_none`, `test_response_timeout_override`) and existing integration test (`test_response_timeout_multiplexed_connection`)
- Manually tested stuck scenarios (network partition and memory pressure) as part of a layered fix set; this change is a prerequisite for reliable timeout delivery under network partition scenarios

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.