### PR TITLE
Add pull_request triggers to Java and Go CD workflows

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -1,6 +1,12 @@
 name: Go - Continuous Deployment
 
 on:
+    pull_request:
+        paths:
+            - .github/workflows/go-cd.yml
+            - .github/workflows/install-shared-dependencies/action.yml
+            - .github/workflows/install-engine/action.yml
+            - .github/json_matrices/**
     push:
         tags:
             - "v*.*"

--- a/.github/workflows/java-cd.yml
+++ b/.github/workflows/java-cd.yml
@@ -1,6 +1,12 @@
 name: Java Prepare Deployment
 
 on:
+    pull_request:
+        paths:
+            - .github/workflows/java-cd.yml
+            - .github/workflows/install-shared-dependencies/action.yml
+            - .github/workflows/install-engine/action.yml
+            - .github/json_matrices/**
     push:
         tags:
             - "v*.*"


### PR DESCRIPTION
## Summary

Adds `pull_request` triggers to Java (`java-cd.yml`) and Go (`go-cd.yml`) CD workflows to match the behavior of Python and Node.js CD workflows.

## Changes

- Added `pull_request` triggers with path filters to both workflows
- Ensures CD workflows run for validation when their files are modified in PRs
- Maintains existing `push` (tags) and `workflow_dispatch` triggers

## Why

Currently only Python/Node.js CD workflows trigger on PRs, creating inconsistent validation behavior. This was discovered in PR #6062 where Java/Go CD modifications weren't validated.

## Testing

This PR itself will test the fix - both Java and Go CD workflows should now trigger since their files are modified.

Fixes #6122