### PR TITLE
fix(ffi): avoid heap corruption in convert_vec_to_pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core/FFI: Fix heap corruption in `convert_vec_to_pointer` where `shrink_to_fit()` (a non-binding hint) was followed by `Vec::from_raw_parts` with `capacity = len`. When the allocator kept extra capacity, deallocation passed the wrong size, corrupting heap metadata and causing delayed SIGABRT crashes after many pubsub messages or response frees. ([#5637](https://github.com/valkey-io/valkey-glide/pull/5637))
 * Core: Honor `AWS_ENDPOINT_URL_STS` in the IAM credentials-provider loader so ElastiCache/MemoryDB IAM auth works in AWS partitions that do not publish a separate FIPS STS hostname (e.g. `us-gov-west-1`). Previously, setting `AWS_USE_FIPS_ENDPOINT=true` made the SDK construct a non-existent `sts-fips.<region>.amazonaws.com`, causing credential acquisition to hang. Matches `boto3` behavior. ([#5967](https://github.com/valkey-io/valkey-glide/issues/5967))
 * Core: Make the pipeline send-timeout liveness-aware so sustained backpressure on a live-but-slow connection waits for channel capacity instead of failing commands with `FatalSendError`, while a genuinely dead connection still fails fast ([#5446](https://github.com/valkey-io/valkey-glide/issues/5446))
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -41,7 +41,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{
     ffi::{CString, c_void},
-    mem,
     os::raw::{c_char, c_double, c_long, c_ulong},
 };
 use tokio::runtime::Builder;
@@ -960,11 +959,20 @@ unsafe fn process_push_notification(
             pattern_ptr,
             pattern_len,
         );
-        // Free memory
-        let _ = Vec::from_raw_parts(message_ptr, message_len as usize, message_len as usize);
-        let _ = Vec::from_raw_parts(channel, channel_len as usize, channel_len as usize);
+        // Free memory — allocated via Box::into_raw(vec.into_boxed_slice())
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            message_ptr,
+            message_len as usize,
+        ));
+        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            channel,
+            channel_len as usize,
+        ));
         if !pattern_ptr.is_null() {
-            let _ = Vec::from_raw_parts(pattern_ptr, pattern_len as usize, pattern_len as usize);
+            let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+                pattern_ptr,
+                pattern_len as usize,
+            ));
         }
     }
 }
@@ -2108,12 +2116,12 @@ unsafe fn free_command_response_elements(command_response: CommandResponse) {
     let sets_value_len = command_response.sets_value_len;
     if !string_value.is_null() {
         let len = string_value_len as usize;
-        unsafe { Vec::from_raw_parts(string_value, len, len) };
+        let _ = unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(string_value, len)) };
     }
     if !array_value.is_null() {
         let len = array_value_len as usize;
-        let vec = unsafe { Vec::from_raw_parts(array_value, len, len) };
-        for element in vec.into_iter() {
+        let boxed = unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(array_value, len)) };
+        for element in Vec::from(boxed).into_iter() {
             unsafe { free_command_response_elements(element) };
         }
     }
@@ -2125,8 +2133,8 @@ unsafe fn free_command_response_elements(command_response: CommandResponse) {
     }
     if !sets_value.is_null() {
         let len = sets_value_len as usize;
-        let vec = unsafe { Vec::from_raw_parts(sets_value, len, len) };
-        for element in vec.into_iter() {
+        let boxed = unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(sets_value, len)) };
+        for element in Vec::from(boxed).into_iter() {
             unsafe { free_command_response_elements(element) };
         }
     }
@@ -2167,12 +2175,12 @@ unsafe fn convert_double_pointer_to_vec<'a>(
     result
 }
 
-fn convert_vec_to_pointer<T>(mut vec: Vec<T>) -> (*mut T, c_long) {
-    vec.shrink_to_fit();
-    let vec_ptr = vec.as_mut_ptr();
+fn convert_vec_to_pointer<T>(vec: Vec<T>) -> (*mut T, c_long) {
+    // into_boxed_slice guarantees capacity == len (unlike shrink_to_fit which is a hint).
+    // This is critical because from_raw_parts later uses len as capacity for dealloc.
     let len = vec.len() as c_long;
-    mem::forget(vec);
-    (vec_ptr, len)
+    let ptr = Box::into_raw(vec.into_boxed_slice()) as *mut T;
+    (ptr, len)
 }
 
 // ==================== Arena-based response builder ====================


### PR DESCRIPTION
### Summary

Fix heap corruption caused by `convert_vec_to_pointer` using `shrink_to_fit()` (which is a non-binding hint) followed by `Vec::from_raw_parts` with `capacity = len`. When the allocator keeps extra capacity, the deallocation passes the wrong size, corrupting heap metadata. This causes delayed SIGABRT crashes after many pubsub messages or response frees accumulate corruption.

### Issue link

This Pull Request is linked to issue: [Python async pubsub SIGABRT crash](https://github.com/valkey-io/valkey-glide/pull/5637)

### Features / Behaviour Changes

No feature or API changes. This is a correctness fix for undefined behavior in unsafe memory management code.

### Implementation

**Root cause**: `convert_vec_to_pointer` called `vec.shrink_to_fit()` then `mem::forget(vec)`, returning `(ptr, len)`. The matching free sites used `Vec::from_raw_parts(ptr, len, len)` — but `shrink_to_fit` is only a hint per the Rust docs. If the allocator keeps `capacity > len`, reconstructing with `capacity = len` causes `dealloc` to pass an incorrect size to the global allocator, corrupting heap metadata.

**Fix**: Replace `shrink_to_fit() + mem::forget()` with `Box::into_raw(vec.into_boxed_slice())`, which **guarantees** `capacity == len` by reallocating if needed. All corresponding free sites now use `Box::from_raw(ptr::slice_from_raw_parts_mut(ptr, len))` to match the `Box<[T]>` allocation.

**Affected call sites**:
- `process_push_notification` — pubsub callback message/channel/pattern buffers
- `free_command_response_elements` — string, array, and set response buffers

### Limitations

None.

### Testing

- The crash was deterministically reproducible on CI (Ubuntu x86_64, Python 3.9) after async pubsub tests followed by hundreds of sync client create/destroy cycles
- `MALLOC_CHECK_=3` detected the corruption earlier (76% vs 87% through the test suite), confirming heap metadata corruption
- Core dump analysis confirmed the crash originated in `ResponseArena::alloc_node` with a corrupted `Value` (address 0x6), consistent with heap metadata corruption from prior deallocations
- CI run pending to confirm the fix eliminates the crash

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the valkey-glide-docs repository if necessary