### PR TITLE
Go: Add MIGRATE command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Changes
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+* Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
 
 ## 2.4
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -7698,6 +7698,91 @@ func (client *baseClient) CopyWithOptions(
 	return handleBoolResponse(result)
 }
 
+// Transfers a key from the current Valkey instance to a destination Valkey instance.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx           - The context for controlling the command execution.
+//	host          - The host of the destination Valkey instance.
+//	port          - The port of the destination Valkey instance.
+//	key           - The key to migrate.
+//	destinationDB - The database index on the destination instance.
+//	timeout       - The timeout in milliseconds.
+//
+// Return value:
+//
+//	"OK" on success, or "NOKEY" if the key does not exist.
+//
+// [valkey.io]: https://valkey.io/commands/migrate/
+func (client *baseClient) Migrate(
+	ctx context.Context,
+	host string,
+	port int64,
+	key string,
+	destinationDB int64,
+	timeout int64,
+) (string, error) {
+	result, err := client.executeCommand(ctx, C.Migrate, []string{
+		host,
+		utils.IntToString(port),
+		key,
+		utils.IntToString(destinationDB),
+		utils.IntToString(timeout),
+	})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(result)
+}
+
+// Transfers a key from the current Valkey instance to a destination Valkey instance with options.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx            - The context for controlling the command execution.
+//	host           - The host of the destination Valkey instance.
+//	port           - The port of the destination Valkey instance.
+//	key            - The key to migrate.
+//	destinationDB  - The database index on the destination instance.
+//	timeout        - The timeout in milliseconds.
+//	migrateOptions - Additional options (COPY, REPLACE, AUTH, AUTH2).
+//
+// Return value:
+//
+//	"OK" on success, or "NOKEY" if the key does not exist.
+//
+// [valkey.io]: https://valkey.io/commands/migrate/
+func (client *baseClient) MigrateWithOptions(
+	ctx context.Context,
+	host string,
+	port int64,
+	key string,
+	destinationDB int64,
+	timeout int64,
+	migrateOptions options.MigrateOptions,
+) (string, error) {
+	optionArgs, err := migrateOptions.ToArgs()
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	args := []string{
+		host,
+		utils.IntToString(port),
+		key,
+		utils.IntToString(destinationDB),
+		utils.IntToString(timeout),
+	}
+	result, err := client.executeCommand(ctx, C.Migrate, append(args, optionArgs...))
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(result)
+}
+
 // Returns stream entries matching a given range of IDs.
 //
 // See [valkey.io] for details.

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -7709,7 +7709,7 @@ func (client *baseClient) CopyWithOptions(
 //	port          - The port of the destination Valkey instance.
 //	key           - The key to migrate.
 //	destinationDB - The database index on the destination instance.
-//	timeout       - The timeout in milliseconds.
+//	timeout       - The maximum idle time in milliseconds for the bulk-transfer.
 //
 // Return value:
 //
@@ -7748,7 +7748,7 @@ func (client *baseClient) Migrate(
 //	port           - The port of the destination Valkey instance.
 //	key            - The key to migrate.
 //	destinationDB  - The database index on the destination instance.
-//	timeout        - The timeout in milliseconds.
+//	timeout        - The maximum idle time in milliseconds for the bulk-transfer.
 //	migrateOptions - Additional options (COPY, REPLACE, AUTH, AUTH2).
 //
 // Return value:

--- a/go/constants/constants.go
+++ b/go/constants/constants.go
@@ -20,8 +20,11 @@ const (
 	WeightsKeyword    string = "WEIGHTS"    // Valkey API keyword for the weights option for multiple commands.
 	RankKeyword       string = "RANK"       // Valkey API keyword use to determine the rank of the match to return.
 	MaxLenKeyword     string = "MAXLEN"     // Valkey API keyword used to determine the maximum number of list items to compare.
+	CopyKeyword       string = "COPY"       // Valkey API keyword used to indicate the copy flag.
 	ReplaceKeyword    string = "REPLACE"    // Subcommand string to replace existing key.
 	ABSTTLKeyword     string = "ABSTTL"     // Subcommand string to represent absolute timestamp (in milliseconds) for TTL.
+	AuthKeyword       string = "AUTH"       // Valkey API keyword for authentication.
+	Auth2Keyword      string = "AUTH2"      // Valkey API keyword for authentication with username and password.
 	StoreKeyword      string = "STORE"
 	DbKeyword         string = "DB"
 	TypeKeyword       string = "TYPE"

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -9408,6 +9408,43 @@ func (suite *GlideTestSuite) TestCopyWithOptions() {
 	})
 }
 
+func (suite *GlideTestSuite) TestMigrate() {
+	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
+		ctx := context.Background()
+		key := "{key}" + uuid.New().String()
+		nonExistentKey := "{key}" + uuid.New().String()
+
+		// Non-existent key returns "NOKEY" (not an error)
+		result, err := client.Migrate(ctx, "nonexistent.host", 6379, nonExistentKey, 0, 1000)
+		suite.NoError(err)
+		suite.Equal("NOKEY", result)
+
+		// Existing key migrated to unreachable host returns an error
+		client.Set(ctx, key, "value")
+		_, err = client.Migrate(ctx, "nonexistent.host", 6379, key, 0, 1000)
+		suite.Error(err)
+	})
+}
+
+func (suite *GlideTestSuite) TestMigrateWithOptions() {
+	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
+		ctx := context.Background()
+		key := "{key}" + uuid.New().String()
+		nonExistentKey := "{key}" + uuid.New().String()
+		migrateOpts := options.NewMigrateOptions().SetCopy().SetReplace()
+
+		// Non-existent key returns "NOKEY" (not an error)
+		result, err := client.MigrateWithOptions(ctx, "nonexistent.host", 6379, nonExistentKey, 0, 1000, *migrateOpts)
+		suite.NoError(err)
+		suite.Equal("NOKEY", result)
+
+		// Existing key migrated to unreachable host returns an error
+		client.Set(ctx, key, "value")
+		_, err = client.MigrateWithOptions(ctx, "nonexistent.host", 6379, key, 0, 1000, *migrateOpts)
+		suite.Error(err)
+	})
+}
+
 func (suite *GlideTestSuite) TestXRangeAndXRevRange() {
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key := uuid.New().String()

--- a/go/interfaces/generic_base_commands.go
+++ b/go/interfaces/generic_base_commands.go
@@ -115,6 +115,18 @@ type GenericBaseCommands interface {
 
 	CopyWithOptions(ctx context.Context, source string, destination string, option options.CopyOptions) (bool, error)
 
+	Migrate(ctx context.Context, host string, port int64, key string, destinationDB int64, timeout int64) (string, error)
+
+	MigrateWithOptions(
+		ctx context.Context,
+		host string,
+		port int64,
+		key string,
+		destinationDB int64,
+		timeout int64,
+		migrateOptions options.MigrateOptions,
+	) (string, error)
+
 	UpdateConnectionPassword(ctx context.Context, password string, immediateAuth bool) (string, error)
 
 	ResetConnectionPassword(ctx context.Context) (string, error)

--- a/go/options/cgo_flags.go
+++ b/go/options/cgo_flags.go
@@ -1,0 +1,15 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package options
+
+// #cgo LDFLAGS: -lglide_ffi
+// #cgo !windows LDFLAGS: -lm
+// #cgo darwin LDFLAGS: -framework Security
+// #cgo darwin,amd64 LDFLAGS: -framework CoreFoundation
+// #cgo linux,amd64,!musl LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-gnu
+// #cgo linux,amd64,musl LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-unknown-linux-musl
+// #cgo linux,arm64,!musl LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-gnu
+// #cgo linux,arm64,musl LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-unknown-linux-musl
+// #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../rustbin/aarch64-apple-darwin
+// #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../rustbin/x86_64-apple-darwin
+import "C"

--- a/go/options/migrate_options.go
+++ b/go/options/migrate_options.go
@@ -41,7 +41,7 @@ func (o *MigrateOptions) SetReplace() *MigrateOptions {
 	return o
 }
 
-// SetPassword sets the AUTH password.
+// SetPassword sets the AUTH password. Clears any previously set username.
 func (o *MigrateOptions) SetPassword(password string) *MigrateOptions {
 	o.Password = password
 	o.Username = "" // clear username to avoid ambiguous AUTH2 state

--- a/go/options/migrate_options.go
+++ b/go/options/migrate_options.go
@@ -1,0 +1,71 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package options
+
+import (
+	"github.com/valkey-io/valkey-glide/go/v2/constants"
+)
+
+// MigrateOptions represents optional arguments for the Migrate and MigrateWithOptions commands.
+//
+// See [valkey.io] for details.
+//
+// [valkey.io]: https://valkey.io/commands/migrate/
+type MigrateOptions struct {
+	// If true, do not remove the key from the source instance.
+	Copy bool
+	// If true, replace the existing key on the destination instance.
+	Replace bool
+	// Authentication password for the destination instance.
+	Password string
+	// Authentication username for the destination instance (requires Password).
+	Username string
+}
+
+// NewMigrateOptions creates a new MigrateOptions with default values.
+func NewMigrateOptions() *MigrateOptions {
+	return &MigrateOptions{}
+}
+
+// SetCopy sets the COPY flag.
+func (o *MigrateOptions) SetCopy() *MigrateOptions {
+	o.Copy = true
+	return o
+}
+
+// SetReplace sets the REPLACE flag.
+func (o *MigrateOptions) SetReplace() *MigrateOptions {
+	o.Replace = true
+	return o
+}
+
+// SetPassword sets the AUTH password.
+func (o *MigrateOptions) SetPassword(password string) *MigrateOptions {
+	o.Password = password
+	o.Username = "" // clear username to avoid ambiguous AUTH2 state
+	return o
+}
+
+// SetAuth2 sets the AUTH2 username and password.
+func (o *MigrateOptions) SetAuth2(username, password string) *MigrateOptions {
+	o.Username = username
+	o.Password = password
+	return o
+}
+
+// ToArgs converts MigrateOptions to a string slice for use in the MIGRATE command.
+func (o *MigrateOptions) ToArgs() ([]string, error) {
+	args := []string{}
+	if o.Copy {
+		args = append(args, constants.CopyKeyword)
+	}
+	if o.Replace {
+		args = append(args, constants.ReplaceKeyword)
+	}
+	if o.Username != "" && o.Password != "" {
+		args = append(args, constants.Auth2Keyword, o.Username, o.Password)
+	} else if o.Password != "" {
+		args = append(args, constants.AuthKeyword, o.Password)
+	}
+	return args, nil
+}

--- a/go/options/migrate_options.go
+++ b/go/options/migrate_options.go
@@ -3,6 +3,8 @@
 package options
 
 import (
+	"fmt"
+
 	"github.com/valkey-io/valkey-glide/go/v2/constants"
 )
 
@@ -61,6 +63,9 @@ func (o *MigrateOptions) ToArgs() ([]string, error) {
 	}
 	if o.Replace {
 		args = append(args, constants.ReplaceKeyword)
+	}
+	if o.Username != "" && o.Password == "" {
+		return nil, fmt.Errorf("username requires a password")
 	}
 	if o.Username != "" && o.Password != "" {
 		args = append(args, constants.Auth2Keyword, o.Username, o.Password)

--- a/go/options/migrate_options_test.go
+++ b/go/options/migrate_options_test.go
@@ -1,0 +1,51 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMigrateOptionsToArgs_UsernameWithoutPassword_ReturnsError(t *testing.T) {
+	opts := MigrateOptions{Username: "user"}
+	_, err := opts.ToArgs()
+	assert.ErrorContains(t, err, "username requires a password")
+}
+
+func TestMigrateOptionsToArgs_SetPasswordClearsUsername(t *testing.T) {
+	opts := NewMigrateOptions().SetAuth2("user", "pass").SetPassword("newpass")
+	args, err := opts.ToArgs()
+	assert.NoError(t, err)
+	// Should emit AUTH (not AUTH2) since SetPassword cleared the username
+	assert.Contains(t, args, "AUTH")
+	assert.NotContains(t, args, "AUTH2")
+	assert.NotContains(t, args, "user")
+}
+
+func TestMigrateOptionsToArgs_Auth2(t *testing.T) {
+	opts := NewMigrateOptions().SetAuth2("user", "pass")
+	args, err := opts.ToArgs()
+	assert.NoError(t, err)
+	assert.Contains(t, args, "AUTH2")
+	assert.Contains(t, args, "user")
+	assert.Contains(t, args, "pass")
+}
+
+func TestMigrateOptionsToArgs_PasswordOnly(t *testing.T) {
+	opts := NewMigrateOptions().SetPassword("secret")
+	args, err := opts.ToArgs()
+	assert.NoError(t, err)
+	assert.Contains(t, args, "AUTH")
+	assert.Contains(t, args, "secret")
+	assert.NotContains(t, args, "AUTH2")
+}
+
+func TestMigrateOptionsToArgs_CopyAndReplace(t *testing.T) {
+	opts := NewMigrateOptions().SetCopy().SetReplace()
+	args, err := opts.ToArgs()
+	assert.NoError(t, err)
+	assert.Contains(t, args, "COPY")
+	assert.Contains(t, args, "REPLACE")
+}

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -5122,6 +5122,53 @@ func (b *BaseBatch[T]) CopyWithOptions(source string, destination string, option
 	}, optionArgs...), reflect.Bool, false)
 }
 
+// Migrate atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+//
+// See [valkey.io] for details.
+//
+// [valkey.io]: https://valkey.io/commands/migrate/
+func (b *BaseBatch[T]) Migrate(
+	host string,
+	port int64,
+	key string,
+	destinationDB int64,
+	timeout int64,
+) *T {
+	return b.addCmdAndTypeChecker(
+		C.Migrate,
+		[]string{host, utils.IntToString(port), key, utils.IntToString(destinationDB), utils.IntToString(timeout)},
+		reflect.String,
+		false,
+	)
+}
+
+// MigrateWithOptions atomically transfers a key from a source Valkey instance to a destination Valkey instance
+// with additional options.
+//
+// See [valkey.io] for details.
+//
+// [valkey.io]: https://valkey.io/commands/migrate/
+func (b *BaseBatch[T]) MigrateWithOptions(
+	host string,
+	port int64,
+	key string,
+	destinationDB int64,
+	timeout int64,
+	migrateOptions options.MigrateOptions,
+) *T {
+	optionArgs, err := migrateOptions.ToArgs()
+	if err != nil {
+		return b.addError("MigrateWithOptions", err)
+	}
+	args := []string{host, utils.IntToString(port), key, utils.IntToString(destinationDB), utils.IntToString(timeout)}
+	return b.addCmdAndTypeChecker(
+		C.Migrate,
+		append(args, optionArgs...),
+		reflect.String,
+		false,
+	)
+}
+
 // Returns stream entries matching a given range of IDs.
 //
 // See [valkey.io] for details.


### PR DESCRIPTION
### Summary

Adds support for the [`MIGRATE`](https://valkey.io/commands/migrate/) command to the Go client. `MIGRATE` atomically transfers a key from the current server to a destination server.

### Issue link

This Pull Request is linked to issue: [Implement MIGRATE command for Python, Node.js, and Go clients](https://github.com/valkey-io/valkey-glide/issues/5932)

### Features / Behaviour Changes

- New `MigrateOptions` struct in `go/options/migrate_options.go` with fluent builder:
  - `SetCopy()` — do not remove the key from the source
  - `SetReplace()` — replace an existing key on the destination
  - `SetPassword(password)` — authenticate with `AUTH` (clears any previously set username)
  - `SetAuth2(username, password)` — authenticate with `AUTH2`
- `Migrate()` added to `baseClient` for the no-options case
- `MigrateWithOptions()` added for the options case
- Both methods added to `GenericBaseCommands` interface and `BaseBatch`
- `AuthKeyword` and `Auth2Keyword` constants added to `go/constants/constants.go`

### Implementation

- Follows the `Copy` / `CopyWithOptions` split pattern (idiomatic Go)
- `ToArgs()` builds protocol args in order: `host port key destination-db timeout [COPY] [REPLACE] [AUTH password | AUTH2 username password]`
- `SetPassword` clears `Username` to prevent ambiguous AUTH2 state
- Multi-key migration via `KEYS` is not supported (consistent with the Java client)

### Limitations

- `KEYS key [key ...]` (multi-key migration) is not implemented.

### Testing

- Integration tests in `go/integTest/shared_commands_test.go` covering `Migrate` and `MigrateWithOptions` against an unreachable host (expects error)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.