### PR TITLE
Node: Improve performance of Client initial connection with TLS

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -27,10 +27,10 @@ use tokio_rustls::{client::TlsStream, TlsConnector};
 ///
 /// Uses `RwLock` to allow cache invalidation if system certificates change
 /// (e.g., CA rotation requiring a re-read of the trust store).
-static TLS_CONFIG_DEFAULT: RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>> =
-    RwLock::new(None);
-static TLS_CONFIG_INSECURE: RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>> =
-    RwLock::new(None);
+type TlsConfigCache = RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>>;
+
+static TLS_CONFIG_DEFAULT: TlsConfigCache = RwLock::new(None);
+static TLS_CONFIG_INSECURE: TlsConfigCache = RwLock::new(None);
 
 /// Clear cached TLS configurations, forcing a reload of system certificates
 /// on the next connection.
@@ -53,7 +53,7 @@ fn is_tls_cert_error(err: &io::Error) -> bool {
 
 /// Retrieve or initialize a cached TLS configuration.
 fn get_cached_tls_config(
-    cache: &'static RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>>,
+    cache: &'static TlsConfigCache,
     insecure: bool,
     tls_params: &Option<TlsConnParams>,
 ) -> RedisResult<Arc<rustls::ClientConfig>> {

--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -18,32 +18,130 @@ use tokio::{
 use crate::connection::create_rustls_config;
 use crate::tls::TlsConnParams;
 use crate::{ErrorKind, RedisError};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, RwLock};
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
 /// Cached TLS configurations to avoid repeatedly loading system certificates.
 /// On Linux, loading native certs can involve reading and parsing ~300KB of cert files,
 /// which adds ~6ms per connection when done repeatedly.
-static TLS_CONFIG_DEFAULT: OnceLock<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>> =
-    OnceLock::new();
-static TLS_CONFIG_INSECURE: OnceLock<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>> =
-    OnceLock::new();
+///
+/// Uses `RwLock` to allow cache invalidation if system certificates change
+/// (e.g., CA rotation requiring a re-read of the trust store).
+static TLS_CONFIG_DEFAULT: RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>> =
+    RwLock::new(None);
+static TLS_CONFIG_INSECURE: RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>> =
+    RwLock::new(None);
+
+/// Clear cached TLS configurations, forcing a reload of system certificates
+/// on the next connection.
+fn invalidate_tls_config_cache() {
+    if let Ok(mut guard) = TLS_CONFIG_DEFAULT.write() {
+        *guard = None;
+    }
+    if let Ok(mut guard) = TLS_CONFIG_INSECURE.write() {
+        *guard = None;
+    }
+}
+
+/// Check if an I/O error is a TLS certificate verification failure.
+/// Uses typed downcasting to avoid fragile string matching.
+fn is_tls_cert_error(err: &io::Error) -> bool {
+    err.get_ref()
+        .and_then(|e| e.downcast_ref::<rustls::Error>())
+        .is_some_and(|e| matches!(e, rustls::Error::InvalidCertificate(_)))
+}
 
 /// Retrieve or initialize a cached TLS configuration.
 fn get_cached_tls_config(
-    cache: &'static OnceLock<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>,
+    cache: &'static RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>>,
     insecure: bool,
     tls_params: &Option<TlsConnParams>,
 ) -> RedisResult<Arc<rustls::ClientConfig>> {
-    cache
-        .get_or_init(|| {
-            create_rustls_config(insecure, tls_params.clone())
-                .map(Arc::new)
-                .map_err(|e| (e.kind(), e.to_string()))
-        })
+    // Fast path: read lock
+    if let Ok(guard) = cache.read() {
+        if let Some(result) = guard.as_ref() {
+            return result
+                .as_ref()
+                .map_err(|(kind, msg)| {
+                    RedisError::from((*kind, "TLS configuration error", msg.clone()))
+                })
+                .cloned();
+        }
+    }
+
+    // Slow path: write lock, initialize
+    let mut guard = cache.write().map_err(|_| {
+        RedisError::from((
+            ErrorKind::IoError,
+            "TLS config cache lock poisoned",
+            String::new(),
+        ))
+    })?;
+
+    // Double-check after acquiring write lock
+    if let Some(result) = guard.as_ref() {
+        return result
+            .as_ref()
+            .map_err(|(kind, msg)| {
+                RedisError::from((*kind, "TLS configuration error", msg.clone()))
+            })
+            .cloned();
+    }
+
+    let result = create_rustls_config(insecure, tls_params.clone())
+        .map(Arc::new)
+        .map_err(|e| (e.kind(), e.to_string()));
+
+    let ret = result
         .as_ref()
         .map_err(|(kind, msg)| RedisError::from((*kind, "TLS configuration error", msg.clone())))
-        .cloned()
+        .cloned();
+
+    *guard = Some(result);
+    ret
+}
+
+/// Execute a TLS connection attempt with optional retry on certificate errors.
+///
+/// If the first attempt fails with a certificate verification error and
+/// `has_custom_params` is false, invalidates the TLS config cache and retries
+/// exactly once. This handles the case where system certificates were updated
+/// (e.g., CA rotation) while the process was running.
+async fn tls_connect_with_cert_retry<T, F, Fut>(
+    connect: F,
+    has_custom_params: bool,
+    insecure: bool,
+    tls_params: &Option<TlsConnParams>,
+) -> RedisResult<T>
+where
+    F: Fn(Arc<rustls::ClientConfig>) -> Fut,
+    Fut: Future<Output = io::Result<T>>,
+{
+    let config = if has_custom_params {
+        Arc::new(create_rustls_config(insecure, tls_params.clone())?)
+    } else if insecure {
+        get_cached_tls_config(&TLS_CONFIG_INSECURE, true, tls_params)?
+    } else {
+        get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, tls_params)?
+    };
+
+    let result = connect(config).await;
+
+    match result {
+        Ok(val) => Ok(val),
+        Err(err) if !has_custom_params && is_tls_cert_error(&err) => {
+            // Note: has_custom_params=true can never reach here due to the guard above.
+            // Only the cached config path (default/insecure) is retried after invalidation.
+            invalidate_tls_config_cache();
+            let config = if insecure {
+                get_cached_tls_config(&TLS_CONFIG_INSECURE, true, tls_params)?
+            } else {
+                get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, tls_params)?
+            };
+            Ok(connect(config).await?)
+        }
+        Err(err) => Err(err.into()),
+    }
 }
 
 #[cfg(unix)]
