### PR TITLE
Java: Add RESET command support

### DIFF
--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -26,6 +26,7 @@ import static command_request.CommandRequestOuterClass.RequestType.LastSave;
 import static command_request.CommandRequestOuterClass.RequestType.Lolwut;
 import static command_request.CommandRequestOuterClass.RequestType.Ping;
 import static command_request.CommandRequestOuterClass.RequestType.RandomKey;
+import static command_request.CommandRequestOuterClass.RequestType.Reset;
 import static command_request.CommandRequestOuterClass.RequestType.Scan;
 import static command_request.CommandRequestOuterClass.RequestType.Select;
 import static command_request.CommandRequestOuterClass.RequestType.Time;
@@ -215,6 +216,11 @@ public class GlideClient extends BaseClient
     public CompletableFuture<String> select(long index) {
         return commandManager.submitNewCommand(
                 Select, new String[] {Long.toString(index)}, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> reset() {
+        return commandManager.submitNewCommand(Reset, new String[0], this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/GlideClusterClient.java
+++ b/java/client/src/main/java/glide/api/GlideClusterClient.java
@@ -58,6 +58,7 @@ import static command_request.CommandRequestOuterClass.RequestType.PubSubShardNu
 import static command_request.CommandRequestOuterClass.RequestType.RandomKey;
 import static command_request.CommandRequestOuterClass.RequestType.ReadOnly;
 import static command_request.CommandRequestOuterClass.RequestType.ReadWrite;
+import static command_request.CommandRequestOuterClass.RequestType.Reset;
 import static command_request.CommandRequestOuterClass.RequestType.SPublish;
 import static command_request.CommandRequestOuterClass.RequestType.SSubscribe;
 import static command_request.CommandRequestOuterClass.RequestType.SSubscribeBlocking;
@@ -384,6 +385,11 @@ public class GlideClusterClient extends BaseClient
     public CompletableFuture<String> select(long index) {
         return commandManager.submitNewCommand(
                 Select, new String[] {Long.toString(index)}, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> reset() {
+        return commandManager.submitNewCommand(Reset, new String[0], this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -263,4 +263,17 @@ public interface ConnectionManagementClusterCommands {
      * }</pre>
      */
     CompletableFuture<String> select(long index);
+
+    /**
+     * Resets the connection state.
+     *
+     * @see <a href="https://valkey.io/commands/reset/">valkey.io</a> for details.
+     * @return <code>String</code> with <code>"RESET"</code>.
+     * @example
+     *     <pre>{@code
+     * String payload = client.reset().get();
+     * assert payload.equals("RESET");
+     * }</pre>
+     */
+    CompletableFuture<String> reset();
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -137,4 +137,17 @@ public interface ConnectionManagementCommands {
      * }</pre>
      */
     CompletableFuture<String> select(long index);
+
+    /**
+     * Resets the connection state.
+     *
+     * @see <a href="https://valkey.io/commands/reset/">valkey.io</a> for details.
+     * @return <code>String</code> with <code>"RESET"</code>.
+     * @example
+     *     <pre>{@code
+     * String payload = client.reset().get();
+     * assert payload.equals("RESET");
+     * }</pre>
+     */
+    CompletableFuture<String> reset();
 }

--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -127,6 +127,7 @@ import static command_request.CommandRequestOuterClass.RequestType.RPushX;
 import static command_request.CommandRequestOuterClass.RequestType.RandomKey;
 import static command_request.CommandRequestOuterClass.RequestType.Rename;
 import static command_request.CommandRequestOuterClass.RequestType.RenameNX;
+import static command_request.CommandRequestOuterClass.RequestType.Reset;
 import static command_request.CommandRequestOuterClass.RequestType.Restore;
 import static command_request.CommandRequestOuterClass.RequestType.SAdd;
 import static command_request.CommandRequestOuterClass.RequestType.SCard;
@@ -417,6 +418,17 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T ping() {
         protobufBatch.addCommands(buildCommand(Ping));
+        return getThis();
+    }
+
+    /**
+     * Resets the connection state.
+     *
+     * @see <a href="https://valkey.io/commands/reset/">valkey.io</a> for details.
+     * @return Command Response - A response from the server with a <code>String</code>.
+     */
+    public T reset() {
+        protobufBatch.addCommands(buildCommand(Reset));
         return getThis();
     }
 

--- a/java/integTest/src/test/java/glide/BatchTestUtilities.java
+++ b/java/integTest/src/test/java/glide/BatchTestUtilities.java
@@ -1024,11 +1024,20 @@ public class BatchTestUtilities {
         // clientId
         // clientGetName
 
-        return new Object[] {
-            "PONG", // ping()
-            value1, // ping(value1)
-            value2, // echo(value2)
-        };
+        Object[] results =
+                new Object[] {
+                    "PONG", // ping()
+                    value1, // ping(value1)
+                    value2, // echo(value2)
+                };
+
+        if (!isAtomic) {
+            // RESET cannot be used inside MULTI/EXEC (atomic batch)
+            batch.reset();
+            results = concatenateArrays(results, new Object[] {"RESET"});
+        }
+
+        return results;
     }
 
     private static Object[] hyperLogLogCommands(BaseBatch<?> batch, boolean isAtomic) {

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -18674,6 +18674,23 @@ public class SharedCommandTests {
         assertEquals("OK", result);
     }
 
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void reset(BaseClient client) {
+        String result =
+                client instanceof GlideClusterClient
+                        ? ((GlideClusterClient) client).reset().get()
+                        : ((GlideClient) client).reset().get();
+        assertEquals("RESET", result);
+        // Verify client recovers after reset
+        String pong =
+                client instanceof GlideClusterClient
+                        ? ((GlideClusterClient) client).ping().get()
+                        : ((GlideClient) client).ping().get();
+        assertEquals("PONG", pong);
+    }
+
     /**
      * Helper method to check if ACL file is configured on the server. Attempts to call ACL LOAD and
      * returns true if successful, false if it fails with ACL file not configured error.


### PR DESCRIPTION
### Summary
Adds `reset()` to the Java standalone (`GlideClient`) and cluster (`GlideClusterClient`) clients, and to `BaseBatch`. The command resets connection state including database index, client name, protocol, and pubsub subscriptions.

### Issue link
This Pull Request is linked to issue: [Implement RESET command for Python, Node.js, Go, and Java clients](https://github.com/valkey-io/valkey-glide/issues/5942)
Closes #5942

### Features / Behaviour Changes
- `reset()` added to `GlideClient`, `GlideClusterClient`, and `BaseBatch`
- Declared in `ConnectionManagementCommands` and `ConnectionManagementClusterCommands` interfaces
- Returns `CompletableFuture<String>` resolving to `"RESET"`

### Implementation
Uses `RequestType.Reset` with no arguments.

### Limitations
- **RESET routing on cluster:** On a cluster connection, one connection serves several nodes and RESET is per-node — so we always reset all nodes when called on the cluster client. This is intentional to ensure consistent state across all nodes.

### Testing
- Integration tests added in `java/integTest/src/test/java/glide/SharedCommandTests.java` and `java/integTest/src/test/java/glide/BatchTestUtilities.java`

### Related PRs
- Core implementation: #5959
- Python RESET: #5944
- Node.js RESET: #5945
- Go RESET: #5946
- Changelog PR: #6067

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary