### PR TITLE
Go: Phase 2 client-side caching - ServerAssisted field and ClientTrackingInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
+* Go: Phase 2 client-side caching - `ServerAssisted` field and `ClientTrackingInfo` command ([#5966](https://github.com/valkey-io/valkey-glide/pull/5966))
 
 ## 2.4
 

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -10867,3 +10867,24 @@ func (client *baseClient) AclWhoAmI(ctx context.Context) (string, error) {
 	}
 	return handleStringResponse(result)
 }
+
+// ClientTrackingInfo returns information about the current client connection's tracking state.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A map of tracking info.
+//
+// [valkey.io]: https://valkey.io/commands/client-trackinginfo/
+func (client *baseClient) ClientTrackingInfo(ctx context.Context) (map[string]interface{}, error) {
+	result, err := client.executeCommand(ctx, C.ClientTrackingInfo, []string{})
+	if err != nil {
+		return nil, err
+	}
+	return handleStringToAnyMapResponse(result)
+}

--- a/go/config/ClientSideCache.go
+++ b/go/config/ClientSideCache.go
@@ -42,10 +42,9 @@ func (e EvictionPolicy) String() string {
 // removed after a specified duration.
 //
 // Important:
-//   - Glide currently supports TTL-based caching only. Invalidation-based
-//     client-side caching (where the server notifies clients of key changes) is not
-//     currently supported. This means cached values may become stale if updated on
-//     the server before the TTL expires.
+//   - Supports both TTL-based expiration and server-assisted invalidation via CLIENT TRACKING
+//     (when ServerAssisted is true). When server-assisted invalidation is not enabled, cached
+//     values may become stale if updated on the server before the TTL expires.
 //   - Currently, Glide's client-side cache supports lazy eviction only. Expired entries
 //     are removed only when accessed after their TTL has expired. There is no proactive
 //     background cleanup of expired entries.
@@ -73,6 +72,10 @@ type ClientSideCache struct {
 
 	// EnableMetrics enables collection of cache metrics such as hit/miss rates.
 	EnableMetrics bool
+
+	// ServerAssisted enables server-assisted client-side caching, where the server
+	// sends invalidation messages to the client when cached keys are modified.
+	ServerAssisted bool
 }
 
 // NewClientSideCache creates a new ClientSideCache configuration with an auto-generated unique ID.
@@ -83,10 +86,9 @@ type ClientSideCache struct {
 // removed after a specified duration.
 //
 // Important:
-//   - Glide currently supports TTL-based caching only. Invalidation-based
-//     client-side caching (where the server notifies clients of key changes) is not
-//     currently supported. This means cached values may become stale if updated on
-//     the server before the TTL expires.
+//   - Supports both TTL-based expiration and server-assisted invalidation via CLIENT TRACKING
+//     (when ServerAssisted is true). When server-assisted invalidation is not enabled, cached
+//     values may become stale if updated on the server before the TTL expires.
 //   - Currently, Glide's client-side cache supports lazy eviction only. Expired entries
 //     are removed only when accessed after their TTL has expired. There is no proactive
 //     background cleanup of expired entries.
@@ -142,15 +144,23 @@ func (c *ClientSideCache) WithMetrics(enable bool) *ClientSideCache {
 	return c
 }
 
+// WithServerAssisted enables or disables server-assisted client-side caching.
+// Returns the same ClientSideCache instance for method chaining.
+func (c *ClientSideCache) WithServerAssisted(enabled bool) *ClientSideCache {
+	c.ServerAssisted = enabled
+	return c
+}
+
 // toProtobuf converts the ClientSideCache configuration to protobuf format.
 // This method is used internally to serialize the cache configuration for
 // communication with the Rust core.
 func (c *ClientSideCache) toProtobuf() *protobuf.ClientSideCache {
 	protoCache := &protobuf.ClientSideCache{
-		CacheId:       c.cacheId,
-		MaxCacheKb:    c.MaxCacheKb,
-		EntryTtlMs:    c.EntryTtlMs,
-		EnableMetrics: c.EnableMetrics,
+		CacheId:        c.cacheId,
+		MaxCacheKb:     c.MaxCacheKb,
+		EntryTtlMs:     c.EntryTtlMs,
+		EnableMetrics:  c.EnableMetrics,
+		ServerAssisted: c.ServerAssisted,
 	}
 
 	if c.EvictionPolicy != nil {

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -1462,3 +1462,18 @@ func TestClusterConfig_PeriodicChecks_ManualInterval(t *testing.T) {
 	assert.True(t, ok, "expected PeriodicChecksManualInterval protobuf type")
 	assert.Equal(t, uint32(30), manual.PeriodicChecksManualInterval.DurationInSec)
 }
+
+func TestClientSideCacheServerAssisted(t *testing.T) {
+	cache, err := NewClientSideCache(1024, 0)
+	if err != nil {
+		t.Fatalf("Failed to create ClientSideCache: %v", err)
+	}
+	cache = cache.WithServerAssisted(true)
+	assert.True(t, cache.ServerAssisted)
+
+	cacheDefault, err := NewClientSideCache(1024, 0)
+	if err != nil {
+		t.Fatalf("Failed to create ClientSideCache: %v", err)
+	}
+	assert.False(t, cacheDefault.ServerAssisted)
+}

--- a/go/connection_management_cluster_commands_test.go
+++ b/go/connection_management_cluster_commands_test.go
@@ -138,3 +138,27 @@ func ExampleClusterClient_ClientGetNameWithOptions() {
 
 	// Output: true
 }
+
+func ExampleClusterClient_ClientTrackingInfo() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.ClientTrackingInfo(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	_, ok := result["flags"]
+	fmt.Println(ok)
+
+	// Output: true
+}
+
+func ExampleClusterClient_ClientTrackingInfoWithOptions() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	opts := options.RouteOption{Route: nil}
+	result, err := client.ClientTrackingInfoWithOptions(context.Background(), opts)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	fmt.Println(result.IsSingleValue())
+
+	// Output: true
+}

--- a/go/connection_management_commands_test.go
+++ b/go/connection_management_commands_test.go
@@ -80,3 +80,15 @@ func ExampleClient_ClientGetName() {
 
 	// Output: true
 }
+
+func ExampleClient_ClientTrackingInfo() {
+	var client *Client = getExampleClient() // example helper function
+	result, err := client.ClientTrackingInfo(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+	}
+	_, ok := result["flags"]
+	fmt.Println(ok)
+
+	// Output: true
+}

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -1297,6 +1297,8 @@ func (client *ClusterClient) ClientGetNameWithOptions(
 
 // Returns information about the current client connection's tracking state.
 //
+// See [valkey.io] for details.
+//
 // Parameters:
 //
 //	ctx - The context for controlling the command execution.

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -1295,6 +1295,40 @@ func (client *ClusterClient) ClientGetNameWithOptions(
 	return models.CreateClusterSingleValue[models.Result[string]](data), nil
 }
 
+// Returns information about the current client connection's tracking state.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command.
+//
+// Return value:
+//
+//	A ClusterValue containing the tracking info map.
+//
+// [valkey.io]: https://valkey.io/commands/client-trackinginfo/
+func (client *ClusterClient) ClientTrackingInfoWithOptions(
+	ctx context.Context,
+	opts options.RouteOption,
+) (models.ClusterValue[map[string]interface{}], error) {
+	response, err := client.executeCommandWithRoute(ctx, C.ClientTrackingInfo, []string{}, opts.Route)
+	if err != nil {
+		return models.CreateEmptyClusterValue[map[string]interface{}](), err
+	}
+	if opts.Route != nil && (opts.Route).IsMultiNode() {
+		data, err := handleMapOfStringAnyMapResponse(response)
+		if err != nil {
+			return models.CreateEmptyClusterValue[map[string]interface{}](), err
+		}
+		return models.CreateClusterMultiValue[map[string]interface{}](data), nil
+	}
+	data, err := handleStringToAnyMapResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[map[string]interface{}](), err
+	}
+	return models.CreateClusterSingleValue[map[string]interface{}](data), nil
+}
+
 // Rewrites the configuration file with the current configuration.
 // The command will be routed a random node.
 //

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -715,6 +715,9 @@ func CreateConnectionManagementTests(batch *pipeline.ClusterBatch, isAtomic bool
 	batch.ClientGetName()
 	testData = append(testData, CommandTestData{ExpectedResponse: connectionName, TestName: "ClientGetName()"})
 
+	batch.ClientTrackingInfo()
+	testData = append(testData, CommandTestData{ExpectedResponse: map[string]interface{}{}, CheckTypeOnly: true, TestName: "ClientTrackingInfo()"})
+
 	return BatchTestData{CommandTestData: testData, TestName: "Connection Management commands"}
 }
 

--- a/go/integTest/batch_test.go
+++ b/go/integTest/batch_test.go
@@ -716,7 +716,11 @@ func CreateConnectionManagementTests(batch *pipeline.ClusterBatch, isAtomic bool
 	testData = append(testData, CommandTestData{ExpectedResponse: connectionName, TestName: "ClientGetName()"})
 
 	batch.ClientTrackingInfo()
-	testData = append(testData, CommandTestData{ExpectedResponse: map[string]interface{}{}, CheckTypeOnly: true, TestName: "ClientTrackingInfo()"})
+	testData = append(testData, CommandTestData{
+		ExpectedResponse: map[string]interface{}{},
+		CheckTypeOnly:    true,
+		TestName:         "ClientTrackingInfo()",
+	})
 
 	return BatchTestData{CommandTestData: testData, TestName: "Connection Management commands"}
 }

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -3266,3 +3266,37 @@ func (suite *GlideTestSuite) TestClusterLinks() {
 	assert.NoError(t, err)
 	assert.NotNil(t, clusterResult.SingleValue())
 }
+
+func (suite *GlideTestSuite) TestClusterClientTrackingInfo() {
+	cache, err := config.NewClientSideCache(1024, 0)
+	require.NoError(suite.T(), err)
+	cache = cache.WithServerAssisted(true)
+	clientConfig := suite.defaultClusterClientConfig().WithClientSideCache(cache)
+	client, err := suite.clusterClient(clientConfig)
+	require.NoError(suite.T(), err)
+	t := suite.T()
+
+	result, err := client.ClientTrackingInfo(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	_, exists := result["flags"]
+	assert.True(t, exists)
+}
+
+func (suite *GlideTestSuite) TestClusterClientTrackingInfoWithOptions() {
+	cache, err := config.NewClientSideCache(1024, 0)
+	require.NoError(suite.T(), err)
+	cache = cache.WithServerAssisted(true)
+	clientConfig := suite.defaultClusterClientConfig().WithClientSideCache(cache)
+	client, err := suite.clusterClient(clientConfig)
+	require.NoError(suite.T(), err)
+	t := suite.T()
+
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.ClientTrackingInfoWithOptions(context.Background(), opts)
+	assert.NoError(t, err)
+	assert.True(t, result.IsSingleValue())
+	assert.NotNil(t, result.SingleValue())
+	_, exists := result.SingleValue()["flags"]
+	assert.True(t, exists)
+}

--- a/go/integTest/standalone_commands_test.go
+++ b/go/integTest/standalone_commands_test.go
@@ -1384,3 +1384,19 @@ func (suite *GlideTestSuite) TestScriptKill() {
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 }
+
+func (suite *GlideTestSuite) TestClientTrackingInfo() {
+	cache, err := config.NewClientSideCache(1024, 0)
+	require.NoError(suite.T(), err)
+	cache = cache.WithServerAssisted(true)
+	clientConfig := suite.defaultClientConfig().WithClientSideCache(cache)
+	client, err := suite.client(clientConfig)
+	require.NoError(suite.T(), err)
+	t := suite.T()
+
+	result, err := client.ClientTrackingInfo(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	_, exists := result["flags"]
+	assert.True(t, exists)
+}

--- a/go/interfaces/connection_management_cluster_commands.go
+++ b/go/interfaces/connection_management_cluster_commands.go
@@ -41,4 +41,9 @@ type ConnectionManagementClusterCommands interface {
 		ctx context.Context,
 		routeOptions options.RouteOption,
 	) (models.ClusterValue[models.Result[string]], error)
+
+	ClientTrackingInfoWithOptions(
+		ctx context.Context,
+		opts options.RouteOption,
+	) (models.ClusterValue[map[string]interface{}], error)
 }

--- a/go/interfaces/generic_base_commands.go
+++ b/go/interfaces/generic_base_commands.go
@@ -130,4 +130,6 @@ type GenericBaseCommands interface {
 	UpdateConnectionPassword(ctx context.Context, password string, immediateAuth bool) (string, error)
 
 	ResetConnectionPassword(ctx context.Context) (string, error)
+
+	ClientTrackingInfo(ctx context.Context) (map[string]interface{}, error)
 }

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -7307,6 +7307,19 @@ func (b *BaseBatch[T]) ClientGetName() *T {
 	return b.addCmdAndTypeChecker(C.ClientGetName, []string{}, reflect.String, true)
 }
 
+// Returns information about the current client connection's tracking state.
+//
+// See [valkey.io] for details.
+//
+// Command Response:
+//
+//	A map of tracking info.
+//
+// [valkey.io]: https://valkey.io/commands/client-trackinginfo/
+func (b *BaseBatch[T]) ClientTrackingInfo() *T {
+	return b.addCmdAndTypeChecker(C.ClientTrackingInfo, []string{}, reflect.Map, false)
+}
+
 // Sets the name of the current connection.
 //
 // See [valkey.io] for details.

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -1330,7 +1330,11 @@ func handleStringToAnyMapResponse(response *C.struct_CommandResponse) (map[strin
 	if err != nil {
 		return nil, err
 	}
-	return result.(map[string]any), nil
+	m, ok := result.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type received: %T", result)
+	}
+	return m, nil
 }
 
 func handleLCSMatchResponse(

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -1412,6 +1412,33 @@ func handleRawStringArrayMapResponse(response *C.struct_CommandResponse) (map[st
 	return mapResult, nil
 }
 
+func handleMapOfStringAnyMapResponse(response *C.struct_CommandResponse) (map[string]map[string]any, error) {
+	defer C.free_command_response(response)
+	typeErr := checkResponseType(response, C.Map, false)
+	if typeErr != nil {
+		return nil, typeErr
+	}
+
+	data, err := parseMap(response)
+	if err != nil {
+		return nil, err
+	}
+
+	outer, ok := data.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type received: %T", data)
+	}
+	result := make(map[string]map[string]any, len(outer))
+	for k, v := range outer {
+		inner, ok := v.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected value type for key %s: %T", k, v)
+		}
+		result[k] = inner
+	}
+	return result, nil
+}
+
 func handleMapOfStringMapResponse(response *C.struct_CommandResponse) (map[string]map[string]string, error) {
 	defer C.free_command_response(response)
 	typeErr := checkResponseType(response, C.Map, false)


### PR DESCRIPTION
### Summary

Adds ServerAssisted field to Go ClientSideCache config and ClientTrackingInfo() diagnostic command.

### Issue link

This Pull Request is linked to issue: [Implement client-side caching Phase 2: server-assisted invalidation via CLIENT TRACKING](https://github.com/valkey-io/valkey-glide/issues/5961)
Closes #5961

### Features / Behaviour Changes

- ServerAssisted bool field + WithServerAssisted() fluent builder in ClientSideCache
- ClientTrackingInfo() on baseClient - available on both Client and ClusterClient
- ClientTrackingInfoWithOptions() cluster override on ClusterClient for routing to specific nodes
- ClientTrackingInfo() in BaseBatch

### Implementation

- config/ClientSideCache.go: ServerAssisted field, WithServerAssisted() builder, serialized in toProtobuf()
- base_client.go: ClientTrackingInfo() - routes to a single node, consistent with CLIENT INFO behavior
- glide_cluster_client.go: ClientTrackingInfoWithOptions() with RouteOptions - use AllNodes to get tracking info from all cluster connections
- response_handlers.go: handleMapOfStringAnyMapResponse for multi-node cluster response

### Limitations

- ServerAssisted: true requires RESP3 protocol (enforced by glide-core)
- In cluster mode, the no-arg variant routes to a single random node; use RouteOptions to query all nodes

### Testing

- Unit test verifying ServerAssisted field defaults and construction
- Integration tests are in the glide-core PR #5962

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and Prettier has been run.
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.