### PR TITLE
Go: Add RESET command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
+* Go: Add RESET command support — standalone client only; RESET resets connection state and is intentionally not exposed on the cluster client interface to avoid partial-reset inconsistency across nodes ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
 
 ## 2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
-* Go: Add RESET command support — standalone client only; RESET resets connection state and is intentionally not exposed on the cluster client interface to avoid partial-reset inconsistency across nodes ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
 
 ## 2.4
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -10867,3 +10867,24 @@ func (client *baseClient) AclWhoAmI(ctx context.Context) (string, error) {
 	}
 	return handleStringResponse(result)
 }
+
+// Reset resets the connection state.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	Returns "RESET" on success.
+//
+// [valkey.io]: https://valkey.io/commands/reset/
+func (client *baseClient) Reset(ctx context.Context) (string, error) {
+	result, err := client.executeCommand(ctx, C.Reset, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(result)
+}

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -715,6 +715,11 @@ func CreateConnectionManagementTests(batch *pipeline.ClusterBatch, isAtomic bool
 	batch.ClientGetName()
 	testData = append(testData, CommandTestData{ExpectedResponse: connectionName, TestName: "ClientGetName()"})
 
+	if !isAtomic {
+		batch.Reset()
+		testData = append(testData, CommandTestData{ExpectedResponse: "RESET", TestName: "Reset()"})
+	}
+
 	return BatchTestData{CommandTestData: testData, TestName: "Connection Management commands"}
 }
 

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -11792,3 +11792,33 @@ func (suite *GlideTestSuite) TestRegisterClientNameAndVersion() {
 		assert.Regexp(suite.T(), "lib-ver=unknown|lib-ver=v", infoStr, "lib-ver not found or incorrect")
 	})
 }
+
+func (suite *GlideTestSuite) TestReset() {
+	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
+		t := suite.T()
+		switch c := client.(type) {
+		case interfaces.GlideClientCommands:
+			result, err := c.Reset(context.Background())
+			assert.Nil(t, err)
+			assert.Equal(t, "RESET", result)
+			// Verify client recovers after reset
+			pong, err := c.Ping(context.Background())
+			assert.Nil(t, err)
+			assert.Equal(t, "PONG", pong)
+		case interfaces.GlideClusterClientCommands:
+			res := sendWithCustomCommand(suite, client, []string{"RESET"}, "Can't send RESET as a custom command")
+			var resetStr string
+			switch v := res.(type) {
+			case string:
+				resetStr = v
+			case models.ClusterValue[any]:
+				resetStr = v.SingleValue().(string)
+			}
+			assert.Equal(t, "RESET", resetStr)
+			// Verify client recovers after reset
+			pong, err := c.Ping(context.Background())
+			assert.Nil(t, err)
+			assert.Equal(t, "PONG", pong)
+		}
+	})
+}

--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
 	"github.com/valkey-io/valkey-glide/go/v2/interfaces"
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
@@ -11806,15 +11807,10 @@ func (suite *GlideTestSuite) TestReset() {
 			assert.Nil(t, err)
 			assert.Equal(t, "PONG", pong)
 		case interfaces.GlideClusterClientCommands:
-			res := sendWithCustomCommand(suite, client, []string{"RESET"}, "Can't send RESET as a custom command")
-			var resetStr string
-			switch v := res.(type) {
-			case string:
-				resetStr = v
-			case models.ClusterValue[any]:
-				resetStr = v.SingleValue().(string)
-			}
-			assert.Equal(t, "RESET", resetStr)
+			clusterClient := client.(*glide.ClusterClient)
+			result, err := clusterClient.Reset(context.Background())
+			assert.Nil(t, err)
+			assert.Equal(t, "RESET", result)
 			// Verify client recovers after reset
 			pong, err := c.Ping(context.Background())
 			assert.Nil(t, err)

--- a/go/interfaces/connection_management_commands.go
+++ b/go/interfaces/connection_management_commands.go
@@ -26,4 +26,6 @@ type ConnectionManagementCommands interface {
 	ClientGetName(ctx context.Context) (models.Result[string], error)
 
 	ClientSetName(ctx context.Context, connectionName string) (string, error)
+
+	Reset(ctx context.Context) (string, error)
 }

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -7307,6 +7307,19 @@ func (b *BaseBatch[T]) ClientGetName() *T {
 	return b.addCmdAndTypeChecker(C.ClientGetName, []string{}, reflect.String, true)
 }
 
+// Resets the connection state.
+//
+// See [valkey.io] for details.
+//
+// Command Response:
+//
+//	Returns "RESET" on success.
+//
+// [valkey.io]: https://valkey.io/commands/reset/
+func (b *BaseBatch[T]) Reset() *T {
+	return b.addCmdAndTypeChecker(C.Reset, []string{}, reflect.String, false)
+}
+
 // Sets the name of the current connection.
 //
 // See [valkey.io] for details.


### PR DESCRIPTION
### Summary
Adds `Reset()` to the Go standalone client (`GlideClient`) and `BaseBatch`. The command resets connection state including database index, client name, protocol, and pubsub subscriptions.

### Issue link
This Pull Request is linked to issue: [Implement RESET command for Python, Node.js, Go, and Java clients](https://github.com/valkey-io/valkey-glide/issues/5942)
Closes #5942

### Features / Behaviour Changes
- `Reset()` added to standalone `GlideClient` and `BaseBatch`
- Declared in `ConnectionManagementCommands` interface
- Returns `"RESET"` on success

### Implementation
Uses `C.Reset` (`RequestType::Reset = 324`) with no arguments.

### Limitations
- **RESET is not exposed on the cluster client.** On a cluster connection, one connection serves several nodes and RESET is per-node — so we would always need to reset all nodes. This partial-reset inconsistency across nodes makes it unsafe to expose on the cluster client interface. Use the standalone client if you need RESET.

### Testing
- Integration tests added in `go/integTest/shared_commands_test.go` and `go/integTest/batch_test.go`

### Related PRs
- Core implementation: #5959
- Python RESET: #5944
- Node.js RESET: #5945
- Java RESET: #5947
- Changelog PR: #6067

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary