### PR TITLE
Node: Add GlideMonitorClient for MONITOR command

### DIFF
--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "455e9fb7743c6f6267eb2830ccc08686fbb3d13c9a689369562fd4d4ef9ea462"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -104,8 +104,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -114,7 +114,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "ring",
  "time",
  "tokio",
  "tracing",
@@ -165,7 +165,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -190,8 +190,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -214,8 +214,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -238,8 +238,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -261,7 +261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -285,6 +285,27 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
 ]
 
 [[package]]
@@ -334,6 +355,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
 version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
@@ -367,7 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -531,15 +561,6 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -600,7 +621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -679,15 +700,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -724,16 +736,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "crypto-common"
@@ -788,23 +790,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -826,7 +818,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -885,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1053,16 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,7 +1209,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest",
 ]
 
 [[package]]
@@ -1383,7 +1365,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1876,7 +1858,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2483,7 +2465,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2540,7 +2522,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2682,17 +2664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,8 +2676,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2888,7 +2859,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3334,6 +3305,7 @@ dependencies = [
  "napi-derive",
  "num-bigint",
  "num-traits",
+ "protobuf",
  "redis",
  "tikv-jemallocator",
  "tokio",
@@ -3346,12 +3318,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "versions"
@@ -3538,7 +3504,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -21,6 +21,7 @@ bytes = "1"
 num-traits = "0.2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
+protobuf = "3"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1"
 num-traits = "0.2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
-protobuf = "3"
+protobuf = { version = "3", default-features = false } # Direct dep required: parse_from_bytes is called directly in the napi layer for MonitorClient
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -957,10 +957,13 @@ pub fn create_monitor_client(
             let p = a.password.to_string();
             if p.is_empty() { None } else { Some(p) }
         }),
+        // MONITOR streams plain-text inline responses, which are incompatible with RESP3 push
+        // messages. RESP2 must always be used for monitor connections regardless of user config.
         protocol: redis::ProtocolVersion::RESP2,
         ..Default::default()
     };
-    let tsfn: napi::threadsafe_function::ThreadsafeFunction<
+    let _client_name = conn_req.client_name.to_string(); // TODO: pass to MonitorClient::new once its signature supports it
+    let mut tsfn: napi::threadsafe_function::ThreadsafeFunction<
         MonitorLine,
         napi::threadsafe_function::ErrorStrategy::Fatal,
     > = callback.create_threadsafe_function(
@@ -984,6 +987,8 @@ pub fn create_monitor_client(
             ])
         },
     )?;
