### PR TITLE
fix(node): use only primary address in Static mode write test

### DIFF
--- a/node/tests/NodeDiscoveryMode.test.ts
+++ b/node/tests/NodeDiscoveryMode.test.ts
@@ -63,11 +63,12 @@ describe("NodeDiscoveryMode", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "skip info replication allows writes_%p",
         async (protocol) => {
+            // Use only the primary address (first address) to avoid connecting
+            // to a replica with NodeDiscoveryMode.Static, which would cause
+            // ReadOnly errors on write operations.
+            const primaryAddress = [cluster.getAddresses()[0]];
             client = await GlideClient.createClient({
-                ...getClientConfigurationOption(
-                    cluster.getAddresses(),
-                    protocol,
-                ),
+                ...getClientConfigurationOption(primaryAddress, protocol),
                 nodeDiscoveryMode: NodeDiscoveryMode.Static,
             });
 


### PR DESCRIPTION
### Summary
Fix flaky test "skip info replication allows writes" in NodeDiscoveryMode.test.ts.

### Issue link
Closes #5920

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
With NodeDiscoveryMode.Static, the client does not run INFO REPLICATION to discover node roles. The test was passing all cluster addresses (primary + replica). Fix: pass only the primary address.

### Limitations
None

### Testing
Deterministic by connecting only to the known primary address.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release