### PR TITLE
fix(node): reduce TLS cluster size to fix flaky test timeout

### DIFF
--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -33,13 +33,11 @@ describe("tls GlideClusterClient", () => {
         cluster = await ValkeyCluster.createCluster(
             true,
             3,
-            2,
+            0,
             getServerVersion,
             true,
             TLS_OPTIONS,
         );
-        // Small delay to ensure cluster is fully ready after TLS setup
-        await new Promise((resolve) => setTimeout(resolve, 1000));
     }, CLUSTER_CREATION_TIMEOUT);
 
     afterEach(async () => {


### PR DESCRIPTION
### Summary
Fix flaky TLS cluster test by reducing cluster size from 9 nodes to 3 nodes.

### Issue link
This Pull Request is linked to issue: [[Node][Flaky Test] GlideClusterClient › clusterClient connect with insecure TLS (protocol: 1)](https://github.com/valkey-io/valkey-glide/issues/4366)
Closes #4366

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root Cause:** The TLS cluster test was creating a 9-node cluster (3 shards × 3 nodes with `-r 2`) which frequently timed out in CI due to:
- Port contention from concurrent test execution (Jest maxWorkers = CPU cores - 1)
- Slow topology propagation with 9 TLS nodes
- Resource exhaustion on constrained CI runners (especially aarch64)

**Fix:** Reduce replica count from 2 to 0. The test only validates that `GlideClusterClient` can establish a TLS connection and respond to `PING` — it does not require replicas. This creates a minimal 3-node cluster (3 primaries), reducing startup time by ~67% and eliminating topology propagation delays.

Also removed the post-creation 1-second sleep that was only needed as a workaround for the 9-node topology propagation delay.

### Limitations
None

### Testing
- Verified the fix correctly passes `-r 0 -n 3 --cluster-mode` to `cluster_manager.py`
- The test validates the same behavior (TLS connection + ping) with a smaller cluster
- CI will validate against TLS-enabled builds

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release