### PR TITLE
Go: Add MonitorClient for MONITOR command

### DIFF
--- a/go/integTest/monitor_commands_test.go
+++ b/go/integTest/monitor_commands_test.go
@@ -1,0 +1,127 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+)
+
+func (suite *GlideTestSuite) TestMonitorReceivesCommands() {
+	var received []glide.MonitorLine
+	var mu sync.Mutex
+
+	monitor, err := glide.NewMonitorClient(
+		suite.defaultClientConfig(),
+		func(line glide.MonitorLine) {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, line)
+		},
+	)
+	require.NoError(suite.T(), err)
+	defer monitor.Close()
+
+	client := suite.defaultClient()
+	key := uuid.New().String()
+	_, err = client.Set(context.Background(), key, "value")
+	require.NoError(suite.T(), err)
+
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var commands []string
+	for _, line := range received {
+		commands = append(commands, line.Command)
+	}
+	assert.Contains(suite.T(), commands, "SET")
+}
+
+func (suite *GlideTestSuite) TestMonitorQueue() {
+	monitor, err := glide.NewMonitorClient(suite.defaultClientConfig(), nil)
+	require.NoError(suite.T(), err)
+	defer monitor.Close()
+
+	client := suite.defaultClient()
+	_, err = client.Ping(context.Background())
+	require.NoError(suite.T(), err)
+
+	time.Sleep(500 * time.Millisecond)
+
+	line, ok := monitor.TryGetMonitorMessage()
+	assert.True(suite.T(), ok)
+	assert.NotEmpty(suite.T(), line.Command)
+	assert.Greater(suite.T(), line.Timestamp, float64(0))
+	assert.GreaterOrEqual(suite.T(), line.DB, int64(0))
+	assert.NotEmpty(suite.T(), line.ClientAddr)
+	assert.NotEmpty(suite.T(), line.Command)
+	assert.NotNil(suite.T(), line.Args)
+}
+
+func (suite *GlideTestSuite) TestMonitorGetMessageBlocking() {
+	monitor, err := glide.NewMonitorClient(suite.defaultClientConfig(), nil)
+	require.NoError(suite.T(), err)
+	defer monitor.Close()
+
+	client := suite.defaultClient()
+	_, err = client.Ping(context.Background())
+	require.NoError(suite.T(), err)
+
+	done := make(chan glide.MonitorLine, 1)
+	go func() {
+		line, err := monitor.GetMonitorMessage()
+		if err == nil {
+			done <- line
+		}
+	}()
+
+	select {
+	case line := <-done:
+		assert.NotEmpty(suite.T(), line.Command)
+	case <-time.After(5 * time.Second):
+		suite.T().Fatal("timed out waiting for monitor message")
+	}
+}
+
+func (suite *GlideTestSuite) TestMonitorCloseIdempotent() {
+	monitor, err := glide.NewMonitorClient(suite.defaultClientConfig(), nil)
+	require.NoError(suite.T(), err)
+
+	monitor.Close()
+	monitor.Close() // Should not panic or error
+}
+
+func (suite *GlideTestSuite) TestMonitorFields() {
+	monitor, err := glide.NewMonitorClient(suite.defaultClientConfig(), nil)
+	require.NoError(suite.T(), err)
+	defer monitor.Close()
+
+	client := suite.defaultClient()
+	key := uuid.New().String()
+	_, err = client.Set(context.Background(), key, "hello")
+	require.NoError(suite.T(), err)
+
+	time.Sleep(500 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		line, ok := monitor.TryGetMonitorMessage()
+		if !ok {
+			break
+		}
+		if line.Command == "SET" {
+			assert.Greater(suite.T(), line.Timestamp, float64(0))
+			assert.GreaterOrEqual(suite.T(), line.DB, int64(0))
+			assert.NotEmpty(suite.T(), line.ClientAddr)
+			assert.Equal(suite.T(), 2, len(line.Args))
+			return
+		}
+	}
+	suite.T().Fatal("SET command not found in monitor queue within expected messages")
+}

