### PR TITLE
Go: Add MEMORY DOCTOR / MEMORY MALLOC-STATS / MEMORY PURGE / MEMORY STATS commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Go: Add `MIGRATE` command support ([#5935](https://github.com/valkey-io/valkey-glide/pull/5935))
 * Core: Avoid panic on cluster `SCAN` when a read-from-replica AZ affinity strategy is configured. The slot map carries no AZ metadata, so these strategies now fall back to their documented round-robin behavior (replicas for `AZAffinity`, replicas plus primary for `AZAffinityReplicasAndPrimary`) instead of hitting `todo!()` ([#5909](https://github.com/valkey-io/valkey-glide/issues/5909))
 * FFI: Add `client_side_cache` configuration to the URI-based client creation API (`create_client_from_uri`) — supports `max_cache_kb`, `entry_ttl_ms`, `eviction_policy` (LRU/LFU), and `enable_metrics` via JSON options; `cache_id` is auto-generated internally ([#5860](https://github.com/valkey-io/valkey-glide/pull/5860))
+* Go: Add MEMORY server management commands (MEMORY DOCTOR, MEMORY MALLOC-STATS, MEMORY PURGE, MEMORY STATS) with full cluster routing support ([#5957](https://github.com/valkey-io/valkey-glide/issues/5957))
 
 ## 2.4
 
@@ -60,7 +61,6 @@
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 * Java: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 * Python: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
-* Go: Add MEMORY server management commands (MEMORY DOCTOR, MEMORY MALLOC-STATS, MEMORY PURGE, MEMORY STATS) with full cluster routing support ([#5957](https://github.com/valkey-io/valkey-glide/issues/5957))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * Node: Client-Side Caching Support ([#5720](https://github.com/valkey-io/valkey-glide/pull/5720))
 * Java: Support custom socket address resolution when connecting to valkey ([#4396](https://github.com/valkey-io/valkey-glide/issues/4396))
 * Python: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
+* Go: Add MEMORY server management commands (MEMORY DOCTOR, MEMORY MALLOC-STATS, MEMORY PURGE, MEMORY STATS) with full cluster routing support ([#5957](https://github.com/valkey-io/valkey-glide/issues/5957))
 
 ### Fixes
 

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -574,6 +574,93 @@ func (client *Client) ConfigResetStat(ctx context.Context) (string, error) {
 	return handleOkResponse(response)
 }
 
+// Provides memory usage diagnosis report.
+// The command returns a detailed analysis of memory consumption patterns in the server.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A string containing the memory usage analysis report.
+//
+// [valkey.io]: https://valkey.io/commands/memory-doctor/
+func (client *Client) MemoryDoctor(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.MemoryDoctor, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(response)
+}
+
+// Returns memory allocator internal statistics.
+// The output of this command is specific to the allocator being used.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A string containing the memory allocator statistics.
+//
+// [valkey.io]: https://valkey.io/commands/memory-malloc-stats/
+func (client *Client) MemoryMallocStats(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.MemoryMallocStats, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(response)
+}
+
+// Attempts to purge dirty pages for reclamation by the allocator.
+// This command can help reduce memory fragmentation.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	OK to confirm that the purge operation was executed.
+//
+// [valkey.io]: https://valkey.io/commands/memory-purge/
+func (client *Client) MemoryPurge(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.MemoryPurge, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
+// Returns memory usage statistics for the server.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A map containing memory usage statistics with metric names as keys and values as their corresponding data.
+//
+// [valkey.io]: https://valkey.io/commands/memory-stats/
+func (client *Client) MemoryStats(ctx context.Context) (map[string]any, error) {
+	response, err := client.executeCommand(ctx, C.MemoryStats, []string{})
+	if err != nil {
+		return nil, err
+	}
+	return handleStringToAnyMapResponse(response)
+}
+
 // Gets the name of the current connection.
 //
 // See [valkey.io] for details.

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -1058,6 +1058,267 @@ func (client *ClusterClient) ConfigResetStatWithOptions(ctx context.Context, opt
 	return handleOkResponse(response)
 }
 
+// Provides memory usage diagnosis report.
+// The command returns a detailed analysis of memory consumption patterns in the server.
+// Routes to all primary nodes by default.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A ClusterValue containing memory usage analysis report(s).
+//	When multiple nodes are queried, returns a map of node addresses to their reports.
+//
+// [valkey.io]: https://valkey.io/commands/memory-doctor/
+func (client *ClusterClient) MemoryDoctor(ctx context.Context) (models.ClusterValue[string], error) {
+	response, err := client.executeCommand(ctx, C.MemoryDoctor, []string{})
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	data, err := handleStringToStringMapResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	return models.CreateClusterMultiValue[string](data), nil
+}
+
+// Provides memory usage diagnosis report with routing configuration.
+// The command returns a detailed analysis of memory consumption patterns in the server.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command. The client will route the
+//	        command to the nodes defined by route.
+//
+// Return value:
+//
+//	A ClusterValue containing memory usage analysis report(s).
+//	Returns a single value when routing to one node, or a map when routing to multiple nodes.
+//
+// [valkey.io]: https://valkey.io/commands/memory-doctor/
+func (client *ClusterClient) MemoryDoctorWithOptions(
+	ctx context.Context,
+	opts options.RouteOption,
+) (models.ClusterValue[string], error) {
+	if opts.Route == nil {
+		return client.MemoryDoctor(ctx)
+	}
+	response, err := client.executeCommandWithRoute(ctx, C.MemoryDoctor, []string{}, opts.Route)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+
+	if opts.Route.IsMultiNode() {
+		data, err := handleStringToStringMapResponse(response)
+		if err != nil {
+			return models.CreateEmptyClusterValue[string](), err
+		}
+		return models.CreateClusterMultiValue[string](data), nil
+	}
+
+	data, err := handleStringResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	return models.CreateClusterSingleValue[string](data), nil
+}
+
+// Returns memory allocator internal statistics.
+// The output of this command is specific to the allocator being used.
+// Routes to all primary nodes by default.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A ClusterValue containing memory allocator statistics.
+//	When multiple nodes are queried, returns a map of node addresses to their statistics.
+//
+// [valkey.io]: https://valkey.io/commands/memory-malloc-stats/
+func (client *ClusterClient) MemoryMallocStats(ctx context.Context) (models.ClusterValue[string], error) {
+	response, err := client.executeCommand(ctx, C.MemoryMallocStats, []string{})
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	data, err := handleStringToStringMapResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	return models.CreateClusterMultiValue[string](data), nil
+}
+
+// Returns memory allocator internal statistics with routing configuration.
+// The output of this command is specific to the allocator being used.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command. The client will route the
+//	        command to the nodes defined by route.
+//
+// Return value:
+//
+//	A ClusterValue containing memory allocator statistics.
+//	Returns a single value when routing to one node, or a map when routing to multiple nodes.
+//
+// [valkey.io]: https://valkey.io/commands/memory-malloc-stats/
+func (client *ClusterClient) MemoryMallocStatsWithOptions(
+	ctx context.Context,
+	opts options.RouteOption,
+) (models.ClusterValue[string], error) {
+	if opts.Route == nil {
+		return client.MemoryMallocStats(ctx)
+	}
+	response, err := client.executeCommandWithRoute(ctx, C.MemoryMallocStats, []string{}, opts.Route)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+
+	if opts.Route.IsMultiNode() {
+		data, err := handleStringToStringMapResponse(response)
+		if err != nil {
+			return models.CreateEmptyClusterValue[string](), err
+		}
+		return models.CreateClusterMultiValue[string](data), nil
+	}
+
+	data, err := handleStringResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	return models.CreateClusterSingleValue[string](data), nil
+}
+
+// Attempts to purge dirty pages for reclamation by the allocator.
+// This command can help reduce memory fragmentation.
+// The command will be routed to all nodes.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	OK to confirm that the purge operation was executed.
+//
+// [valkey.io]: https://valkey.io/commands/memory-purge/
+func (client *ClusterClient) MemoryPurge(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.MemoryPurge, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
+// Attempts to purge dirty pages for reclamation by the allocator.
+// This command can help reduce memory fragmentation.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command. The client will route the
+//	        command to the nodes defined by route.
+//
+// Return value:
+//
+//	OK to confirm that the purge operation was executed.
+//
+// [valkey.io]: https://valkey.io/commands/memory-purge/
+func (client *ClusterClient) MemoryPurgeWithOptions(ctx context.Context, opts options.RouteOption) (string, error) {
+	response, err := client.executeCommandWithRoute(ctx, C.MemoryPurge, []string{}, opts.Route)
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
+// Returns memory usage statistics for the server.
+// Routes to all primary nodes by default.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A ClusterValue containing memory usage statistics.
+//	When multiple nodes are queried, returns a map of node addresses to their stats maps.
+//
+// [valkey.io]: https://valkey.io/commands/memory-stats/
+func (client *ClusterClient) MemoryStats(ctx context.Context) (models.ClusterValue[map[string]any], error) {
+	response, err := client.executeCommand(ctx, C.MemoryStats, []string{})
+	if err != nil {
+		return models.CreateEmptyClusterValue[map[string]any](), err
+	}
+	data, err := handleStringToStringAnyMapMapResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[map[string]any](), err
+	}
+	return models.CreateClusterMultiValue[map[string]any](data), nil
+}
+
+// Returns memory usage statistics for the server with routing configuration.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command. The client will route the
+//	        command to the nodes defined by route.
+//
+// Return value:
+//
+//	A ClusterValue containing memory usage statistics.
+//	Returns a single stats map when routing to one node, or a map of nodes when routing to multiple.
+//
+// [valkey.io]: https://valkey.io/commands/memory-stats/
+func (client *ClusterClient) MemoryStatsWithOptions(
+	ctx context.Context,
+	opts options.RouteOption,
+) (models.ClusterValue[map[string]any], error) {
+	if opts.Route == nil {
+		return client.MemoryStats(ctx)
+	}
+	response, err := client.executeCommandWithRoute(ctx, C.MemoryStats, []string{}, opts.Route)
+	if err != nil {
+		return models.CreateEmptyClusterValue[map[string]any](), err
+	}
+
+	if opts.Route.IsMultiNode() {
+		data, err := handleStringToStringAnyMapMapResponse(response)
+		if err != nil {
+			return models.CreateEmptyClusterValue[map[string]any](), err
+		}
+		return models.CreateClusterMultiValue[map[string]any](data), nil
+	}
+
+	data, err := handleStringToAnyMapResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[map[string]any](), err
+	}
+	return models.CreateClusterSingleValue[map[string]any](data), nil
+}
+
 // Sets configuration parameters to the specified values.
 // Starting from server version 7, command supports multiple parameters.
 // The command will be sent to all nodes.

--- a/go/integTest/memory_commands_test.go
+++ b/go/integTest/memory_commands_test.go
@@ -4,6 +4,7 @@ package integTest
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/stretchr/testify/assert"
@@ -146,7 +147,7 @@ func (suite *GlideTestSuite) TestMemoryStats_StandaloneWithDataOperations() {
 	assert.NoError(t, err)
 
 	for i := 0; i < 100; i++ {
-		key := "memory_test_key_" + string(rune(i))
+		key := fmt.Sprintf("memory_test_key_%d", i)
 		value := strings.Repeat("x", 1000)
 		_, err := client.Set(context.Background(), key, value)
 		assert.NoError(t, err)

--- a/go/integTest/memory_commands_test.go
+++ b/go/integTest/memory_commands_test.go
@@ -1,0 +1,316 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/options"
+)
+
+// Standalone Client Tests
+
+func (suite *GlideTestSuite) TestMemoryDoctor_Standalone() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryDoctor(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result, "MemoryDoctor should return a non-empty report")
+	assert.IsType(t, "", result, "MemoryDoctor should return a string")
+	assert.True(t, len(result) > 10, "MemoryDoctor report should have substantial content")
+}
+
+func (suite *GlideTestSuite) TestMemoryDoctor_StandaloneContentValidation() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryDoctor(context.Background())
+
+	assert.NoError(t, err)
+	lowerResult := strings.ToLower(result)
+	hasExpectedContent := strings.Contains(lowerResult, "sam") ||
+		strings.Contains(lowerResult, "memory") ||
+		strings.Contains(lowerResult, "peak")
+	assert.True(t, hasExpectedContent, "MemoryDoctor report should contain relevant keywords")
+}
+
+func (suite *GlideTestSuite) TestMemoryMallocStats_Standalone() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryMallocStats(context.Background())
+
+	assert.NoError(t, err)
+	assert.IsType(t, "", result, "MemoryMallocStats should return a string")
+}
+
+func (suite *GlideTestSuite) TestMemoryPurge_Standalone() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryPurge(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result, "MemoryPurge should return OK")
+}
+
+func (suite *GlideTestSuite) TestMemoryPurge_StandaloneIdempotency() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result1, err1 := client.MemoryPurge(context.Background())
+	result2, err2 := client.MemoryPurge(context.Background())
+	result3, err3 := client.MemoryPurge(context.Background())
+
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NoError(t, err3)
+	assert.Equal(t, "OK", result1)
+	assert.Equal(t, "OK", result2)
+	assert.Equal(t, "OK", result3)
+}
+
+func (suite *GlideTestSuite) TestMemoryStats_Standalone() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryStats(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result, "MemoryStats should return a non-nil map")
+	assert.True(t, len(result) > 0, "MemoryStats should return a map with data")
+}
+
+func (suite *GlideTestSuite) TestMemoryStats_StandaloneExpectedKeys() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryStats(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	expectedKeys := []string{
+		"peak.allocated",
+		"total.allocated",
+		"startup.allocated",
+		"replication.backlog",
+		"clients.slaves",
+		"clients.normal",
+		"aof.buffer",
+	}
+
+	foundKeys := 0
+	for _, key := range expectedKeys {
+		if _, exists := result[key]; exists {
+			foundKeys++
+		}
+	}
+
+	assert.True(t, foundKeys > 0, "MemoryStats should contain at least one expected key")
+}
+
+func (suite *GlideTestSuite) TestMemoryStats_StandaloneValueTypes() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result, err := client.MemoryStats(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	for key, value := range result {
+		switch v := value.(type) {
+		case int, int64, int32, int16, int8:
+			// Valid integer types
+		case string:
+			// Some values might be strings
+		case map[string]any:
+			// Nested maps are valid
+		default:
+			t.Logf("Key %s has unexpected type: %T", key, v)
+		}
+	}
+}
+
+func (suite *GlideTestSuite) TestMemoryStats_StandaloneWithDataOperations() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	statsBefore, err := client.MemoryStats(context.Background())
+	assert.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
+		key := "memory_test_key_" + string(rune(i))
+		value := strings.Repeat("x", 1000)
+		_, err := client.Set(context.Background(), key, value)
+		assert.NoError(t, err)
+	}
+
+	statsAfter, err := client.MemoryStats(context.Background())
+	assert.NoError(t, err)
+
+	assert.NotNil(t, statsBefore)
+	assert.NotNil(t, statsAfter)
+
+	totalBefore, ok1 := statsBefore["total.allocated"].(int64)
+	totalAfter, ok2 := statsAfter["total.allocated"].(int64)
+	assert.True(t, ok1, "total.allocated should be present in stats before")
+	assert.True(t, ok2, "total.allocated should be present in stats after")
+	assert.Greater(t, totalAfter, totalBefore, "Memory should increase after writing data")
+}
+
+// Cluster Client Tests
+
+func (suite *GlideTestSuite) TestMemoryDoctor_Cluster() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	result, err := client.MemoryDoctor(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsMultiValue(), "Default routing should return multi-value")
+
+	multiValue := result.MultiValue()
+	assert.NotEmpty(t, multiValue, "Should have results from multiple nodes")
+
+	for _, report := range multiValue {
+		assert.NotEmpty(t, report)
+	}
+}
+
+func (suite *GlideTestSuite) TestMemoryDoctorWithOptions_ClusterSingleNode() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.MemoryDoctorWithOptions(context.Background(), opts)
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsSingleValue(), "RandomRoute should return single value")
+	assert.NotEmpty(t, result.SingleValue())
+}
+
+func (suite *GlideTestSuite) TestMemoryMallocStats_Cluster() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	result, err := client.MemoryMallocStats(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsMultiValue(), "Default routing should return multi-value")
+}
+
+func (suite *GlideTestSuite) TestMemoryMallocStatsWithOptions_ClusterSingleNode() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.MemoryMallocStatsWithOptions(context.Background(), opts)
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsSingleValue(), "RandomRoute should return single value")
+}
+
+func (suite *GlideTestSuite) TestMemoryPurge_Cluster() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	result, err := client.MemoryPurge(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+}
+
+func (suite *GlideTestSuite) TestMemoryPurgeWithOptions_ClusterAllNodes() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	opts := options.RouteOption{Route: config.AllNodes}
+	result, err := client.MemoryPurgeWithOptions(context.Background(), opts)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", result)
+}
+
+func (suite *GlideTestSuite) TestMemoryStats_Cluster() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	result, err := client.MemoryStats(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsMultiValue(), "Default routing should return multi-value")
+
+	multiValue := result.MultiValue()
+	assert.NotEmpty(t, multiValue)
+
+	for _, stats := range multiValue {
+		assert.NotNil(t, stats)
+		assert.True(t, len(stats) > 0)
+	}
+}
+
+func (suite *GlideTestSuite) TestMemoryStatsWithOptions_ClusterSingleNode() {
+	client := suite.defaultClusterClient()
+	t := suite.T()
+
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.MemoryStatsWithOptions(context.Background(), opts)
+
+	assert.NoError(t, err)
+	assert.True(t, result.IsSingleValue(), "RandomRoute should return single value")
+
+	stats := result.SingleValue()
+	assert.NotNil(t, stats)
+	assert.True(t, len(stats) > 0)
+}
+
+// Context Cancellation Tests
+
+func (suite *GlideTestSuite) TestMemoryCommands_StandaloneContextCancellation() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.MemoryDoctor(ctx)
+	assert.Error(t, err)
+
+	_, err = client.MemoryMallocStats(ctx)
+	assert.Error(t, err)
+
+	_, err = client.MemoryPurge(ctx)
+	assert.Error(t, err)
+
+	_, err = client.MemoryStats(ctx)
+	assert.Error(t, err)
+}
+
+func (suite *GlideTestSuite) TestMemoryCommands_StandaloneSequentialExecution() {
+	client := suite.defaultClient()
+	t := suite.T()
+
+	result1, err1 := client.MemoryDoctor(context.Background())
+	assert.NoError(t, err1)
+	assert.NotEmpty(t, result1)
+
+	result2, err2 := client.MemoryMallocStats(context.Background())
+	assert.NoError(t, err2)
+	assert.IsType(t, "", result2)
+
+	result3, err3 := client.MemoryPurge(context.Background())
+	assert.NoError(t, err3)
+	assert.Equal(t, "OK", result3)
+
+	result4, err4 := client.MemoryStats(context.Background())
+	assert.NoError(t, err4)
+	assert.NotNil(t, result4)
+	assert.True(t, len(result4) > 0)
+}

