### PR TITLE
Java: Add retry logic to PubSubTests createClient for connection refused

### DIFF
--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -42,6 +42,7 @@ import glide.api.models.configuration.RequestRoutingConfiguration.SlotKeyRoute;
 import glide.api.models.configuration.RequestRoutingConfiguration.SlotType;
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration;
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration.PubSubChannelMode;
+import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.ConfigurationError;
 import glide.api.models.exceptions.RequestException;
 import java.util.ArrayList;
@@ -159,12 +160,24 @@ public class PubSubTests {
 
     @SneakyThrows
     private BaseClient createClient(boolean standalone) {
-        BaseClient client =
-                standalone
-                        ? GlideClient.createClient(commonClientConfig().build()).get()
-                        : GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
-        senders.add(client);
-        return client;
+        int maxAttempts = 5;
+        for (int attempt = 1; ; attempt++) {
+            try {
+                BaseClient client =
+                        standalone
+                                ? GlideClient.createClient(commonClientConfig().build()).get()
+                                : GlideClusterClient.createClient(commonClusterClientConfig().build()).get();
+                senders.add(client);
+                return client;
+            } catch (ExecutionException e) {
+                if (attempt >= maxAttempts
+                        || !(e.getCause() instanceof ClosingException)
+                        || !e.getMessage().contains("Connection refused")) {
+                    throw e;
+                }
+                Thread.sleep(200);
+            }
+        }
     }
 
     @SneakyThrows


### PR DESCRIPTION
Fixes flaky tests on Windows CI where the cluster may not be fully ready when tests attempt to connect.

Adds retry logic (5 attempts, 200ms delay) to `createClient()` that only retries on `ClosingException` with 'Connection refused' message. All other exceptions are rethrown immediately.

Validated with 100 consecutive test runs (0 failures).

Fixes #6137
Fixes #6139