+    // Unref so the TSFN does not prevent the Node.js event loop from exiting naturally.
+    tsfn.unref(&env)?;
     let on_line: MonitorLineCallback = Arc::new(move |line: MonitorLine| {
         tsfn.call(
             line,

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1,12 +1,18 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+use glide_core::client::{MonitorClient, MonitorLine, MonitorLineCallback, NodeAddress, TlsMode};
+use glide_core::connection_request;
 use glide_core::errors::error_message;
 use glide_core::{
     DEFAULT_FLUSH_SIGNAL_INTERVAL_MS, GlideOpenTelemetry, GlideOpenTelemetryConfigBuilder,
     GlideOpenTelemetrySignalsExporter, GlideSpan, Telemetry,
 };
 use logger_core::log_warn_lazy;
+use protobuf::Message;
 use redis::GlideConnectionOptions;
+use std::collections::HashMap as StdHashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -906,4 +912,108 @@ pub fn register_address_resolver(
 #[napi(js_name = "removeAddressResolver")]
 pub fn remove_address_resolver(key: String) {
     glide_core::address_resolver_registry::remove(&key);
+}
+
+static NEXT_MONITOR_HANDLE: AtomicU64 = AtomicU64::new(1);
+
+fn monitor_store() -> &'static Mutex<StdHashMap<u64, MonitorClient>> {
+    static STORE: OnceLock<Mutex<StdHashMap<u64, MonitorClient>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(StdHashMap::new()))
+}
+
+#[napi(js_name = "createMonitorClient", ts_return_type = "Promise<number>")]
+pub fn create_monitor_client(
+    env: Env,
+    connection_request_bytes: Uint8Array,
+    #[napi(
+        ts_arg_type = "(timestamp: number, db: number, clientAddr: string, command: string, args: string[]) => void"
+    )]
+    callback: napi::JsFunction,
+) -> Result<JsObject> {
+    let (deferred, promise) = env.create_deferred()?;
+    let conn_req =
+        connection_request::ConnectionRequest::parse_from_bytes(&connection_request_bytes)
+            .map_err(|e| napi::Error::new(Status::InvalidArg, e.to_string()))?;
+    let proto_addr = conn_req
+        .addresses
+        .first()
+        .ok_or_else(|| napi::Error::new(Status::InvalidArg, "No addresses provided"))?;
+    let address = NodeAddress {
+        host: proto_addr.host.to_string(),
+        port: proto_addr.port as u16,
+    };
+    let tls_mode = match conn_req.tls_mode.enum_value_or_default() {
+        connection_request::TlsMode::NoTls => TlsMode::NoTls,
+        connection_request::TlsMode::SecureTls => TlsMode::SecureTls,
+        connection_request::TlsMode::InsecureTls => TlsMode::InsecureTls,
+    };
+    let redis_conn_info = redis::RedisConnectionInfo {
+        db: conn_req.database_id as i64,
+        username: conn_req.authentication_info.as_ref().and_then(|a| {
+            let u = a.username.to_string();
+            if u.is_empty() { None } else { Some(u) }
+        }),
+        password: conn_req.authentication_info.as_ref().and_then(|a| {
+            let p = a.password.to_string();
+            if p.is_empty() { None } else { Some(p) }
+        }),
+        protocol: redis::ProtocolVersion::RESP2,
+        ..Default::default()
+    };
+    let tsfn: napi::threadsafe_function::ThreadsafeFunction<
+        MonitorLine,
+        napi::threadsafe_function::ErrorStrategy::Fatal,
+    > = callback.create_threadsafe_function(
+        0,
+        |ctx: napi::threadsafe_function::ThreadSafeCallContext<MonitorLine>| {
+            let line = ctx.value;
+            let ts = ctx.env.create_double(line.timestamp)?;
+            let db = ctx.env.create_int64(line.db)?;
+            let addr = ctx.env.create_string(&line.client_addr)?;
+            let cmd = ctx.env.create_string(&line.command)?;
+            let mut args_arr = ctx.env.create_array_with_length(line.args.len())?;
+            for (i, arg) in line.args.iter().enumerate() {
+                args_arr.set_element(i as u32, ctx.env.create_string(arg)?)?;
+            }
+            Ok(vec![
+                ts.into_unknown(),
+                db.into_unknown(),
+                addr.into_unknown(),
+                cmd.into_unknown(),
+                args_arr.into_unknown(),
+            ])
+        },
+    )?;
+    let on_line: MonitorLineCallback = Arc::new(move |line: MonitorLine| {
+        tsfn.call(
+            line,
+            napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+        );
+    });
+    let glide_rt = get_or_init_runtime().map_err(|e| napi::Error::new(Status::Unknown, e))?;
+    glide_rt.runtime.spawn(async move {
+        match MonitorClient::new(&address, redis_conn_info, tls_mode, on_line).await {
+            Ok(client) => {
+                let handle_id = NEXT_MONITOR_HANDLE.fetch_add(1, Ordering::Relaxed);
+                monitor_store().lock().unwrap().insert(handle_id, client);
+                deferred.resolve(move |_| Ok(handle_id as i64));
+            }
+            Err(e) => deferred.reject(napi::Error::new(Status::Unknown, e.to_string())),
+        }
+    });
+    Ok(promise)
+}
+
+#[napi(js_name = "closeMonitorClient", ts_return_type = "Promise<void>")]
+pub fn close_monitor_client(env: Env, handle_id: i64) -> Result<JsObject> {
+    let (deferred, promise) = env.create_deferred()?;
+    let client = monitor_store().lock().unwrap().remove(&(handle_id as u64));
+    let glide_rt = get_or_init_runtime().map_err(|e| napi::Error::new(Status::Unknown, e))?;
+    glide_rt.runtime.spawn(async move {
+        if let Some(c) = client {
+            c.stop_async().await;
+        }
+        deferred.resolve(|_| Ok(()));
+    });
+    Ok(promise)
 }

