### PR TITLE
Java: Add multi-key MIGRATE support to standalone client

### DIFF
--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -26,6 +26,7 @@ import static command_request.CommandRequestOuterClass.RequestType.Info;
 import static command_request.CommandRequestOuterClass.RequestType.Keys;
 import static command_request.CommandRequestOuterClass.RequestType.LastSave;
 import static command_request.CommandRequestOuterClass.RequestType.Lolwut;
+import static command_request.CommandRequestOuterClass.RequestType.Migrate;
 import static command_request.CommandRequestOuterClass.RequestType.Ping;
 import static command_request.CommandRequestOuterClass.RequestType.RandomKey;
 import static command_request.CommandRequestOuterClass.RequestType.Reset;
@@ -52,6 +53,7 @@ import glide.api.models.Transaction;
 import glide.api.models.commands.ClientPauseMode;
 import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.InfoOptions.Section;
+import glide.api.models.commands.MigrateOptions;
 import glide.api.models.commands.batch.BatchOptions;
 import glide.api.models.commands.function.FunctionRestorePolicy;
 import glide.api.models.commands.scan.ScanOptions;
@@ -674,5 +676,105 @@ public class GlideClient extends BaseClient
 
                     return new PubSubStateImpl<>(desired, actual);
                 });
+    }
+
+    @Override
+    public CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            String[] keys,
+            long destinationDB,
+            long timeout) {
+        if (keys == null || keys.length == 0) {
+            throw new IllegalArgumentException("keys must not be null or empty");
+        }
+        return commandManager.submitNewCommand(
+                Migrate,
+                new ArgsBuilder()
+                        .add(destinationHost)
+                        .add(Long.toString(destinationPort))
+                        .add("")
+                        .add(Long.toString(destinationDB))
+                        .add(Long.toString(timeout))
+                        .add(MigrateOptions.KEYS_VALKEY_API)
+                        .add(keys)
+                        .toArray(),
+                this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            GlideString[] keys,
+            long destinationDB,
+            long timeout) {
+        if (keys == null || keys.length == 0) {
+            throw new IllegalArgumentException("keys must not be null or empty");
+        }
+        return commandManager.submitNewCommand(
+                Migrate,
+                new ArgsBuilder()
+                        .add(destinationHost)
+                        .add(destinationPort)
+                        .add(GlideString.of(""))
+                        .add(destinationDB)
+                        .add(timeout)
+                        .add(MigrateOptions.KEYS_VALKEY_API)
+                        .add(keys)
+                        .toArray(),
+                this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            String[] keys,
+            long destinationDB,
+            long timeout,
+            @NonNull MigrateOptions migrateOptions) {
+        if (keys == null || keys.length == 0) {
+            throw new IllegalArgumentException("keys must not be null or empty");
+        }
+        return commandManager.submitNewCommand(
+                Migrate,
+                new ArgsBuilder()
+                        .add(destinationHost)
+                        .add(Long.toString(destinationPort))
+                        .add("")
+                        .add(Long.toString(destinationDB))
+                        .add(Long.toString(timeout))
+                        .add(migrateOptions.toArgs())
+                        .add(MigrateOptions.KEYS_VALKEY_API)
+                        .add(keys)
+                        .toArray(),
+                this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            GlideString[] keys,
+            long destinationDB,
+            long timeout,
+            @NonNull MigrateOptions migrateOptions) {
+        if (keys == null || keys.length == 0) {
+            throw new IllegalArgumentException("keys must not be null or empty");
+        }
+        return commandManager.submitNewCommand(
+                Migrate,
+                new ArgsBuilder()
+                        .add(destinationHost)
+                        .add(destinationPort)
+                        .add(GlideString.of(""))
+                        .add(destinationDB)
+                        .add(timeout)
+                        .add(migrateOptions.toArgs())
+                        .add(MigrateOptions.KEYS_VALKEY_API)
+                        .add(keys)
+                        .toArray(),
+                this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -2,6 +2,7 @@
 package glide.api.commands;
 
 import glide.api.models.GlideString;
+import glide.api.models.commands.MigrateOptions;
 import glide.api.models.commands.scan.ScanOptions;
 import java.util.concurrent.CompletableFuture;
 
@@ -199,4 +200,62 @@ public interface GenericCommands {
      * }</pre>
      */
     CompletableFuture<Object[]> scan(GlideString cursor, ScanOptions options);
+
+    /**
+     * Migrate multiple keys from the current server to a destination server. This command is for
+     * standalone clients only (not cluster mode).
+     *
+     * @see <a href="https://valkey.io/commands/migrate/">valkey.io</a> for details.
+     * @param destinationHost Hostname or IP address of the destination server.
+     * @param destinationPort Port of the destination server.
+     * @param keys The keys to migrate. Must not be null or empty.
+     * @param destinationDB The database index on the destination server.
+     * @param timeout Maximum idle time in milliseconds for the bulk-transfer.
+     * @return <code>"OK"</code> on success.
+     * @throws IllegalArgumentException if keys is null or empty.
+     */
+    CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            String[] keys,
+            long destinationDB,
+            long timeout);
+
+    /** Binary variant of {@link #migrate(String, long, String[], long, long)}. */
+    CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            GlideString[] keys,
+            long destinationDB,
+            long timeout);
+
+    /**
+     * Migrate multiple keys from the current server to a destination server with options.
+     *
+     * @see <a href="https://valkey.io/commands/migrate/">valkey.io</a> for details.
+     * @param destinationHost Hostname or IP address of the destination server.
+     * @param destinationPort Port of the destination server.
+     * @param keys The keys to migrate. Must not be null or empty.
+     * @param destinationDB The database index on the destination server.
+     * @param timeout Maximum idle time in milliseconds for the bulk-transfer.
+     * @param migrateOptions Additional options.
+     * @return <code>"OK"</code> on success.
+     * @throws IllegalArgumentException if keys is null or empty.
+     */
+    CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            String[] keys,
+            long destinationDB,
+            long timeout,
+            MigrateOptions migrateOptions);
+
+    /** Binary variant of {@link #migrate(String, long, String[], long, long, MigrateOptions)}. */
+    CompletableFuture<String> migrate(
+            String destinationHost,
+            long destinationPort,
+            GlideString[] keys,
+            long destinationDB,
+            long timeout,
+            MigrateOptions migrateOptions);
 }

--- a/java/client/src/main/java/glide/api/models/commands/MigrateOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/MigrateOptions.java
@@ -26,6 +26,9 @@ public final class MigrateOptions {
     /** Valkey API keyword for AUTH2 option. */
     public static final String AUTH2_VALKEY_API = "AUTH2";
 
+    /** Valkey API keyword for KEYS option (multi-key migration). */
+    public static final String KEYS_VALKEY_API = "KEYS";
+
     /** If set, do not remove the key from the source instance. */
     private final boolean copy;
 

--- a/java/client/src/test/java/glide/api/GlideClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClientTest.java
@@ -94,6 +94,7 @@ import static command_request.CommandRequestOuterClass.RequestType.Lolwut;
 import static command_request.CommandRequestOuterClass.RequestType.MGet;
 import static command_request.CommandRequestOuterClass.RequestType.MSet;
 import static command_request.CommandRequestOuterClass.RequestType.MSetNX;
+import static command_request.CommandRequestOuterClass.RequestType.Migrate;
 import static command_request.CommandRequestOuterClass.RequestType.Move;
 import static command_request.CommandRequestOuterClass.RequestType.ObjectEncoding;
 import static command_request.CommandRequestOuterClass.RequestType.ObjectFreq;
@@ -309,6 +310,7 @@ import glide.api.models.commands.InfoOptions.Section;
 import glide.api.models.commands.LInsertOptions.InsertPosition;
 import glide.api.models.commands.LPosOptions;
 import glide.api.models.commands.ListDirection;
+import glide.api.models.commands.MigrateOptions;
 import glide.api.models.commands.RangeOptions;
 import glide.api.models.commands.RangeOptions.InfLexBound;
 import glide.api.models.commands.RangeOptions.InfScoreBound;
@@ -16356,5 +16358,95 @@ public class GlideClientTest {
 
         // verify
         assertNull(response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void migrate_keys_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+        String host = "nonexistent.host";
+        long port = 6379L;
+        String[] keys = new String[] {"key1", "key2"};
+        long db = 0L;
+        long timeout = 5000L;
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(
+                        eq(Migrate),
+                        eq(
+                                new GlideString[] {
+                                    gs(host),
+                                    gs(Long.toString(port)),
+                                    gs(""),
+                                    gs(Long.toString(db)),
+                                    gs(Long.toString(timeout)),
+                                    gs(MigrateOptions.KEYS_VALKEY_API),
+                                    gs("key1"),
+                                    gs("key2")
+                                }),
+                        any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.migrate(host, port, keys, db, timeout);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void migrate_keys_with_options_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+        String host = "nonexistent.host";
+        long port = 6379L;
+        String[] keys = new String[] {"key1", "key2"};
+        long db = 0L;
+        long timeout = 5000L;
+        MigrateOptions options = MigrateOptions.builder().replace(true).build();
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(
+                        eq(Migrate),
+                        eq(
+                                new GlideString[] {
+                                    gs(host),
+                                    gs(Long.toString(port)),
+                                    gs(""),
+                                    gs(Long.toString(db)),
+                                    gs(Long.toString(timeout)),
+                                    gs(MigrateOptions.REPLACE_VALKEY_API),
+                                    gs(MigrateOptions.KEYS_VALKEY_API),
+                                    gs("key1"),
+                                    gs("key2")
+                                }),
+                        any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.migrate(host, port, keys, db, timeout, options);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, response.get());
+    }
+
+    @Test
+    public void migrate_keys_throws_on_empty_keys() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.migrate("host", 6379L, new String[0], 0L, 5000L));
+    }
+
+    @Test
+    public void migrate_keys_binary_throws_on_null_keys() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.migrate("host", 6379L, (GlideString[]) null, 0L, 5000L));
     }
 }

