### PR TITLE
Python: Include _fast_response extension in glide-sync wheel

### DIFF
--- a/python/glide-sync/MANIFEST.in
+++ b/python/glide-sync/MANIFEST.in
@@ -4,7 +4,7 @@ recursive-include ffi *
 recursive-include glide-core *
 recursive-include logger_core *
 recursive-include glide_shared *
-recursive-include glide-shared *
+recursive-include glide-shared-rs *
 prune **/target
 prune **/tests
 prune **/benches/

--- a/python/glide-sync/setup.py
+++ b/python/glide-sync/setup.py
@@ -199,11 +199,18 @@ class build_ext(build_ext_orig):
             glide_shared_rs = VENDORED_DEPENDENCIES["glide-shared-rs"].source
 
         print(f"[INFO] Building _fast_response extension in {glide_shared_rs}")
-        env["PYO3_PYTHON"] = sys.executable
+        pyo3_env = env.copy()
+        pyo3_env["PYO3_PYTHON"] = sys.executable
+        # On macOS, PyO3 extension modules need undefined dynamic_lookup linker flag
+        if sys.platform == "darwin":
+            pyo3_env["RUSTFLAGS"] = (
+                pyo3_env.get("RUSTFLAGS", "")
+                + " -C link-arg=-undefined -C link-arg=dynamic_lookup"
+            )
         subprocess.run(
             ["cargo", "build"] + (["--release"] if release else []),
             cwd=glide_shared_rs,
-            env=env,
+            env=pyo3_env,
             check=True,
         )
 

--- a/python/glide-sync/setup.py
+++ b/python/glide-sync/setup.py
@@ -54,10 +54,6 @@ VENDORED_DEPENDENCIES = {
         source=ROOT.parent / "glide-shared" / "glide_shared",
         dist=ROOT / "glide_shared",
     ),
-    "glide-shared-rs": VendorFolder(
-        source=ROOT.parent / "glide-shared",
-        dist=ROOT / "glide-shared-rs",
-    ),
     "ffi": VendorFolder(
         source=ROOT.parent.parent / "ffi",
         dist=ROOT / "ffi",
@@ -71,6 +67,10 @@ VENDORED_DEPENDENCIES = {
         dist=ROOT / "logger_core",
     ),
 }
+
+# Rust source for the _fast_response PyO3 extension (only Cargo.toml + src/)
+GLIDE_SHARED_RS_SOURCE = ROOT.parent / "glide-shared"
+GLIDE_SHARED_RS_DIST = ROOT / "glide-shared-rs"
 
 
 # Helper to safely remove files, directories, or symlinks
@@ -99,12 +99,22 @@ def vendor_dependencies():
         print(f"[INFO] Copying {folder.source} → {folder.dist}")
         shutil.copytree(folder.source, folder.dist, ignore=ignore_dirs)
 
+    # Vendor only the Rust build files for glide-shared (Cargo.toml + src/)
+    if GLIDE_SHARED_RS_DIST.exists():
+        remove_existing(GLIDE_SHARED_RS_DIST)
+    GLIDE_SHARED_RS_DIST.mkdir()
+    shutil.copy2(
+        GLIDE_SHARED_RS_SOURCE / "Cargo.toml", GLIDE_SHARED_RS_DIST / "Cargo.toml"
+    )
+    shutil.copytree(GLIDE_SHARED_RS_SOURCE / "src", GLIDE_SHARED_RS_DIST / "src")
+
 
 def cleanup_vendored():
     """Remove all vendored dependency folders."""
     print("[INFO] Cleaning up vendored dependencies")
     for folder in VENDORED_DEPENDENCIES.values():
         remove_existing(folder.dist)
+    remove_existing(GLIDE_SHARED_RS_DIST)
 
 
 # ------------------------------------------------------------------------------
@@ -194,9 +204,9 @@ class build_ext(build_ext_orig):
         shutil.copy2(built_lib, dest_dir / lib_name)
 
         # Build _fast_response native extension from glide-shared Rust crate
-        glide_shared_rs = VENDORED_DEPENDENCIES["glide-shared-rs"].dist
+        glide_shared_rs = GLIDE_SHARED_RS_DIST
         if not glide_shared_rs.exists():
-            glide_shared_rs = VENDORED_DEPENDENCIES["glide-shared-rs"].source
+            glide_shared_rs = GLIDE_SHARED_RS_SOURCE
 
         print(f"[INFO] Building _fast_response extension in {glide_shared_rs}")
         pyo3_env = env.copy()
@@ -215,8 +225,12 @@ class build_ext(build_ext_orig):
         )
 
         # Copy the built extension with the correct Python extension suffix
-        ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")  # e.g. .cpython-311-darwin.so
-        src_lib = glide_shared_rs / "target" / target_dir / ("lib_fast_response" + suffix)
+        ext_suffix = sysconfig.get_config_var(
+            "EXT_SUFFIX"
+        )  # e.g. .cpython-311-darwin.so
+        src_lib = (
+            glide_shared_rs / "target" / target_dir / ("lib_fast_response" + suffix)
+        )
         dest_shared = Path(self.build_lib) / "glide_shared"
         dest_shared.mkdir(parents=True, exist_ok=True)
         dest_ext = dest_shared / ("_fast_response" + ext_suffix)

