### PR TITLE
Core: Phase 2 client-side caching - server-assisted invalidation via CLIENT TRACKING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Pending 2.5
 
 #### Changes
+* CORE: Phase 2 client-side caching - server-assisted invalidation via CLIENT TRACKING ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))

--- a/glide-core/redis-rs/redis/src/aio/mod.rs
+++ b/glide-core/redis-rs/redis/src/aio/mod.rs
@@ -225,6 +225,37 @@ where
         }
     }
 
+    if connection_info.server_assisted_cache {
+        if connection_info.protocol == ProtocolVersion::RESP2 {
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "server_assisted_cache requires RESP3 protocol",
+            )));
+        }
+        match cmd("CLIENT")
+            .arg("TRACKING")
+            .arg("ON")
+            .arg("BCAST")
+            .query_async(con)
+            .await
+        {
+            Ok(Value::Okay) => {}
+            Err(e) => {
+                return Err(RedisError::from((
+                    ErrorKind::ClientError,
+                    "Failed to enable server-assisted client tracking",
+                    e.to_string(),
+                )));
+            }
+            _ => {
+                return Err(RedisError::from((
+                    ErrorKind::ClientError,
+                    "Unexpected response from CLIENT TRACKING ON BCAST",
+                )));
+            }
+        }
+    }
+
     if discover_az {
         update_az_from_info(con).await?;
     }

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -113,6 +113,7 @@ pin_project! {
         disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
         is_stream_closed: Arc<AtomicBool>,
         response_sync_lost: bool,
+        cache: Option<Arc<dyn GlideCache>>,
     }
 
         impl<T> PinnedDrop for PipelineSink<T> {
@@ -140,6 +141,7 @@ where
         push_manager: Arc<ArcSwap<PushManager>>,
         disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
         is_stream_closed: Arc<AtomicBool>,
+        cache: Option<Arc<dyn GlideCache>>,
     ) -> Self
     where
         T: Sink<SinkItem, Error = RedisError> + Stream<Item = RedisResult<Value>> + 'static,
@@ -152,6 +154,7 @@ where
             disconnect_notifier,
             is_stream_closed,
             response_sync_lost: false,
+            cache,
         }
     }
 
