### PR TITLE
docs: add documentation update reminder to PR template and contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,4 +52,4 @@ Before submitting the PR make sure the following are checked:
 -   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
 -   [ ] Destination branch is correct - main or release
 -   [ ] Create merge commit if merging release branch into main, squash otherwise.
--   [ ] Make sure to update the documentation on https://glide.valkey.io if necessary
+-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,3 +52,4 @@ Before submitting the PR make sure the following are checked:
 -   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
 -   [ ] Destination branch is correct - main or release
 -   [ ] Create merge commit if merging release branch into main, squash otherwise.
+-   [ ] Make sure to update the documentation on https://glide.valkey.io if necessary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ To send us a pull request, please:
    - All commits require a DCO signoff (`git commit -s -m "message"`) and should follow the [Conventional Commits](https://www.conventionalcommits.org/) format: `<type>(<scope>): <description>`. To add a signoff to an existing commit: `git commit --amend --signoff --no-edit`.
    - All commits must be cryptographically signed so they show as "Verified" on GitHub. Use GPG or SSH signing by configuring `git config commit.gpgsign true`. To sign a commit: `git commit -S -s -m "message"`. See [GitHub's guide on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for setup instructions.
 5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+6. Make sure to update the documentation on https://glide.valkey.io if necessary.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To send us a pull request, please:
    - All commits require a DCO signoff (`git commit -s -m "message"`) and should follow the [Conventional Commits](https://www.conventionalcommits.org/) format: `<type>(<scope>): <description>`. To add a signoff to an existing commit: `git commit --amend --signoff --no-edit`.
    - All commits must be cryptographically signed so they show as "Verified" on GitHub. Use GPG or SSH signing by configuring `git config commit.gpgsign true`. To sign a commit: `git commit -S -s -m "message"`. See [GitHub's guide on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for setup instructions.
 5. Send us a pull request, answering any default questions in the pull request interface.
-6. Make sure to update the documentation on https://glide.valkey.io if necessary.
+6. Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary.
 7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and


### PR DESCRIPTION
### Summary

Add a checklist item to the PR template and a step to the contributing guide reminding contributors to update the documentation on https://glide.valkey.io if necessary.

### Issue link

~~This Pull Request is linked to issue: [<Issue Title>](<Issue URL>)~~
~~Closes <Issue #>~~

### Features / Behaviour Changes

N/A

### Implementation

- Added `- [ ] Make sure to update the documentation on https://glide.valkey.io if necessary` to the checklist in `.github/pull_request_template.md`
- Added step 6 with the same reminder to the PR submission steps in `CONTRIBUTING.md` (former step 6 renumbered to 7)

### Limitations

N/A

### Testing

Documentation-only change, no code tests required.

### Checklist

- ~~[ ] This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- ~~[ ] Tests are added or updated.~~
- ~~[ ] CHANGELOG.md and documentation files are updated.~~
- ~~[ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~~
- [x] Destination branch is correct - main
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation on https://glide.valkey.io if necessary