### PR TITLE
Java: implement MONITOR command

### DIFF
--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "redis",
  "scopeguard",
  "serde",
+ "serde_json",
  "telemetrylib",
  "tokio",
  "tracing",

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -21,7 +21,7 @@ jni = "0.21.1"
 log = "0.4.20"
 bytes = { version = "1.6.0" }
 serde = "1.0.225"
-serde_json = "1"
+serde_json = "1.0.149"
 # Additional dependencies for JNI implementation
 anyhow = "1.0"
 dashmap = "6.1.0"

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -21,6 +21,7 @@ jni = "0.21.1"
 log = "0.4.20"
 bytes = { version = "1.6.0" }
 serde = "1.0.225"
+serde_json = "1"
 # Additional dependencies for JNI implementation
 anyhow = "1.0"
 dashmap = "6.1.0"

--- a/java/client/src/main/java/glide/api/MonitorClient.java
+++ b/java/client/src/main/java/glide/api/MonitorClient.java
@@ -1,14 +1,18 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
+import com.google.protobuf.ByteString;
 import connection_request.ConnectionRequestOuterClass.AuthenticationInfo;
 import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
 import connection_request.ConnectionRequestOuterClass.NodeAddress;
 import connection_request.ConnectionRequestOuterClass.ProtocolVersion;
 import connection_request.ConnectionRequestOuterClass.TlsMode;
 import glide.api.models.commands.MonitorMsg;
+import glide.api.models.configuration.AdvancedBaseClientConfiguration;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.ServerCredentials;
+import glide.api.models.configuration.TlsAdvancedConfiguration;
+import glide.api.models.exceptions.ConfigurationError;
 import glide.api.models.exceptions.ConnectionException;
 import glide.internal.GlideNativeBridge;
 import glide.internal.MonitorCallback;
