### PR TITLE
Fix flaky PubSubTests.test_ssubscribe_channels_different_slots on Windows

### DIFF
--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -176,10 +176,20 @@ public class PubSubTests {
 
     @SneakyThrows
     private GlideClusterClient createClusterClient() {
-        GlideClusterClient client =
-                GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
-        senders.add(client);
-        return client;
+        int maxRetries = 3;
+        for (int attempt = 1; ; attempt++) {
+            try {
+                GlideClusterClient client =
+                        GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
+                senders.add(client);
+                return client;
+            } catch (ExecutionException e) {
+                if (attempt >= maxRetries || !e.getMessage().contains("Connection refused")) {
+                    throw e;
+                }
+                Thread.sleep(500 * attempt);
+            }
+        }
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Summary
Fix flaky `PubSubTests.test_ssubscribe_channels_different_slots` by adding retry logic with backoff to `createClusterClient()` to handle transient "Connection refused" errors on Windows CI.

### Issue link
This Pull Request is linked to issue: [[Java][Flaky Test] PubSubTests > test_ssubscribe_channels_different_slots - Connection refused on Windows](https://github.com/valkey-io/valkey-glide/issues/6117)
Closes #6117

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** On Windows CI, the Valkey cluster node may not yet be accepting connections when the test attempts to create a `GlideClusterClient`. This results in a transient `ExecutionException` with "Connection refused".

**Fix:** The `createClusterClient()` helper method now retries up to 3 times with increasing backoff (500ms × attempt) when it catches an `ExecutionException` containing "Connection refused". Non-connection errors are immediately re-thrown.

### Limitations
None

### Testing
The fix targets only transient connection failures during client creation. The retry logic is scoped to `ExecutionException` with "Connection refused" message, ensuring no masking of real errors.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release