### PR TITLE
[Python] Fix flaky test_subscription_sync_timestamp_metric_on_success

### DIFF
--- a/python/tests/async_tests/test_pubsub.py
+++ b/python/tests/async_tests/test_pubsub.py
@@ -4016,7 +4016,7 @@ class TestPubSub:
                 expected_channels={channel1, channel2},
             )
 
-            # Poll until timestamp increases - the sync cycle may not have
+            # Poll until timestamp increases - Wait for the sync timestamp to update. Although the subscription state is confirmed, the timestamp may update asynchronously.
             # updated the timestamp yet or may complete within the same millisecond
             timeout_sec = 5
             poll_interval = 0.1

--- a/python/tests/async_tests/test_pubsub.py
+++ b/python/tests/async_tests/test_pubsub.py
@@ -4016,11 +4016,23 @@ class TestPubSub:
                 expected_channels={channel1, channel2},
             )
 
-            # Check that timestamp was updated
-            stats_after_first = await listening_client.get_statistics()
-            timestamp_after_first = int(
-                stats_after_first.get("subscription_last_sync_timestamp", "0")
-            )
+            # Poll until timestamp increases - the sync cycle may not have
+            # updated the timestamp yet or may complete within the same millisecond
+            timeout_sec = 5
+            poll_interval = 0.1
+            elapsed = 0.0
+            timestamp_after_first = initial_timestamp
+            while elapsed < timeout_sec:
+                stats_after_first = await listening_client.get_statistics()
+                timestamp_after_first = int(
+                    stats_after_first.get(
+                        "subscription_last_sync_timestamp", "0"
+                    )
+                )
+                if timestamp_after_first > initial_timestamp:
+                    break
+                await anyio.sleep(poll_interval)
+                elapsed += poll_interval
 
             assert (
                 timestamp_after_first > initial_timestamp


### PR DESCRIPTION
### Summary
Fix flaky `test_subscription_sync_timestamp_metric_on_success` by replacing the immediate timestamp assertion with a polling loop.

### Issue link
This Pull Request is linked to issue: [[Python][Flaky Test] test_subscription_sync_timestamp_metric_on_success](https://github.com/valkey-io/valkey-glide/issues/5212)
Closes #5212

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The test captures `initial_timestamp` from `get_statistics()` after client creation, then subscribes to channels and immediately checks if the timestamp has increased. The subscription sync cycle can complete within the same millisecond as the initial timestamp capture, causing `timestamp_after_first == initial_timestamp` and the assertion to fail.

**Fix:** Replace the immediate `get_statistics()` call and assertion with a polling loop that retries every 100ms for up to 5 seconds, waiting for the `subscription_last_sync_timestamp` to increase beyond the initial value. This handles the race condition where the sync cycle hasn't updated the timestamp yet or completed too quickly.

### Limitations
None

### Testing
Ran the test 100 times with parallelism of 10 (`pytest --count=100 -n 10 -x`). All 100 runs passed.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release