### PR TITLE
Node.js: Add MIGRATE command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Changes
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+* Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 
 ## 2.4

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -56,6 +56,7 @@ import {
     ListDirection,
     Logger,
     MemberOrigin, // eslint-disable-line @typescript-eslint/no-unused-vars
+    MigrateOptions,
     OpenTelemetry,
     RangeByIndex,
     RangeByLex,
@@ -166,6 +167,7 @@ import {
     createLeakedOtelSpan,
     createOtelSpanWithTraceContext,
     createMGet,
+    createMigrate,
     createMSet,
     createMSetNX,
     createMove,
@@ -2441,6 +2443,43 @@ export class BaseClient {
     ): Promise<boolean> {
         return this.createWritePromise(
             createCopy(source, destination, options),
+        );
+    }
+
+    /**
+     * Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+     * Once the key is successfully transferred, it is deleted from the source instance.
+     *
+     * @see {@link https://valkey.io/commands/migrate/|valkey.io} for details.
+     *
+     * @param host - The host of the destination Valkey instance.
+     * @param port - The port of the destination Valkey instance.
+     * @param key - The key to migrate.
+     * @param destinationDB - The database index on the destination instance.
+     * @param timeout - The maximum idle time in milliseconds for the bulk-transfer.
+     * @param options - Optional migration options.
+     * @returns "OK" on success, or "NOKEY" if the key does not exist.
+     *
+     * @example
+     * ```typescript
+     * const result = await client.migrate("127.0.0.1", 6379, "mykey", 0, 5000);
+     * console.log(result); // Output: "OK" - "mykey" was migrated to the destination instance.
+     * ```
+     * ```typescript
+     * const result = await client.migrate("127.0.0.1", 6379, "mykey", 0, 5000, { copy: true, replace: true });
+     * console.log(result); // Output: "OK" - "mykey" was copied to the destination, replacing any existing key.
+     * ```
+     */
+    public async migrate(
+        host: string,
+        port: number,
+        key: GlideString,
+        destinationDB: number,
+        timeout: number,
+        options?: MigrateOptions,
+    ): Promise<string> {
+        return this.createWritePromise(
+            createMigrate(host, port, key, destinationDB, timeout, options),
         );
     }
 

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -52,6 +52,7 @@ import {
     ListDirection,
     LolwutOptions,
     MemberOrigin, // eslint-disable-line @typescript-eslint/no-unused-vars
+    MigrateOptions,
     RangeByIndex,
     RangeByLex,
     RangeByScore,
@@ -173,6 +174,7 @@ import {
     createLastSave,
     createLolwut,
     createMGet,
+    createMigrate,
     createMSet,
     createMSetNX,
     createMove,
@@ -453,6 +455,32 @@ export class BaseBatch<T extends BaseBatch<T>> {
     ): T {
         return this.addAndReturn(createCopy(source, destination, options));
     }
+
+    /**
+     * Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+     *
+     * @see {@link https://valkey.io/commands/migrate/|valkey.io} for details.
+     *
+     * @param host - The host of the destination Valkey instance.
+     * @param port - The port of the destination Valkey instance.
+     * @param key - The key to migrate.
+     * @param destinationDB - The database index on the destination instance.
+     * @param timeout - The maximum idle time in milliseconds for the bulk-transfer.
+     * @param options - Optional migration options.
+     */
+    public migrate(
+        host: string,
+        port: number,
+        key: GlideString,
+        destinationDB: number,
+        timeout: number,
+        options?: MigrateOptions,
+    ): T {
+        return this.addAndReturn(
+            createMigrate(host, port, key, destinationDB, timeout, options),
+        );
+    }
+
     /**
      * Gets information and statistics about the server.
      *

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -3379,6 +3379,58 @@ export function createCopy(
 }
 
 /**
+ * Optional arguments for the {@link BaseClient.migrate} command.
+ */
+export interface MigrateOptions {
+    /** If true, do not remove the key from the source instance. */
+    copy?: boolean;
+    /** If true, replace the existing key on the destination instance. */
+    replace?: boolean;
+    /** Authentication password for the destination instance. */
+    password?: string;
+    /** Authentication username for the destination instance (requires password). */
+    username?: string;
+}
+
+/** @internal */
+export function createMigrate(
+    host: string,
+    port: number,
+    key: GlideString,
+    destinationDB: number,
+    timeout: number,
+    options?: MigrateOptions,
+): command_request.Command {
+    const args: GlideString[] = [
+        host,
+        port.toString(),
+        key,
+        destinationDB.toString(),
+        timeout.toString(),
+    ];
+
+    if (options) {
+        if (options.username !== undefined && options.password === undefined) {
+            throw new Error(
+                "MigrateOptions: 'username' requires 'password' to be set",
+            );
+        }
+
+        if (options.copy) args.push("COPY");
+
+        if (options.replace) args.push("REPLACE");
+
+        if (options.username !== undefined && options.password !== undefined) {
+            args.push("AUTH2", options.username, options.password);
+        } else if (options.password !== undefined) {
+            args.push("AUTH", options.password);
+        }
+    }
+
+    return createCommand(RequestType.Migrate, args);
+}
+
+/**
  * @internal
  */
 export function createMove(

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -760,6 +760,49 @@ describe("GlideClient", () => {
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "migrate test_%p",
+        async (protocol) => {
+            const client = await GlideClient.createClient(
+                getClientConfigurationOption(cluster.getAddresses(), protocol),
+            );
+
+            const key = getRandomKey();
+            const [serverHost, serverPort] = cluster.getAddresses()[0];
+
+            // NOKEY when key does not exist
+            expect(
+                await client.migrate(serverHost, serverPort, key, 0, 1000),
+            ).toEqual("NOKEY");
+
+            // Error when host is invalid
+            await client.set(key, "value");
+            await expect(
+                client.migrate("invalid-host", 6379, key, 0, 1000),
+            ).rejects.toThrow();
+
+            // Error with options (COPY, REPLACE, AUTH)
+            await expect(
+                client.migrate("invalid-host", 6379, key, 0, 1000, {
+                    copy: true,
+                    replace: true,
+                    password: "secret",
+                }),
+            ).rejects.toThrow();
+
+            // Error with AUTH2 (username + password)
+            await expect(
+                client.migrate("invalid-host", 6379, key, 0, 1000, {
+                    username: "user",
+                    password: "secret",
+                }),
+            ).rejects.toThrow();
+
+            client.close();
+        },
+        TIMEOUT,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "move test_%p",
         async (protocol) => {
             const client = await GlideClient.createClient(

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -916,6 +916,27 @@ describe("GlideClusterClient", () => {
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "migrate test_%p",
+        async (protocol) => {
+            client = await GlideClusterClient.createClient(
+                getClientConfigurationOption(cluster.getAddresses(), protocol),
+            );
+            const key = getRandomKey();
+            // Non-existent key returns NOKEY
+            const result = await client.migrate(
+                "localhost",
+                cluster.getAddresses()[0][1],
+                key,
+                0,
+                5000,
+            );
+            expect(result).toEqual("NOKEY");
+            client.close();
+        },
+        TIMEOUT,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "select test %p",
         async (protocol) => {
             if (cluster.checkIfServerVersionLessThan("9.0.0")) return;


### PR DESCRIPTION
### Summary

Adds support for the [`MIGRATE`](https://valkey.io/commands/migrate/) command to the Node.js client. `MIGRATE` atomically transfers a key from the current server to a destination server.

### Issue link

This Pull Request is linked to issue: [Implement MIGRATE command for Python, Node.js, and Go clients](https://github.com/valkey-io/valkey-glide/issues/5932)
Closes #5932

### Features / Behaviour Changes

- New `MigrateOptions` interface in `Commands.ts` with fields:
  - `copy?: boolean` — do not remove the key from the source
  - `replace?: boolean` — replace an existing key on the destination
  - `password?: string` — authenticate with `AUTH`
  - `username?: string` — authenticate with `AUTH2` (requires `password`)
- `migrate()` method added to `BaseClient`, available on both `GlideClient` and `GlideClusterClient`
- `migrate()` added to `BaseBatch` for batch support
- `MigrateOptions` exported from `index.ts`

### Implementation

- `createMigrate()` factory function in `Commands.ts` builds the protocol args
- Runtime guard: passing `username` without `password` throws `Error`
- Protocol arg order: `host port key destination-db timeout [COPY] [REPLACE] [AUTH password | AUTH2 username password]`
- Multi-key migration via `KEYS` is not supported (consistent with the Java client)

### Limitations

- `KEYS key [key ...]` (multi-key migration) is not implemented.

### Testing

- Integration tests in `GlideClient.test.ts` covering NOKEY, COPY, REPLACE, AUTH, AUTH2 option paths
- Integration tests in `GlideClusterClient.test.ts` covering NOKEY path
- `tsc` compilation passes with 0 errors
- ESLint and Prettier pass cleanly

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.