--- a/node/src/GlideMonitorClient.ts
+++ b/node/src/GlideMonitorClient.ts
@@ -4,78 +4,91 @@ import { closeMonitorClient, createMonitorClient } from "../build-ts/native";
 import { connection_request } from "../build-ts/ProtobufMessage";
 import { BaseClientConfiguration } from "./BaseClient.js";
 
-/**
- * Represents a single line received from the MONITOR command.
- */
 export interface MonitorLine {
-    /** Unix timestamp of when the command was received. */
     timestamp: number;
-    /** Database index on which the command was executed. */
     db: number;
-    /** Client address (e.g. "127.0.0.1:52345"). */
     clientAddr: string;
-    /** Command name (e.g. "set"). */
     command: string;
-    /** Command arguments. */
     args: string[];
 }
 
-/**
- * A client that listens to all commands processed by the server via the MONITOR command.
- * Standalone-only; cluster mode is not supported.
- *
- * @example
- * ```typescript
- * const monitor = await GlideMonitorClient.create(
- *     { addresses: [{ host: "localhost", port: 6379 }] },
- *     (line) => console.log(line.command, line.args),
- * );
- * // ... use a regular client to run commands ...
- * await monitor.close();
- * ```
- */
 export class GlideMonitorClient {
     private handleId: number | null = null;
     private closed = false;
+    private readonly queue: MonitorLine[] = [];
+    private waiters: { resolve: (line: MonitorLine) => void; reject: (err: Error) => void }[] = [];
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     private constructor() {}
 
     /**
-     * Creates a new GlideMonitorClient connected to a standalone server.
-     *
-     * @param options - Connection options. Must target a standalone server.
-     * @param callback - Called for each received MonitorLine.
-     * @returns A connected GlideMonitorClient.
+     * Creates a GlideMonitorClient that streams server-side commands.
+     * @param options - Connection configuration.
+     * @param callback - Optional callback invoked for each monitor line.
+     *   If omitted, use {@link getNextMessage} or {@link tryGetNextMessage} to poll.
      */
     static async create(
         options: BaseClientConfiguration,
-        callback: (line: MonitorLine) => void,
+        callback?: (line: MonitorLine) => void,
     ): Promise<GlideMonitorClient> {
         const client = new GlideMonitorClient();
         const request = GlideMonitorClient.buildConnectionRequest(options);
-        const bytes =
-            connection_request.ConnectionRequest.encode(request).finish();
+        const bytes = connection_request.ConnectionRequest.encode(request).finish();
         client.handleId = await createMonitorClient(
             Buffer.from(bytes),
-            (
-                timestamp: number,
-                db: number,
-                clientAddr: string,
-                command: string,
-                args: string[],
-            ) => callback({ timestamp, db, clientAddr, command, args }),
+            (timestamp, db, clientAddr, command, args) => {
+                const line: MonitorLine = { timestamp, db, clientAddr, command, args };
+
+                if (callback) {
+                    callback(line);
+                } else {
+                    const waiter = client.waiters.shift();
+
+                    if (waiter) {
+                        waiter.resolve(line);
+                    } else {
+                        client.queue.push(line);
+                    }
+                }
+            },
         );
         return client;
     }
 
     /**
-     * Stops the monitor client and releases its resources.
-     * Idempotent — safe to call multiple times.
+     * Returns the next monitor line, waiting until one arrives.
+     * Only usable when no callback was provided to {@link create}.
+     * Rejects if the client is already closed.
      */
+    getNextMessage(): Promise<MonitorLine> {
+        if (this.closed) {
+            return Promise.reject(new Error("Monitor is closed"));
+        }
+
+        if (this.queue.length > 0) {
+            return Promise.resolve(this.queue.shift()!);
+        }
+
+        return new Promise((resolve, reject) => this.waiters.push({ resolve, reject }));
+    }
+
+    /**
+     * Returns the next monitor line immediately, or `undefined` if none is queued.
+     * Only usable when no callback was provided to {@link create}.
+     */
+    tryGetNextMessage(): MonitorLine | undefined {
+        return this.queue.shift();
+    }
+
+    /** Stops monitoring. Idempotent — safe to call multiple times. */
     async close(): Promise<void> {
         if (this.closed) return;
         this.closed = true;
+
+        // Reject any pending getNextMessage() waiters so callers don't hang.
+        for (const { reject } of this.waiters.splice(0)) {
+            reject(new Error("Monitor is closed"));
+        }
 
         if (this.handleId !== null) {
             const id = this.handleId;
@@ -103,6 +116,7 @@ export class GlideMonitorClient {
                       })
                     : undefined,
             databaseId: options.databaseId ?? 0,
+            clientName: options.clientName,
         });
     }
 }