--- a/go/interfaces/server_management_cluster_commands.go
+++ b/go/interfaces/server_management_cluster_commands.go
@@ -61,6 +61,102 @@ type ServerManagementClusterCommands interface {
 
 	ConfigRewriteWithOptions(ctx context.Context, routeOption options.RouteOption) (string, error)
 
+	// MemoryDoctor provides memory usage diagnosis report.
+	// Routes to all primary nodes by default.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A ClusterValue containing the memory usage analysis report(s).
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-doctor/
+	MemoryDoctor(ctx context.Context) (models.ClusterValue[string], error)
+
+	// MemoryDoctorWithOptions provides memory usage diagnosis report with routing configuration.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//   routeOption - Specifies the routing configuration for the command.
+	//
+	// Return value:
+	//   A ClusterValue containing the memory usage analysis report(s).
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-doctor/
+	MemoryDoctorWithOptions(ctx context.Context, routeOption options.RouteOption) (models.ClusterValue[string], error)
+
+	// MemoryMallocStats returns memory allocator internal statistics.
+	// Routes to all primary nodes by default.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A ClusterValue containing the memory allocator statistics.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-malloc-stats/
+	MemoryMallocStats(ctx context.Context) (models.ClusterValue[string], error)
+
+	// MemoryMallocStatsWithOptions returns memory allocator internal statistics with routing configuration.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//   routeOption - Specifies the routing configuration for the command.
+	//
+	// Return value:
+	//   A ClusterValue containing the memory allocator statistics.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-malloc-stats/
+	MemoryMallocStatsWithOptions(ctx context.Context, routeOption options.RouteOption) (models.ClusterValue[string], error)
+
+	// MemoryPurge attempts to purge dirty pages for reclamation by the allocator.
+	// Routes to all nodes by default.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   "OK" to confirm that the purge operation was executed.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-purge/
+	MemoryPurge(ctx context.Context) (string, error)
+
+	// MemoryPurgeWithOptions attempts to purge dirty pages with routing configuration.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//   routeOption - Specifies the routing configuration for the command.
+	//
+	// Return value:
+	//   "OK" to confirm that the purge operation was executed.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-purge/
+	MemoryPurgeWithOptions(ctx context.Context, routeOption options.RouteOption) (string, error)
+
+	// MemoryStats returns memory usage statistics for the server.
+	// Routes to all primary nodes by default.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A ClusterValue containing memory usage statistics map(s).
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-stats/
+	MemoryStats(ctx context.Context) (models.ClusterValue[map[string]any], error)
+
+	// MemoryStatsWithOptions returns memory usage statistics with routing configuration.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//   routeOption - Specifies the routing configuration for the command.
+	//
+	// Return value:
+	//   A ClusterValue containing memory usage statistics map(s).
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-stats/
+	MemoryStatsWithOptions(ctx context.Context, routeOption options.RouteOption) (models.ClusterValue[map[string]any], error)
+
 	// AclCat returns a list of all ACL categories.
 	//
 	// See [valkey.io] for details.

--- a/go/interfaces/server_management_commands.go
+++ b/go/interfaces/server_management_commands.go
@@ -46,6 +46,46 @@ type ServerManagementCommands interface {
 
 	ConfigRewrite(ctx context.Context) (string, error)
 
+	// MemoryDoctor provides memory usage diagnosis report.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A string containing the memory usage analysis report.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-doctor/
+	MemoryDoctor(ctx context.Context) (string, error)
+
+	// MemoryMallocStats returns memory allocator internal statistics.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A string containing the memory allocator statistics.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-malloc-stats/
+	MemoryMallocStats(ctx context.Context) (string, error)
+
+	// MemoryPurge attempts to purge dirty pages for reclamation by the allocator.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   "OK" to confirm that the purge operation was executed.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-purge/
+	MemoryPurge(ctx context.Context) (string, error)
+
+	// MemoryStats returns memory usage statistics for the server.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A map containing memory usage statistics.
+	//
+	// [valkey.io]: https://valkey.io/commands/memory-stats/
+	MemoryStats(ctx context.Context) (map[string]any, error)
+
 	// AclCat returns a list of all ACL categories.
 	//
 	// See [valkey.io] for details.

--- a/go/memory_commands_test.go
+++ b/go/memory_commands_test.go
@@ -1,0 +1,174 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/options"
+)
+
+func ExampleClient_MemoryDoctor() {
+	var client *Client = getExampleClient() // example helper function
+	result, err := client.MemoryDoctor(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	fmt.Printf("MemoryDoctor result is of type %T\n", result)
+
+	// Output:
+	// MemoryDoctor result is of type string
+}
+
+func ExampleClient_MemoryMallocStats() {
+	var client *Client = getExampleClient() // example helper function
+	result, err := client.MemoryMallocStats(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	fmt.Printf("MemoryMallocStats result is of type %T\n", result)
+
+	// Output:
+	// MemoryMallocStats result is of type string
+}
+
+func ExampleClient_MemoryPurge() {
+	var client *Client = getExampleClient() // example helper function
+	result, err := client.MemoryPurge(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	fmt.Println(result)
+
+	// Output:
+	// OK
+}
+
+func ExampleClient_MemoryStats() {
+	var client *Client = getExampleClient() // example helper function
+	result, err := client.MemoryStats(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// Verify we get expected keys in the stats map
+	hasExpectedKeys := false
+	if result != nil {
+		// Check for common memory stats keys
+		_, hasPeakAllocated := result["peak.allocated"]
+		_, hasTotalAllocated := result["total.allocated"]
+		_, hasUsedMemory := result["used_memory"]
+		hasExpectedKeys = hasPeakAllocated || hasTotalAllocated || hasUsedMemory
+	}
+	fmt.Println(hasExpectedKeys)
+
+	// Output:
+	// true
+}
+
+func ExampleClusterClient_MemoryDoctor() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.MemoryDoctor(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// Default routing returns multi-value (all primaries)
+	fmt.Println(result.IsMultiValue())
+
+	// Output:
+	// true
+}
+
+func ExampleClusterClient_MemoryDoctorWithOptions() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.MemoryDoctorWithOptions(context.Background(), opts)
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// RandomRoute returns single value
+	fmt.Println(result.IsSingleValue())
+
+	// Output:
+	// true
+}
+
+func ExampleClusterClient_MemoryMallocStats() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.MemoryMallocStats(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// Default routing returns multi-value (all primaries)
+	fmt.Println(result.IsMultiValue())
+
+	// Output:
+	// true
+}
+
+func ExampleClusterClient_MemoryMallocStatsWithOptions() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.MemoryMallocStatsWithOptions(context.Background(), opts)
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// RandomRoute returns single value
+	fmt.Println(result.IsSingleValue())
+
+	// Output:
+	// true
+}
+
+func ExampleClusterClient_MemoryPurge() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.MemoryPurge(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	fmt.Println(result)
+
+	// Output:
+	// OK
+}
+
+func ExampleClusterClient_MemoryPurgeWithOptions() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	opts := options.RouteOption{Route: config.AllNodes}
+	result, err := client.MemoryPurgeWithOptions(context.Background(), opts)
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	fmt.Println(result)
+
+	// Output:
+	// OK
+}
+
+func ExampleClusterClient_MemoryStats() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.MemoryStats(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// Default routing returns multi-value (all primaries)
+	fmt.Println(result.IsMultiValue())
+
+	// Output:
+	// true
+}
+
+func ExampleClusterClient_MemoryStatsWithOptions() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	opts := options.RouteOption{Route: config.RandomRoute}
+	result, err := client.MemoryStatsWithOptions(context.Background(), opts)
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	}
+	// RandomRoute returns single value
+	fmt.Println(result.IsSingleValue())
+
+	// Output:
+	// true
+}

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -1799,3 +1799,45 @@ func handleStringToArrayOfMapsMapResponse(
 
 	return resultMap, nil
 }
