### PR TITLE
[Python] Fix flaky test: test_tls_with_self_signed_certificate_succeeds

### DIFF
--- a/python/tests/async_tests/test_tls.py
+++ b/python/tests/async_tests/test_tls.py
@@ -61,6 +61,7 @@ class TestTls:
             protocol=protocol,
             use_tls=True,
             root_pem_cacerts=certificate,
+            request_timeout=5000,
         )
 
         await assert_connected(client)


### PR DESCRIPTION
### Summary
Fix flaky `test_tls_with_self_signed_certificate_succeeds` by increasing the request timeout from the default 1000ms to 5000ms.

### Issue link
This Pull Request is linked to issue: [[Python][Flaky Test] test_tls_with_self_signed_certificate_succeeds](https://github.com/valkey-io/valkey-glide/issues/5477)
Closes #5477

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The test uses `create_client()` with the default `request_timeout=1000ms`. When connecting with TLS using self-signed certificates, the TLS handshake can occasionally take longer than expected, causing the first `ping()` command after connection to time out with `glide_shared.exceptions.TimeoutError: timed out`.

**Fix:** Increase `request_timeout` to 5000ms for this specific test, matching the timeout used by the `glide_client` fixture for general test operations. This gives sufficient headroom for the TLS handshake overhead without changing what the test validates.

### Limitations
None

### Testing
Ran the test 100 times with 10 parallel workers (`pytest --count=100 -n 10 -x`). All 400 test cases (100 runs × 4 parametrized variants) passed with 0 failures.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release