--- a/node/src/GlideMonitorClient.ts
+++ b/node/src/GlideMonitorClient.ts
@@ -1,0 +1,108 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX-Identifier: Apache-2.0
+
+import { closeMonitorClient, createMonitorClient } from "../build-ts/native";
+import { connection_request } from "../build-ts/ProtobufMessage";
+import { BaseClientConfiguration } from "./BaseClient.js";
+
+/**
+ * Represents a single line received from the MONITOR command.
+ */
+export interface MonitorLine {
+    /** Unix timestamp of when the command was received. */
+    timestamp: number;
+    /** Database index on which the command was executed. */
+    db: number;
+    /** Client address (e.g. "127.0.0.1:52345"). */
+    clientAddr: string;
+    /** Command name (e.g. "set"). */
+    command: string;
+    /** Command arguments. */
+    args: string[];
+}
+
+/**
+ * A client that listens to all commands processed by the server via the MONITOR command.
+ * Standalone-only; cluster mode is not supported.
+ *
+ * @example
+ * ```typescript
+ * const monitor = await GlideMonitorClient.create(
+ *     { addresses: [{ host: "localhost", port: 6379 }] },
+ *     (line) => console.log(line.command, line.args),
+ * );
+ * // ... use a regular client to run commands ...
+ * await monitor.close();
+ * ```
+ */
+export class GlideMonitorClient {
+    private handleId: number | null = null;
+    private closed = false;
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() {}
+
+    /**
+     * Creates a new GlideMonitorClient connected to a standalone server.
+     *
+     * @param options - Connection options. Must target a standalone server.
+     * @param callback - Called for each received MonitorLine.
+     * @returns A connected GlideMonitorClient.
+     */
+    static async create(
+        options: BaseClientConfiguration,
+        callback: (line: MonitorLine) => void,
+    ): Promise<GlideMonitorClient> {
+        const client = new GlideMonitorClient();
+        const request = GlideMonitorClient.buildConnectionRequest(options);
+        const bytes =
+            connection_request.ConnectionRequest.encode(request).finish();
+        client.handleId = await createMonitorClient(
+            Buffer.from(bytes),
+            (
+                timestamp: number,
+                db: number,
+                clientAddr: string,
+                command: string,
+                args: string[],
+            ) => callback({ timestamp, db, clientAddr, command, args }),
+        );
+        return client;
+    }
+
+    /**
+     * Stops the monitor client and releases its resources.
+     * Idempotent — safe to call multiple times.
+     */
+    async close(): Promise<void> {
+        if (this.closed) return;
+        this.closed = true;
+
+        if (this.handleId !== null) {
+            const id = this.handleId;
+            this.handleId = null;
+            await closeMonitorClient(id);
+        }
+    }
+
+    private static buildConnectionRequest(
+        options: BaseClientConfiguration,
+    ): connection_request.IConnectionRequest {
+        return connection_request.ConnectionRequest.create({
+            addresses: options.addresses?.map((a) => ({
+                host: a.host,
+                port: a.port,
+            })),
+            tlsMode: options.useTLS
+                ? connection_request.TlsMode.SecureTls
+                : connection_request.TlsMode.NoTls,
+            authenticationInfo:
+                options.credentials != null && "password" in options.credentials
+                    ? connection_request.AuthenticationInfo.create({
+                          username: options.credentials.username ?? "",
+                          password: options.credentials.password,
+                      })
+                    : undefined,
+            databaseId: options.databaseId ?? 0,
+        });
+    }
+}

