### PR TITLE
fix(test): fix flaky `PAUSE`/`UNPAUSE` test

### DIFF
--- a/go/integTest/client_pause_test.go
+++ b/go/integTest/client_pause_test.go
@@ -37,14 +37,9 @@ func (suite *GlideTestSuite) TestClientPauseAllThenUnpause() {
 			err   error
 		}
 
-		getCh := make(chan stringResult, 1)
 		setCh := make(chan stringResult, 1)
 		unpauseCh := make(chan stringResult, 1)
 
-		go func() {
-			v, err := client.Get(ctx, key)
-			getCh <- stringResult{value: v.Value(), err: err}
-		}()
 		go func() {
 			v, err := client.Set(ctx, key, "after")
 			setCh <- stringResult{value: v, err: err}
@@ -66,8 +61,6 @@ func (suite *GlideTestSuite) TestClientPauseAllThenUnpause() {
 
 		// Verify that none of the commands completed while paused.
 		select {
-		case r := <-getCh:
-			suite.Failf("GET completed while paused", "value=%q err=%v", r.value, r.err)
 		case r := <-setCh:
 			suite.Failf("SET completed while paused", "value=%q err=%v", r.value, r.err)
 		case r := <-unpauseCh:
@@ -86,12 +79,9 @@ func (suite *GlideTestSuite) TestClientPauseAllThenUnpause() {
 			}
 		}
 
-		getRes := collect(getCh, "GET")
 		setRes := collect(setCh, "SET")
 		unpauseRes := collect(unpauseCh, "UNPAUSE")
 
-		suite.NoError(getRes.err)
-		suite.Equal("before", getRes.value)
 		suite.NoError(setRes.err)
 		suite.Equal("OK", setRes.value)
 		suite.NoError(unpauseRes.err)

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -606,19 +606,16 @@ public class CommandTests {
 
         assertEquals(OK, clusterClient.clientPause(2000, ClientPauseMode.ALL).get());
 
-        CompletableFuture<String> get = clusterClient.get(key);
         CompletableFuture<String> set = clusterClient.set(key, "after");
         CompletableFuture<String> unpause = clusterClient.clientUnpause();
 
         Thread.sleep(300);
 
         // Verify that none of the commands completes.
-        assertFalse(get.isDone());
         assertFalse(set.isDone());
         assertFalse(unpause.isDone());
 
         // Verify that all commands complete once pause expires.
-        assertEquals("before", get.get(5, java.util.concurrent.TimeUnit.SECONDS));
         assertEquals(OK, set.get(5, java.util.concurrent.TimeUnit.SECONDS));
         assertEquals(OK, unpause.get(5, java.util.concurrent.TimeUnit.SECONDS));
         assertEquals("after", clusterClient.get(key).get());

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -343,19 +343,16 @@ public class CommandTests {
 
         assertEquals(OK, regularClient.clientPause(2000, ClientPauseMode.ALL).get());
 
-        CompletableFuture<String> get = regularClient.get(key);
         CompletableFuture<String> set = regularClient.set(key, "after");
         CompletableFuture<String> unpause = regularClient.clientUnpause();
 
         Thread.sleep(300);
 
         // Verify that none of the commands completes.
-        assertFalse(get.isDone());
         assertFalse(set.isDone());
         assertFalse(unpause.isDone());
 
         // Verify that all commands complete once pause expires.
-        assertEquals("before", get.get(5, java.util.concurrent.TimeUnit.SECONDS));
         assertEquals(OK, set.get(5, java.util.concurrent.TimeUnit.SECONDS));
         assertEquals(OK, unpause.get(5, java.util.concurrent.TimeUnit.SECONDS));
         assertEquals("after", regularClient.get(key).get());

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -2008,11 +2008,6 @@ describe("GlideClient", () => {
                 "OK",
             );
 
-            let getDone = false;
-            const get = client.get(key).then((r) => {
-                getDone = true;
-                return r;
-            });
             let setDone = false;
             const set = client.set(key, "after").then((r) => {
                 setDone = true;
@@ -2027,12 +2022,10 @@ describe("GlideClient", () => {
             await sleep(300);
 
             // Verify that none of the commands completes during the pause window.
-            expect(getDone).toBe(false);
             expect(setDone).toBe(false);
             expect(unpauseDone).toBe(false);
 
             // Verify that all commands complete once pause expires naturally.
-            expect(await get).toEqual("before");
             expect(await set).toEqual("OK");
             expect(await unpause).toEqual("OK");
             expect(await client.get(key)).toEqual("after");

--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -182,11 +182,6 @@ describe("GlideClusterClient", () => {
                 }),
             ).toEqual("OK");
 
-            let getDone = false;
-            const get = client.get(key).then((r) => {
-                getDone = true;
-                return r;
-            });
             let setDone = false;
             const set = client.set(key, "after").then((r) => {
                 setDone = true;
@@ -203,12 +198,10 @@ describe("GlideClusterClient", () => {
             await sleep(300);
 
             // Verify that none of the commands completes during the pause window.
-            expect(getDone).toBe(false);
             expect(setDone).toBe(false);
             expect(unpauseDone).toBe(false);
 
             // Verify that all commands complete once pause expires naturally.
-            expect(await get).toEqual("before");
             expect(await set).toEqual("OK");
             expect(await unpause).toEqual("OK");
             expect(await client.get(key)).toEqual("after");

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -10039,16 +10039,10 @@ class TestCommands:
             else:
                 assert await glide_client.client_pause(2000, ClientPauseMode.ALL) == OK
 
-            get_result: List[Optional[bytes]] = [None]
             set_result: List[Optional[bytes]] = [None]
             unpause_result: List[Optional[str]] = [None]
-            get_done = anyio.Event()
             set_done = anyio.Event()
             unpause_done = anyio.Event()
-
-            async def run_get() -> None:
-                get_result[0] = await glide_client.get(key)
-                get_done.set()
 
             async def run_set() -> None:
                 set_result[0] = await glide_client.set(key, "after")
@@ -10064,24 +10058,20 @@ class TestCommands:
                 unpause_done.set()
 
             async with anyio.create_task_group() as tg:
-                tg.start_soon(run_get)
                 tg.start_soon(run_set)
                 tg.start_soon(run_unpause)
 
                 await anyio.sleep(0.3)
 
                 # Verify that none of the commands completes.
-                assert not get_done.is_set()
                 assert not set_done.is_set()
                 assert not unpause_done.is_set()
 
                 # Verify that all commands complete once pause expires.
                 with anyio.fail_after(5.0):
-                    await get_done.wait()
                     await set_done.wait()
                     await unpause_done.wait()
 
-            assert get_result[0] == b"before"
             assert set_result[0] == OK
             assert unpause_result[0] == OK
             assert await glide_client.get(key) == b"after"

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9883,16 +9883,10 @@ class TestCommands:
             else:
                 assert glide_sync_client.client_pause(2000, ClientPauseMode.ALL) == OK
 
-            get_result: List[Optional[bytes]] = [None]
             set_result: List[Optional[bytes]] = [None]
             unpause_result: List[Optional[str]] = [None]
-            get_done = threading.Event()
             set_done = threading.Event()
             unpause_done = threading.Event()
-
-            def run_get() -> None:
-                get_result[0] = glide_sync_client.get(key)
-                get_done.set()
 
             def run_set() -> None:
                 set_result[0] = glide_sync_client.set(key, "after")
@@ -9908,7 +9902,6 @@ class TestCommands:
                 unpause_done.set()
 
             threads = [
-                threading.Thread(target=run_get, daemon=True),
                 threading.Thread(target=run_set, daemon=True),
                 threading.Thread(target=run_unpause, daemon=True),
             ]
@@ -9918,16 +9911,13 @@ class TestCommands:
                 time.sleep(0.3)
 
                 # Verify that none of the commands completes.
-                assert not get_done.is_set()
                 assert not set_done.is_set()
                 assert not unpause_done.is_set()
 
                 # Verify that all commands complete once pause expires.
-                assert get_done.wait(timeout=5.0)
                 assert set_done.wait(timeout=5.0)
                 assert unpause_done.wait(timeout=5.0)
 
-                assert get_result[0] == b"before"
                 assert set_result[0] == OK
                 assert unpause_result[0] == OK
                 assert glide_sync_client.get(key) == b"after"


### PR DESCRIPTION
### Summary

Remove the concurrent `GET` from `PAUSE`/`UNPAUSE` integration tests across all language clients to fix a flaky test failure caused by a race condition between `GET` and `SET` commands dispatched concurrently.

### Issue link

This Pull Request is linked to a flaky CI failure in `TestGlideTestSuite/TestClientPauseAllThenUnpause`:

```text
=== NAME  TestGlideTestSuite/TestClientPauseAllThenUnpause
    client_pause_test.go:94:
        Error Trace: .../go/integTest/client_pause_test.go:94
        Error:       Not equal:
                     expected: "before"
                     actual  : "after"
        Test:        TestGlideTestSuite/TestClientPauseAllThenUnpause
```

### Features / Behaviour Changes

:white_circle: None — test-only change.

### Implementation

The `clientPauseAll_then_clientUnpause` tests launched `GET`, `SET`, and `CLIENT UNPAUSE` concurrently during a `CLIENT PAUSE ALL` window. After the pause expired, the test asserted that `GET` returned the pre-pause value `"before"`. However, since all three commands are dispatched from separate concurrent execution contexts (goroutines in Go, async tasks in Python), their arrival order at `glide-core` is non-deterministic.

Other clients (Java, Node) were updated simply for cross-client consistency.

The fix removes `GET` from the concurrent pause window entirely. The test now launches only `SET` and `CLIENT UNPAUSE` concurrently, then verifies:

1. Both commands are blocked during the pause.
2. Both commands complete once the pause expires or is lifted.
3. A sequential `GET` after the pause confirms the `SET` wrote successfully.

### Limitations

:white_circle: None.

### Testing

Ran the modified tests locally 5 times without failure for each client.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] ~~CHANGELOG.md and documentation files are updated.~~ (Test-only fix, no docs needed.)
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] ~~Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary~~ (No API changes.)