### PR TITLE
Core: Use watchdog diagnostics to inform CB recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Core, Python, Java, Node, Go: Add `SAVE`, `BGSAVE` and `BGREWRITEAOF` command support ([#6095](https://github.com/valkey-io/valkey-glide/issues/6095))
 * Java: Add `FAILOVER` and `REPLICAOF` command support ([#6170](https://github.com/valkey-io/valkey-glide/pull/6170))
 * Core, Java, Python, Node, Go: Add client-wide circuit breaker that detects sustained error rates and rejects requests at the FFI boundary before threads park. Opt-in via `ClientCircuitBreakerConfiguration`. Tracks error rate in a sliding window, trips when threshold is exceeded, and recovers automatically via optimistic HalfOpen with consecutive success validation. Java additionally performs a synchronous pre-check to prevent thread explosion under `managedBlock()`. ([#5996](https://github.com/valkey-io/valkey-glide/issues/5996))
+* Core: Use watchdog diagnostics to inform circuit breaker recovery. Tolerates straggler failures in HalfOpen when inflight is draining below trip level, and excludes blocking commands from latency tracking. ([#6208](https://github.com/valkey-io/valkey-glide/issues/6208))
 * Core, Python, Java, Node, Go: Add `CLIENT PAUSE` and `CLIENT UNPAUSE` command support ([#6035](https://github.com/valkey-io/valkey-glide/issues/6035))
 * Go: Add RESET command support ([#5946](https://github.com/valkey-io/valkey-glide/pull/5946))
 * Java: Add RESET command support ([#5947](https://github.com/valkey-io/valkey-glide/pull/5947))

--- a/glide-core/README.md
+++ b/glide-core/README.md
@@ -145,7 +145,7 @@ Closed → Open → HalfOpen → Closed
 
 - **Closed**: Normal operation. Errors tracked in a sliding window.
 - **Open**: Requests rejected immediately. Transitions to HalfOpen after `open_timeout`.
-- **HalfOpen**: All traffic allowed (optimistic). Closes after `consecutive_successes` successful commands. Reopens on any error.
+- **HalfOpen**: All traffic allowed (optimistic). Closes after `consecutive_successes` successful commands. Reopens on failure unless inflight is draining (straggler tolerance).
 
 ### Configuration
 
@@ -161,6 +161,12 @@ Closed → Open → HalfOpen → Closed
 ### Error Classification
 
 Only transport-level errors count toward tripping: `IoError`, `FatalSendError`, `FatalReceiveError`, and connection drops. Server-side errors (WRONGTYPE, MOVED, etc.) do not count. Timeouts are opt-in via `count_timeouts`.
+
+### Recovery Guards
+
+Before closing the breaker (HalfOpen to Closed), straggler tolerance prevents premature reopening:
+
+- **Straggler tolerance**: a failure in HalfOpen does not immediately reopen the breaker if inflight count is below the level at trip time (system is draining). This tolerates late responses from the previous degraded period. Capped at 2 forgiven failures per HalfOpen cycle.
 
 ### Exception Type
 

--- a/glide-core/src/client/circuit_breaker.rs
+++ b/glide-core/src/client/circuit_breaker.rs
@@ -87,6 +87,10 @@ struct BreakerState {
     opened_at: Option<Instant>,
     /// Consecutive successful probes in HalfOpen state.
     consecutive_success_count: u32,
+    /// Number of straggler failures forgiven in current HalfOpen period.
+    stragglers_forgiven: u32,
+    /// Inflight count when the breaker tripped (for drain comparison).
+    inflight_at_trip: u32,
     /// Error type counts since last trip/reset. For diagnostic logging.
     error_counts: HashMap<String, u32>,
 }
@@ -110,6 +114,8 @@ impl ClientCircuitBreaker {
                 error_count: 0,
                 opened_at: None,
                 consecutive_success_count: 0,
+                stragglers_forgiven: 0,
+                inflight_at_trip: 0,
                 error_counts: HashMap::new(),
             }),
             healthy: AtomicBool::new(true),
@@ -146,6 +152,7 @@ impl ClientCircuitBreaker {
         if now.duration_since(opened_at) >= self.config.open_timeout {
             state.phase = CircuitState::HalfOpen;
             state.consecutive_success_count = 0;
+            state.stragglers_forgiven = 0;
             self.healthy.store(true, Ordering::Release);
             true
         } else {
@@ -165,7 +172,8 @@ impl ClientCircuitBreaker {
     /// Report a command result. Called after each command completes.
     /// `is_error` should be true only for transport-level errors.
     /// `error_kind` is the error type string for diagnostic logging (only used when is_error=true).
-    pub fn on_result(&self, is_error: bool, error_kind: Option<&str>) {
+    /// `current_inflight` is the number of inflight requests at reporting time.
+    pub fn on_result(&self, is_error: bool, error_kind: Option<&str>, current_inflight: u32) {
         let mut state = self.state.write().unwrap_or_else(|e| e.into_inner());
         let now = Instant::now();
 
@@ -226,21 +234,31 @@ impl ClientCircuitBreaker {
                 if errors >= self.config.min_errors {
                     let rate = errors as f32 / total as f32;
                     if rate >= self.config.failure_rate_threshold {
-                        self.trip(&mut state, now, errors, total);
+                        self.trip(&mut state, now, errors, total, current_inflight);
                     }
                 }
             }
             CircuitState::HalfOpen => {
                 if is_error {
-                    // Probe failed, reopen
-                    state.phase = CircuitState::Open;
-                    state.opened_at = Some(now);
-                    state.consecutive_success_count = 0;
-                    self.healthy.store(false, Ordering::Release);
-                    log_warn(
-                        "circuit_breaker",
-                        "Probe failed. Client circuit breaker remains open",
-                    );
+                    if current_inflight < state.inflight_at_trip && state.stragglers_forgiven < 2 {
+                        // Inflight is below the level at trip time: system is draining
+                        state.consecutive_success_count = 0;
+                        state.stragglers_forgiven += 1;
+                        log_warn(
+                            "circuit_breaker",
+                            "HalfOpen failure with draining inflight, treating as straggler",
+                        );
+                    } else {
+                        // Genuine failure, reopen
+                        state.phase = CircuitState::Open;
+                        state.opened_at = Some(now);
+                        state.consecutive_success_count = 0;
+                        self.healthy.store(false, Ordering::Release);
+                        log_warn(
+                            "circuit_breaker",
+                            "Probe failed. Client circuit breaker remains open",
+                        );
+                    }
                 } else {
                     state.consecutive_success_count += 1;
                     if state.consecutive_success_count >= self.config.consecutive_successes {
@@ -273,12 +291,20 @@ impl ClientCircuitBreaker {
         }
     }
 
-    fn trip(&self, state: &mut BreakerState, now: Instant, errors: u32, total: u32) {
+    fn trip(
+        &self,
+        state: &mut BreakerState,
+        now: Instant,
+        errors: u32,
+        total: u32,
+        current_inflight: u32,
+    ) {
         state.phase = CircuitState::Open;
         state.opened_at = Some(now);
         state.records.clear();
         state.error_count = 0;
         state.consecutive_success_count = 0;
+        state.inflight_at_trip = current_inflight;
         self.healthy.store(false, Ordering::Release);
         self.trip_count.fetch_add(1, Ordering::Relaxed);
 
@@ -355,10 +381,10 @@ mod tests {
 
         // 4 errors, 6 successes = 40% < 50% threshold
         for _ in 0..6 {
-            cb.on_result(false, None);
+            cb.on_result(false, None, 0);
         }
         for _ in 0..4 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         assert!(cb.is_healthy());
@@ -371,10 +397,10 @@ mod tests {
 
         // 6 errors, 4 successes = 60% > 50% threshold, 6 >= min_errors(5)
         for _ in 0..4 {
-            cb.on_result(false, None);
+            cb.on_result(false, None, 0);
         }
         for _ in 0..6 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         assert!(!cb.is_healthy());
@@ -388,7 +414,7 @@ mod tests {
 
         // 4 errors, 0 successes = 100% rate but only 4 < min_errors(5)
         for _ in 0..4 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         assert!(cb.is_healthy());
@@ -401,7 +427,7 @@ mod tests {
 
         // Trip it
         for _ in 0..10 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
         assert!(!cb.is_healthy());
         assert_eq!(cb.rejection_count(), 1); // is_healthy() increments when rejecting
@@ -413,7 +439,7 @@ mod tests {
 
         // Trip it
         for _ in 0..10 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         // Wait for open_timeout
@@ -430,7 +456,7 @@ mod tests {
 
         // Trip it
         for _ in 0..10 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         // Wait for open_timeout
@@ -440,10 +466,10 @@ mod tests {
         assert!(cb.is_healthy());
 
         // Probe 1 succeeds
-        cb.on_result(false, None);
+        cb.on_result(false, None, 0);
 
         // Probe 2 succeeds (consecutive_successes = 2)
-        cb.on_result(false, None);
+        cb.on_result(false, None, 0);
 
         assert_eq!(cb.state(), CircuitState::Closed);
         assert!(cb.is_healthy());
@@ -455,7 +481,7 @@ mod tests {
 
         // Trip it
         for _ in 0..10 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         // Wait for open_timeout
@@ -465,7 +491,7 @@ mod tests {
         assert!(cb.is_healthy());
 
         // Probe fails
-        cb.on_result(true, Some("IoError"));
+        cb.on_result(true, Some("IoError"), 0);
 
         assert_eq!(cb.state(), CircuitState::Open);
         assert!(!cb.is_healthy());
@@ -482,14 +508,14 @@ mod tests {
 
         // Add 3 errors (below min_errors threshold of 5)
         for _ in 0..3 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         // Wait for window to expire
         std::thread::sleep(Duration::from_millis(60));
 
         // Add 1 success after window expires
-        cb.on_result(false, None);
+        cb.on_result(false, None, 0);
 
         assert!(cb.is_healthy());
         assert_eq!(cb.state(), CircuitState::Closed);
@@ -505,7 +531,7 @@ mod tests {
 
         // Trip the breaker
         for _ in 0..10 {
-            cb.on_result(true, Some("IoError"));
+            cb.on_result(true, Some("IoError"), 0);
         }
 
         // Wait for open_timeout to elapse
@@ -525,5 +551,27 @@ mod tests {
         // All should get true (HalfOpen allows traffic), but only one transition should occur
         assert!(allowed > 0);
         assert_eq!(cb.state(), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn draining_inflight_forgives_halfopen_failure() {
+        let cb = ClientCircuitBreaker::new(default_config());
+
+        // Trip it with high inflight (simulates saturated state)
+        for _ in 0..10 {
+            cb.on_result(true, Some("IoError"), 500);
+        }
+
+        // Wait for open_timeout
+        std::thread::sleep(Duration::from_millis(110));
+        assert!(cb.is_healthy()); // HalfOpen
+
+        // Failure with lower inflight than at trip: draining, should stay HalfOpen
+        cb.on_result(true, Some("IoError"), 100);
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        // Failure with same inflight as trip: not draining, should reopen
+        cb.on_result(true, Some("IoError"), 500);
+        assert_eq!(cb.state(), CircuitState::Open);
     }
 }

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -431,6 +431,18 @@ fn get_timeout_from_cmd_arg(
     }
 }
 
+/// Returns true for commands with user-specified blocking timeouts that
+/// should be excluded from latency tracking (they distort p99).
+fn is_blocking_command(cmd: &Cmd) -> bool {
+    let command = cmd.command().unwrap_or_default();
+    match command.as_slice() {
+        b"BLPOP" | b"BRPOP" | b"BLMOVE" | b"BZPOPMAX" | b"BZPOPMIN" | b"BRPOPLPUSH" | b"BLMPOP"
+        | b"BZMPOP" | b"WAIT" | b"WAITAOF" => true,
+        b"XREAD" | b"XREADGROUP" => cmd.position(b"BLOCK").is_some(),
+        _ => false,
+    }
+}
+
 fn get_request_timeout(cmd: &Cmd, default_timeout: Duration) -> RedisResult<Option<Duration>> {
     let command = cmd.command().unwrap_or_default();
     let timeout = match command.as_slice() {
@@ -1117,6 +1129,12 @@ impl Client {
             let self_clone = self.clone();
             let owned_cmd = cmd.clone();
 
+            // Captured by the timeout path for watchdog-informed CB decisions.
+            let mut timeout_cause: Option<crate::timeout_watchdog::TimeoutCause> = None;
+
+            // Blocking commands have artificially long latencies; exclude from tracker.
+            let is_blocking_cmd = is_blocking_command(cmd);
+
             let result = match request_timeout {
                 Some(duration) => {
                     // Compute inflight count (cheap atomic load)
@@ -1150,8 +1168,10 @@ impl Client {
                     tokio::select! {
                         result = &mut execute => {
                             // Record latency into per-client tracker
-                            let elapsed = cmd_start.elapsed();
-                            self.latency_tracker.record(elapsed);
+                            if !is_blocking_cmd {
+                                let elapsed = cmd_start.elapsed();
+                                self.latency_tracker.record(elapsed);
+                            }
                             result
                         }
                         recv_result = timeout_rx => {
@@ -1201,6 +1221,7 @@ impl Client {
                                             node: node.clone(),
                                         }
                                     };
+                                    timeout_cause = Some(cause.clone());
                                     let event = crate::timeout_watchdog::TimeoutEvent {
                                         cause,
                                         command,
@@ -1263,11 +1284,26 @@ impl Client {
                             ) || e.is_connection_dropped()
                         };
                         if counts {
-                            let kind_str = match e.kind() {
-                                ErrorKind::IoError => "IoError",
-                                ErrorKind::FatalSendError => "FatalSendError",
-                                ErrorKind::FatalReceiveError => "FatalReceiveError",
-                                _ => "Timeout",
+                            let kind_str = if e.is_timeout() {
+                                match &timeout_cause {
+                                    Some(
+                                        crate::timeout_watchdog::TimeoutCause::SystemOverload {
+                                            ..
+                                        },
+                                    ) => "TimeoutSystemOverload",
+                                    Some(
+                                        crate::timeout_watchdog::TimeoutCause::ClientBackpressure {
+                                            ..
+                                        },
+                                    ) => "TimeoutClientBackpressure",
+                                    _ => "TimeoutServerUnresponsive",
+                                }
+                            } else {
+                                match e.kind() {
+                                    ErrorKind::FatalSendError => "FatalSendError",
+                                    ErrorKind::FatalReceiveError => "FatalReceiveError",
+                                    _ => "IoError",
+                                }
                             };
                             (true, Some(kind_str))
                         } else {
@@ -1275,7 +1311,10 @@ impl Client {
                         }
                     }
                 };
-                cb.on_result(is_error, error_kind);
+                let current_inflight = (self.inflight_requests_limit
+                    - self.inflight_requests_allowed.load(Ordering::Relaxed))
+                    as u32;
+                cb.on_result(is_error, error_kind, current_inflight);
             }
 
             result
@@ -2612,6 +2651,7 @@ mod tests {
     use crate::client::types::{ConnectionRequest, NodeAddress, OTelMetadata};
     use crate::client::{
         BLOCKING_CMD_TIMEOUT_EXTENSION, RequestTimeoutOption, TimeUnit, get_request_timeout,
+        is_blocking_command,
     };
 
     use super::{Client, ClientWrapper, LazyClient, get_timeout_from_cmd_arg};
@@ -3229,5 +3269,74 @@ mod tests {
         let mut cmd = Cmd::new();
         cmd.arg("PING");
         assert!(!client.is_reset_command(&cmd));
+    }
+
+    #[test]
+    fn test_is_blocking_command() {
+        // Always-blocking commands
+        let mut cmd = Cmd::new();
+        cmd.arg("BLPOP").arg("key").arg("5");
+        assert!(is_blocking_command(&cmd));
+
+        let mut cmd = Cmd::new();
+        cmd.arg("BRPOP").arg("key").arg("5");
+        assert!(is_blocking_command(&cmd));
+
+        let mut cmd = Cmd::new();
+        cmd.arg("WAIT").arg("1").arg("5000");
+        assert!(is_blocking_command(&cmd));
+
+        // XREAD with BLOCK is blocking
+        let mut cmd = Cmd::new();
+        cmd.arg("XREAD")
+            .arg("BLOCK")
+            .arg("5000")
+            .arg("STREAMS")
+            .arg("s1")
+            .arg("$");
+        assert!(is_blocking_command(&cmd));
+
+        // XREAD without BLOCK is NOT blocking
+        let mut cmd = Cmd::new();
+        cmd.arg("XREAD")
+            .arg("COUNT")
+            .arg("10")
+            .arg("STREAMS")
+            .arg("s1")
+            .arg("$");
+        assert!(!is_blocking_command(&cmd));
+
+        // XREADGROUP with BLOCK is blocking
+        let mut cmd = Cmd::new();
+        cmd.arg("XREADGROUP")
+            .arg("GROUP")
+            .arg("g1")
+            .arg("c1")
+            .arg("BLOCK")
+            .arg("0")
+            .arg("STREAMS")
+            .arg("s1")
+            .arg(">");
+        assert!(is_blocking_command(&cmd));
+
+        // XREADGROUP without BLOCK is NOT blocking
+        let mut cmd = Cmd::new();
+        cmd.arg("XREADGROUP")
+            .arg("GROUP")
+            .arg("g1")
+            .arg("c1")
+            .arg("STREAMS")
+            .arg("s1")
+            .arg(">");
+        assert!(!is_blocking_command(&cmd));
+
+        // Non-blocking commands
+        let mut cmd = Cmd::new();
+        cmd.arg("GET").arg("key");
+        assert!(!is_blocking_command(&cmd));
+
+        let mut cmd = Cmd::new();
+        cmd.arg("SET").arg("key").arg("value");
+        assert!(!is_blocking_command(&cmd));
     }
 }


### PR DESCRIPTION
### Summary

Make use of watchdog metrics in circuit breaker recovery decisions to reduce flapping. Adds straggler tolerance, diagnostic timeout labeling, and blocking command exclusion from latency tracking.

### Issue link

Closes #6208

### Features / Behaviour Changes

- Straggler tolerance: A failure in HalfOpen no longer immediately reopens the CB if current inflight is below the level at trip time. This treats the failure as a straggler from the previous degraded period and resets the success count instead. Capped at 2 forgiven failures per HalfOpen cycle.
- Timeout errors reported to the CB are labeled by watchdog cause (`TimeoutServerUnresponsive` vs `TimeoutSystemOverload` vs `TimeoutClientBackpressure`) for diagnostic visibility.
- Blocking commands (BLPOP, XREAD BLOCK, etc.) are excluded from the latency tracker to avoid distorting p99 values.

### Implementation

- `circuit_breaker.rs: on_result()` accepts `current_inflight`. Compares against `inflight_at_trip` (recorded when CB trips) to determine if system is draining. Straggler forgiveness capped at 2 per HalfOpen period.
- `client/mod.rs`: Passes current inflight count (one Relaxed atomic load). Captures `timeout_cause` from watchdog event for diagnostic labeling. `is_blocking_command()` helper excludes blocking commands from latency tracker (BLOCK-aware for XREAD/XREADGROUP).

### Limitations

- Timeout cause classification (`ClientBackpressure` vs `ServerUnresponsive`) could not be used for smarter tripping decisions (originally considered in [#6208](https://github.com/valkey-io/valkey-glide/issues/6208)). The watchdog's `scheduling_delay` field equals total elapsed time (not true scheduling delay), making it impossible to reliably distinguish server-induced backpressure from Tokio starvation. Tripping logic remains unchanged.
- A p99 latency recovery guard was explored but removed as the latency tracker only records successful completions bounded by `request_timeout`, so p99 cannot meaningfully exceed the threshold under the current design. Can be revisited if the tracker is enhanced to record connection-layer round-trip time.

### Testing

- new unit test, `draining_inflight_forgives_halfopen_failure`, passes
- 10 existing CB unit tests pass
- e2e benchmark (5 min per phase): 85.7% -> 97.2% fast errors with CB (consistent with baseline, no regression)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main.
- [x] Make sure to update the documentation in the valkey-glide-docs repository if necessary