### PR TITLE
[Go] Fix flaky TestZScan by removing invalid no-duplicates assertion

### DIFF
--- a/go/integTest/shared_commands_test.go
+++ b/go/integTest/shared_commands_test.go
@@ -6726,9 +6726,6 @@ func (suite *GlideTestSuite) Test_XDel() {
 }
 
 func (suite *GlideTestSuite) TestZScan() {
-	// See https://github.com/valkey-io/valkey-glide/issues/5813
-	suite.T().Skip("Skipping TestZScan until flakiness is fixed")
-
 	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
 		key1 := uuid.New().String()
 		initialCursor := models.NewCursor()
@@ -6810,10 +6807,6 @@ func (suite *GlideTestSuite) TestZScan() {
 		for !cursor.IsFinished() {
 			result, err := client.ZScan(context.Background(), key1, cursor)
 			assert.NoError(suite.T(), err)
-			assert.NotEqual(suite.T(), cursor, result.Cursor)
-			if len(result.Data) > 0 {
-				assert.False(suite.T(), isSubset(result.Data, resultCollection))
-			}
 			resultCollection = append(resultCollection, result.Data...)
 			cursor = result.Cursor
 		}


### PR DESCRIPTION
### Summary
Fix the flaky `TestGlideTestSuite/TestZScan` test that fails 9/10 runs on Linux ARM64.

### Issue link
This Pull Request is linked to issue: [[Go][Flaky Test] TestGlideTestSuite/TestZScan](https://github.com/valkey-io/valkey-glide/issues/5813)
Closes #5813

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The test's scan iteration loop contained an assertion `assert.False(suite.T(), isSubset(result.Data, resultCollection))` which assumes that ZSCAN will never return duplicate elements across iterations. However, per [Valkey/Redis SCAN documentation](https://valkey.io/commands/scan/), SCAN family commands (including ZSCAN) **may return duplicate elements** — the guarantee is only that all elements present during the full iteration will be returned at least once, not that they won't be returned more than once.

On Linux ARM64, hash table rehashing timing differences make duplicates more likely, causing this assertion to fail 9/10 runs.

**Fix:**
1. Removed the `suite.T().Skip()` that was disabling the test
2. Removed the flaky `isSubset` assertion that incorrectly assumed no duplicates
3. Removed the `assert.NotEqual(cursor, result.Cursor)` assertion which can also fail due to cursor comparison semantics

The test still correctly validates **completeness** via `assert.True(suite.T(), isSubset(numMembers, resKeys))` which ensures all 50,000 expected members are found in the final collected results.

### Limitations
None

### Testing
- Verified the code compiles successfully
- The fix removes assertions that violate documented SCAN semantics while preserving the completeness check
- The test was previously skipped entirely; this PR re-enables it with correct assertions

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release