### PR TITLE
Add retry logic for JedisCluster connection on Windows (#6086)

### DIFF
--- a/java/integTest/src/test/java/compatibility/jedis/JedisClusterTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/JedisClusterTest.java
@@ -50,8 +50,24 @@ public class JedisClusterTest {
 
     @BeforeEach
     void setup() {
-        jedisCluster = new JedisCluster(clusterNodes);
-        assertNotNull(jedisCluster, "JedisCluster instance should be created successfully");
+        int maxRetries = 3;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                jedisCluster = new JedisCluster(clusterNodes);
+                assertNotNull(jedisCluster, "JedisCluster instance should be created successfully");
+                return;
+            } catch (Exception e) {
+                if (attempt == maxRetries) {
+                    throw e;
+                }
+                try {
+                    Thread.sleep(1000 * attempt);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(ie);
+                }
+            }
+        }
     }
 
     @AfterEach

--- a/java/integTest/src/test/java/compatibility/jedis/UnifiedJedisClusterTest.java
+++ b/java/integTest/src/test/java/compatibility/jedis/UnifiedJedisClusterTest.java
@@ -78,10 +78,26 @@ public class UnifiedJedisClusterTest {
 
     @BeforeEach
     void setup() {
-        // Create GLIDE UnifiedJedis compatibility layer instance for cluster
-        unifiedJedis = new UnifiedJedis(clusterNodes);
-        assertNotNull(
-                unifiedJedis, "GLIDE UnifiedJedis cluster instance should be created successfully");
+        int maxRetries = 3;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                unifiedJedis = new UnifiedJedis(clusterNodes);
+                assertNotNull(
+                        unifiedJedis,
+                        "GLIDE UnifiedJedis cluster instance should be created successfully");
+                return;
+            } catch (Exception e) {
+                if (attempt == maxRetries) {
+                    throw e;
+                }
+                try {
+                    Thread.sleep(1000 * attempt);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(ie);
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
### Summary
Adds retry with backoff when creating JedisCluster/UnifiedJedis instances in test setup to handle transient Connection refused errors on Windows CI.

### Issue link
This Pull Request is linked to issue: [Java: JedisClusterTest Connection refused on Windows](https://github.com/valkey-io/valkey-glide/issues/6086)
Closes #6086

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
Root cause: On Windows CI runners, the cluster nodes may not be immediately ready to accept connections when the test setup runs. This causes intermittent `Connection refused` errors.

Fix:
- Added a retry loop (max 3 attempts) with linear backoff (1s, 2s, 3s) in the `@BeforeEach setup()` methods of both `JedisClusterTest` and `UnifiedJedisClusterTest`
- If all retries are exhausted, the original exception is rethrown
- Properly handles `InterruptedException` by restoring the interrupt flag

### Limitations
None

### Testing
Verified both test files compile and the retry logic is correct.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release