+
+// handleStringToStringAnyMapMapResponse processes a multi-node map response where each node returns a map[string]any.
+// Used for MEMORY STATS in cluster mode with AllPrimaries routing.
+func handleStringToStringAnyMapMapResponse(
+	response *C.struct_CommandResponse,
+) (map[string]map[string]any, error) {
+	defer C.free_command_response(response)
+
+	typeErr := checkResponseType(response, C.Map, false)
+	if typeErr != nil {
+		return nil, typeErr
+	}
+
+	result, err := parseMap(response)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, nil
+	}
+
+	parsedMap, ok := result.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type: %T", result)
+	}
+
+	resultMap := make(map[string]map[string]any)
+	for key, value := range parsedMap {
+		if value == nil {
+			resultMap[key] = nil
+			continue
+		}
+		mapValue, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected value type for key %s: %T", key, value)
+		}
+		resultMap[key] = mapValue
+	}
+
+	return resultMap, nil
+}


### PR DESCRIPTION
### Summary

Implements the `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands for the Go client (both standalone `Client` and `ClusterClient`), exposed through `interfaces.ServerManagementCommands` / `interfaces.ServerManagementClusterCommands`.

### Issue link

This Pull Request is linked to issue: [Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands](https://github.com/valkey-io/valkey-glide/issues/6286)
Part of #6286

### Features / Behaviour Changes

**New API methods (standalone `Client`):**
- `MemoryDoctor(ctx)` — returns `(string, error)` containing memory usage diagnosis report
- `MemoryMallocStats(ctx)` — returns `(string, error)` containing allocator internal statistics
- `MemoryPurge(ctx)` — returns `(string, error)` with `"OK"` after attempting to purge dirty pages
- `MemoryStats(ctx)` — returns `(map[string]any, error)` with detailed memory usage statistics

**New API methods (`ClusterClient`):**
- `MemoryDoctor(ctx)` — returns `(models.ClusterValue[string], error)` (default: all primaries, multi-value)
- `MemoryDoctorWithOptions(ctx, routeOption)` — returns `(models.ClusterValue[string], error)` with custom routing
- `MemoryMallocStats(ctx)` — returns `(models.ClusterValue[string], error)` (default: all primaries, multi-value)
- `MemoryMallocStatsWithOptions(ctx, routeOption)` — returns `(models.ClusterValue[string], error)` with custom routing
- `MemoryPurge(ctx)` — returns `(string, error)` with `"OK"` (default: all nodes)
- `MemoryPurgeWithOptions(ctx, routeOption)` — returns `(string, error)` with custom routing
- `MemoryStats(ctx)` — returns `(models.ClusterValue[map[string]any], error)` (default: all primaries, multi-value)
- `MemoryStatsWithOptions(ctx, routeOption)` — returns `(models.ClusterValue[map[string]any], error)` with custom routing

**Routing & response semantics:**
- `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, and `MEMORY STATS` route to all primary nodes by default, returning a multi-value `ClusterValue` with results from each primary. Users can specify `options.RouteOption` to target `RandomRoute`, `AllPrimaries`, or `AllNodes`.
- `MEMORY PURGE` is executed on all nodes by default in cluster mode. Returns `"OK"` when complete.
- The `*WithOptions` variants accept `options.RouteOption` for flexible routing. When `routeOption.Route == nil`, the method falls back to the default routing behavior. When routing to a single node (`IsMultiNode() == false`), returns a single-value `ClusterValue`; when routing to multiple nodes, returns a multi-value `ClusterValue`.