@@ -194,6 +197,26 @@ where
         if let Ok(res) = &result {
             if let Value::Push { kind, data: _data } = res {
                 self_.push_manager.load().try_send_raw(res);
+                if kind == &PushKind::Invalidate {
+                    if let Some(cache) = self_.cache {
+                        match _data.first() {
+                            Some(Value::Array(keys)) => {
+                                for key in keys {
+                                    if let Value::BulkString(k) = key {
+                                        cache.invalidate(k);
+                                    } else if let Value::VerbatimString { text, .. } = key {
+                                        cache.invalidate(text.as_bytes());
+                                    }
+                                }
+                            }
+                            Some(Value::Nil) => {
+                                cache.flush_all();
+                            }
+                            None => { /* malformed push, ignore */ }
+                            _ => {}
+                        }
+                    }
+                }
                 if !kind.has_reply() {
                     return;
                 }
@@ -503,6 +526,7 @@ where
     fn new<T>(
         sink_stream: T,
         disconnect_notifier: Option<Box<dyn DisconnectNotifier>>,
+        cache: Option<Arc<dyn GlideCache>>,
     ) -> (Self, impl Future<Output = ()>)
     where
         T: Sink<SinkItem, Error = RedisError> + Stream<Item = RedisResult<Value>> + 'static,
@@ -521,6 +545,7 @@ where
             push_manager.clone(),
             disconnect_notifier,
             is_stream_closed.clone(),
+            cache,
         );
         let f = stream::poll_fn(move |cx| receiver.poll_recv(cx))
             .map(Ok)
@@ -702,8 +727,11 @@ impl MultiplexedConnection {
         let codec = ValueCodec::default()
             .framed(stream)
             .and_then(|msg| async move { msg });
-        let (mut pipeline, driver) =
-            Pipeline::new(codec, glide_connection_options.disconnect_notifier);
+        let (mut pipeline, driver) = Pipeline::new(
+            codec,
+            glide_connection_options.disconnect_notifier,
+            connection_info.redis.cache.clone(),
+        );
         let driver = Box::pin(driver);
         let pm = PushManager::new(
             glide_connection_options.push_sender,
@@ -1157,7 +1185,7 @@ mod tests {
         };
 
         // Create pipeline but don't drive it, the channel will fill and send() will block
-        let (mut pipeline, driver) = Pipeline::new(stalling_sink, None);
+        let (mut pipeline, driver) = Pipeline::new(stalling_sink, None, None);
         std::mem::forget(driver);
 
         // Fill the 50-slot pipeline channel
@@ -1296,7 +1324,7 @@ mod tests {
             waker: None,
         };
 
-        let (pipeline, driver) = Pipeline::new(stream, None);
+        let (pipeline, driver) = Pipeline::new(stream, None, None);
         let driver_handle = tokio::spawn(driver);
 
         // Send first command — this should go through fine

--- a/glide-core/redis-rs/redis/src/cache/glide_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/glide_cache.rs
@@ -456,6 +456,9 @@ pub trait GlideCache: Send + Sync + Debug {
     /// * `key` - The key to invalidate
     fn invalidate(&self, key: &[u8]);
 
+    /// Removes all entries from the cache
+    fn flush_all(&self);
+
     // ==================== Metrics ====================
 
     /// Returns current cache metrics (hits, misses, etc.)
@@ -635,6 +638,20 @@ impl<S: EvictionStrategy + 'static> GlideCache for GlideCacheImpl<S> {
                 self.core.current_memory()
             );
         }
+    }
+
+    fn flush_all(&self) {
+        let mut store = self.store.write().unwrap();
+        while let Some(entry) = store.evict_one() {
+            self.core.uncharge(entry.size);
+        }
+        if let Some(stats) = self.core.stats() {
+            stats.record_invalidation();
+        }
+        debug!(
+            "cache_flush_all - [{}] Flushed all entries",
+            store.policy_name()
+        );
     }
 
     fn entry_count(&self) -> u64 {

--- a/glide-core/redis-rs/redis/src/cache/glide_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/glide_cache.rs
@@ -644,9 +644,9 @@ impl<S: EvictionStrategy + 'static> GlideCache for GlideCacheImpl<S> {
         let mut store = self.store.write().unwrap();
         while let Some(entry) = store.evict_one() {
             self.core.uncharge(entry.size);
-        }
-        if let Some(stats) = self.core.stats() {
-            stats.record_invalidation();
+            if let Some(stats) = self.core.stats() {
+                stats.record_invalidation();
+            }
         }
         debug!(
             "cache_flush_all - [{}] Flushed all entries",

--- a/glide-core/redis-rs/redis/src/cache/lfu_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/lfu_cache.rs
@@ -461,6 +461,32 @@ mod tests {
     }
 
     #[test]
+    fn test_flush_all_records_invalidation_per_key() {
+        let cache = new_lfu_cache(make_config(10_000));
+
+        cache.insert(
+            b"key1".to_vec(),
+            CachedKeyType::String,
+            Value::BulkString(b"v1".to_vec()),
+        );
+        cache.insert(
+            b"key2".to_vec(),
+            CachedKeyType::String,
+            Value::BulkString(b"v2".to_vec()),
+        );
+        cache.insert(
+            b"key3".to_vec(),
+            CachedKeyType::String,
+            Value::BulkString(b"v3".to_vec()),
+        );
+
+        cache.flush_all();
+
+        let metrics = cache.metrics().unwrap();
+        assert_eq!(metrics.invalidations(), 3);
+    }
+
+    #[test]
     fn test_metrics_evictions() {
         // Small cache to force eviction
         let cache = new_lfu_cache(make_config(150));

--- a/glide-core/redis-rs/redis/src/cache/lru_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/lru_cache.rs
@@ -299,6 +299,32 @@ mod tests {
     }
 
     #[test]
+    fn test_flush_all_records_invalidation_per_key() {
+        let cache = new_lru_cache(make_config(10_000));
+
+        cache.insert(
+            b"key1".to_vec(),
+            CachedKeyType::String,
+            Value::BulkString(b"v1".to_vec()),
+        );
+        cache.insert(
+            b"key2".to_vec(),
+            CachedKeyType::String,
+            Value::BulkString(b"v2".to_vec()),
+        );
+        cache.insert(
+            b"key3".to_vec(),
+            CachedKeyType::String,
+            Value::BulkString(b"v3".to_vec()),
+        );
+
+        cache.flush_all();
+
+        let metrics = cache.metrics().unwrap();
+        assert_eq!(metrics.invalidations(), 3);
+    }
+
+    #[test]
     fn test_metrics_evictions() {
         // Small cache to force eviction
         let cache = new_lru_cache(make_config(150));

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -1028,6 +1028,7 @@ pub(crate) fn get_connection_info(
             protocol: cluster_params.protocol,
             db: cluster_params.database_id,
             cache: cluster_params.cache,
+            server_assisted_cache: cluster_params.server_assisted_cache,
         },
     })
 }

--- a/glide-core/redis-rs/redis/src/cluster_client.rs
+++ b/glide-core/redis-rs/redis/src/cluster_client.rs
@@ -50,6 +50,7 @@ struct BuilderParams {
     database_id: i64,
     tcp_nodelay: bool,
     cache: Option<Arc<dyn GlideCache>>,
+    server_assisted_cache: bool,
     address_resolver: Option<Arc<dyn AddressResolver>>,
 }
 
@@ -155,6 +156,7 @@ pub struct ClusterParams {
     pub(crate) database_id: i64,
     pub(crate) tcp_nodelay: bool,
     pub(crate) cache: Option<Arc<dyn GlideCache>>,
+    pub(crate) server_assisted_cache: bool,
     /// Optional callback for resolving addresses before connection.
     pub(crate) address_resolver: Option<Arc<dyn AddressResolver>>,
 }
@@ -190,6 +192,7 @@ impl ClusterParams {
             database_id: value.database_id,
             tcp_nodelay: value.tcp_nodelay,
             cache: value.cache,
+            server_assisted_cache: value.server_assisted_cache,
             address_resolver: value.address_resolver,
         })
     }