@@ -103,10 +107,11 @@ public class MonitorClient implements AutoCloseable {
      * @throws InterruptedException if interrupted while waiting.
      */
     public MonitorMsg getMonitorMessage() throws InterruptedException {
-        if (closed.get()) {
-            return null;
+        while (!closed.get()) {
+            MonitorMsg msg = queue.poll(100, TimeUnit.MILLISECONDS);
+            if (msg != null) return msg;
         }
-        return queue.take();
+        return null;
     }
 
     /**
@@ -158,10 +163,30 @@ public class MonitorClient implements AutoCloseable {
                     NodeAddress.newBuilder().setHost(addr.getHost()).setPort(addr.getPort()).build());
         }
 
+        AdvancedBaseClientConfiguration advanced = config.getAdvancedConfiguration();
+        boolean insecureTls = false;
+        if (advanced != null) {
+            TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
+            if (tlsConfig != null && tlsConfig.isUseInsecureTLS()) {
+                if (!config.isUseTLS()) {
+                    throw new ConfigurationError(
+                            "`useInsecureTLS` cannot be enabled when `useTLS` is disabled.");
+                }
+                insecureTls = true;
+            }
+        }
+
         if (config.isUseTLS()) {
-            builder.setTlsMode(TlsMode.SecureTls);
+            builder.setTlsMode(insecureTls ? TlsMode.InsecureTls : TlsMode.SecureTls);
         } else {
             builder.setTlsMode(TlsMode.NoTls);
+        }
+
+        if (advanced != null) {
+            TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
+            if (tlsConfig != null && tlsConfig.getRootCertificates() != null) {
+                builder.addRootCerts(ByteString.copyFrom(tlsConfig.getRootCertificates()));
+            }
         }
 
         ServerCredentials creds = config.getCredentials();

--- a/java/client/src/main/java/glide/api/MonitorClient.java
+++ b/java/client/src/main/java/glide/api/MonitorClient.java
@@ -1,0 +1,263 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api;
+
+import connection_request.ConnectionRequestOuterClass.AuthenticationInfo;
+import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
+import connection_request.ConnectionRequestOuterClass.NodeAddress;
+import connection_request.ConnectionRequestOuterClass.ProtocolVersion;
+import connection_request.ConnectionRequestOuterClass.TlsMode;
+import glide.api.models.commands.MonitorMsg;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.ServerCredentials;
+import glide.api.models.exceptions.ConnectionException;
+import glide.internal.GlideNativeBridge;
+import glide.internal.MonitorCallback;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import lombok.NonNull;
+
+/**
+ * A dedicated client for the MONITOR command. Opens its own connection to the Valkey server and
+ * streams all commands processed by the server.
+ *
+ * <p>Standalone (non-cluster) connections only.
+ *
+ * <p>Supports two consumption modes:
+ *
+ * <ul>
+ *   <li>Callback mode: supply a {@link Consumer} to {@link #create}; each message is delivered to
+ *       the callback on a background thread.
+ *   <li>Queue mode: use {@link #getMonitorMessage()} / {@link #tryGetMonitorMessage()} to poll.
+ * </ul>
+ */
+public class MonitorClient implements AutoCloseable {
+
+    private final long nativeMonitorId;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final BlockingQueue<MonitorMsg> queue;
+
+    private MonitorClient(long nativeMonitorId, BlockingQueue<MonitorMsg> queue) {
+        this.nativeMonitorId = nativeMonitorId;
+        this.queue = queue;
+    }
+
+    /**
+     * Creates a new {@link MonitorClient} for the given standalone configuration.
+     *
+     * @param config The standalone client configuration.
+     * @return A new {@link MonitorClient} instance.
+     * @throws ConnectionException if the native monitor client cannot be created.
+     * @throws NullPointerException if {@code config} is null.
+     * @throws IllegalArgumentException Not applicable - cluster configurations are rejected at
+     *     compile time since this method only accepts {@link GlideClientConfiguration}.
+     */
+    public static MonitorClient create(@NonNull GlideClientConfiguration config)
+            throws ConnectionException {
+        return create(config, null);
+    }
+
+    /**
+     * Creates a new {@link MonitorClient} with a callback for each monitor message.
+     *
+     * @param config The standalone client configuration.
+     * @param callback Optional callback invoked for each message. If null, messages are queued.
+     * @return A new {@link MonitorClient} instance.
+     * @throws ConnectionException if the native monitor client cannot be created.
+     */
+    public static MonitorClient create(
+            @NonNull GlideClientConfiguration config, Consumer<MonitorMsg> callback)
+            throws ConnectionException {
+        byte[] configBytes = serializeConfig(config);
+
+        // Create the queue first so the JNI callback closure captures it directly.
+        BlockingQueue<MonitorMsg> queue = new LinkedBlockingQueue<>();
+        MonitorCallback jniCallback =
+                (timestamp, db, clientAddr, command, argsJson) -> {
+                    List<String> args = parseArgsJson(argsJson);
+                    MonitorMsg msg = new MonitorMsg(timestamp, db, clientAddr, command, args);
+                    if (callback != null) {
+                        callback.accept(msg);
+                    } else {
+                        queue.offer(msg);
+                    }
+                };
+
+        long monitorId = GlideNativeBridge.createMonitorClient(configBytes, jniCallback);
+        if (monitorId == 0) {
+            throw new ConnectionException("Failed to create native monitor client");
+        }
+
+        return new MonitorClient(monitorId, queue);
+    }
+
+    /**
+     * Blocks until a monitor message is available.
+     *
+     * @return The next {@link MonitorMsg}, or {@code null} if the client is closed.
+     * @throws InterruptedException if interrupted while waiting.
+     */
+    public MonitorMsg getMonitorMessage() throws InterruptedException {
+        if (closed.get()) {
+            return null;
+        }
+        return queue.take();
+    }
+
+    /**
+     * Blocks until a monitor message is available or the timeout expires.
+     *
+     * @param timeoutMs Maximum wait time in milliseconds.
+     * @return The next {@link MonitorMsg}, or {@code null} if timed out or closed.
+     * @throws InterruptedException if interrupted while waiting.
+     */
+    public MonitorMsg getMonitorMessage(long timeoutMs) throws InterruptedException {
+        if (closed.get()) {
+            return null;
+        }
+        return queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    /** Returns a message immediately if one is available, or {@code null} otherwise. */
+    public MonitorMsg tryGetMonitorMessage() {
+        if (closed.get()) {
+            return null;
+        }
+        return queue.poll();
+    }
+
+    /** Returns {@code true} if {@link #stop()} or {@link #close()} has been called. */
+    public boolean isClosed() {
+        return closed.get();
+    }
+
+    /** Stops monitoring and releases resources. Idempotent. */
+    public void stop() {
+        if (closed.compareAndSet(false, true)) {
+            GlideNativeBridge.closeMonitorClient(nativeMonitorId);
+        }
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    // ---- helpers ----
+
+    private static byte[] serializeConfig(GlideClientConfiguration config) {
+        ConnectionRequest.Builder builder = ConnectionRequest.newBuilder();
+
+        for (glide.api.models.configuration.NodeAddress addr : config.getAddresses()) {
+            builder.addAddresses(
+                    NodeAddress.newBuilder().setHost(addr.getHost()).setPort(addr.getPort()).build());
+        }
+
+        if (config.isUseTLS()) {
+            builder.setTlsMode(TlsMode.SecureTls);
+        } else {
+            builder.setTlsMode(TlsMode.NoTls);
+        }
+
+        ServerCredentials creds = config.getCredentials();
+        if (creds != null) {
+            AuthenticationInfo.Builder authBuilder = AuthenticationInfo.newBuilder();
+            if (creds.getUsername() != null) {
+                authBuilder.setUsername(creds.getUsername());
+            }
+            if (creds.getPassword() != null) {
+                authBuilder.setPassword(creds.getPassword());
+            }
+            builder.setAuthenticationInfo(authBuilder.build());
+        }
+
+        if (config.getDatabaseId() != null) {
+            builder.setDatabaseId(config.getDatabaseId());
+        }
+
+        if (config.getProtocol() != null) {
+            if ("RESP2".equals(config.getProtocol().name())) {
+                builder.setProtocol(ProtocolVersion.RESP2);
+            } else if ("RESP3".equals(config.getProtocol().name())) {
+                builder.setProtocol(ProtocolVersion.RESP3);
+            }
+        }
+
+        return builder.build().toByteArray();
+    }
+
+    /**
+     * Parse a JSON array string like {@code ["a","b","c"]} into a {@link List}.
+     *
+     * <p>Uses a simple hand-rolled parser to avoid a JSON library dependency.
+     */
+    static List<String> parseArgsJson(String json) {
+        if (json == null || json.equals("[]")) {
+            return Collections.emptyList();
+        }
+        List<String> result = new ArrayList<>();
+        // Strip surrounding brackets
+        int i = 1;
+        int len = json.length();
+        while (i < len - 1) {
+            // Skip whitespace / commas
+            char c = json.charAt(i);
+            if (c == ',' || c == ' ') {
+                i++;
+                continue;
+            }
+            if (c == '"') {
+                // Read quoted string
+                i++; // skip opening quote
+                StringBuilder sb = new StringBuilder();
+                while (i < len) {
+                    char ch = json.charAt(i++);
+                    if (ch == '"') {
+                        break;
+                    }
+                    if (ch == '\\' && i < len) {
+                        char escaped = json.charAt(i++);
+                        switch (escaped) {
+                            case '"':
+                                sb.append('"');
+                                break;
+                            case '\\':
+                                sb.append('\\');
+                                break;
+                            case 'n':
+                                sb.append('\n');
+                                break;
+                            case 'r':
+                                sb.append('\r');
+                                break;
+                            case 't':
+                                sb.append('\t');
+                                break;
+                            case 'u':
+                                // Parse 4 hex digits (JSON unicode escape)
+                                if (i + 4 <= len) {
+                                    String hex = json.substring(i, i + 4);
+                                    sb.append((char) Integer.parseInt(hex, 16));
+                                    i += 4;
+                                }
+                                break;
+                            default:
+                                sb.append(escaped);
+                        }
+                    } else {
+                        sb.append(ch);
+                    }
+                }
+                result.add(sb.toString());
+            } else {
+                i++;
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/java/client/src/main/java/glide/api/MonitorClient.java
+++ b/java/client/src/main/java/glide/api/MonitorClient.java
@@ -37,6 +37,8 @@ import lombok.NonNull;
  *       the callback on a background thread.
  *   <li>Queue mode: use {@link #getMonitorMessage()} / {@link #tryGetMonitorMessage()} to poll.
  * </ul>
+ *
+ * @since Valkey 1.0.0.
  */
 public class MonitorClient implements AutoCloseable {
 

--- a/java/client/src/main/java/glide/api/MonitorClient.java
+++ b/java/client/src/main/java/glide/api/MonitorClient.java
@@ -8,14 +8,12 @@ import connection_request.ConnectionRequestOuterClass.NodeAddress;
 import connection_request.ConnectionRequestOuterClass.ProtocolVersion;
 import connection_request.ConnectionRequestOuterClass.TlsMode;
 import glide.api.models.commands.MonitorMsg;
-import glide.api.models.configuration.AdvancedBaseClientConfiguration;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.ServerCredentials;
-import glide.api.models.configuration.TlsAdvancedConfiguration;
-import glide.api.models.exceptions.ConfigurationError;
 import glide.api.models.exceptions.ConnectionException;
 import glide.internal.GlideNativeBridge;
 import glide.internal.MonitorCallback;
+import glide.managers.TlsConfigHelper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,8 +37,6 @@ import lombok.NonNull;
  *       the callback on a background thread.
  *   <li>Queue mode: use {@link #getMonitorMessage()} / {@link #tryGetMonitorMessage()} to poll.
  * </ul>
- *
- * @since 2.4.0
  */
 public class MonitorClient implements AutoCloseable {
 
@@ -165,30 +161,16 @@ public class MonitorClient implements AutoCloseable {
                     NodeAddress.newBuilder().setHost(addr.getHost()).setPort(addr.getPort()).build());
         }
 
-        AdvancedBaseClientConfiguration advanced = config.getAdvancedConfiguration();
-        boolean insecureTls = false;
-        if (advanced != null) {
-            TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
-            if (tlsConfig != null && tlsConfig.isUseInsecureTLS()) {
-                if (!config.isUseTLS()) {
-                    throw new ConfigurationError(
-                            "`useInsecureTLS` cannot be enabled when `useTLS` is disabled.");
-                }
-                insecureTls = true;
-            }
-        }
-
+        boolean insecureTls = TlsConfigHelper.resolveInsecureTls(config);
         if (config.isUseTLS()) {
             builder.setTlsMode(insecureTls ? TlsMode.InsecureTls : TlsMode.SecureTls);
         } else {
             builder.setTlsMode(TlsMode.NoTls);
         }
 
-        if (advanced != null) {
-            TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
-            if (tlsConfig != null && tlsConfig.getRootCertificates() != null) {
-                builder.addRootCerts(ByteString.copyFrom(tlsConfig.getRootCertificates()));
-            }
+        byte[] rootCerts = TlsConfigHelper.extractRootCertificates(config);
+        if (rootCerts != null) {
+            builder.addRootCerts(ByteString.copyFrom(rootCerts));
         }
 
         ServerCredentials creds = config.getCredentials();

--- a/java/client/src/main/java/glide/api/MonitorClient.java
+++ b/java/client/src/main/java/glide/api/MonitorClient.java
@@ -39,6 +39,8 @@ import lombok.NonNull;
  *       the callback on a background thread.
  *   <li>Queue mode: use {@link #getMonitorMessage()} / {@link #tryGetMonitorMessage()} to poll.
  * </ul>
+ *
+ * @since 2.4.0
  */
 public class MonitorClient implements AutoCloseable {
 

--- a/java/client/src/main/java/glide/api/models/commands/MonitorMsg.java
+++ b/java/client/src/main/java/glide/api/models/commands/MonitorMsg.java
@@ -1,0 +1,24 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.commands;
+
+import java.util.List;
+import lombok.Value;
+
+/** Represents a single line received from the MONITOR command. */
+@Value
+public class MonitorMsg {
+    /** Unix timestamp of the command. */
+    double timestamp;
+
+    /** Database index on which the command was executed. */
+    long db;
+
+    /** Address of the client that issued the command (ip:port or unix:/path). */
+    String clientAddr;
+
+    /** The command name (e.g., "SET", "GET"). */
+    String command;
+
+    /** The command arguments (not including the command name). */
+    List<String> args;
+}

--- a/java/client/src/main/java/glide/internal/GlideNativeBridge.java
+++ b/java/client/src/main/java/glide/internal/GlideNativeBridge.java
@@ -102,4 +102,11 @@ public class GlideNativeBridge {
 
     /** Get cache metrics */
     public static native void getCacheMetrics(long clientPtr, long callbackId, int metricsType);
+
+    /** Create a MONITOR client; returns a native monitor ID, or 0 on failure. */
+    public static native long createMonitorClient(
+            byte[] connectionRequestBytes, MonitorCallback callback);
+
+    /** Close a MONITOR client by the ID returned from {@link #createMonitorClient}. */
+    public static native void closeMonitorClient(long monitorId);
 }

--- a/java/client/src/main/java/glide/internal/MonitorCallback.java
+++ b/java/client/src/main/java/glide/internal/MonitorCallback.java
@@ -1,0 +1,9 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.internal;
+
+/** JNI callback interface for MONITOR messages. Called from Rust on a background thread. */
+@FunctionalInterface
+public interface MonitorCallback {
+    void onMonitorMessage(
+            double timestamp, long db, String clientAddr, String command, String argsJson);
+}

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -23,9 +23,7 @@ import glide.api.models.configuration.PeriodicChecksManualInterval;
 import glide.api.models.configuration.PeriodicChecksStatus;
 import glide.api.models.configuration.ServerCredentials;
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration;
-import glide.api.models.configuration.TlsAdvancedConfiguration;
 import glide.api.models.exceptions.ClosingException;
-import glide.api.models.exceptions.ConfigurationError;
 import glide.api.models.exceptions.GlideException;
 import glide.internal.AsyncRegistry;
 import glide.internal.GlideNativeBridge;
@@ -597,30 +595,10 @@ public class ConnectionManager {
     }
 
     private static boolean resolveInsecureTls(BaseClientConfiguration configuration) {
-        AdvancedBaseClientConfiguration advanced = configuration.getAdvancedConfiguration();
-        if (advanced == null) {
-            return false;
-        }
-        TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
-        if (tlsConfig != null && tlsConfig.isUseInsecureTLS()) {
-            if (!configuration.isUseTLS()) {
-                throw new ConfigurationError(
-                        "`useInsecureTLS` cannot be enabled when `useTLS` is disabled.");
-            }
-            return true;
-        }
-        return false;
+        return TlsConfigHelper.resolveInsecureTls(configuration);
     }
 
     private static byte[] extractRootCertificates(BaseClientConfiguration configuration) {
-        AdvancedBaseClientConfiguration advanced = configuration.getAdvancedConfiguration();
-        if (advanced == null) {
-            return null;
-        }
-        TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
-        if (tlsConfig == null) {
-            return null;
-        }
-        return tlsConfig.getRootCertificates();
+        return TlsConfigHelper.extractRootCertificates(configuration);
     }
 }

--- a/java/client/src/main/java/glide/managers/TlsConfigHelper.java
+++ b/java/client/src/main/java/glide/managers/TlsConfigHelper.java
@@ -1,0 +1,43 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.managers;
+
+import glide.api.models.configuration.AdvancedBaseClientConfiguration;
+import glide.api.models.configuration.BaseClientConfiguration;
+import glide.api.models.configuration.TlsAdvancedConfiguration;
+import glide.api.models.exceptions.ConfigurationError;
+
+/** TLS configuration helpers shared by connection builders. */
+public final class TlsConfigHelper {
+
+    private TlsConfigHelper() {}
+
+    /** Returns {@code true} if insecure TLS is requested, throws if misconfigured. */
+    public static boolean resolveInsecureTls(BaseClientConfiguration configuration) {
+        AdvancedBaseClientConfiguration advanced = configuration.getAdvancedConfiguration();
+        if (advanced == null) {
+            return false;
+        }
+        TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
+        if (tlsConfig != null && tlsConfig.isUseInsecureTLS()) {
+            if (!configuration.isUseTLS()) {
+                throw new ConfigurationError(
+                        "`useInsecureTLS` cannot be enabled when `useTLS` is disabled.");
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /** Returns the root certificates bytes, or {@code null} if not configured. */
+    public static byte[] extractRootCertificates(BaseClientConfiguration configuration) {
+        AdvancedBaseClientConfiguration advanced = configuration.getAdvancedConfiguration();
+        if (advanced == null) {
+            return null;
+        }
+        TlsAdvancedConfiguration tlsConfig = advanced.getTlsAdvancedConfiguration();
+        if (tlsConfig == null) {
+            return null;
+        }
+        return tlsConfig.getRootCertificates();
+    }
+}

--- a/java/client/src/test/java/glide/api/MonitorClientTest.java
+++ b/java/client/src/test/java/glide/api/MonitorClientTest.java
@@ -1,0 +1,71 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class MonitorClientTest {
+
+    @Test
+    public void parseArgsJson_empty() {
+        List<String> result = MonitorClient.parseArgsJson("[]");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void parseArgsJson_null() {
+        List<String> result = MonitorClient.parseArgsJson(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void parseArgsJson_singleArg() {
+        List<String> result = MonitorClient.parseArgsJson("[\"key\"]");
+        assertEquals(Collections.singletonList("key"), result);
+    }
+
+    @Test
+    public void parseArgsJson_multipleArgs() {
+        List<String> result = MonitorClient.parseArgsJson("[\"key\",\"val\"]");
+        assertEquals(Arrays.asList("key", "val"), result);
+    }
+
+    @Test
+    public void parseArgsJson_escapedQuote() {
+        // JSON: ["he said \"hi\""]
+        List<String> result = MonitorClient.parseArgsJson("[\"he said \\\"hi\\\"\"]");
+        assertEquals(Collections.singletonList("he said \"hi\""), result);
+    }
+
+    @Test
+    public void parseArgsJson_escapedBackslash() {
+        // JSON: ["a\\b"]
+        List<String> result = MonitorClient.parseArgsJson("[\"a\\\\b\"]");
+        assertEquals(Collections.singletonList("a\\b"), result);
+    }
+
+    @Test
+    public void parseArgsJson_controlCharNewline() {
+        // serde_json encodes newline as \n in JSON: ["line1\nline2"]
+        List<String> result = MonitorClient.parseArgsJson("[\"line1\\nline2\"]");
+        assertEquals(Collections.singletonList("line1\nline2"), result);
+    }
+
+    @Test
+    void parseArgsJsonUnicodeEscape() {
+        // \u0041 is 'A'
+        List<String> result = MonitorClient.parseArgsJson("[\"\\u0041\"]");
+        assertEquals(Collections.singletonList("A"), result);
+    }
+
+    @Test
+    void monitorRejectsNullConfig() {
+        assertThrows(NullPointerException.class, () -> MonitorClient.create(null));
+    }
+}

--- a/java/integTest/src/test/java/glide/standalone/MonitorClientTests.java
+++ b/java/integTest/src/test/java/glide/standalone/MonitorClientTests.java
@@ -45,6 +45,7 @@ public class MonitorClientTests {
                                 }
                             })) {
 
+                Thread.sleep(200);
                 client.set(key, value).get();
 
                 assertTrue(latch.await(5, TimeUnit.SECONDS), "Expected a SET monitor message");
@@ -62,9 +63,10 @@ public class MonitorClientTests {
         try (MonitorClient monitor = MonitorClient.create(config);
                 GlideClient client = GlideClient.createClient(config).get()) {
 
+            Thread.sleep(200);
             client.ping().get();
 
-            MonitorMsg msg = monitor.getMonitorMessage(5000);
+            MonitorMsg msg = monitor.getMonitorMessage(10000);
             assertNotNull(msg, "Expected a monitor message after PING");
         }
     }
@@ -107,6 +109,7 @@ public class MonitorClientTests {
         try (MonitorClient monitor = MonitorClient.create(config);
                 GlideClient client = GlideClient.createClient(config).get()) {
 
+            Thread.sleep(200);
             String key = UUID.randomUUID().toString();
             client.set(key, "value").get();
 

--- a/java/integTest/src/test/java/glide/standalone/MonitorClientTests.java
+++ b/java/integTest/src/test/java/glide/standalone/MonitorClientTests.java
@@ -1,0 +1,133 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.standalone;
+
+import static glide.TestUtilities.commonClientConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import glide.api.GlideClient;
+import glide.api.MonitorClient;
+import glide.api.models.commands.MonitorMsg;
+import glide.api.models.configuration.GlideClientConfiguration;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Timeout(30)
+public class MonitorClientTests {
+
+    @Test
+    @SneakyThrows
+    public void monitorReceivesCommands() {
+        GlideClientConfiguration config = commonClientConfig().requestTimeout(5000).build();
+        try (GlideClient client = GlideClient.createClient(config).get()) {
+
+            String key = UUID.randomUUID().toString();
+            String value = UUID.randomUUID().toString();
+
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicReference<MonitorMsg> received = new AtomicReference<>();
+
+            try (MonitorClient monitorWithCb =
+                    MonitorClient.create(
+                            config,
+                            msg -> {
+                                if ("SET".equalsIgnoreCase(msg.getCommand())) {
+                                    received.compareAndSet(null, msg);
+                                    latch.countDown();
+                                }
+                            })) {
+
+                client.set(key, value).get();
+
+                assertTrue(latch.await(5, TimeUnit.SECONDS), "Expected a SET monitor message");
+                assertNotNull(received.get());
+                assertEquals(key, received.get().getArgs().get(0));
+                assertEquals(value, received.get().getArgs().get(1));
+            }
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void monitorQueueMode() {
+        GlideClientConfiguration config = commonClientConfig().requestTimeout(5000).build();
+        try (MonitorClient monitor = MonitorClient.create(config);
+                GlideClient client = GlideClient.createClient(config).get()) {
+
+            client.ping().get();
+
+            MonitorMsg msg = monitor.getMonitorMessage(5000);
+            assertNotNull(msg, "Expected a monitor message after PING");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void monitorClose() {
+        GlideClientConfiguration config = commonClientConfig().requestTimeout(5000).build();
+        MonitorClient monitor = MonitorClient.create(config);
+
+        assertFalse(monitor.isClosed());
+        monitor.stop();
+        assertTrue(monitor.isClosed());
+    }
+
+    @Test
+    @SneakyThrows
+    public void monitorStopIdempotent() {
+        GlideClientConfiguration config = commonClientConfig().requestTimeout(5000).build();
+        MonitorClient monitor = MonitorClient.create(config);
+
+        monitor.stop();
+        monitor.stop(); // Should not throw
+    }
+
+    @Test
+    public void monitorRejectsNullConfig() {
+        assertThrows(
+                NullPointerException.class,
+                () -> {
+                    // @NonNull on the config parameter throws NullPointerException for null input.
+                    MonitorClient.create(null);
+                });
+    }
+
+    @Test
+    @SneakyThrows
+    public void monitorMsgFieldTypes() {
+        GlideClientConfiguration config = commonClientConfig().requestTimeout(5000).build();
+        try (MonitorClient monitor = MonitorClient.create(config);
+                GlideClient client = GlideClient.createClient(config).get()) {
+
+            String key = UUID.randomUUID().toString();
+            client.set(key, "value").get();
+
+            // Wait for the SET to appear
+            MonitorMsg msg = null;
+            long deadline = System.currentTimeMillis() + 5000;
+            while (System.currentTimeMillis() < deadline) {
+                MonitorMsg candidate = monitor.tryGetMonitorMessage();
+                if (candidate != null && "SET".equalsIgnoreCase(candidate.getCommand())) {
+                    msg = candidate;
+                    break;
+                }
+                Thread.sleep(100);
+            }
+
+            assertNotNull(msg, "Expected a SET monitor message");
+            assertTrue(msg.getTimestamp() > 0.0, "timestamp should be positive");
+            assertTrue(msg.getDb() >= 0, "db should be non-negative");
+            assertNotNull(msg.getClientAddr(), "clientAddr should not be null");
+            assertNotNull(msg.getCommand(), "command should not be null");
+            assertNotNull(msg.getArgs(), "args should not be null");
+        }
+    }
+}

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -3,7 +3,6 @@
 use glide_core::client::FINISHED_SCAN_CURSOR;
 use glide_core::errors::error_message;
 use logger_core::log_warn_lazy;
-
 // Protocol constants for Java (defined directly since we don't use socket layer)
 const TYPE_HASH: &str = "hash";
 const TYPE_LIST: &str = "list";
@@ -2674,6 +2673,165 @@ fn get_ok_jstring<'a>(env: &mut JNIEnv<'a>) -> Result<JString<'a>, FFIError> {
         .expect("OK_STRING_GLOBAL should be initialized");
     let local = env.new_local_ref(global.as_obj())?;
     Ok(JString::from(local))
+}
+
+// ==================== MONITOR CLIENT SUPPORT ====================
+
+static MONITOR_CLIENTS: std::sync::OnceLock<
+    dashmap::DashMap<u64, glide_core::client::MonitorClient>,
+> = std::sync::OnceLock::new();
+static NEXT_MONITOR_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn get_monitor_clients() -> &'static dashmap::DashMap<u64, glide_core::client::MonitorClient> {
+    MONITOR_CLIENTS.get_or_init(dashmap::DashMap::new)
+}
+
+/// Create a MONITOR client that streams all commands to a Java callback.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_createMonitorClient(
+    mut env: JNIEnv,
+    _class: JClass,
+    connection_request_bytes: JByteArray,
+    callback_object: JObject,
+) -> jlong {
+    run_ffi(|| {
+        fn create_monitor(
+            env: &mut JNIEnv,
+            connection_request_bytes: JByteArray,
+            callback_object: JObject,
+        ) -> Result<jlong, FFIError> {
+            let request_bytes = env.convert_byte_array(&connection_request_bytes)?;
+            let proto_request =
+                glide_core::connection_request::ConnectionRequest::parse_from_bytes(&request_bytes)
+                    .map_err(|e| {
+                        FFIError::Logger(format!("Failed to parse ConnectionRequest: {e}"))
+                    })?;
+
+            // Extract first address
+            let addr_proto = proto_request
+                .addresses
+                .first()
+                .ok_or_else(|| FFIError::Logger("No addresses in ConnectionRequest".to_string()))?;
+            let address = glide_core::client::NodeAddress {
+                host: addr_proto.host.to_string(),
+                port: addr_proto.port as u16,
+            };
+
+            // Build RedisConnectionInfo from protobuf auth fields
+            let redis_connection_info =
+                if let Some(auth) = proto_request.authentication_info.as_ref() {
+                    redis::RedisConnectionInfo {
+                        db: 0,
+                        username: if auth.username.is_empty() {
+                            None
+                        } else {
+                            Some(auth.username.to_string())
+                        },
+                        password: if auth.password.is_empty() {
+                            None
+                        } else {
+                            Some(auth.password.to_string())
+                        },
+                        protocol: redis::ProtocolVersion::RESP2,
+                        client_name: None,
+                        lib_name: None,
+                        cache: None,
+                        server_assisted_cache: false,
+                    }
+                } else {
+                    redis::RedisConnectionInfo {
+                        db: 0,
+                        username: None,
+                        password: None,
+                        protocol: redis::ProtocolVersion::RESP2,
+                        client_name: None,
+                        lib_name: None,
+                        cache: None,
+                        server_assisted_cache: false,
+                    }
+                };
+
+            // TLS mode
+            let tls_mode = match proto_request.tls_mode.enum_value_or_default() {
+                glide_core::connection_request::TlsMode::SecureTls => {
+                    glide_core::client::TlsMode::SecureTls
+                }
+                glide_core::connection_request::TlsMode::InsecureTls => {
+                    glide_core::client::TlsMode::InsecureTls
+                }
+                _ => glide_core::client::TlsMode::NoTls,
+            };
+
+            // Cache JVM if not already cached
+            if let Ok(jvm) = env.get_java_vm() {
+                let _ = jni_client::JVM.set(Arc::new(jvm));
+            }
+
+            // Make a global ref so the callback object outlives this stack frame
+            let callback_global = env.new_global_ref(&callback_object)?;
+
+            let on_line: glide_core::client::MonitorLineCallback =
+                Arc::new(move |line: glide_core::client::MonitorLine| {
+                    let Some(jvm) = jni_client::JVM.get() else {
+                        log::warn!("MonitorClient callback: JVM not initialized, dropping message");
+                        return;
+                    };
+                    let Ok(mut cb_env) = jvm.attach_current_thread_as_daemon() else {
+                        return;
+                    };
+                    let args_json =
+                        serde_json::to_string(&line.args).unwrap_or_else(|_| "[]".to_string());
+                    let Ok(j_client_addr) = cb_env.new_string(&line.client_addr) else {
+                        return;
+                    };
+                    let Ok(j_command) = cb_env.new_string(&line.command) else {
+                        return;
+                    };
+                    let Ok(j_args_json) = cb_env.new_string(&args_json) else {
+                        return;
+                    };
+                    let _ = cb_env.call_method(
+                        &callback_global,
+                        "onMonitorMessage",
+                        "(DJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+                        &[
+                            jni::objects::JValue::Double(line.timestamp),
+                            jni::objects::JValue::Long(line.db),
+                            jni::objects::JValue::Object(&j_client_addr),
+                            jni::objects::JValue::Object(&j_command),
+                            jni::objects::JValue::Object(&j_args_json),
+                        ],
+                    );
+                });
+
+            let monitor = jni_client::get_runtime()
+                .block_on(glide_core::client::MonitorClient::new(
+                    &address,
+                    redis_connection_info,
+                    tls_mode,
+                    on_line,
+                ))
+                .map_err(|e| FFIError::Logger(format!("Failed to create MonitorClient: {e}")))?;
+
+            let id = NEXT_MONITOR_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            get_monitor_clients().insert(id, monitor);
+            Ok(id as jlong)
+        }
+
+        let result = create_monitor(&mut env, connection_request_bytes, callback_object);
+        handle_errors(&mut env, result)
+    })
+    .unwrap_or(0)
+}
+
+/// Close a MONITOR client by ID (drops it, stopping the monitor stream).
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_closeMonitorClient(
+    _env: JNIEnv,
+    _class: JClass,
+    monitor_id: jlong,
+) {
+    get_monitor_clients().remove(&(monitor_id as u64));
 }
 
 /// Get cache metrics asynchronously

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2721,7 +2721,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createMonitorClient
             let redis_connection_info =
                 if let Some(auth) = proto_request.authentication_info.as_ref() {
                     redis::RedisConnectionInfo {
-                        db: 0,
+                        db: proto_request.database_id as i64,
                         username: if auth.username.is_empty() {
                             None
                         } else {
@@ -2732,7 +2732,12 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createMonitorClient
                         } else {
                             Some(auth.password.to_string())
                         },
-                        protocol: redis::ProtocolVersion::RESP2,
+                        protocol: match proto_request.protocol.enum_value_or_default() {
+                            glide_core::connection_request::ProtocolVersion::RESP3 => {
+                                redis::ProtocolVersion::RESP3
+                            }
+                            _ => redis::ProtocolVersion::RESP2,
+                        },
                         client_name: None,
                         lib_name: None,
                         cache: None,
@@ -2740,10 +2745,15 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createMonitorClient
                     }
                 } else {
                     redis::RedisConnectionInfo {
-                        db: 0,
+                        db: proto_request.database_id as i64,
                         username: None,
                         password: None,
-                        protocol: redis::ProtocolVersion::RESP2,
+                        protocol: match proto_request.protocol.enum_value_or_default() {
+                            glide_core::connection_request::ProtocolVersion::RESP3 => {
+                                redis::ProtocolVersion::RESP3
+                            }
+                            _ => redis::ProtocolVersion::RESP2,
+                        },
                         client_name: None,
                         lib_name: None,
                         cache: None,
@@ -2790,7 +2800,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createMonitorClient
                     let Ok(j_args_json) = cb_env.new_string(&args_json) else {
                         return;
                     };
-                    let _ = cb_env.call_method(
+                    let result = cb_env.call_method(
                         &callback_global,
                         "onMonitorMessage",
                         "(DJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
@@ -2802,6 +2812,10 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createMonitorClient
                             jni::objects::JValue::Object(&j_args_json),
                         ],
                     );
+                    if let Err(e) = result {
+                        log::warn!("MonitorClient: JNI callback failed: {e}");
+                        let _ = cb_env.exception_clear();
+                    }
                 });
 
             let monitor = jni_client::get_runtime()


### PR DESCRIPTION
### Summary

Ports the MONITOR command implementation from Python (PR #6132) to Java. Adds a `MonitorClient` class that opens a dedicated connection to Valkey, sends the MONITOR command, and streams all processed commands to the caller via a callback or a blocking queue.

### Issue link

Related to https://github.com/valkey-io/valkey-glide/pull/6132 (Python sync/async implementation) and https://github.com/valkey-io/valkey-glide/pull/5977 (Rust core).

### Features / Behaviour Changes

- New `MonitorClient` class with two consumption modes:
  - **Callback mode**: supply a `MonitorCallback` that is invoked for each received `MonitorMsg`
  - **Queue mode**: `poll()` / `take()` on a `LinkedBlockingQueue<MonitorMsg>`
- `MonitorClient` implements `AutoCloseable` for use in try-with-resources; `stop()` is idempotent
- New `MonitorMsg` value class carrying `timestamp`, `db`, `clientAddr`, `command`, and `args`
- New `MonitorCallback` JNI callback interface
- JNI layer in Rust: `create_monitor_client` / `close_monitor_client` functions in `java/src/lib.rs`

### Implementation

Key files changed:

| File | Change |
|------|--------|
| `java/src/lib.rs` | Two new JNI functions: `create_monitor_client` (opens connection, sends MONITOR, spawns listener thread that calls back into Java) and `close_monitor_client` |
| `glide/internal/MonitorCallback.java` | Single-method JNI callback interface `onMessage(MonitorMsg)` |
| `glide/api/models/commands/MonitorMsg.java` | Immutable value record holding the five fields of a MONITOR line |
| `glide/api/MonitorClient.java` | Public API: `create()`, `stop()`, queue/callback wiring, `AutoCloseable` |
| `glide/internal/GlideNativeBridge.java` | Added `createMonitorClient` / `closeMonitorClient` native declarations |

The Rust core (`glide-core/src/client/monitor_client.rs`) was already present from PR #5977; this PR only adds the Java binding.

### Limitations

- MONITOR is a debugging tool and has known performance implications on the server side; this is documented in the class Javadoc.
- Cluster mode is not supported (same limitation as Python).

### Testing

- **6 integration tests** in `MonitorClientTests`:
  1. Receives commands after MONITOR starts
  2. Queue (poll) mode works end-to-end
  3. Close/lifecycle: no messages after `stop()`
  4. Idempotent stop (calling `stop()` twice does not throw)
  5. Null config rejection
  6. Field type validation on `MonitorMsg`
- **9 unit tests** in `MonitorClientTest` covering the `parseArgsJson` helper edge-cases (empty array, single arg, multi-arg, nested quotes, unicode, null input, etc.)

### Checklist

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary