### PR TITLE
fix(build): fix Makefile issues across Go and root targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ This is the Valkey GLIDE mono-repository containing a Rust core (`glide-core`) a
 make all
 
 # Individual language builds
-make java          # Build Java client (release mode)
+make java          # Build Java client
 make python        # Build Python async + sync clients (release mode)
 make node          # Build Node.js client (release mode)
 make go            # Build Go client
@@ -83,7 +83,7 @@ cargo fmt
 
 ```bash
 cd java
-./gradlew :client:buildAllRelease
+./gradlew :client:buildAll
 ./gradlew :integTest:test
 ./gradlew :spotlessApply
 ```
@@ -104,7 +104,7 @@ cd node
 npm ci
 npm run build:release
 npm test
-npx run lint:fix
+npm run lint:fix
 ```
 
 **Go:**

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: java java-test python python-test node node-test go go-test python-lint jav
 ## Java targets
 ##
 java:
-	@echo "$(GREEN)Building for Java (release)$(RESET)"
+	@echo "$(GREEN)Building for Java$(RESET)"
 	@cd java && ./gradlew :client:buildAll
 
 java-lint:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: java java-test python python-test node node-test go go-test python-lint jav
 ##
 java:
 	@echo "$(GREEN)Building for Java (release)$(RESET)"
-	@cd java && ./gradlew :client:buildAllRelease
+	@cd java && ./gradlew :client:buildAll
 
 java-lint:
 	@echo "$(GREEN)Running spotlessApply$(RESET)"
@@ -61,7 +61,7 @@ node-test: .build/node_deps check-valkey-server
 
 node-lint: .build/node_deps
 	@echo "$(GREEN)Running linters for NodeJS$(RESET)"
-	@cd node && npx run lint:fix
+	@cd node && npm run lint:fix
 
 ##
 ## Prettier targets

--- a/go/Makefile
+++ b/go/Makefile
@@ -68,8 +68,8 @@ install-build-tools:
 
 install-dev-tools:
 	go install github.com/vakenbolt/go-test-report@v0.9.3
-	go install mvdan.cc/gofumpt@v0.6.0
-	go install github.com/segmentio/golines@v0.12.2
+	go install mvdan.cc/gofumpt@v0.9.1
+	go install github.com/segmentio/golines@v0.13.0
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 install-tools: install-build-tools install-dev-tools
@@ -116,8 +116,9 @@ gen-c-bindings:
 	cd $(GLIDE_FFI_PATH) && \
 	cbindgen --config cbindgen.toml --crate glide-ffi --output $(GO_DIR)/lib.h --lang c
 	@# Add include guard to prevent multiple inclusion errors with CGo
-	@sed -i.bak '1 a\
-	#pragma once' $(GO_DIR)/lib.h && rm -f $(GO_DIR)/lib.h.bak
+	@awk 'NR==1 {print; print "#pragma once"; next} {print}' \
+		$(GO_DIR)/lib.h > $(GO_DIR)/lib.h.new && \
+		mv $(GO_DIR)/lib.h.new $(GO_DIR)/lib.h
 
 generate-protobuf:
 	rm -rf internal/protobuf


### PR DESCRIPTION
### Summary

Fix several Makefile issues across the root and Go build targets. Extracted from #6068 at reviewer request to keep the feature PR focused.

### Issue link

:white_circle: None — build fixes extracted from #6068.

### Features / Behaviour Changes

:white_circle: None — build infrastructure only.

### Implementation

- **Root Makefile:** Fix `npx run lint:fix` → `npm run lint:fix` in the `node-lint` target (`npx run` is not a valid command).
- **Root Makefile:** Fix `buildAllRelease` → `buildAll` in the `java` target (the `buildAllRelease` Gradle task does not exist).
- **Go Makefile:** Bump `gofumpt` v0.6.0 → v0.9.1 and `golines` v0.12.2 → v0.13.0 for latest fixes and Go compatibility.
- **Go Makefile:** Replace `sed -i` with `awk` for `#pragma once` injection in the `gen-c-bindings` target to fix macOS compatibility (BSD `sed` requires a different `-i` syntax than GNU `sed`).

### Limitations

:white_circle: None.

### Testing

Verified `make node-lint`, `make java`, and `make go` targets work correctly after changes.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated.~~ Not applicable — build scripts only.
- [x] ~~CHANGELOG.md and documentation files are updated.~~ Not applicable — infrastructure fix.
- [x] ~~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~~ Not applicable — no code changes.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] ~~Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary~~ Not applicable.