### PR TITLE
Fix flaky test: test_cluster_connection_fails_with_permission_denied

### DIFF
--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -177,9 +177,31 @@ impl RedisCluster {
             script_args.push("-r");
             script_args.push(&replicas_num);
         }
-        let (stdout, stderr) =
-            Self::execute_cluster_script(script_args, use_tls, None, tls_paths.as_ref());
-        let (cluster_folder, servers) = Self::parse_start_script_output(&stdout, &stderr);
+
+        let max_retries = 3;
+        let mut last_err = String::new();
+        let (cluster_folder, servers) = (|| {
+            for attempt in 0..max_retries {
+                let (stdout, stderr) = Self::execute_cluster_script(
+                    script_args.clone(),
+                    use_tls,
+                    None,
+                    tls_paths.as_ref(),
+                );
+                match Self::parse_start_script_output(&stdout, &stderr) {
+                    Ok(result) => return result,
+                    Err(e) => {
+                        last_err = e;
+                        if attempt < max_retries - 1 {
+                            std::thread::sleep(std::time::Duration::from_secs(1));
+                        }
+                    }
+                }
+            }
+            panic!(
+                "Failed to start cluster after {max_retries} attempts. Last error: {last_err}"
+            );
+        })();
         let mut password: Option<String> = None;
         if let Some(info) = conn_info {
             password.clone_from(&info.password);
@@ -199,7 +221,10 @@ impl RedisCluster {
         Some(line[prefix.len()..].to_string())
     }
 
-    fn parse_start_script_output(output: &str, _errors: &str) -> (String, Vec<ValkeyServerInfo>) {
+    fn parse_start_script_output(
+        output: &str,
+        errors: &str,
+    ) -> Result<(String, Vec<ValkeyServerInfo>), String> {
         let prefixes = vec!["CLUSTER_FOLDER", "SERVERS_JSON"];
         let mut values = std::collections::HashMap::<String, String>::new();
         let lines: Vec<&str> = output.split('\n').map(|line| line.trim()).collect();
@@ -215,10 +240,17 @@ impl RedisCluster {
             }
         }
 
-        let cluster_folder = values.get("CLUSTER_FOLDER").unwrap();
-        let cluster_nodes_json = values.get("SERVERS_JSON").unwrap();
-        let servers: Vec<ValkeyServerInfo> = serde_json::from_str(cluster_nodes_json).unwrap();
-        (cluster_folder.clone(), servers)
+        let cluster_folder = values.get("CLUSTER_FOLDER").ok_or_else(|| {
+            format!(
+                "CLUSTER_FOLDER not found in script output.\nStdout: {output}\nStderr: {errors}"
+            )
+        })?;
+        let cluster_nodes_json = values.get("SERVERS_JSON").ok_or_else(|| {
+            format!("SERVERS_JSON not found in script output.\nStdout: {output}\nStderr: {errors}")
+        })?;
+        let servers: Vec<ValkeyServerInfo> = serde_json::from_str(cluster_nodes_json)
+            .map_err(|e| format!("Failed to parse SERVERS_JSON: {e}\nJSON: {cluster_nodes_json}"))?;
+        Ok((cluster_folder.clone(), servers))
     }
 
     fn execute_cluster_script(
@@ -412,7 +444,7 @@ INFO:root:Created Cluster Redis in 24.8926 seconds
 CLUSTER_FOLDER=/Users/user/glide-for-redis/utils/clusters/redis-cluster-2024-11-05T16-05-44Z-2bz4YS
 CLUSTER_NODES=127.0.0.1:39163,127.0.0.1:23178,127.0.0.1:25186,127.0.0.1:52500,127.0.0.1:48252,127.0.0.1:19544,127.0.0.1:37455,127.0.0.1:9282,127.0.0.1:19843
         "#;
-        let (folder, servers) = RedisCluster::parse_start_script_output(script_output, "");
+        let (folder, servers) = RedisCluster::parse_start_script_output(script_output, "").unwrap();
         assert_eq!(servers.len(), 9);
         assert_eq!(
             folder,


### PR DESCRIPTION
### Summary
Fix flaky test `test_cluster_connection_fails_with_permission_denied` by adding retry logic to cluster startup and replacing bare `unwrap()` calls with proper error handling.

### Issue link
This Pull Request is linked to issue: [[Rust][Flaky Test] test_cluster_connection_fails_with_permission_denied](https://github.com/valkey-io/valkey-glide/issues/6162)
Closes #6162

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The `cluster_manager.py` script can transiently fail due to port conflicts or startup races under CI load, producing incomplete output that lacks the expected `CLUSTER_FOLDER` and `SERVERS_JSON` lines. The previous code called `.unwrap()` on `HashMap::get()` which panics with an unhelpful `None` error when this happens.

**Fix:**
1. Convert `parse_start_script_output` to return `Result<_, String>` with descriptive error messages that include the actual script stdout/stderr for debugging.
2. Add retry logic (up to 3 attempts with 1-second delays) in `new_with_tls_paths` around the script execution + parsing. This handles transient infrastructure failures gracefully.

### Limitations
None

### Testing
Ran the test 100 times consecutively — all 100 runs passed. Also verified the `test_parse_start_script_output` unit test passes.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release