### PR TITLE
changelog: add Go and Java RESET command support entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Pending 2.5
 
 #### Changes
+* Go: Add RESET command support — standalone client only; RESET resets connection state and is intentionally not exposed on the cluster client interface to avoid partial-reset inconsistency across nodes ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
+* Java: Add RESET command support — resets connection state (database index, client name, protocol, pubsub subscriptions); available on both standalone and cluster clients ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))
 * CORE/FFI: Add `MonitorClient` for the MONITOR command — dedicated non-pooled connection streaming parsed `MonitorLine { timestamp, db, client_addr, command, args }` structs via callback; FFI exports `create_monitor_client()` and `close_monitor_client()` with clean async shutdown; standalone-only (cluster mode not supported) ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
 * Node: Add RESET command support — resets connection state (database index, client name, protocol, pubsub subscriptions); available on both standalone and cluster clients ([#5945](https://github.com/valkey-io/valkey-glide/pull/5945))
 * Python: Add RESET command support — resets connection state (database index, client name, protocol, pubsub subscriptions); available on both standalone and cluster clients ([#5944](https://github.com/valkey-io/valkey-glide/pull/5944))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## Pending 2.5
 
 #### Changes
-* Go: Add RESET command support — standalone client only; RESET resets connection state and is intentionally not exposed on the cluster client interface to avoid partial-reset inconsistency across nodes ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
-* Java: Add RESET command support — resets connection state (database index, client name, protocol, pubsub subscriptions); available on both standalone and cluster clients ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))
-* CORE/FFI: Add `MonitorClient` for the MONITOR command — dedicated non-pooled connection streaming parsed `MonitorLine { timestamp, db, client_addr, command, args }` structs via callback; FFI exports `create_monitor_client()` and `close_monitor_client()` with clean async shutdown; standalone-only (cluster mode not supported) ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
-* Node: Add RESET command support — resets connection state (database index, client name, protocol, pubsub subscriptions); available on both standalone and cluster clients ([#5945](https://github.com/valkey-io/valkey-glide/pull/5945))
-* Python: Add RESET command support — resets connection state (database index, client name, protocol, pubsub subscriptions); available on both standalone and cluster clients ([#5944](https://github.com/valkey-io/valkey-glide/pull/5944))
+* Go: Add RESET command support ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
+* Java: Add RESET command support ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))
+* CORE/FFI: Add `MonitorClient` for the MONITOR command ([#5977](https://github.com/valkey-io/valkey-glide/pull/5977))
+* Node: Add RESET command support ([#5945](https://github.com/valkey-io/valkey-glide/pull/5945))
+* Python: Add RESET command support ([#5944](https://github.com/valkey-io/valkey-glide/pull/5944))
 * Python: Add `MIGRATE` command support ([#5933](https://github.com/valkey-io/valkey-glide/pull/5933))
-* CORE: Phase 2 client-side caching - server-assisted invalidation via CLIENT TRACKING ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
-* CORE: Add RESET command support — track and reset connection state (database index, client name, protocol, pubsub subscriptions) on RESET; route RESET to all nodes in cluster mode ([#5959](https://github.com/valkey-io/valkey-glide/pull/5959))
+* CORE: Phase 2 client-side caching ([#5962](https://github.com/valkey-io/valkey-glide/pull/5962))
+* CORE: Add RESET command support ([#5959](https://github.com/valkey-io/valkey-glide/pull/5959))
 * Node: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))
 * Node: Add `MIGRATE` command support ([#5934](https://github.com/valkey-io/valkey-glide/pull/5934))
 * Go: Support custom socket address resolution when connecting to valkey ([#5873](https://github.com/valkey-io/valkey-glide/issues/5873))


### PR DESCRIPTION
### Summary
Adds CHANGELOG.md entries for the Go and Java RESET command implementations.

### Issue link
This Pull Request is linked to issue: [Implement RESET command for Python, Node.js, Go, and Java clients](https://github.com/valkey-io/valkey-glide/issues/5942)

### Features / Behaviour Changes
Adds changelog entries for:
- Go RESET command support (standalone only)
- Java RESET command support (standalone + cluster)

### Implementation
Changelog-only PR. No code changes.

### Limitations
N/A

### Testing
N/A — changelog only

### Related PRs
- Go RESET implementation: #5946
- Java RESET implementation: #5947
- Core implementation: #5959
- Python RESET: #5944
- Node.js RESET: #5945

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the valkey-glide-docs repository if necessary