### PR TITLE
fix(python): pin pytest<9.1 to fix fixture finalizer assertion errors

### DIFF
--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,7 +1,7 @@
 maturin==1.13.3
 anyio[trio]>=4.9.0
 uvloop
-pytest
+pytest<9.1
 pytest-html
 pytest-timeout
 black >= 24.3.0


### PR DESCRIPTION
### Summary

Pin `pytest<9.1` to fix 218 CI test failures on Python 3.13 with uvloop/trio backends.

### Issue link

This Pull Request fixes CI failures affecting all `TestAuthCommands` and `TestOpenTelemetryGlide` tests on the Python 3.13 workflow.

### Features / Behaviour Changes

No feature changes. Pins a dev dependency version.

### Implementation

pytest 9.1+ added a strict `assert not self._finalizers` invariant check in `FixtureDef.execute()` that fires when anyio's parametrized backend fixture (asyncio/uvloop/trio) transitions between backends during re-parametrization. This causes an `AssertionError` at `_pytest/fixtures.py:1220` during test setup.

Key observations:
- Only affects Python 3.13 (not 3.9) — likely due to dependency resolution installing latest pytest
- Only affects uvloop and trio backends — asyncio works fine
- The first backend succeeds; the assertion triggers on backend transitions
- The error cascades: once one fixture's finalizer state is corrupted, all subsequent parametrized tests fail

Pin `pytest<9.1` until anyio is updated to handle the new fixture finalization protocol.

### Limitations

This is a version pin workaround. The underlying incompatibility is between anyio's pytest plugin and pytest 9.1+'s stricter fixture invariants. Should be revisited when anyio releases a compatible version.

### Testing

- The fix addresses the exact `assert not self._finalizers` assertion seen in CI
- Python 3.9 workflow was already passing (uses older pytest)
- asyncio backend was already passing (not affected by the fixture transition issue)

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.