### PR TITLE
Java: Skip AZ affinity tests on Windows due to zero replicas

### DIFF
--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -139,6 +139,11 @@ public class ConnectionTests {
     @Test
     public void test_routing_by_slot_to_replica_with_az_affinity_strategy_to_all_replicas() {
         assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"), "Skip for versions below 8");
+        // Windows integration tests has replicas set to zero due to resource limitations
+        // on Github Action using Windows runner with WSL
+        // TODO: Remove the skip after fixing Windows Replicas issues
+        // https://github.com/valkey-io/valkey-glide/issues/5210
+        assumeTrue(!isWindows(), "Skip on Windows");
 
         String az = "us-east-1a";
 
@@ -354,6 +359,11 @@ public class ConnectionTests {
     @Test
     public void test_az_affinity_replicas_and_primary_routes_to_primary() {
         assumeTrue(SERVER_VERSION.isGreaterThanOrEqualTo("8.0.0"), "Skip for versions below 8");
+        // Windows integration tests has replicas set to zero due to resource limitations
+        // on Github Action using Windows runner with WSL
+        // TODO: Remove the skip after fixing Windows Replicas issues
+        // https://github.com/valkey-io/valkey-glide/issues/5210
+        assumeTrue(!isWindows(), "Skip on Windows");
 
         String az = "us-east-1a";
         String otherAz = "us-east-1b";


### PR DESCRIPTION
### Summary
Skip AZ affinity tests on Windows where replicas are unavailable due to resource limitations.

### Issue link
This Pull Request is linked to issue: [[Java][Flaky Test] ConnectionTests > test_az_affinity on Windows](https://github.com/valkey-io/valkey-glide/issues/6124)
Closes #6124

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
Windows CI runs with 0 replicas due to resource limitations (issue #5210). The `test_routing_by_slot_to_replica_with_az_affinity_strategy_to_all_replicas` and `test_az_affinity_replicas_and_primary_routes_to_primary` tests require replicas to be available, so they fail on Windows.

Added `assumeTrue(!isWindows(), "Skip on Windows")` checks consistent with other AZ tests in the same file that already skip on Windows for the same reason.

### Limitations
None

### Testing
Tests pass reliably on Linux (10/10 runs verified). On Windows CI, the tests will be gracefully skipped until the replica issue (#5210) is resolved.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release