--- a/go/integTest/monitor_commands_test.go
+++ b/go/integTest/monitor_commands_test.go
@@ -33,15 +33,23 @@ func (suite *GlideTestSuite) TestMonitorReceivesCommands() {
 	_, err = client.Set(context.Background(), key, "value")
 	require.NoError(suite.T(), err)
 
-	time.Sleep(500 * time.Millisecond)
-
-	mu.Lock()
-	defer mu.Unlock()
-	var commands []string
-	for _, line := range received {
-		commands = append(commands, line.Command)
+	deadline := time.Now().Add(5 * time.Second)
+	found := false
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		for _, line := range received {
+			if line.Command == "SET" {
+				found = true
+				break
+			}
+		}
+		mu.Unlock()
+		if found {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	assert.Contains(suite.T(), commands, "SET")
+	assert.True(suite.T(), found, "SET command not found in monitor output")
 }
 
 func (suite *GlideTestSuite) TestMonitorQueue() {
@@ -53,15 +61,21 @@ func (suite *GlideTestSuite) TestMonitorQueue() {
 	_, err = client.Ping(context.Background())
 	require.NoError(suite.T(), err)
 
-	time.Sleep(500 * time.Millisecond)
-
-	line, ok := monitor.TryGetMonitorMessage()
-	assert.True(suite.T(), ok)
+	deadline := time.Now().Add(5 * time.Second)
+	var line glide.MonitorLine
+	var ok bool
+	for time.Now().Before(deadline) {
+		line, ok = monitor.TryGetMonitorMessage()
+		if ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.True(suite.T(), ok, "timed out waiting for monitor message")
 	assert.NotEmpty(suite.T(), line.Command)
 	assert.Greater(suite.T(), line.Timestamp, float64(0))
 	assert.GreaterOrEqual(suite.T(), line.DB, int64(0))
 	assert.NotEmpty(suite.T(), line.ClientAddr)
-	assert.NotEmpty(suite.T(), line.Command)
 	assert.NotNil(suite.T(), line.Args)
 }
 
@@ -108,12 +122,12 @@ func (suite *GlideTestSuite) TestMonitorFields() {
 	_, err = client.Set(context.Background(), key, "hello")
 	require.NoError(suite.T(), err)
 
-	time.Sleep(500 * time.Millisecond)
-
-	for i := 0; i < 10; i++ {
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
 		line, ok := monitor.TryGetMonitorMessage()
 		if !ok {
-			break
+			time.Sleep(10 * time.Millisecond)
+			continue
 		}
 		if line.Command == "SET" {
 			assert.Greater(suite.T(), line.Timestamp, float64(0))
@@ -123,5 +137,5 @@ func (suite *GlideTestSuite) TestMonitorFields() {
 			return
 		}
 	}
-	suite.T().Fatal("SET command not found in monitor queue within expected messages")
+	suite.T().Fatal("SET command not found in monitor queue within timeout")
 }

--- a/go/monitor_client.go
+++ b/go/monitor_client.go
@@ -64,6 +64,10 @@ func monitorCallback(
 		return
 	}
 
+	if clientAddr == nil || command == nil {
+		return
+	}
+
 	args := []string{}
 	if argsJsonLen > 0 && argsJson != nil {
 		jsonBytes := C.GoBytes(argsJson, C.int(argsJsonLen))
@@ -78,18 +82,10 @@ func monitorCallback(
 		Args:       args,
 	}
 
-	client.mu.Lock()
-	cb := client.callback
-	if cb == nil {
-		client.queue = append(client.queue, line)
-		client.cond.Broadcast()
-		client.mu.Unlock()
-		return
+	select {
+	case client.ch <- line:
+	default:
 	}
-	client.activeCBs.Add(1)
-	client.mu.Unlock()
-	cb(line)
-	client.activeCBs.Done()
 }
 
 // MonitorClient listens to all commands processed by the server via the MONITOR command.
@@ -101,7 +97,36 @@ type MonitorClient struct {
 	callback   func(MonitorLine)
 	queue      []MonitorLine
 	closed     bool
-	activeCBs  sync.WaitGroup
+	ch         chan MonitorLine
+	done       chan struct{}
+	wg         sync.WaitGroup
+}
+
+func (c *MonitorClient) startDispatcher() {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		for {
+			select {
+			case line, ok := <-c.ch:
+				if !ok {
+					return
+				}
+				c.mu.Lock()
+				cb := c.callback
+				if cb == nil {
+					c.queue = append(c.queue, line)
+					c.cond.Broadcast()
+					c.mu.Unlock()
+				} else {
+					c.mu.Unlock()
+					cb(line)
+				}
+			case <-c.done:
+				return
+			}
+		}
+	}()
 }
 
 // NewMonitorClient creates a new MonitorClient connected to a standalone server.
@@ -137,9 +162,12 @@ func NewMonitorClient(cfg *config.ClientConfiguration, callback func(MonitorLine
 	client := &MonitorClient{
 		coreClient: cResponse.conn_ptr,
 		callback:   callback,
+		ch:         make(chan MonitorLine, 512),
+		done:       make(chan struct{}),
 	}
 	client.cond = sync.NewCond(&client.mu)
 	registerMonitorClient(client, uintptr(cResponse.conn_ptr))
+	client.startDispatcher()
 	return client, nil
 }
 
@@ -178,7 +206,6 @@ func (c *MonitorClient) TryGetMonitorMessage() (MonitorLine, bool) {
 }
 
 // Close stops the monitor client and releases its resources.
-// Calling Close from within a MonitorClient callback will deadlock.
 func (c *MonitorClient) Close() {
 	c.mu.Lock()
 	if c.closed {
@@ -188,12 +215,11 @@ func (c *MonitorClient) Close() {
 	c.closed = true
 	c.mu.Unlock()
 
+	close(c.done)
+	c.wg.Wait()
 	c.cond.Broadcast()
-	c.activeCBs.Wait()
 
-	if c.coreClient != nil {
-		unregisterMonitorClient(uintptr(c.coreClient))
-		C.close_monitor_client(c.coreClient)
-		c.coreClient = nil
-	}
+	unregisterMonitorClient(uintptr(c.coreClient))
+	C.close_monitor_client(c.coreClient)
+	c.coreClient = nil
 }

--- a/go/monitor_client.go
+++ b/go/monitor_client.go
@@ -1,0 +1,194 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+// #include "lib.h"
+// void monitorCallback(uintptr_t clientPtr, double timestamp, int64_t db,
+//                      void *clientAddr, int64_t clientAddrLen,
+//                      void *command, int64_t commandLen,
+//                      void *argsJson, int64_t argsJsonLen);
+import "C"
+
+import (
+	"encoding/json"
+	"sync"
+	"unsafe"
+
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"google.golang.org/protobuf/proto"
+)
+
+// MonitorLine represents a single line received from the MONITOR command.
+type MonitorLine struct {
+	Timestamp  float64
+	DB         int64
+	ClientAddr string
+	Command    string
+	Args       []string
+}
+
+var (
+	monitorRegistry   = make(map[uintptr]*MonitorClient)
+	monitorRegistryMu sync.RWMutex
+)
+
+func registerMonitorClient(client *MonitorClient, ptrValue uintptr) {
+	monitorRegistryMu.Lock()
+	defer monitorRegistryMu.Unlock()
+	monitorRegistry[ptrValue] = client
+}
+
+func unregisterMonitorClient(ptrValue uintptr) {
+	monitorRegistryMu.Lock()
+	defer monitorRegistryMu.Unlock()
+	delete(monitorRegistry, ptrValue)
+}
+
+func getMonitorClientByPtr(ptrValue uintptr) *MonitorClient {
+	monitorRegistryMu.RLock()
+	defer monitorRegistryMu.RUnlock()
+	return monitorRegistry[ptrValue]
+}
+
+//export monitorCallback
+func monitorCallback(
+	clientPtr C.uintptr_t,
+	timestamp C.double,
+	db C.int64_t,
+	clientAddr unsafe.Pointer, clientAddrLen C.int64_t,
+	command unsafe.Pointer, commandLen C.int64_t,
+	argsJson unsafe.Pointer, argsJsonLen C.int64_t,
+) {
+	client := getMonitorClientByPtr(uintptr(clientPtr))
+	if client == nil {
+		return
+	}
+
+	args := []string{}
+	if argsJsonLen > 0 && argsJson != nil {
+		jsonBytes := C.GoBytes(argsJson, C.int(argsJsonLen))
+		_ = json.Unmarshal(jsonBytes, &args)
+	}
+
+	line := MonitorLine{
+		Timestamp:  float64(timestamp),
+		DB:         int64(db),
+		ClientAddr: string(C.GoBytes(clientAddr, C.int(clientAddrLen))),
+		Command:    string(C.GoBytes(command, C.int(commandLen))),
+		Args:       args,
+	}
+
+	client.mu.Lock()
+	cb := client.callback
+	if cb == nil {
+		client.queue = append(client.queue, line)
+		client.cond.Broadcast()
+	}
+	client.mu.Unlock()
+	if cb != nil {
+		cb(line)
+	}
+}
+
+// MonitorClient listens to all commands processed by the server via the MONITOR command.
+// It is standalone-only; cluster mode is not supported.
+type MonitorClient struct {
+	coreClient unsafe.Pointer
+	mu         sync.Mutex
+	cond       *sync.Cond
+	callback   func(MonitorLine)
+	queue      []MonitorLine
+	closed     bool
+}
+
+// NewMonitorClient creates a new MonitorClient connected to a standalone server.
+// If callback is non-nil, it is called for each received MonitorLine; otherwise messages
+// are queued and can be retrieved with GetMonitorMessage or TryGetMonitorMessage.
+func NewMonitorClient(cfg *config.ClientConfiguration, callback func(MonitorLine)) (*MonitorClient, error) {
+	request, err := cfg.ToProtobuf()
+	if err != nil {
+		return nil, err
+	}
+	msg, err := proto.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	byteCount := len(msg)
+	requestBytes := C.CBytes(msg)
+	defer C.free(requestBytes)
+
+	cResponse := (*C.struct_ConnectionResponse)(
+		C.create_monitor_client(
+			(*C.uint8_t)(requestBytes),
+			C.uintptr_t(byteCount),
+			C.MonitorCallback(unsafe.Pointer(C.monitorCallback)),
+		),
+	)
+	defer C.free_connection_response(cResponse)
+
+	if cErr := cResponse.connection_error_message; cErr != nil {
+		return nil, NewConnectionError(C.GoString(cErr))
+	}
+
+	client := &MonitorClient{
+		coreClient: cResponse.conn_ptr,
+		callback:   callback,
+	}
+	client.cond = sync.NewCond(&client.mu)
+	registerMonitorClient(client, uintptr(cResponse.conn_ptr))
+	return client, nil
+}
+
+// GetMonitorMessage blocks until a MonitorLine is available and returns it.
+// Returns an error if the client has been closed.
+func (c *MonitorClient) GetMonitorMessage() (MonitorLine, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for len(c.queue) == 0 && !c.closed {
+		c.cond.Wait()
+	}
+	if c.closed && len(c.queue) == 0 {
+		return MonitorLine{}, NewConnectionError("monitor client is closed")
+	}
+	line := c.queue[0]
+	c.queue = c.queue[1:]
+	if len(c.queue) == 0 {
+		c.queue = nil
+	}
+	return line, nil
+}
+
+// TryGetMonitorMessage returns a MonitorLine if one is available, or (MonitorLine{}, false) if none.
+func (c *MonitorClient) TryGetMonitorMessage() (MonitorLine, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.queue) == 0 {
+		return MonitorLine{}, false
+	}
+	line := c.queue[0]
+	c.queue = c.queue[1:]
+	if len(c.queue) == 0 {
+		c.queue = nil
+	}
+	return line, true
+}
+
+// Close stops the monitor client and releases its resources.
+func (c *MonitorClient) Close() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.mu.Unlock()
+
+	c.cond.Broadcast()
+
+	if c.coreClient != nil {
+		unregisterMonitorClient(uintptr(c.coreClient))
+		C.close_monitor_client(c.coreClient)
+		c.coreClient = nil
+	}
+}

--- a/go/monitor_client.go
+++ b/go/monitor_client.go
@@ -83,11 +83,13 @@ func monitorCallback(
 	if cb == nil {
 		client.queue = append(client.queue, line)
 		client.cond.Broadcast()
+		client.mu.Unlock()
+		return
 	}
+	client.activeCBs.Add(1)
 	client.mu.Unlock()
-	if cb != nil {
-		cb(line)
-	}
+	cb(line)
+	client.activeCBs.Done()
 }
 
 // MonitorClient listens to all commands processed by the server via the MONITOR command.
@@ -99,6 +101,7 @@ type MonitorClient struct {
 	callback   func(MonitorLine)
 	queue      []MonitorLine
 	closed     bool
+	activeCBs  sync.WaitGroup
 }
 
 // NewMonitorClient creates a new MonitorClient connected to a standalone server.
@@ -175,6 +178,7 @@ func (c *MonitorClient) TryGetMonitorMessage() (MonitorLine, bool) {
 }
 
 // Close stops the monitor client and releases its resources.
+// Calling Close from within a MonitorClient callback will deadlock.
 func (c *MonitorClient) Close() {
 	c.mu.Lock()
 	if c.closed {
@@ -185,6 +189,7 @@ func (c *MonitorClient) Close() {
 	c.mu.Unlock()
 
 	c.cond.Broadcast()
+	c.activeCBs.Wait()
 
 	if c.coreClient != nil {
 		unregisterMonitorClient(uintptr(c.coreClient))


### PR DESCRIPTION
### Summary

Ports the MONITOR command to the Go client, implementing `MonitorClient` that lets users observe all commands processed by a standalone Valkey server.

### Issue link

This Pull Request is linked to issue: #5977 (Rust/FFI core), #6132 (Python implementation)

### Features / Behaviour Changes

- New `MonitorClient` type for standalone clients
- `NewMonitorClient(cfg, callback)` — factory that connects and starts monitoring
- Callback mode: supply a `func(MonitorLine)` to receive each line as it arrives
- Queue mode: omit the callback and use `GetMonitorMessage()` (blocking) or `TryGetMonitorMessage()` (non-blocking) to pull messages
- `Close()` — idempotent and thread-safe

### Implementation

- `go/lib.h`: Added `MonitorCallback` typedef and `create_monitor_client`/`close_monitor_client` declarations. These are also auto-generated by cbindgen from `ffi/src/lib.rs` (already present via #5977), so CI will regenerate them correctly.
- `go/monitor_client.go`: Uses the same cgo registry pattern as `callbacks.go`. A separate `monitorRegistry` map (keyed by `conn_ptr`) routes C callbacks to the correct Go client. The exported `monitorCallback` C function is called from Rust on each MONITOR line; it copies the callback reference under the lock and invokes it outside the lock to prevent deadlock.
- `go/integTest/monitor_commands_test.go`: Standalone-only integration tests.

### Limitations

- Standalone mode only — MONITOR is not supported in cluster mode
- Queue mode has no capacity limit; callers are responsible for draining the queue

### Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- `make lint` ✅ (pre-existing staticcheck env issue in `example_utils.go` unrelated to this PR)
- Integration tests added: `TestMonitorReceivesCommands`, `TestMonitorQueue`, `TestMonitorGetMessageBlocking`, `TestMonitorCloseIdempotent`, `TestMonitorFields`

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
