### PR TITLE
Python: Phase 2 client-side caching - server_assisted field and client_trackinginfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Changes
 * Python: Add `MIGRATE` command support ([#5933](https://github.com/valkey-io/valkey-glide/pull/5933))
+* Python: Phase 2 client-side caching - `server_assisted` field and `client_trackinginfo` command ([#5963](https://github.com/valkey-io/valkey-glide/pull/5963))
 * CORE: Phase 2 client-side caching - server-assisted invalidation via CLIENT TRACKING ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))

--- a/python/glide-async/python/glide/async_commands/cluster_commands.py
+++ b/python/glide-async/python/glide/async_commands/cluster_commands.py
@@ -1610,7 +1610,23 @@ class ClusterCommands(CoreCommands):
     async def client_trackinginfo(
         self, route: Optional[Route] = None
     ) -> TClusterResponse[dict]:
-        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        """
+        Returns information about the current client's server-assisted client-side caching.
+
+        See https://valkey.io/commands/client-trackinginfo/ for more details.
+
+        Args:
+            route (Optional[Route]): The command will be sent to a random node, unless `route` is provided,
+                in which case the client will route the command to the nodes defined by `route`.
+
+        Returns:
+            TClusterResponse[dict]: A dictionary of tracking info fields and their values.
+
+            If a single node route is requested, returns a dict with the tracking info.
+
+            Otherwise, returns a dict of [bytes, dict] where each key contains the address of
+            the queried node and the value contains the tracking info for that node.
+        """
         return cast(
             TClusterResponse[dict],
             await self._execute_command(RequestType.ClientTrackingInfo, [], route),

--- a/python/glide-async/python/glide/async_commands/cluster_commands.py
+++ b/python/glide-async/python/glide/async_commands/cluster_commands.py
@@ -1606,3 +1606,12 @@ class ClusterCommands(CoreCommands):
             raise ValueError(f"Timeout must be non-negative, got: {timeout_ms}")
         args = (list(channels) if channels else []) + [str(timeout_ms)]
         await self._execute_command(RequestType.SUnsubscribeBlocking, list(args))
+
+    async def client_trackinginfo(
+        self, route: Optional[Route] = None
+    ) -> TClusterResponse[dict]:
+        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        return cast(
+            TClusterResponse[dict],
+            await self._execute_command(RequestType.ClientTrackingInfo, [], route),
+        )

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -8218,3 +8218,9 @@ class CoreCommands(Protocol):
             raise ValueError(f"Timeout must be non-negative, got: {timeout_ms}")
         args = (list(patterns) if patterns else []) + [str(timeout_ms)]
         await self._execute_command(RequestType.PUnsubscribeBlocking, list(args))
+
+    async def client_trackinginfo(self) -> dict:
+        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        return cast(
+            dict, await self._execute_command(RequestType.ClientTrackingInfo, [])
+        )

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -8220,7 +8220,14 @@ class CoreCommands(Protocol):
         await self._execute_command(RequestType.PUnsubscribeBlocking, list(args))
 
     async def client_trackinginfo(self) -> dict:
-        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        """
+        Returns information about the current client's server-assisted client-side caching.
+
+        See https://valkey.io/commands/client-trackinginfo/ for more details.
+
+        Returns:
+            dict: A dictionary of tracking info fields and their values.
+        """
         return cast(
             dict, await self._execute_command(RequestType.ClientTrackingInfo, [])
         )

--- a/python/glide-shared/glide_shared/cache.py
+++ b/python/glide-shared/glide_shared/cache.py
@@ -53,6 +53,7 @@ class ClientSideCache:
     entry_ttl_ms: int
     eviction_policy: Optional[EvictionPolicy] = None
     enable_metrics: bool = False
+    server_assisted: bool = False
 
     @classmethod
     def create(

--- a/python/glide-shared/glide_shared/cache.py
+++ b/python/glide-shared/glide_shared/cache.py
@@ -36,8 +36,10 @@ class ClientSideCache:
     uses Time-To-Live (TTL) based expiration, where entries are automatically
     removed after a specified duration.
 
-    Cached entries expire based on TTL. Server-side key changes are not propagated
-    to the cache, so values may become stale before TTL expires.
+    Cached entries expire based on TTL. By default, server-side key changes are not
+    propagated to the cache, so values may become stale before TTL expires. When
+    ``server_assisted=True``, the server sends invalidation messages to keep the
+    cache consistent with server-side changes.
     Expiration is lazy — entries are removed when accessed after their TTL, not
     proactively in the background.
     Supported read commands: GET, HGETALL, SMEMBERS.
@@ -62,6 +64,7 @@ class ClientSideCache:
         entry_ttl_ms: int,
         eviction_policy: Optional[EvictionPolicy] = None,
         enable_metrics: bool = False,
+        server_assisted: bool = False,
     ) -> "ClientSideCache":
         """
         Create a new client-side cache configuration with an auto-generated unique ID.
@@ -86,6 +89,8 @@ class ClientSideCache:
                 policy of LRU will be used.
                 See `EvictionPolicy` enum for available options.
             enable_metrics (bool): If True, enables collection of cache metrics such as hit/miss rates.
+            server_assisted (bool): If True, enables server-assisted invalidation, where the server
+                sends invalidation messages when tracked keys are modified.
 
         Returns:
             ClientSideCache: A new ClientSideCache instance.
@@ -114,4 +119,5 @@ class ClientSideCache:
             entry_ttl_ms=entry_ttl_ms,
             eviction_policy=eviction_policy,
             enable_metrics=enable_metrics,
+            server_assisted=server_assisted,
         )

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -819,6 +819,16 @@ class BaseBatch:
         """
         return self.append_command(RequestType.ClientGetName, [])
 
+    def client_trackinginfo(self: TBatch) -> TBatch:
+        """
+        Return info about server-assisted client-side caching.
+        See [valkey.io](https://valkey.io/commands/client-trackinginfo/) for more details.
+
+        Command response:
+            dict: A dictionary of tracking info.
+        """
+        return self.append_command(RequestType.ClientTrackingInfo, [])
+
     def hgetall(self: TBatch, key: TEncodable) -> TBatch:
         """
         Returns all fields and values of the hash stored at `key`.

--- a/python/glide-shared/glide_shared/config.py
+++ b/python/glide-shared/glide_shared/config.py
@@ -904,6 +904,9 @@ class BaseClientConfiguration:
             request.client_side_cache.eviction_policy = (
                 self.client_side_cache.eviction_policy.value
             )
+        request.client_side_cache.server_assisted = (
+            self.client_side_cache.server_assisted
+        )
 
     def _create_a_protobuf_conn_request(
         self, cluster_mode: bool = False

--- a/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
@@ -1551,7 +1551,23 @@ class ClusterCommands(CoreCommands):
     def client_trackinginfo(
         self, route: Optional[Route] = None
     ) -> TClusterResponse[dict]:
-        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        """
+        Returns information about the current client's server-assisted client-side caching.
+
+        See https://valkey.io/commands/client-trackinginfo/ for more details.
+
+        Args:
+            route (Optional[Route]): The command will be sent to a random node, unless `route` is provided,
+                in which case the client will route the command to the nodes defined by `route`.
+
+        Returns:
+            TClusterResponse[dict]: A dictionary of tracking info fields and their values.
+
+            If a single node route is requested, returns a dict with the tracking info.
+
+            Otherwise, returns a dict of [bytes, dict] where each key contains the address of
+            the queried node and the value contains the tracking info for that node.
+        """
         return cast(
             TClusterResponse[dict],
             self._execute_command(RequestType.ClientTrackingInfo, [], route),

--- a/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/cluster_commands.py
@@ -1547,3 +1547,12 @@ class ClusterCommands(CoreCommands):
             (list(channels) if channels else []) + [str(timeout_ms)],
         )
         self._execute_command(RequestType.SUnsubscribeBlocking, args)
+
+    def client_trackinginfo(
+        self, route: Optional[Route] = None
+    ) -> TClusterResponse[dict]:
+        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        return cast(
+            TClusterResponse[dict],
+            self._execute_command(RequestType.ClientTrackingInfo, [], route),
+        )

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -8059,3 +8059,7 @@ class CoreCommands(Protocol):
             (list(patterns) if patterns else []) + [str(timeout_ms)],
         )
         self._execute_command(RequestType.PUnsubscribeBlocking, args)
+
+    def client_trackinginfo(self) -> dict:
+        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        return cast(dict, self._execute_command(RequestType.ClientTrackingInfo, []))

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -8061,5 +8061,12 @@ class CoreCommands(Protocol):
         self._execute_command(RequestType.PUnsubscribeBlocking, args)
 
     def client_trackinginfo(self) -> dict:
-        """Return info about server-assisted client-side caching. See https://valkey.io/commands/client-trackinginfo/"""
+        """
+        Returns information about the current client's server-assisted client-side caching.
+
+        See https://valkey.io/commands/client-trackinginfo/ for more details.
+
+        Returns:
+            dict: A dictionary of tracking info fields and their values.
+        """
         return cast(dict, self._execute_command(RequestType.ClientTrackingInfo, []))

--- a/python/tests/async_tests/test_client_side_cache.py
+++ b/python/tests/async_tests/test_client_side_cache.py
@@ -583,7 +583,7 @@ class TestClientSideCache:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP3])
     async def test_client_trackinginfo(self, request, protocol, cluster_mode):
-        """Test that client_trackinginfo returns a non-empty dict with expected keys."""
+        """Test that client_trackinginfo reflects active tracking state after cache use."""
         cache = ClientSideCache.create(
             max_cache_kb=1,
             entry_ttl_ms=60_000,
@@ -597,17 +597,22 @@ class TestClientSideCache:
             cache=cache,
         )
 
+        # Exercise the cache: SET then GET to populate it
+        key = "trackinginfo_test_key"
+        assert await client.set(key, "value") == "OK"
+        assert await client.get(key) == b"value"  # cache miss, populates cache
+        assert client.get_cache_entry_count() == 1  # key is now tracked
+
         result = await client.client_trackinginfo()
         assert isinstance(result, dict)
-        # All three top-level keys must be present
         assert b"flags" in result
         assert b"redirect" in result
         assert b"prefixes" in result
-        # Tracking is enabled (server_assisted=True)
+        # Tracking is on with server_assisted=True
         assert b"on" in result[b"flags"]
-        # redirect is an integer (-1 means no redirect)
-        assert isinstance(result[b"redirect"], int)
-        # prefixes is a list
-        assert isinstance(result[b"prefixes"], list)
+        # No redirect client configured
+        assert result[b"redirect"] == -1
+        # No broadcast prefixes in default (non-bcast) mode
+        assert result[b"prefixes"] == []
 
         await client.close()

--- a/python/tests/async_tests/test_client_side_cache.py
+++ b/python/tests/async_tests/test_client_side_cache.py
@@ -610,9 +610,10 @@ class TestClientSideCache:
         assert b"prefixes" in result
         # Tracking is on with server_assisted=True
         assert b"on" in result[b"flags"]
+        assert b"bcast" in result[b"flags"]  # server_assisted=True uses BCAST mode
         # No redirect client configured
         assert result[b"redirect"] == -1
-        # No broadcast prefixes in default (non-bcast) mode
+        # BCAST mode with no PREFIX args → empty prefixes list
         assert result[b"prefixes"] == []
 
         await client.close()

--- a/python/tests/async_tests/test_client_side_cache.py
+++ b/python/tests/async_tests/test_client_side_cache.py
@@ -599,8 +599,15 @@ class TestClientSideCache:
 
         result = await client.client_trackinginfo()
         assert isinstance(result, dict)
-        assert len(result) > 0
+        # All three top-level keys must be present
         assert b"flags" in result
+        assert b"redirect" in result
+        assert b"prefixes" in result
+        # Tracking is enabled (server_assisted=True)
         assert b"on" in result[b"flags"]
+        # redirect is an integer (-1 means no redirect)
+        assert isinstance(result[b"redirect"], int)
+        # prefixes is a list
+        assert isinstance(result[b"prefixes"], list)
 
         await client.close()

--- a/python/tests/async_tests/test_client_side_cache.py
+++ b/python/tests/async_tests/test_client_side_cache.py
@@ -569,3 +569,38 @@ class TestClientSideCache:
         # Negative should raise
         with pytest.raises(ValueError, match="entry_ttl_ms must be non-negative"):
             ClientSideCache.create(max_cache_kb=1, entry_ttl_ms=-1)
+
+    def test_server_assisted_field(self):
+        """Test that server_assisted field is set correctly on ClientSideCache."""
+        cache = ClientSideCache.create(
+            max_cache_kb=1, entry_ttl_ms=60_000, server_assisted=True
+        )
+        assert cache.server_assisted is True
+
+        cache = ClientSideCache.create(max_cache_kb=1, entry_ttl_ms=60_000)
+        assert cache.server_assisted is False
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_client_trackinginfo(self, request, protocol, cluster_mode):
+        """Test that client_trackinginfo returns a non-empty dict with expected keys."""
+        cache = ClientSideCache.create(
+            max_cache_kb=1,
+            entry_ttl_ms=60_000,
+            server_assisted=True,
+        )
+
+        client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            cache=cache,
+        )
+
+        result = await client.client_trackinginfo()
+        assert isinstance(result, dict)
+        assert len(result) > 0
+        assert b"flags" in result
+        assert b"on" in result[b"flags"]
+
+        await client.close()

