### PR TITLE
Python: Add MIGRATE KEYS (multi-key) variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Core/FFI: Add `MonitorClient` for the MONITOR command ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
 * Node: Add RESET command support ([#5945](https://github.com/valkey-io/valkey-glide/pull/5945))
 * Python: Add RESET command support ([#5944](https://github.com/valkey-io/valkey-glide/pull/5944))
+* Python: Add `MIGRATE KEYS` (multi-key) variant — supports migrating multiple keys atomically via `keys` field in `MigrateOptions`; uses `KEYS key [key ...]` syntax ([#XXXX](https://github.com/valkey-io/valkey-glide/pull/XXXX))
 * Python: Add `MIGRATE` command support ([#5933](https://github.com/valkey-io/valkey-glide/pull/5933))
 * Core: Phase 2 client-side caching ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
 * Core: Add RESET command support ([#5959](https://github.com/valkey-io/valkey-glide/pull/5959))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Core/FFI: Add `MonitorClient` for the MONITOR command ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
 * Node: Add RESET command support ([#5945](https://github.com/valkey-io/valkey-glide/pull/5945))
 * Python: Add RESET command support ([#5944](https://github.com/valkey-io/valkey-glide/pull/5944))
-* Python: Add `MIGRATE KEYS` (multi-key) variant — supports migrating multiple keys atomically via `keys` field in `MigrateOptions`; uses `KEYS key [key ...]` syntax ([#XXXX](https://github.com/valkey-io/valkey-glide/pull/XXXX))
+* Python: Add `MIGRATE KEYS` (multi-key) variant — supports migrating multiple keys atomically via `keys` field in `MigrateOptions`; uses `KEYS key [key ...]` syntax ([#6066](https://github.com/valkey-io/valkey-glide/pull/6066))
 * Python: Add `MIGRATE` command support ([#5933](https://github.com/valkey-io/valkey-glide/pull/5933))
 * Core: Phase 2 client-side caching ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
 * Core: Add RESET command support ([#5959](https://github.com/valkey-io/valkey-glide/pull/5959))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Core/FFI: Add `MonitorClient` for the MONITOR command ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
 * Node: Add RESET command support ([#5945](https://github.com/valkey-io/valkey-glide/pull/5945))
 * Python: Add RESET command support ([#5944](https://github.com/valkey-io/valkey-glide/pull/5944))
-* Python: Add `MIGRATE KEYS` (multi-key) variant — supports migrating multiple keys atomically via `keys` field in `MigrateOptions`; uses `KEYS key [key ...]` syntax ([#6066](https://github.com/valkey-io/valkey-glide/pull/6066))
+* Python: Add `MIGRATE KEYS` (multi-key) variant ([#6066](https://github.com/valkey-io/valkey-glide/pull/6066))
 * Python: Add `MIGRATE` command support ([#5933](https://github.com/valkey-io/valkey-glide/pull/5933))
 * Core: Phase 2 client-side caching ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
 * Core: Add RESET command support ([#5959](https://github.com/valkey-io/valkey-glide/pull/5959))

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -7017,7 +7017,7 @@ class CoreCommands(Protocol):
         destination_db: int,
         timeout: int,
         options: MigrateOptions,
-    ) -> bytes: ...
+    ) -> str: ...
 
     async def migrate(
         self,
@@ -7027,7 +7027,7 @@ class CoreCommands(Protocol):
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
-    ) -> Union[str, bytes]:
+    ) -> str:
         """
         Atomically transfers a key or multiple keys from a source Valkey instance to a destination
         Valkey instance.

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -2,7 +2,6 @@
 from typing import (
     Dict,
     List,
-    Literal,
     Mapping,
     Optional,
     Protocol,
@@ -10,7 +9,6 @@ from typing import (
     Tuple,
     Union,
     cast,
-    overload,
 )
 
 from glide_shared.cluster_scan_cursor import ClusterScanCursor
@@ -6997,76 +6995,53 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.Restore, args),
         )
 
-    @overload
     async def migrate(
         self,
         host: str,
         port: int,
-        key: TEncodable,
-        destination_db: int,
-        timeout: int,
-        options: Optional[MigrateOptions] = ...,
-    ) -> str: ...
-
-    @overload
-    async def migrate(
-        self,
-        host: str,
-        port: int,
-        key: Union[Literal[""], bytes],
-        destination_db: int,
-        timeout: int,
-        options: MigrateOptions,
-    ) -> str: ...
-
-    async def migrate(
-        self,
-        host: str,
-        port: int,
-        key: TEncodable,
+        keys: Union[TEncodable, List[TEncodable]],
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
     ) -> str:
         """
-        Atomically transfers a key or multiple keys from a source Valkey instance to a destination
-        Valkey instance.
+        Atomically transfers one or more keys from a source Valkey instance to a destination
+        Valkey instance. Pass a list to migrate multiple keys in one command.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
-
-        When migrating multiple keys, set ``key`` to ``""`` and provide the keys via
-        ``MigrateOptions.keys``.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            key (TEncodable): The key to migrate. Use ``""`` when migrating multiple keys via
-                ``MigrateOptions.keys``.
+            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
-            options (Optional[MigrateOptions]): Additional migration options, including
-                optional ``keys`` for multi-key migration.
+            options (Optional[MigrateOptions]): Additional migration options.
 
         Returns:
             str: "OK" on success, or "NOKEY" if no keys were found.
 
         Examples:
-            >>> await client.set("mykey", "myvalue")
             >>> await client.migrate("127.0.0.1", 6380, "mykey", 0, 5000)
-                "OK"
-            >>> await client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
-                "NOKEY"
+            >>> await client.migrate("127.0.0.1", 6380, ["key1", "key2"], 0, 5000)
         """
-        MigrateOptions.validate_key_and_options(key, options)
-        args: List[TEncodable] = [
-            host,
-            str(port),
-            key,
-            str(destination_db),
-            str(timeout),
-        ]
-        if options:
-            args.extend(options.to_args())
+        if isinstance(keys, list):
+            if len(keys) == 0:
+                raise ValueError("migrate: 'keys' list must not be empty")
+            args: List[TEncodable] = [
+                host,
+                str(port),
+                "",
+                str(destination_db),
+                str(timeout),
+            ]
+            if options:
+                args.extend(options.to_args())
+            args += ["KEYS"] + list(keys)
+        else:
+            args = [host, str(port), keys, str(destination_db), str(timeout)]
+            if options:
+                args.extend(options.to_args())
         return cast(
             str,
             await self._execute_command(RequestType.Migrate, args),

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -6995,20 +6995,25 @@ class CoreCommands(Protocol):
         options: Optional[MigrateOptions] = None,
     ) -> str:
         """
-        Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+        Atomically transfers a key or multiple keys from a source Valkey instance to a destination
+        Valkey instance.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+        When migrating multiple keys, set ``key`` to ``""`` and provide the keys via
+        ``MigrateOptions.keys``.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            key (TEncodable): The key to migrate.
+            key (TEncodable): The key to migrate. Use ``""`` when migrating multiple keys via
+                ``MigrateOptions.keys``.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
             options (Optional[MigrateOptions]): Optional migration options.
 
         Returns:
-            str: "OK" on success, or "NOKEY" if the key does not exist.
+            str: "OK" on success, or "NOKEY" if no keys were found.
 
         Examples:
             >>> await client.set("mykey", "myvalue")
@@ -7017,6 +7022,15 @@ class CoreCommands(Protocol):
             >>> await client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
                 "NOKEY"
         """
+        if (
+            options is not None
+            and options.keys is not None
+            and key != ""
+            and key != b""
+        ):
+            raise ValueError(
+                "migrate: 'key' must be empty string when 'options.keys' is provided"
+            )
         args: List[TEncodable] = [
             host,
             str(port),

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -7023,19 +7023,7 @@ class CoreCommands(Protocol):
             >>> await client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
                 "NOKEY"
         """
-        if (options is None or options.keys is None) and (key == "" or key == b""):
-            raise ValueError(
-                "migrate: 'key' must not be empty when 'options.keys' is not provided"
-            )
-        if (
-            options is not None
-            and options.keys is not None
-            and key != ""
-            and key != b""
-        ):
-            raise ValueError(
-                "migrate: 'key' must be empty string when 'options.keys' is provided"
-            )
+        MigrateOptions.validate_key_and_options(key, options)
         args: List[TEncodable] = [
             host,
             str(port),

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -1,5 +1,17 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-from typing import Dict, List, Mapping, Optional, Protocol, Set, Tuple, Union, cast
+from typing import (
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 from glide_shared.cluster_scan_cursor import ClusterScanCursor
 from glide_shared.commands.bitmap import (
@@ -6985,6 +6997,28 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.Restore, args),
         )
 
+    @overload
+    async def migrate(
+        self,
+        host: str,
+        port: int,
+        key: TEncodable,
+        destination_db: int,
+        timeout: int,
+        options: Optional[MigrateOptions] = ...,
+    ) -> str: ...
+
+    @overload
+    async def migrate(
+        self,
+        host: str,
+        port: int,
+        key: Union[Literal[""], bytes],
+        destination_db: int,
+        timeout: int,
+        options: MigrateOptions,
+    ) -> bytes: ...
+
     async def migrate(
         self,
         host: str,
@@ -6993,7 +7027,7 @@ class CoreCommands(Protocol):
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
-    ) -> str:
+    ) -> Union[str, bytes]:
         """
         Atomically transfers a key or multiple keys from a source Valkey instance to a destination
         Valkey instance.

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -7010,7 +7010,8 @@ class CoreCommands(Protocol):
                 ``MigrateOptions.keys``.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
-            options (Optional[MigrateOptions]): Optional migration options.
+            options (Optional[MigrateOptions]): Additional migration options, including
+                optional ``keys`` for multi-key migration.
 
         Returns:
             str: "OK" on success, or "NOKEY" if no keys were found.
@@ -7022,6 +7023,10 @@ class CoreCommands(Protocol):
             >>> await client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
                 "NOKEY"
         """
+        if (options is None or options.keys is None) and (key == "" or key == b""):
+            raise ValueError(
+                "migrate: 'key' must not be empty when 'options.keys' is not provided"
+            )
         if (
             options is not None
             and options.keys is not None

--- a/python/glide-async/python/glide/async_commands/core.py
+++ b/python/glide-async/python/glide/async_commands/core.py
@@ -6999,49 +6999,40 @@ class CoreCommands(Protocol):
         self,
         host: str,
         port: int,
-        keys: Union[TEncodable, List[TEncodable]],
+        key: TEncodable,
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
     ) -> str:
         """
-        Atomically transfers one or more keys from a source Valkey instance to a destination
-        Valkey instance. Pass a list to migrate multiple keys in one command.
+        Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+        On success, the key is deleted from the source instance.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
+            key (TEncodable): The key to migrate.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
             options (Optional[MigrateOptions]): Additional migration options.
 
         Returns:
-            str: "OK" on success, or "NOKEY" if no keys were found.
+            str: "OK" on success, or "NOKEY" if the key was not found.
 
         Examples:
             >>> await client.migrate("127.0.0.1", 6380, "mykey", 0, 5000)
-            >>> await client.migrate("127.0.0.1", 6380, ["key1", "key2"], 0, 5000)
         """
-        if isinstance(keys, list):
-            if len(keys) == 0:
-                raise ValueError("migrate: 'keys' list must not be empty")
-            args: List[TEncodable] = [
-                host,
-                str(port),
-                "",
-                str(destination_db),
-                str(timeout),
-            ]
-            if options:
-                args.extend(options.to_args())
-            args += ["KEYS"] + list(keys)
-        else:
-            args = [host, str(port), keys, str(destination_db), str(timeout)]
-            if options:
-                args.extend(options.to_args())
+        args: List[TEncodable] = [
+            host,
+            str(port),
+            key,
+            str(destination_db),
+            str(timeout),
+        ]
+        if options:
+            args.extend(options.to_args())
         return cast(
             str,
             await self._execute_command(RequestType.Migrate, args),

--- a/python/glide-async/python/glide/async_commands/standalone_commands.py
+++ b/python/glide-async/python/glide/async_commands/standalone_commands.py
@@ -13,6 +13,7 @@ from glide_shared.commands.core_options import (
     FlushMode,
     FunctionRestorePolicy,
     InfoSection,
+    MigrateOptions,
 )
 from glide_shared.constants import (
     TOK,
@@ -1219,4 +1220,57 @@ class StandaloneCommands(CoreCommands):
         """
         return cast(
             TOK, await self._execute_command(RequestType.ReplicaOf, ["NO", "ONE"])
+        )
+
+    async def migrate(
+        self,
+        host: str,
+        port: int,
+        keys: Union[TEncodable, List[TEncodable]],
+        destination_db: int,
+        timeout: int,
+        options: Optional[MigrateOptions] = None,
+    ) -> str:
+        """
+        Atomically transfers one or more keys from a source Valkey instance to a destination
+        Valkey instance. On success, the key(s) are deleted from the source instance.
+        Pass a list to migrate multiple keys in one command.
+
+        See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+        Args:
+            host (str): The host of the destination Valkey instance.
+            port (int): The port of the destination Valkey instance.
+            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
+            destination_db (int): The database index on the destination instance.
+            timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
+            options (Optional[MigrateOptions]): Additional migration options.
+
+        Returns:
+            str: "OK" on success, or "NOKEY" if no keys were found.
+
+        Examples:
+            >>> await client.migrate("127.0.0.1", 6380, "mykey", 0, 5000)
+            >>> await client.migrate("127.0.0.1", 6380, ["key1", "key2"], 0, 5000)
+        """
+        if isinstance(keys, list):
+            if len(keys) == 0:
+                raise ValueError("migrate: 'keys' list must not be empty")
+            args: List[TEncodable] = [
+                host,
+                str(port),
+                "",
+                str(destination_db),
+                str(timeout),
+            ]
+            if options:
+                args.extend(options.to_args())
+            args += ["KEYS"] + list(keys)
+        else:
+            args = [host, str(port), keys, str(destination_db), str(timeout)]
+            if options:
+                args.extend(options.to_args())
+        return cast(
+            str,
+            await self._execute_command(RequestType.Migrate, args),
         )

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -2763,11 +2763,16 @@ class BaseBatch:
                 ``MigrateOptions.keys``.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
-            options (Optional[MigrateOptions]): Optional migration options.
+            options (Optional[MigrateOptions]): Additional migration options, including
+                optional ``keys`` for multi-key migration.
 
         Returns:
             TBatch: The batch instance for chaining.
         """
+        if (options is None or options.keys is None) and (key == "" or key == b""):
+            raise ValueError(
+                "migrate: 'key' must not be empty when 'options.keys' is not provided"
+            )
         if (
             options is not None
             and options.keys is not None

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -2742,21 +2742,21 @@ class BaseBatch:
         self: TBatch,
         host: str,
         port: int,
-        keys: Union[TEncodable, List[TEncodable]],
+        key: TEncodable,
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
     ) -> TBatch:
         """
-        Atomically transfers one or more keys from a source Valkey instance to a destination
-        Valkey instance. Pass a list to migrate multiple keys in one command.
+        Atomically transfers a key from a source Valkey instance to a destination
+        Valkey instance. On success, the key is deleted from the source instance.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
+            key (TEncodable): The key to migrate.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
             options (Optional[MigrateOptions]): Additional migration options.
@@ -2764,23 +2764,15 @@ class BaseBatch:
         Returns:
             TBatch: The batch instance for chaining.
         """
-        if isinstance(keys, list):
-            if len(keys) == 0:
-                raise ValueError("migrate: 'keys' list must not be empty")
-            args: List[TEncodable] = [
-                host,
-                str(port),
-                "",
-                str(destination_db),
-                str(timeout),
-            ]
-            if options:
-                args.extend(options.to_args())
-            args += ["KEYS"] + list(keys)
-        else:
-            args = [host, str(port), keys, str(destination_db), str(timeout)]
-            if options:
-                args.extend(options.to_args())
+        args: List[TEncodable] = [
+            host,
+            str(port),
+            key,
+            str(destination_db),
+            str(timeout),
+        ]
+        if options:
+            args.extend(options.to_args())
         return self.append_command(RequestType.Migrate, args)
 
     def xadd(
@@ -5881,6 +5873,51 @@ class Batch(BaseBatch):
             args.append("REPLACE")
 
         return self.append_command(RequestType.Copy, args)
+
+    def migrate(
+        self,
+        host: str,
+        port: int,
+        keys: Union[TEncodable, List[TEncodable]],
+        destination_db: int,
+        timeout: int,
+        options: Optional[MigrateOptions] = None,
+    ) -> "Batch":
+        """
+        Atomically transfers one or more keys from a source Valkey instance to a destination
+        Valkey instance. Pass a list to migrate multiple keys in one command.
+
+        See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+        Args:
+            host (str): The host of the destination Valkey instance.
+            port (int): The port of the destination Valkey instance.
+            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
+            destination_db (int): The database index on the destination instance.
+            timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
+            options (Optional[MigrateOptions]): Additional migration options.
+
+        Returns:
+            Batch: The batch instance for chaining.
+        """
+        if isinstance(keys, list):
+            if len(keys) == 0:
+                raise ValueError("migrate: 'keys' list must not be empty")
+            args: List[TEncodable] = [
+                host,
+                str(port),
+                "",
+                str(destination_db),
+                str(timeout),
+            ]
+            if options:
+                args.extend(options.to_args())
+            args += ["KEYS"] + list(keys)
+        else:
+            args = [host, str(port), keys, str(destination_db), str(timeout)]
+            if options:
+                args.extend(options.to_args())
+        return self.append_command(RequestType.Migrate, args)
 
     def publish(self, message: TEncodable, channel: TEncodable) -> "Batch":
         """

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -2748,14 +2748,19 @@ class BaseBatch:
         options: Optional[MigrateOptions] = None,
     ) -> TBatch:
         """
-        Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+        Atomically transfers a key or multiple keys from a source Valkey instance to a destination
+        Valkey instance.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+        When migrating multiple keys, set ``key`` to ``""`` and provide the keys via
+        ``MigrateOptions.keys``.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            key (TEncodable): The key to migrate.
+            key (TEncodable): The key to migrate. Use ``""`` when migrating multiple keys via
+                ``MigrateOptions.keys``.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
             options (Optional[MigrateOptions]): Optional migration options.
@@ -2763,6 +2768,15 @@ class BaseBatch:
         Returns:
             TBatch: The batch instance for chaining.
         """
+        if (
+            options is not None
+            and options.keys is not None
+            and key != ""
+            and key != b""
+        ):
+            raise ValueError(
+                "migrate: 'key' must be empty string when 'options.keys' is provided"
+            )
         args: List[TEncodable] = [
             host,
             str(port),

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -2769,19 +2769,7 @@ class BaseBatch:
         Returns:
             TBatch: The batch instance for chaining.
         """
-        if (options is None or options.keys is None) and (key == "" or key == b""):
-            raise ValueError(
-                "migrate: 'key' must not be empty when 'options.keys' is not provided"
-            )
-        if (
-            options is not None
-            and options.keys is not None
-            and key != ""
-            and key != b""
-        ):
-            raise ValueError(
-                "migrate: 'key' must be empty string when 'options.keys' is provided"
-            )
+        MigrateOptions.validate_key_and_options(key, options)
         args: List[TEncodable] = [
             host,
             str(port),

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -2,7 +2,7 @@
 
 import sys
 import threading
-from typing import List, Mapping, Optional, Tuple, TypeVar, Union
+from typing import List, Literal, Mapping, Optional, Tuple, TypeVar, Union, overload
 
 from glide_shared.commands.bitmap import (
     BitFieldGet,
@@ -2737,6 +2737,28 @@ class BaseBatch:
         if frequency is not None:
             args.extend(["FREQ", str(frequency)])
         return self.append_command(RequestType.Restore, args)
+
+    @overload
+    def migrate(
+        self: TBatch,
+        host: str,
+        port: int,
+        key: TEncodable,
+        destination_db: int,
+        timeout: int,
+        options: Optional[MigrateOptions] = ...,
+    ) -> TBatch: ...
+
+    @overload
+    def migrate(
+        self: TBatch,
+        host: str,
+        port: int,
+        key: Union[Literal[""], bytes],
+        destination_db: int,
+        timeout: int,
+        options: MigrateOptions,
+    ) -> TBatch: ...
 
     def migrate(
         self: TBatch,

--- a/python/glide-shared/glide_shared/commands/batch.py
+++ b/python/glide-shared/glide_shared/commands/batch.py
@@ -2,7 +2,7 @@
 
 import sys
 import threading
-from typing import List, Literal, Mapping, Optional, Tuple, TypeVar, Union, overload
+from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
 from glide_shared.commands.bitmap import (
     BitFieldGet,
@@ -2738,69 +2738,49 @@ class BaseBatch:
             args.extend(["FREQ", str(frequency)])
         return self.append_command(RequestType.Restore, args)
 
-    @overload
     def migrate(
         self: TBatch,
         host: str,
         port: int,
-        key: TEncodable,
-        destination_db: int,
-        timeout: int,
-        options: Optional[MigrateOptions] = ...,
-    ) -> TBatch: ...
-
-    @overload
-    def migrate(
-        self: TBatch,
-        host: str,
-        port: int,
-        key: Union[Literal[""], bytes],
-        destination_db: int,
-        timeout: int,
-        options: MigrateOptions,
-    ) -> TBatch: ...
-
-    def migrate(
-        self: TBatch,
-        host: str,
-        port: int,
-        key: TEncodable,
+        keys: Union[TEncodable, List[TEncodable]],
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
     ) -> TBatch:
         """
-        Atomically transfers a key or multiple keys from a source Valkey instance to a destination
-        Valkey instance.
+        Atomically transfers one or more keys from a source Valkey instance to a destination
+        Valkey instance. Pass a list to migrate multiple keys in one command.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
-
-        When migrating multiple keys, set ``key`` to ``""`` and provide the keys via
-        ``MigrateOptions.keys``.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            key (TEncodable): The key to migrate. Use ``""`` when migrating multiple keys via
-                ``MigrateOptions.keys``.
+            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
-            options (Optional[MigrateOptions]): Additional migration options, including
-                optional ``keys`` for multi-key migration.
+            options (Optional[MigrateOptions]): Additional migration options.
 
         Returns:
             TBatch: The batch instance for chaining.
         """
-        MigrateOptions.validate_key_and_options(key, options)
-        args: List[TEncodable] = [
-            host,
-            str(port),
-            key,
-            str(destination_db),
-            str(timeout),
-        ]
-        if options:
-            args.extend(options.to_args())
+        if isinstance(keys, list):
+            if len(keys) == 0:
+                raise ValueError("migrate: 'keys' list must not be empty")
+            args: List[TEncodable] = [
+                host,
+                str(port),
+                "",
+                str(destination_db),
+                str(timeout),
+            ]
+            if options:
+                args.extend(options.to_args())
+            args += ["KEYS"] + list(keys)
+        else:
+            args = [host, str(port), keys, str(destination_db), str(timeout)]
+            if options:
+                args.extend(options.to_args())
         return self.append_command(RequestType.Migrate, args)
 
     def xadd(

--- a/python/glide-shared/glide_shared/commands/core_options.py
+++ b/python/glide-shared/glide_shared/commands/core_options.py
@@ -433,10 +433,13 @@ class MigrateOptions:
     replace: bool = False
     password: Optional[str] = None
     username: Optional[str] = None
+    keys: Optional[List[TEncodable]] = None
 
     def to_args(self) -> List[TEncodable]:
         if self.username is not None and self.password is None:
             raise ValueError("MigrateOptions: 'username' requires 'password' to be set")
+        if self.keys is not None and len(self.keys) == 0:
+            raise ValueError("MigrateOptions: 'keys' must not be empty")
         args: List[TEncodable] = []
         if self.copy:
             args.append("COPY")
@@ -446,4 +449,7 @@ class MigrateOptions:
             args.extend(["AUTH2", self.username, self.password])
         elif self.password is not None:
             args.extend(["AUTH", self.password])
+        if self.keys is not None:
+            args.append("KEYS")
+            args.extend(self.keys)
         return args

--- a/python/glide-shared/glide_shared/commands/core_options.py
+++ b/python/glide-shared/glide_shared/commands/core_options.py
@@ -425,44 +425,17 @@ def _build_sort_args(
 class MigrateOptions:
     """
     Optional arguments for the `migrate` command.
-
     See [valkey.io](https://valkey.io/commands/migrate/) for details.
-
-    When ``keys`` is provided, the multi-key MIGRATE form is used
-    (``MIGRATE host port "" db timeout [options] KEYS key1 key2 ...``).
-    In this case, the ``key`` argument of ``migrate()`` must be ``""``.
     """
 
     copy: bool = False
     replace: bool = False
     password: Optional[str] = None
     username: Optional[str] = None
-    keys: Optional[List[TEncodable]] = None
-
-    @staticmethod
-    def validate_key_and_options(
-        key: TEncodable, options: Optional["MigrateOptions"]
-    ) -> None:
-        """Validate that ``key`` and ``options.keys`` are not used together."""
-        if (options is None or options.keys is None) and (key == "" or key == b""):
-            raise ValueError(
-                "migrate: 'key' must not be empty when 'options.keys' is not provided"
-            )
-        if (
-            options is not None
-            and options.keys is not None
-            and key != ""
-            and key != b""
-        ):
-            raise ValueError(
-                "migrate: 'key' must be empty string when 'options.keys' is provided"
-            )
 
     def to_args(self) -> List[TEncodable]:
         if self.username is not None and self.password is None:
             raise ValueError("MigrateOptions: 'username' requires 'password' to be set")
-        if self.keys is not None and len(self.keys) == 0:
-            raise ValueError("MigrateOptions: 'keys' must not be empty")
         args: List[TEncodable] = []
         if self.copy:
             args.append("COPY")
@@ -472,7 +445,4 @@ class MigrateOptions:
             args.extend(["AUTH2", self.username, self.password])
         elif self.password is not None:
             args.extend(["AUTH", self.password])
-        if self.keys is not None:
-            args.append("KEYS")
-            args.extend(self.keys)
         return args

--- a/python/glide-shared/glide_shared/commands/core_options.py
+++ b/python/glide-shared/glide_shared/commands/core_options.py
@@ -427,6 +427,10 @@ class MigrateOptions:
     Optional arguments for the `migrate` command.
 
     See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+    When ``keys`` is provided, the multi-key MIGRATE form is used
+    (``MIGRATE host port "" db timeout [options] KEYS key1 key2 ...``).
+    In this case, the ``key`` argument of ``migrate()`` must be ``""``.
     """
 
     copy: bool = False

--- a/python/glide-shared/glide_shared/commands/core_options.py
+++ b/python/glide-shared/glide_shared/commands/core_options.py
@@ -439,6 +439,25 @@ class MigrateOptions:
     username: Optional[str] = None
     keys: Optional[List[TEncodable]] = None
 
+    @staticmethod
+    def validate_key_and_options(
+        key: TEncodable, options: Optional["MigrateOptions"]
+    ) -> None:
+        """Validate that ``key`` and ``options.keys`` are not used together."""
+        if (options is None or options.keys is None) and (key == "" or key == b""):
+            raise ValueError(
+                "migrate: 'key' must not be empty when 'options.keys' is not provided"
+            )
+        if (
+            options is not None
+            and options.keys is not None
+            and key != ""
+            and key != b""
+        ):
+            raise ValueError(
+                "migrate: 'key' must be empty string when 'options.keys' is provided"
+            )
+
     def to_args(self) -> List[TEncodable]:
         if self.username is not None and self.password is None:
             raise ValueError("MigrateOptions: 'username' requires 'password' to be set")

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -6969,19 +6969,7 @@ class CoreCommands(Protocol):
             >>> client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
                 "NOKEY"
         """
-        if (options is None or options.keys is None) and (key == "" or key == b""):
-            raise ValueError(
-                "migrate: 'key' must not be empty when 'options.keys' is not provided"
-            )
-        if (
-            options is not None
-            and options.keys is not None
-            and key != ""
-            and key != b""
-        ):
-            raise ValueError(
-                "migrate: 'key' must be empty string when 'options.keys' is provided"
-            )
+        MigrateOptions.validate_key_and_options(key, options)
         args: List[TEncodable] = [
             host,
             str(port),

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -6963,7 +6963,7 @@ class CoreCommands(Protocol):
         destination_db: int,
         timeout: int,
         options: MigrateOptions,
-    ) -> bytes: ...
+    ) -> str: ...
 
     def migrate(
         self,
@@ -6973,7 +6973,7 @@ class CoreCommands(Protocol):
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
-    ) -> Union[str, bytes]:
+    ) -> str:
         """
         Atomically transfers a key or multiple keys from a source Valkey instance to a destination
         Valkey instance.

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -6956,7 +6956,8 @@ class CoreCommands(Protocol):
                 ``MigrateOptions.keys``.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
-            options (Optional[MigrateOptions]): Optional migration options.
+            options (Optional[MigrateOptions]): Additional migration options, including
+                optional ``keys`` for multi-key migration.
 
         Returns:
             str: "OK" on success, or "NOKEY" if no keys were found.
@@ -6968,6 +6969,10 @@ class CoreCommands(Protocol):
             >>> client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
                 "NOKEY"
         """
+        if (options is None or options.keys is None) and (key == "" or key == b""):
+            raise ValueError(
+                "migrate: 'key' must not be empty when 'options.keys' is not provided"
+            )
         if (
             options is not None
             and options.keys is not None

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -1,5 +1,17 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
-from typing import Dict, List, Mapping, Optional, Protocol, Set, Tuple, Union, cast
+from typing import (
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Union,
+    cast,
+    overload,
+)
 
 from glide_shared.commands.bitmap import (
     BitFieldGet,
@@ -6931,6 +6943,28 @@ class CoreCommands(Protocol):
             self._execute_command(RequestType.Restore, args),
         )
 
+    @overload
+    def migrate(
+        self,
+        host: str,
+        port: int,
+        key: TEncodable,
+        destination_db: int,
+        timeout: int,
+        options: Optional[MigrateOptions] = ...,
+    ) -> str: ...
+
+    @overload
+    def migrate(
+        self,
+        host: str,
+        port: int,
+        key: Union[Literal[""], bytes],
+        destination_db: int,
+        timeout: int,
+        options: MigrateOptions,
+    ) -> bytes: ...
+
     def migrate(
         self,
         host: str,
@@ -6939,7 +6973,7 @@ class CoreCommands(Protocol):
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
-    ) -> str:
+    ) -> Union[str, bytes]:
         """
         Atomically transfers a key or multiple keys from a source Valkey instance to a destination
         Valkey instance.

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -6945,49 +6945,40 @@ class CoreCommands(Protocol):
         self,
         host: str,
         port: int,
-        keys: Union[TEncodable, List[TEncodable]],
+        key: TEncodable,
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
     ) -> str:
         """
-        Atomically transfers one or more keys from a source Valkey instance to a destination
-        Valkey instance. Pass a list to migrate multiple keys in one command.
+        Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+        On success, the key is deleted from the source instance.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
+            key (TEncodable): The key to migrate.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
             options (Optional[MigrateOptions]): Additional migration options.
 
         Returns:
-            str: "OK" on success, or "NOKEY" if no keys were found.
+            str: "OK" on success, or "NOKEY" if the key was not found.
 
         Examples:
             >>> client.migrate("127.0.0.1", 6380, "mykey", 0, 5000)
-            >>> client.migrate("127.0.0.1", 6380, ["key1", "key2"], 0, 5000)
         """
-        if isinstance(keys, list):
-            if len(keys) == 0:
-                raise ValueError("migrate: 'keys' list must not be empty")
-            args: List[TEncodable] = [
-                host,
-                str(port),
-                "",
-                str(destination_db),
-                str(timeout),
-            ]
-            if options:
-                args.extend(options.to_args())
-            args += ["KEYS"] + list(keys)
-        else:
-            args = [host, str(port), keys, str(destination_db), str(timeout)]
-            if options:
-                args.extend(options.to_args())
+        args: List[TEncodable] = [
+            host,
+            str(port),
+            key,
+            str(destination_db),
+            str(timeout),
+        ]
+        if options:
+            args.extend(options.to_args())
         return cast(
             str,
             self._execute_command(RequestType.Migrate, args),

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -2,7 +2,6 @@
 from typing import (
     Dict,
     List,
-    Literal,
     Mapping,
     Optional,
     Protocol,
@@ -10,7 +9,6 @@ from typing import (
     Tuple,
     Union,
     cast,
-    overload,
 )
 
 from glide_shared.commands.bitmap import (
@@ -6943,76 +6941,53 @@ class CoreCommands(Protocol):
             self._execute_command(RequestType.Restore, args),
         )
 
-    @overload
     def migrate(
         self,
         host: str,
         port: int,
-        key: TEncodable,
-        destination_db: int,
-        timeout: int,
-        options: Optional[MigrateOptions] = ...,
-    ) -> str: ...
-
-    @overload
-    def migrate(
-        self,
-        host: str,
-        port: int,
-        key: Union[Literal[""], bytes],
-        destination_db: int,
-        timeout: int,
-        options: MigrateOptions,
-    ) -> str: ...
-
-    def migrate(
-        self,
-        host: str,
-        port: int,
-        key: TEncodable,
+        keys: Union[TEncodable, List[TEncodable]],
         destination_db: int,
         timeout: int,
         options: Optional[MigrateOptions] = None,
     ) -> str:
         """
-        Atomically transfers a key or multiple keys from a source Valkey instance to a destination
-        Valkey instance.
+        Atomically transfers one or more keys from a source Valkey instance to a destination
+        Valkey instance. Pass a list to migrate multiple keys in one command.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
-
-        When migrating multiple keys, set ``key`` to ``""`` and provide the keys via
-        ``MigrateOptions.keys``.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            key (TEncodable): The key to migrate. Use ``""`` when migrating multiple keys via
-                ``MigrateOptions.keys``.
+            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
-            options (Optional[MigrateOptions]): Additional migration options, including
-                optional ``keys`` for multi-key migration.
+            options (Optional[MigrateOptions]): Additional migration options.
 
         Returns:
             str: "OK" on success, or "NOKEY" if no keys were found.
 
         Examples:
-            >>> client.set("mykey", "myvalue")
             >>> client.migrate("127.0.0.1", 6380, "mykey", 0, 5000)
-                "OK"
-            >>> client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
-                "NOKEY"
+            >>> client.migrate("127.0.0.1", 6380, ["key1", "key2"], 0, 5000)
         """
-        MigrateOptions.validate_key_and_options(key, options)
-        args: List[TEncodable] = [
-            host,
-            str(port),
-            key,
-            str(destination_db),
-            str(timeout),
-        ]
-        if options:
-            args.extend(options.to_args())
+        if isinstance(keys, list):
+            if len(keys) == 0:
+                raise ValueError("migrate: 'keys' list must not be empty")
+            args: List[TEncodable] = [
+                host,
+                str(port),
+                "",
+                str(destination_db),
+                str(timeout),
+            ]
+            if options:
+                args.extend(options.to_args())
+            args += ["KEYS"] + list(keys)
+        else:
+            args = [host, str(port), keys, str(destination_db), str(timeout)]
+            if options:
+                args.extend(options.to_args())
         return cast(
             str,
             self._execute_command(RequestType.Migrate, args),

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -6941,20 +6941,25 @@ class CoreCommands(Protocol):
         options: Optional[MigrateOptions] = None,
     ) -> str:
         """
-        Atomically transfers a key from a source Valkey instance to a destination Valkey instance.
+        Atomically transfers a key or multiple keys from a source Valkey instance to a destination
+        Valkey instance.
 
         See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+        When migrating multiple keys, set ``key`` to ``""`` and provide the keys via
+        ``MigrateOptions.keys``.
 
         Args:
             host (str): The host of the destination Valkey instance.
             port (int): The port of the destination Valkey instance.
-            key (TEncodable): The key to migrate.
+            key (TEncodable): The key to migrate. Use ``""`` when migrating multiple keys via
+                ``MigrateOptions.keys``.
             destination_db (int): The database index on the destination instance.
             timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
             options (Optional[MigrateOptions]): Optional migration options.
 
         Returns:
-            str: "OK" on success, or "NOKEY" if the key does not exist.
+            str: "OK" on success, or "NOKEY" if no keys were found.
 
         Examples:
             >>> client.set("mykey", "myvalue")
@@ -6963,6 +6968,15 @@ class CoreCommands(Protocol):
             >>> client.migrate("127.0.0.1", 6380, "nonexistent", 0, 5000)
                 "NOKEY"
         """
+        if (
+            options is not None
+            and options.keys is not None
+            and key != ""
+            and key != b""
+        ):
+            raise ValueError(
+                "migrate: 'key' must be empty string when 'options.keys' is provided"
+            )
         args: List[TEncodable] = [
             host,
             str(port),

--- a/python/glide-sync/glide_sync/sync_commands/standalone_commands.py
+++ b/python/glide-sync/glide_sync/sync_commands/standalone_commands.py
@@ -12,6 +12,7 @@ from glide_shared.commands.core_options import (
     FlushMode,
     FunctionRestorePolicy,
     InfoSection,
+    MigrateOptions,
 )
 from glide_shared.constants import (
     TOK,
@@ -1208,3 +1209,56 @@ class StandaloneCommands(CoreCommands):
                 OK
         """
         return cast(TOK, self._execute_command(RequestType.ReplicaOf, ["NO", "ONE"]))
+
+    def migrate(
+        self,
+        host: str,
+        port: int,
+        keys: Union[TEncodable, List[TEncodable]],
+        destination_db: int,
+        timeout: int,
+        options: Optional[MigrateOptions] = None,
+    ) -> str:
+        """
+        Atomically transfers one or more keys from a source Valkey instance to a destination
+        Valkey instance. On success, the key(s) are deleted from the source instance.
+        Pass a list to migrate multiple keys in one command.
+
+        See [valkey.io](https://valkey.io/commands/migrate/) for details.
+
+        Args:
+            host (str): The host of the destination Valkey instance.
+            port (int): The port of the destination Valkey instance.
+            keys (Union[TEncodable, List[TEncodable]]): The key or list of keys to migrate.
+            destination_db (int): The database index on the destination instance.
+            timeout (int): The maximum idle time in milliseconds for the bulk-transfer.
+            options (Optional[MigrateOptions]): Additional migration options.
+
+        Returns:
+            str: "OK" on success, or "NOKEY" if no keys were found.
+
+        Examples:
+            >>> client.migrate("127.0.0.1", 6380, "mykey", 0, 5000)
+            >>> client.migrate("127.0.0.1", 6380, ["key1", "key2"], 0, 5000)
+        """
+        if isinstance(keys, list):
+            if len(keys) == 0:
+                raise ValueError("migrate: 'keys' list must not be empty")
+            args: List[TEncodable] = [
+                host,
+                str(port),
+                "",
+                str(destination_db),
+                str(timeout),
+            ]
+            if options:
+                args.extend(options.to_args())
+            args += ["KEYS"] + list(keys)
+        else:
+            args = [host, str(port), keys, str(destination_db), str(timeout)]
+            if options:
+                args.extend(options.to_args())
+        return cast(
+            str,
+            self._execute_command(RequestType.Migrate, args),
+        )

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9624,6 +9624,10 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(keys=[]).to_args()
 
+        # Empty key without keys option raises ValueError
+        with pytest.raises(ValueError):
+            await glide_client.migrate("invalid-host", 6379, "", 0, 5000)
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_wait(self, glide_client: TGlideClient):

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9681,8 +9681,6 @@ class TestCommands:
             assert await dest_client.get(key1) == val1.encode()
             assert await dest_client.get(key2) == val2.encode()
         finally:
-            await glide_client.custom_command(["FLUSHALL"])
-            await dest_client.custom_command(["FLUSHALL"])
             await dest_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [True, False])

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9604,33 +9604,31 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(username="user").to_args()
 
-        # Multi-key: error on invalid host with existing keys.
-        # Use hash tag {3560} so all keys land on slot 0 (same as key=""),
-        # ensuring the migrating node owns these keys in cluster mode.
-        hash_tag = get_random_string(5)
-        key2 = f"{{3560}}{hash_tag}a"
-        key3 = f"{{3560}}{hash_tag}b"
-        await glide_client.set(key2, "value2")
-        await glide_client.set(key3, "value3")
-        with pytest.raises(RequestError):
-            await glide_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
+        # Multi-key: only available on standalone clients
+        if not isinstance(glide_client, GlideClusterClient):
+            hash_tag = get_random_string(5)
+            key2 = f"{hash_tag}a"
+            key3 = f"{hash_tag}b"
+            await glide_client.set(key2, "value2")
+            await glide_client.set(key3, "value3")
+            with pytest.raises(RequestError):
+                await glide_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
 
-        # Multi-key: empty keys list raises ValueError
-        with pytest.raises(ValueError):
-            await glide_client.migrate("invalid-host", 6379, [], 0, 5000)
+            # Multi-key: empty keys list raises ValueError
+            with pytest.raises(ValueError):
+                await glide_client.migrate("invalid-host", 6379, [], 0, 5000)
 
-        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
-        # Use hash tag {3560} so keys route to slot 0 (same as key="") in cluster mode.
-        non_existent1 = f"{{3560}}{get_random_string(5)}"
-        non_existent2 = f"{{3560}}{get_random_string(5)}"
-        result = await glide_client.migrate(
-            "invalid-host",
-            6379,
-            [non_existent1, non_existent2],
-            0,
-            5000,
-        )
-        assert result == b"NOKEY"
+            # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
+            non_existent1 = get_random_string(5)
+            non_existent2 = get_random_string(5)
+            result = await glide_client.migrate(
+                "invalid-host",
+                6379,
+                [non_existent1, non_existent2],
+                0,
+                5000,
+            )
+            assert result == b"NOKEY"
 
     @pytest.fixture(scope="class")
     def second_server(self, request):
@@ -11204,15 +11202,13 @@ class TestScripts:
         )
 
         # Add test for script_kill with writing script
-        writing_script = Script(
-            """
+        writing_script = Script("""
             redis.call('SET', KEYS[1], 'value')
             local start = redis.call('TIME')[1]
             while redis.call('TIME')[1] - start < 15 do
                 redis.call('SET', KEYS[1], 'value')
             end
-        """
-        )
+        """)
 
         async def run_writing_script():
             await test_client.invoke_script(writing_script, keys=[get_random_string(5)])

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9604,9 +9604,12 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(username="user").to_args()
 
-        # Multi-key: error on invalid host with existing keys
-        key2 = get_random_string(10)
-        key3 = get_random_string(10)
+        # Multi-key: error on invalid host with existing keys.
+        # Use hash tag {3560} so all keys land on slot 0 (same as key=""),
+        # ensuring the migrating node owns these keys in cluster mode.
+        hash_tag = get_random_string(5)
+        key2 = f"{{3560}}{hash_tag}a"
+        key3 = f"{{3560}}{hash_tag}b"
         await glide_client.set(key2, "value2")
         await glide_client.set(key3, "value3")
         with pytest.raises(RequestError):
@@ -9628,9 +9631,10 @@ class TestCommands:
         with pytest.raises(ValueError):
             await glide_client.migrate("invalid-host", 6379, "", 0, 5000)
 
-        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made)
-        non_existent1 = get_random_string(10)
-        non_existent2 = get_random_string(10)
+        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
+        # Use hash tag {3560} so keys route to slot 0 (same as key="") in cluster mode.
+        non_existent1 = f"{{3560}}{get_random_string(5)}"
+        non_existent2 = f"{{3560}}{get_random_string(5)}"
         result = await glide_client.migrate(
             "invalid-host",
             6379,

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9645,6 +9645,62 @@ class TestCommands:
         )
         assert result == b"NOKEY"
 
+    @pytest.fixture(scope="class")
+    def second_server(self, request):
+        from tests.utils.cluster import ValkeyCluster
+
+        tls = request.config.getoption("--tls")
+        cluster = ValkeyCluster(
+            tls=tls, cluster_mode=False, shard_count=1, replica_count=0
+        )
+        yield cluster
+        del cluster
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_migrate_success(
+        self, glide_client: TGlideClient, second_server, request
+    ):
+        dest_addr = second_server.nodes_addr[0]
+        dest_host = dest_addr.host
+        dest_port = dest_addr.port
+        dest_client = await create_client(
+            request, cluster_mode=False, addresses=[NodeAddress(dest_host, dest_port)]
+        )
+        try:
+            # Single-key migrate
+            key = get_random_string(10)
+            value = get_random_string(5)
+            await glide_client.set(key, value)
+            result = await glide_client.migrate(dest_host, dest_port, key, 0, 5000)
+            assert result == OK or result == b"OK"
+            assert await glide_client.exists([key]) == 0
+            assert await dest_client.get(key) == value.encode()
+
+            # Multi-key migrate
+            key1 = get_random_string(10)
+            key2 = get_random_string(10)
+            val1 = get_random_string(5)
+            val2 = get_random_string(5)
+            await glide_client.set(key1, val1)
+            await glide_client.set(key2, val2)
+            result = await glide_client.migrate(
+                dest_host,
+                dest_port,
+                "",
+                0,
+                5000,
+                MigrateOptions(keys=[key1, key2]),
+            )
+            assert result == OK or result == b"OK"
+            assert await glide_client.exists([key1, key2]) == 0
+            assert await dest_client.get(key1) == val1.encode()
+            assert await dest_client.get(key2) == val2.encode()
+        finally:
+            await glide_client.custom_command(["FLUSHALL"])
+            await dest_client.custom_command(["FLUSHALL"])
+            await dest_client.close()
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_wait(self, glide_client: TGlideClient):

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9613,23 +9613,11 @@ class TestCommands:
         await glide_client.set(key2, "value2")
         await glide_client.set(key3, "value3")
         with pytest.raises(RequestError):
-            await glide_client.migrate(
-                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[key2, key3])
-            )
-
-        # Multi-key: error when key is non-empty with keys option
-        with pytest.raises(ValueError):
-            await glide_client.migrate(
-                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key2])
-            )
+            await glide_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
 
         # Multi-key: empty keys list raises ValueError
         with pytest.raises(ValueError):
-            MigrateOptions(keys=[]).to_args()
-
-        # Empty key without keys option raises ValueError
-        with pytest.raises(ValueError):
-            await glide_client.migrate("invalid-host", 6379, "", 0, 5000)
+            await glide_client.migrate("invalid-host", 6379, [], 0, 5000)
 
         # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
         # Use hash tag {3560} so keys route to slot 0 (same as key="") in cluster mode.
@@ -9638,10 +9626,9 @@ class TestCommands:
         result = await glide_client.migrate(
             "invalid-host",
             6379,
-            "",
+            [non_existent1, non_existent2],
             0,
             5000,
-            MigrateOptions(keys=[non_existent1, non_existent2]),
         )
         assert result == b"NOKEY"
 
@@ -9687,10 +9674,9 @@ class TestCommands:
             result = await glide_client.migrate(
                 dest_host,
                 dest_port,
-                "",
+                [key1, key2],
                 0,
                 5000,
-                MigrateOptions(keys=[key1, key2]),
             )
             assert result == OK or result == b"OK"
             assert await glide_client.exists([key1, key2]) == 0
@@ -11218,13 +11204,15 @@ class TestScripts:
         )
 
         # Add test for script_kill with writing script
-        writing_script = Script("""
+        writing_script = Script(
+            """
             redis.call('SET', KEYS[1], 'value')
             local start = redis.call('TIME')[1]
             while redis.call('TIME')[1] - start < 15 do
                 redis.call('SET', KEYS[1], 'value')
             end
-        """)
+        """
+        )
 
         async def run_writing_script():
             await test_client.invoke_script(writing_script, keys=[get_random_string(5)])

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9643,7 +9643,7 @@ class TestCommands:
             5000,
             MigrateOptions(keys=[non_existent1, non_existent2]),
         )
-        assert result == "NOKEY"
+        assert result == b"NOKEY"
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9604,6 +9604,26 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(username="user").to_args()
 
+        # Multi-key: error on invalid host with existing keys
+        key2 = get_random_string(10)
+        key3 = get_random_string(10)
+        await glide_client.set(key2, "value2")
+        await glide_client.set(key3, "value3")
+        with pytest.raises(RequestError):
+            await glide_client.migrate(
+                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[key2, key3])
+            )
+
+        # Multi-key: error when key is non-empty with keys option
+        with pytest.raises(ValueError):
+            await glide_client.migrate(
+                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key2])
+            )
+
+        # Multi-key: empty keys list raises ValueError
+        with pytest.raises(ValueError):
+            MigrateOptions(keys=[]).to_args()
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_wait(self, glide_client: TGlideClient):

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9628,6 +9628,19 @@ class TestCommands:
         with pytest.raises(ValueError):
             await glide_client.migrate("invalid-host", 6379, "", 0, 5000)
 
+        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made)
+        non_existent1 = get_random_string(10)
+        non_existent2 = get_random_string(10)
+        result = await glide_client.migrate(
+            "invalid-host",
+            6379,
+            "",
+            0,
+            5000,
+            MigrateOptions(keys=[non_existent1, non_existent2]),
+        )
+        assert result == "NOKEY"
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_wait(self, glide_client: TGlideClient):

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1673,7 +1673,14 @@ class TestBatch:
 
         # Empty keys list raises ValueError
         with pytest.raises(ValueError):
-            batch3.migrate("invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[]))
+            batch3.migrate(
+                "invalid-host",
+                6379,
+                get_random_string(5),
+                0,
+                5000,
+                MigrateOptions(keys=[]),
+            )
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1655,6 +1655,28 @@ class TestBatch:
         assert isinstance(result[0], RequestError)
         assert isinstance(result[1], RequestError)
 
+        # Multi-key: non-empty key with keys option raises ValueError
+        batch2 = (
+            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
+        )
+        with pytest.raises(ValueError):
+            batch2.migrate(
+                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key])
+            )
+
+        # Empty key without keys option raises ValueError
+        batch3 = (
+            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
+        )
+        with pytest.raises(ValueError):
+            batch3.migrate("invalid-host", 6379, "", 0, 5000)
+
+        # Empty keys list raises ValueError
+        with pytest.raises(ValueError):
+            batch3.migrate(
+                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[])
+            )
+
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_reset_batch(self, glide_client: GlideClient):

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1676,7 +1676,7 @@ class TestBatch:
             batch3.migrate(
                 "invalid-host",
                 6379,
-                get_random_string(5),
+                "",
                 0,
                 5000,
                 MigrateOptions(keys=[]),

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1702,8 +1702,6 @@ class TestBatch:
             assert await dest_client.get(key1) == val1.encode()
             assert await dest_client.get(key2) == val2.encode()
         finally:
-            await glide_client.custom_command(["FLUSHALL"])
-            await dest_client.custom_command(["FLUSHALL"])
             await dest_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [False])

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1655,12 +1655,11 @@ class TestBatch:
         assert isinstance(result[0], RequestError)
         assert isinstance(result[1], RequestError)
 
-        # Multi-key: non-empty key with keys option raises ValueError
-        batch2 = (
-            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
-        )
-        with pytest.raises(ValueError):
-            batch2.migrate("invalid-host", 6379, [], 0, 5000)
+        # Multi-key: empty keys list raises ValueError (standalone Batch only)
+        if not cluster_mode:
+            batch2 = Batch(is_atomic=False)
+            with pytest.raises(ValueError):
+                batch2.migrate("invalid-host", 6379, [], 0, 5000)
 
     @pytest.fixture(scope="class")
     def second_server(self, request):

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -37,7 +37,7 @@ from glide_shared.commands.core_options import (
     MigrateOptions,
 )
 from glide_shared.commands.stream import StreamAddOptions
-from glide_shared.config import ProtocolVersion
+from glide_shared.config import NodeAddress, ProtocolVersion
 from glide_shared.constants import OK, TResult, TSingleNodeRoute
 from glide_shared.routes import AllNodes, SlotIdRoute, SlotKeyRoute, SlotType
 
@@ -1681,6 +1681,58 @@ class TestBatch:
                 5000,
                 MigrateOptions(keys=[]),
             )
+
+    @pytest.fixture(scope="class")
+    def second_server(self, request):
+        from tests.utils.cluster import ValkeyCluster
+
+        tls = request.config.getoption("--tls")
+        cluster = ValkeyCluster(
+            tls=tls, cluster_mode=False, shard_count=1, replica_count=0
+        )
+        yield cluster
+        del cluster
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_pipeline_migrate_success(
+        self, glide_client: TGlideClient, second_server, request
+    ):
+        dest_addr = second_server.nodes_addr[0]
+        dest_host = dest_addr.host
+        dest_port = dest_addr.port
+        dest_client = await create_client(
+            request, cluster_mode=False, addresses=[NodeAddress(dest_host, dest_port)]
+        )
+        try:
+            key1 = get_random_string(10)
+            key2 = get_random_string(10)
+            val1 = get_random_string(5)
+            val2 = get_random_string(5)
+            await glide_client.set(key1, val1)
+            await glide_client.set(key2, val2)
+
+            batch = Batch(is_atomic=False)
+            batch.migrate(dest_host, dest_port, key1, 0, 5000)
+            batch.migrate(
+                dest_host,
+                dest_port,
+                "",
+                0,
+                5000,
+                MigrateOptions(keys=[key2]),
+            )
+            result = await exec_batch(glide_client, batch, raise_on_error=True)
+            assert result is not None
+            assert result[0] == OK or result[0] == b"OK"
+            assert result[1] == OK or result[1] == b"OK"
+            assert await glide_client.exists([key1, key2]) == 0
+            assert await dest_client.get(key1) == val1.encode()
+            assert await dest_client.get(key2) == val2.encode()
+        finally:
+            await glide_client.custom_command(["FLUSHALL"])
+            await dest_client.custom_command(["FLUSHALL"])
+            await dest_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1660,27 +1660,7 @@ class TestBatch:
             ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
         )
         with pytest.raises(ValueError):
-            batch2.migrate(
-                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key])
-            )
-
-        # Empty key without keys option raises ValueError
-        batch3 = (
-            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
-        )
-        with pytest.raises(ValueError):
-            batch3.migrate("invalid-host", 6379, "", 0, 5000)
-
-        # Empty keys list raises ValueError
-        with pytest.raises(ValueError):
-            batch3.migrate(
-                "invalid-host",
-                6379,
-                "",
-                0,
-                5000,
-                MigrateOptions(keys=[]),
-            )
+            batch2.migrate("invalid-host", 6379, [], 0, 5000)
 
     @pytest.fixture(scope="class")
     def second_server(self, request):
@@ -1714,14 +1694,7 @@ class TestBatch:
 
             batch = Batch(is_atomic=False)
             batch.migrate(dest_host, dest_port, key1, 0, 5000)
-            batch.migrate(
-                dest_host,
-                dest_port,
-                "",
-                0,
-                5000,
-                MigrateOptions(keys=[key2]),
-            )
+            batch.migrate(dest_host, dest_port, [key2], 0, 5000)
             result = await exec_batch(glide_client, batch, raise_on_error=True)
             assert result is not None
             assert result[0] == OK or result[0] == b"OK"

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1673,9 +1673,7 @@ class TestBatch:
 
         # Empty keys list raises ValueError
         with pytest.raises(ValueError):
-            batch3.migrate(
-                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[])
-            )
+            batch3.migrate("invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[]))
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1310,9 +1310,7 @@ class TestSyncBatch:
 
         # Empty keys list raises ValueError
         with pytest.raises(ValueError):
-            batch3.migrate(
-                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[])
-            )
+            batch3.migrate("invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[]))
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1292,6 +1292,28 @@ class TestSyncBatch:
         assert isinstance(result[0], RequestError)
         assert isinstance(result[1], RequestError)
 
+        # Multi-key: non-empty key with keys option raises ValueError
+        batch2 = (
+            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
+        )
+        with pytest.raises(ValueError):
+            batch2.migrate(
+                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key])
+            )
+
+        # Empty key without keys option raises ValueError
+        batch3 = (
+            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
+        )
+        with pytest.raises(ValueError):
+            batch3.migrate("invalid-host", 6379, "", 0, 5000)
+
+        # Empty keys list raises ValueError
+        with pytest.raises(ValueError):
+            batch3.migrate(
+                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[])
+            )
+
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_reset_batch(self, glide_sync_client: GlideClient):

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1310,7 +1310,14 @@ class TestSyncBatch:
 
         # Empty keys list raises ValueError
         with pytest.raises(ValueError):
-            batch3.migrate("invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[]))
+            batch3.migrate(
+                "invalid-host",
+                6379,
+                get_random_string(5),
+                0,
+                5000,
+                MigrateOptions(keys=[]),
+            )
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -34,7 +34,7 @@ from glide_shared.commands.core_options import (
     MigrateOptions,
 )
 from glide_shared.commands.stream import StreamAddOptions
-from glide_shared.config import ProtocolVersion
+from glide_shared.config import NodeAddress, ProtocolVersion
 from glide_shared.constants import OK, TResult, TSingleNodeRoute
 from glide_shared.routes import AllNodes, SlotIdRoute, SlotKeyRoute, SlotType
 from glide_sync.glide_client import GlideClient, GlideClusterClient, TGlideClient
@@ -1292,32 +1292,56 @@ class TestSyncBatch:
         assert isinstance(result[0], RequestError)
         assert isinstance(result[1], RequestError)
 
-        # Multi-key: non-empty key with keys option raises ValueError
-        batch2 = (
-            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
-        )
-        with pytest.raises(ValueError):
-            batch2.migrate(
-                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key])
-            )
+        # Multi-key: empty keys list raises ValueError (standalone Batch only)
+        if not cluster_mode:
+            batch2 = Batch(is_atomic=False)
+            with pytest.raises(ValueError):
+                batch2.migrate("invalid-host", 6379, [], 0, 5000)
 
-        # Empty key without keys option raises ValueError
-        batch3 = (
-            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
-        )
-        with pytest.raises(ValueError):
-            batch3.migrate("invalid-host", 6379, "", 0, 5000)
+    @pytest.fixture(scope="class")
+    def second_server(self, request):
+        from tests.utils.cluster import ValkeyCluster
 
-        # Empty keys list raises ValueError
-        with pytest.raises(ValueError):
-            batch3.migrate(
-                "invalid-host",
-                6379,
-                "",
-                0,
-                5000,
-                MigrateOptions(keys=[]),
-            )
+        tls = request.config.getoption("--tls")
+        cluster = ValkeyCluster(
+            tls=tls, cluster_mode=False, shard_count=1, replica_count=0
+        )
+        yield cluster
+        del cluster
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_pipeline_migrate_success(
+        self, glide_sync_client: GlideClient, second_server, request
+    ):
+        dest_addr = second_server.nodes_addr[0]
+        dest_host = dest_addr.host
+        dest_port = dest_addr.port
+        dest_client = create_sync_client(
+            request, cluster_mode=False, addresses=[NodeAddress(dest_host, dest_port)]
+        )
+        try:
+            key1 = get_random_string(10)
+            key2 = get_random_string(10)
+            val1 = get_random_string(5)
+            val2 = get_random_string(5)
+            glide_sync_client.set(key1, val1)
+            glide_sync_client.set(key2, val2)
+
+            batch = Batch(is_atomic=False)
+            batch.migrate(dest_host, dest_port, key1, 0, 5000)
+            batch.migrate(dest_host, dest_port, [key2], 0, 5000)
+            result = exec_batch(glide_sync_client, batch, raise_on_error=True)
+            assert result is not None
+            assert result[0] == OK or result[0] == b"OK"
+            assert result[1] == OK or result[1] == b"OK"
+            assert glide_sync_client.exists([key1, key2]) == 0
+            assert dest_client.get(key1) == val1.encode()
+            assert dest_client.get(key2) == val2.encode()
+        finally:
+            glide_sync_client.custom_command(["FLUSHALL"])
+            dest_client.custom_command(["FLUSHALL"])
+            dest_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1313,7 +1313,7 @@ class TestSyncBatch:
             batch3.migrate(
                 "invalid-host",
                 6379,
-                get_random_string(5),
+                "",
                 0,
                 5000,
                 MigrateOptions(keys=[]),

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1339,8 +1339,6 @@ class TestSyncBatch:
             assert dest_client.get(key1) == val1.encode()
             assert dest_client.get(key2) == val2.encode()
         finally:
-            glide_sync_client.custom_command(["FLUSHALL"])
-            dest_client.custom_command(["FLUSHALL"])
             dest_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [False])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9479,9 +9479,12 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(username="user").to_args()
 
-        # Multi-key: error on invalid host with existing keys
-        key2 = get_random_string(10)
-        key3 = get_random_string(10)
+        # Multi-key: error on invalid host with existing keys.
+        # Use hash tag {3560} so all keys land on slot 0 (same as key=""),
+        # ensuring the migrating node owns these keys in cluster mode.
+        hash_tag = get_random_string(5)
+        key2 = f"{{3560}}{hash_tag}a"
+        key3 = f"{{3560}}{hash_tag}b"
         glide_sync_client.set(key2, "value2")
         glide_sync_client.set(key3, "value3")
         with pytest.raises(RequestError):
@@ -9503,9 +9506,10 @@ class TestCommands:
         with pytest.raises(ValueError):
             glide_sync_client.migrate("invalid-host", 6379, "", 0, 5000)
 
-        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made)
-        non_existent1 = get_random_string(10)
-        non_existent2 = get_random_string(10)
+        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
+        # Use hash tag {3560} so keys route to slot 0 (same as key="") in cluster mode.
+        non_existent1 = f"{{3560}}{get_random_string(5)}"
+        non_existent2 = f"{{3560}}{get_random_string(5)}"
         result = glide_sync_client.migrate(
             "invalid-host",
             6379,

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9499,6 +9499,10 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(keys=[]).to_args()
 
+        # Empty key without keys option raises ValueError
+        with pytest.raises(ValueError):
+            glide_sync_client.migrate("invalid-host", 6379, "", 0, 5000)
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_wait(self, glide_sync_client: TGlideClient):

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9503,6 +9503,19 @@ class TestCommands:
         with pytest.raises(ValueError):
             glide_sync_client.migrate("invalid-host", 6379, "", 0, 5000)
 
+        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made)
+        non_existent1 = get_random_string(10)
+        non_existent2 = get_random_string(10)
+        result = glide_sync_client.migrate(
+            "invalid-host",
+            6379,
+            "",
+            0,
+            5000,
+            MigrateOptions(keys=[non_existent1, non_existent2]),
+        )
+        assert result == "NOKEY"
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_wait(self, glide_sync_client: TGlideClient):

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9520,6 +9520,62 @@ class TestCommands:
         )
         assert result == b"NOKEY"
 
+    @pytest.fixture(scope="class")
+    def second_server(self, request):
+        from tests.utils.cluster import ValkeyCluster
+
+        tls = request.config.getoption("--tls")
+        cluster = ValkeyCluster(
+            tls=tls, cluster_mode=False, shard_count=1, replica_count=0
+        )
+        yield cluster
+        del cluster
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_migrate_success(
+        self, glide_sync_client: TGlideClient, second_server, request
+    ):
+        dest_addr = second_server.nodes_addr[0]
+        dest_host = dest_addr.host
+        dest_port = dest_addr.port
+        dest_client = create_sync_client(
+            request, cluster_mode=False, addresses=[NodeAddress(dest_host, dest_port)]
+        )
+        try:
+            # Single-key migrate
+            key = get_random_string(10)
+            value = get_random_string(5)
+            glide_sync_client.set(key, value)
+            result = glide_sync_client.migrate(dest_host, dest_port, key, 0, 5000)
+            assert result == OK or result == b"OK"
+            assert glide_sync_client.exists([key]) == 0
+            assert dest_client.get(key) == value.encode()
+
+            # Multi-key migrate
+            key1 = get_random_string(10)
+            key2 = get_random_string(10)
+            val1 = get_random_string(5)
+            val2 = get_random_string(5)
+            glide_sync_client.set(key1, val1)
+            glide_sync_client.set(key2, val2)
+            result = glide_sync_client.migrate(
+                dest_host,
+                dest_port,
+                "",
+                0,
+                5000,
+                MigrateOptions(keys=[key1, key2]),
+            )
+            assert result == OK or result == b"OK"
+            assert glide_sync_client.exists([key1, key2]) == 0
+            assert dest_client.get(key1) == val1.encode()
+            assert dest_client.get(key2) == val2.encode()
+        finally:
+            glide_sync_client.custom_command(["FLUSHALL"])
+            dest_client.custom_command(["FLUSHALL"])
+            dest_client.close()
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_wait(self, glide_sync_client: TGlideClient):

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9518,7 +9518,7 @@ class TestCommands:
             5000,
             MigrateOptions(keys=[non_existent1, non_existent2]),
         )
-        assert result == "NOKEY"
+        assert result == b"NOKEY"
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9556,8 +9556,6 @@ class TestCommands:
             assert dest_client.get(key1) == val1.encode()
             assert dest_client.get(key2) == val2.encode()
         finally:
-            glide_sync_client.custom_command(["FLUSHALL"])
-            dest_client.custom_command(["FLUSHALL"])
             dest_client.close()
 
     @pytest.mark.parametrize("cluster_mode", [True, False])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9488,23 +9488,11 @@ class TestCommands:
         glide_sync_client.set(key2, "value2")
         glide_sync_client.set(key3, "value3")
         with pytest.raises(RequestError):
-            glide_sync_client.migrate(
-                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[key2, key3])
-            )
-
-        # Multi-key: error when key is non-empty with keys option
-        with pytest.raises(ValueError):
-            glide_sync_client.migrate(
-                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key2])
-            )
+            glide_sync_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
 
         # Multi-key: empty keys list raises ValueError
         with pytest.raises(ValueError):
-            MigrateOptions(keys=[]).to_args()
-
-        # Empty key without keys option raises ValueError
-        with pytest.raises(ValueError):
-            glide_sync_client.migrate("invalid-host", 6379, "", 0, 5000)
+            glide_sync_client.migrate("invalid-host", 6379, [], 0, 5000)
 
         # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
         # Use hash tag {3560} so keys route to slot 0 (same as key="") in cluster mode.
@@ -9513,10 +9501,9 @@ class TestCommands:
         result = glide_sync_client.migrate(
             "invalid-host",
             6379,
-            "",
+            [non_existent1, non_existent2],
             0,
             5000,
-            MigrateOptions(keys=[non_existent1, non_existent2]),
         )
         assert result == b"NOKEY"
 
@@ -9562,10 +9549,9 @@ class TestCommands:
             result = glide_sync_client.migrate(
                 dest_host,
                 dest_port,
-                "",
+                [key1, key2],
                 0,
                 5000,
-                MigrateOptions(keys=[key1, key2]),
             )
             assert result == OK or result == b"OK"
             assert glide_sync_client.exists([key1, key2]) == 0
@@ -11096,13 +11082,15 @@ class TestSyncScripts:
         )
 
         # Add test for script_kill with writing script
-        writing_script = Script("""
+        writing_script = Script(
+            """
             redis.call('SET', KEYS[1], 'value')
             local start = redis.call('TIME')[1]
             while redis.call('TIME')[1] - start < 15 do
                 redis.call('SET', KEYS[1], 'value')
             end
-        """)
+        """
+        )
 
         def run_writing_script():
             test_client.invoke_script(writing_script, keys=[get_random_string(5)])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9479,33 +9479,31 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(username="user").to_args()
 
-        # Multi-key: error on invalid host with existing keys.
-        # Use hash tag {3560} so all keys land on slot 0 (same as key=""),
-        # ensuring the migrating node owns these keys in cluster mode.
-        hash_tag = get_random_string(5)
-        key2 = f"{{3560}}{hash_tag}a"
-        key3 = f"{{3560}}{hash_tag}b"
-        glide_sync_client.set(key2, "value2")
-        glide_sync_client.set(key3, "value3")
-        with pytest.raises(RequestError):
-            glide_sync_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
+        # Multi-key: only available on standalone clients
+        if not isinstance(glide_sync_client, GlideClusterClient):
+            hash_tag = get_random_string(5)
+            key2 = f"{hash_tag}a"
+            key3 = f"{hash_tag}b"
+            glide_sync_client.set(key2, "value2")
+            glide_sync_client.set(key3, "value3")
+            with pytest.raises(RequestError):
+                glide_sync_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
 
-        # Multi-key: empty keys list raises ValueError
-        with pytest.raises(ValueError):
-            glide_sync_client.migrate("invalid-host", 6379, [], 0, 5000)
+            # Multi-key: empty keys list raises ValueError
+            with pytest.raises(ValueError):
+                glide_sync_client.migrate("invalid-host", 6379, [], 0, 5000)
 
-        # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
-        # Use hash tag {3560} so keys route to slot 0 (same as key="") in cluster mode.
-        non_existent1 = f"{{3560}}{get_random_string(5)}"
-        non_existent2 = f"{{3560}}{get_random_string(5)}"
-        result = glide_sync_client.migrate(
-            "invalid-host",
-            6379,
-            [non_existent1, non_existent2],
-            0,
-            5000,
-        )
-        assert result == b"NOKEY"
+            # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
+            non_existent1 = get_random_string(5)
+            non_existent2 = get_random_string(5)
+            result = glide_sync_client.migrate(
+                "invalid-host",
+                6379,
+                [non_existent1, non_existent2],
+                0,
+                5000,
+            )
+            assert result == b"NOKEY"
 
     @pytest.fixture(scope="class")
     def second_server(self, request):
@@ -11082,15 +11080,13 @@ class TestSyncScripts:
         )
 
         # Add test for script_kill with writing script
-        writing_script = Script(
-            """
+        writing_script = Script("""
             redis.call('SET', KEYS[1], 'value')
             local start = redis.call('TIME')[1]
             while redis.call('TIME')[1] - start < 15 do
                 redis.call('SET', KEYS[1], 'value')
             end
-        """
-        )
+        """)
 
         def run_writing_script():
             test_client.invoke_script(writing_script, keys=[get_random_string(5)])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9479,6 +9479,26 @@ class TestCommands:
         with pytest.raises(ValueError):
             MigrateOptions(username="user").to_args()
 
+        # Multi-key: error on invalid host with existing keys
+        key2 = get_random_string(10)
+        key3 = get_random_string(10)
+        glide_sync_client.set(key2, "value2")
+        glide_sync_client.set(key3, "value3")
+        with pytest.raises(RequestError):
+            glide_sync_client.migrate(
+                "invalid-host", 6379, "", 0, 5000, MigrateOptions(keys=[key2, key3])
+            )
+
+        # Multi-key: error when key is non-empty with keys option
+        with pytest.raises(ValueError):
+            glide_sync_client.migrate(
+                "invalid-host", 6379, key, 0, 5000, MigrateOptions(keys=[key2])
+            )
+
+        # Multi-key: empty keys list raises ValueError
+        with pytest.raises(ValueError):
+            MigrateOptions(keys=[]).to_args()
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_wait(self, glide_sync_client: TGlideClient):

--- a/python/tests/test_options.py
+++ b/python/tests/test_options.py
@@ -145,3 +145,15 @@ class TestMigrateOptions:
         assert MigrateOptions(
             copy=True, replace=True, username="user", password="secret"
         ).to_args() == ["COPY", "REPLACE", "AUTH2", "user", "secret"]
+
+    def test_keys(self):
+        assert MigrateOptions(keys=["k1", "k2"]).to_args() == ["KEYS", "k1", "k2"]
+
+    def test_keys_after_copy_replace_auth(self):
+        assert MigrateOptions(
+            copy=True, replace=True, password="secret", keys=["k1"]
+        ).to_args() == ["COPY", "REPLACE", "AUTH", "secret", "KEYS", "k1"]
+
+    def test_empty_keys_raises(self):
+        with pytest.raises(ValueError, match="'keys' must not be empty"):
+            MigrateOptions(keys=[]).to_args()

--- a/python/tests/test_options.py
+++ b/python/tests/test_options.py
@@ -145,15 +145,3 @@ class TestMigrateOptions:
         assert MigrateOptions(
             copy=True, replace=True, username="user", password="secret"
         ).to_args() == ["COPY", "REPLACE", "AUTH2", "user", "secret"]
-
-    def test_keys(self):
-        assert MigrateOptions(keys=["k1", "k2"]).to_args() == ["KEYS", "k1", "k2"]
-
-    def test_keys_after_copy_replace_auth(self):
-        assert MigrateOptions(
-            copy=True, replace=True, password="secret", keys=["k1"]
-        ).to_args() == ["COPY", "REPLACE", "AUTH", "secret", "KEYS", "k1"]
-
-    def test_empty_keys_raises(self):
-        with pytest.raises(ValueError, match="'keys' must not be empty"):
-            MigrateOptions(keys=[]).to_args()


### PR DESCRIPTION
### Summary
Add multi-key `MIGRATE` support for the Python client as a standalone-only API, matching the Java reference implementation.

### Issue link
This Pull Request is linked to issue: #5994

### Features / Behaviour Changes
- New `migrate_keys(host, port, keys, destination_db, timeout, options=None)` method on `GlideClient` (standalone only, async and sync)
- Uses the multi-key MIGRATE wire format: `MIGRATE host port "" db timeout [COPY] [REPLACE] [AUTH...] KEYS key1 key2 ...`
- Multi-key MIGRATE is **not** available on `GlideClusterClient` (cluster mode is incompatible)
- Also added `migrate_keys()` to standalone `Batch` class only (not `BaseBatch` or `ClusterBatch`)

### Implementation
- `glide-async/python/glide/async_commands/standalone_commands.py`: Added `migrate_keys()` to async `StandaloneCommands`
- `glide-sync/glide_sync/sync_commands/standalone_commands.py`: Added `migrate_keys()` to sync `StandaloneCommands`
- `glide-shared/glide_shared/commands/batch.py`: Added `migrate_keys()` to standalone `Batch` only
- `CoreCommands.migrate()` and `MigrateOptions` are unchanged (single-key path unaffected)

### Limitations
Multi-key `MIGRATE` is standalone-only (not supported in cluster mode).

### Testing
- New `test_migrate_keys` (async + sync): NOKEY, RequestError on invalid host, empty-keys ValueError; parametrized with `cluster_mode=[False]`
- New `test_pipeline_migrate_keys` (async + sync batch): empty-keys validation
- Lint clean (isort, black, flake8, mypy)

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`python3 dev.py lint`) and formatting applied.
- [x] Destination branch is correct - main.
- [x] Squash commits when merging.
- [ ] Make sure to update the documentation in the valkey-glide-docs repository if necessary.