### PR TITLE
fix(node): resolve OpenTelemetry test flakiness from timeouts

### DIFF
--- a/node/tests/OpenTelemetry.test.ts
+++ b/node/tests/OpenTelemetry.test.ts
@@ -72,6 +72,39 @@ function readAndParseSpanFile(path: string): {
     };
 }
 
+/**
+ * Polls for the span file to exist and contain at least one expected span name.
+ * Replaces fixed setTimeout waits which are unreliable in CI.
+ */
+async function waitForSpanFile(
+    path: string,
+    expectedSpanName: string,
+    timeoutMs: number = 10000,
+    intervalMs: number = 200,
+): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (fs.existsSync(path)) {
+            try {
+                const { spanNames } = readAndParseSpanFile(path);
+
+                if (spanNames.includes(expectedSpanName)) {
+                    return;
+                }
+            } catch {
+                // File may be partially written; retry
+            }
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw new Error(
+        `Timed out waiting for span "${expectedSpanName}" in ${path}`,
+    );
+}
+
 const TIMEOUT = 50000;
 const VALID_ENDPOINT_TRACES = "/tmp/spans.json";
 const VALID_FILE_ENDPOINT_TRACES = "file://" + VALID_ENDPOINT_TRACES;
@@ -202,7 +235,7 @@ describe("OpenTelemetry GlideClusterClient", () => {
         };
         OpenTelemetry.init(openTelemetryConfig);
         await teardown_otel_test();
-    }, 40000);
+    }, 60000);
 
     async function teardown_otel_test() {
         // Clean up OpenTelemetry files
@@ -221,6 +254,8 @@ describe("OpenTelemetry GlideClusterClient", () => {
     });
 
     afterAll(async () => {
+        if (!cluster) return;
+
         if (testsFailed === 0) {
             await cluster.close();
         } else {
@@ -330,7 +365,7 @@ describe("OpenTelemetry GlideClusterClient", () => {
             }
 
             // Wait for spans to be flushed to file
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await waitForSpanFile(VALID_ENDPOINT_TRACES, "Get");
 
             // Read the span file and check span name
             const { spanNames } = readAndParseSpanFile(VALID_ENDPOINT_TRACES);
@@ -366,7 +401,8 @@ describe("OpenTelemetry GlideClusterClient", () => {
                 "value",
             );
 
-            await new Promise((resolve) => setTimeout(resolve, 500));
+            // Wait for spans to be flushed to file
+            await waitForSpanFile(VALID_ENDPOINT_TRACES, "Set");
 
             // Read the span file and check span name
             const { spanNames } = readAndParseSpanFile(VALID_ENDPOINT_TRACES);
@@ -437,7 +473,7 @@ describe("OpenTelemetry GlideClusterClient", () => {
             client2.get("test_key");
 
             // Wait for spans to be flushed to file
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await waitForSpanFile(VALID_ENDPOINT_TRACES, "Get");
 
             // Read and check span names from the file using the helper function
             const { spanNames } = readAndParseSpanFile(VALID_ENDPOINT_TRACES);
@@ -482,7 +518,7 @@ describe("OpenTelemetry GlideClusterClient", () => {
             }
 
             // Wait for spans to be flushed to file
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await waitForSpanFile(VALID_ENDPOINT_TRACES, "Batch");
 
             // Read and check span names from the file using the helper function
             const { spanNames } = readAndParseSpanFile(VALID_ENDPOINT_TRACES);
@@ -529,6 +565,8 @@ describe("OpenTelemetry GlideClient", () => {
     });
 
     afterAll(async () => {
+        if (!cluster) return;
+
         if (testsFailed === 0) {
             await cluster.close();
         } else {
@@ -912,7 +950,7 @@ describe("OpenTelemetry parent span context propagation", () => {
                   getServerVersion,
               )
             : await ValkeyCluster.createCluster(true, 3, 1, getServerVersion);
-    }, 40000);
+    }, 60000);
 
     afterEach(async () => {
         OpenTelemetry.setParentSpanContextProvider(null);
@@ -925,7 +963,7 @@ describe("OpenTelemetry parent span context propagation", () => {
     });
 
     afterAll(async () => {
-        await cluster.close();
+        if (cluster) await cluster.close();
     });
 
     it(
@@ -972,7 +1010,7 @@ describe("OpenTelemetry parent span context propagation", () => {
             await client.get("ctx_propagation_test_key");
 
             // Wait for spans to be flushed to file
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await waitForSpanFile(VALID_ENDPOINT_TRACES, "Get");
 
             const { spans, spanNames } = readAndParseSpanFile(
                 VALID_ENDPOINT_TRACES,
@@ -1041,7 +1079,7 @@ describe("OpenTelemetry parent span context propagation", () => {
             expect(result).toBe("fallback_test_value");
 
             // Wait for spans to be flushed to file
-            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await waitForSpanFile(VALID_ENDPOINT_TRACES, "Get");
 
             const { spans, spanNames } = readAndParseSpanFile(
                 VALID_ENDPOINT_TRACES,


### PR DESCRIPTION
### Summary
Fix flaky OpenTelemetry tests that fail with `beforeAll` timeouts and missing span file errors.

### Issue link
This Pull Request is linked to issues:
- [[Node][Flaky Test] OpenTelemetry GlideClient tests failures](https://github.com/valkey-io/valkey-glide/issues/5483)
- [[Node][Flaky Test] invalid parent context falls back to standalone span](https://github.com/valkey-io/valkey-glide/issues/5481)
- [[Node][Flaky Test] GLIDE spans inherit trace_id and parent_span_id](https://github.com/valkey-io/valkey-glide/issues/5480)

Closes #5483
Closes #5481
Closes #5480

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root causes:**
1. `beforeAll` timeout of 40000ms is insufficient for creating a 6-node cluster in CI.
2. Fixed `setTimeout(5000ms)` waits for span file flushing are unreliable under CI load.
3. `afterAll` crashes when `beforeAll` times out and `cluster` is never initialized.

**Fixes:**
1. Increase `beforeAll` timeout from 40000ms to 60000ms.
2. Replace fixed `setTimeout` waits with a polling helper (`waitForSpanFile`) that retries until the expected span appears in the file (10s timeout, 200ms interval).
3. Add null guards in all `afterAll` blocks.

### Limitations
None

### Testing
The `waitForSpanFile` helper uses a polling loop with condition check instead of a fixed sleep, making it resilient to variable CI performance. Null guards prevent cascading failures when setup fails.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release