### PR TITLE
deps(node): bump protobufjs-cli to ^1.3.2 (CVE-2026-54271)

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -23,7 +23,7 @@
                 "jest": "29",
                 "jest-html-reporter": "4",
                 "lint-staged": "16",
-                "protobufjs-cli": "1",
+                "protobufjs-cli": "^1.3.2",
                 "replace": "1",
                 "semver": "7",
                 "ts-jest": "29",
@@ -68,6 +68,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1130,9 +1131,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
@@ -1148,12 +1149,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1394,6 +1389,7 @@
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -1418,6 +1414,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
             "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -1484,6 +1481,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1784,6 +1782,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -2989,6 +2988,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -4398,6 +4398,7 @@
             "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -4877,19 +4878,19 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
@@ -4901,9 +4902,9 @@
             }
         },
         "node_modules/protobufjs-cli": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.2.2.tgz",
-            "integrity": "sha512-gc27fy6Om+92g4UxqOs9ECTc3Xy7zXsnBSFR0dCSEvIRG8cn3eU8x+CcN8ouBB3EjIBVnEOeQb0iVKC4lnBoKA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.3.3.tgz",
+            "integrity": "sha512-zwmt6JeStPjeofZbl+QADexAVzP1EgsIAsO7mCfKkW/8oBxHwgTqJ1aD7zDrcCC0Nb+SLWSvCR3RDaKgIO3P8w==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -4926,7 +4927,7 @@
                 "node": ">=12.0.0"
             },
             "peerDependencies": {
-                "protobufjs": ">=7.5.6 <8"
+                "protobufjs": "^7.6.2"
             }
         },
         "node_modules/protobufjs-cli/node_modules/brace-expansion": {
@@ -5831,6 +5832,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -5987,6 +5989,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/node/package.json
+++ b/node/package.json
@@ -95,7 +95,7 @@
         "lint-staged": "16",
         "jest": "29",
         "jest-html-reporter": "4",
-        "protobufjs-cli": "1",
+        "protobufjs-cli": "^1.3.2",
         "replace": "1",
         "semver": "7",
         "ts-jest": "29",


### PR DESCRIPTION
## Summary

Resolves [GHSA-pr59-h9ph-3fr8](https://github.com/advisories/GHSA-pr59-h9ph-3fr8) / CVE-2026-54271 (HIGH, CWE-94): code injection in `pbjs` static output from crafted JSON descriptor names. Patched in `protobufjs-cli` 1.3.2.

## Changes

- `node/package.json`: `protobufjs-cli` (devDependency) `"1"` → `"^1.3.2"`
- `node/package-lock.json`: `protobufjs-cli` now resolves to 1.3.3

## Risk

Build-time-only (dev) dependency. `pbjs`/`pbts` generate static code from GLIDE's own first-party `.proto` files, so the crafted-descriptor injection path is not attacker-reachable. One-line bump, taken regardless.

> **Note:** Regenerating the lockfile also advances the transitive `protobufjs` 7.6.0 → 7.6.4 (`protobufjs-cli` depends on `protobufjs`). This overlaps with the direct-dependency bump in the companion protobufjs PR — whichever merges second will need a trivial lockfile rebase.

## Verification

- `npm install` resolves cleanly.
- `npm run build-protobuf` (pbjs/pbts static codegen at 1.3.3) succeeds; `pbjs --version` confirms 1.3.3.

Clears Dependabot alert #25.