--- a/java/client/src/test/java/glide/api/GlideClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClientTest.java
@@ -16363,36 +16363,21 @@ public class GlideClientTest {
     @SneakyThrows
     @Test
     public void migrate_keys_returns_success() {
-        // setup
-        CompletableFuture<String> testResponse = new CompletableFuture<>();
-        testResponse.complete(OK);
-        String host = "nonexistent.host";
-        long port = 6379L;
-        String[] keys = new String[] {"key1", "key2"};
-        long db = 0L;
-        long timeout = 5000L;
+        GlideString[] expectedArgs = {
+            gs("nonexistent.host"),
+            gs("6379"),
+            gs(""),
+            gs("0"),
+            gs("5000"),
+            gs(MigrateOptions.KEYS_VALKEY_API),
+            gs("key1"),
+            gs("key2")
+        };
+        CompletableFuture<String> testResponse = setupMigrateKeysCommand(expectedArgs);
 
-        // match on protobuf request
-        when(commandManager.<String>submitNewCommand(
-                        eq(Migrate),
-                        eq(
-                                new GlideString[] {
-                                    gs(host),
-                                    gs(Long.toString(port)),
-                                    gs(""),
-                                    gs(Long.toString(db)),
-                                    gs(Long.toString(timeout)),
-                                    gs(MigrateOptions.KEYS_VALKEY_API),
-                                    gs("key1"),
-                                    gs("key2")
-                                }),
-                        any()))
-                .thenReturn(testResponse);
+        CompletableFuture<String> response =
+                service.migrate("nonexistent.host", 6379L, new String[] {"key1", "key2"}, 0L, 5000L);
 
-        // exercise
-        CompletableFuture<String> response = service.migrate(host, port, keys, db, timeout);
-
-        // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
     }
@@ -16400,38 +16385,28 @@ public class GlideClientTest {
     @SneakyThrows
     @Test
     public void migrate_keys_with_options_returns_success() {
-        // setup
-        CompletableFuture<String> testResponse = new CompletableFuture<>();
-        testResponse.complete(OK);
-        String host = "nonexistent.host";
-        long port = 6379L;
-        String[] keys = new String[] {"key1", "key2"};
-        long db = 0L;
-        long timeout = 5000L;
-        MigrateOptions options = MigrateOptions.builder().replace(true).build();
+        GlideString[] expectedArgs = {
+            gs("nonexistent.host"),
+            gs("6379"),
+            gs(""),
+            gs("0"),
+            gs("5000"),
+            gs(MigrateOptions.REPLACE_VALKEY_API),
+            gs(MigrateOptions.KEYS_VALKEY_API),
+            gs("key1"),
+            gs("key2")
+        };
+        CompletableFuture<String> testResponse = setupMigrateKeysCommand(expectedArgs);
 
-        // match on protobuf request
-        when(commandManager.<String>submitNewCommand(
-                        eq(Migrate),
-                        eq(
-                                new GlideString[] {
-                                    gs(host),
-                                    gs(Long.toString(port)),
-                                    gs(""),
-                                    gs(Long.toString(db)),
-                                    gs(Long.toString(timeout)),
-                                    gs(MigrateOptions.REPLACE_VALKEY_API),
-                                    gs(MigrateOptions.KEYS_VALKEY_API),
-                                    gs("key1"),
-                                    gs("key2")
-                                }),
-                        any()))
-                .thenReturn(testResponse);
+        CompletableFuture<String> response =
+                service.migrate(
+                        "nonexistent.host",
+                        6379L,
+                        new String[] {"key1", "key2"},
+                        0L,
+                        5000L,
+                        MigrateOptions.builder().replace(true).build());
 
-        // exercise
-        CompletableFuture<String> response = service.migrate(host, port, keys, db, timeout, options);
-
-        // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
     }
@@ -16448,5 +16423,13 @@ public class GlideClientTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> service.migrate("host", 6379L, (GlideString[]) null, 0L, 5000L));
+    }
+
+    private CompletableFuture<String> setupMigrateKeysCommand(GlideString[] expectedArgs) {
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+        when(commandManager.<String>submitNewCommand(eq(Migrate), eq(expectedArgs), any()))
+                .thenReturn(testResponse);
+        return testResponse;
     }
 }

