### PR TITLE
fix(core): avoid panic on cluster scan with AZ affinity read strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
+* CORE: Avoid panic on cluster `SCAN` when a read-from-replica AZ affinity strategy is configured. The slot map carries no AZ metadata, so these strategies now fall back to their documented round-robin behavior (replicas for `AZAffinity`, replicas plus primary for `AZAffinityReplicasAndPrimary`) instead of hitting `todo!()` ([#5909](https://github.com/valkey-io/valkey-glide/issues/5909))
 
 ## 2.4
 

--- a/glide-core/redis-rs/redis/src/cluster_slotmap.rs
+++ b/glide-core/redis-rs/redis/src/cluster_slotmap.rs
@@ -63,30 +63,34 @@ fn get_address_from_slot(
     if slot_addr == SlotAddr::Master || addrs.replicas().is_empty() {
         return addrs.primary();
     }
+    let round_robin_replica = || {
+        let index = slot
+            .last_used_replica
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % addrs.replicas().len();
+        addrs.replicas()[index].clone()
+    };
+    let round_robin_all_nodes = || {
+        // Round-robin across all nodes: primary + all replicas
+        let total_nodes = addrs.replicas().len() + 1;
+        let index = slot
+            .last_used_replica // named for replica-based strategy, but index 0 refers to primary
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % total_nodes;
+        if index == 0 {
+            addrs.primary()
+        } else {
+            addrs.replicas()[index - 1].clone()
+        }
+    };
     match read_from_replica {
         ReadFromReplicaStrategy::AlwaysFromPrimary => addrs.primary(),
-        ReadFromReplicaStrategy::RoundRobin => {
-            let index = slot
-                .last_used_replica
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                % addrs.replicas().len();
-            addrs.replicas()[index].clone()
-        }
-        ReadFromReplicaStrategy::AllNodes => {
-            // Round-robin across all nodes: primary + all replicas
-            let total_nodes = addrs.replicas().len() + 1;
-            let index = slot
-                .last_used_replica // named for replica-based strategy, but index 0 refers to primary
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                % total_nodes;
-            if index == 0 {
-                addrs.primary()
-            } else {
-                addrs.replicas()[index - 1].clone()
-            }
-        }
-        ReadFromReplicaStrategy::AZAffinity(_az) => todo!(), // Drop sync client
-        ReadFromReplicaStrategy::AZAffinityReplicasAndPrimary(_az) => todo!(), // Drop sync client
+        ReadFromReplicaStrategy::RoundRobin => round_robin_replica(),
+        ReadFromReplicaStrategy::AllNodes => round_robin_all_nodes(),
+        // The slot map carries no AZ metadata, so fall back to the documented
+        // behavior of these strategies when no local node is known.
+        ReadFromReplicaStrategy::AZAffinity(_az) => round_robin_replica(),
+        ReadFromReplicaStrategy::AZAffinityReplicasAndPrimary(_az) => round_robin_all_nodes(),
     }
 }
 
@@ -856,6 +860,52 @@ mod tests_cluster_slotmap {
         let slot_map = get_slot_map(ReadFromReplicaStrategy::AllNodes);
         let route = Route::new(2001, SlotAddr::ReplicaOptional);
         // With 3 replicas + 1 primary = 4 nodes total, we should cycle through all
+        let mut addresses = vec![
+            slot_map.slot_addr_for_route(&route).unwrap(),
+            slot_map.slot_addr_for_route(&route).unwrap(),
+            slot_map.slot_addr_for_route(&route).unwrap(),
+            slot_map.slot_addr_for_route(&route).unwrap(),
+        ];
+        addresses.sort();
+        assert_eq!(
+            addresses,
+            vec![
+                "node3:6379",
+                "replica4:6379",
+                "replica5:6379",
+                "replica6:6379"
+            ]
+            .into_iter()
+            .map(|s| Arc::new(s.to_string()))
+            .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slot_map_az_affinity_falls_back_to_round_robin_replicas() {
+        let slot_map = get_slot_map(ReadFromReplicaStrategy::AZAffinity("zone-a".to_string()));
+        let route = Route::new(2001, SlotAddr::ReplicaOptional);
+        let mut addresses = vec![
+            slot_map.slot_addr_for_route(&route).unwrap(),
+            slot_map.slot_addr_for_route(&route).unwrap(),
+            slot_map.slot_addr_for_route(&route).unwrap(),
+        ];
+        addresses.sort();
+        assert_eq!(
+            addresses,
+            vec!["replica4:6379", "replica5:6379", "replica6:6379"]
+                .into_iter()
+                .map(|s| Arc::new(s.to_string()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_slot_map_az_affinity_replicas_and_primary_falls_back_to_all_nodes() {
+        let slot_map = get_slot_map(ReadFromReplicaStrategy::AZAffinityReplicasAndPrimary(
+            "zone-a".to_string(),
+        ));
+        let route = Route::new(2001, SlotAddr::ReplicaOptional);
         let mut addresses = vec![
             slot_map.slot_addr_for_route(&route).unwrap(),
             slot_map.slot_addr_for_route(&route).unwrap(),


### PR DESCRIPTION
### Summary

`GlideClusterClient.scan()` with an AZ affinity read-from-replica strategy panics the glide-worker thread because `get_address_from_slot` in `cluster_slotmap.rs` hits `todo!()` for those variants.

### Issue link

This Pull Request is linked to issue: [Cluster scan panics with AZAffinity/AZAffinityReplicasAndPrimary read strategy](https://github.com/valkey-io/valkey-glide/issues/5909)
Closes #5909

### Features / Behaviour Changes

`SCAN` (and other slot-map lookups) no longer panic when `AZAffinity` or `AZAffinityReplicasAndPrimary` is configured.

### Implementation

The slot map carries no AZ metadata, so the two AZ variants now fall back to the round-robin behavior documented for them when no local node is known: `AZAffinity` reads from replicas round-robin (same as `RoundRobin`) and `AZAffinityReplicasAndPrimary` round-robins across replicas plus the primary (same as `AllNodes`). The shared round-robin code was extracted into two closures.

### Limitations

This is the slot-map-level fallback; true AZ-aware selection still happens in the async connections layer which has the per-node AZ information.

### Testing

Added `test_slot_map_az_affinity_falls_back_to_round_robin_replicas` and `test_slot_map_az_affinity_replicas_and_primary_falls_back_to_all_nodes`; ran `cargo test --lib cluster_slotmap`, `cargo fmt --check`, and `cargo clippy --lib` for the `redis` crate, all clean.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in cluster SCAN operations when using Availability Zone affinity strategy for read replicas in cases where AZ metadata is unavailable. The system now automatically uses an alternative selection method instead of crashing.

* **Tests**
  * Added test coverage for Availability Zone affinity fallback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valkey-io/valkey-glide/pull/5936)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->