@@ -222,6 +225,7 @@ impl ClusterParams {
             database_id: 0,
             tcp_nodelay: false,
             cache: None,
+            server_assisted_cache: false,
             address_resolver: None,
         }
     }
@@ -590,6 +594,12 @@ impl ClusterClientBuilder {
     /// Sets the cache for the new ClusterClient.
     pub fn cache(mut self, cache: Option<Arc<dyn GlideCache>>) -> ClusterClientBuilder {
         self.builder_params.cache = cache;
+        self
+    }
+
+    /// Sets whether server-assisted client-side caching (CLIENT TRACKING) is enabled.
+    pub fn server_assisted_cache(mut self, enabled: bool) -> ClusterClientBuilder {
+        self.builder_params.server_assisted_cache = enabled;
         self
     }
 

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -237,6 +237,8 @@ pub struct RedisConnectionInfo {
     pub lib_name: Option<String>,
     /// Optionally a cache used for client-side caching
     pub cache: Option<Arc<dyn GlideCache>>,
+    /// Whether to enable server-assisted client tracking (CLIENT TRACKING ON BCAST)
+    pub server_assisted_cache: bool,
 }
 
 impl FromStr for ConnectionInfo {
@@ -396,6 +398,7 @@ fn url_to_tcp_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
             client_name: None,
             lib_name: None,
             cache: None,
+            server_assisted_cache: false,
         },
     })
 }
