### PR TITLE
test(ffi): add native-memory leak regression tests for OpenTelemetry spans

### DIFF
--- a/ffi/tests/test_otel_ffi_integration.rs
+++ b/ffi/tests/test_otel_ffi_integration.rs
@@ -1,3 +1,4 @@
+use glide_core::GlideSpan;
 use glide_core::request_type::RequestType;
 use glide_ffi::{
     create_batch_otel_span, create_batch_otel_span_with_parent, create_named_otel_span,
@@ -8,6 +9,29 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::Duration;
+
+/// Take a co-owning [`Arc<GlideSpan>`] for a span pointer returned by one of the
+/// `create_*_otel_span` FFI functions, WITHOUT consuming the reference still held by
+/// the raw pointer.
+///
+/// The FFI create functions leave the span's strong count at 1 (the count owned by the
+/// raw pointer handed back to the caller). Cloning that ownership here lets a test observe
+/// the strong count across a subsequent `drop_otel_span` call: a correct drop releases the
+/// FFI-held reference, so the count returned to this owner must fall back to 1. If
+/// `drop_otel_span` ever leaked (e.g. failed to call `Arc::from_raw`), the count would stay
+/// at 2 and the assertion would fire.
+///
+/// # Safety
+/// `span_ptr` must be a live span pointer returned by a `create_*_otel_span` FFI function
+/// that has NOT yet been passed to `drop_otel_span`.
+unsafe fn co_owner(span_ptr: u64) -> Arc<GlideSpan> {
+    unsafe {
+        // Bump the strong count so converting the raw pointer back to an Arc does not steal
+        // the reference owned by the FFI-side raw pointer.
+        Arc::increment_strong_count(span_ptr as *const GlideSpan);
+        Arc::from_raw(span_ptr as *const GlideSpan)
+    }
+}
 
 #[test]
 fn test_create_otel_span_with_valid_inputs() {
@@ -1134,4 +1158,171 @@ fn test_regression_no_error_logs_for_custom_command() {
 
     // If we reach here without panics, the fix is working correctly
     // No error logs should have been produced
+}
+
+// ---------------------------------------------------------------------------
+// Native-memory leak regression tests (tracked by issue #6226).
+//
+// These replace the two Java integration tests `testSpanMemoryLeak` and
+// `testSpanTransactionMemoryLeak` disabled in #6008. Those tests ran commands and then
+// asserted on the JVM heap (`Runtime.totalMemory() - freeMemory()`), but OpenTelemetry
+// spans are allocated in native Rust memory (`Arc<GlideSpan>` handed across FFI via
+// `Arc::into_raw`), so a JVM-heap measurement could never observe the leak it targeted
+// and varied 20-30% from GC/JIT noise.
+//
+// Scope: these are FFI-boundary guards. They prove `drop_otel_span` releases its
+// `Arc<GlideSpan>` reference rather than leaking it — the only layer at which a leak can
+// occur given the current design. They do not cover a wrapper that forgets to call
+// `drop_otel_span` at all; that is a per-language binding concern.
+//
+// The checks below instead observe the span's `Arc` strong count directly, so a leak in
+// `drop_otel_span` (a missed `Arc::from_raw`) is caught deterministically at the layer
+// where it can actually occur.
+// ---------------------------------------------------------------------------
+
+/// A single create -> drop cycle must release the span's native allocation: the FFI-held
+/// `Arc` reference is gone after `drop_otel_span`, leaving only the test's co-owner.
+#[test]
+fn test_drop_otel_span_releases_native_reference() {
+    logger_core::init(Some(logger_core::Level::Debug), None);
+
+    let span_ptr = create_otel_span(RequestType::Get);
+    assert_ne!(span_ptr, 0, "Span creation should succeed");
+
+    // Co-own the span so we can watch the strong count across the FFI drop.
+    let owner = unsafe { co_owner(span_ptr) };
+    assert_eq!(
+        Arc::strong_count(&owner),
+        2,
+        "Before drop: the FFI raw pointer and the test co-owner should both hold a reference"
+    );
+
+    unsafe {
+        drop_otel_span(span_ptr);
+    }
+
+    assert_eq!(
+        Arc::strong_count(&owner),
+        1,
+        "After drop: only the test co-owner should remain; drop_otel_span must release the \
+         FFI-held reference rather than leak it"
+    );
+}
+
+/// Repeatedly creating and dropping spans through the FFI entry points must not accumulate
+/// native allocations: every span's reference count must return to baseline after its drop.
+/// This is the sustained-load loop the disabled Java `testSpanMemoryLeak` intended, run at
+/// the FFI boundary where the allocation actually lives.
+#[test]
+fn test_span_create_drop_loop_does_not_leak() {
+    logger_core::init(Some(logger_core::Level::Debug), None);
+
+    const ITERATIONS: usize = 1000;
+    let named = CString::new("loop_named_span").expect("CString::new failed");
+
+    for i in 0..ITERATIONS {
+        // Rotate across the parentless create paths to exercise each one's into_raw/from_raw.
+        let span_ptr = match i % 3 {
+            0 => create_otel_span(RequestType::Get),
+            1 => create_otel_span(RequestType::Set),
+            _ => unsafe { create_named_otel_span(named.as_ptr()) },
+        };
+        assert_ne!(span_ptr, 0, "Span creation should succeed on iteration {i}");
+
+        let owner = unsafe { co_owner(span_ptr) };
+        assert_eq!(
+            Arc::strong_count(&owner),
+            2,
+            "Iteration {i}: span should have exactly the FFI reference plus the test co-owner"
+        );
+
+        unsafe {
+            drop_otel_span(span_ptr);
+        }
+
+        assert_eq!(
+            Arc::strong_count(&owner),
+            1,
+            "Iteration {i}: drop_otel_span must release the native reference (no leak)"
+        );
+        // `owner` is dropped here, fully reclaiming the span before the next iteration.
+    }
+}
+
+/// A parent batch span with command children (the shape exercised by the disabled
+/// `testSpanTransactionMemoryLeak`) must release every native allocation once each span is
+/// dropped, including the parent reference held by its children's creation path.
+#[test]
+fn test_batch_span_hierarchy_does_not_leak() {
+    logger_core::init(Some(logger_core::Level::Debug), None);
+
+    let parent_ptr = create_batch_otel_span();
+    assert_ne!(parent_ptr, 0, "Batch parent span creation should succeed");
+    let parent_owner = unsafe { co_owner(parent_ptr) };
+
+    assert_eq!(
+        Arc::strong_count(&parent_owner),
+        2,
+        "Parent before children: FFI reference plus test co-owner"
+    );
+
+    // Create a batch of command children, mirroring an exec/transaction with multiple commands.
+    // Include a nested batch span via create_batch_otel_span_with_parent to match the
+    // parented-batch shape of the disabled testSpanTransactionMemoryLeak.
+    const CHILDREN: usize = 50;
+    let mut child_ptrs = Vec::with_capacity(CHILDREN + 1);
+    for i in 0..CHILDREN {
+        let request_type = if i % 2 == 0 {
+            RequestType::Set
+        } else {
+            RequestType::Get
+        };
+        let child_ptr = unsafe { create_otel_span_with_parent(request_type, parent_ptr) };
+        assert_ne!(child_ptr, 0, "Child span {i} creation should succeed");
+        child_ptrs.push(child_ptr);
+    }
+    let nested_batch_ptr = unsafe { create_batch_otel_span_with_parent(parent_ptr) };
+    assert_ne!(
+        nested_batch_ptr, 0,
+        "Nested batch span creation should succeed"
+    );
+    child_ptrs.push(nested_batch_ptr);
+
+    // Creating children must not bump the parent's strong count: the link is via span context,
+    // not a retained clone of the parent's outer Arc. A leak here would be masked if the count
+    // were only checked after all drops, so assert stability while the children are still live.
+    assert_eq!(
+        Arc::strong_count(&parent_owner),
+        2,
+        "Parent count must be unchanged by child creation (children hold no parent Arc clone)"
+    );
+
+    // Each child holds only its own FFI reference, so dropping a child returns its count to the
+    // co-owner baseline.
+    for (i, &child_ptr) in child_ptrs.iter().enumerate() {
+        let child_owner = unsafe { co_owner(child_ptr) };
+        assert_eq!(
+            Arc::strong_count(&child_owner),
+            2,
+            "Child {i} before drop: FFI reference plus test co-owner"
+        );
+        unsafe {
+            drop_otel_span(child_ptr);
+        }
+        assert_eq!(
+            Arc::strong_count(&child_owner),
+            1,
+            "Child {i} after drop: native reference released (no leak)"
+        );
+    }
+
+    // The parent falls back to the co-owner baseline once its own FFI reference is dropped.
+    unsafe {
+        drop_otel_span(parent_ptr);
+    }
+    assert_eq!(
+        Arc::strong_count(&parent_owner),
+        1,
+        "Parent batch span after drop: native reference released (no leak)"
+    );
 }


### PR DESCRIPTION
### Summary

Adds deterministic native-memory leak regression tests for OpenTelemetry spans at the FFI boundary, in `ffi/tests/test_otel_ffi_integration.rs`. These replace the JVM-heap leak tests removed in #6119, which could not observe the leak they targeted because spans are allocated in native Rust memory (`Arc<GlideSpan>` via `Arc::into_raw`), not on the JVM heap.

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] testSpan related memory tests](https://github.com/valkey-io/valkey-glide/issues/6226)
Closes #6226

### Features / Behaviour Changes

Adds three tests that observe the span's `Arc` strong count directly, so a leak in `drop_otel_span` (a missed `Arc::from_raw`) is caught deterministically:

- `test_drop_otel_span_releases_native_reference` — a single create→drop cycle must release the FFI-held reference (count 2→1 against a test co-owner).
- `test_span_create_drop_loop_does_not_leak` — sustained loop (1000 iterations) over `create_otel_span` (Get/Set) and `create_named_otel_span`; every span returns to baseline after its drop. Analog of `testSpanMemoryLeak`.
- `test_batch_span_hierarchy_does_not_leak` — a parented batch with 50 command children plus a nested `create_batch_otel_span_with_parent`; asserts the parent count is unchanged by child creation and every span releases its reference. Analog of `testSpanTransactionMemoryLeak`.

### Implementation

A small `co_owner` unsafe helper takes a co-owning `Arc<GlideSpan>` (`Arc::increment_strong_count` then `Arc::from_raw`, mirroring the existing `span_from_pointer` pattern) so a test can watch the strong count across the FFI drop without stealing the FFI-held reference. The create functions leave the strong count at 1; `co_owner` makes it 2; a correct `drop_otel_span` returns it to 1, while a leak would leave it at 2 and fail the assertion.

Reviewers: please pay attention to the soundness of `co_owner` and the assumption in `test_batch_span_hierarchy_does_not_leak` that `create_otel_span_with_parent` does not retain a clone of the parent's outer `Arc` (verified against `add_span` / `span_from_pointer` in `glide-core/telemetry/src/open_telemetry.rs`).

### Limitations

These are FFI-boundary guards: they prove `drop_otel_span` releases its `Arc` reference rather than leaking it — the only layer at which a leak can occur given the current design. They do not cover a per-language wrapper that forgets to call `drop_otel_span` at all; that is a binding-specific concern.

### Testing

`cargo test --test test_otel_ffi_integration` — 28 passed (3 new). `cargo fmt --check` and `cargo clippy --tests` clean.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