### Implementation

1. **`CHANGELOG.md`** — adds entry for Go MEMORY commands feature under the next release section.

2. **`go/glide_client.go`** — adds four standalone methods. Uses `handleStringResponse` for DOCTOR/MALLOC-STATS, `handleOkResponse` for PURGE, and `handleStringToAnyMapResponse` for STATS.

3. **`go/glide_cluster_client.go`** — adds eight cluster methods (four base + four `*WithOptions` variants). Base methods use `executeCommand` with default routing and `handleStringToStringMapResponse` (for multi-node string responses) or `handleStringToStringAnyMapMapResponse` (for multi-node map responses). `*WithOptions` variants use `executeCommandWithRoute` and check `IsMultiNode()` to determine response handling.

4. **`go/interfaces/server_management_commands.go`** — adds four standalone method signatures to the `ServerManagementCommands` interface with GoDoc.

5. **`go/interfaces/server_management_cluster_commands.go`** — adds eight cluster method signatures to the `ServerManagementClusterCommands` interface with GoDoc documenting default routing behavior.

6. **`go/response_handlers.go`** — adds `handleStringToStringAnyMapMapResponse` for multi-node MEMORY STATS responses. Parses a `map[string]map[string]any` structure where keys are node addresses and values are per-node stats maps.

7. **`go/memory_commands_test.go`** (12 example tests) — `ExampleClient_*` / `ExampleClusterClient_*` for every new public API method.