@@ -430,6 +433,7 @@ fn url_to_unix_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
             client_name: None,
             lib_name: None,
             cache: None,
+            server_assisted_cache: false,
         },
     })
 }
@@ -1878,6 +1882,7 @@ mod tests {
                         client_name: None,
                         lib_name: None,
                         cache: None,
+                        server_assisted_cache: false,
                     },
                 },
             ),

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -203,6 +203,12 @@ pub async fn get_valkey_connection_info(
             )
         });
 
+    let server_assisted_cache = connection_request
+        .client_side_cache
+        .as_ref()
+        .map(|c| c.server_assisted)
+        .unwrap_or(false);
+
     match &connection_request.authentication_info {
         Some(info) => {
             // If we have IAM configuration and a token manager, use the IAM token as password
@@ -222,6 +228,7 @@ pub async fn get_valkey_connection_info(
                     client_name,
                     lib_name,
                     cache,
+                    server_assisted_cache,
                 }
             } else {
                 // Regular password-based authentication
@@ -233,6 +240,7 @@ pub async fn get_valkey_connection_info(
                     client_name,
                     lib_name,
                     cache,
+                    server_assisted_cache,
                 }
             }
         }
@@ -242,6 +250,7 @@ pub async fn get_valkey_connection_info(
             client_name,
             lib_name,
             cache,
+            server_assisted_cache,
             ..Default::default()
         },
     }
@@ -1804,6 +1813,7 @@ async fn create_cluster_client(
     builder = builder.use_protocol(request.protocol.unwrap_or_default());
     builder = builder.database_id(valkey_connection_info.db);
     builder = builder.cache(valkey_connection_info.cache);
+    builder = builder.server_assisted_cache(valkey_connection_info.server_assisted_cache);
     if let Some(client_name) = valkey_connection_info.client_name {
         builder = builder.client_name(client_name);
     }

--- a/glide-core/src/client/types.rs
+++ b/glide-core/src/client/types.rs
@@ -72,6 +72,7 @@ pub struct ClientSideCache {
     pub entry_ttl_ms: u64,
     pub eviction_policy: Option<EvictionPolicy>,
     pub enable_metrics: bool,
+    pub server_assisted: bool,
 }
 
 /// Authentication information for connecting to Redis/Valkey servers
@@ -367,6 +368,7 @@ impl From<protobuf::ConnectionRequest> for ConnectionRequest {
                         protobuf::EvictionPolicy::LFU => EvictionPolicy::Lfu,
                     }),
                 enable_metrics: proto_cache.enable_metrics,
+                server_assisted: proto_cache.server_assisted,
             });
 
         // Convert protobuf compression config to internal compression config

