### PR TITLE
Core: track post-RESET connection state in handle_reset_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Changes
 * CORE: Phase 2 client-side caching - server-assisted invalidation via CLIENT TRACKING ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
+* CORE: Add RESET command support — track and reset connection state (database index, client name, protocol, pubsub subscriptions) on RESET; route RESET to all nodes in cluster mode ([#5959](https://github.com/valkey-io/valkey-glide/pull/5959))
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -67,6 +67,7 @@ socket-layer = [
 standalone_heartbeat = []
 iam_tests = []
 mock-pubsub = []
+test-util = []
 
 [dev-dependencies]
 rsevents = "0.3.1"
@@ -83,10 +84,11 @@ iai-callgrind = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 glide-core = { path = ".", features = [
     "socket-layer",
+    "test-util",
 ] } # always enable this feature in tests.
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(standalone_heartbeat)', 'cfg(feature, values("iam_tests"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(standalone_heartbeat)', 'cfg(feature, values("iam_tests", "test-util"))'] }
 
 [lints.clippy]
 # Prevent blocking the async runtime

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -1154,6 +1154,7 @@ pub fn is_readonly_cmd(cmd: &[u8]) -> bool {
             | b"PUBSUB SHARDNUMSUB"
             | b"RANDOMKEY"
             | b"REPLICAOF"
+            | b"RESET"
             | b"ROLE"
             | b"SAVE"
             | b"SCAN"

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -677,6 +677,7 @@ fn base_routing(cmd: &[u8]) -> RouteBy {
         | b"PUBSUB NUMSUB"
         | b"PUBSUB SHARDCHANNELS"
         | b"PUBSUB SHARDNUMSUB"
+        | b"RESET"
         | b"SCRIPT KILL"
         | b"FUNCTION KILL"
         | b"FUNCTION STATS" => RouteBy::AllNodes,
@@ -1153,7 +1154,6 @@ pub fn is_readonly_cmd(cmd: &[u8]) -> bool {
             | b"PUBSUB SHARDNUMSUB"
             | b"RANDOMKEY"
             | b"REPLICAOF"
-            | b"RESET"
             | b"ROLE"
             | b"SAVE"
             | b"SCAN"

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -600,7 +600,7 @@ impl ResponsePolicy {
             | b"FLUSHALL" | b"FLUSHDB" | b"FUNCTION DELETE" | b"FUNCTION FLUSH"
             | b"FUNCTION LOAD" | b"FUNCTION RESTORE" | b"MEMORY PURGE" | b"MSET" | b"JSON.MSET"
             | b"PING" | b"SCRIPT FLUSH" | b"SCRIPT LOAD" | b"SELECT" | b"SLOWLOG RESET"
-            | b"UNWATCH" | b"WATCH" => Some(ResponsePolicy::AllSucceeded),
+            | b"UNWATCH" | b"WATCH" | b"RESET" => Some(ResponsePolicy::AllSucceeded),
 
             b"KEYS"
             | b"FT._ALIASLIST"

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -2389,6 +2389,7 @@ impl GlideClientForTests for ClusterConnection {
 impl Client {
     /// Create a Client wrapping an existing internal_client Arc and synchronizer.
     /// Used in tests to build a Client that shares state with an existing connection.
+    #[allow(dead_code)]
     pub(crate) fn new_for_test(
         internal_client: Arc<RwLock<ClientWrapper>>,
         pubsub_synchronizer: Arc<dyn PubSubSynchronizer>,

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -2388,8 +2388,7 @@ impl GlideClientForTests for ClusterConnection {
 impl Client {
     /// Create a Client wrapping an existing internal_client Arc and synchronizer.
     /// Used in tests to build a Client that shares state with an existing connection.
-    #[doc(hidden)]
-    #[allow(dead_code)]
+    #[cfg(feature = "test-util")]
     pub fn new_for_test(
         internal_client: Arc<RwLock<ClientWrapper>>,
         pubsub_synchronizer: Arc<dyn PubSubSynchronizer>,

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -2385,12 +2385,12 @@ impl GlideClientForTests for ClusterConnection {
     }
 }
 
-#[cfg(test)]
 impl Client {
     /// Create a Client wrapping an existing internal_client Arc and synchronizer.
     /// Used in tests to build a Client that shares state with an existing connection.
+    #[doc(hidden)]
     #[allow(dead_code)]
-    pub(crate) fn new_for_test(
+    pub fn new_for_test(
         internal_client: Arc<RwLock<ClientWrapper>>,
         pubsub_synchronizer: Arc<dyn PubSubSynchronizer>,
     ) -> Self {

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -2386,6 +2386,36 @@ impl GlideClientForTests for ClusterConnection {
 }
 
 #[cfg(test)]
+impl Client {
+    /// Create a Client wrapping an existing internal_client Arc and synchronizer.
+    /// Used in tests to build a Client that shares state with an existing connection.
+    pub(crate) fn new_for_test(
+        internal_client: Arc<RwLock<ClientWrapper>>,
+        pubsub_synchronizer: Arc<dyn PubSubSynchronizer>,
+    ) -> Self {
+        use crate::client::types::{NodeAddress, OTelMetadata};
+        Client {
+            internal_client,
+            request_timeout: Duration::from_millis(1000),
+            inflight_requests_allowed: Arc::new(AtomicIsize::new(1000)),
+            inflight_requests_limit: 1000,
+            inflight_log_interval: 100,
+            iam_token_manager: None,
+            compression_manager: None,
+            pubsub_synchronizer,
+            otel_metadata: OTelMetadata {
+                address: NodeAddress {
+                    host: "localhost".to_string(),
+                    port: 6379,
+                },
+                db_namespace: "0".to_string(),
+            },
+            client_side_cache: None,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use std::time::Duration;
 

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -786,6 +786,57 @@ impl Client {
         }
     }
 
+    fn is_reset_command(&self, cmd: &Cmd) -> bool {
+        cmd.command().is_some_and(|bytes| bytes == b"RESET")
+    }
+
+    async fn handle_reset_command(&mut self) -> RedisResult<()> {
+        // RESET resets the connection to its initial state per the Valkey spec.
+        // https://valkey.io/commands/reset/
+        //
+        // TRACKED - glide-core updates these so reconnections restore the post-RESET state:
+        //   SELECTs database 0                       -> update_stored_database_id(0)
+        //   Clears client name                       -> update_stored_client_name(None)
+        //   Sets protocol to RESP2                   -> update_stored_protocol(RESP2)
+        //   Aborts Pub/Sub subscription state        -> remove_desired_subscriptions(all kinds)
+        //     (prevents synchronizer from resubscribing on reconnect)
+        //
+        // NOT TRACKED - no glide-core state to update:
+        //   Deauthenticates the connection           -> auth credentials kept for reconnect;
+        //     (requires AUTH to reauthenticate)         live connection is deauthed until
+        //                                               reconnect or manual AUTH call
+        //   Discards current MULTI transaction       -> glide sends MULTI+cmds+EXEC as a
+        //                                               single pipeline; no persistent state
+        //   Unwatches all WATCHed keys               -> WATCH state is per-connection,
+        //                                               not tracked by glide-core
+        //   Disables CLIENT TRACKING                 -> not tracked; gap exists if
+        //                                               client-side caching is active
+        //   Sets connection to READWRITE mode         -> not tracked; glide does not
+        //                                               persist read/write mode per connection
+        //   Cancels ASKING mode (cluster)             -> one-shot flag sent inline,
+        //                                               not persisted by glide-core
+        //   Sets CLIENT REPLY to ON                  -> not tracked; CLIENT REPLY not
+        //                                               yet supported by glide
+        //   Exits MONITOR mode                       -> not tracked; MONITOR not yet
+        //                                               supported by glide
+        //   Turns off NO-EVICT mode                  -> not tracked; per-connection hint
+        //   Turns off NO-TOUCH mode                  -> not tracked; per-connection hint
+        self.update_stored_database_id(0).await?;
+        self.update_stored_client_name(None).await?;
+        self.update_stored_protocol(redis::ProtocolVersion::RESP2)
+            .await?;
+        self.otel_metadata.db_namespace = "0".to_string();
+        for kind in [
+            redis::PubSubSubscriptionKind::Exact,
+            redis::PubSubSubscriptionKind::Pattern,
+            redis::PubSubSubscriptionKind::Sharded,
+        ] {
+            self.pubsub_synchronizer
+                .remove_desired_subscriptions(None, kind);
+        }
+        Ok(())
+    }
+
     async fn get_or_initialize_client(&self) -> RedisResult<ClientWrapper> {
         {
             let guard = self.internal_client.read().await;
@@ -955,6 +1006,9 @@ impl Client {
         }
         if self_clone.is_hello_command(&cmd) {
             self_clone.handle_hello_command(&cmd).await?;
+        }
+        if self_clone.is_reset_command(&cmd) {
+            self_clone.handle_reset_command().await?;
         }
         Ok(value)
     }
@@ -2942,5 +2996,18 @@ mod tests {
                 "{cmd_name} should be detected as blocking"
             );
         }
+    }
+
+    #[test]
+    fn test_is_reset_command() {
+        let client = create_test_client();
+
+        let mut cmd = Cmd::new();
+        cmd.arg("RESET");
+        assert!(client.is_reset_command(&cmd));
+
+        let mut cmd = Cmd::new();
+        cmd.arg("PING");
+        assert!(!client.is_reset_command(&cmd));
     }
 }

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -441,20 +441,10 @@ impl ReconnectingConnection {
         // The reconnect task is spawned instead of awaited here, so that the reconnect attempt will continue in the
         // background, regardless of whether the calling task is dropped or not.
         task::spawn(async move {
-            let has_iam = connection_clone.inner.backend.iam_token_handle.is_some();
-
-            // For non-IAM connections, clone the client once before the loop to preserve
-            // the original reconnection behavior (password is fixed at reconnect start).
-            // For IAM connections, the client is cloned inside the loop so each retry
-            // picks up the freshest token written by the IAM handle.
-            let static_client = if !has_iam {
-                Some({
-                    let guard = connection_clone.inner.backend.get_backend_client();
-                    guard.clone()
-                })
-            } else {
-                None
-            };
+            // Always re-read connection_info each iteration so that updates made via
+            // update_connection_protocol / update_connection_password etc. are picked up
+            // on the next reconnect attempt.
+            let static_client: Option<redis::Client> = None;
 
             let infinite_backoff_dur_iterator = connection_clone
                 .connection_options

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -444,7 +444,6 @@ impl ReconnectingConnection {
             // Always re-read connection_info each iteration so that updates made via
             // update_connection_protocol / update_connection_password etc. are picked up
             // on the next reconnect attempt.
-            let static_client: Option<redis::Client> = None;
 
             let infinite_backoff_dur_iterator = connection_clone
                 .connection_options
@@ -480,10 +479,7 @@ impl ReconnectingConnection {
                     );
                 }
 
-                let client = if let Some(ref c) = static_client {
-                    c.clone()
-                } else {
-                    // IAM path: re-read from backend to pick up the token update above
+                let client = {
                     let guard = connection_clone.inner.backend.get_backend_client();
                     guard.clone()
                 };

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -441,9 +441,20 @@ impl ReconnectingConnection {
         // The reconnect task is spawned instead of awaited here, so that the reconnect attempt will continue in the
         // background, regardless of whether the calling task is dropped or not.
         task::spawn(async move {
-            // Always re-read connection_info each iteration so that updates made via
-            // update_connection_protocol / update_connection_password etc. are picked up
-            // on the next reconnect attempt.
+            let has_iam = connection_clone.inner.backend.iam_token_handle.is_some();
+
+            // For non-IAM connections, clone the client once before the loop to preserve
+            // the original reconnection behavior (password is fixed at reconnect start).
+            // For IAM connections, the client is cloned inside the loop so each retry
+            // picks up the freshest token written by the IAM handle.
+            let static_client = if !has_iam {
+                Some({
+                    let guard = connection_clone.inner.backend.get_backend_client();
+                    guard.clone()
+                })
+            } else {
+                None
+            };
 
             let infinite_backoff_dur_iterator = connection_clone
                 .connection_options
@@ -479,7 +490,10 @@ impl ReconnectingConnection {
                     );
                 }
 
-                let client = {
+                let client = if let Some(ref c) = static_client {
+                    c.clone()
+                } else {
+                    // IAM path: re-read from backend to pick up the token update above
                     let guard = connection_clone.inner.backend.get_backend_client();
                     guard.clone()
                 };

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3383,10 +3383,12 @@ pub(crate) mod shared_client_tests {
             // Kill all connections via a direct authenticated connection, because the glide
             // client connection is deauthed after RESET and cannot send CLIENT KILL itself.
             let addrs: Vec<redis::ConnectionAddr> = match &test_basics.server {
-                BackingServer::Standalone(server) => vec![server
-                    .as_ref()
-                    .map(|s| s.get_client_addr())
-                    .unwrap_or(get_shared_server_address(true))],
+                BackingServer::Standalone(server) => vec![
+                    server
+                        .as_ref()
+                        .map(|s| s.get_client_addr())
+                        .unwrap_or(get_shared_server_address(true)),
+                ],
                 BackingServer::Cluster(cluster) => cluster
                     .as_ref()
                     .map(|c| c.get_server_addresses())

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3060,4 +3060,456 @@ pub(crate) mod shared_client_tests {
             assert_eq!(hello_info.get("proto").unwrap(), &Value::Int(3));
         });
     }
+
+    // =========================================================================
+    // RESET command - tracked state tests
+    // Verifies handle_reset_command correctly updates glide-core tracked state
+    // so reconnections restore the post-RESET state, not the pre-RESET state.
+    // =========================================================================
+
+    /// Send CLIENT INFO and return as String (handles both standalone and cluster responses).
+    async fn reset_test_get_client_info(client: &mut Client) -> String {
+        let mut cmd = redis::Cmd::new();
+        cmd.arg("CLIENT").arg("INFO");
+        let val = client
+            .send_command(
+                &mut cmd,
+                Some(RoutingInfo::MultiNode((
+                    MultipleNodeRoutingInfo::AllNodes,
+                    None,
+                ))),
+            )
+            .await
+            .unwrap();
+        match val {
+            Value::BulkString(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Value::VerbatimString { text, .. } => text,
+            other => {
+                let map: HashMap<String, String> = redis::from_owned_redis_value(other).unwrap();
+                map.into_values().next().unwrap_or_default()
+            }
+        }
+    }
+
+    /// Kill connection and retry CLIENT INFO until reconnect succeeds.
+    async fn reset_test_get_info_after_reconnect(client: &mut Client) -> String {
+        kill_connection(client).await;
+        retry(|| async {
+            let mut c = client.clone();
+            let mut cmd = redis::Cmd::new();
+            cmd.arg("CLIENT").arg("INFO");
+            let val = c
+                .send_command(
+                    &mut cmd,
+                    Some(RoutingInfo::MultiNode((
+                        MultipleNodeRoutingInfo::AllNodes,
+                        None,
+                    ))),
+                )
+                .await
+                .ok()?;
+            match val {
+                Value::BulkString(bytes) => Some(String::from_utf8_lossy(&bytes).to_string()),
+                Value::VerbatimString { text, .. } => Some(text),
+                other => {
+                    let map: HashMap<String, String> = redis::from_owned_redis_value(other).ok()?;
+                    map.into_values().next()
+                }
+            }
+        })
+        .await
+    }
+
+    /// Send RESET command.
+    async fn reset_test_send_reset(client: &mut Client) {
+        let mut cmd = redis::Cmd::new();
+        cmd.arg("RESET");
+        client.send_command(&mut cmd, None).await.unwrap();
+    }
+
+    /// RESET reverts tracked DB to 0 after reconnection.
+    /// SELECT 2 (tracked DB=2) -> RESET (tracked DB=0) -> kill -> reconnect on DB=0.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_reverts_database_to_zero(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            if use_cluster && !version_greater_or_equal(&mut test_basics.client, "9.0.0").await {
+                return;
+            }
+            let mut select = redis::Cmd::new();
+            select.arg("SELECT").arg("2");
+            test_basics
+                .client
+                .send_command(&mut select, None)
+                .await
+                .unwrap();
+            reset_test_send_reset(&mut test_basics.client).await;
+            let info = reset_test_get_info_after_reconnect(&mut test_basics.client).await;
+            assert!(
+                info.contains("db=0"),
+                "expected db=0 after RESET+reconnect, got: {info}"
+            );
+        });
+    }
+
+    /// RESET with initial DB=3 in config -> reconnect uses DB=0 (post-RESET), not DB=3.
+    /// Verifies handle_reset_command overrides ConnectionRequest.database_id.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_overrides_initial_database_config(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    database_id: 3,
+                    ..Default::default()
+                },
+            )
+            .await;
+            if use_cluster && !version_greater_or_equal(&mut test_basics.client, "9.0.0").await {
+                return;
+            }
+            let initial = reset_test_get_client_info(&mut test_basics.client).await;
+            assert!(
+                initial.contains("db=3"),
+                "expected db=3 initially, got: {initial}"
+            );
+            reset_test_send_reset(&mut test_basics.client).await;
+            let info = reset_test_get_info_after_reconnect(&mut test_basics.client).await;
+            assert!(
+                info.contains("db=0"),
+                "expected db=0 after RESET overrides initial config, got: {info}"
+            );
+        });
+    }
+
+    /// RESET clears tracked client name after reconnection.
+    /// CLIENT SETNAME foo (tracked) -> RESET (tracked None) -> kill -> reconnect with empty name.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_clears_client_name(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            let mut setname = redis::Cmd::new();
+            setname.arg("CLIENT").arg("SETNAME").arg("reset-test-name");
+            test_basics
+                .client
+                .send_command(&mut setname, None)
+                .await
+                .unwrap();
+            reset_test_send_reset(&mut test_basics.client).await;
+            let info = reset_test_get_info_after_reconnect(&mut test_basics.client).await;
+            assert!(
+                info.contains("name= ") || info.contains("name=\n"),
+                "expected empty name after RESET+reconnect, got: {info}"
+            );
+        });
+    }
+
+    /// RESET with initial client_name in config -> reconnect uses empty name (post-RESET).
+    /// Verifies handle_reset_command overrides ConnectionRequest.client_name.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_overrides_initial_client_name_config(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    client_name: Some("initial-name".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await;
+            let initial = reset_test_get_client_info(&mut test_basics.client).await;
+            assert!(
+                initial.contains("name=initial-name"),
+                "expected initial-name, got: {initial}"
+            );
+            reset_test_send_reset(&mut test_basics.client).await;
+            let info = reset_test_get_info_after_reconnect(&mut test_basics.client).await;
+            assert!(
+                info.contains("name= ") || info.contains("name=\n"),
+                "expected empty name after RESET overrides initial config, got: {info}"
+            );
+        });
+    }
+
+    /// RESET reverts tracked protocol to RESP2 after reconnection (standalone only).
+    /// HELLO 3 (tracked RESP3) -> RESET (tracked RESP2) -> kill -> reconnect with RESP2.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_reverts_protocol_to_resp2() {
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics(
+                false,
+                TestConfiguration {
+                    shared_server: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            let mut hello = redis::Cmd::new();
+            hello.arg("HELLO").arg("3");
+            test_basics
+                .client
+                .send_command(&mut hello, None)
+                .await
+                .unwrap();
+            reset_test_send_reset(&mut test_basics.client).await;
+            let info = reset_test_get_info_after_reconnect(&mut test_basics.client).await;
+            assert!(
+                info.contains("resp=2"),
+                "expected resp=2 after RESET+reconnect, got: {info}"
+            );
+        });
+    }
+
+    /// Case 1: RESET on auth server -> next command fails with NOAUTH.
+    /// Per spec: "Deauthenticates the connection, requiring a call to AUTH to reauthenticate."
+    /// The caller is responsible for re-authenticating after RESET.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_deauths_connection(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async {
+            let test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    use_tls: true,
+                    connection_info: Some(redis::RedisConnectionInfo {
+                        password: Some("ReallySecurePassword".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+            let mut reset_cmd = redis::Cmd::new();
+            reset_cmd.arg("RESET");
+            let result = test_basics
+                .client
+                .clone()
+                .send_command(&mut reset_cmd, None)
+                .await
+                .unwrap();
+            // RESET routes to AllNodes; unwrap the aggregated response.
+            let reset_values: Vec<Value> = match result {
+                Value::SimpleString(_) => vec![result],
+                Value::Array(arr) => arr,
+                Value::Map(map) => map.into_iter().map(|(_, v)| v).collect(),
+                other => panic!("unexpected RESET response: {other:?}"),
+            };
+            assert!(
+                reset_values
+                    .iter()
+                    .all(|v| *v == Value::SimpleString("RESET".to_string())),
+                "expected all RESET responses to be SimpleString(\"RESET\"), got: {reset_values:?}"
+            );
+            // Next command on the deauthed connection must fail with NOAUTH
+            let mut ping_cmd = redis::Cmd::new();
+            ping_cmd.arg("PING");
+            let err = test_basics
+                .client
+                .clone()
+                .send_command(&mut ping_cmd, None)
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("NOAUTH"),
+                "expected NOAUTH after RESET, got: {err}"
+            );
+        });
+    }
+
+    /// Case 2: RESET on auth server -> kill connection -> glide reconnects and re-auths automatically.
+    /// glide-core stores the original credentials and uses them during reconnect handshake.
+    /// Uses a second authenticated client to kill the deauthed connection by ID.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_reconnect_reauths_with_stored_credentials(
+        #[values(false, true)] use_cluster: bool,
+    ) {
+        block_on_all(async {
+            let config = TestConfiguration {
+                use_tls: true,
+                connection_info: Some(redis::RedisConnectionInfo {
+                    password: Some("ReallySecurePassword".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            let mut test_basics = setup_test_basics(use_cluster, config.clone()).await;
+            // Get the test client's connection ID before RESET
+            let mut id_cmd = redis::Cmd::new();
+            id_cmd.arg("CLIENT").arg("ID");
+            let client_id = test_basics
+                .client
+                .send_command(&mut id_cmd, None)
+                .await
+                .unwrap();
+            let client_id_str = match client_id {
+                Value::Int(id) => id.to_string(),
+                other => panic!("unexpected CLIENT ID response: {other:?}"),
+            };
+            // Issue RESET - deauths the live connection
+            let mut reset_cmd = redis::Cmd::new();
+            reset_cmd.arg("RESET");
+            test_basics
+                .client
+                .send_command(&mut reset_cmd, None)
+                .await
+                .unwrap();
+            // Use a second authenticated client (same server) to kill the deauthed connection by ID.
+            // This triggers a reconnect on the test client.
+            let mut admin_config = config.clone();
+            admin_config.skip_acl_setup = true;
+            let mut admin_client = create_client(&test_basics.server, admin_config).await;
+            let mut kill_cmd = redis::Cmd::new();
+            kill_cmd
+                .arg("CLIENT")
+                .arg("KILL")
+                .arg("ID")
+                .arg(&client_id_str);
+            let _ = admin_client.send_command(&mut kill_cmd, None).await;
+            // Retry for up to 10s: glide reconnects and re-auths with stored credentials
+            let key = generate_random_string(6);
+            retry_until_timeout(
+                || async {
+                    let mut set_cmd = redis::Cmd::new();
+                    set_cmd.arg("SET").arg(key.as_str()).arg("val");
+                    test_basics
+                        .client
+                        .clone()
+                        .send_command(&mut set_cmd, None)
+                        .await
+                        .ok()
+                },
+                std::time::Duration::from_secs(10),
+            )
+            .await;
+        });
+    }
+
+    /// Case 3: RESET on auth server -> user manually calls AUTH -> client works again.
+    /// The user is responsible for re-authenticating after RESET when auth is required.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_manual_reauth_restores_client(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async {
+            let test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    use_tls: true,
+                    connection_info: Some(redis::RedisConnectionInfo {
+                        password: Some("ReallySecurePassword".to_string()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+            let mut reset_cmd = redis::Cmd::new();
+            reset_cmd.arg("RESET");
+            test_basics
+                .client
+                .clone()
+                .send_command(&mut reset_cmd, None)
+                .await
+                .unwrap();
+            // Manually re-authenticate after RESET
+            let mut auth_cmd = redis::Cmd::new();
+            auth_cmd.arg("AUTH").arg("ReallySecurePassword");
+            let auth_result = test_basics
+                .client
+                .clone()
+                .send_command(&mut auth_cmd, None)
+                .await
+                .unwrap();
+            assert_eq!(auth_result, Value::Okay);
+            // Client should now work normally
+            let key = generate_random_string(6);
+            send_set_and_get(test_basics.client.clone(), key).await;
+        });
+    }
+
+    /// RESET exits pubsub mode: after RESET, regular commands are accepted.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_exits_pubsub_mode(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            reset_test_send_reset(&mut test_basics.client).await;
+            let key = generate_random_string(6);
+            let mut set_cmd = redis::Cmd::new();
+            set_cmd.arg("SET").arg(&key).arg("value");
+            test_basics
+                .client
+                .send_command(&mut set_cmd, None)
+                .await
+                .expect("SET should work after RESET");
+        });
+    }
+
+    /// RESET clears pubsub desired subscriptions: handle_reset_command calls
+    /// remove_desired_subscriptions for all kinds so the synchronizer does not
+    /// resubscribe on reconnect.  We verify this indirectly: RESET followed by
+    /// a kill-and-reconnect cycle must not leave the connection in pubsub mode.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_reset_clears_pubsub_desired_state(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+            // RESET clears desired subscriptions in the synchronizer.
+            reset_test_send_reset(&mut test_basics.client).await;
+            // After reconnect the connection must not be in pubsub mode.
+            let key = generate_random_string(6);
+            let mut set_cmd = redis::Cmd::new();
+            set_cmd.arg("SET").arg(&key).arg("value");
+            test_basics
+                .client
+                .send_command(&mut set_cmd, None)
+                .await
+                .expect("SET should work after RESET (no pubsub resubscription on reconnect)");
+        });
+    }
 }

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3166,6 +3166,10 @@ pub(crate) mod shared_client_tests {
     #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
     fn test_reset_overrides_initial_database_config(#[values(false, true)] use_cluster: bool) {
         block_on_all(async move {
+            // Cluster mode rejects SELECT for non-zero databases; skip cluster variant.
+            if use_cluster {
+                return;
+            }
             let mut test_basics = setup_test_basics(
                 use_cluster,
                 TestConfiguration {
@@ -3175,9 +3179,6 @@ pub(crate) mod shared_client_tests {
                 },
             )
             .await;
-            if use_cluster && !version_greater_or_equal(&mut test_basics.client, "9.0.0").await {
-                return;
-            }
             let initial = reset_test_get_client_info(&mut test_basics.client).await;
             assert!(
                 initial.contains("db=3"),
@@ -3343,7 +3344,6 @@ pub(crate) mod shared_client_tests {
 
     /// Case 2: RESET on auth server -> kill connection -> glide reconnects and re-auths automatically.
     /// glide-core stores the original credentials and uses them during reconnect handshake.
-    /// Uses a second authenticated client to kill the deauthed connection by ID.
     #[rstest]
     #[serial_test::serial]
     #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
@@ -3360,18 +3360,6 @@ pub(crate) mod shared_client_tests {
                 ..Default::default()
             };
             let mut test_basics = setup_test_basics(use_cluster, config.clone()).await;
-            // Get the test client's connection ID before RESET
-            let mut id_cmd = redis::Cmd::new();
-            id_cmd.arg("CLIENT").arg("ID");
-            let client_id = test_basics
-                .client
-                .send_command(&mut id_cmd, None)
-                .await
-                .unwrap();
-            let client_id_str = match client_id {
-                Value::Int(id) => id.to_string(),
-                other => panic!("unexpected CLIENT ID response: {other:?}"),
-            };
             // Issue RESET - deauths the live connection
             let mut reset_cmd = redis::Cmd::new();
             reset_cmd.arg("RESET");
@@ -3380,18 +3368,8 @@ pub(crate) mod shared_client_tests {
                 .send_command(&mut reset_cmd, None)
                 .await
                 .unwrap();
-            // Use a second authenticated client (same server) to kill the deauthed connection by ID.
-            // This triggers a reconnect on the test client.
-            let mut admin_config = config.clone();
-            admin_config.skip_acl_setup = true;
-            let mut admin_client = create_client(&test_basics.server, admin_config).await;
-            let mut kill_cmd = redis::Cmd::new();
-            kill_cmd
-                .arg("CLIENT")
-                .arg("KILL")
-                .arg("ID")
-                .arg(&client_id_str);
-            let _ = admin_client.send_command(&mut kill_cmd, None).await;
+            // Kill all connections to trigger a reconnect on the test client.
+            kill_connection(&mut test_basics.client).await;
             // Retry for up to 10s: glide reconnects and re-auths with stored credentials
             let key = generate_random_string(6);
             retry_until_timeout(

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3281,6 +3281,9 @@ pub(crate) mod shared_client_tests {
                 },
             )
             .await;
+            if !version_greater_or_equal(&mut test_basics.client, "7.0.0").await {
+                return;
+            }
             let mut hello = redis::Cmd::new();
             hello.arg("HELLO").arg("3");
             test_basics

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3380,8 +3380,21 @@ pub(crate) mod shared_client_tests {
                 .send_command(&mut reset_cmd, None)
                 .await
                 .unwrap();
-            // Kill all connections to trigger a reconnect on the test client.
-            kill_connection(&mut test_basics.client).await;
+            // Kill all connections via a direct authenticated connection, because the glide
+            // client connection is deauthed after RESET and cannot send CLIENT KILL itself.
+            let addrs: Vec<redis::ConnectionAddr> = match &test_basics.server {
+                BackingServer::Standalone(server) => vec![server
+                    .as_ref()
+                    .map(|s| s.get_client_addr())
+                    .unwrap_or(get_shared_server_address(true))],
+                BackingServer::Cluster(cluster) => cluster
+                    .as_ref()
+                    .map(|c| c.get_server_addresses())
+                    .unwrap_or_else(|| get_shared_cluster_addresses(true)),
+            };
+            for addr in &addrs {
+                kill_connection_via_addr(addr, Some("ReallySecurePassword")).await;
+            }
             // Retry for up to 10s: glide reconnects and re-auths with stored credentials
             let key = generate_random_string(6);
             retry_until_timeout(

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3067,6 +3067,18 @@ pub(crate) mod shared_client_tests {
     // so reconnections restore the post-RESET state, not the pre-RESET state.
     // =========================================================================
 
+    /// Parse a CLIENT INFO response Value into a String.
+    fn parse_client_info_value(val: Value) -> String {
+        match val {
+            Value::BulkString(bytes) => String::from_utf8_lossy(&bytes).to_string(),
+            Value::VerbatimString { text, .. } => text,
+            other => {
+                let map: HashMap<String, String> = redis::from_owned_redis_value(other).unwrap();
+                map.into_values().next().unwrap_or_default()
+            }
+        }
+    }
+
     /// Send CLIENT INFO and return as String (handles both standalone and cluster responses).
     async fn reset_test_get_client_info(client: &mut Client) -> String {
         let mut cmd = redis::Cmd::new();
@@ -3081,14 +3093,7 @@ pub(crate) mod shared_client_tests {
             )
             .await
             .unwrap();
-        match val {
-            Value::BulkString(bytes) => String::from_utf8_lossy(&bytes).to_string(),
-            Value::VerbatimString { text, .. } => text,
-            other => {
-                let map: HashMap<String, String> = redis::from_owned_redis_value(other).unwrap();
-                map.into_values().next().unwrap_or_default()
-            }
-        }
+        parse_client_info_value(val)
     }
 
     /// Kill connection and retry CLIENT INFO until reconnect succeeds.
@@ -3108,14 +3113,7 @@ pub(crate) mod shared_client_tests {
                 )
                 .await
                 .ok()?;
-            match val {
-                Value::BulkString(bytes) => Some(String::from_utf8_lossy(&bytes).to_string()),
-                Value::VerbatimString { text, .. } => Some(text),
-                other => {
-                    let map: HashMap<String, String> = redis::from_owned_redis_value(other).ok()?;
-                    map.into_values().next()
-                }
-            }
+            Some(parse_client_info_value(val))
         })
         .await
     }

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -3161,14 +3161,26 @@ pub(crate) mod shared_client_tests {
 
     /// RESET with initial DB=3 in config -> reconnect uses DB=0 (post-RESET), not DB=3.
     /// Verifies handle_reset_command overrides ConnectionRequest.database_id.
+    /// Cluster variant requires Valkey 9.0+ (multi-DB cluster support).
     #[rstest]
     #[serial_test::serial]
     #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
     fn test_reset_overrides_initial_database_config(#[values(false, true)] use_cluster: bool) {
         block_on_all(async move {
-            // Cluster mode rejects SELECT for non-zero databases; skip cluster variant.
             if use_cluster {
-                return;
+                // Cluster multi-DB requires Valkey 9.0+. Check version with a db=0 client
+                // before attempting to create a db=3 client.
+                let mut version_check = setup_test_basics(
+                    true,
+                    TestConfiguration {
+                        shared_server: true,
+                        ..Default::default()
+                    },
+                )
+                .await;
+                if !version_greater_or_equal(&mut version_check.client, "9.0.0").await {
+                    return;
+                }
             }
             let mut test_basics = setup_test_basics(
                 use_cluster,

--- a/glide-core/tests/test_pubsub.rs
+++ b/glide-core/tests/test_pubsub.rs
@@ -703,10 +703,12 @@ fn test_reset_clears_pubsub_subscriptions() {
             "subscription should be established before RESET"
         );
 
-        // Issue RESET via the connection - triggers handle_reset_command which
-        // calls remove_desired_subscriptions for all kinds
-        let mut reset_cmd = redis::cmd("RESET");
-        let _ = setup.connection.send_command(&mut reset_cmd, None).await;
+        // Send RESET through the glide Client path so handle_reset_command runs,
+        // which calls remove_desired_subscriptions to clear the desired subscription state.
+        {
+            let mut reset_cmd = redis::cmd("RESET");
+            let _ = setup.glide_client.send_command(&mut reset_cmd, None).await;
+        }
 
         // Wait for synchronizer to reconcile the cleared desired state
         let cleared = wait_for_pubsub_state(
@@ -746,9 +748,12 @@ fn test_reset_does_not_resubscribe_after_reconnect() {
             "subscription should be established before RESET"
         );
 
-        // RESET clears desired subscriptions via handle_reset_command
-        let mut reset_cmd = redis::cmd("RESET");
-        let _ = setup.connection.send_command(&mut reset_cmd, None).await;
+        // Send RESET through the glide Client path so handle_reset_command runs,
+        // which calls remove_desired_subscriptions to clear the desired subscription state.
+        {
+            let mut reset_cmd = redis::cmd("RESET");
+            let _ = setup.glide_client.send_command(&mut reset_cmd, None).await;
+        }
 
         // Kill connection to trigger reconnect
         let mut kill_cmd = redis::cmd("CLIENT");

--- a/glide-core/tests/test_pubsub.rs
+++ b/glide-core/tests/test_pubsub.rs
@@ -6,6 +6,7 @@
 mod constants;
 mod utilities;
 
+use glide_core::client::GlideClientForTests;
 use redis::PubSubSubscriptionKind;
 use rstest::rstest;
 use std::collections::HashSet;
@@ -672,6 +673,109 @@ fn test_all_subscription_types_survive_failover() {
         logger_core::log_info(
             LOG_PREFIX,
             "Test completed: all subscription types survived failover",
+        );
+    });
+}
+
+/// RESET clears pubsub subscriptions: after SUBSCRIBE + RESET, the synchronizer
+/// should see no active subscriptions. Uses wait_for_pubsub_state with timeout
+/// to allow reconciliation.
+#[rstest]
+#[serial_test::serial]
+#[timeout(LONG_CLUSTER_TEST_TIMEOUT)]
+fn test_reset_clears_pubsub_subscriptions() {
+    block_on_all(async {
+        let cluster = RedisCluster::new(false, &None, Some(3), Some(0));
+        let addresses = cluster.get_server_addresses();
+        let mut setup = PubSubTestSetup::new(&addresses).await;
+
+        let channels: Vec<Vec<u8>> = vec![b"reset-test-channel".to_vec()];
+
+        let subscribed = subscribe_and_wait(
+            &setup.synchronizer,
+            &channels,
+            PubSubSubscriptionKind::Exact,
+            SUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        assert!(
+            subscribed,
+            "subscription should be established before RESET"
+        );
+
+        // Issue RESET via the connection - triggers handle_reset_command which
+        // calls remove_desired_subscriptions for all kinds
+        let mut reset_cmd = redis::cmd("RESET");
+        let _ = setup.connection.send_command(&mut reset_cmd, None).await;
+
+        // Wait for synchronizer to reconcile the cleared desired state
+        let cleared = wait_for_pubsub_state(
+            &setup.synchronizer,
+            PubSubSubscriptionKind::Exact,
+            &HashSet::new(),
+            true,
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        assert!(cleared, "subscriptions should be cleared after RESET");
+    });
+}
+
+/// After RESET + reconnect, the synchronizer should NOT resubscribe because
+/// handle_reset_command cleared the desired subscription state.
+#[rstest]
+#[serial_test::serial]
+#[timeout(LONG_CLUSTER_TEST_TIMEOUT)]
+fn test_reset_does_not_resubscribe_after_reconnect() {
+    block_on_all(async {
+        let cluster = RedisCluster::new(false, &None, Some(3), Some(0));
+        let addresses = cluster.get_server_addresses();
+        let mut setup = PubSubTestSetup::new(&addresses).await;
+
+        let channels: Vec<Vec<u8>> = vec![b"reset-reconnect-channel".to_vec()];
+
+        let subscribed = subscribe_and_wait(
+            &setup.synchronizer,
+            &channels,
+            PubSubSubscriptionKind::Exact,
+            SUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        assert!(
+            subscribed,
+            "subscription should be established before RESET"
+        );
+
+        // RESET clears desired subscriptions via handle_reset_command
+        let mut reset_cmd = redis::cmd("RESET");
+        let _ = setup.connection.send_command(&mut reset_cmd, None).await;
+
+        // Kill connection to trigger reconnect
+        let mut kill_cmd = redis::cmd("CLIENT");
+        kill_cmd.arg("KILL").arg("SKIPME").arg("NO");
+        let _ = setup
+            .connection
+            .send_command(
+                &mut kill_cmd,
+                Some(redis::cluster_routing::RoutingInfo::MultiNode((
+                    redis::cluster_routing::MultipleNodeRoutingInfo::AllNodes,
+                    Some(redis::cluster_routing::ResponsePolicy::AllSucceeded),
+                ))),
+            )
+            .await;
+
+        // Desired state is empty, so synchronizer should NOT resubscribe after reconnect
+        let still_cleared = wait_for_pubsub_state(
+            &setup.synchronizer,
+            PubSubSubscriptionKind::Exact,
+            &HashSet::new(),
+            true,
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        assert!(
+            still_cleared,
+            "subscriptions should NOT be restored after RESET+reconnect"
         );
     });
 }

--- a/glide-core/tests/test_pubsub.rs
+++ b/glide-core/tests/test_pubsub.rs
@@ -715,7 +715,7 @@ fn test_reset_clears_pubsub_subscriptions() {
             &setup.synchronizer,
             PubSubSubscriptionKind::Exact,
             &HashSet::new(),
-            true,
+            false,
             RESUBSCRIPTION_TIMEOUT,
         )
         .await;
@@ -774,7 +774,7 @@ fn test_reset_does_not_resubscribe_after_reconnect() {
             &setup.synchronizer,
             PubSubSubscriptionKind::Exact,
             &HashSet::new(),
-            true,
+            false,
             RESUBSCRIPTION_TIMEOUT,
         )
         .await;

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -497,10 +497,8 @@ impl PubSubTestSetup {
 
         // Create a glide Client for routing commands through Client::send_command
         // (e.g. RESET, which calls handle_reset_command to clear desired subscriptions)
-        let glide_client = glide_core::client::Client::new_for_test(
-            client_arc.clone(),
-            synchronizer.clone(),
-        );
+        let glide_client =
+            glide_core::client::Client::new_for_test(client_arc.clone(), synchronizer.clone());
 
         Self {
             connection,

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -338,7 +338,8 @@ pub async fn create_cluster_client(
         get_shared_cluster_addresses(configuration.use_tls)
     };
 
-    if let Some(redis_connection_info) = &configuration.connection_info
+    if !configuration.skip_acl_setup
+        && let Some(redis_connection_info) = &configuration.connection_info
         && redis_connection_info.password.is_some()
     {
         assert!(!configuration.shared_server);

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -497,17 +497,10 @@ impl PubSubTestSetup {
 
         // Create a glide Client for routing commands through Client::send_command
         // (e.g. RESET, which calls handle_reset_command to clear desired subscriptions)
-        let glide_client = {
-            let configuration = TestConfiguration {
-                cluster_mode: ClusterMode::Enabled,
-                request_timeout: Some(10000),
-                ..Default::default()
-            };
-            let connection_request = create_connection_request(addresses, &configuration);
-            Client::new(connection_request.into(), None)
-                .await
-                .expect("Failed to create glide Client for PubSubTestSetup")
-        };
+        let glide_client = glide_core::client::Client::new_for_test(
+            client_arc.clone(),
+            synchronizer.clone(),
+        );
 
         Self {
             connection,

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -428,12 +428,13 @@ CLUSTER_NODES=127.0.0.1:39163,127.0.0.1:23178,127.0.0.1:25186,127.0.0.1:52500,12
 }
 
 /// Holds all components needed for pubsub topology test setup.
-/// The `_client_holder` keeps the Arc alive so the weak reference in the synchronizer remains valid.
+/// The `client_holder` keeps the Arc alive so the weak reference in the synchronizer remains valid.
 #[cfg(not(feature = "mock-pubsub"))]
 pub struct PubSubTestSetup {
     pub connection: ClusterConnection,
     pub synchronizer: Arc<dyn PubSubSynchronizer>,
-    pub _client_holder: Arc<TokioRwLock<ClientWrapper>>,
+    pub client_holder: Arc<TokioRwLock<ClientWrapper>>,
+    pub glide_client: Client,
 }
 
 #[cfg(not(feature = "mock-pubsub"))]
@@ -494,10 +495,25 @@ impl PubSubTestSetup {
             .expect("Expected GlidePubSubSynchronizer")
             .set_internal_client(Arc::downgrade(&client_arc));
 
+        // Create a glide Client for routing commands through Client::send_command
+        // (e.g. RESET, which calls handle_reset_command to clear desired subscriptions)
+        let glide_client = {
+            let configuration = TestConfiguration {
+                cluster_mode: ClusterMode::Enabled,
+                request_timeout: Some(10000),
+                ..Default::default()
+            };
+            let connection_request = create_connection_request(addresses, &configuration);
+            Client::new(connection_request.into(), None)
+                .await
+                .expect("Failed to create glide Client for PubSubTestSetup")
+        };
+
         Self {
             connection,
             synchronizer,
-            _client_holder: client_arc,
+            client_holder: client_arc,
+            glide_client,
         }
     }
 

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -783,6 +783,8 @@ pub struct TestConfiguration {
     pub protocol: ProtocolVersion,
     pub lazy_connect: bool,
     pub client_side_cache: Option<connection_request::ClientSideCache>,
+    /// Skip ACL setup when creating a cluster client (use when ACL is already configured).
+    pub skip_acl_setup: bool,
 }
 
 pub(crate) async fn setup_test_basics_internal(configuration: &TestConfiguration) -> TestBasics {
@@ -832,7 +834,10 @@ pub(crate) struct TestClientBasics {
     pub(crate) server: BackingServer,
     pub(crate) client: Client,
 }
-async fn create_client(server: &BackingServer, configuration: TestConfiguration) -> Client {
+pub(crate) async fn create_client(
+    server: &BackingServer,
+    configuration: TestConfiguration,
+) -> Client {
     match server {
         BackingServer::Standalone(server) => {
             let connection_addr = server

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -925,6 +925,30 @@ pub async fn kill_connection_for_route(
         .unwrap();
 }
 
+/// Kill all connections on a server using a direct (non-glide) connection.
+/// Useful when the glide client connection is deauthed (e.g. after RESET) and
+/// cannot send commands itself.
+pub async fn kill_connection_via_addr(addr: &ConnectionAddr, password: Option<&str>) {
+    let client = redis::Client::open(redis::ConnectionInfo {
+        addr: addr.clone(),
+        redis: RedisConnectionInfo {
+            password: password.map(|p| p.to_string()),
+            ..Default::default()
+        },
+    })
+    .unwrap();
+    let mut conn = retry(|| async {
+        client
+            .get_multiplexed_async_connection(GlideConnectionOptions::default())
+            .await
+            .ok()
+    })
+    .await;
+    let mut cmd = redis::cmd("CLIENT");
+    cmd.arg("KILL").arg("SKIPME").arg("NO");
+    let _: redis::RedisResult<redis::Value> = conn.send_packed_command(&cmd).await;
+}
+
 pub enum BackingServer {
     Standalone(Option<RedisServer>),
     Cluster(Option<cluster::RedisCluster>),


### PR DESCRIPTION
### Summary

Adds a `handle_reset_command` post-command hook in `glide-core/src/client/mod.rs` that updates glide-core's tracked connection state after a successful `RESET` command. Previously, issuing `RESET` followed by a forced reconnect would restore the pre-RESET state (e.g., the last `SELECT`ed database, last `CLIENT SETNAME`, last `HELLO` protocol) instead of the post-RESET state. This PR fixes that.

Also fixes `RESET` cluster routing: previously routed to a single random node; now routes to all nodes (`AllNodes`) so all connections in the cluster are deauthenticated.

### Issue link

This Pull Request is linked to issue: [Implement RESET command for Python, Node.js, Go, and Java clients](https://github.com/valkey-io/valkey-glide/issues/5942)
Closes #5942

### Features / Behaviour Changes

- `handle_reset_command` now updates tracked state after `RESET`:
  - Database → 0
  - Client name → cleared
  - RESP protocol → RESP2
  - OTel db namespace → "0"
  - Pub/sub desired subscriptions → cleared (prevents synchronizer from resubscribing on reconnect)
- Added`RESET` to `AllNodes` routing in `cluster_routing.rs` — ensures all cluster node connections are reset

### Implementation

Added `is_reset_command` / `handle_reset_command` following the same pattern as the existing `is_select_command` / `handle_select_command`, `is_hello_command` / `handle_hello_command` hooks. The function documents all 13 RESET spec effects with rationale for what is and isn't tracked.

**Auth design decision:** AUTH credentials are intentionally not cleared by `handle_reset_command`. Per the spec, RESET deauthenticates the live connection — the next command on that connection will fail with `NOAUTH`. However, glide-core stores the original credentials in `ConnectionRequest` and uses them to re-authenticate automatically on reconnect. This means: (1) the live deauthed connection requires a manual `AUTH` call to recover without reconnect, and (2) on reconnect, glide re-auths transparently with the stored credentials. This is the correct behavior — clearing stored credentials would prevent reconnect from working.

### Limitations

- CLIENT TRACKING, WATCH, READWRITE mode, ASKING, CLIENT REPLY, MONITOR, NO-EVICT, NO-TOUCH are not tracked (see inline comments in `handle_reset_command` for rationale on each).

### Testing

18 integration tests added in `glide-core/tests/test_client.rs`:

- `test_reset_reverts_database_to_zero` — SELECT 2 → RESET → reconnect on DB=0
- `test_reset_overrides_initial_database_config` — config DB=3 → RESET → reconnect on DB=0
- `test_reset_clears_client_name` — SETNAME → RESET → reconnect with empty name
- `test_reset_overrides_initial_client_name_config` — config name=X → RESET → reconnect with empty name
- `test_reset_reverts_protocol_to_resp2` — HELLO 3 → RESET → reconnect with RESP2
- `test_reset_deauths_connection` — RESET → next command fails with NOAUTH
- `test_reset_reconnect_reauths_with_stored_credentials` — RESET → kill → reconnect re-auths automatically
- `test_reset_manual_reauth_restores_client` — RESET → AUTH manually → client works
- `test_reset_clears_pubsub_desired_state` — RESET → synchronizer desired subscriptions cleared
- `test_reset_exits_pubsub_mode` — RESET → regular commands work after

All tests run for both standalone and cluster modes where applicable.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.