### PR TITLE
Update CD workflows to be consistent across all clients, add pre-publish smoke tests, and better AWS_ACTION gates

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -130,6 +130,9 @@ jobs:
               run: |
                   mkdir -p $GITHUB_WORKSPACE/ffi/target/release
                   cp ffi/target/*/release/libglide_ffi.a $GITHUB_WORKSPACE/ffi/target/release/
+            - name: Smoke test binary
+              run: |
+                  file ffi/target/release/libglide_ffi.a | grep -q "archive"
             - name: Upload artifacts
               continue-on-error: true
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -1,6 +1,12 @@
 name: Go - Continuous Deployment
 
 on:
+    pull_request:
+        paths:
+            - .github/workflows/go-cd.yml
+            - .github/workflows/install-shared-dependencies/action.yml
+            - .github/workflows/install-engine/action.yml
+            - .github/json_matrices/**
     push:
         tags:
             - "v*.*"
@@ -53,7 +59,6 @@ jobs:
                   echo "PLATFORM_MATRIX=${PLATFORM_MATRIX}" >> $GITHUB_OUTPUT
 
     validate-release-version:
-        if: ${{ github.event_name == 'push' || inputs.pkg_go_dev_publish }}
         runs-on: ubuntu-latest
         outputs:
             RELEASE_VERSION: ${{ steps.release-tag.outputs.RELEASE_VERSION }}
@@ -77,21 +82,25 @@ jobs:
             - name: Validate Version Against RegEx and output
               id: release-tag
               run: |
-                  if ${{ github.event_name == 'workflow_dispatch' }}; then
+                  if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                    R_VERSION="v0.0.0"
+                  elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
                     R_VERSION="${{ env.INPUT_VERSION }}"
                   else
                     R_VERSION="${{ env.TAG_VERSION }}"
                   fi
-                  echo "Releassing version is: ${R_VERSION}"
-                  if ! echo "${R_VERSION}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
-                      echo "Version is not valid, must be v*.*.* or v*.*.*-rc*"
-                      exit 1
+                  echo "Release version is: ${R_VERSION}"
+                  if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+                    if ! echo "${R_VERSION}" | grep -Pq '^v\d+\.\d+\.\d+(-rc\d+)?$'; then
+                        echo "Version is not valid, must be v*.*.* or v*.*.*-rc*"
+                        exit 1
+                    fi
                   fi
                   echo "RELEASE_VERSION=${R_VERSION}" >> $GITHUB_OUTPUT
 
     create-binaries:
         needs: [load-platform-matrix, validate-release-version]
-        if: success()
+        if: github.repository_owner == 'valkey-io'
         strategy:
             fail-fast: false
             matrix:
@@ -147,6 +156,7 @@ jobs:
         if: ${{ github.event_name == 'push' || inputs.pkg_go_dev_publish == true }}
         needs: [validate-release-version, create-binaries]
         runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
         permissions:
             contents: write
         steps:
@@ -164,14 +174,14 @@ jobs:
                   for dir in */; do
                     target_name=${dir%/}
                     PLATFORMS+=("$target_name")
-                    
+
                     mkdir -p $GITHUB_WORKSPACE/go/rustbin/${target_name}
                     cp ${target_name}/ffi/target/release/libglide_ffi.a $GITHUB_WORKSPACE/go/rustbin/${target_name}/
-                    
+
                     # Create doc.go marker file for vendoring support
                     # Convert platform name to valid Go package name (hyphens to underscores)
                     package_name="rustbin_${target_name//-/_}"
-                    
+
                     cat > "$GITHUB_WORKSPACE/go/rustbin/${target_name}/doc.go" << EOF
                   // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -1,6 +1,12 @@
 name: Java Prepare Deployment
 
 on:
