### PR TITLE
[Go] Fix flaky PubSub coexistence tests message ordering

### DIFF
--- a/go/integTest/pubsub_coexistence_test.go
+++ b/go/integTest/pubsub_coexistence_test.go
@@ -51,17 +51,21 @@ func (suite *GlideTestSuite) TestPubSubExactCoexistence() {
 			time.Sleep(200 * time.Millisecond)
 
 			// Receive first with WaitForMessage (async style)
+			var received []string
 			select {
 			case msg1 := <-queue.WaitForMessage():
-				assert.Equal(t, "msg1", msg1.Message)
+				received = append(received, msg1.Message)
 			case <-time.After(3 * time.Second):
-				t.Fatal("Timeout waiting for msg1")
+				t.Fatal("Timeout waiting for first message")
 			}
 
 			// Receive second with Pop (sync style)
 			msg2 := queue.Pop()
 			assert.NotNil(t, msg2)
-			assert.Equal(t, "msg2", msg2.Message)
+			received = append(received, msg2.Message)
+
+			// Messages may arrive in any order
+			assert.ElementsMatch(t, []string{"msg1", "msg2"}, received)
 		})
 	}
 }
@@ -103,16 +107,20 @@ func (suite *GlideTestSuite) TestPubSubPatternCoexistence() {
 
 			time.Sleep(200 * time.Millisecond)
 
+			var received []string
 			select {
 			case msg1 := <-queue.WaitForMessage():
-				assert.Equal(t, "msg1", msg1.Message)
+				received = append(received, msg1.Message)
 			case <-time.After(3 * time.Second):
-				t.Fatal("Timeout waiting for msg1")
+				t.Fatal("Timeout waiting for first message")
 			}
 
 			msg2 := queue.Pop()
 			assert.NotNil(t, msg2)
-			assert.Equal(t, "msg2", msg2.Message)
+			received = append(received, msg2.Message)
+
+			// Messages may arrive in any order
+			assert.ElementsMatch(t, []string{"msg1", "msg2"}, received)
 		})
 	}
 }


### PR DESCRIPTION
### Summary
Fix flaky `TestPubSubExactCoexistence` and `TestPubSubPatternCoexistence` tests that intermittently fail due to message ordering assumptions.

### Issue link
This Pull Request is linked to issues:
- [TestGlideTestSuite/TestPubSubExactCoexistence/StandaloneClient](https://github.com/valkey-io/valkey-glide/issues/5706)
- [TestGlideTestSuite/TestPubSubPatternCoexistence](https://github.com/valkey-io/valkey-glide/issues/5549)

Closes #5706
Closes #5549

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** Both tests publish two messages (`msg1`, `msg2`) and then assert they arrive in publish order using `assert.Equal`. However, PubSub message delivery order is not guaranteed by the server, so messages can arrive as `msg2` then `msg1`, causing the test to fail intermittently.

**Fix:** Collect both received messages into a slice and use `assert.ElementsMatch` to verify both expected messages were received regardless of order. This preserves the test validation (both messages must be received via both retrieval methods) while eliminating the non-deterministic ordering assumption.

### Limitations
None

### Testing
Both tests were run 100 times locally (`go test -run <TestName> -count=100 -timeout=120m ./integTest/...`) and passed all 100 iterations without failure.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release