### PR TITLE
Fix flaky TestPubSubPatternCoexistence and TestPubSubExactCoexistence

### DIFF
--- a/go/integTest/pubsub_coexistence_test.go
+++ b/go/integTest/pubsub_coexistence_test.go
@@ -51,17 +51,21 @@ func (suite *GlideTestSuite) TestPubSubExactCoexistence() {
 			time.Sleep(200 * time.Millisecond)
 
 			// Receive first with WaitForMessage (async style)
+			var received []string
 			select {
 			case msg1 := <-queue.WaitForMessage():
-				assert.Equal(t, "msg1", msg1.Message)
+				received = append(received, msg1.Message)
 			case <-time.After(3 * time.Second):
-				t.Fatal("Timeout waiting for msg1")
+				t.Fatal("Timeout waiting for first message")
 			}
 
 			// Receive second with Pop (sync style)
 			msg2 := queue.Pop()
 			assert.NotNil(t, msg2)
-			assert.Equal(t, "msg2", msg2.Message)
+			received = append(received, msg2.Message)
+
+			// Messages may arrive in any order
+			assert.ElementsMatch(t, []string{"msg1", "msg2"}, received)
 		})
 	}
 }
@@ -103,16 +107,20 @@ func (suite *GlideTestSuite) TestPubSubPatternCoexistence() {
 
 			time.Sleep(200 * time.Millisecond)
 
+			var received []string
 			select {
 			case msg1 := <-queue.WaitForMessage():
-				assert.Equal(t, "msg1", msg1.Message)
+				received = append(received, msg1.Message)
 			case <-time.After(3 * time.Second):
-				t.Fatal("Timeout waiting for msg1")
+				t.Fatal("Timeout waiting for first message")
 			}
 
 			msg2 := queue.Pop()
 			assert.NotNil(t, msg2)
-			assert.Equal(t, "msg2", msg2.Message)
+			received = append(received, msg2.Message)
+
+			// Messages may arrive in any order
+			assert.ElementsMatch(t, []string{"msg1", "msg2"}, received)
 		})
 	}
 }


### PR DESCRIPTION
### Summary
Fix flaky `TestPubSubPatternCoexistence` and `TestPubSubExactCoexistence` tests by making message order assertions order-independent.

### Issue link
This Pull Request is linked to issue: [[Go][Flaky Test] TestGlideTestSuite/TestPubSubPatternCoexistence](https://github.com/valkey-io/valkey-glide/issues/5549)
Closes #5549

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** Both tests publish two messages ("msg1" and "msg2") and then assert they are received in that exact order. However, PubSub message delivery order is not guaranteed, so when "msg2" arrives before "msg1", the test fails.

**Fix:** Instead of asserting each message individually in sequence (`assert.Equal(t, "msg1", ...)` then `assert.Equal(t, "msg2", ...)`), collect both received messages into a slice and use `assert.ElementsMatch` to verify both expected messages were received regardless of order.

### Limitations
None

### Testing
The fix was verified by confirming the test file parses and formats correctly with `gofmt`. The full integration test requires the Rust core to be compiled (CGo dependency), which is handled by CI.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release