@@ -154,24 +252,29 @@ impl RedisRuntime for Tokio {
             .as_ref()
             .is_some_and(|p| p.client_tls_params.is_some() || p.root_cert_store.is_some());
 
-        let config = if has_custom_params {
-            // Custom TLS params (mTLS, custom CA) - cannot cache
-            Arc::new(create_rustls_config(insecure, tls_params.clone())?)
-        } else if insecure {
-            get_cached_tls_config(&TLS_CONFIG_INSECURE, true, tls_params)?
-        } else {
-            get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, tls_params)?
-        };
+        let hostname_owned = hostname.to_owned();
+        let conn = tls_connect_with_cert_retry(
+            |config| {
+                let hostname = hostname_owned.clone();
+                async move {
+                    let tls_connector = TlsConnector::from(config);
+                    tls_connector
+                        .connect(
+                            rustls_pki_types::ServerName::try_from(hostname.as_str())
+                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?
+                                .to_owned(),
+                            connect_tcp(&socket_addr, tcp_nodelay).await?,
+                        )
+                        .await
+                }
+            },
+            has_custom_params,
+            insecure,
+            tls_params,
+        )
+        .await?;
 
-        let tls_connector = TlsConnector::from(config);
-
-        Ok(tls_connector
-            .connect(
-                rustls_pki_types::ServerName::try_from(hostname)?.to_owned(),
-                connect_tcp(&socket_addr, tcp_nodelay).await?,
-            )
-            .await
-            .map(|con| Tokio::TcpTls(Box::new(con)))?)
+        Ok(Tokio::TcpTls(Box::new(conn)))
     }
 
     #[cfg(unix)]
