### PR TITLE
Fix flaky test_sync_pubsub_combined_exact_and_pattern_one_client

### DIFF
--- a/python/tests/sync_tests/test_sync_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pubsub.py
@@ -812,17 +812,24 @@ class TestSyncPubSub:
                 if cluster_mode:
                     assert result == 1
 
-            # Wait for messages to propagate
+            # Wait for messages to propagate. Both the Callback and Sync read
+            # paths are non-blocking, so they must poll until every message has
+            # arrived; a fixed sleep races against slow CI (e.g. aarch64). Only
+            # the Async path (get_pubsub_message) blocks per-message and needs
+            # no pre-wait.
             if method == MethodTesting.Callback:
-                # Callback messages arrive asynchronously; poll until all are received
+                # Callback messages arrive asynchronously; poll the callback list.
                 wait_for_messages(
                     len(all_channels_and_messages), callback_messages, timeout=10.0
                 )
-            else:
-                # For Async (blocking read) and Sync (non-blocking read),
-                # allow a brief propagation window for messages to reach the
-                # internal queue before non-blocking try_get_pubsub_message calls
-                time.sleep(1)
+            elif method == MethodTesting.Sync:
+                # try_get_pubsub_message is non-blocking; poll the client's
+                # internal pubsub queue (a List[PubSubMsg]) until all arrive.
+                wait_for_messages(
+                    len(all_channels_and_messages),
+                    listening_client._pubsub_queue,
+                    timeout=10.0,
+                )
 
             # Check if all messages are received correctly
             for index in range(len(all_channels_and_messages)):

--- a/python/tests/sync_tests/test_sync_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pubsub.py
@@ -812,8 +812,17 @@ class TestSyncPubSub:
                 if cluster_mode:
                     assert result == 1
 
-            # allow the message to propagate
-            time.sleep(1)
+            # Wait for messages to propagate
+            if method == MethodTesting.Callback:
+                # Callback messages arrive asynchronously; poll until all are received
+                wait_for_messages(
+                    len(all_channels_and_messages), callback_messages, timeout=10.0
+                )
+            else:
+                # For Async (blocking read) and Sync (non-blocking read),
+                # allow a brief propagation window for messages to reach the
+                # internal queue before non-blocking try_get_pubsub_message calls
+                time.sleep(1)
 
             # Check if all messages are received correctly
             for index in range(len(all_channels_and_messages)):


### PR DESCRIPTION
### Summary
Replaces fixed `time.sleep(1)` with `wait_for_messages()` polling for the non-blocking read paths (Callback and Sync), preventing timeout failures on slower aarch64 CI.

### Issue link

Closes #6087

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
The root cause is that the fixed `time.sleep(1)` is insufficient on slower CI machines (aarch64) for the read paths that do not block waiting for messages. The test exercises three read methods, which behave differently:

- **Async** (`get_pubsub_message()`) — blocks per-message until a message is available, so it is inherently race-free and needs no pre-wait.
- **Sync** (`try_get_pubsub_message()`) — non-blocking; returns `None` immediately when the internal queue is empty.
- **Callback** — non-blocking; messages are appended to a list asynchronously.

Both the Callback and Sync paths are therefore vulnerable to the same race: a fixed sleep can elapse before all 512 messages have propagated. For these two paths we now poll with the existing `wait_for_messages()` utility, which checks a condition until all expected messages arrive or a timeout is reached. The Callback path polls the callback list; the Sync path polls the client's internal `_pubsub_queue` (a `List[PubSubMsg]`). The Async path keeps its existing behaviour since it already blocks per-message.

### Limitations
None

### Testing
Verified locally — all 18 Sync/Callback parametrizations of `test_sync_pubsub_combined_exact_and_pattern_one_client` pass (cluster/standalone × subscription methods). Matches the polling pattern used by other tests in this file (e.g. `test_sync_pubsub_exact_max_size_message_callback`).

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
