### PR TITLE
[Python] Fix flaky test: add retry logic to function_scoped_cluster fixture

### DIFF
--- a/python/tests/sync_tests/test_sync_scan.py
+++ b/python/tests/sync_tests/test_sync_scan.py
@@ -1,3 +1,4 @@
+import random
 import time
 from typing import Generator, List, cast
 
@@ -63,12 +64,24 @@ def is_cluster_ready(client: GlideClusterClient, count: int) -> bool:
 def function_scoped_cluster():
     """
     Function-scoped fixture to create a new cluster for each test invocation.
+    Retries cluster creation to handle transient port conflicts when running
+    tests in parallel.
     """
-    cluster = ValkeyCluster(
-        tls=False, cluster_mode=True, shard_count=3, replica_count=0
-    )
-    yield cluster
-    del cluster
+    max_retries = 5
+    last_exception = None
+    for attempt in range(max_retries):
+        try:
+            cluster = ValkeyCluster(
+                tls=False, cluster_mode=True, shard_count=3, replica_count=0
+            )
+            yield cluster
+            del cluster
+            return
+        except Exception as e:
+            last_exception = e
+            if attempt < max_retries - 1:
+                time.sleep(2 + random.uniform(0, 2))
+    raise last_exception
 
 
 # Since the cluster for slots covered is created separately, we need to create a client for the specific cluster


### PR DESCRIPTION
### Summary
Fix flaky test `test_sync_cluster_scan_non_covered_slots` by adding retry logic to the `function_scoped_cluster` fixture.

### Issue link
This Pull Request is linked to issue: [[Python][Flaky Test] test_sync_cluster_scan_non_covered_slots](https://github.com/valkey-io/valkey-glide/issues/5478)
Closes #5478

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The `function_scoped_cluster` fixture creates a new ValkeyCluster by invoking `cluster_manager.py`. When ports from a recently torn down cluster have not been fully released, the script times out with "Timeout exceeded trying to check if address already in use" and subsequently fails with "Failed to send CLUSTER MEET command."

**Fix:** Add retry logic (up to 5 attempts) with a randomized delay of 2-4 seconds between retries. The random jitter prevents thundering herd issues when multiple test workers retry simultaneously. This gives the OS time to release ports from recently stopped clusters.

### Limitations
None

### Testing
Ran the test 100 times with 10 parallel workers (`pytest --count=100 -n 10 -x`) — all 200 test cases (100 iterations x 2 protocol versions) passed successfully.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release