### PR TITLE
test(python): deterministic channel names in sync pubsub test

### DIFF
--- a/python/tests/sync_tests/test_sync_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pubsub.py
@@ -773,16 +773,17 @@ class TestSyncPubSub:
         """
 
         NUM_CHANNELS = 256
-        PATTERN = "{{{}}}:{}".format("pattern", "*")
+        PATTERN = "{pattern}:*"
 
-        # Create dictionaries of channels and their corresponding messages
+        # Create dictionaries of channels and their corresponding messages.
+        # Deterministic, index-unique names keep exact channels and the
+        # subscribed pattern from overlapping, so callback counts stay exact.
         exact_channels_and_messages = {
-            "{{{}}}:{}".format("channel", get_random_string(5)): get_random_string(10)
-            for _ in range(NUM_CHANNELS)
+            f"{{channel}}:exact_{i}": f"exact_message_{i}" for i in range(NUM_CHANNELS)
         }
         pattern_channels_and_messages = {
-            "{{{}}}:{}".format("pattern", get_random_string(5)): get_random_string(5)
-            for _ in range(NUM_CHANNELS)
+            f"{{pattern}}:match_{i}": f"pattern_message_{i}"
+            for i in range(NUM_CHANNELS)
         }
 
         all_channels_and_messages = {


### PR DESCRIPTION
### Summary
Fix flaky test `test_sync_pubsub_combined_exact_and_pattern_one_client` by making channel names deterministic using indexed names instead of random strings.

### Issue link
This Pull Request is linked to issue: [[Python][Flaky Test] test_sync_pubsub_combined_exact_and_pattern_one_client - callback count mismatch](https://github.com/valkey-io/valkey-glide/issues/6084)
Closes #6084

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
The root cause is that `get_random_string(5)` used in a dictionary comprehension (`for _ in range(NUM_CHANNELS)`) can produce duplicate keys. When duplicates occur, the dictionary has fewer entries than NUM_CHANNELS (256), resulting in fewer messages being published and received, which causes the assertion `len(callback) == expected_callback_messages_count` (512) to fail.

The fix replaces random channel names with deterministic indexed names (e.g., `{channel}:exact_0`, `{pattern}:match_0`), guaranteeing exactly NUM_CHANNELS unique entries. This matches the approach already applied to:
- The async version of this test (fixed in PR #4880, later made fully deterministic)
- Other sync combined tests (`test_sync_pubsub_combined_exact_and_pattern_multiple_clients`, etc.)

### Limitations
None

### Testing
- Verified the fix is consistent with the async test version and other already-fixed sync tests
- The change is purely mechanical: replacing random names with indexed deterministic names

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release