### PR TITLE
[Python] Fix flaky test: test_sync_standalone_scan_with_count timeout

### DIFF
--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -1526,9 +1526,9 @@ class TestCommands:
             glide_sync_client.blpop(["foo"], 0.001)
 
         def endless_blpop_call():
-            glide_sync_client.blpop(["non_existent_key"], 0)
+            glide_sync_client.blpop(["non_existent_key"], 10)
 
-        # blpop is called against a non-existing key with no timeout, but we wrap the call in the `run_sync_func_with_timeout_in_thread` function
+        # blpop is called against a non-existing key with a long timeout, but we wrap the call in the `run_sync_func_with_timeout_in_thread` function
         # to avoid having the test block forever
         with pytest.raises(TimeoutError):
             run_sync_func_with_timeout_in_thread(
@@ -1608,10 +1608,10 @@ class TestCommands:
         with pytest.raises(RequestError):
             glide_sync_client.blmpop([key4], ListDirection.LEFT, 0.1, 1)
 
-        # BLMPOP is called against a non-existing key with no timeout, but we wrap the call in a timeout to
+        # BLMPOP is called against a non-existing key with a long timeout, but we wrap the call in a timeout to
         # avoid having the test block forever
         def endless_blmpop_call():
-            glide_sync_client.blmpop([key3], ListDirection.LEFT, 0, 1)
+            glide_sync_client.blmpop([key3], ListDirection.LEFT, 10, 1)
 
         with pytest.raises(TimeoutError):
             run_sync_func_with_timeout_in_thread(
@@ -1705,9 +1705,9 @@ class TestCommands:
             glide_sync_client.brpop(["foo"], 0.001)
 
         def endless_brpop_call():
-            glide_sync_client.brpop(["non_existent_key"], 0)
+            glide_sync_client.brpop(["non_existent_key"], 10)
 
-        # brpop is called against a non-existing key with no timeout, but we wrap the call in the `run with timeout` function
+        # brpop is called against a non-existing key with a long timeout, but we wrap the call in the `run with timeout` function
         # to avoid having the test block forever
         with pytest.raises(TimeoutError):
             run_sync_func_with_timeout_in_thread(
@@ -1916,7 +1916,7 @@ class TestCommands:
                 key1, key3, ListDirection.LEFT, ListDirection.LEFT, 0.1
             )
 
-        # BLMOVE is called against a non-existing key with no timeout, but we wrap the call in a timeout to
+        # BLMOVE is called against a non-existing key with a long timeout, but we wrap the call in a timeout to
         # avoid having the test block forever
         def endless_blmove_call():
             glide_sync_client.blmove(
@@ -1924,7 +1924,7 @@ class TestCommands:
                 key2,
                 ListDirection.LEFT,
                 ListDirection.RIGHT,
-                0,
+                10,
             )
 
         with pytest.raises(TimeoutError):
@@ -4128,9 +4128,9 @@ class TestCommands:
             glide_sync_client.bzpopmin(["foo"], 0.5)
 
         def endless_bzpopmin_call():
-            glide_sync_client.bzpopmin(["non_existent_key"], 0)
+            glide_sync_client.bzpopmin(["non_existent_key"], 10)
 
-        # bzpopmin is called against a non-existing key with no timeout, but we wrap the call the `run_sync_func_with_timeout_in_thread` function
+        # bzpopmin is called against a non-existing key with a long timeout, but we wrap the call the `run_sync_func_with_timeout_in_thread` function
         # to avoid having the test block forever
         with pytest.raises(TimeoutError):
             run_sync_func_with_timeout_in_thread(
@@ -4189,9 +4189,9 @@ class TestCommands:
             glide_sync_client.bzpopmax(["foo"], 0.5)
 
         def endless_bzpopmax_call():
-            glide_sync_client.bzpopmax(["non_existent_key"], 0)
+            glide_sync_client.bzpopmax(["non_existent_key"], 10)
 
-        # bzpopmax is called against a non-existing key with no timeout, but we wrap the call in the `run_sync_func_with_timeout_in_thread` function
+        # bzpopmax is called against a non-existing key with a long timeout, but we wrap the call in the `run_sync_func_with_timeout_in_thread` function
         # to avoid having the test block forever
         with pytest.raises(TimeoutError):
             run_sync_func_with_timeout_in_thread(
@@ -4866,9 +4866,9 @@ class TestCommands:
         assert compare_maps(entries, result_map) is True  # type: ignore
 
         def endless_bzmpop_call():
-            glide_sync_client.bzmpop(["non_existent_key"], ScoreFilter.MAX, 0)
+            glide_sync_client.bzmpop(["non_existent_key"], ScoreFilter.MAX, 10)
 
-        # bzmpop is called against a non-existing key with no timeout, but we wrap the call in the `run_sync_func_with_timeout_in_thread` function
+        # bzmpop is called against a non-existing key with a long timeout, but we wrap the call in the `run_sync_func_with_timeout_in_thread` function
         # to avoid having the test block forever
         with pytest.raises(TimeoutError):
             run_sync_func_with_timeout_in_thread(


### PR DESCRIPTION
### Summary
Fix flaky test `test_sync_standalone_scan_with_count` which times out after 300s due to zombie threads from blocking command tests.

### Issue link
This Pull Request is linked to issue: [[Python][Flaky Test] test_sync_standalone_scan_with_count](https://github.com/valkey-io/valkey-glide/issues/5244)
Closes #5244

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The `test_sync_blpop`, `test_sync_blmpop`, `test_sync_brpop`, `test_sync_blmove`, `test_sync_bzpopmin`, `test_sync_bzpopmax`, and `test_sync_bzmpop` tests use `run_sync_func_with_timeout_in_thread` to test blocking commands with `timeout=0` (infinite). When the wrapper timeout fires and calls `client.close()`, the native Rust blocking call is not always interrupted, leaving zombie threads blocked indefinitely. These threads accumulate across test runs and eventually cause subsequent tests (like the scan test) to hang.

**Fix:** Changed the blocking command timeout from `0` (infinite) to `10` seconds in all `endless_*_call` functions. The wrapper timeout is 3s (or 0.5s for some tests), so the tests still validate the timeout behavior correctly (TimeoutError is raised when the wrapper times out before the blocking command returns). The key difference is that the thread now naturally terminates after 10s instead of blocking forever, preventing zombie thread accumulation.

### Limitations
None

### Testing
- Ran `test_sync_standalone_scan_with_count` 100 times (200 test items with 2 protocol versions) — all passed
- Ran all modified blocking command tests (`test_sync_blpop`, `test_sync_blmpop`, `test_sync_brpop`, `test_sync_blmove`, `test_sync_bzpopmin`, `test_sync_bzpopmax`, `test_sync_bzmpop`) — all 28 test items passed

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release