### PR TITLE
Pypi-CD: bump publish-binaries timeout from 120 to 180 minutes

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -92,7 +92,7 @@ jobs:
         if: github.repository_owner == 'valkey-io'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
-        timeout-minutes: 120
+        timeout-minutes: 180
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
The `publish-binaries` job in `pypi-cd.yml` hits the 120-minute timeout on the `macos-15-intel` x86_64 matrix entry. The workload (9 async maturin builds + 9 cibuildwheel sync builds, all recompiling Rust from scratch) takes ~130-140 minutes on that runner, so the v2.4.1-rc1 run was canceled mid build with 2 sync wheels still pending.

Bumping the timeout to 180 minutes to unblock the v2.4.1 RC. Workaround only; the proper fix (avoid rebuilding `libglide_ffi` 9 times per arch, add Cargo caching) will be tracked separately on main.

Failed run: <https://github.com/valkey-io/valkey-glide/actions/runs/26414547548/job/77756752820>