### PR TITLE
fix(ci): Update `valkey-bundle` image to a stable version

### DIFF
--- a/.github/workflows/start-valkey-docker/action.yml
+++ b/.github/workflows/start-valkey-docker/action.yml
@@ -9,7 +9,7 @@ description: >
 inputs:
     engine-version:
         description: >
-            Valkey engine version (e.g. 9.1, 8.1).
+            Valkey engine version (e.g. 9.1).
         required: true
 
 runs:

--- a/.github/workflows/start-valkey-docker/action.yml
+++ b/.github/workflows/start-valkey-docker/action.yml
@@ -9,8 +9,7 @@ description: >
 inputs:
     engine-version:
         description: >
-            Valkey engine version (e.g. 9.0, 8.1). The Docker image is
-            pinned to 9.1-rc1 regardless - see the TODO in the image step.
+            Valkey engine version (e.g. 9.1, 8.1).
         required: true
 
 runs:
@@ -19,12 +18,8 @@ runs:
         - name: Determine Docker image
           id: docker-image
           shell: bash
-          env:
-              ENGINE_VERSION: ${{ inputs.engine-version }}
           run: |
-              # TEMPORARY: Pin to 9.1-rc1 until stable per-version valkey-bundle tags exist.
-              # TODO: switch to valkey/valkey-bundle:${ENGINE_VERSION} once stable tags are published.
-              IMAGE="valkey/valkey-bundle:9.1-rc1"
+              IMAGE="valkey/valkey-bundle:9.1"
               echo "image=$IMAGE" >> $GITHUB_OUTPUT
               echo "Using Docker image: $IMAGE"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Updates the `valkey-bundle` docker image used in CI to a stable version.

### Issue link

Closes #6048 

### Features / Behaviour Changes

Changes from RC to the latest stable version.

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

Currently being hardcoded to 9.1 due to issues with `valkey-bundle` having different release timelines than the original `valkey-server` (can break CI if a new version is added to the matrix but not yet released for `valkey-bundle`). Older versions of `valkey-bundle` may not support the necessary features we need to run the tests, so tests may also fail.

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
