### PR TITLE
Cherry-pick of #5952 to release 2.4

### DIFF
--- a/java/e2e/inflight-pressure-test/src/main/java/InflightLimitTest.java
+++ b/java/e2e/inflight-pressure-test/src/main/java/InflightLimitTest.java
@@ -1,0 +1,188 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+import glide.api.GlideClusterClient;
+import glide.api.models.configuration.AdvancedGlideClusterClientConfiguration;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.PeriodicChecksManualInterval;
+import glide.api.models.configuration.RequestRoutingConfiguration;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Validates the synchronous inflight limit check at the JNI boundary.
+ *
+ * <p>Test strategy: 1. CLIENT PAUSE all primaries for 15s (stalls all responses) 2. Blast requests
+ * from a fixed thread pool 3. After Java timeout fires (3s), verify that inflight rejections occur
+ * (proves the Rust-side synchronous check is working) 4. After pause ends, verify recovery (ops
+ * resume)
+ *
+ * <p>PASS criteria: - inflightRejections > 0 (synchronous check is triggering) - ops resume after
+ * pause ends (client recovers)
+ *
+ * <p>Exit 0 = PASS, Exit 1 = FAIL
+ */
+public class InflightLimitTest {
+    static final AtomicLong totalOps = new AtomicLong();
+    static final AtomicLong totalErrs = new AtomicLong();
+    static final AtomicLong inflightRejections = new AtomicLong();
+    static final AtomicLong timeoutErrors = new AtomicLong();
+    static final AtomicInteger currentBlocking = new AtomicInteger();
+    static final int PAUSE_DURATION_MS = 15000;
+    static final int REQUEST_TIMEOUT_MS = 3000;
+    static final int TEST_DURATION_SEC = 22;
+    static final int WORKER_THREADS = 200;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("Usage: InflightLimitTest <host> <port> [--tls]");
+            System.exit(1);
+        }
+        String host = args[0];
+        int port = Integer.parseInt(args[1]);
+        boolean tls = args.length > 2 && args[2].equals("--tls");
+        System.out.printf("[INIT] host=%s port=%d tls=%s%n", host, port, tls);
+
+        GlideClusterClient glide = connectWithRetry(host, port, tls);
+        if (glide == null) {
+            System.out.println("[FAIL] Cannot connect");
+            System.exit(1);
+        }
+        System.out.println("[INIT] Connected");
+        for (int i = 0; i < 100; i++) glide.set("itest:" + i, "value-" + i).get();
+        System.out.println("[INIT] Pre-populated 100 keys");
+        if (glide.get("itest:0").get() == null) {
+            System.out.println("[FAIL] GET null");
+            System.exit(1);
+        }
+
+        // CLIENT PAUSE ALL_PRIMARIES
+        boolean pauseApplied = false;
+        try {
+            RequestRoutingConfiguration.Route allPrimaries =
+                    RequestRoutingConfiguration.SimpleMultiNodeRoute.ALL_PRIMARIES;
+            glide
+                    .customCommand(
+                            new String[] {"CLIENT", "PAUSE", String.valueOf(PAUSE_DURATION_MS), "ALL"},
+                            allPrimaries)
+                    .get(5, TimeUnit.SECONDS);
+            pauseApplied = true;
+            System.out.printf("[TEST] CLIENT PAUSE %dms ALL_PRIMARIES OK%n", PAUSE_DURATION_MS);
+        } catch (Exception e) {
+            System.out.println("[WARN] CLIENT PAUSE failed: " + e.getMessage());
+        }
+
+        ExecutorService workers =
+                Executors.newFixedThreadPool(
+                        WORKER_THREADS,
+                        r -> {
+                            Thread t = new Thread(r);
+                            t.setDaemon(true);
+                            return t;
+                        });
+        System.out.println("[TEST] Starting " + WORKER_THREADS + " workers...");
+        for (int w = 0; w < WORKER_THREADS; w++) {
+            final int wid = w;
+            workers.submit(() -> workerLoop(glide, wid));
+        }
+
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < TEST_DURATION_SEC * 1000L) {
+            Thread.sleep(2000);
+            long elapsed = (System.currentTimeMillis() - startTime) / 1000;
+            System.out.printf(
+                    "[MON] t=%ds blk=%d ops=%d errs=%d rej=%d to=%d%n",
+                    elapsed,
+                    currentBlocking.get(),
+                    totalOps.get(),
+                    totalErrs.get(),
+                    inflightRejections.get(),
+                    timeoutErrors.get());
+        }
+        workers.shutdownNow();
+
+        long ops = totalOps.get();
+        long rejections = inflightRejections.get();
+        long timeouts = timeoutErrors.get();
+        System.out.printf("%n[RESULT] ops=%d rejections=%d timeouts=%d%n", ops, rejections, timeouts);
+
+        // Validation
+        boolean pass = true;
+        if (pauseApplied && rejections == 0) {
+            System.out.println("[FAIL] No inflight rejections detected - synchronous check not working");
+            pass = false;
+        }
+        if (pauseApplied && rejections > 0) {
+            System.out.printf(
+                    "[PASS] %d inflight rejections - synchronous check is working%n", rejections);
+        }
+        if (ops == 0) {
+            System.out.println("[FAIL] No successful ops - client did not recover after pause");
+            pass = false;
+        } else {
+            System.out.printf("[PASS] %d ops completed - client recovered after pause%n", ops);
+        }
+        if (timeouts > 0) {
+            System.out.printf("[INFO] %d timeout errors (expected during pause)%n", timeouts);
+        }
+        System.exit(pass ? 0 : 1);
+    }
+
+    static void workerLoop(GlideClusterClient client, int workerId) {
+        Random rng = new Random(workerId);
+        while (!Thread.currentThread().isInterrupted()) {
+            int key = rng.nextInt(100);
+            currentBlocking.incrementAndGet();
+            try {
+                client.get("itest:" + key).get();
+                totalOps.incrementAndGet();
+            } catch (Exception e) {
+                totalErrs.incrementAndGet();
+                String msg = e.getMessage();
+                if (msg != null) {
+                    if (msg.contains("inflight")) inflightRejections.incrementAndGet();
+                    else if (msg.contains("timed out") || msg.contains("Timeout"))
+                        timeoutErrors.incrementAndGet();
+                }
+            } finally {
+                currentBlocking.decrementAndGet();
+            }
+            try {
+                Thread.sleep(0, 100_000);
+            } catch (InterruptedException e) {
+                break;
+            }
+        }
+    }
+
+    static GlideClusterClient connectWithRetry(String host, int port, boolean tls) {
+        for (int attempt = 1; attempt <= 30; attempt++) {
+            try {
+                return GlideClusterClient.createClient(
+                                GlideClusterClientConfiguration.builder()
+                                        .address(NodeAddress.builder().host(host).port(port).build())
+                                        .requestTimeout(REQUEST_TIMEOUT_MS)
+                                        .useTLS(tls)
+                                        .advancedConfiguration(
+                                                AdvancedGlideClusterClientConfiguration.builder()
+                                                        .connectionTimeout(3000)
+                                                        .periodicChecks(
+                                                                PeriodicChecksManualInterval.builder().durationInSec(60).build())
+                                                        .build())
+                                        .build())
+                        .get();
+            } catch (Exception e) {
+                System.out.printf("[INIT] attempt %d: %s%n", attempt, e.getMessage());
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException ie) {
+                    break;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -425,11 +425,11 @@ fn process_callback_job_with_env(
     binary_mode: bool,
 ) {
     if take_timed_out_callback(callback_id) {
-        logger_core::log_warn_rate_limited!(
+        logger_core::log_debug_rate_limited!(
             "jni_callback",
             5,
             format!(
-                "Rust task completed for callback_id={} but Java already timed out. Task was leaked.",
+                "Rust task completed for callback_id={} after Java timeout — result discarded.",
                 callback_id
             )
         );
@@ -1001,6 +1001,57 @@ fn get_glide_core_client_cache_safe(env: &mut JNIEnv) -> Result<GlideCoreClientC
     }
 
     Ok(guard.as_ref().cloned().unwrap())
+}
+
+/// Complete a callback with an error synchronously from the JNI calling thread.
+/// This bypasses the async callback channel entirely — used for immediate rejection
+/// (e.g., inflight limit exceeded) where the Java thread must not park.
+///
+/// Requires the calling thread to already have a JNIEnv (which JNI entry points always do).
+pub fn complete_error_sync(env: &mut JNIEnv, callback_id: jni::sys::jlong, message: &str) {
+    let Ok(method_cache) = get_method_cache(env) else {
+        log::error!(
+            "complete_error_sync: method cache not initialized for callback_id={}",
+            callback_id
+        );
+        return;
+    };
+
+    // Create the error message string — a small Java heap allocation,
+    // not affected by native memory pressure.
+    let Ok(error_msg) = env.new_string(message) else {
+        log::error!(
+            "complete_error_sync: failed to create error string for callback_id={}",
+            callback_id
+        );
+        return;
+    };
+
+    // Call AsyncRegistry.completeCallbackWithErrorCode(callbackId, errorCode, errorMessage)
+    // Error code 4 = RequestException (matches the existing inflight error path)
+    let result = unsafe {
+        env.call_static_method_unchecked(
+            &method_cache.async_handle_table_class,
+            method_cache.complete_error_with_code_method,
+            jni::signature::ReturnType::Primitive(jni::signature::Primitive::Boolean),
+            &[
+                jni::sys::jvalue { j: callback_id },
+                jni::sys::jvalue { i: 4 }, // RequestException error code
+                jni::sys::jvalue {
+                    l: error_msg.into_raw(),
+                },
+            ],
+        )
+    };
+
+    if let Err(e) = result {
+        log::error!(
+            "complete_error_sync: JNI call failed for callback_id={}: {:?}",
+            callback_id,
+            e
+        );
+        let _ = env.exception_clear();
+    }
 }
 
 #[cfg(test)]

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1550,6 +1550,24 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandAsync
         };
 
         let handle_id = client_ptr as u64;
+
+        // Synchronous inflight check: reject immediately if at capacity.
+        // This prevents Java threads from parking on futures that would be
+        // rejected asynchronously, avoiding thread explosion under memory pressure.
+        {
+            let handle_table = jni_client::get_handle_table();
+            if let Some(client_ref) = handle_table.get(&handle_id)
+                && client_ref.available_inflight_count() <= 0
+            {
+                jni_client::complete_error_sync(
+                    &mut env,
+                    callback_id,
+                    "Client reached maximum inflight requests",
+                );
+                return Some(());
+            }
+        }
+
         get_runtime().spawn(execute_command_request_and_complete(
             handle_id,
             command_request,
@@ -1911,6 +1929,22 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBinaryComman
         };
 
         let handle_id = client_ptr as u64;
+
+        // Synchronous inflight check (same as executeCommandAsync)
+        {
+            let handle_table = jni_client::get_handle_table();
+            if let Some(client_ref) = handle_table.get(&handle_id)
+                && client_ref.available_inflight_count() <= 0
+            {
+                jni_client::complete_error_sync(
+                    &mut env,
+                    callback_id,
+                    "Client reached maximum inflight requests",
+                );
+                return Some(());
+            }
+        }
+
         get_runtime().spawn(execute_command_request_and_complete(
             handle_id,
             command_request,

--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -348,6 +348,22 @@ macro_rules! log_info_rate_limited {
     }};
 }
 
+#[macro_export]
+macro_rules! log_debug_rate_limited {
+    ($identifier:expr, $interval_secs:expr, $message:expr) => {{
+        static LAST_LOG: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let last = LAST_LOG.load(std::sync::atomic::Ordering::Relaxed);
+        if now >= last + $interval_secs {
+            LAST_LOG.store(now, std::sync::atomic::Ordering::Relaxed);
+            $crate::log_debug($identifier, $message);
+        }
+    }};
+}
+
 // Logs the given log, with log_identifier and log level prefixed. If the given log level is below the threshold of given when the logger was initialized, the log will be ignored.
 // log_identifier should be used to add context to a log, and make it easier to connect it to other relevant logs. For example, it can be used to pass a task identifier.
 // If this is called before a logger was initialized the log will not be registered.


### PR DESCRIPTION
Cherry-pick of #5952 (synchronous inflight check) to release 2.4.

Adds a synchronous inflight request limit check at the JNI boundary before spawning async Tokio tasks. When the inflight limit is reached, the error is delivered immediately to the caller on the same thread, preventing `ForkJoinPool` thread explosion under memory pressure.