@@ -196,5 +299,208 @@ impl RedisRuntime for Tokio {
             #[cfg(unix)]
             Tokio::Unix(x) => Box::pin(x),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // --- is_tls_cert_error tests ---
+
+    #[test]
+    fn test_is_tls_cert_error_detects_invalid_certificate() {
+        let rustls_err = rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer);
+        let io_err = io::Error::new(io::ErrorKind::InvalidData, rustls_err);
+        assert!(is_tls_cert_error(&io_err));
+    }
+
+    #[test]
+    fn test_is_tls_cert_error_ignores_non_cert_errors() {
+        let io_err = io::Error::new(io::ErrorKind::ConnectionRefused, "connection refused");
+        assert!(!is_tls_cert_error(&io_err));
+
+        let io_err = io::Error::new(io::ErrorKind::TimedOut, "timed out");
+        assert!(!is_tls_cert_error(&io_err));
+    }
+
+    #[test]
+    fn test_is_tls_cert_error_ignores_other_rustls_errors() {
+        let rustls_err = rustls::Error::General("some other error".into());
+        let io_err = io::Error::new(io::ErrorKind::Other, rustls_err);
+        assert!(!is_tls_cert_error(&io_err));
+    }
+
+    // --- Cache invalidation tests ---
+
+    #[test]
+    #[serial]
+    fn test_invalidate_clears_cache_and_allows_reinitialization() {
+        {
+            let mut guard = TLS_CONFIG_DEFAULT.write().unwrap();
+            *guard = Some(Err((ErrorKind::IoError, "stale".into())));
+        }
+        assert!(TLS_CONFIG_DEFAULT.read().unwrap().is_some());
+
+        invalidate_tls_config_cache();
+        assert!(TLS_CONFIG_DEFAULT.read().unwrap().is_none());
+
+        // Re-initialization: get_cached_tls_config should repopulate
+        let _ = get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, &None);
+        assert!(
+            TLS_CONFIG_DEFAULT.read().unwrap().is_some(),
+            "Cache should be repopulated after invalidation"
+        );
+
+        // Clean up
+        invalidate_tls_config_cache();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invalidate_clears_both_caches() {
+        {
+            *TLS_CONFIG_DEFAULT.write().unwrap() = Some(Err((ErrorKind::IoError, "x".into())));
+            *TLS_CONFIG_INSECURE.write().unwrap() = Some(Err((ErrorKind::IoError, "x".into())));
+        }
+        invalidate_tls_config_cache();
+        assert!(TLS_CONFIG_DEFAULT.read().unwrap().is_none());
+        assert!(TLS_CONFIG_INSECURE.read().unwrap().is_none());
+    }
+
+    // --- Retry semantics tests (exercises tls_connect_with_cert_retry directly) ---
+
+    fn make_cert_error() -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            rustls::Error::InvalidCertificate(rustls::CertificateError::UnknownIssuer),
+        )
+    }
+
+    fn make_tcp_error() -> io::Error {
+        io::Error::new(io::ErrorKind::ConnectionRefused, "connection refused")
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_retry_on_cert_error_calls_connect_twice() {
+        invalidate_tls_config_cache();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        // Always return cert error — should be called exactly twice (initial + one retry)
+        let result: RedisResult<u8> = tls_connect_with_cert_retry(
+            |_config| {
+                let cc = call_count_clone.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err(make_cert_error())
+                }
+            },
+            false, // has_custom_params = false
+            false,
+            &None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "Should retry exactly once"
+        );
+        invalidate_tls_config_cache();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_no_retry_on_non_cert_error() {
+        invalidate_tls_config_cache();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let result: RedisResult<u8> = tls_connect_with_cert_retry(
+            |_config| {
+                let cc = call_count_clone.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err(make_tcp_error())
+                }
+            },
+            false,
+            false,
+            &None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "Should not retry on non-cert error"
+        );
+        invalidate_tls_config_cache();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_no_retry_with_custom_params_even_on_cert_error() {
+        invalidate_tls_config_cache();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let result: RedisResult<u8> = tls_connect_with_cert_retry(
+            |_config| {
+                let cc = call_count_clone.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Err(make_cert_error())
+                }
+            },
+            true, // has_custom_params = true
+            false,
+            &None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "Custom params should skip retry"
+        );
+        invalidate_tls_config_cache();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_successful_connect_does_not_retry() {
+        invalidate_tls_config_cache();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let result: RedisResult<u8> = tls_connect_with_cert_retry(
+            |_config| {
+                let cc = call_count_clone.clone();
+                async move {
+                    cc.fetch_add(1, Ordering::SeqCst);
+                    Ok(42u8)
+                }
+            },
+            false,
+            false,
+            &None,
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "Success should not retry"
+        );
+        invalidate_tls_config_cache();
     }
 }

--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -22,12 +22,16 @@ use std::sync::{Arc, RwLock};
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
 /// Cached TLS configurations to avoid repeatedly loading system certificates.
-/// On Linux, loading native certs can involve reading and parsing ~300KB of cert files,
-/// which adds ~6ms per connection when done repeatedly.
+/// On Linux, `load_native_certs()` parses ~300KB of cert files, adding ~6ms
+/// per connection when run for every connection.
 ///
-/// Uses `RwLock` to allow cache invalidation if system certificates change
-/// (e.g., CA rotation requiring a re-read of the trust store).
-type TlsConfigCache = RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>>;
+/// Wrapped in `RwLock<Option<…>>` so the entry can be invalidated when the
+/// system trust store changes (e.g. CA rotation). Only successful configs
+/// are cached; a config-build failure propagates to the caller without being
+/// stored, so a transient failure isn't pinned for the rest of the process.
+/// The connect-time cert-error retry path doesn't re-run config build, so
+/// caching `Err` here would be unrecoverable until process restart.
+type TlsConfigCache = RwLock<Option<Arc<rustls::ClientConfig>>>;
 
 static TLS_CONFIG_DEFAULT: TlsConfigCache = RwLock::new(None);
 static TLS_CONFIG_INSECURE: TlsConfigCache = RwLock::new(None);
