### PR TITLE
[Core] Fix flaky test test_pipeline_can_reconnect

### DIFF
--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -1998,22 +1998,25 @@ pub(crate) mod shared_client_tests {
             )
             .await;
 
-            let res = retry(|| async {
-                let mut client = test_basics.client.clone();
-                client
-                    .send_pipeline(
-                        &pipeline,
-                        None,
-                        false,
-                        None,
-                        PipelineRetryStrategy {
-                            retry_server_error: true,
-                            retry_connection_error: false,
-                        },
-                    )
-                    .await
-                    .ok()
-            })
+            let res = retry_until_timeout(
+                || async {
+                    let mut client = test_basics.client.clone();
+                    client
+                        .send_pipeline(
+                            &pipeline,
+                            None,
+                            false,
+                            None,
+                            PipelineRetryStrategy {
+                                retry_server_error: true,
+                                retry_connection_error: false,
+                            },
+                        )
+                        .await
+                        .ok()
+                },
+                std::time::Duration::from_millis(10_000),
+            )
             .await;
 
             let expected = Value::Array(vec![
@@ -2152,22 +2155,25 @@ pub(crate) mod shared_client_tests {
             // Kill all connections.
             kill_connection(&mut test_basics.client).await;
 
-            let res = retry(|| async {
-                let mut client = test_basics.client.clone();
-                client
-                    .send_pipeline(
-                        &pipeline,
-                        None,
-                        false,
-                        None,
-                        PipelineRetryStrategy {
-                            retry_server_error: true,
-                            retry_connection_error: false,
-                        },
-                    )
-                    .await
-                    .ok()
-            })
+            let res = retry_until_timeout(
+                || async {
+                    let mut client = test_basics.client.clone();
+                    client
+                        .send_pipeline(
+                            &pipeline,
+                            None,
+                            false,
+                            None,
+                            PipelineRetryStrategy {
+                                retry_server_error: true,
+                                retry_connection_error: false,
+                            },
+                        )
+                        .await
+                        .ok()
+                },
+                std::time::Duration::from_millis(10_000),
+            )
             .await;
 
             let expected = Value::Array(vec![


### PR DESCRIPTION
### Summary

Fix flaky test `test_pipeline_can_reconnect` (and related `test_pipeline_reconnect_after_kill_all_connections`) by increasing the retry timeout from 3s to 10s.

### Issue link

This Pull Request is linked to issue: [[Core][Flaky Test] shared_client_tests::test_pipeline_can_reconnect::use_cluster_1_false](https://github.com/valkey-io/valkey-glide/issues/4839)
Closes #4839

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The `retry()` helper uses a 3000ms timeout. The client's reconnection strategy uses exponential backoff (`factor: 100, exponent_base: 2, number_of_retries: 5, jitter_percent: 20`), which can take up to ~3720ms total. Under CI load, the retry timeout expires before reconnection completes, causing the pipeline to fail with "channel closed".

**Fix:** Replace `retry()` with `retry_until_timeout()` using a 10s timeout, giving the reconnection sufficient time to complete even under heavy CI load. The test's overall timeout (`SHORT_CLUSTER_TEST_TIMEOUT = 50s`) still provides a safety bound.

### Limitations

None

### Testing

Both `test_pipeline_can_reconnect` variants (use_cluster=false and use_cluster=true) passed 100 consecutive runs with `--test-threads=10`.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release