### PR TITLE
test(core): deflake subscription-survives-failover test

### DIFF
--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -554,18 +554,33 @@ pub struct ClusterNodeInfo {
 impl ClusterTopology {
     /// Get cluster topology from a connection.
     pub async fn from_connection(connection: &mut ClusterConnection) -> Self {
+        Self::try_from_connection(connection)
+            .await
+            .expect("Failed to get CLUSTER NODES")
+    }
+
+    /// Try to get cluster topology, returning an error instead of panicking.
+    /// Useful in retry loops where transient errors (e.g. connection recovery) are expected.
+    pub async fn try_from_connection(
+        connection: &mut ClusterConnection,
+    ) -> Result<Self, redis::RedisError> {
         let nodes_output = connection
             .route_command(
                 redis::cmd("CLUSTER").arg("NODES"),
                 RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random),
             )
-            .await
-            .expect("Failed to get CLUSTER NODES");
+            .await?;
 
         let nodes_str = match nodes_output {
             Value::BulkString(b) => String::from_utf8_lossy(&b).to_string(),
             Value::VerbatimString { text, .. } => text,
-            _ => panic!("Unexpected CLUSTER NODES response type"),
+            other => {
+                return Err(redis::RedisError::from((
+                    redis::ErrorKind::TypeError,
+                    "Unexpected CLUSTER NODES response type",
+                    format!("{other:?}"),
+                )));
+            }
         };
 
         let nodes = Self::parse_cluster_nodes(&nodes_str);
@@ -573,11 +588,11 @@ impl ClusterTopology {
         let all_node_addresses: Vec<(String, u16)> =
             nodes.iter().map(|n| (n.host.clone(), n.port)).collect();
 
-        Self {
+        Ok(Self {
             nodes,
             primary_nodes,
             all_node_addresses,
-        }
+        })
     }
 
     /// Parse CLUSTER NODES output to extract node information.
@@ -832,12 +847,20 @@ pub async fn wait_for_node_to_become_primary(
     let start = std::time::Instant::now();
 
     while start.elapsed() < timeout {
-        let topology = ClusterTopology::from_connection(connection).await;
-
-        if let Some(node) = topology.nodes.iter().find(|n| n.node_id == node_id)
-            && node.is_primary
-        {
-            return true;
+        match ClusterTopology::try_from_connection(connection).await {
+            Ok(topology) => {
+                if let Some(node) = topology.nodes.iter().find(|n| n.node_id == node_id)
+                    && node.is_primary
+                {
+                    return true;
+                }
+            }
+            Err(e) => {
+                logger_core::log_debug(
+                    "wait_for_node_to_become_primary",
+                    format!("CLUSTER NODES failed (retrying): {:?}", e),
+                );
+            }
         }
 
         tokio::time::sleep(Duration::from_millis(200)).await;


### PR DESCRIPTION
### Summary
Fix flaky `test_all_subscription_types_survive_failover` test that panics with "Connection in recovery" error after cluster failover.

### Issue link
This Pull Request is linked to issue: [[Rust][Flaky Test] test_all_subscription_types_survive_failover](https://github.com/valkey-io/valkey-glide/issues/5922)
Closes #5922

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** After a cluster failover is triggered, `wait_for_node_to_become_primary` polls `CLUSTER NODES` to verify the replica has been promoted. However, the connection may be in a transient "recovery" state immediately after failover, causing `route_command` to return an error. The existing code used `.expect()` which panicked on this transient error instead of retrying.

**Fix:** 
- Added `ClusterTopology::try_from_connection()` that returns `Result<Self, redis::RedisError>` instead of panicking.
- Modified `wait_for_node_to_become_primary()` to use `try_from_connection()` and gracefully handle errors by logging and continuing the retry loop. Since this function already has a timeout-based retry loop, transient connection recovery errors are naturally resolved on subsequent iterations.

### Limitations
None

### Testing
Tested 250 times locally with 0 failures.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release