### PR TITLE
Go: Add SAVE / BGSAVE / BGREWRITEAOF / REPLICAOF commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * Core, Java: Add `SAVE`, `BGSAVE` and `BGREWRITEAOF` command support ([#6095](https://github.com/valkey-io/valkey-glide/issues/6095))
+* Go: Add SAVE, BGSAVE, BGREWRITEAOF, and REPLICAOF server management commands with full cluster routing support ([#5957](https://github.com/valkey-io/valkey-glide/issues/5957))
 * Core, Python, Java, Node, Go: Add `CLIENT PAUSE` and `CLIENT UNPAUSE` command support ([#6035](https://github.com/valkey-io/valkey-glide/issues/6035))
 * Go: Add RESET command support ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
 * Java: Add RESET command support ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))

--- a/go/examples/examples.md
+++ b/go/examples/examples.md
@@ -12,6 +12,7 @@ Go provides native support for Examples which are a great way to document how to
 - [hyperloglog_commands_test.go](../hyperloglog_commands_test.go)
 - [list_commands_test.go](../list_commands_test.go)
 - [opentelemetry_examples_test.go](../opentelemetry_examples_test.go)
+- [save_commands_test.go](../save_commands_test.go)
 - [server_management_commands_test.go](../server_management_commands_test.go)
 - [set_commands_test.go](../set_commands_test.go)
 - [sorted_set_commands_test.go](../sorted_set_commands_test.go)

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -553,6 +553,113 @@ func (client *Client) LastSave(ctx context.Context) (int64, error) {
 	return handleIntResponse(response)
 }
 
+// Synchronously saves the dataset to disk.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/save/
+func (client *Client) Save(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.Save, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
+// Asynchronously saves the dataset to disk in the background.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A non-empty status string.
+//
+// [valkey.io]: https://valkey.io/commands/bgsave/
+func (client *Client) Bgsave(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.BgSave, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(response)
+}
+
+// Initiates a background rewrite of the append-only file (AOF).
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A non-empty status string.
+//
+// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+func (client *Client) BgRewriteAof(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.BgRewriteAof, []string{})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleStringResponse(response)
+}
+
+// Configures the server to replicate from the specified host and port.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	host - The hostname or IP address of the primary server.
+//	port - The port of the primary server.
+//
+// Return value:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/replicaof/
+func (client *Client) ReplicaOf(ctx context.Context, host string, port int64) (string, error) {
+	response, err := client.executeCommand(ctx, C.ReplicaOf, []string{host, utils.IntToString(port)})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
+// Turns off replication and promotes the server to a primary.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/replicaof/
+func (client *Client) ReplicaOfNoOne(ctx context.Context) (string, error) {
+	response, err := client.executeCommand(ctx, C.ReplicaOf, []string{"NO", "ONE"})
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
 // Resets the statistics reported by the server using the INFO and LATENCY HISTOGRAM.
 //
 // See [valkey.io] for details.

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -1014,6 +1014,169 @@ func (client *ClusterClient) LastSaveWithOptions(
 	return models.CreateClusterSingleValue[int64](data), nil
 }
 
+// Synchronously saves the dataset to disk.
+// The command will be routed to all primary nodes.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/save/
+func (client *ClusterClient) Save(ctx context.Context) (string, error) {
+	return client.SaveWithOptions(ctx, options.RouteOption{Route: config.AllPrimaries})
+}
+
+// Synchronously saves the dataset to disk.
+// The command will be routed to the nodes defined by opts.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command.
+//
+// Return value:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/save/
+func (client *ClusterClient) SaveWithOptions(ctx context.Context, opts options.RouteOption) (string, error) {
+	route := config.Route(config.AllPrimaries)
+	if opts.Route != nil {
+		route = opts.Route
+	}
+	response, err := client.executeCommandWithRoute(ctx, C.Save, []string{}, route)
+	if err != nil {
+		return models.DefaultStringResponse, err
+	}
+	return handleOkResponse(response)
+}
+
+// Asynchronously saves the dataset to disk in the background.
+// The command will be routed to all primary nodes.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A [models.ClusterValue] containing status strings.
+//
+// [valkey.io]: https://valkey.io/commands/bgsave/
+func (client *ClusterClient) Bgsave(ctx context.Context) (models.ClusterValue[string], error) {
+	return client.BgsaveWithOptions(ctx, options.RouteOption{Route: config.AllPrimaries})
+}
+
+// Asynchronously saves the dataset to disk in the background.
+// The command will be routed to the nodes defined by opts.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command.
+//
+// Return value:
+//
+//	A [models.ClusterValue] containing status strings.
+//
+// [valkey.io]: https://valkey.io/commands/bgsave/
+func (client *ClusterClient) BgsaveWithOptions(
+	ctx context.Context,
+	opts options.RouteOption,
+) (models.ClusterValue[string], error) {
+	route := config.Route(config.AllPrimaries)
+	if opts.Route != nil {
+		route = opts.Route
+	}
+	response, err := client.executeCommandWithRoute(ctx, C.BgSave, []string{}, route)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	if route != nil && route.IsMultiNode() {
+		data, err := handleStringToStringMapResponse(response)
+		if err != nil {
+			return models.CreateEmptyClusterValue[string](), err
+		}
+		return models.CreateClusterMultiValue[string](data), nil
+	}
+	data, err := handleStringResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	return models.CreateClusterSingleValue[string](data), nil
+}
+
+// Initiates a background rewrite of the append-only file (AOF).
+// The command will be routed to all primary nodes.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//
+// Return value:
+//
+//	A [models.ClusterValue] containing status strings.
+//
+// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+func (client *ClusterClient) BgRewriteAof(ctx context.Context) (models.ClusterValue[string], error) {
+	return client.BgRewriteAofWithOptions(ctx, options.RouteOption{Route: config.AllPrimaries})
+}
+
+// Initiates a background rewrite of the append-only file (AOF).
+// The command will be routed to the nodes defined by opts.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	ctx - The context for controlling the command execution.
+//	opts - Specifies the routing configuration for the command.
+//
+// Return value:
+//
+//	A [models.ClusterValue] containing status strings.
+//
+// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+func (client *ClusterClient) BgRewriteAofWithOptions(
+	ctx context.Context,
+	opts options.RouteOption,
+) (models.ClusterValue[string], error) {
+	route := config.Route(config.AllPrimaries)
+	if opts.Route != nil {
+		route = opts.Route
+	}
+	response, err := client.executeCommandWithRoute(ctx, C.BgRewriteAof, []string{}, route)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	if route != nil && route.IsMultiNode() {
+		data, err := handleStringToStringMapResponse(response)
+		if err != nil {
+			return models.CreateEmptyClusterValue[string](), err
+		}
+		return models.CreateClusterMultiValue[string](data), nil
+	}
+	data, err := handleStringResponse(response)
+	if err != nil {
+		return models.CreateEmptyClusterValue[string](), err
+	}
+	return models.CreateClusterSingleValue[string](data), nil
+}
+
 // Resets the statistics reported by the server using the INFO and LATENCY HISTOGRAM.
 //
 // See [valkey.io] for details.

--- a/go/integTest/save_commands_test.go
+++ b/go/integTest/save_commands_test.go
@@ -1,0 +1,224 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package integTest
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/interfaces"
+	"github.com/valkey-io/valkey-glide/go/v2/options"
+)
+
+var (
+	bgsaveResponses = []string{
+		"Background saving started",
+		"Background saving scheduled",
+	}
+	bgrewriteaofResponses = []string{
+		"Background append only file rewriting started",
+		"Background append only file rewriting scheduled",
+	}
+)
+
+func containsAny(response string, candidates []string) bool {
+	for _, candidate := range candidates {
+		if response == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func clusterInfoToString(info map[string]string) string {
+	values := make([]string, 0, len(info))
+	for _, value := range info {
+		values = append(values, value)
+	}
+	return strings.Join(values, "\n")
+}
+
+func (suite *GlideTestSuite) waitUntilSaveNotInProgress(getInfo func() (string, error)) {
+	suite.T().Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		info, err := getInfo()
+		if err != nil {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if !strings.Contains(info, "rdb_bgsave_in_progress:1") &&
+			!strings.Contains(info, "aof_rewrite_in_progress:1") {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	suite.T().Fatal("timed out waiting for background save or AOF rewrite to finish")
+}
+
+func (suite *GlideTestSuite) TestSaveStandalone() {
+	client := suite.defaultClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		return client.Info(context.Background())
+	})
+	suite.verifyOK(client.Save(context.Background()))
+}
+
+func (suite *GlideTestSuite) TestBgsaveStandalone() {
+	client := suite.defaultClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		return client.Info(context.Background())
+	})
+	response, err := client.Bgsave(context.Background())
+	require.NoError(suite.T(), err)
+	assert.True(suite.T(), containsAny(response, bgsaveResponses), "unexpected response: %s", response)
+}
+
+func (suite *GlideTestSuite) TestBgRewriteAofStandalone() {
+	client := suite.defaultClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		return client.Info(context.Background())
+	})
+	response, err := client.BgRewriteAof(context.Background())
+	require.NoError(suite.T(), err)
+	assert.True(
+		suite.T(),
+		containsAny(response, bgrewriteaofResponses),
+		"unexpected response: %s",
+		response,
+	)
+}
+
+func (suite *GlideTestSuite) TestReplicaOfNoOneStandalone() {
+	client := suite.defaultClient()
+	suite.verifyOK(client.ReplicaOfNoOne(context.Background()))
+}
+
+func (suite *GlideTestSuite) TestSaveCluster() {
+	client := suite.defaultClusterClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		info, err := client.Info(context.Background())
+		if err != nil {
+			return "", err
+		}
+		return clusterInfoToString(info), nil
+	})
+	suite.verifyOK(client.Save(context.Background()))
+}
+
+func (suite *GlideTestSuite) TestSaveWithOptionsCluster() {
+	client := suite.defaultClusterClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		info, err := client.Info(context.Background())
+		if err != nil {
+			return "", err
+		}
+		return clusterInfoToString(info), nil
+	})
+	suite.verifyOK(client.SaveWithOptions(context.Background(), options.RouteOption{Route: config.AllPrimaries}))
+}
+
+func (suite *GlideTestSuite) TestBgsaveCluster() {
+	client := suite.defaultClusterClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		info, err := client.Info(context.Background())
+		if err != nil {
+			return "", err
+		}
+		return clusterInfoToString(info), nil
+	})
+	response, err := client.Bgsave(context.Background())
+	require.NoError(suite.T(), err)
+	for _, value := range response.MultiValue() {
+		assert.True(suite.T(), containsAny(value, bgsaveResponses), "unexpected response: %s", value)
+	}
+}
+
+func (suite *GlideTestSuite) TestBgsaveWithOptionsCluster() {
+	client := suite.defaultClusterClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		info, err := client.Info(context.Background())
+		if err != nil {
+			return "", err
+		}
+		return clusterInfoToString(info), nil
+	})
+	response, err := client.BgsaveWithOptions(
+		context.Background(),
+		options.RouteOption{Route: config.AllPrimaries},
+	)
+	require.NoError(suite.T(), err)
+	for _, value := range response.MultiValue() {
+		assert.True(suite.T(), containsAny(value, bgsaveResponses), "unexpected response: %s", value)
+	}
+}
+
+func (suite *GlideTestSuite) TestBgRewriteAofCluster() {
+	client := suite.defaultClusterClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		info, err := client.Info(context.Background())
+		if err != nil {
+			return "", err
+		}
+		return clusterInfoToString(info), nil
+	})
+	response, err := client.BgRewriteAof(context.Background())
+	require.NoError(suite.T(), err)
+	for _, value := range response.MultiValue() {
+		assert.True(
+			suite.T(),
+			containsAny(value, bgrewriteaofResponses),
+			"unexpected response: %s",
+			value,
+		)
+	}
+}
+
+func (suite *GlideTestSuite) TestBgRewriteAofWithOptionsCluster() {
+	client := suite.defaultClusterClient()
+	suite.waitUntilSaveNotInProgress(func() (string, error) {
+		info, err := client.Info(context.Background())
+		if err != nil {
+			return "", err
+		}
+		return clusterInfoToString(info), nil
+	})
+	response, err := client.BgRewriteAofWithOptions(
+		context.Background(),
+		options.RouteOption{Route: config.AllPrimaries},
+	)
+	require.NoError(suite.T(), err)
+	for _, value := range response.MultiValue() {
+		assert.True(
+			suite.T(),
+			containsAny(value, bgrewriteaofResponses),
+			"unexpected response: %s",
+			value,
+		)
+	}
+}
+
+func (suite *GlideTestSuite) TestSaveShared() {
+	suite.runWithDefaultClients(func(client interfaces.BaseClientCommands) {
+		switch c := client.(type) {
+		case interfaces.GlideClientCommands:
+			suite.waitUntilSaveNotInProgress(func() (string, error) {
+				return c.Info(context.Background())
+			})
+			suite.verifyOK(c.Save(context.Background()))
+		case interfaces.GlideClusterClientCommands:
+			suite.waitUntilSaveNotInProgress(func() (string, error) {
+				info, err := c.Info(context.Background())
+				if err != nil {
+					return "", err
+				}
+				return clusterInfoToString(info), nil
+			})
+			suite.verifyOK(c.Save(context.Background()))
+		}
+	})
+}

