### PR TITLE
Fix flaky test: test_lazy_connection_establishes_on_first_command

### DIFF
--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -735,6 +735,7 @@ public class ConnectionTests {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @Timeout(30)
     public void test_lazy_connection_establishes_on_first_command(boolean clusterMode)
             throws Exception {
         BaseClient monitoringClient = null;

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -146,6 +146,10 @@ public class TestUtilities {
                                     // Explicitly set no credentials for dedicated clusters to avoid
                                     // authentication issues from environment or global state
                                     .credentials(null)
+                                    .advancedConfiguration(
+                                            AdvancedGlideClusterClientConfiguration.builder()
+                                                    .connectionTimeout(10000)
+                                                    .build())
                                     .build())
                     .get();
         } else {
@@ -160,6 +164,10 @@ public class TestUtilities {
                                     // Explicitly set no credentials for dedicated clusters to avoid
                                     // authentication issues from environment or global state
                                     .credentials(null)
+                                    .advancedConfiguration(
+                                            AdvancedGlideClientConfiguration.builder()
+                                                    .connectionTimeout(10000)
+                                                    .build())
                                     .build())
                     .get();
         }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -165,9 +165,7 @@ public class TestUtilities {
                                     // authentication issues from environment or global state
                                     .credentials(null)
                                     .advancedConfiguration(
-                                            AdvancedGlideClientConfiguration.builder()
-                                                    .connectionTimeout(10000)
-                                                    .build())
+                                            AdvancedGlideClientConfiguration.builder().connectionTimeout(10000).build())
                                     .build())
                     .get();
         }


### PR DESCRIPTION
### Summary

Fix flaky test `ConnectionTests.test_lazy_connection_establishes_on_first_command` by increasing the connection timeout and JUnit test timeout.

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] test_lazy_connection_establishes_on_first_command](https://github.com/valkey-io/valkey-glide/issues/4765)
Closes #4765

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The `createDedicatedClient` helper in `TestUtilities.java` uses the default `connectionTimeout` of 2000ms. When the test creates a fresh `ValkeyCluster` instance, the server may not be fully ready to accept connections within 2000ms, especially on Windows CI or resource-constrained environments. This results in either:
1. `TimeoutException` - the JUnit class-level `@Timeout(10)` is exceeded
2. `ClosingException: Connection refused` - the server is not ready within the connection timeout

**Fix:**
1. Added explicit `connectionTimeout(10000)` via `AdvancedGlideClusterClientConfiguration`/`AdvancedGlideClientConfiguration` to the `createDedicatedClient` method, aligning with the 10000ms timeout already used in `CommandTests` (PR #5309).
2. Added `@Timeout(30)` on `test_lazy_connection_establishes_on_first_command` to override the class-level 10s timeout, since this test starts a dedicated cluster from scratch.

### Limitations

None

### Testing

The fix follows the same pattern as PR #5309 which resolved similar flakiness in other test classes. The increased timeout gives sufficient headroom for cluster startup on slow CI environments.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.