--- a/node/src/GlideMonitorClient.ts
+++ b/node/src/GlideMonitorClient.ts
@@ -16,7 +16,10 @@ export class GlideMonitorClient {
     private handleId: number | null = null;
     private closed = false;
     private readonly queue: MonitorLine[] = [];
-    private waiters: { resolve: (line: MonitorLine) => void; reject: (err: Error) => void }[] = [];
+    private waiters: {
+        resolve: (line: MonitorLine) => void;
+        reject: (err: Error) => void;
+    }[] = [];
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     private constructor() {}
@@ -33,11 +36,18 @@ export class GlideMonitorClient {
     ): Promise<GlideMonitorClient> {
         const client = new GlideMonitorClient();
         const request = GlideMonitorClient.buildConnectionRequest(options);
-        const bytes = connection_request.ConnectionRequest.encode(request).finish();
+        const bytes =
+            connection_request.ConnectionRequest.encode(request).finish();
         client.handleId = await createMonitorClient(
             Buffer.from(bytes),
             (timestamp, db, clientAddr, command, args) => {
-                const line: MonitorLine = { timestamp, db, clientAddr, command, args };
+                const line: MonitorLine = {
+                    timestamp,
+                    db,
+                    clientAddr,
+                    command,
+                    args,
+                };
 
                 if (callback) {
                     callback(line);
@@ -69,7 +79,9 @@ export class GlideMonitorClient {
             return Promise.resolve(this.queue.shift()!);
         }
 
-        return new Promise((resolve, reject) => this.waiters.push({ resolve, reject }));
+        return new Promise((resolve, reject) =>
+            this.waiters.push({ resolve, reject }),
+        );
     }
 
     /**

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -18,6 +18,7 @@ export * from "./Errors.js";
 export * from "./EvictionPolicy.js";
 export * from "./GlideClient.js";
 export * from "./GlideClusterClient.js";
+export * from "./GlideMonitorClient.js";
 export * from "./Logger.js";
 export * from "./OpenTelemetry.js";
 export * from "./server-modules/GlideFt.js";

--- a/node/tests/GlideMonitorClient.test.ts
+++ b/node/tests/GlideMonitorClient.test.ts
@@ -2,108 +2,123 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 import { ValkeyCluster } from "../../utils/TestUtils.js";
-import {
-    GlideClient,
-    GlideMonitorClient,
-    MonitorLine,
-    ProtocolVersion,
-} from "../build-ts";
-import {
-    getClientConfigurationOption,
-    getServerVersion,
-    parseEndpoints,
-} from "./TestUtilities";
+import { GlideClient, GlideMonitorClient, MonitorLine, ProtocolVersion } from "../build-ts";
+import { getClientConfigurationOption, getServerVersion, parseEndpoints } from "./TestUtilities";
 
 describe("GlideMonitorClient", () => {
     let cluster: ValkeyCluster;
 
     beforeAll(async () => {
-        const standaloneAddresses: string =
-            global.STAND_ALONE_ENDPOINT as string;
+        const standaloneAddresses: string = global.STAND_ALONE_ENDPOINT as string;
         cluster = standaloneAddresses
-            ? await ValkeyCluster.initFromExistingCluster(
-                  false,
-                  parseEndpoints(standaloneAddresses),
-                  getServerVersion,
-              )
+            ? await ValkeyCluster.initFromExistingCluster(false, parseEndpoints(standaloneAddresses), getServerVersion)
             : await ValkeyCluster.createCluster(false, 1, 1, getServerVersion);
     }, 40000);
 
-    afterAll(async () => {
-        await cluster.close();
-    }, 20000);
+    afterAll(async () => { await cluster.close(); }, 20000);
 
     it("monitor receives commands", async () => {
-        const received: MonitorLine[] = [];
-        const config = getClientConfigurationOption(
-            cluster.getAddresses(),
-            ProtocolVersion.RESP2,
-        );
-        const monitor = await GlideMonitorClient.create(config, (line) =>
-            received.push(line),
-        );
+        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const monitor = await GlideMonitorClient.create(config);
 
         try {
             const client = await GlideClient.createClient(config);
 
             try {
-                await client.set(`monitor_key_${Date.now()}`, "monitor_val");
-                await new Promise((r) => setTimeout(r, 500));
+                const key = `monitor_key_${Date.now()}`;
+                await client.set(key, "monitor_val");
+                let line: MonitorLine | undefined;
+                const deadline = Date.now() + 5000;
+
+                while (Date.now() < deadline) {
+                    const next = await Promise.race([
+                        monitor.getNextMessage(),
+                        new Promise<undefined>((r) => setTimeout(r, 100, undefined)),
+                    ]);
+
+                    if (next && next.command.toLowerCase() === "set") {
+                        line = next;
+                        break;
+                    }
+                }
+
+                expect(line).toBeDefined();
+                expect(line!.command.toLowerCase()).toBe("set");
             } finally {
                 client.close();
             }
         } finally {
             await monitor.close();
         }
-
-        expect(received.map((m) => m.command.toLowerCase())).toContain("set");
     });
 
     it("monitor line has correct field types", async () => {
-        const config = getClientConfigurationOption(
-            cluster.getAddresses(),
-            ProtocolVersion.RESP2,
-        );
-        let capturedLine: MonitorLine | null = null;
-        const monitor = await GlideMonitorClient.create(config, (line) => {
-            if (capturedLine === null) capturedLine = line;
-        });
+        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const monitor = await GlideMonitorClient.create(config);
 
         try {
             const client = await GlideClient.createClient(config);
 
             try {
                 await client.ping();
-                await new Promise((r) => setTimeout(r, 500));
+                let line: MonitorLine | undefined;
+                const deadline = Date.now() + 5000;
+
+                while (Date.now() < deadline) {
+                    const next = await Promise.race([
+                        monitor.getNextMessage(),
+                        new Promise<undefined>((r) => setTimeout(r, 100, undefined)),
+                    ]);
+
+                    if (next && next.command.toLowerCase() === "ping") {
+                        line = next;
+                        break;
+                    }
+                }
+
+                expect(line).toBeDefined();
+                const l = line!;
+                expect(typeof l.timestamp).toBe("number");
+                expect(l.timestamp).toBeGreaterThan(0);
+                expect(typeof l.db).toBe("number");
+                expect(l.db).toBeGreaterThanOrEqual(0);
+                expect(typeof l.clientAddr).toBe("string");
+                expect(l.clientAddr.length).toBeGreaterThan(0);
+                expect(typeof l.command).toBe("string");
+                expect(l.command.length).toBeGreaterThan(0);
+                expect(Array.isArray(l.args)).toBe(true);
             } finally {
                 client.close();
             }
         } finally {
             await monitor.close();
         }
-
-        expect(capturedLine).not.toBeNull();
-        const line = capturedLine!;
-        expect(typeof line.timestamp).toBe("number");
-        expect(line.timestamp).toBeGreaterThan(0);
-        expect(typeof line.db).toBe("number");
-        expect(line.db).toBeGreaterThanOrEqual(0);
-        expect(typeof line.clientAddr).toBe("string");
-        expect(line.clientAddr.length).toBeGreaterThan(0);
-        expect(typeof line.command).toBe("string");
-        expect(line.command.length).toBeGreaterThan(0);
-        expect(Array.isArray(line.args)).toBe(true);
     });
 
     it("monitor close is idempotent", async () => {
-        const config = getClientConfigurationOption(
-            cluster.getAddresses(),
-            ProtocolVersion.RESP2,
-        );
-        const monitor = await GlideMonitorClient.create(config, () => {
-            // no-op
-        });
+        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const monitor = await GlideMonitorClient.create(config);
         await monitor.close();
         await expect(monitor.close()).resolves.not.toThrow();
+    });
+
+    it("getNextMessage works without callback", async () => {
+        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const monitor = await GlideMonitorClient.create(config);
+
+        try {
+            const client = await GlideClient.createClient(config);
+
+            try {
+                await client.set("poll_test", "val");
+                const line = await monitor.getNextMessage();
+                expect(line).toBeDefined();
+                expect(typeof line.command).toBe("string");
+            } finally {
+                client.close();
+            }
+        } finally {
+            await monitor.close();
+        }
     });
 });

--- a/node/tests/GlideMonitorClient.test.ts
+++ b/node/tests/GlideMonitorClient.test.ts
@@ -2,23 +2,42 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 import { ValkeyCluster } from "../../utils/TestUtils.js";
-import { GlideClient, GlideMonitorClient, MonitorLine, ProtocolVersion } from "../build-ts";
-import { getClientConfigurationOption, getServerVersion, parseEndpoints } from "./TestUtilities";
+import {
+    GlideClient,
+    GlideMonitorClient,
+    MonitorLine,
+    ProtocolVersion,
+} from "../build-ts";
+import {
+    getClientConfigurationOption,
+    getServerVersion,
+    parseEndpoints,
+} from "./TestUtilities";
 
 describe("GlideMonitorClient", () => {
     let cluster: ValkeyCluster;
 
     beforeAll(async () => {
-        const standaloneAddresses: string = global.STAND_ALONE_ENDPOINT as string;
+        const standaloneAddresses: string =
+            global.STAND_ALONE_ENDPOINT as string;
         cluster = standaloneAddresses
-            ? await ValkeyCluster.initFromExistingCluster(false, parseEndpoints(standaloneAddresses), getServerVersion)
+            ? await ValkeyCluster.initFromExistingCluster(
+                  false,
+                  parseEndpoints(standaloneAddresses),
+                  getServerVersion,
+              )
             : await ValkeyCluster.createCluster(false, 1, 1, getServerVersion);
     }, 40000);
 
-    afterAll(async () => { await cluster.close(); }, 20000);
+    afterAll(async () => {
+        await cluster.close();
+    }, 20000);
 
     it("monitor receives commands", async () => {
-        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
         const monitor = await GlideMonitorClient.create(config);
 
         try {
@@ -33,7 +52,9 @@ describe("GlideMonitorClient", () => {
                 while (Date.now() < deadline) {
                     const next = await Promise.race([
                         monitor.getNextMessage(),
-                        new Promise<undefined>((r) => setTimeout(r, 100, undefined)),
+                        new Promise<undefined>((r) =>
+                            setTimeout(r, 100, undefined),
+                        ),
                     ]);
 
                     if (next && next.command.toLowerCase() === "set") {
@@ -53,7 +74,10 @@ describe("GlideMonitorClient", () => {
     });
 
     it("monitor line has correct field types", async () => {
-        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
         const monitor = await GlideMonitorClient.create(config);
 
         try {
@@ -67,7 +91,9 @@ describe("GlideMonitorClient", () => {
                 while (Date.now() < deadline) {
                     const next = await Promise.race([
                         monitor.getNextMessage(),
-                        new Promise<undefined>((r) => setTimeout(r, 100, undefined)),
+                        new Promise<undefined>((r) =>
+                            setTimeout(r, 100, undefined),
+                        ),
                     ]);
 
                     if (next && next.command.toLowerCase() === "ping") {
@@ -96,14 +122,20 @@ describe("GlideMonitorClient", () => {
     });
 
     it("monitor close is idempotent", async () => {
-        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
         const monitor = await GlideMonitorClient.create(config);
         await monitor.close();
         await expect(monitor.close()).resolves.not.toThrow();
     });
 
     it("getNextMessage works without callback", async () => {
-        const config = getClientConfigurationOption(cluster.getAddresses(), ProtocolVersion.RESP2);
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
         const monitor = await GlideMonitorClient.create(config);
 
         try {

--- a/node/tests/GlideMonitorClient.test.ts
+++ b/node/tests/GlideMonitorClient.test.ts
@@ -1,0 +1,109 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { ValkeyCluster } from "../../utils/TestUtils.js";
+import {
+    GlideClient,
+    GlideMonitorClient,
+    MonitorLine,
+    ProtocolVersion,
+} from "../build-ts";
+import {
+    getClientConfigurationOption,
+    getServerVersion,
+    parseEndpoints,
+} from "./TestUtilities";
+
+describe("GlideMonitorClient", () => {
+    let cluster: ValkeyCluster;
+
+    beforeAll(async () => {
+        const standaloneAddresses: string =
+            global.STAND_ALONE_ENDPOINT as string;
+        cluster = standaloneAddresses
+            ? await ValkeyCluster.initFromExistingCluster(
+                  false,
+                  parseEndpoints(standaloneAddresses),
+                  getServerVersion,
+              )
+            : await ValkeyCluster.createCluster(false, 1, 1, getServerVersion);
+    }, 40000);
+
+    afterAll(async () => {
+        await cluster.close();
+    }, 20000);
+
+    it("monitor receives commands", async () => {
+        const received: MonitorLine[] = [];
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
+        const monitor = await GlideMonitorClient.create(config, (line) =>
+            received.push(line),
+        );
+
+        try {
+            const client = await GlideClient.createClient(config);
+
+            try {
+                await client.set(`monitor_key_${Date.now()}`, "monitor_val");
+                await new Promise((r) => setTimeout(r, 500));
+            } finally {
+                client.close();
+            }
+        } finally {
+            await monitor.close();
+        }
+
+        expect(received.map((m) => m.command.toLowerCase())).toContain("set");
+    });
+
+    it("monitor line has correct field types", async () => {
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
+        let capturedLine: MonitorLine | null = null;
+        const monitor = await GlideMonitorClient.create(config, (line) => {
+            if (capturedLine === null) capturedLine = line;
+        });
+
+        try {
+            const client = await GlideClient.createClient(config);
+
+            try {
+                await client.ping();
+                await new Promise((r) => setTimeout(r, 500));
+            } finally {
+                client.close();
+            }
+        } finally {
+            await monitor.close();
+        }
+
+        expect(capturedLine).not.toBeNull();
+        const line = capturedLine!;
+        expect(typeof line.timestamp).toBe("number");
+        expect(line.timestamp).toBeGreaterThan(0);
+        expect(typeof line.db).toBe("number");
+        expect(line.db).toBeGreaterThanOrEqual(0);
+        expect(typeof line.clientAddr).toBe("string");
+        expect(line.clientAddr.length).toBeGreaterThan(0);
+        expect(typeof line.command).toBe("string");
+        expect(line.command.length).toBeGreaterThan(0);
+        expect(Array.isArray(line.args)).toBe(true);
+    });
+
+    it("monitor close is idempotent", async () => {
+        const config = getClientConfigurationOption(
+            cluster.getAddresses(),
+            ProtocolVersion.RESP2,
+        );
+        const monitor = await GlideMonitorClient.create(config, () => {
+            // no-op
+        });
+        await monitor.close();
+        await expect(monitor.close()).resolves.not.toThrow();
+    });
+});


### PR DESCRIPTION
### Summary

Ports the MONITOR command to the Node.js client, implementing `GlideMonitorClient` that lets users observe all commands processed by a standalone Valkey server.

### Issue link

This Pull Request is linked to issue: #5977 (Rust/FFI core), #6132 (Python implementation)

### Features / Behaviour Changes

- New `GlideMonitorClient` class and `MonitorLine` interface exported from the package
- `GlideMonitorClient.create(options, callback)` — static async factory
- `close()` — idempotent, race-condition-safe (guard set before the first `await`)
- `MonitorLine` fields: `timestamp`, `db`, `clientAddr`, `command`, `args`

### Implementation

- `node/rust-client/src/lib.rs`: Added `createMonitorClient` and `closeMonitorClient` napi-rs async functions. These call `glide_core::client::MonitorClient::new(...)` directly using `get_or_init_runtime()` — the same approach used by the Python PyO3 binding. A `OnceLock<Mutex<HashMap<u64, MonitorClient>>>` store with an `AtomicU64` handle counter manages client lifetimes.
- `node/rust-client/Cargo.toml`: Added `protobuf = "3"` as a direct dependency (needed for `parse_from_bytes` in the napi layer).
- `node/src/GlideMonitorClient.ts`: Builds a protobuf `ConnectionRequest` from `BaseClientConfiguration` and passes it as bytes to the Rust binding.
- `node/src/index.ts`: Exports `GlideMonitorClient` and `MonitorLine`.
- `node/tests/GlideMonitorClient.test.ts`: Integration tests.

### Limitations

- Standalone mode only — MONITOR is not supported in cluster mode
- Callback-based only (no internal queue)
- The `protocol` option is ignored; MONITOR always uses RESP2

### Testing

- `npm run build` ✅
- `npm run lint` ✅
- Integration tests added: `monitor receives commands`, `monitor line has correct field types`, `monitor close is idempotent`

### Checklist

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