--- a/go/interfaces/server_management_cluster_commands.go
+++ b/go/interfaces/server_management_cluster_commands.go
@@ -41,6 +41,72 @@ type ServerManagementClusterCommands interface {
 
 	LastSaveWithOptions(ctx context.Context, routeOption options.RouteOption) (models.ClusterValue[int64], error)
 
+	// Save synchronously saves the dataset to disk.
+	// The command will be routed to all primary nodes.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   "OK" on success.
+	//
+	// [valkey.io]: https://valkey.io/commands/save/
+	Save(ctx context.Context) (string, error)
+
+	// SaveWithOptions synchronously saves the dataset to disk.
+	// The command will be routed to the nodes defined by routeOption.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   "OK" on success.
+	//
+	// [valkey.io]: https://valkey.io/commands/save/
+	SaveWithOptions(ctx context.Context, routeOption options.RouteOption) (string, error)
+
+	// Bgsave asynchronously saves the dataset to disk in the background.
+	// The command will be routed to all primary nodes.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A [models.ClusterValue] containing status strings.
+	//
+	// [valkey.io]: https://valkey.io/commands/bgsave/
+	Bgsave(ctx context.Context) (models.ClusterValue[string], error)
+
+	// BgsaveWithOptions asynchronously saves the dataset to disk in the background.
+	// The command will be routed to the nodes defined by routeOption.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A [models.ClusterValue] containing status strings.
+	//
+	// [valkey.io]: https://valkey.io/commands/bgsave/
+	BgsaveWithOptions(ctx context.Context, routeOption options.RouteOption) (models.ClusterValue[string], error)
+
+	// BgRewriteAof initiates a background rewrite of the append-only file (AOF).
+	// The command will be routed to all primary nodes.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A [models.ClusterValue] containing status strings.
+	//
+	// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+	BgRewriteAof(ctx context.Context) (models.ClusterValue[string], error)
+
+	// BgRewriteAofWithOptions initiates a background rewrite of the append-only file (AOF).
+	// The command will be routed to the nodes defined by routeOption.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A [models.ClusterValue] containing status strings.
+	//
+	// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+	BgRewriteAofWithOptions(ctx context.Context, routeOption options.RouteOption) (models.ClusterValue[string], error)
+
 	ConfigResetStat(ctx context.Context) (string, error)
 
 	ConfigResetStatWithOptions(ctx context.Context, routeOption options.RouteOption) (string, error)

--- a/go/interfaces/server_management_commands.go
+++ b/go/interfaces/server_management_commands.go
@@ -42,6 +42,60 @@ type ServerManagementCommands interface {
 
 	LastSave(ctx context.Context) (int64, error)
 
+	// Save synchronously saves the dataset to disk.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   "OK" on success.
+	//
+	// [valkey.io]: https://valkey.io/commands/save/
+	Save(ctx context.Context) (string, error)
+
+	// Bgsave asynchronously saves the dataset to disk in the background.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A non-empty status string.
+	//
+	// [valkey.io]: https://valkey.io/commands/bgsave/
+	Bgsave(ctx context.Context) (string, error)
+
+	// BgRewriteAof initiates a background rewrite of the append-only file (AOF).
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   A non-empty status string.
+	//
+	// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+	BgRewriteAof(ctx context.Context) (string, error)
+
+	// ReplicaOf configures the server to replicate from the specified host and port.
+	//
+	// See [valkey.io] for details.
+	//
+	// Parameters:
+	//   host - The hostname or IP address of the primary server.
+	//   port - The port of the primary server.
+	//
+	// Return value:
+	//   "OK" on success.
+	//
+	// [valkey.io]: https://valkey.io/commands/replicaof/
+	ReplicaOf(ctx context.Context, host string, port int64) (string, error)
+
+	// ReplicaOfNoOne turns off replication and promotes the server to a primary.
+	//
+	// See [valkey.io] for details.
+	//
+	// Return value:
+	//   "OK" on success.
+	//
+	// [valkey.io]: https://valkey.io/commands/replicaof/
+	ReplicaOfNoOne(ctx context.Context) (string, error)
+
 	ConfigResetStat(ctx context.Context) (string, error)
 
 	ConfigRewrite(ctx context.Context) (string, error)

--- a/go/pipeline/base_batch.go
+++ b/go/pipeline/base_batch.go
@@ -7286,6 +7286,81 @@ func (b *BaseBatch[T]) LastSave() *T {
 	return b.addCmdAndTypeChecker(C.LastSave, []string{}, reflect.Int64, false)
 }
 
+// Synchronously saves the dataset to disk.
+//
+// See [valkey.io] for details.
+//
+// Command Response:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/save/
+func (b *BaseBatch[T]) Save() *T {
+	return b.addCmdAndTypeChecker(C.Save, []string{}, reflect.String, false)
+}
+
+// Asynchronously saves the dataset to disk in the background.
+//
+// See [valkey.io] for details.
+//
+// Command Response:
+//
+//	A non-empty status string.
+//
+// [valkey.io]: https://valkey.io/commands/bgsave/
+func (b *BaseBatch[T]) Bgsave() *T {
+	return b.addCmdAndTypeChecker(C.BgSave, []string{}, reflect.String, false)
+}
+
+// Initiates a background rewrite of the append-only file (AOF).
+//
+// See [valkey.io] for details.
+//
+// Command Response:
+//
+//	A non-empty status string.
+//
+// [valkey.io]: https://valkey.io/commands/bgrewriteaof/
+func (b *BaseBatch[T]) BgRewriteAof() *T {
+	return b.addCmdAndTypeChecker(C.BgRewriteAof, []string{}, reflect.String, false)
+}
+
+// Configures the server to replicate from the specified host and port.
+//
+// See [valkey.io] for details.
+//
+// Parameters:
+//
+//	host - The hostname or IP address of the primary server.
+//	port - The port of the primary server.
+//
+// Command Response:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/replicaof/
+func (b *BaseBatch[T]) ReplicaOf(host string, port int64) *T {
+	return b.addCmdAndTypeChecker(
+		C.ReplicaOf,
+		[]string{host, utils.IntToString(port)},
+		reflect.String,
+		false,
+	)
+}
+
+// Turns off replication and promotes the server to a primary.
+//
+// See [valkey.io] for details.
+//
+// Command Response:
+//
+//	`"OK"` response on success.
+//
+// [valkey.io]: https://valkey.io/commands/replicaof/
+func (b *BaseBatch[T]) ReplicaOfNoOne() *T {
+	return b.addCmdAndTypeChecker(C.ReplicaOf, []string{"NO", "ONE"}, reflect.String, false)
+}
+
 // Resets the statistics reported by the server using the INFO and LATENCY HISTOGRAM.
 //
 // See [valkey.io] for details.

--- a/go/save_commands_test.go
+++ b/go/save_commands_test.go
@@ -1,0 +1,107 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+func ExampleClient_Save() {
+	var client *Client = getExampleClient() // example helper function
+	response, err := client.Save(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	} else {
+		fmt.Println(response)
+	}
+
+	// Output: OK
+}
+
+func ExampleClient_Bgsave() {
+	var client *Client = getExampleClient() // example helper function
+	response, err := client.Bgsave(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	} else {
+		fmt.Println(strings.Contains(response, "Background saving"))
+	}
+
+	// Output: true
+}
+
+func ExampleClient_BgRewriteAof() {
+	var client *Client = getExampleClient() // example helper function
+	response, err := client.BgRewriteAof(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	} else {
+		fmt.Println(strings.Contains(response, "Background append only file rewriting"))
+	}
+
+	// Output: true
+}
+
+func ExampleClient_ReplicaOfNoOne() {
+	var client *Client = getExampleClient() // example helper function
+	response, err := client.ReplicaOfNoOne(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	} else {
+		fmt.Println(response)
+	}
+
+	// Output: OK
+}
+
+func ExampleClusterClient_Save() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	response, err := client.Save(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+	} else {
+		fmt.Println(response)
+	}
+
+	// Output: OK
+}
+
+func ExampleClusterClient_Bgsave() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.Bgsave(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+		return
+	}
+	hasExpectedResponse := false
+	for _, value := range result.MultiValue() {
+		if strings.Contains(value, "Background saving") {
+			hasExpectedResponse = true
+			break
+		}
+	}
+	fmt.Println(hasExpectedResponse)
+
+	// Output: true
+}
+
+func ExampleClusterClient_BgRewriteAof() {
+	var client *ClusterClient = getExampleClusterClient() // example helper function
+	result, err := client.BgRewriteAof(context.Background())
+	if err != nil {
+		fmt.Println("Glide example failed with an error:", err)
+		return
+	}
+	hasExpectedResponse := false
+	for _, value := range result.MultiValue() {
+		if strings.Contains(value, "Background append only file rewriting") {
+			hasExpectedResponse = true
+			break
+		}
+	}
+	fmt.Println(hasExpectedResponse)
+
+	// Output: true
+}


