### PR TITLE
Go: Fix flaky TestMemoryStats_StandaloneWithDataOperations

### DIFF
--- a/go/integTest/memory_commands_test.go
+++ b/go/integTest/memory_commands_test.go
@@ -146,9 +146,10 @@ func (suite *GlideTestSuite) TestMemoryStats_StandaloneWithDataOperations() {
 	statsBefore, err := client.MemoryStats(context.Background())
 	assert.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
+	// Write enough data (~10MB) to reliably exceed any background memory reclamation jitter.
+	for i := 0; i < 1000; i++ {
 		key := fmt.Sprintf("memory_test_key_%d", i)
-		value := strings.Repeat("x", 1000)
+		value := strings.Repeat("x", 10000)
 		_, err := client.Set(context.Background(), key, value)
 		assert.NoError(t, err)
 	}


### PR DESCRIPTION
### Summary
Fix flaky `TestMemoryStats_StandaloneWithDataOperations` by increasing data volume to reliably exceed background memory reclamation jitter.

### Issue link
This Pull Request is linked to issue: [[Go][Flaky Test] TestMemoryStats_StandaloneWithDataOperations](https://github.com/valkey-io/valkey-glide/issues/6233)
Closes #6233

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root Cause:** The test wrote 100 keys with 1KB values (~100KB total). Valkey's background memory management (lazy-free, jemalloc purging) can reclaim more memory than this between the before/after measurements, causing `total.allocated` to occasionally decrease despite new data being written.

**Fix:** Increase data volume to 1000 keys × 10KB values (~10MB total). This makes the memory increase deterministic because the delta far exceeds any background memory fluctuation.

### Limitations
None

### Testing
Ran the test 100 times consecutively with `go test -run TestGlideTestSuite/TestMemoryStats_StandaloneWithDataOperations -count=100 -timeout=60m ./integTest/...` — all 100 runs passed.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release