### PR TITLE
Node.js: Phase 2 client-side caching - serverAssisted field and clientTrackingInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * CORE: Phase 2 client-side caching - server-assisted invalidation via CLIENT TRACKING ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
+* Node.js: Phase 2 client-side caching - `serverAssisted` field and `clientTrackingInfo` command ([#5964](https://github.com/valkey-io/valkey-glide/pull/5964))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
 

--- a/glide-core/redis-rs/redis/src/cache/glide_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/glide_cache.rs
@@ -647,6 +647,7 @@ impl<S: EvictionStrategy + 'static> GlideCache for GlideCacheImpl<S> {
             if let Some(stats) = self.core.stats() {
                 stats.record_invalidation();
             }
+        }
         debug!(
             "cache_flush_all - [{}] Flushed all entries",
             store.policy_name()

--- a/glide-core/redis-rs/redis/src/cache/glide_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/glide_cache.rs
@@ -647,7 +647,6 @@ impl<S: EvictionStrategy + 'static> GlideCache for GlideCacheImpl<S> {
             if let Some(stats) = self.core.stats() {
                 stats.record_invalidation();
             }
-        }
         debug!(
             "cache_flush_all - [{}] Flushed all entries",
             store.policy_name()

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -99,6 +99,7 @@ import {
     createBitField,
     createBitOp,
     createBitPos,
+    createClientTrackingInfo,
     createCopy,
     createDecr,
     createDecrBy,
@@ -9320,6 +9321,17 @@ export class BaseClient {
     }
 
     /**
+     * Returns information about the current client connection's tracking state.
+     *
+     * @see {@link https://valkey.io/commands/client-trackinginfo/|valkey.io} for details.
+     *
+     * @returns A map of tracking info.
+     */
+    public async clientTrackingInfo(): Promise<Record<string, unknown>> {
+        return this.createWritePromise(createClientTrackingInfo());
+    }
+
+    /**
      * @internal
      */
     protected createClientRequest(
@@ -9402,6 +9414,7 @@ export class BaseClient {
                 entryTtlMs: cache.entryTtlMs,
                 evictionPolicy: cache.evictionPolicy,
                 enableMetrics: cache.enableMetrics,
+                serverAssisted: cache.serverAssisted,
             });
         }
 

--- a/node/src/Batch.ts
+++ b/node/src/Batch.ts
@@ -89,6 +89,7 @@ import {
     createBitPos,
     createClientGetName,
     createClientId,
+    createClientTrackingInfo,
     createConfigGet,
     createConfigResetStat,
     createConfigRewrite,
@@ -556,6 +557,15 @@ export class BaseBatch<T extends BaseBatch<T>> {
      */
     public clientGetName(): T {
         return this.addAndReturn(createClientGetName());
+    }
+
+    /** Returns information about the current client connection's tracking state.
+     * @see {@link https://valkey.io/commands/client-trackinginfo/|valkey.io} for details.
+     *
+     * Command Response - A map of tracking info.
+     */
+    public clientTrackingInfo(): T {
+        return this.addAndReturn(createClientTrackingInfo());
     }
 
     /**

--- a/node/src/ClientSideCache.ts
+++ b/node/src/ClientSideCache.ts
@@ -33,6 +33,12 @@ export interface ClientSideCacheConfig {
      * Defaults to false if not specified.
      */
     enableMetrics?: boolean;
+
+    /**
+     * Whether to use server-assisted (invalidation-based) caching mode.
+     * Defaults to false if not specified.
+     */
+    serverAssisted?: boolean;
 }
 
 /**
@@ -48,6 +54,11 @@ export interface ClientSideCacheOptions {
      * Whether to enable metrics collection for this cache.
      */
     enableMetrics?: boolean;
+
+    /**
+     * Whether to use server-assisted (invalidation-based) caching mode.
+     */
+    serverAssisted?: boolean;
 }
 
 /**
@@ -100,6 +111,11 @@ export class ClientSideCache {
     readonly enableMetrics: boolean;
 
     /**
+     * Whether server-assisted caching mode is enabled.
+     */
+    readonly serverAssisted: boolean;
+
+    /**
      * Creates a new ClientSideCache instance.
      *
      * @param config - Configuration options for the cache
@@ -122,6 +138,7 @@ export class ClientSideCache {
         this.entryTtlMs = config.entryTtlMs;
         this.evictionPolicy = config.evictionPolicy;
         this.enableMetrics = config.enableMetrics ?? false;
+        this.serverAssisted = config.serverAssisted ?? false;
     }
 
     /**
@@ -156,6 +173,7 @@ export class ClientSideCache {
             entryTtlMs,
             evictionPolicy: options?.evictionPolicy,
             enableMetrics: options?.enableMetrics,
+            serverAssisted: options?.serverAssisted,
         });
     }
 }

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -431,6 +431,13 @@ export function createClientId(): command_request.Command {
 /**
  * @internal
  */
+export function createClientTrackingInfo(): command_request.Command {
+    return createCommand(RequestType.ClientTrackingInfo, []);
+}
+
+/**
+ * @internal
+ */
 export function createConfigGet(parameters: string[]): command_request.Command {
     return createCommand(RequestType.ConfigGet, parameters);
 }

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -34,6 +34,7 @@ import {
     LolwutOptions,
     createClientGetName,
     createClientId,
+    createClientTrackingInfo,
     createConfigGet,
     createConfigResetStat,
     createConfigRewrite,
@@ -1061,6 +1062,26 @@ export class GlideClusterClient extends BaseClient {
             createClientGetName(),
             options,
         ).then((res) => convertClusterGlideRecord(res, true, options?.route));
+    }
+
+    /**
+     * Returns information about the current client connection's tracking state.
+     *
+     * @see {@link https://valkey.io/commands/client-trackinginfo/|valkey.io} for details.
+     *
+     * @param options - (Optional) See {@link RouteOption}.
+     *
+     * @returns A map of tracking info. When specifying a route other than a single node,
+     *     it returns a dictionary where each address is the key and its corresponding node response is the value.
+     */
+    public async clientTrackingInfo(
+        options?: RouteOption,
+    ): Promise<ClusterResponse<Record<string, unknown>>> {
+        return this.createWritePromise<
+            ClusterGlideRecord<Record<string, unknown>>
+        >(createClientTrackingInfo(), options).then((res) =>
+            convertClusterGlideRecord(res, true, options?.route),
+        );
     }
 
     /**

--- a/node/tests/ClientSideCache.test.ts
+++ b/node/tests/ClientSideCache.test.ts
@@ -693,6 +693,26 @@ describe("ClientSideCache", () => {
                     },
                     TIMEOUT,
                 );
+
+                it(
+                    "test clientTrackingInfo returns tracking enabled",
+                    async () => {
+                        const cache = ClientSideCache.create(1, 60000, {
+                            serverAssisted: true,
+                        });
+
+                        client = await createStandaloneClientWithCache(
+                            protocol,
+                            cache,
+                        );
+
+                        const info = await client.clientTrackingInfo();
+                        expect(typeof info).toBe("object");
+                        expect(info).toHaveProperty("flags");
+                        expect(info["flags"]).toContain("on");
+                    },
+                    TIMEOUT,
+                );
             },
         );
     });
@@ -1333,6 +1353,30 @@ describe("ClientSideCache", () => {
                         expect(entryCount).toBe(3);
 
                         await client.flushall();
+                    },
+                    TIMEOUT,
+                );
+
+                it(
+                    "test clientTrackingInfo returns tracking enabled",
+                    async () => {
+                        const cache = ClientSideCache.create(1, 60000, {
+                            serverAssisted: true,
+                        });
+
+                        client = await createClusterClientWithCache(
+                            protocol,
+                            cache,
+                        );
+
+                        const info =
+                            (await client.clientTrackingInfo()) as Record<
+                                string,
+                                unknown
+                            >;
+                        expect(typeof info).toBe("object");
+                        expect(info).toHaveProperty("flags");
+                        expect(info["flags"]).toContain("on");
                     },
                     TIMEOUT,
                 );

--- a/node/tests/ClientSideCache.test.ts
+++ b/node/tests/ClientSideCache.test.ts
@@ -29,6 +29,21 @@ const TIMEOUT = 50000;
 const CLEANUP_TIMEOUT = 10000;
 
 describe("ClientSideCache", () => {
+    it("ClientSideCache with serverAssisted", () => {
+        const cache = new ClientSideCache({
+            maxCacheKb: 1024,
+            entryTtlMs: 0,
+            serverAssisted: true,
+        });
+        expect(cache.serverAssisted).toBe(true);
+
+        const cacheDefault = new ClientSideCache({
+            maxCacheKb: 1024,
+            entryTtlMs: 0,
+        });
+        expect(cacheDefault.serverAssisted).toBe(false);
+    });
+
     let standaloneCluster: ValkeyCluster;
     let clusterCluster: ValkeyCluster;
 


### PR DESCRIPTION
### Summary

Adds serverAssisted field to Node.js ClientSideCache config and clientTrackingInfo() diagnostic command.

### Issue link

This Pull Request is linked to issue: [Implement client-side caching Phase 2: server-assisted invalidation via CLIENT TRACKING](https://github.com/valkey-io/valkey-glide/issues/5961)
Closes #5961

### Features / Behaviour Changes

- serverAssisted?: boolean in ClientSideCacheConfig interface and ClientSideCache class (default false)
- clientTrackingInfo() on BaseClient - available on both GlideClient and GlideClusterClient
- clientTrackingInfo(options?: RouteOption) cluster override on GlideClusterClient for routing to specific nodes
- clientTrackingInfo() in BaseBatch

### Implementation

- ClientSideCache.ts: serverAssisted field added to config interface and class; serialized to protobuf
- BaseClient.ts: clientTrackingInfo() - routes to a single node, consistent with CLIENT INFO behavior
- GlideClusterClient.ts: cluster override with optional RouteOption - use AllNodes to get tracking info from all cluster connections
- Batch.ts: batch method

### Limitations

- serverAssisted: true requires RESP3 protocol (enforced by glide-core)
- In cluster mode, the no-arg variant routes to a single random node; use RouteOption to query all nodes

### Testing

- Unit test verifying serverAssisted field defaults and construction
- Integration tests are in the glide-core PR #5962

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and Prettier has been run.
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.