### PR TITLE
Update/review prs.md comment resolving policy

### DIFF
--- a/REVIEWING_PRS.md
+++ b/REVIEWING_PRS.md
@@ -59,6 +59,19 @@ This practice keeps the review process accountable and prevents feedback from be
 
 **Exception — stale threads:** If the original commenter has not responded after a reasonable period of time, a maintainer or the PR author may resolve the thread to keep the review moving forward.
 
+**Linking fixes to feedback:** When addressing review feedback, the PR author should reply with a link to the commit or code change that resolves the comment. This helps the reviewer quickly verify the fix without searching through the diff. This is especially important for larger or more complex PRs that may require multiple iterations of feedback.
+
+> **Note:** A reply like "Addressed it" or "Fixed" without context is not sufficient. Include a direct link or reference so the reviewer can locate the change without effort.
+>
+> Good examples:
+> - "Fixed in [abc1234](link-to-commit) — renamed the variable as suggested."
+> - "Addressed here: [link to updated line]. I went with option B since it avoids the extra allocation."
+>
+> Poor examples:
+> - "Done."
+> - "Addressed it."
+> - "Fixed, PTAL."
+
 ## Stale PR Policy
 
 The repository uses an automated [stale bot](.github/workflows/stale.yml) to manage inactive pull requests:

--- a/REVIEWING_PRS.md
+++ b/REVIEWING_PRS.md
@@ -47,6 +47,16 @@ The repository uses two merge strategies depending on the branch context:
 
 Most contributor PRs target `main` from a feature branch, so squash and merge is the typical path. The maintainer merging the PR will select the appropriate strategy.
 
+## Resolving Review Comments
+
+The original commenter is responsible for resolving their own review comments. This ensures the person who raised the feedback can verify that it has been adequately addressed or responded to before the conversation is marked as resolved.
+
+- **Do not resolve someone else's comment.** Only the person who left the feedback should mark it as resolved.
+- **If the feedback has been addressed,** the original commenter should verify the change and resolve the thread.
+- **If the contributor disagrees,** the original commenter should resolve the thread once the discussion has reached a conclusion — whether that means the suggestion was adopted, an alternative was agreed upon, or the commenter is satisfied with the explanation provided.
+
+This practice keeps the review process accountable and prevents feedback from being dismissed without acknowledgment.
+
 ## Stale PR Policy
 
 The repository uses an automated [stale bot](.github/workflows/stale.yml) to manage inactive pull requests:

--- a/REVIEWING_PRS.md
+++ b/REVIEWING_PRS.md
@@ -57,6 +57,8 @@ The original commenter is responsible for resolving their own review comments. T
 
 This practice keeps the review process accountable and prevents feedback from being dismissed without acknowledgment.
 
+**Exception — stale threads:** If the original commenter has not responded after a reasonable period of time, a maintainer or the PR author may resolve the thread to keep the review moving forward.
+
 ## Stale PR Policy
 
 The repository uses an automated [stale bot](.github/workflows/stale.yml) to manage inactive pull requests:


### PR DESCRIPTION
### Summary

Add a "Resolving Review Comments" section to `REVIEWING_PRS.md` that establishes the policy that the original commenter is responsible for resolving their own review threads. This ensures feedback is not dismissed without the commenter verifying it has been addressed.

### Issue link

This Pull Request is linked to issue: N/A

### Features / Behaviour Changes

- Added a new "Resolving Review Comments" section to the PR review guide.
- The section clarifies that only the person who left a review comment should mark it as resolved.
- Covers the expected workflow for addressed feedback, disagreements, and reaching resolution.

### Implementation

A new markdown section was inserted into `REVIEWING_PRS.md` between "Merge Strategies" and "Stale PR Policy". It contains bullet-point guidelines covering three scenarios: feedback addressed, contributor disagrees, and general accountability.

### Limitations

None. This is a documentation-only change.

### Testing

No automated tests required — this is a documentation update. The markdown renders correctly and the file structure remains consistent with the rest of the document.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] ~Tests are added or updated.~
- [ ] ~CHANGELOG.md and documentation files are updated.~
- [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] ~Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary~
