### PR TITLE
deps(node): bump protobufjs to ^7.6.3 (CVE-2026-48712, CVE-2026-54269)

### DIFF
--- a/node/hybrid-node-tests/pnpm-pubsub-test/pnpm-pubsub-test.cjs
+++ b/node/hybrid-node-tests/pnpm-pubsub-test/pnpm-pubsub-test.cjs
@@ -2,23 +2,42 @@
 /* eslint @typescript-eslint/no-require-imports: off */
 "use strict";
 
-// Patch Module._resolveFilename to block 'long' resolution from
-// @protobufjs/inquire, simulating pnpm strict hoisting where inquire's
-// eval-wrapped require("long") fails. This forces protobufjs to return
-// JS numbers instead of Long objects for uint64 fields, exercising the
-// code path that requires correct 64-bit pointer handling.
+// Patch Module._resolveFilename to block 'long' resolution from within
+// protobufjs, simulating pnpm strict hoisting where protobufjs's
+// require("long") fails. This forces protobufjs to return JS numbers
+// instead of Long objects for uint64 fields, exercising the code path
+// that requires correct 64-bit pointer handling.
+//
+// protobufjs <= 7.6.0 loaded `long` via the @protobufjs/inquire helper;
+// 7.6.1+ dropped that dependency and requires `long` directly from its
+// own sources (e.g. protobufjs/src/util/minimal.js). Match both so the
+// guard keeps firing across versions. `longBlockCount` asserts the
+// interception actually triggered — otherwise the test would pass
+// trivially without exercising the JS-number pointer path.
 const Module = require("module");
 const origResolve = Module._resolveFilename;
+
+let longBlockCount = 0;
+
+function isProtobufjsCaller(filename) {
+    // Match the legacy @protobufjs/* helpers and protobufjs's own sources,
+    // while excluding unrelated packages that merely contain "protobuf".
+    return (
+        filename.includes("@protobufjs") ||
+        /[/\\]protobufjs[/\\]/.test(filename)
+    );
+}
 
 Module._resolveFilename = function (request, parent, ...rest) {
     if (
         request === "long" &&
         parent &&
         parent.filename &&
-        parent.filename.includes("@protobufjs")
+        isProtobufjsCaller(parent.filename)
     ) {
+        longBlockCount += 1;
         throw new Error(
-            "Simulated pnpm strict hoisting: long not found from @protobufjs/inquire",
+            "Simulated pnpm strict hoisting: long not found from protobufjs",
         );
     }
 
@@ -136,7 +155,22 @@ async function main() {
         await testProcessResponse(port);
         await testPubSub(port);
 
-        console.log("All pnpm pointer tests passed");
+        // Guard against the test silently passing trivially: if the
+        // interception never fired, protobufjs loaded `long` from a path
+        // this test no longer recognizes, so the JS-number pointer path
+        // was never exercised. Fail loudly so the matcher gets updated.
+        if (longBlockCount === 0) {
+            throw new Error(
+                "long-resolution guard never fired: protobufjs did not " +
+                    "require 'long' from a recognized path, so the JS-number " +
+                    "pointer path was not exercised. Update isProtobufjsCaller() " +
+                    "to match where the current protobufjs version loads 'long'.",
+            );
+        }
+
+        console.log(
+            `All pnpm pointer tests passed (long-resolution blocked ${longBlockCount} time(s))`,
+        );
         process.exit(0);
     } catch (error) {
         console.error("Error:", error.message);

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "long": "5",
-                "protobufjs": "7"
+                "protobufjs": "^7.6.3"
             },
             "devDependencies": {
                 "@jest/globals": "29",
@@ -68,6 +68,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1130,9 +1131,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
@@ -1148,12 +1149,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1394,6 +1389,7 @@
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -1418,6 +1414,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
             "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -1484,6 +1481,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1784,6 +1782,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -2989,6 +2988,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -4398,6 +4398,7 @@
             "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -4877,19 +4878,19 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
@@ -5831,6 +5832,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -5987,6 +5989,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/node/package.json
+++ b/node/package.json
@@ -32,7 +32,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "long": "5",
-        "protobufjs": "7"
+        "protobufjs": "^7.6.3"
     },
     "keywords": [
         "valkey",

--- a/node/pm-and-types-tests/depend-on-glide-package/package-lock.json
+++ b/node/pm-and-types-tests/depend-on-glide-package/package-lock.json
@@ -58,9 +58,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
@@ -76,12 +76,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -380,6 +374,7 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
             "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.12.0",
                 "pg-pool": "^3.13.0",
@@ -504,19 +499,18 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",

--- a/utils/release-candidate-testing/node/package-lock.json
+++ b/utils/release-candidate-testing/node/package-lock.json
@@ -35,9 +35,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
@@ -53,12 +53,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -210,19 +204,18 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",


### PR DESCRIPTION
## Summary

Resolves two Dependabot advisories on `protobufjs` by raising the declared range and regenerating the affected lockfiles.

| Advisory | Severity | Issue | Patched |
|---|---|---|---|
| [GHSA-wcpc-wj8m-hjx6](https://github.com/advisories/GHSA-wcpc-wj8m-hjx6) / CVE-2026-48712 | HIGH | DoS via unbounded `google.protobuf.Any` expansion during JSON conversion | 7.6.1 |
| [GHSA-f38q-mgvj-vph7](https://github.com/advisories/GHSA-f38q-mgvj-vph7) / CVE-2026-54269 | MEDIUM | Schema-derived names can shadow runtime-significant properties | 7.6.3 |

## Changes

- `node/package.json`: `protobufjs` `"7"` → `"^7.6.3"` (direct runtime dep)
- Regenerated lockfiles, all now resolve `protobufjs@7.6.4`:
  - `node/package-lock.json`
  - `node/pm-and-types-tests/depend-on-glide-package/package-lock.json` (transitive)
  - `utils/release-candidate-testing/node/package-lock.json` (transitive)

## Risk

Patch-level bump within v7 — no API changes. GLIDE uses fixed internal protobuf schemas and does not expand untrusted `Any` values via JSON conversion, so practical exploitability of CVE-2026-48712 is low, but `protobufjs` is a direct runtime dependency so we patch rather than dismiss.

## Verification

- `npm install` resolves cleanly at 7.6.4.
- `npm run build-protobuf` (pbjs/pbts static codegen) succeeds against 7.6.4.

Clears Dependabot alerts #30, #31, #33, #34, #36, #37.