--- a/python/tests/async_tests/test_client_side_cache.py
+++ b/python/tests/async_tests/test_client_side_cache.py
@@ -581,7 +581,7 @@ class TestClientSideCache:
         assert cache.server_assisted is False
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP3])
     async def test_client_trackinginfo(self, request, protocol, cluster_mode):
         """Test that client_trackinginfo returns a non-empty dict with expected keys."""
         cache = ClientSideCache.create(

--- a/python/tests/sync_tests/test_sync_client_side_cache.py
+++ b/python/tests/sync_tests/test_sync_client_side_cache.py
@@ -610,9 +610,10 @@ class TestSyncClientSideCache:
         assert b"prefixes" in result
         # Tracking is on with server_assisted=True
         assert b"on" in result[b"flags"]
+        assert b"bcast" in result[b"flags"]  # server_assisted=True uses BCAST mode
         # No redirect client configured
         assert result[b"redirect"] == -1
-        # No broadcast prefixes in default (non-bcast) mode
+        # BCAST mode with no PREFIX args → empty prefixes list
         assert result[b"prefixes"] == []
 
         client.close()

--- a/python/tests/sync_tests/test_sync_client_side_cache.py
+++ b/python/tests/sync_tests/test_sync_client_side_cache.py
@@ -581,7 +581,7 @@ class TestSyncClientSideCache:
         assert cache.server_assisted is False
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
-    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP3])
     def test_sync_client_trackinginfo(self, request, protocol, cluster_mode):
         """Test that client_trackinginfo returns a non-empty dict with expected keys."""
         cache = ClientSideCache.create(

--- a/python/tests/sync_tests/test_sync_client_side_cache.py
+++ b/python/tests/sync_tests/test_sync_client_side_cache.py
@@ -599,8 +599,15 @@ class TestSyncClientSideCache:
 
         result = client.client_trackinginfo()
         assert isinstance(result, dict)
-        assert len(result) > 0
+        # All three top-level keys must be present
         assert b"flags" in result
+        assert b"redirect" in result
+        assert b"prefixes" in result
+        # Tracking is enabled (server_assisted=True)
         assert b"on" in result[b"flags"]
+        # redirect is an integer (-1 means no redirect)
+        assert isinstance(result[b"redirect"], int)
+        # prefixes is a list
+        assert isinstance(result[b"prefixes"], list)
 
         client.close()

--- a/python/tests/sync_tests/test_sync_client_side_cache.py
+++ b/python/tests/sync_tests/test_sync_client_side_cache.py
@@ -583,7 +583,7 @@ class TestSyncClientSideCache:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP3])
     def test_sync_client_trackinginfo(self, request, protocol, cluster_mode):
