### PR TITLE
test(core): deflake monitor start-and-receive-line test

### DIFF
--- a/glide-core/tests/test_monitor.rs
+++ b/glide-core/tests/test_monitor.rs
@@ -72,7 +72,8 @@ mod test_monitor {
             .await
             .unwrap();
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        // Generous deadline to tolerate slow/loaded CI; not a behavioral change.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
         loop {
             if lines.lock().unwrap().iter().any(|l| {
                 l.command == "SET" && l.args.first().map(|s| s.as_str()) == Some("monitor_test_key")


### PR DESCRIPTION
### Summary
Fix flaky test `test_monitor_start_and_receive_line` by increasing the polling timeout from 5s to 15s.

### Issue link
This Pull Request is linked to issue: [[Rust][Flaky Test] test_monitor_start_and_receive_line](https://github.com/valkey-io/valkey-glide/issues/6161)
Closes #6161

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The test uses a polling loop with a 10ms interval and 5-second deadline to wait for the MONITOR stream to deliver a SET command notification. Under CI load (GitHub Actions runners with concurrent tests), scheduling delays can cause the monitor notification delivery to exceed the 5-second window.

**Fix:** Increase the deadline from 5 seconds to 15 seconds. The polling pattern itself is correct and efficient (short sleep interval with condition check), so only the outer timeout needed adjustment. This gives sufficient headroom for CI environments under load while still failing quickly if the monitor stream is truly broken.

### Limitations
None

### Testing
Ran the test 100 times consecutively — all 100 runs passed.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release