### PR TITLE
[Go] Fix flaky TestScriptKillWithRoute race condition

### DIFF
--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -2745,32 +2745,41 @@ func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 	code := CreateLongRunningLuaScript(10, true)
 	script := options.NewScript(code)
 
-	// Kill in a goroutine - polls until the script is running, matching testFunctionKillNoWrite pattern
-	var killErr error
-	var result string
+	// Start InvokeScript in a goroutine so it begins executing immediately
+	var invokeErr error
+	invokeDone := make(chan struct{})
 	go func() {
-		timeout := time.After(8 * time.Second)
-		ticker := time.NewTicker(500 * time.Millisecond)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-timeout:
-				return
-			case <-ticker.C:
-				result, killErr = killClient.ScriptKillWithRoute(context.Background(), route)
-				if killErr == nil {
-					return
-				}
-			}
-		}
+		defer close(invokeDone)
+		_, invokeErr = invokeClient.InvokeScriptWithRoute(context.Background(), *script, route)
 	}()
 
-	// Block until script is killed (returns error) - guarantees script is running on server
-	_, err = invokeClient.InvokeScriptWithRoute(context.Background(), *script, route)
-	assert.Error(suite.T(), err)
-	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "script killed"))
+	// Poll ScriptKill on the main goroutine until the script is running and killed
+	killTimeout := time.After(10 * time.Second)
+	killTicker := time.NewTicker(500 * time.Millisecond)
+	defer killTicker.Stop()
 
+	var killErr error
+	var result string
+	for {
+		select {
+		case <-killTimeout:
+			suite.T().Fatal("Timed out waiting for script kill to succeed")
+			return
+		case <-killTicker.C:
+			result, killErr = killClient.ScriptKillWithRoute(context.Background(), route)
+			if killErr == nil {
+				goto killDone
+			}
+		}
+	}
+killDone:
+	killTicker.Stop()
+
+	// Wait for invoke to complete after kill
+	<-invokeDone
+
+	assert.Error(suite.T(), invokeErr)
+	assert.True(suite.T(), strings.Contains(strings.ToLower(invokeErr.Error()), "script killed"))
 	assert.NoError(suite.T(), killErr)
 	assert.Equal(suite.T(), "OK", result)
 	script.Close()

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -2754,32 +2754,18 @@ func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 	}()
 
 	// Poll ScriptKill on the main goroutine until the script is running and killed
-	killTimeout := time.After(10 * time.Second)
-	killTicker := time.NewTicker(500 * time.Millisecond)
-	defer killTicker.Stop()
-
 	var killErr error
 	var result string
-	for {
-		select {
-		case <-killTimeout:
-			suite.T().Fatal("Timed out waiting for script kill to succeed")
-			return
-		case <-killTicker.C:
-			result, killErr = killClient.ScriptKillWithRoute(context.Background(), route)
-			if killErr == nil {
-				goto killDone
-			}
-		}
-	}
-killDone:
-	killTicker.Stop()
+	require.Eventually(suite.T(), func() bool {
+		result, killErr = killClient.ScriptKillWithRoute(context.Background(), route)
+		return killErr == nil
+	}, 10*time.Second, 500*time.Millisecond, "Timed out waiting for script kill to succeed")
 
 	// Wait for invoke to complete after kill
 	<-invokeDone
 
-	assert.Error(suite.T(), invokeErr)
-	assert.True(suite.T(), strings.Contains(strings.ToLower(invokeErr.Error()), "script killed"))
+	require.Error(suite.T(), invokeErr)
+	assert.Contains(suite.T(), strings.ToLower(invokeErr.Error()), "script killed")
 	assert.NoError(suite.T(), killErr)
 	assert.Equal(suite.T(), "OK", result)
 	script.Close()


### PR DESCRIPTION
### Summary

Fix the flaky `TestScriptKillWithRoute` test (Go) by eliminating a race condition between the kill goroutine and `InvokeScript` execution.

### Issue link

This Pull Request is linked to issue: [[Core][Flaky Test] TestGlideTestSuite/TestScriptKillWithRoute](https://github.com/valkey-io/valkey-glide/issues/5817)
Closes #5817

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Root cause

The test started a kill-polling goroutine with an 8-second timeout *before* calling `InvokeScriptWithRoute` on the main goroutine. Under CI load, the main goroutine might not get scheduled quickly enough, so the kill goroutine could exhaust its timeout receiving `NotBusy` responses before the script ever started executing on the server.

### Implementation

Restructure the test so that:

1. `InvokeScriptWithRoute` is started in a goroutine first, so it begins executing immediately.
2. `ScriptKillWithRoute` is polled on the main goroutine until the script is running and the kill succeeds.
3. After the kill succeeds, the test waits for the invoke goroutine to complete.
4. Both the kill result (`OK`) and the invoke error (`script killed`) are asserted.

This removes the race because `InvokeScript` is dispatched immediately and the main goroutine owns the kill-polling lifecycle with a generous timeout.

**Review feedback addressed (commit `Address feedback by using require.Eventually`):**

- Replaced the manual `for`/`select` + `goto killDone` polling loop with testify's `require.Eventually(...)` — more idiomatic, removes the `goto`/label and the redundant `killTicker.Stop()`, and gives a clear timeout failure message.
- Changed `assert.Error(invokeErr)` to `require.Error(invokeErr)` to prevent a potential nil-pointer panic on the subsequent `invokeErr.Error()` call.
- Switched the message check to `assert.Contains(...)` for clearer failure output.

Final kill/poll section:

```go
// Start InvokeScript in a goroutine so it begins executing immediately
var invokeErr error
invokeDone := make(chan struct{})
go func() {
    defer close(invokeDone)
    _, invokeErr = invokeClient.InvokeScriptWithRoute(context.Background(), *script, route)
}()

// Poll ScriptKill on the main goroutine until the script is running and killed
var killErr error
var result string
require.Eventually(suite.T(), func() bool {
    result, killErr = killClient.ScriptKillWithRoute(context.Background(), route)
    return killErr == nil
}, 10*time.Second, 500*time.Millisecond, "Timed out waiting for script kill to succeed")

// Wait for invoke to complete after kill
<-invokeDone

require.Error(suite.T(), invokeErr)
assert.Contains(suite.T(), strings.ToLower(invokeErr.Error()), "script killed")
assert.NoError(suite.T(), killErr)
assert.Equal(suite.T(), "OK", result)
```

### Testing

Verified locally against a Valkey 9.0.1 cluster (3 shards × 3 replicas) started via `utils/cluster_manager.py`, building the Go client + FFI from this branch.

- `go vet ./integTest/` — passes clean.
- **Flakiness run: 100 consecutive executions of `TestScriptKillWithRoute` → 99 pass / 1 fail.** The single failure was the very first iteration and was caused by a leftover long-running Lua script from a previously interrupted run still executing on the cluster, which tripped the test's initial "no script running" (`notbusy`) check. It was not a failure of the fixed logic.
- **Clean confirmation run: 25 consecutive executions → 25 / 25 pass**, after confirming the cluster reported `NOTBUSY` (no leftover script) beforehand.

Net: **124 / 125** runs passed, with the one failure fully explained as cross-run test contamination rather than a code flake. The fixed coordination logic was non-flaky across all clean runs.

Each execution completed in ~5 s.

### Note for reviewers

This test is inherently sensitive to a pre-existing running script on the target primary: if a prior run is interrupted while its long-running script is still executing, the next run's initial `notbusy` assertion can fail. That is a test-isolation property of the harness and is unrelated to this fix.

### Limitations

None.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