-        """Test that client_trackinginfo returns a non-empty dict with expected keys."""
+        """Test that client_trackinginfo reflects active tracking state after cache use."""
         cache = ClientSideCache.create(
             max_cache_kb=1,
             entry_ttl_ms=60_000,
@@ -597,17 +597,22 @@ class TestSyncClientSideCache:
             cache=cache,
         )
 
+        # Exercise the cache: SET then GET to populate it
+        key = "trackinginfo_test_key"
+        assert client.set(key, "value") == "OK"
+        assert client.get(key) == b"value"  # cache miss, populates cache
+        assert client.get_cache_entry_count() == 1  # key is now tracked
+
         result = client.client_trackinginfo()
         assert isinstance(result, dict)
-        # All three top-level keys must be present
         assert b"flags" in result
         assert b"redirect" in result
         assert b"prefixes" in result
-        # Tracking is enabled (server_assisted=True)
+        # Tracking is on with server_assisted=True
         assert b"on" in result[b"flags"]
-        # redirect is an integer (-1 means no redirect)
-        assert isinstance(result[b"redirect"], int)
-        # prefixes is a list
-        assert isinstance(result[b"prefixes"], list)
+        # No redirect client configured
+        assert result[b"redirect"] == -1
+        # No broadcast prefixes in default (non-bcast) mode
+        assert result[b"prefixes"] == []
 
         client.close()

--- a/python/tests/sync_tests/test_sync_client_side_cache.py
+++ b/python/tests/sync_tests/test_sync_client_side_cache.py
@@ -569,3 +569,38 @@ class TestSyncClientSideCache:
         # Negative should raise
         with pytest.raises(ValueError, match="entry_ttl_ms must be non-negative"):
             ClientSideCache.create(max_cache_kb=1, entry_ttl_ms=-1)
+
+    def test_sync_server_assisted_field(self):
+        """Test that server_assisted field is set correctly on ClientSideCache."""
+        cache = ClientSideCache.create(
+            max_cache_kb=1, entry_ttl_ms=60_000, server_assisted=True
+        )
+        assert cache.server_assisted is True
+
+        cache = ClientSideCache.create(max_cache_kb=1, entry_ttl_ms=60_000)
+        assert cache.server_assisted is False
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_client_trackinginfo(self, request, protocol, cluster_mode):
+        """Test that client_trackinginfo returns a non-empty dict with expected keys."""
+        cache = ClientSideCache.create(
+            max_cache_kb=1,
+            entry_ttl_ms=60_000,
+            server_assisted=True,
+        )
+
+        client = create_sync_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            cache=cache,
+        )
+
+        result = client.client_trackinginfo()
+        assert isinstance(result, dict)
+        assert len(result) > 0
+        assert b"flags" in result
+        assert b"on" in result[b"flags"]
+
+        client.close()