8. **`go/integTest/memory_commands_test.go`** (19 integration tests) — comprehensive integration tests covering standalone and cluster clients.

### Limitations

- `MEMORY DOCTOR` report format may vary across Valkey versions. The client returns the raw string without parsing.
- `MEMORY MALLOC-STATS` output is allocator-specific and may return an empty string if the allocator doesn't support detailed statistics.
- `MEMORY PURGE` effectiveness varies by allocator implementation and current memory fragmentation state.
- `MEMORY STATS` keys and value types may vary across Valkey versions. The Go client returns the map without schema validation.

### Testing

**Example tests** (`go/memory_commands_test.go`, 12 cases —  PASS)
**Integration tests** (`go/integTest/memory_commands_test.go`, 19 cases —  PASS)

Tests cover:
- Happy path execution for all commands (standalone and cluster)
- Content validation (non-empty responses, expected keywords)
- Type validation (string vs map return types, nested structure)
- Idempotency (multiple PURGE invocations return consistent results)
- Cluster routing (`RandomRoute`, `AllPrimaries`, `AllNodes`)
- Error paths (context cancellation)
- Sequential execution (all four commands in series)
- Data operation effects (asserts `total.allocated` increases after writing data)

**Static analysis:** `go vet`, `staticcheck`, `gofumpt`, and `golines -m 127` all pass (`make lint-ci` exit 0).

### Checklist

Before submitting the PR make sure the following are checked:
- [x] This Pull Request is related to one issue (#6286).
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added (12 example tests + 19 integration tests = 31 total).
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make lint-ci`) and pass.
- [x] Destination branch is `main`.
- [x] Squash on merge.