--- a/glide-core/src/protobuf/connection_request.proto
+++ b/glide-core/src/protobuf/connection_request.proto
@@ -97,6 +97,7 @@ message ClientSideCache {
     uint64 entry_ttl_ms = 3; // 0 = no expiration
     optional EvictionPolicy eviction_policy = 4;
     bool enable_metrics = 5;
+    bool server_assisted = 6;
 }
 
 enum EvictionPolicy {

--- a/glide-core/tests/test_cache.rs
+++ b/glide-core/tests/test_cache.rs
@@ -8,6 +8,7 @@ pub(crate) mod test_cache {
     use super::*;
     use glide_core::connection_request::ClientSideCache;
     use glide_core::connection_request::EvictionPolicy;
+    use glide_core::connection_request::ProtocolVersion;
     use redis::Value;
     use redis::cache::glide_cache::CachedKeyType;
     use rstest::rstest;
@@ -1173,6 +1174,227 @@ pub(crate) mod test_cache {
                 .await
                 .unwrap();
             assert_command_count(&mut test_basics.client, "GET", 2, use_cluster).await;
+        });
+    }
+
+    /// Test that server-assisted caching invalidates a key when it is updated by another client.
+    /// Flow: client1 (server_assisted=true) GETs key (cached), client2 SETs key,
+    /// server sends invalidation push, client1 GETs key again -> cache miss -> fresh value.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_server_assisted_cache_invalidation(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async move {
+            // Client 1: server-assisted cache enabled
+            let mut cached_client = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    protocol: ProtocolVersion::RESP3,
+                    client_side_cache: Some(ClientSideCache {
+                        cache_id: "server_assisted_invalidation_test".to_string().into(),
+                        max_cache_kb: 1024,
+                        entry_ttl_ms: 0,
+                        eviction_policy: None,
+                        enable_metrics: true,
+                        server_assisted: true,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            // Client 2: plain client for writing (triggers invalidation); no cache so SET goes to server
+            let mut writer = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            let key = generate_random_string(10);
+            let value1 = "original";
+            let value2 = "updated";
+
+            // Set initial value via writer
+            let mut set_cmd = redis::Cmd::new();
+            set_cmd.arg("SET").arg(&key).arg(value1);
+            writer
+                .client
+                .send_command(&mut set_cmd, None)
+                .await
+                .unwrap();
+
+            // GET via cached client -> populates cache
+            let mut get_cmd = redis::Cmd::new();
+            get_cmd.arg("GET").arg(&key);
+            let result1 = cached_client
+                .client
+                .send_command(&mut get_cmd, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                result1,
+                Value::BulkString(value1.as_bytes().to_vec()),
+                "first GET should return original value"
+            );
+
+            // GET again -> should be a cache hit
+            let mut get_cmd = redis::Cmd::new();
+            get_cmd.arg("GET").arg(&key);
+            let result2 = cached_client
+                .client
+                .send_command(&mut get_cmd, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                result2,
+                Value::BulkString(value1.as_bytes().to_vec()),
+                "second GET should return cached value"
+            );
+
+            // Writer updates the key -> server sends invalidation push to cached_client
+            let mut set_cmd2 = redis::Cmd::new();
+            set_cmd2.arg("SET").arg(&key).arg(value2);
+            writer
+                .client
+                .send_command(&mut set_cmd2, None)
+                .await
+                .unwrap();
+
+            // Allow time for invalidation push to be processed
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // GET via cached client -> cache miss -> fresh value from server
+            let mut get_cmd = redis::Cmd::new();
+            get_cmd.arg("GET").arg(&key);
+            let result3 = cached_client
+                .client
+                .send_command(&mut get_cmd, None)
+                .await
+                .unwrap();
+            assert_eq!(
+                result3,
+                Value::BulkString(value2.as_bytes().to_vec()),
+                "GET after invalidation should return updated value"
+            );
+        });
+    }
+
+    /// Test that a nil invalidation (FLUSHDB in BCAST mode) flushes the entire cache.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_server_assisted_nil_invalidation_flushes_cache(
+        #[values(false, true)] use_cluster: bool,
+    ) {
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics(
+                use_cluster,
+                TestConfiguration {
+                    shared_server: false,
+                    protocol: ProtocolVersion::RESP3,
+                    client_side_cache: Some(ClientSideCache {
+                        cache_id: "nil_invalidation_test".to_string().into(),
+                        max_cache_kb: 1024,
+                        entry_ttl_ms: 0,
+                        eviction_policy: None,
+                        enable_metrics: true,
+                        server_assisted: true,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            let key = generate_random_string(10);
+
+            let mut set_cmd = redis::Cmd::new();
+            set_cmd.arg("SET").arg(&key).arg("value");
+            test_basics
+                .client
+                .send_command(&mut set_cmd, None)
+                .await
+                .unwrap();
+
+            // Populate cache
+            let mut get_cmd = redis::Cmd::new();
+            get_cmd.arg("GET").arg(&key);
+            test_basics
+                .client
+                .send_command(&mut get_cmd, None)
+                .await
+                .unwrap();
+
+            // Verify cache has the entry
+            let entry_count_before = test_basics.client.cache_entry_count().unwrap();
+            assert_eq!(
+                entry_count_before,
+                Value::Int(1),
+                "cache should have entries before flush"
+            );
+
+            // FLUSHDB triggers a nil invalidation push in BCAST mode, flushing the entire cache
+            let mut flushdb = redis::Cmd::new();
+            flushdb.arg("FLUSHDB");
+            let _ = test_basics.client.send_command(&mut flushdb, None).await;
+
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+            // Cache should be empty after nil invalidation (triggered by FLUSHDB)
+            let entry_count_after = test_basics.client.cache_entry_count().unwrap();
+            assert_eq!(
+                entry_count_after,
+                Value::Int(0),
+                "cache should be empty after nil invalidation"
+            );
+        });
+    }
+
+    /// Test that server_assisted=true with RESP2 returns an error at connection time.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_server_assisted_requires_resp3(#[values(false, true)] use_cluster: bool) {
+        block_on_all(async move {
+            let configuration = TestConfiguration {
+                shared_server: false,
+                protocol: ProtocolVersion::RESP2,
+                client_side_cache: Some(ClientSideCache {
+                    cache_id: "resp2_server_assisted_test".to_string().into(),
+                    max_cache_kb: 1024,
+                    entry_ttl_ms: 0,
+                    eviction_policy: None,
+                    enable_metrics: false,
+                    server_assisted: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            // Spin up a standalone server or use shared cluster address
+            let _server;
+            let addr = if use_cluster {
+                cluster::get_shared_cluster_addresses(false)
+                    .into_iter()
+                    .next()
+                    .expect("cluster address")
+            } else {
+                _server = RedisServer::new(ServerType::Tcp { tls: false });
+                _server.get_client_addr()
+            };
+
+            let connection_request =
+                create_connection_request(std::slice::from_ref(&addr), &configuration);
+            let result = glide_core::client::Client::new(connection_request.into(), None).await;
+            assert!(
+                result.is_err(),
+                "server_assisted=true with RESP2 should fail at connection time"
+            );
         });
     }
 }


### PR DESCRIPTION
### Summary

Implements Phase 2 of client-side caching: server-assisted cache invalidation via CLIENT TRACKING ON BCAST. When server_assisted=true is set in ClientSideCache config, glide automatically enables server-side tracking and processes invalidation push messages to keep the local cache coherent.

### Issue link

This Pull Request is linked to issue: [Implement client-side caching Phase 2: server-assisted invalidation via CLIENT TRACKING](https://github.com/valkey-io/valkey-glide/issues/5961)

### Features / Behaviour Changes

- New server_assisted field in ClientSideCache protobuf message
- When server_assisted=true: glide sends CLIENT TRACKING ON BCAST on connection setup and re-sends on every reconnect
- PushKind::Invalidate messages from the server evict specific keys or flush the entire cache (on nil)
- Cluster support: tracking enabled on all node connections
- GlideCache::flush_all() method added

### Implementation

- aio/mod.rs: setup_connection() sends CLIENT TRACKING ON BCAST after auth/select/setname; RESP3 guard returns InvalidClientConfig if RESP2 is used
- multiplexed_connection.rs: PushKind::Invalidate handler - array of keys to per-key invalidate(), nil to flush_all()
- glide_cache.rs: flush_all() drains all entries and records one bulk invalidation metric
- cluster_client.rs + cluster.rs: server_assisted_cache propagated through ClusterParams to all node connections

### Limitations

- Requires RESP3 protocol; server_assisted=true with RESP2 returns an error
- BCAST mode only; OPTIN/OPTOUT modes not supported

### Testing

- test_server_assisted_cache_invalidation - two-client test verifying cache eviction on key update
- test_server_assisted_nil_invalidation_flushes_cache - verifies nil invalidation flushes entire cache
- test_server_assisted_requires_resp3 - verifies error on RESP2 + server_assisted=true

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and Prettier has been run.
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.