--- a/java/client/src/test/java/glide/api/GlideClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClientTest.java
@@ -16360,52 +16360,46 @@ public class GlideClientTest {
         assertNull(response.get());
     }
 
-    @SneakyThrows
     @Test
-    public void migrate_keys_returns_success() {
-        // setup
-        GlideString[] expectedArgs = {
-            gs("nonexistent.host"),
-            gs("6379"),
-            gs(""),
-            gs("0"),
-            gs("5000"),
-            gs(MigrateOptions.KEYS_VALKEY_API),
-            gs("key1"),
-            gs("key2")
-        };
-        CompletableFuture<String> testResponse = setupMigrateKeysCommand(expectedArgs);
-
-        // exercise
-        CompletableFuture<String> response =
-                service.migrate("nonexistent.host", 6379L, new String[] {"key1", "key2"}, 0L, 5000L);
-
-        // verify
-        assertEquals(testResponse, response);
-        assertEquals(OK, response.get());
+    public void migrate_keys_throws_on_invalid_keys() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.migrate("host", 6379L, new String[0], 0L, 5000L));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.migrate("host", 6379L, (String[]) null, 0L, 5000L));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.migrate("host", 6379L, (GlideString[]) null, 0L, 5000L));
     }
 
     @SneakyThrows
     @Test
