### PR TITLE
chore: temporarily allow pyo3 advisory pending version bump

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,7 @@ yanked = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    "RUSTSEC-2026-0176", # pyo3: upgrade to >=0.29.0 requires code migration, tracked separately
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
### Summary

Temporarily adds pyo3 advisory to the `deny.toml` ignore list to unblock CI.

The upgrade to pyo3 `>=0.29.0` requires an API migration due to breaking changes (`PyObject` removal, `Python::with_gil` renamed, return type changes). This is being tracked separately.

### Changes

- Added advisory entry to `deny.toml` ignore list

### Testing

- CI lint (cargo-deny) will pass with this change
- No runtime behavior change