### PR TITLE
[Node] Fix flaky CompressionMaxSize.test.ts beforeAll timeout

### DIFF
--- a/node/tests/CompressionMaxSize.test.ts
+++ b/node/tests/CompressionMaxSize.test.ts
@@ -30,7 +30,7 @@ import {
     parseEndpoints,
 } from "./TestUtilities";
 
-const TIMEOUT = 30000;
+const TIMEOUT = 50000;
 
 function generateCompressibleText(sizeBytes: number): string {
     const pattern = "A".repeat(10) + "B".repeat(10) + "C".repeat(10);


### PR DESCRIPTION
### Summary

Fix flaky `CompressionMaxSize.test.ts` test suite `beforeAll` hook timeout by increasing the `TIMEOUT` constant from 30000ms to 50000ms, matching the standard timeout used across the Node.js test suite.

### Issue link

This Pull Request is linked to issue: [[Node][Flaky Test] CompressionMaxSize.test.ts beforeAll hook timeout](https://github.com/valkey-io/valkey-glide/issues/6193)
Closes #6193

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The `beforeAll` hook in `CompressionMaxSize.test.ts` initializes both a standalone cluster and a cluster-mode cluster. The `TIMEOUT` constant was set to 30000ms (30s), which is insufficient on CI runners under load — especially since this hook creates TWO separate clusters that each require server startup and cluster formation.

**Fix:** Increase `TIMEOUT` from 30000ms to 50000ms to match the standard value used across all other Node.js test files that perform cluster initialization (GlideClient.test.ts, GlideClusterClient.test.ts, ClientSideCache.test.ts, ScanTest.test.ts, AuthTest.test.ts, TlsCertificateTest.test.ts, etc.).

### Limitations

None

### Testing

- Ran the full `CompressionMaxSize` test suite (6 tests) 100 consecutive times locally with zero failures.
- All runs completed successfully with test times ranging from 19-30 seconds, well within the new 50s timeout.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release