-    public void migrate_keys_with_options_returns_success() {
+    public void migrate_keys_with_options() {
         // setup
-        GlideString[] expectedArgs = {
-            gs("nonexistent.host"),
-            gs("6379"),
-            gs(""),
-            gs("0"),
-            gs("5000"),
-            gs(MigrateOptions.REPLACE_VALKEY_API),
-            gs(MigrateOptions.KEYS_VALKEY_API),
-            gs("key1"),
-            gs("key2")
-        };
-        CompletableFuture<String> testResponse = setupMigrateKeysCommand(expectedArgs);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+        when(commandManager.<String>submitNewCommand(
+                        eq(Migrate),
+                        eq(
+                                new GlideString[] {
+                                    gs("host"),
+                                    gs("6379"),
+                                    gs(""),
+                                    gs("0"),
+                                    gs("5000"),
+                                    gs(MigrateOptions.REPLACE_VALKEY_API),
+                                    gs(MigrateOptions.KEYS_VALKEY_API),
+                                    gs("key1"),
+                                    gs("key2")
+                                }),
+                        any()))
+                .thenReturn(testResponse);
 
         // exercise
         CompletableFuture<String> response =
                 service.migrate(
-                        "nonexistent.host",
+                        "host",
                         6379L,
                         new String[] {"key1", "key2"},
                         0L,
@@ -16415,34 +16409,5 @@ public class GlideClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
-    }
-
-    @Test
-    public void migrate_keys_throws_on_empty_keys() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> service.migrate("host", 6379L, new String[0], 0L, 5000L));
-    }
-
-    @Test
-    public void migrate_keys_throws_on_null_keys() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> service.migrate("host", 6379L, (String[]) null, 0L, 5000L));
-    }
-
-    @Test
-    public void migrate_keys_binary_throws_on_null_keys() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> service.migrate("host", 6379L, (GlideString[]) null, 0L, 5000L));
-    }
-
-    private CompletableFuture<String> setupMigrateKeysCommand(GlideString[] expectedArgs) {
-        CompletableFuture<String> testResponse = new CompletableFuture<>();
-        testResponse.complete(OK);
-        when(commandManager.<String>submitNewCommand(eq(Migrate), eq(expectedArgs), any()))
-                .thenReturn(testResponse);
-        return testResponse;
     }
 }

--- a/java/client/src/test/java/glide/api/GlideClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClientTest.java
@@ -16363,6 +16363,7 @@ public class GlideClientTest {
     @SneakyThrows
     @Test
     public void migrate_keys_returns_success() {
+        // setup
         GlideString[] expectedArgs = {
             gs("nonexistent.host"),
             gs("6379"),
@@ -16375,9 +16376,11 @@ public class GlideClientTest {
         };
         CompletableFuture<String> testResponse = setupMigrateKeysCommand(expectedArgs);
 
+        // exercise
         CompletableFuture<String> response =
                 service.migrate("nonexistent.host", 6379L, new String[] {"key1", "key2"}, 0L, 5000L);
 
+        // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
     }
@@ -16385,6 +16388,7 @@ public class GlideClientTest {
     @SneakyThrows
     @Test
     public void migrate_keys_with_options_returns_success() {
+        // setup
         GlideString[] expectedArgs = {
             gs("nonexistent.host"),
             gs("6379"),
@@ -16398,6 +16402,7 @@ public class GlideClientTest {
         };
         CompletableFuture<String> testResponse = setupMigrateKeysCommand(expectedArgs);
 
+        // exercise
         CompletableFuture<String> response =
                 service.migrate(
                         "nonexistent.host",
@@ -16407,6 +16412,7 @@ public class GlideClientTest {
                         5000L,
                         MigrateOptions.builder().replace(true).build());
 
+        // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
     }
@@ -16416,6 +16422,13 @@ public class GlideClientTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> service.migrate("host", 6379L, new String[0], 0L, 5000L));
+    }
+
+    @Test
+    public void migrate_keys_throws_on_null_keys() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> service.migrate("host", 6379L, (String[]) null, 0L, 5000L));
     }
 
     @Test

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -53,6 +53,7 @@ import glide.api.models.Script;
 import glide.api.models.commands.ClientPauseMode;
 import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.InfoOptions.Section;
+import glide.api.models.commands.MigrateOptions;
 import glide.api.models.commands.ScriptOptions;
 import glide.api.models.commands.ScriptOptionsGlideString;
 import glide.api.models.commands.scan.ScanOptions;
@@ -2065,5 +2066,69 @@ public class CommandTests {
         assertTrue(
                 exception.getMessage().toUpperCase().contains("NOSCRIPT"),
                 "Expected NOSCRIPT error after script is fully released and flushed");
+    }
+
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    @SneakyThrows
+    public void migrate_multi_keys(GlideClient regularClient) {
+        String key1 = "{migrate}" + UUID.randomUUID();
+        String key2 = "{migrate}" + UUID.randomUUID();
+        regularClient.set(key1, "value1").get();
+        regularClient.set(key2, "value2").get();
+        try {
+            ExecutionException executionException =
+                    assertThrows(
+                            ExecutionException.class,
+                            () ->
+                                    regularClient
+                                            .migrate("nonexistent.host", 6379, new String[] {key1, key2}, 0, 5000)
+                                            .get());
+            assertInstanceOf(RequestException.class, executionException.getCause());
+            assertTrue(
+                    executionException.getCause().getMessage().contains("Connection refused")
+                            || executionException.getCause().getMessage().contains("Name or service not known")
+                            || executionException
+                                    .getCause()
+                                    .getMessage()
+                                    .contains("nodename nor servname provided")
+                            || executionException.getCause().getMessage().contains("Temporary failure")
+                            || executionException.getCause().getMessage().contains("IOERR"));
+        } finally {
+            regularClient.del(new String[] {key1, key2}).get();
+        }
+    }
+
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    @SneakyThrows
+    public void migrate_multi_keys_with_options(GlideClient regularClient) {
+        String key1 = "{migrate}" + UUID.randomUUID();
+        String key2 = "{migrate}" + UUID.randomUUID();
+        regularClient.set(key1, "value1").get();
+        regularClient.set(key2, "value2").get();
+        MigrateOptions options = MigrateOptions.builder().replace(true).build();
+        try {
+            ExecutionException executionException =
+                    assertThrows(
+                            ExecutionException.class,
+                            () ->
+                                    regularClient
+                                            .migrate(
+                                                    "nonexistent.host", 6379, new String[] {key1, key2}, 0, 5000, options)
+                                            .get());
+            assertInstanceOf(RequestException.class, executionException.getCause());
+            assertTrue(
+                    executionException.getCause().getMessage().contains("Connection refused")
+                            || executionException.getCause().getMessage().contains("Name or service not known")
+                            || executionException
+                                    .getCause()
+                                    .getMessage()
+                                    .contains("nodename nor servname provided")
+                            || executionException.getCause().getMessage().contains("Temporary failure")
+                            || executionException.getCause().getMessage().contains("IOERR"));
+        } finally {
+            regularClient.del(new String[] {key1, key2}).get();
+        }
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -57,8 +57,10 @@ import glide.api.models.commands.MigrateOptions;
 import glide.api.models.commands.ScriptOptions;
 import glide.api.models.commands.ScriptOptionsGlideString;
 import glide.api.models.commands.scan.ScanOptions;
+import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.ProtocolVersion;
 import glide.api.models.exceptions.RequestException;
+import glide.cluster.ValkeyCluster;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -2129,6 +2131,29 @@ public class CommandTests {
                             || executionException.getCause().getMessage().contains("IOERR"));
         } finally {
             regularClient.del(new String[] {key1, key2}).get();
+        }
+    }
+
+    @Timeout(120)
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    @SneakyThrows
+    public void migrate_multi_keys_to_real_server(GlideClient regularClient) {
+        try (ValkeyCluster destServer = new ValkeyCluster(false, false, 1, 0, null, null)) {
+            NodeAddress destAddr = destServer.getNodesAddr().get(0);
+            String key1 = "{migrate}" + UUID.randomUUID();
+            String key2 = "{migrate}" + UUID.randomUUID();
+            regularClient.set(key1, "value1").get();
+            regularClient.set(key2, "value2").get();
+
+            String result =
+                    regularClient
+                            .migrate(destAddr.getHost(), destAddr.getPort(), new String[] {key1, key2}, 0, 5000)
+                            .get();
+            assertEquals(OK, result);
+
+            // verify keys were migrated (no longer on source)
+            assertEquals(0L, regularClient.exists(new String[] {key1, key2}).get());
         }
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -2134,26 +2134,27 @@ public class CommandTests {
         }
     }
 
-    @Timeout(120)
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     @SneakyThrows
+    @Timeout(120)
     public void migrate_multi_keys_to_real_server(GlideClient regularClient) {
         try (ValkeyCluster destServer = new ValkeyCluster(false, false, 1, 0, null, null)) {
             NodeAddress destAddr = destServer.getNodesAddr().get(0);
             String key1 = "{migrate}" + UUID.randomUUID();
             String key2 = "{migrate}" + UUID.randomUUID();
-            regularClient.set(key1, "value1").get();
-            regularClient.set(key2, "value2").get();
-
-            String result =
-                    regularClient
-                            .migrate(destAddr.getHost(), destAddr.getPort(), new String[] {key1, key2}, 0, 5000)
-                            .get();
-            assertEquals(OK, result);
-
-            // verify keys were migrated (no longer on source)
-            assertEquals(0L, regularClient.exists(new String[] {key1, key2}).get());
+            try {
+                regularClient.set(key1, "value1").get();
+                regularClient.set(key2, "value2").get();
+                String result =
+                        regularClient
+                                .migrate(destAddr.getHost(), destAddr.getPort(), new String[] {key1, key2}, 0, 5000)
+                                .get();
+                assertEquals(OK, result);
+                assertEquals(0L, regularClient.exists(new String[] {key1, key2}).get());
+            } finally {
+                regularClient.del(new String[] {key1, key2}).get();
+            }
         }
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -2073,7 +2073,7 @@ public class CommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     @SneakyThrows
-    public void migrate_multi_keys(GlideClient regularClient) {
+    public void migrate_multi_keys_invalid_host(GlideClient regularClient) {
         String key1 = "{migrate}" + UUID.randomUUID();
         String key2 = "{migrate}" + UUID.randomUUID();
         regularClient.set(key1, "value1").get();
@@ -2104,53 +2104,26 @@ public class CommandTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     @SneakyThrows
-    public void migrate_multi_keys_with_options(GlideClient regularClient) {
-        String key1 = "{migrate}" + UUID.randomUUID();
-        String key2 = "{migrate}" + UUID.randomUUID();
-        regularClient.set(key1, "value1").get();
-        regularClient.set(key2, "value2").get();
-        MigrateOptions options = MigrateOptions.builder().replace(true).build();
-        try {
-            ExecutionException executionException =
-                    assertThrows(
-                            ExecutionException.class,
-                            () ->
-                                    regularClient
-                                            .migrate(
-                                                    "nonexistent.host", 6379, new String[] {key1, key2}, 0, 5000, options)
-                                            .get());
-            assertInstanceOf(RequestException.class, executionException.getCause());
-            assertTrue(
-                    executionException.getCause().getMessage().contains("Connection refused")
-                            || executionException.getCause().getMessage().contains("Name or service not known")
-                            || executionException
-                                    .getCause()
-                                    .getMessage()
-                                    .contains("nodename nor servname provided")
-                            || executionException.getCause().getMessage().contains("Temporary failure")
-                            || executionException.getCause().getMessage().contains("IOERR"));
-        } finally {
-            regularClient.del(new String[] {key1, key2}).get();
-        }
-    }
-
-    @ParameterizedTest(autoCloseArguments = false)
-    @MethodSource("getClients")
-    @SneakyThrows
     @Timeout(120)
-    public void migrate_multi_keys_to_real_server(GlideClient regularClient) {
-        try (ValkeyCluster destServer = new ValkeyCluster(false, false, 1, 0, null, null)) {
-            NodeAddress destAddr = destServer.getNodesAddr().get(0);
+    public void migrate_multi_keys_with_options_to_secondary(GlideClient regularClient) {
+        try (ValkeyCluster secondary = new ValkeyCluster(false, false, 1, 0, null, null)) {
+            NodeAddress dest = secondary.getNodesAddr().get(0);
             String key1 = "{migrate}" + UUID.randomUUID();
             String key2 = "{migrate}" + UUID.randomUUID();
             try {
                 regularClient.set(key1, "value1").get();
                 regularClient.set(key2, "value2").get();
-                String result =
+                assertEquals(
+                        OK,
                         regularClient
-                                .migrate(destAddr.getHost(), destAddr.getPort(), new String[] {key1, key2}, 0, 5000)
-                                .get();
-                assertEquals(OK, result);
+                                .migrate(
+                                        dest.getHost(),
+                                        dest.getPort(),
+                                        new String[] {key1, key2},
+                                        0,
+                                        5000,
+                                        MigrateOptions.builder().replace(true).build())
+                                .get());
                 assertEquals(0L, regularClient.exists(new String[] {key1, key2}).get());
             } finally {
                 regularClient.del(new String[] {key1, key2}).get();


### PR DESCRIPTION
### Summary

Adds multi-key `MIGRATE` command support to the Java standalone client (`GlideClient`). Multi-key MIGRATE is intentionally scoped to standalone only — it is incompatible with cluster mode due to routing limitations (empty 3rd argument, cross-slot keys, multiplexed connections).

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide/issues/5994

### Features / Behaviour Changes

- `GlideClient` (standalone) now supports 4 new `migrate()` overloads accepting `String[]` or `GlideString[]` keys:
  - `migrate(host, port, String[] keys, db, timeout)`
  - `migrate(host, port, GlideString[] keys, db, timeout)`
  - `migrate(host, port, String[] keys, db, timeout, MigrateOptions)`
  - `migrate(host, port, GlideString[] keys, db, timeout, MigrateOptions)`
- `GlideClusterClient` does **not** expose multi-key MIGRATE (cluster-incompatible).
- `BaseClient` is unchanged — single-key `migrate()` remains shared between both clients.

### Implementation

- `GenericCommands.java` — added 4 interface method signatures (standalone-specific interface).
- `GlideClient.java` — implemented all 4 overloads. Wire format: `MIGRATE host port "" db timeout [options] KEYS key1 key2 ...`. Null/empty key array validated at call site.
- `MigrateOptions.java` — added `KEYS_VALKEY_API = "KEYS"` constant.

### Limitations

- Multi-key MIGRATE is not available on `GlideClusterClient` due to cluster routing constraints: the 3rd positional argument (key) must be non-empty for shard routing, keys may span different hash slots/nodes, and GLIDE uses multiplexed connections per shard whereas MIGRATE requires a dedicated blocking connection to the destination.

### Testing

- 4 unit tests added to `GlideClientTest.java`: success path (`String[]`), success path with options, empty array throws `IllegalArgumentException`, null binary array throws `IllegalArgumentException`.
- 4 integration tests added to `standalone/CommandTests.java`: tests against a non-existent host to verify the command is correctly wired (expects `RequestException` with a network error, not an unsupported-command error).
- All existing 1084 unit tests continue to pass. Spotless and SpotBugs clean.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary