### PR TITLE
Java: Increase request timeout in test_cache_ttl_expiration

### DIFF
--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -223,12 +223,16 @@ public class ClientSideCacheTests {
         BaseClient shortTtlClient;
         if (client instanceof GlideClient) {
             shortTtlClient =
-                    GlideClient.createClient(commonClientConfig().clientSideCache(shortTtlCache).build())
+                    GlideClient.createClient(
+                                    commonClientConfig().requestTimeout(10000).clientSideCache(shortTtlCache).build())
                             .get();
         } else {
             shortTtlClient =
                     GlideClusterClient.createClient(
-                                    commonClusterClientConfig().clientSideCache(shortTtlCache).build())
+                                    commonClusterClientConfig()
+                                            .requestTimeout(10000)
+                                            .clientSideCache(shortTtlCache)
+                                            .build())
                             .get();
         }
 


### PR DESCRIPTION
Adds `requestTimeout(10000)` to the `shortTtlClient` builder in `test_cache_ttl_expiration` to prevent `TimeoutException` on Windows CI runners which have higher latency.

This follows the same pattern used in 8+ other test files (TimeoutTests.java, SharedClientTests.java, VectorSearchTests.java, PubSubTests.java, BatchTests.java, etc.).

Validated with 100 consecutive test runs (0 failures).

Fixes #6138