--- a/python/glide-sync/setup.py
+++ b/python/glide-sync/setup.py
@@ -29,6 +29,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -52,6 +53,10 @@ VENDORED_DEPENDENCIES = {
     "glide_shared": VendorFolder(
         source=ROOT.parent / "glide-shared" / "glide_shared",
         dist=ROOT / "glide_shared",
+    ),
+    "glide-shared-rs": VendorFolder(
+        source=ROOT.parent / "glide-shared",
+        dist=ROOT / "glide-shared-rs",
     ),
     "ffi": VendorFolder(
         source=ROOT.parent.parent / "ffi",
@@ -126,6 +131,7 @@ class CleanCommand(Command):
             "dist",
             "*.egg-info",
             "glide_shared",
+            "glide-shared-rs",
             "ffi",
             "glide-core",
             "logger_core",
@@ -152,7 +158,7 @@ class bdist_wheel(bdist_wheel_orig):
 
 
 class build_ext(build_ext_orig):
-    """Builds the Rust FFI library using Cargo"""
+    """Builds the Rust FFI library and _fast_response native extension using Cargo"""
 
     def run(self):
         # Detect release mode
@@ -186,6 +192,29 @@ class build_ext(build_ext_orig):
         dest_dir.mkdir(parents=True, exist_ok=True)
         print(f"[INFO] Copying {built_lib} → {dest_dir / lib_name}")
         shutil.copy2(built_lib, dest_dir / lib_name)
+
+        # Build _fast_response native extension from glide-shared Rust crate
+        glide_shared_rs = VENDORED_DEPENDENCIES["glide-shared-rs"].dist
+        if not glide_shared_rs.exists():
+            glide_shared_rs = VENDORED_DEPENDENCIES["glide-shared-rs"].source
+
+        print(f"[INFO] Building _fast_response extension in {glide_shared_rs}")
+        env["PYO3_PYTHON"] = sys.executable
+        subprocess.run(
+            ["cargo", "build"] + (["--release"] if release else []),
+            cwd=glide_shared_rs,
+            env=env,
+            check=True,
+        )
+
+        # Copy the built extension with the correct Python extension suffix
+        ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")  # e.g. .cpython-311-darwin.so
+        src_lib = glide_shared_rs / "target" / target_dir / ("lib_fast_response" + suffix)
+        dest_shared = Path(self.build_lib) / "glide_shared"
+        dest_shared.mkdir(parents=True, exist_ok=True)
+        dest_ext = dest_shared / ("_fast_response" + ext_suffix)
+        print(f"[INFO] Copying {src_lib} → {dest_ext}")
+        shutil.copy2(src_lib, dest_ext)
 
         super().run()
         cleanup_vendored()
@@ -237,7 +266,10 @@ class build_py(build_py_orig):
 
 setup(
     name="valkey-glide-sync",
-    package_data={"glide_sync": ["*.so", "*.dll", "*.dylib", "*.pyi", "py.typed"]},
+    package_data={
+        "glide_sync": ["*.so", "*.dll", "*.dylib", "*.pyi", "py.typed"],
+        "glide_shared": ["*.so", "*.pyd", "*.dylib"],
+    },
     distclass=BinaryDistribution,
     cmdclass={
         "build_py": build_py,


### PR DESCRIPTION
### Summary
Fix `import glide_sync` failing with `ModuleNotFoundError: No module named 'glide_shared._fast_response'`

### Issue link
Closes #5988

### Features / Behaviour Changes
No behaviour changes. This PR fixes a packaging bug where the `_fast_response` native extension was never included in the `valkey-glide-sync` wheel.

### Implementation
**Root cause:** `glide_sync/glide_client.py` imports `from glide_shared._fast_response import parse_response`, but the `setup.py` only vendored the `glide_shared` Python files — not the compiled Rust extension module (`_fast_response`, a PyO3 cdylib defined in `python/glide-shared/src/lib.rs`).

**Fix:** Add the `glide-shared` Rust crate build to the existing `build_ext` command, following the same `cargo build` pattern already used for the FFI library:

- Added `glide-shared-rs` to `VENDORED_DEPENDENCIES` (the Rust crate source)
- In `build_ext.run()`, build the glide-shared crate with `cargo build` + `PYO3_PYTHON` env var
- On macOS, set `RUSTFLAGS` with `-undefined dynamic_lookup` (same as maturin does internally)
- Copy the output with the correct Python extension suffix via `sysconfig.get_config_var("EXT_SUFFIX")`
- Added `glide_shared` to `package_data` for `.so`/`.pyd`/`.dylib` files
- Updated `MANIFEST.in` to include `glide-shared-rs` in sdist

### Limitations
None

### Testing
- Built wheel locally with `pip wheel . --no-deps` — succeeds
- Confirmed `_fast_response.cpython-311-darwin.so` (913KB) is included in the wheel
- Confirmed the native extension loads correctly and exports `parse_response`

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release