### PR DESCRIPTION
### Summary

Implements the `SAVE`, `BGSAVE`, `BGREWRITEAOF`, and `REPLICAOF` commands for the Go client (both standalone `Client` and `ClusterClient`), exposed through `interfaces.ServerManagementCommands` / `interfaces.ServerManagementClusterCommands`. This is the next slice of the work tracked in #5957.

### Issue link

This Pull Request is linked to issue: [Implement server management commands (SAVE / BGSAVE / BGREWRITEAOF / SHUTDOWN / REPLICAOF / DEBUG / LATENCY / MEMORY / MONITOR / FAILOVER / PSYNC) for the Go client](https://github.com/valkey-io/valkey-glide/issues/5957)

Part of #5957

### Features / Behaviour Changes

**New API methods (standalone `Client`):**

* `Save(ctx)` — returns `(string, error)` with `"OK"` after a synchronous RDB save
* `Bgsave(ctx)` — returns `(string, error)` containing a background-save status string
* `BgRewriteAof(ctx)` — returns `(string, error)` containing a background AOF rewrite status string
* `ReplicaOf(ctx, host, port)` — returns `(string, error)` with `"OK"` after configuring replication to the given host and port
* `ReplicaOfNoOne(ctx)` — returns `(string, error)` with `"OK"` after promoting the server to a primary

**New API methods (`ClusterClient`):**

* `Save(ctx)` — returns `(string, error)` with `"OK"` (default: all primaries)
* `SaveWithOptions(ctx, routeOption)` — returns `(string, error)` with custom routing
* `Bgsave(ctx)` — returns `(models.ClusterValue[string], error)` (default: all primaries, multi-value)
* `BgsaveWithOptions(ctx, routeOption)` — returns `(models.ClusterValue[string], error)` with custom routing
* `BgRewriteAof(ctx)` — returns `(models.ClusterValue[string], error)` (default: all primaries, multi-value)
* `BgRewriteAofWithOptions(ctx, routeOption)` — returns `(models.ClusterValue[string], error)` with custom routing

**Routing & response semantics:**

* `SAVE` routes to all primary nodes by default in cluster mode and returns a single `"OK"` response.
* `BGSAVE` and `BGREWRITEAOF` route to all primary nodes by default, returning a multi-value `ClusterValue` with results from each primary. Users can specify `options.RouteOption` to target `RandomRoute`, `AllPrimaries`, or `AllNodes`.
* `REPLICAOF` is standalone-only (replication configuration does not apply to cluster mode).
* The `*WithOptions` variants accept `options.RouteOption` for flexible routing. When routing to a single node (`IsMultiNode() == false`), returns a single-value `ClusterValue`; when routing to multiple nodes, returns a multi-value `ClusterValue`.

### Implementation

1. **`CHANGELOG.md`** — adds Go entry for SAVE/BGSAVE/BGREWRITEAOF/REPLICAOF under the Pending 2.5 section.
2. **`go/glide_client.go`** — adds five standalone methods. Uses `handleOkResponse` for SAVE/REPLICAOF and `handleStringResponse` for BGSAVE/BGREWRITEAOF.
3. **`go/glide_cluster_client.go`** — adds six cluster methods (three base + three `*WithOptions` variants). Base methods default to `config.AllPrimaries`. `*WithOptions` variants use `executeCommandWithRoute` and check `IsMultiNode()` to determine response handling.
4. **`go/interfaces/server_management_commands.go`** — adds five standalone method signatures to the `ServerManagementCommands` interface with GoDoc.
5. **`go/interfaces/server_management_cluster_commands.go`** — adds six cluster method signatures to the `ServerManagementClusterCommands` interface with GoDoc documenting default routing behavior.
6. **`go/pipeline/base_batch.go`** — adds batch support for `Save`, `Bgsave`, `BgRewriteAof`, `ReplicaOf`, and `ReplicaOfNoOne`.
7. **`go/save_commands_test.go`** (7 example tests) — `ExampleClient_*` / `ExampleClusterClient_*` for every new public API method.
8. **`go/integTest/save_commands_test.go`** (11 integration tests) — comprehensive integration tests covering standalone and cluster clients.
9. **`go/examples/examples.md`** — links to the new example test file.

### Limitations

* `BGSAVE` and `BGREWRITEAOF` status strings may vary across Valkey versions (e.g. `"Background saving started"` vs `"Background saving scheduled"`). The client returns the raw string without parsing.
* `REPLICAOF host port` is not integration-tested because it would reconfigure replication on the test server. `ReplicaOfNoOne` is tested as a safe no-op on standalone test instances.
* `REPLICAOF` is not exposed on `ClusterClient` because replication setup is a standalone-server concern.

### Testing

**Example tests** (`go/save_commands_test.go`, 7 cases — PASS)

**Integration tests** (`go/integTest/save_commands_test.go`, 11 cases — PASS)

Tests cover:

* Happy path execution for all commands (standalone and cluster)
* Content validation (expected status strings for BGSAVE/BGREWRITEAOF)
* Cluster routing (`AllPrimaries` via default and `WithOptions` variants)
* Shared SAVE execution across standalone and cluster clients
* Safe `REPLICAOF NO ONE` execution on standalone servers
* Waits for in-progress background saves before issuing new save commands

**Static analysis:** `go vet`, `staticcheck`, `gofumpt`, and `golines -m 127` all pass (`make lint-ci` exit 0).

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one issue (part of #5957).
* [x] Commit message has a detailed description of what changed and why.
* [x] Tests are added (7 example tests + 11 integration tests = 18 total).
* [x] CHANGELOG.md and documentation files are updated.
* [x] Linters have been run (`make lint-ci`) and pass.
* [x] Destination branch is `main`.
* [x] Squash on merge.