### PR TITLE
fix: suppress false-positive response-wait warnings for blocking commands

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -737,19 +737,12 @@ where
         let recv_elapsed = recv_start.elapsed();
         // For blocking commands (e.g. XREAD BLOCK, BLPOP) the client intentionally
         // waits for a server-side event, so a long receive time is expected and not
-        // indicative of a slow connection.  Use the request timeout plus a small
-        // latency margin as the threshold so transient network latency near the
-        // timeout boundary does not trigger a spurious warning; the warning then
-        // only fires when the response is genuinely late.  For non-blocking
-        // commands, keep the original heuristic (min(timeout/2, 5s)).
-        const BLOCKING_RECV_WARN_MARGIN: std::time::Duration =
-            std::time::Duration::from_millis(250);
-        let recv_warn_threshold = if is_blocking {
-            timeout.saturating_add(BLOCKING_RECV_WARN_MARGIN)
-        } else {
-            std::cmp::min(timeout / 2, std::time::Duration::from_secs(5))
-        };
-        if recv_elapsed > recv_warn_threshold {
+        // indicative of a slow connection.  Since recv_elapsed cannot exceed the
+        // request timeout, simply skip the warning for blocking commands rather than
+        // padding the threshold.  For non-blocking commands, keep the original
+        // heuristic (min(timeout/2, 5s)).
+        let recv_warn_threshold = std::cmp::min(timeout / 2, std::time::Duration::from_secs(5));
+        if !is_blocking && recv_elapsed > recv_warn_threshold {
             logger_core::log_warn_rate_limited!(
                 "pipeline",
                 5,

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -1447,7 +1447,12 @@ mod tests {
         let timeout = Duration::from_secs(2);
         let start = std::time::Instant::now();
         let result = pipeline
-            .send_single(crate::cmd("PING").get_packed_command(), timeout, false, false)
+            .send_single(
+                crate::cmd("PING").get_packed_command(),
+                timeout,
+                false,
+                false,
+            )
             .await;
         let elapsed = start.elapsed();
 
@@ -1689,7 +1694,12 @@ mod tests {
         let timeout = Duration::from_millis(200);
         let start = std::time::Instant::now();
         let result = pipeline
-            .send_single(crate::cmd("PING").get_packed_command(), timeout, false, false)
+            .send_single(
+                crate::cmd("PING").get_packed_command(),
+                timeout,
+                false,
+                false,
+            )
             .await;
         let elapsed = start.elapsed();
 
@@ -1807,8 +1817,13 @@ mod tests {
         for _ in 0..300 {
             let mut p = pipeline.clone();
             handles.push(tokio::spawn(async move {
-                p.send_single(crate::cmd("PING").get_packed_command(), timeout, false, false)
-                    .await
+                p.send_single(
+                    crate::cmd("PING").get_packed_command(),
+                    timeout,
+                    false,
+                    false,
+                )
+                .await
             }));
         }
 
@@ -1916,7 +1931,8 @@ mod tests {
             let mut p = pipeline.clone();
             let packed = packed.clone();
             handles.push(tokio::spawn(async move {
-                p.send_single(packed, Duration::from_secs(60), false, false).await
+                p.send_single(packed, Duration::from_secs(60), false, false)
+                    .await
             }));
         }
         let mut ok = 0usize;

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -737,11 +737,15 @@ where
         let recv_elapsed = recv_start.elapsed();
         // For blocking commands (e.g. XREAD BLOCK, BLPOP) the client intentionally
         // waits for a server-side event, so a long receive time is expected and not
-        // indicative of a slow connection.  Use the full timeout as the threshold so
-        // the warning only fires when the response is genuinely late.  For non-blocking
+        // indicative of a slow connection.  Use the request timeout plus a small
+        // latency margin as the threshold so transient network latency near the
+        // timeout boundary does not trigger a spurious warning; the warning then
+        // only fires when the response is genuinely late.  For non-blocking
         // commands, keep the original heuristic (min(timeout/2, 5s)).
+        const BLOCKING_RECV_WARN_MARGIN: std::time::Duration =
+            std::time::Duration::from_millis(250);
         let recv_warn_threshold = if is_blocking {
-            timeout
+            timeout.saturating_add(BLOCKING_RECV_WARN_MARGIN)
         } else {
             std::cmp::min(timeout / 2, std::time::Duration::from_secs(5))
         };

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -636,8 +636,10 @@ where
         item: SinkItem,
         timeout: Duration,
         is_fenced: bool,
+        is_blocking: bool,
     ) -> RedisResult<Value> {
-        self.send_recv(item, None, timeout, true, is_fenced).await
+        self.send_recv(item, None, timeout, true, is_fenced, is_blocking)
+            .await
     }
 
     async fn send_recv(
@@ -648,6 +650,7 @@ where
         timeout: Duration,
         is_atomic: bool,
         is_fenced: bool,
+        is_blocking: bool,
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
@@ -732,7 +735,16 @@ where
         let recv_start = std::time::Instant::now();
         let recv_result = Runtime::locate().timeout(timeout, receiver).await;
         let recv_elapsed = recv_start.elapsed();
-        let recv_warn_threshold = std::cmp::min(timeout / 2, std::time::Duration::from_secs(5));
+        // For blocking commands (e.g. XREAD BLOCK, BLPOP) the client intentionally
+        // waits for a server-side event, so a long receive time is expected and not
+        // indicative of a slow connection.  Use the full timeout as the threshold so
+        // the warning only fires when the response is genuinely late.  For non-blocking
+        // commands, keep the original heuristic (min(timeout/2, 5s)).
+        let recv_warn_threshold = if is_blocking {
+            timeout
+        } else {
+            std::cmp::min(timeout / 2, std::time::Duration::from_secs(5))
+        };
         if recv_elapsed > recv_warn_threshold {
             logger_core::log_warn_rate_limited!(
                 "pipeline",
@@ -895,7 +907,12 @@ impl MultiplexedConnection {
         let timeout = cmd.response_timeout().unwrap_or(self.response_timeout);
         let result = self
             .pipeline
-            .send_single(cmd.get_packed_command(), timeout, cmd.is_fenced())
+            .send_single(
+                cmd.get_packed_command(),
+                timeout,
+                cmd.is_fenced(),
+                cmd.is_blocking(),
+            )
             .await;
         if self.protocol != ProtocolVersion::RESP2 {
             if let Err(e) = &result {
@@ -936,6 +953,7 @@ impl MultiplexedConnection {
                 Some(offset + count),
                 self.response_timeout,
                 cmd.is_atomic(),
+                false,
                 false,
             )
             .await;
@@ -1415,6 +1433,7 @@ mod tests {
                         crate::cmd("PING").get_packed_command(),
                         Duration::from_secs(60),
                         false,
+                        false,
                     )
                     .await;
             });
@@ -1428,7 +1447,7 @@ mod tests {
         let timeout = Duration::from_secs(2);
         let start = std::time::Instant::now();
         let result = pipeline
-            .send_single(crate::cmd("PING").get_packed_command(), timeout, false)
+            .send_single(crate::cmd("PING").get_packed_command(), timeout, false, false)
             .await;
         let elapsed = start.elapsed();
 
@@ -1556,6 +1575,7 @@ mod tests {
                     crate::cmd("GET").arg("key1").get_packed_command(),
                     Duration::from_secs(5),
                     false,
+                    false,
                 )
                 .await
         });
@@ -1576,6 +1596,7 @@ mod tests {
                         .arg("value")
                         .get_packed_command(),
                     Duration::from_secs(5),
+                    false,
                     false,
                 )
                 .await
@@ -1657,6 +1678,7 @@ mod tests {
                         crate::cmd("PING").get_packed_command(),
                         Duration::from_secs(60),
                         false,
+                        false,
                     )
                     .await;
             });
@@ -1667,7 +1689,7 @@ mod tests {
         let timeout = Duration::from_millis(200);
         let start = std::time::Instant::now();
         let result = pipeline
-            .send_single(crate::cmd("PING").get_packed_command(), timeout, false)
+            .send_single(crate::cmd("PING").get_packed_command(), timeout, false, false)
             .await;
         let elapsed = start.elapsed();
 
@@ -1703,6 +1725,7 @@ mod tests {
                     crate::cmd("PING").get_packed_command(),
                     Duration::from_secs(5),
                     false,
+                    false,
                 )
                 .await
             }));
@@ -1736,6 +1759,7 @@ mod tests {
                 p.send_single(
                     crate::cmd("PING").get_packed_command(),
                     Duration::from_secs(30),
+                    false,
                     false,
                 )
                 .await
@@ -1783,7 +1807,7 @@ mod tests {
         for _ in 0..300 {
             let mut p = pipeline.clone();
             handles.push(tokio::spawn(async move {
-                p.send_single(crate::cmd("PING").get_packed_command(), timeout, false)
+                p.send_single(crate::cmd("PING").get_packed_command(), timeout, false, false)
                     .await
             }));
         }
@@ -1840,6 +1864,7 @@ mod tests {
                 crate::cmd("PING").get_packed_command(),
                 Duration::from_secs(5),
                 false,
+                false,
             )
             .await;
         let elapsed = start.elapsed();
@@ -1891,7 +1916,7 @@ mod tests {
             let mut p = pipeline.clone();
             let packed = packed.clone();
             handles.push(tokio::spawn(async move {
-                p.send_single(packed, Duration::from_secs(60), false).await
+                p.send_single(packed, Duration::from_secs(60), false, false).await
             }));
         }
         let mut ok = 0usize;
@@ -2079,6 +2104,7 @@ mod tests {
                     crate::cmd("PING").get_packed_command(),
                     Duration::from_secs(3600),
                     false,
+                    false,
                 )
                 .await
             }));
@@ -2091,6 +2117,7 @@ mod tests {
                 .send_single(
                     crate::cmd("PING").get_packed_command(),
                     Duration::from_secs(3600),
+                    false,
                     false,
                 )
                 .await

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -877,7 +877,10 @@ mod tests {
     #[test]
     fn test_is_blocking_defaults_to_false() {
         let cmd = Cmd::new();
-        assert!(!cmd.is_blocking(), "new Cmd must default to is_blocking=false");
+        assert!(
+            !cmd.is_blocking(),
+            "new Cmd must default to is_blocking=false"
+        );
     }
 
     #[test]
@@ -900,9 +903,6 @@ mod tests {
         cmd.set_is_blocking(true);
 
         let cloned = cmd.clone();
-        assert!(
-            cloned.is_blocking(),
-            "clone must preserve is_blocking=true"
-        );
+        assert!(cloned.is_blocking(), "clone must preserve is_blocking=true");
     }
 }

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -40,6 +40,11 @@ pub struct Cmd {
     span: Option<GlideSpan>,
     //  A flag indicating whether this is a fenced command  (will have PING appended to ensure ordering)
     is_fenced: bool,
+    /// Whether this is a blocking command (e.g. XREAD BLOCK, BLPOP). When true,
+    /// the response-wait warning in the multiplexed connection is suppressed for
+    /// waits that are within the blocking window, because long waits are expected
+    /// and not indicative of a slow connection.
+    is_blocking: bool,
     /// Per-command response timeout. When set, overrides the connection-level
     /// response_timeout for this specific command. Used to propagate the
     /// caller's request_timeout into the multiplexed connection layer.
@@ -68,6 +73,7 @@ impl Clone for Cmd {
             no_response: self.no_response,
             span: self.span.clone(),
             is_fenced: self.is_fenced,
+            is_blocking: self.is_blocking,
             response_timeout: self.response_timeout,
             #[cfg(feature = "cluster-async")]
             inflight_tracker: self.inflight_tracker.clone(),
@@ -397,6 +403,7 @@ impl Cmd {
             no_response: false,
             span: None,
             is_fenced: false,
+            is_blocking: false,
             response_timeout: None,
             #[cfg(feature = "cluster-async")]
             inflight_tracker: None,
@@ -414,6 +421,7 @@ impl Cmd {
             no_response: false,
             span: None,
             is_fenced: false,
+            is_blocking: false,
             response_timeout: None,
             #[cfg(feature = "cluster-async")]
             inflight_tracker: None,
@@ -712,6 +720,22 @@ impl Cmd {
         self.is_fenced
     }
 
+    /// Mark this command as blocking (e.g. XREAD BLOCK, BLPOP). Blocking
+    /// commands intentionally wait for a server event and thus have long
+    /// response times; the pipeline layer suppresses its response-wait warning
+    /// for these commands to avoid spurious noise.
+    #[inline]
+    pub fn set_is_blocking(&mut self, blocking: bool) -> &mut Cmd {
+        self.is_blocking = blocking;
+        self
+    }
+
+    /// Check whether this command is a blocking command.
+    #[inline]
+    pub fn is_blocking(&self) -> bool {
+        self.is_blocking
+    }
+
     /// Set a per-command response timeout that overrides the connection default.
     #[inline]
     pub fn set_response_timeout(&mut self, timeout: Option<std::time::Duration>) {
@@ -848,5 +872,37 @@ mod tests {
 
         cmd.set_response_timeout(None);
         assert_eq!(cmd.response_timeout(), None);
+    }
+
+    #[test]
+    fn test_is_blocking_defaults_to_false() {
+        let cmd = Cmd::new();
+        assert!(!cmd.is_blocking(), "new Cmd must default to is_blocking=false");
+    }
+
+    #[test]
+    fn test_set_is_blocking_round_trip() {
+        let mut cmd = Cmd::new();
+        cmd.arg("XREAD").arg("BLOCK").arg("5000");
+
+        assert!(!cmd.is_blocking());
+        cmd.set_is_blocking(true);
+        assert!(cmd.is_blocking());
+
+        cmd.set_is_blocking(false);
+        assert!(!cmd.is_blocking());
+    }
+
+    #[test]
+    fn test_is_blocking_preserved_on_clone() {
+        let mut cmd = Cmd::new();
+        cmd.arg("BLPOP").arg("mylist").arg("0");
+        cmd.set_is_blocking(true);
+
+        let cloned = cmd.clone();
+        assert!(
+            cloned.is_blocking(),
+            "clone must preserve is_blocking=true"
+        );
     }
 }

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1127,16 +1127,18 @@ impl Client {
                 None
             };
             let self_clone = self.clone();
+
+            // Blocking commands have artificially long latencies; exclude from tracker.
+            let is_blocking_cmd = is_blocking_command(cmd);
+            // Propagate the blocking flag into the Cmd BEFORE cloning owned_cmd so
+            // the copy that actually travels to the multiplexed connection carries
+            // it, letting that connection suppress false-positive response-wait
+            // warnings (#6283).
+            cmd.set_is_blocking(is_blocking_cmd);
             let owned_cmd = cmd.clone();
 
             // Captured by the timeout path for watchdog-informed CB decisions.
             let mut timeout_cause: Option<crate::timeout_watchdog::TimeoutCause> = None;
-
-            // Blocking commands have artificially long latencies; exclude from tracker.
-            let is_blocking_cmd = is_blocking_command(cmd);
-            // Propagate blocking flag into the Cmd so the multiplexed connection
-            // can suppress false-positive response-wait warnings (#6283).
-            cmd.set_is_blocking(is_blocking_cmd);
 
             let result = match request_timeout {
                 Some(duration) => {

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1134,6 +1134,9 @@ impl Client {
 
             // Blocking commands have artificially long latencies; exclude from tracker.
             let is_blocking_cmd = is_blocking_command(cmd);
+            // Propagate blocking flag into the Cmd so the multiplexed connection
+            // can suppress false-positive response-wait warnings (#6283).
+            cmd.set_is_blocking(is_blocking_cmd);
 
             let result = match request_timeout {
                 Some(duration) => {


### PR DESCRIPTION
## Summary

- Adds `is_blocking: bool` field to `Cmd` with `set_is_blocking()` / `is_blocking()` accessors
- In `glide-core/src/client/mod.rs`, propagates the existing `is_blocking_command()` result into the `Cmd` before dispatch
- In `multiplexed_connection.rs`, threads `is_blocking` through `send_single` → `send_recv`: when true, sets `recv_warn_threshold = timeout` instead of `min(timeout/2, 5s)`

## Why this matters

Closes #6283. Blocking commands (XREAD BLOCK, BLPOP, BRPOP, etc.) intentionally wait for a server-side event. The existing `recv_warn_threshold = min(timeout/2, 5s)` fires a `WARN pipeline - Response wait took …` on every blocking call that waits longer than that threshold — for `BLOCK 5000` that is ~2.75 s, so the warning fires reliably for any modestly-loaded stream consumer. The warning was designed to catch genuinely slow non-blocking commands. A maintainer (@xShinnRyuu) confirmed the diagnosis and explicitly invited a PR.

For blocking commands the threshold is now set to `timeout`, meaning the warning only fires if the response arrives *after* the full request timeout — which indicates a genuine anomaly rather than expected blocking behavior. Non-blocking commands retain the original `min(timeout/2, 5s)` heuristic unchanged.

## Testing

- Unit tests in `cmd.rs`: default `is_blocking()` is false, round-trip `set_is_blocking()`, preserved on clone
- All existing `multiplexed_connection.rs` pipeline tests pass (`cargo test --lib -- tests`: 275 passed)
- `cargo fmt --check` and `cargo build` clean on `glide-core`

Fixes #6283