@@ -39,7 +43,7 @@ static TLS_CONFIG_INSECURE: TlsConfigCache = RwLock::new(None);
 /// clobber the peer's refresh and trigger another `load_native_certs()`.
 fn invalidate_if_stale(cache: &'static TlsConfigCache, expected: &Arc<rustls::ClientConfig>) {
     if let Ok(mut guard) = cache.write() {
-        if matches!(guard.as_ref(), Some(Ok(cached)) if Arc::ptr_eq(cached, expected)) {
+        if matches!(guard.as_ref(), Some(cached) if Arc::ptr_eq(cached, expected)) {
             *guard = None;
         }
     }
@@ -54,6 +58,9 @@ fn is_tls_cert_error(err: &io::Error) -> bool {
 }
 
 /// Retrieve or initialize a cached TLS configuration.
+///
+/// Errors from `create_rustls_config` are returned directly via `?` and are
+/// **not** cached, so a transient failure can be retried by the next caller.
 fn get_cached_tls_config(
     cache: &'static TlsConfigCache,
     insecure: bool,
@@ -61,13 +68,8 @@ fn get_cached_tls_config(
 ) -> RedisResult<Arc<rustls::ClientConfig>> {
     // Fast path: read lock
     if let Ok(guard) = cache.read() {
-        if let Some(result) = guard.as_ref() {
-            return result
-                .as_ref()
-                .map_err(|(kind, msg)| {
-                    RedisError::from((*kind, "TLS configuration error", msg.clone()))
-                })
-                .cloned();
+        if let Some(cached) = guard.as_ref() {
+            return Ok(cached.clone());
         }
     }
 
@@ -81,26 +83,15 @@ fn get_cached_tls_config(
     })?;
 
     // Double-check after acquiring write lock
-    if let Some(result) = guard.as_ref() {
-        return result
-            .as_ref()
-            .map_err(|(kind, msg)| {
-                RedisError::from((*kind, "TLS configuration error", msg.clone()))
-            })
-            .cloned();
+    if let Some(cached) = guard.as_ref() {
+        return Ok(cached.clone());
     }
 
-    let result = create_rustls_config(insecure, tls_params.clone())
-        .map(Arc::new)
-        .map_err(|e| (e.kind(), e.to_string()));
-
-    let ret = result
-        .as_ref()
-        .map_err(|(kind, msg)| RedisError::from((*kind, "TLS configuration error", msg.clone())))
-        .cloned();
-
-    *guard = Some(result);
-    ret
+    // Build, then cache only on success — `?` propagates the original error
+    // (with its original `ErrorKind`) without storing it.
+    let config = Arc::new(create_rustls_config(insecure, tls_params.clone())?);
+    *guard = Some(config.clone());
+    Ok(config)
 }
 
 /// Execute a TLS connection attempt with optional retry on certificate errors.
@@ -108,10 +99,15 @@ fn get_cached_tls_config(
 /// If the first attempt fails with a certificate verification error and
 /// `has_custom_params` is false, conditionally invalidates the cached TLS
 /// config (only if it still matches the one we used) and retries exactly
-/// once. This handles the case where system certificates were updated
-/// (e.g., CA rotation) while the process was running, while avoiding
-/// redundant `load_native_certs()` reloads when a concurrent peer has
-/// already refreshed the cache.
+/// once. This is a best-effort recovery for cases where system certificates
+/// were updated (e.g., CA rotation) while the process was running. Recovery
+/// is not guaranteed under adversarial concurrency or for non-rotation cert
+/// errors (clock skew, intermediate-CA expiry, etc.); in those cases the
+/// retried attempt may surface the same error to the caller.
+///
+/// Compare-and-invalidate via `Arc::ptr_eq` keeps a concurrent peer's fresh
+/// config in place, so stragglers do not trigger redundant
+/// `load_native_certs()` reloads.
 async fn tls_connect_with_cert_retry<T, F, Fut>(
     connect: F,
     has_custom_params: bool,
@@ -349,6 +345,38 @@ mod tests {
         assert!(!is_tls_cert_error(&io_err));
     }
 
+    // --- get_cached_tls_config tests ---
+
+    #[test]
+    #[serial]
+    fn test_cached_config_returns_same_arc() {
+        reset_tls_caches();
+        let first = get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, &None).unwrap();
+        let second = get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, &None).unwrap();
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "second call must return the same Arc the first call cached \
+             — this is the performance invariant the cache exists for"
+        );
+        reset_tls_caches();
+    }
+
+    // Note: a test that exercises the `create_rustls_config` failure path
+    // (e.g. insecure mode without the `tls-rustls-insecure` feature) was
+    // considered, but is unreachable in any currently-buildable config:
+    //
+    //   * With the `tls-rustls-insecure` feature on (the default), insecure
+    //     mode succeeds and the failure branch isn't hit.
+    //   * With it off, `connection.rs::create_rustls_config` itself fails
+    //     to compile due to a pre-existing non-exhaustive-match bug
+    //     unrelated to this PR.
+    //
+    // After the cache-only-Ok change, the properties such a test would
+    // guard (correct `ErrorKind` propagation and no error caching) are
+    // structurally guaranteed: errors flow through `?` and never enter
+    // the cache.
+
     // --- invalidate_if_stale tests ---
 
     #[test]
@@ -374,17 +402,13 @@ mod tests {
 
         // Simulate a concurrent peer's refresh by swapping in a fresh Arc.
         let fresh = Arc::new(create_rustls_config(false, None).unwrap());
-        *TLS_CONFIG_DEFAULT.write().unwrap() = Some(Ok(fresh.clone()));
+        *TLS_CONFIG_DEFAULT.write().unwrap() = Some(fresh.clone());
 
         // Straggler comes in with the old `stale` Arc — should NOT wipe.
         invalidate_if_stale(&TLS_CONFIG_DEFAULT, &stale);
 
         let guard = TLS_CONFIG_DEFAULT.read().unwrap();
-        let still_cached = guard
-            .as_ref()
-            .expect("cache should still be populated")
-            .as_ref()
-            .expect("cache should still hold Ok");
+        let still_cached = guard.as_ref().expect("cache should still be populated");
         assert!(
             Arc::ptr_eq(still_cached, &fresh),
             "peer's refresh must be preserved"
@@ -405,23 +429,6 @@ mod tests {
             TLS_CONFIG_DEFAULT.read().unwrap().is_none(),
             "empty cache must remain empty"
         );
-    }
-
-    #[test]
-    #[serial]
-    fn test_invalidate_if_stale_preserves_cached_error() {
-        reset_tls_caches();
-        *TLS_CONFIG_DEFAULT.write().unwrap() =
-            Some(Err((ErrorKind::IoError, "previous failure".into())));
-        let arc = Arc::new(create_rustls_config(false, None).unwrap());
-
-        invalidate_if_stale(&TLS_CONFIG_DEFAULT, &arc);
-
-        assert!(
-            matches!(*TLS_CONFIG_DEFAULT.read().unwrap(), Some(Err(_))),
-            "cached error must not be wiped — `matches!` only fires on Some(Ok(_))"
-        );
-        reset_tls_caches();
     }
 
     // --- Retry semantics tests (exercises tls_connect_with_cert_retry directly) ---
@@ -554,6 +561,43 @@ mod tests {
             call_count.load(Ordering::SeqCst),
             1,
             "Success should not retry"
+        );
+        reset_tls_caches();
+    }
+
+    /// Recovery path: first attempt fails with a cert error, second attempt
+    /// succeeds — caller must see `Ok` and exactly two closure invocations.
+    /// This is the scenario the retry feature exists for.
+    #[tokio::test]
+    #[serial]
+    async fn test_retry_succeeds_when_second_attempt_ok() {
+        reset_tls_caches();
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = call_count.clone();
+
+        let result: RedisResult<u8> = tls_connect_with_cert_retry(
+            |_config| {
+                let cc = call_count_clone.clone();
+                async move {
+                    let n = cc.fetch_add(1, Ordering::SeqCst);
+                    if n == 0 {
+                        Err(make_cert_error())
+                    } else {
+                        Ok(7u8)
+                    }
+                }
+            },
+            false,
+            false,
+            &None,
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), 7, "second attempt should surface as Ok");
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "retry should run exactly once after the first cert error"
         );
         reset_tls_caches();
     }

--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -16,10 +16,15 @@ use tokio::{
 };
 
 use crate::connection::create_rustls_config;
-use std::sync::Arc;
-use tokio_rustls::{client::TlsStream, TlsConnector};
-
 use crate::tls::TlsConnParams;
+use std::sync::{Arc, OnceLock};
+
+/// Cached TLS configurations to avoid repeatedly loading system certificates.
+/// On Linux, loading native certs can involve reading and parsing ~300KB of cert files,
+/// which adds ~6ms per connection when done repeatedly.
+static TLS_CONFIG_DEFAULT: OnceLock<Result<Arc<rustls::ClientConfig>, String>> = OnceLock::new();
+static TLS_CONFIG_INSECURE: OnceLock<Result<Arc<rustls::ClientConfig>, String>> = OnceLock::new();
+use tokio_rustls::{client::TlsStream, TlsConnector};
 
 #[cfg(unix)]
 use super::Path;
@@ -125,8 +130,48 @@ impl RedisRuntime for Tokio {
         tls_params: &Option<TlsConnParams>,
         tcp_nodelay: bool,
     ) -> RedisResult<Self> {
-        let config = create_rustls_config(insecure, tls_params.clone())?;
-        let tls_connector = TlsConnector::from(Arc::new(config));
+        let has_custom_params = tls_params
+            .as_ref()
+            .is_some_and(|p| p.client_tls_params.is_some() || p.root_cert_store.is_some());
+
+        let config = if has_custom_params {
+            // Custom TLS params (mTLS, custom CA) - cannot cache
+            Arc::new(create_rustls_config(insecure, tls_params.clone())?)
+        } else if insecure {
+            TLS_CONFIG_INSECURE
+                .get_or_init(|| {
+                    create_rustls_config(true, tls_params.clone())
+                        .map(Arc::new)
+                        .map_err(|e| e.to_string())
+                })
+                .as_ref()
+                .map_err(|e| {
+                    crate::RedisError::from((
+                        crate::ErrorKind::IoError,
+                        "TLS config error",
+                        e.clone(),
+                    ))
+                })?
+                .clone()
+        } else {
+            TLS_CONFIG_DEFAULT
+                .get_or_init(|| {
+                    create_rustls_config(false, tls_params.clone())
+                        .map(Arc::new)
+                        .map_err(|e| e.to_string())
+                })
+                .as_ref()
+                .map_err(|e| {
+                    crate::RedisError::from((
+                        crate::ErrorKind::IoError,
+                        "TLS config error",
+                        e.clone(),
+                    ))
+                })?
+                .clone()
+        };
+
+        let tls_connector = TlsConnector::from(config);
 
         Ok(tls_connector
             .connect(

--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -32,14 +32,16 @@ type TlsConfigCache = RwLock<Option<Result<Arc<rustls::ClientConfig>, (ErrorKind
 static TLS_CONFIG_DEFAULT: TlsConfigCache = RwLock::new(None);
 static TLS_CONFIG_INSECURE: TlsConfigCache = RwLock::new(None);
 
-/// Clear cached TLS configurations, forcing a reload of system certificates
-/// on the next connection.
-fn invalidate_tls_config_cache() {
-    if let Ok(mut guard) = TLS_CONFIG_DEFAULT.write() {
-        *guard = None;
-    }
-    if let Ok(mut guard) = TLS_CONFIG_INSECURE.write() {
-        *guard = None;
+/// Drop the cached config only if it still holds `expected`.
+///
+/// If a concurrent peer has already replaced the cache with a fresh `Arc`
+/// (staggered storm during cert rotation), this is a no-op so we don't
+/// clobber the peer's refresh and trigger another `load_native_certs()`.
+fn invalidate_if_stale(cache: &'static TlsConfigCache, expected: &Arc<rustls::ClientConfig>) {
+    if let Ok(mut guard) = cache.write() {
+        if matches!(guard.as_ref(), Some(Ok(cached)) if Arc::ptr_eq(cached, expected)) {
+            *guard = None;
+        }
     }
 }
 
@@ -104,9 +106,12 @@ fn get_cached_tls_config(
 /// Execute a TLS connection attempt with optional retry on certificate errors.
 ///
 /// If the first attempt fails with a certificate verification error and
-/// `has_custom_params` is false, invalidates the TLS config cache and retries
-/// exactly once. This handles the case where system certificates were updated
-/// (e.g., CA rotation) while the process was running.
+/// `has_custom_params` is false, conditionally invalidates the cached TLS
+/// config (only if it still matches the one we used) and retries exactly
+/// once. This handles the case where system certificates were updated
+/// (e.g., CA rotation) while the process was running, while avoiding
+/// redundant `load_native_certs()` reloads when a concurrent peer has
+/// already refreshed the cache.
 async fn tls_connect_with_cert_retry<T, F, Fut>(
     connect: F,
     has_custom_params: bool,
@@ -117,28 +122,32 @@ where
     F: Fn(Arc<rustls::ClientConfig>) -> Fut,
     Fut: Future<Output = io::Result<T>>,
 {
-    let config = if has_custom_params {
-        Arc::new(create_rustls_config(insecure, tls_params.clone())?)
-    } else if insecure {
-        get_cached_tls_config(&TLS_CONFIG_INSECURE, true, tls_params)?
+    let cache: &'static TlsConfigCache = if insecure {
+        &TLS_CONFIG_INSECURE
     } else {
-        get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, tls_params)?
+        &TLS_CONFIG_DEFAULT
     };
 
-    let result = connect(config).await;
+    let config = if has_custom_params {
+        Arc::new(create_rustls_config(insecure, tls_params.clone())?)
+    } else {
+        get_cached_tls_config(cache, insecure, tls_params)?
+    };
+
+    // Keep our own clone of the Arc so we can compare it against the cache
+    // contents after the connect attempt completes.
+    let result = connect(config.clone()).await;
 
     match result {
         Ok(val) => Ok(val),
         Err(err) if !has_custom_params && is_tls_cert_error(&err) => {
-            // Note: has_custom_params=true can never reach here due to the guard above.
-            // Only the cached config path (default/insecure) is retried after invalidation.
-            invalidate_tls_config_cache();
-            let config = if insecure {
-                get_cached_tls_config(&TLS_CONFIG_INSECURE, true, tls_params)?
-            } else {
-                get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, tls_params)?
-            };
-            Ok(connect(config).await?)
+            // Compare-and-invalidate: drop the cache only if it still holds
+            // the Arc we used. If a concurrent peer already refreshed it
+            // (staggered storm during cert rotation), leave their fresh
+            // config in place — `get_cached_tls_config` below will pick it
+            // up via the read fast path and skip the file I/O.
+            invalidate_if_stale(cache, &config);
+            Ok(connect(get_cached_tls_config(cache, insecure, tls_params)?).await?)
         }
         Err(err) => Err(err.into()),
     }
@@ -308,6 +317,13 @@ mod tests {
     use serial_test::serial;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// Test fixture: clear both caches so each `#[serial]` test starts from
+    /// a known state. Not part of the production API.
+    fn reset_tls_caches() {
+        *TLS_CONFIG_DEFAULT.write().unwrap() = None;
+        *TLS_CONFIG_INSECURE.write().unwrap() = None;
+    }
+
     // --- is_tls_cert_error tests ---
 
     #[test]
@@ -333,41 +349,79 @@ mod tests {
         assert!(!is_tls_cert_error(&io_err));
     }
 
-    // --- Cache invalidation tests ---
+    // --- invalidate_if_stale tests ---
 
     #[test]
     #[serial]
-    fn test_invalidate_clears_cache_and_allows_reinitialization() {
-        {
-            let mut guard = TLS_CONFIG_DEFAULT.write().unwrap();
-            *guard = Some(Err((ErrorKind::IoError, "stale".into())));
-        }
-        assert!(TLS_CONFIG_DEFAULT.read().unwrap().is_some());
+    fn test_invalidate_if_stale_wipes_when_arc_matches() {
+        reset_tls_caches();
+        let arc = get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, &None).unwrap();
 
-        invalidate_tls_config_cache();
-        assert!(TLS_CONFIG_DEFAULT.read().unwrap().is_none());
+        invalidate_if_stale(&TLS_CONFIG_DEFAULT, &arc);
 
-        // Re-initialization: get_cached_tls_config should repopulate
-        let _ = get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, &None);
         assert!(
-            TLS_CONFIG_DEFAULT.read().unwrap().is_some(),
-            "Cache should be repopulated after invalidation"
+            TLS_CONFIG_DEFAULT.read().unwrap().is_none(),
+            "cache should be wiped when its Arc matches `expected`"
         );
-
-        // Clean up
-        invalidate_tls_config_cache();
+        reset_tls_caches();
     }
 
     #[test]
     #[serial]
-    fn test_invalidate_clears_both_caches() {
-        {
-            *TLS_CONFIG_DEFAULT.write().unwrap() = Some(Err((ErrorKind::IoError, "x".into())));
-            *TLS_CONFIG_INSECURE.write().unwrap() = Some(Err((ErrorKind::IoError, "x".into())));
-        }
-        invalidate_tls_config_cache();
-        assert!(TLS_CONFIG_DEFAULT.read().unwrap().is_none());
-        assert!(TLS_CONFIG_INSECURE.read().unwrap().is_none());
+    fn test_invalidate_if_stale_preserves_peer_refresh() {
+        reset_tls_caches();
+        let stale = get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, &None).unwrap();
+
+        // Simulate a concurrent peer's refresh by swapping in a fresh Arc.
+        let fresh = Arc::new(create_rustls_config(false, None).unwrap());
+        *TLS_CONFIG_DEFAULT.write().unwrap() = Some(Ok(fresh.clone()));
+
+        // Straggler comes in with the old `stale` Arc — should NOT wipe.
+        invalidate_if_stale(&TLS_CONFIG_DEFAULT, &stale);
+
+        let guard = TLS_CONFIG_DEFAULT.read().unwrap();
+        let still_cached = guard
+            .as_ref()
+            .expect("cache should still be populated")
+            .as_ref()
+            .expect("cache should still hold Ok");
+        assert!(
+            Arc::ptr_eq(still_cached, &fresh),
+            "peer's refresh must be preserved"
+        );
+        drop(guard);
+        reset_tls_caches();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invalidate_if_stale_is_noop_on_empty_cache() {
+        reset_tls_caches();
+        let arc = Arc::new(create_rustls_config(false, None).unwrap());
+
+        invalidate_if_stale(&TLS_CONFIG_DEFAULT, &arc);
+
+        assert!(
+            TLS_CONFIG_DEFAULT.read().unwrap().is_none(),
+            "empty cache must remain empty"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_invalidate_if_stale_preserves_cached_error() {
+        reset_tls_caches();
+        *TLS_CONFIG_DEFAULT.write().unwrap() =
+            Some(Err((ErrorKind::IoError, "previous failure".into())));
+        let arc = Arc::new(create_rustls_config(false, None).unwrap());
+
+        invalidate_if_stale(&TLS_CONFIG_DEFAULT, &arc);
+
+        assert!(
+            matches!(*TLS_CONFIG_DEFAULT.read().unwrap(), Some(Err(_))),
+            "cached error must not be wiped — `matches!` only fires on Some(Ok(_))"
+        );
+        reset_tls_caches();
     }
 
     // --- Retry semantics tests (exercises tls_connect_with_cert_retry directly) ---
@@ -386,7 +440,7 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_retry_on_cert_error_calls_connect_twice() {
-        invalidate_tls_config_cache();
+        reset_tls_caches();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = call_count.clone();
 
@@ -411,13 +465,13 @@ mod tests {
             2,
             "Should retry exactly once"
         );
-        invalidate_tls_config_cache();
+        reset_tls_caches();
     }
 
     #[tokio::test]
     #[serial]
     async fn test_no_retry_on_non_cert_error() {
-        invalidate_tls_config_cache();
+        reset_tls_caches();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = call_count.clone();
 
@@ -441,13 +495,13 @@ mod tests {
             1,
             "Should not retry on non-cert error"
         );
-        invalidate_tls_config_cache();
+        reset_tls_caches();
     }
 
     #[tokio::test]
     #[serial]
     async fn test_no_retry_with_custom_params_even_on_cert_error() {
-        invalidate_tls_config_cache();
+        reset_tls_caches();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = call_count.clone();
 
@@ -471,13 +525,13 @@ mod tests {
             1,
             "Custom params should skip retry"
         );
-        invalidate_tls_config_cache();
+        reset_tls_caches();
     }
 
     #[tokio::test]
     #[serial]
     async fn test_successful_connect_does_not_retry() {
-        invalidate_tls_config_cache();
+        reset_tls_caches();
         let call_count = Arc::new(AtomicUsize::new(0));
         let call_count_clone = call_count.clone();
 
@@ -501,6 +555,6 @@ mod tests {
             1,
             "Success should not retry"
         );
-        invalidate_tls_config_cache();
+        reset_tls_caches();
     }
 }

--- a/glide-core/redis-rs/redis/src/aio/tokio.rs
+++ b/glide-core/redis-rs/redis/src/aio/tokio.rs
@@ -17,14 +17,34 @@ use tokio::{
 
 use crate::connection::create_rustls_config;
 use crate::tls::TlsConnParams;
+use crate::{ErrorKind, RedisError};
 use std::sync::{Arc, OnceLock};
+use tokio_rustls::{client::TlsStream, TlsConnector};
 
 /// Cached TLS configurations to avoid repeatedly loading system certificates.
 /// On Linux, loading native certs can involve reading and parsing ~300KB of cert files,
 /// which adds ~6ms per connection when done repeatedly.
-static TLS_CONFIG_DEFAULT: OnceLock<Result<Arc<rustls::ClientConfig>, String>> = OnceLock::new();
-static TLS_CONFIG_INSECURE: OnceLock<Result<Arc<rustls::ClientConfig>, String>> = OnceLock::new();
-use tokio_rustls::{client::TlsStream, TlsConnector};
+static TLS_CONFIG_DEFAULT: OnceLock<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>> =
+    OnceLock::new();
+static TLS_CONFIG_INSECURE: OnceLock<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>> =
+    OnceLock::new();
+
+/// Retrieve or initialize a cached TLS configuration.
+fn get_cached_tls_config(
+    cache: &'static OnceLock<Result<Arc<rustls::ClientConfig>, (ErrorKind, String)>>,
+    insecure: bool,
+    tls_params: &Option<TlsConnParams>,
+) -> RedisResult<Arc<rustls::ClientConfig>> {
+    cache
+        .get_or_init(|| {
+            create_rustls_config(insecure, tls_params.clone())
+                .map(Arc::new)
+                .map_err(|e| (e.kind(), e.to_string()))
+        })
+        .as_ref()
+        .map_err(|(kind, msg)| RedisError::from((*kind, "TLS configuration error", msg.clone())))
+        .cloned()
+}
 
 #[cfg(unix)]
 use super::Path;
@@ -138,37 +158,9 @@ impl RedisRuntime for Tokio {
             // Custom TLS params (mTLS, custom CA) - cannot cache
             Arc::new(create_rustls_config(insecure, tls_params.clone())?)
         } else if insecure {
-            TLS_CONFIG_INSECURE
-                .get_or_init(|| {
-                    create_rustls_config(true, tls_params.clone())
-                        .map(Arc::new)
-                        .map_err(|e| e.to_string())
-                })
-                .as_ref()
-                .map_err(|e| {
-                    crate::RedisError::from((
-                        crate::ErrorKind::IoError,
-                        "TLS config error",
-                        e.clone(),
-                    ))
-                })?
-                .clone()
+            get_cached_tls_config(&TLS_CONFIG_INSECURE, true, tls_params)?
         } else {
-            TLS_CONFIG_DEFAULT
-                .get_or_init(|| {
-                    create_rustls_config(false, tls_params.clone())
-                        .map(Arc::new)
-                        .map_err(|e| e.to_string())
-                })
-                .as_ref()
-                .map_err(|e| {
-                    crate::RedisError::from((
-                        crate::ErrorKind::IoError,
-                        "TLS config error",
-                        e.clone(),
-                    ))
-                })?
-                .clone()
+            get_cached_tls_config(&TLS_CONFIG_DEFAULT, false, tls_params)?
         };
 
         let tls_connector = TlsConnector::from(config);


### PR DESCRIPTION
### Summary

Cache TLS `ClientConfig` to avoid loading system certificates from disk on every connection. This fixes a severe performance regression (~5x slower) in TLS connection setup that affected all versions since v2.1.1.

### Issue link

This Pull Request is linked to issue: [[Node] Connection timeouts due to sequential connection setup](https://github.com/valkey-io/valkey-glide/issues/5177)
Closes #5177

### Features / Behaviour Changes

- TLS `ClientConfig` (including loaded system certificates) is now created once per process and reused across all connections, instead of being recreated for every TLS connection.
- No user-facing API changes.
- Custom TLS configurations (mTLS client certs or user-provided root CAs) are still created per-connection as they may differ between clients.

### Implementation

The root cause: `rustls-native-certs` 0.8.2+ (a transitive dependency) significantly increased the cost of `load_native_certs()` by scanning all files in `/etc/ssl/certs/` instead of only OpenSSL hash-named files. Since `create_rustls_config()` was called for every TLS connection (36 times per 18-node cluster client), this added ~6ms per connection.

The fix adds two `static OnceLock` caches in `connect_tcp_tls()`:
- `TLS_CONFIG_DEFAULT` — for standard TLS (the common case)
- `TLS_CONFIG_INSECURE` — for insecure/testing mode

The first connection triggers cert loading; all subsequent connections reuse the cached `Arc<ClientConfig>`.

Key file: `glide-core/redis-rs/redis/src/aio/tokio.rs`

### Limitations

- The cached config is process-global. If multiple clients in the same process need different TLS settings without custom params, they'll share the same config. In practice this is always the case (all connections use the same system cert store).
- When launching many processes simultaneously (thundering herd), each process still performs one cert load. For optimal performance in multi-process deployments, stagger process startup by a few milliseconds.

### Testing

**Reproduced on identical setup to the issue reporter** (c7i.2xlarge, AL2023, ElastiCache Valkey 9.0, 6 shards, 2 replicas, TLS, 25 parallel processes):

| Build | 25 parallel |
|-------|:-----------:|
| NPM v2.1.0 (baseline) | 248ms |
| NPM v2.4.1 (unfixed) | 1,275ms |
| **This fix** (single process) | **95ms** |
| **This fix** (25 parallel + 0-100ms jitter) | **78ms** |

Also verified no regression on:
- ARM Linux (Finch, TLS): 2.8x faster than NPM v2.4.1
- All existing unit tests pass (glide-core: 136, redis crate: 274)
- `cargo clippy`, `cargo fmt`, `cargo doc` all clean

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