+    pull_request:
+        paths:
+            - .github/workflows/java-cd.yml
+            - .github/workflows/install-shared-dependencies/action.yml
+            - .github/workflows/install-engine/action.yml
+            - .github/json_matrices/**
     push:
         tags:
             - "v*.*"
@@ -56,7 +62,9 @@ jobs:
               id: release-version
               shell: bash
               run: |
-                  if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+                  if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                      R_VERSION="0.0.0"
+                  elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
                       R_VERSION="${{ env.INPUT_VERSION }}"
                   else
                       R_VERSION=${GITHUB_REF:11}

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -63,7 +63,7 @@ jobs:
               shell: bash
               run: |
                   if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                      R_VERSION="0.0.0"
+                      R_VERSION="255.255.255"
                   elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
                       R_VERSION="${{ env.INPUT_VERSION }}"
                   else
@@ -372,7 +372,12 @@ jobs:
               working-directory: java
               shell: bash
               run: |
-                  jar xf bundle-uber-jar.jar
+                  # Extract in a temp dir so the working directory is not polluted; clean up on exit.
+                  bundle="$PWD/bundle-uber-jar.jar"
+                  tmp_dir=$(mktemp -d)
+                  trap 'rm -rf "$tmp_dir"' EXIT
+                  cd "$tmp_dir"
+                  jar xf "$bundle"
                   INNER_JAR=$(find . -maxdepth 1 -name 'valkey-glide-*.jar' ! -name '*sources*' ! -name '*javadoc*' | head -1)
                   mkdir inner && (cd inner && jar xf "../$INNER_JAR")
                   find inner/natives -name "*.so" -o -name "*.dylib" -o -name "*.dll" | grep -q .

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -205,6 +205,11 @@ jobs:
                   cd -
                   cp $jedis_src_folder/jedis-bundle.jar jedis-bundle-${{ matrix.host.TARGET }}.jar
 
+            - name: Smoke test native library
+              shell: bash
+              run: |
+                  find java/client/build/resources/main/natives -name "*.so" -o -name "*.dylib" -o -name "*.dll" | grep -q .
+
             - name: Upload artifacts to publish
               continue-on-error: true
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -354,6 +359,13 @@ jobs:
                   ls -ltr
                   cd -
                   cp $src_folder/jedis-bundle.jar jedis-bundle-no-classifier.jar
+
+            - name: Smoke test uber JAR
+              working-directory: java
+              shell: bash
+              run: |
+                  jar xf bundle-uber-jar.jar
+                  jar tf valkey-glide-*.jar | grep -q "natives/.*\.\(so\|dylib\|dll\)"
 
             - name: Upload uber JAR artifact
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -365,7 +365,9 @@ jobs:
               shell: bash
               run: |
                   jar xf bundle-uber-jar.jar
-                  jar tf valkey-glide-*.jar | grep -q "natives/.*\.\(so\|dylib\|dll\)"
+                  INNER_JAR=$(find . -maxdepth 1 -name 'valkey-glide-*.jar' ! -name '*sources*' ! -name '*javadoc*' | head -1)
+                  mkdir inner && (cd inner && jar xf "../$INNER_JAR")
+                  find inner/natives -name "*.so" -o -name "*.dylib" -o -name "*.dll" | grep -q .
 
             - name: Upload uber JAR artifact
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -272,6 +272,10 @@ jobs:
                   echo "Built native module for ${{ matrix.TARGET }}:"
                   ls -la ../${{ matrix.TARGET }}/
 
+            - name: Smoke test native module
+              working-directory: ./node
+              run: file ${{ matrix.TARGET }}/*.node | grep -qi "shared object\|dynamic\|mach-o"
+
             # Upload the native .node modules as artifacts
             - name: Upload Native Modules
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -37,6 +37,7 @@ permissions:
 jobs:
     get-build-parameters:
         runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
         outputs:
             release_version: ${{ steps.get-params.outputs.release_version }}
             npm_tag: ${{ steps.get-params.outputs.npm_tag }}
@@ -153,18 +154,18 @@ jobs:
                   export PLATFORM_MATRIX=$(jq 'map(
                       select(.PACKAGE_MANAGERS != null and (.PACKAGE_MANAGERS | contains(["npm"])))
                       | .runner = (
-                          if (.CD_RUNNER != null) 
-                          then .CD_RUNNER 
-                          elif (.RUNNER != null and (.RUNNER | type != "array")) then .RUNNER 
+                          if (.CD_RUNNER != null)
+                          then .CD_RUNNER
+                          elif (.RUNNER != null and (.RUNNER | type != "array")) then .RUNNER
                           else "ubuntu-latest"
                           end
                       )
                       | .build_type = (
-                          if (.TARGET | contains("musl")) 
-                          then "musl" 
-                          elif (.TARGET | contains("gnu")) 
-                          then "gnu" 
-                          else "mac" 
+                          if (.TARGET | contains("musl"))
+                          then "musl"
+                          elif (.TARGET | contains("gnu"))
+                          then "gnu"
+                          else "mac"
                           end
                       )
                       | if .RUNNER == "macos13" then .["test-runner"] = "macos13" else . end
@@ -504,7 +505,7 @@ jobs:
                   if [[ "${{ matrix.build_type }}" == "gnu" ]]; then
                       echo "Installing Valkey on GNU/Linux..."
                       sudo apt update
-                      sudo apt install -y valkey || { 
+                      sudo apt install -y valkey || {
                           echo "Valkey not found in default repos, trying alternative source..."
                           curl -fsSL https://packages.redis.io/valkey/setup-valkey | sudo bash -
                           sudo apt install -y valkey || {
@@ -626,7 +627,7 @@ jobs:
                       elif [[ "$build_type" == "gnu" ]]; then
                         additional_suffix="-gnu"
                       fi
-                      
+
                       package_name="@valkey/valkey-glide-${os}-${arch}${additional_suffix}"
                       attempt_deprecate "${package_name}@${VERSION}" "${DEPRECATION_MESSAGE}"
                     else

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -41,6 +41,7 @@ permissions:
 jobs:
     load-platform-matrix:
         runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
         outputs:
             PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.PLATFORM_MATRIX }}
             TESTS_PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.TESTS_PLATFORM_MATRIX }}
@@ -62,9 +63,9 @@ jobs:
                   # For building and publishing, replace "ephemeral" with "persistent" in RUNNER
                   export PLATFORM_MATRIX=$(echo "${TESTS_PLATFORM_MATRIX}" | jq 'map(
                       .RUNNER = (
-                          if (.RUNNER | type == "array") 
-                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end)) 
-                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end) 
+                          if (.RUNNER | type == "array")
+                          then (.RUNNER | map(if . == "ephemeral" then "persistent" else . end))
+                          else (if .RUNNER == "ephemeral" then "persistent" else .RUNNER end)
                           end
                       )
                   )' | jq -c .)
@@ -274,34 +275,34 @@ jobs:
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
                     PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_arm64
                     PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_arm64
-                    
+
                     echo "Downloading PyPy 3.9 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.10 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.11 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                   elif [[ "$ARCH" == "x86_64" ]]; then
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
                     PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
                     PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_x86_64
-                    
+
                     echo "Downloading PyPy 3.9 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.10 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                    
+
                     echo "Downloading PyPy 3.11 for x86_64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2" 
+                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                   fi
 
@@ -471,6 +472,7 @@ jobs:
     build-source-dist-and-publish-to-pypi:
         name: Publish the base PyPi package
         runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
         needs: publish-binaries
         steps:
             - name: Checkout
@@ -608,7 +610,7 @@ jobs:
                       echo "Downloading PyPy 3.10 for x86_64"
                       curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                       sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                      
+
                     elif [[ "$ARCH" == "aarch64" ]]; then
                       PYPY_VERSION_3_10=pypy3.10-v7.3.19-aarch64
                       echo "Downloading PyPy 3.10 for aarch64"
@@ -624,7 +626,7 @@ jobs:
                       echo "Downloading PyPy 3.10 for arm64"
                       curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
                       sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                      
+
                     else
                       PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
                       echo "Downloading PyPy 3.10 for x86_64"

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -447,8 +447,8 @@ jobs:
 
             - name: Smoke test wheels
               run: |
-                  python3 -m venv /tmp/smoke-async && /tmp/smoke-async/bin/pip install --no-index --find-links python/glide-async/wheels valkey-glide && /tmp/smoke-async/bin/python -c "from glide import GlideClient"
-                  python3 -m venv /tmp/smoke-sync && /tmp/smoke-sync/bin/pip install --no-index --find-links python/glide-sync/wheels valkey-glide-sync && /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient"
+                  python3 -m venv /tmp/smoke-async && /tmp/smoke-async/bin/pip install --find-links python/glide-async/wheels valkey-glide && /tmp/smoke-async/bin/python -c "from glide import GlideClient"
+                  python3 -m venv /tmp/smoke-sync && /tmp/smoke-sync/bin/pip install --find-links python/glide-sync/wheels valkey-glide-sync && /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient"
 
             ### UPLOAD WHEELS ###
 

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -445,6 +445,11 @@ jobs:
                   CIBW_ENABLE: ${{ steps.cibw_config.outputs.enable_flags }}
                   MACOSX_DEPLOYMENT_TARGET: "10.12"
 
+            - name: Smoke test wheels
+              run: |
+                  python3 -m venv /tmp/smoke-async && /tmp/smoke-async/bin/pip install --find-links python/glide-async/wheels valkey-glide && /tmp/smoke-async/bin/python -c "from glide import GlideClient"
+                  python3 -m venv /tmp/smoke-sync && /tmp/smoke-sync/bin/pip install --find-links python/glide-sync/wheels valkey-glide-sync && /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient"
+
             ### UPLOAD WHEELS ###
 
             - name: Upload Python Async client wheels

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -447,8 +447,8 @@ jobs:
 
             - name: Smoke test wheels
               run: |
-                  python3 -m venv /tmp/smoke-async && /tmp/smoke-async/bin/pip install --find-links python/glide-async/wheels valkey-glide && /tmp/smoke-async/bin/python -c "from glide import GlideClient"
-                  python3 -m venv /tmp/smoke-sync && /tmp/smoke-sync/bin/pip install --find-links python/glide-sync/wheels valkey-glide-sync && /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient"
+                  python3 -m venv /tmp/smoke-async && /tmp/smoke-async/bin/pip install --no-index --find-links python/glide-async/wheels valkey-glide && /tmp/smoke-async/bin/python -c "from glide import GlideClient"
+                  python3 -m venv /tmp/smoke-sync && /tmp/smoke-sync/bin/pip install --no-index --find-links python/glide-sync/wheels valkey-glide-sync && /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient"
 
             ### UPLOAD WHEELS ###
 

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -161,8 +161,9 @@ jobs:
                       python3.14 -m pip install --upgrade pip
                   fi
 
-            - name: Set up Python
+            - name: Set up Python 3.14
               if: ${{ !contains(matrix.build.RUNNER, 'self-hosted') }}
+              id: setup_python
               uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
               with:
                   python-version: "3.14"
@@ -405,17 +406,26 @@ jobs:
 
             ### SYNC CLIENT ###
 
-            - name: Determine Python command
+            - name: Determine Python 3.14 path
               id: python_cmd
               run: |
-                  if command -v python3.14 &> /dev/null; then
-                      echo "cmd=python3.14" >> "$GITHUB_OUTPUT"
+                  # Use absolute path so python3.14 is never the default interpreter
+                  if [[ -n "${{ steps.setup_python.outputs.python-path }}" ]]; then
+                      echo "cmd=${{ steps.setup_python.outputs.python-path }}" >> "$GITHUB_OUTPUT"
+                  elif command -v python3.14 &> /dev/null; then
+                      echo "cmd=$(which python3.14)" >> "$GITHUB_OUTPUT"
                   else
-                      echo "cmd=python3" >> "$GITHUB_OUTPUT"
+                      echo "::error::python3.14 not found — required to build and test cp314 wheels"
+                      exit 1
                   fi
 
             - name: Install cibuildwheel
-              run: ${{ steps.python_cmd.outputs.cmd }} -m pip install cibuildwheel
+              run: |
+                  PY="${{ steps.python_cmd.outputs.cmd }}"
+                  # Bootstrap pip via get-pip.py to avoid the broken system pip
+                  # (system pip imports distutils which was removed in Python 3.12+)
+                  curl -sS https://bootstrap.pypa.io/get-pip.py | $PY
+                  $PY -m pip install "cibuildwheel>=4.0.0"
 
             - name: Determine cibuildwheel version and set enable flags
               id: cibw_config
@@ -448,8 +458,23 @@ jobs:
 
             - name: Smoke test wheels
               run: |
-                  python3 -m venv /tmp/smoke-async && /tmp/smoke-async/bin/pip install --find-links python/glide-async/wheels valkey-glide && /tmp/smoke-async/bin/python -c "from glide import GlideClient"
-                  python3 -m venv /tmp/smoke-sync && /tmp/smoke-sync/bin/pip install --find-links python/glide-sync/wheels valkey-glide-sync && /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient"
+                  # Use the same Python version used to build wheels (3.14) so pip selects
+                  # the local cp314 wheel instead of falling back to a PyPI-published version.
+                  # Create venvs with --without-pip since ensurepip is broken on the
+                  # self-hosted runner, then bootstrap pip via get-pip.py.
+                  PYTHON=${{ steps.python_cmd.outputs.cmd }}
+                  curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+
+                  rm -rf /tmp/smoke-async /tmp/smoke-sync
+                  $PYTHON -m venv --without-pip /tmp/smoke-async
+                  /tmp/smoke-async/bin/python /tmp/get-pip.py
+                  /tmp/smoke-async/bin/pip install --find-links python/glide-async/wheels "valkey-glide==${RELEASE_VERSION}"
+                  /tmp/smoke-async/bin/python -c "from glide import GlideClient; print('Async smoke test passed')"
+
+                  $PYTHON -m venv --without-pip /tmp/smoke-sync
+                  /tmp/smoke-sync/bin/python /tmp/get-pip.py
+                  /tmp/smoke-sync/bin/pip install --find-links python/glide-sync/wheels "valkey-glide-sync==${RELEASE_VERSION}"
+                  /tmp/smoke-sync/bin/python -c "from glide_sync import GlideClient; print('Sync smoke test passed')"
 
             ### UPLOAD WHEELS ###
 

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -470,6 +470,7 @@ jobs:
                   if-no-files-found: error
 
     build-source-dist-and-publish-to-pypi:
+        if: ${{ github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true }}
         name: Publish the base PyPi package
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS


### PR DESCRIPTION
## Summary

Standardizes all four CD workflows (Java, Go, Node, Python) by adding consistent `AWS_ACTIONS` approval gates, fixing PR-event validation for Go, and adding pre-publish smoke tests that verify built artifacts are valid before publishing. This prevents shipping broken artifacts where the build environment masks missing dependencies.

## Issue Links

- Fixes [(cd-workflows): Java and Go CD workflows missing pull_request triggers unlike Python/Node.js workflows #6122](https://github.com/valkey-io/valkey-glide/issues/6122)
- Related: [python: importing valkey-glide-sync fails #5988](https://github.com/valkey-io/valkey-glide/issues/5988)

## Changes

### Approval Gates (AWS_ACTIONS environment)

All CD workflows now have exactly two `AWS_ACTIONS` gates:
1. **Start gate** — blocks the workflow from beginning until approved
2. **Publish gate** — blocks the actual release/publish step until approved

| Workflow | Start Gate | Publish Gate |
|----------|-----------|-------------|
| `java-cd.yml` | `load-platform-matrix` | `publish-release-to-maven` |
| `go-cd.yml` | `load-platform-matrix` | `commit-auto-gen-files-with-tag` |
| `npm-cd.yml` | `get-build-parameters` | `prepare-and-publish` |
| `pypi-cd.yml` | `load-platform-matrix` | `build-source-dist-and-publish-to-pypi` |

### PR Validation Fix (Go)

- Removed the `if` gate on `validate-release-version` that skipped it on PRs
- The job now runs unconditionally, outputting `v0.0.0` for PR events and validating the version regex only for non-PR events
- `create-binaries` uses a standard `needs` + `if: github.repository_owner == 'valkey-io'` (no `always()` workaround needed)

### Smoke Tests (pre-publish)

Each CD workflow now includes a smoke test step (per matrix build) between artifact build and upload/publish. If any smoke test fails, the pipeline stops before uploading/publishing the artifact.

- **pypi-cd.yml**: Creates a fresh python3.14 venv (via `--without-pip` + `get-pip.py` to work around broken `ensurepip` on persistent runners), installs the locally-built wheel pinned to `==${RELEASE_VERSION}` (preventing PyPI fallback), and verifies `from glide import GlideClient` / `from glide_sync import GlideClient`
- **npm-cd.yml**: Verifies each `.node` native module is a valid shared library using `file`
- **java-cd.yml**: Verifies native library (`.so`/`.dylib`/`.dll`) exists in each per-platform build; extracts the uber JAR bundle and verifies the inner JAR contains native libs under `natives/`
- **go-cd.yml**: Verifies `libglide_ffi.a` is a valid archive (`file | grep "archive"`)

### Python CD Fixes

- **cibuildwheel upgraded to >= 4.0.0**: cibuildwheel 2.x didn't have Python 3.14 in its known build identifiers. Version 4.0.0 includes cp314 as a stable target.
- **pip bootstrap via `get-pip.py`**: The self-hosted persistent runner's system pip imports `distutils` (removed in Python 3.12+). We now use `get-pip.py` to install a working pip into python3.14's site-packages.
- **Portable `sed -i`**: macOS (BSD sed) requires `sed -i ''` vs Linux (GNU sed) `sed -i`. Added OS detection.
- **Python 3.14 resolved by absolute path**: The `python_cmd` step outputs the absolute path to python3.14 (from `actions/setup-python` output or `which python3.14`), failing explicitly if not found. This ensures the smoke test venv matches the cp314 wheel ABI.
- **Version-pinned smoke test install**: `pip install "valkey-glide==${RELEASE_VERSION}"` forces pip to use the local 0.1.0 wheel (which doesn't exist on PyPI) instead of silently picking a higher-versioned published release. Transitive deps (protobuf, anyio, cffi) still resolve from PyPI.

## Platform Coverage

All smoke tests run unconditionally on every matrix entry (no `if:` conditions). Every artifact for every platform is validated:

| Language | Platforms | What is verified |
|----------|-----------|-----------------|
| Python | `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin` | Wheel installs and native extension imports in a fresh python3.14 venv |
| Node.js | `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-musl` | `.node` file is a valid shared library (ELF/Mach-O) |
| Java | `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-musl`, `x86_64-pc-windows-msvc` | Native lib exists per platform + uber JAR contains all natives |
| Go | `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-musl`, `x86_64-unknown-linux-musl` | Static library is a valid archive |

## Implementation

Single steps added to existing build jobs — no new jobs, no modified dependency chains, no artifact re-downloads. Each test runs on the same runner immediately after the artifact is produced:

- **Python:** fresh python3.14 venv (absolute path, `--without-pip` + `get-pip.py`); version-pinned install ensures the local wheel is used, not PyPI; `--find-links` provides the wheel directory
- **Node.js:** `file` command validates the binary format (matches `shared object`, `dynamic`, or `mach-o`)
- **Java:** proper extraction of inner JAR from uber JAR bundle before validating native library contents
- **Go:** `file | grep "archive"` validates the static library (matches on both linux and macOS)

## Why

- CD workflows had inconsistent approval gates — some had none, some had one, Java had two
- Go CD was unreachable on PRs (`validate-release-version` was skipped, cascading to skip all downstream jobs)
- No pre-publish validation existed to catch broken artifacts before release

## Limitations

- Python smoke test requires network access to install transitive dependencies (`protobuf`, `anyio`) from PyPI
- Node.js smoke test validates the binary format but does not `require()` the module (would need `napi prepublish` to wire up optional dependencies first)

## Testing

This PR itself validates the fix — all four CD workflows trigger since their files are modified. The Go workflow now successfully runs `create-binaries` on PR events using the `v0.0.0` dummy version.

Verified the Python smoke test installs `valkey-glide-0.1.0` and `valkey-glide-sync-0.1.0` (the local wheels), not the published PyPI versions — confirmed in [run 27244048138](https://github.com/valkey-io/valkey-glide/actions/runs/27244048138/job/80454779018).