### PR DESCRIPTION
### Summary

Adds server_assisted field to Python ClientSideCache config and client_trackinginfo() diagnostic command.

### Issue link

This Pull Request is linked to issue: [Implement client-side caching Phase 2: server-assisted invalidation via CLIENT TRACKING](https://github.com/valkey-io/valkey-glide/issues/5961)
Closes #5961

### Features / Behaviour Changes

- server_assisted: bool = False field in ClientSideCache dataclass - enables server-assisted invalidation when True
- client_trackinginfo() on CoreCommands base class (async + sync) - available on both standalone and cluster clients
- client_trackinginfo(route=...) cluster override in cluster_commands.py for routing to specific nodes
- client_trackinginfo() in BaseBatch

### Implementation

- cache.py: added server_assisted field to ClientSideCache dataclass
- config.py: serializes server_assisted to protobuf in _set_client_side_cache_in_request()
- core.py: client_trackinginfo() on CoreCommands base (no route) - routes to a single node, consistent with CLIENT INFO behavior
- cluster_commands.py: cluster override with optional route parameter - use AllNodes() to get tracking info from all cluster connections

### Limitations

- server_assisted=True requires RESP3 protocol (enforced by glide-core)
- In cluster mode, the no-arg variant routes to a single random node; use the route parameter to query all nodes

### Testing

- Unit test verifying server_assisted field defaults and construction
- Integration tests are in the glide-core PR #5962

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and Prettier has been run.
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.