### PR TITLE
Core: Client Connection Pooling Prototype

### DIFF
--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -746,6 +746,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1074,6 +1087,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
+ "dashmap 5.5.3",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -1107,6 +1121,7 @@ dependencies = [
 name = "glide-ffi"
 version = "0.1.0"
 dependencies = [
+ "dashmap 5.5.3",
  "glide-core",
  "lazy_static",
  "libc",
@@ -2206,7 +2221,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.1.0",
  "dispose",
  "futures",
  "futures-util",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
 libc = "0.2"
+dashmap = "5"
 protobuf = { version = "3", features = [] }
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }
 glide-core = { path = "../glide-core", features = ["proto"] }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5462,6 +5462,16 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
     match pool_arc.try_lock() {
         Ok(mut pool) => {
             let result = pool.try_acquire();
+
+            // Record OTel metrics for pool hit/miss
+            if result >= 0 {
+                // Pool hit — client acquired from idle
+                let _ = GlideOpenTelemetry::record_pool_hit();
+            } else {
+                // Pool miss — no idle client available
+                let _ = GlideOpenTelemetry::record_pool_miss();
+            }
+
             if result < 0 && pool.should_create() {
                 // Trigger background creation
                 pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5395,6 +5395,7 @@ pub unsafe extern "C" fn glide_pool_create(
         min_idle,
         idle_timeout: std::time::Duration::from_millis(idle_timeout_ms),
         request_timeout: std::time::Duration::from_millis(request_timeout_ms),
+        test_on_borrow: false,
         connection_request: connection_request.clone(),
     };
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5324,22 +5324,20 @@ fn get_pool_clients() -> &'static dashmap::DashMap<u64, PoolClientEntry> {
 fn create_pool_client_sync(
     connection_request_bytes: &[u8],
 ) -> Result<(usize, glide_core::client::Client), String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
+    // Each pooled client gets a lightweight current_thread runtime for block_on,
+    // but shares the global POOL_RUNTIME for background I/O (connection drivers,
+    // reconnection). This avoids creating N OS threads for N pooled clients.
+    let main_runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("Runtime creation failed: {}", e))?;
 
-    let bg_runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .worker_threads(1)
-        .thread_name("glide-pool-client")
-        .build()
-        .map_err(|e| format!("BG runtime creation failed: {}", e))?;
+    let shared_bg = get_pool_runtime();
 
-    // Parse and create client on background runtime
+    // Create client on the shared background runtime
     let client = {
-        let _guard = bg_runtime.enter();
-        bg_runtime.block_on(async {
+        let _guard = shared_bg.enter();
+        shared_bg.block_on(async {
             let proto = glide_core::connection_request::ConnectionRequest::parse_from_bytes(
                 connection_request_bytes,
             )
@@ -5351,15 +5349,28 @@ fn create_pool_client_sync(
         })?
     };
 
-    // Build ClientAdapter (sync mode: current_thread main + multi_thread background)
+    // Build ClientAdapter: current_thread for block_on, shared bg for I/O.
+    // Note: background_runtime is None — the shared POOL_RUNTIME handles
+    // spawned tasks. The SyncClient execute_request enters the bg context
+    // via the pool runtime handle stored separately.
     let core = Arc::new(CommandExecutionCore {
         client: client.clone(),
         client_type: ClientType::SyncClient,
     });
+    // For sync dispatch to work correctly, we need a background_runtime ref
+    // so execute_request can enter its context during block_on.
+    // Clone the pool runtime's handle into a dedicated wrapper.
+    let bg_handle = shared_bg.handle().clone();
+    let bg_wrapper = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(0) // No actual threads — we just need the Handle
+        .build()
+        .ok(); // Fallback: if this fails, sync dispatch still works without bg context
+
     let adapter = Arc::new(ClientAdapter {
-        runtime,
+        runtime: main_runtime,
         pipe_client_id: std::sync::atomic::AtomicU64::new(0),
-        background_runtime: Some(bg_runtime),
+        background_runtime: bg_wrapper,
         core,
         pubsub_callback: Arc::new(std::sync::RwLock::new(None)),
     });
@@ -5461,14 +5472,18 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
 
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let result = pool.try_acquire();
+            let mut evicted = Vec::new();
+            let result = pool.try_acquire(&mut evicted);
+
+            // Clean up evicted entries from POOL_CLIENTS
+            for evicted_id in &evicted {
+                get_pool_clients().remove(evicted_id);
+            }
 
             // Record OTel metrics for pool hit/miss
             if result >= 0 {
-                // Pool hit — client acquired from idle
                 let _ = GlideOpenTelemetry::record_pool_hit();
             } else {
-                // Pool miss — no idle client available
                 let _ = GlideOpenTelemetry::record_pool_miss();
             }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5461,7 +5461,7 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
     match pool_arc.try_lock() {
         Ok(mut pool) => {
             let result = pool.try_acquire();
-            if result == -1 && pool.should_create() {
+            if result < 0 && pool.should_create() {
                 // Trigger background creation
                 pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);
                 let pool_clone = pool_arc.clone();

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5277,3 +5277,334 @@ pub unsafe extern "C-unwind" fn close_monitor_client(client_ptr: *const c_void) 
         let _ = unsafe { Box::from_raw(client_ptr as *mut MonitorAdapter) };
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CLIENT-INSTANCE POOL FFI (Feature 1)
+//
+// These functions expose glide-core's ClientPool to all language bindings.
+// The pool manages GlideClient lifecycle (creation, LIFO reuse, bounded size).
+// Language bindings call these via their FFI mechanism (CFFI, Ruby FFI, JNI, CGO).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+use glide_core::pool::{self, ClientPool, ClientState, PoolConfig, PooledClient, POOL_RUNNING};
+use std::sync::atomic::Ordering as AtomicOrdering;
+
+/// Shared Tokio runtime for pool background operations (client creation, eviction).
+/// All pooled clients share this runtime rather than each getting their own.
+static POOL_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+
+/// Maps client_id → (ClientAdapter raw pointer, PooledClient).
+/// When a client is acquired, the entry moves here. On release, it moves back to pool.idle.
+static POOL_CLIENTS: std::sync::OnceLock<dashmap::DashMap<u64, PoolClientEntry>> =
+    std::sync::OnceLock::new();
+
+struct PoolClientEntry {
+    adapter_ptr: usize,  // *const ClientAdapter as usize (for command dispatch)
+    client: glide_core::client::Client,
+    created_at: std::time::Instant,
+}
+
+fn get_pool_runtime() -> &'static tokio::runtime::Runtime {
+    POOL_RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("glide-pool")
+            .build()
+            .expect("Failed to create pool runtime")
+    })
+}
+
+fn get_pool_clients() -> &'static dashmap::DashMap<u64, PoolClientEntry> {
+    POOL_CLIENTS.get_or_init(dashmap::DashMap::new)
+}
+
+/// Create a GlideClient + ClientAdapter for the pool.
+/// Runs on a dedicated thread (not inside an existing runtime) to avoid nesting.
+fn create_pool_client_sync(
+    connection_request_bytes: &[u8],
+) -> Result<(usize, glide_core::client::Client), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Runtime creation failed: {}", e))?;
+
+    let bg_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(1)
+        .thread_name("glide-pool-client")
+        .build()
+        .map_err(|e| format!("BG runtime creation failed: {}", e))?;
+
+    // Parse and create client on background runtime
+    let client = {
+        let _guard = bg_runtime.enter();
+        bg_runtime.block_on(async {
+            let proto = glide_core::connection_request::ConnectionRequest::parse_from_bytes(
+                connection_request_bytes,
+            )
+            .map_err(|e| format!("Protobuf parse error: {}", e))?;
+            let req = glide_core::client::ConnectionRequest::from(proto);
+            glide_core::client::Client::new(req, None)
+                .await
+                .map_err(|e| format!("Client creation failed: {}", e))
+        })?
+    };
+
+    // Build ClientAdapter (sync mode: current_thread main + multi_thread background)
+    let core = Arc::new(CommandExecutionCore {
+        client: client.clone(),
+        client_type: ClientType::SyncClient,
+    });
+    let adapter = Arc::new(ClientAdapter {
+        runtime,
+        pipe_client_id: std::sync::atomic::AtomicU64::new(0),
+        background_runtime: Some(bg_runtime),
+        core,
+        pubsub_callback: Arc::new(std::sync::RwLock::new(None)),
+    });
+    let ptr = Arc::into_raw(adapter) as usize;
+
+    Ok((ptr, client))
+}
+
+/// Create a new client-instance pool.
+///
+/// Spawns `min_idle` background client creation tasks. Returns pool_id (positive)
+/// on success, -1 on invalid config, -2 on other errors.
+///
+/// # Safety
+/// `connection_request_ptr` must point to `connection_request_len` valid bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn glide_pool_create(
+    max_size: u32,
+    min_idle: u32,
+    idle_timeout_ms: u64,
+    request_timeout_ms: u64,
+    connection_request_ptr: *const u8,
+    connection_request_len: usize,
+) -> i64 {
+    let connection_request = if connection_request_ptr.is_null() || connection_request_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(connection_request_ptr, connection_request_len) }.to_vec()
+    };
+
+    let config = PoolConfig {
+        max_size,
+        min_idle,
+        idle_timeout: std::time::Duration::from_millis(idle_timeout_ms),
+        request_timeout: std::time::Duration::from_millis(request_timeout_ms),
+        connection_request: connection_request.clone(),
+    };
+
+    let pool = match ClientPool::new(config) {
+        Ok(p) => p,
+        Err(_) => return -1,
+    };
+
+    let pool_id = pool::register_pool(pool);
+
+    // Spawn min_idle background client creation
+    if min_idle > 0 {
+        let pool_arc = pool::get_pool(pool_id).unwrap();
+        for _ in 0..min_idle {
+            let pool_clone = pool_arc.clone();
+            let bytes = connection_request.clone();
+            std::thread::spawn(move || {
+                match create_pool_client_sync(&bytes) {
+                    Ok((adapter_ptr, client)) => {
+                        let rt = get_pool_runtime();
+                        rt.block_on(async {
+                            let mut pool = pool_clone.lock().await;
+                            if pool.state.load(AtomicOrdering::Acquire) != POOL_RUNNING {
+                                return;
+                            }
+                            let client_id = pool.next_id();
+                            let entry = PooledClient {
+                                client_id,
+                                client: client.clone(),
+                                created_at: std::time::Instant::now(),
+                                last_idle_at: std::time::Instant::now(),
+                                borrowed_at: None,
+                                state: ClientState::Idle,
+                            };
+                            pool.idle.push_back(entry);
+                            pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);
+                            // Store adapter mapping
+                            get_pool_clients().insert(client_id, PoolClientEntry {
+                                adapter_ptr,
+                                client,
+                                created_at: std::time::Instant::now(),
+                            });
+                        });
+                    }
+                    Err(e) => {
+                        logger_core::log_error_lazy!("pool", format!("Background client creation failed: {}", e));
+                    }
+                }
+            });
+        }
+    }
+
+    pool_id as i64
+}
+
+/// Non-blocking acquire. Returns client_id >= 0, -1 if exhausted, -2 if invalid pool.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
+    let pool_arc = match pool::get_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -2,
+    };
+
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let result = pool.try_acquire();
+            if result == -1 && pool.should_create() {
+                // Trigger background creation
+                pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);
+                let pool_clone = pool_arc.clone();
+                let bytes = pool.config.connection_request.clone();
+                drop(pool);
+                std::thread::spawn(move || {
+                    match create_pool_client_sync(&bytes) {
+                        Ok((adapter_ptr, client)) => {
+                            let rt = get_pool_runtime();
+                            rt.block_on(async {
+                                let mut pool = pool_clone.lock().await;
+                                if pool.state.load(AtomicOrdering::Acquire) != POOL_RUNNING {
+                                    pool.total_count.fetch_sub(1, AtomicOrdering::AcqRel);
+                                    return;
+                                }
+                                let client_id = pool.next_id();
+                                let entry = PooledClient {
+                                    client_id,
+                                    client: client.clone(),
+                                    created_at: std::time::Instant::now(),
+                                    last_idle_at: std::time::Instant::now(),
+                                    borrowed_at: None,
+                                    state: ClientState::Idle,
+                                };
+                                pool.idle.push_back(entry);
+                                get_pool_clients().insert(client_id, PoolClientEntry {
+                                    adapter_ptr,
+                                    client,
+                                    created_at: std::time::Instant::now(),
+                                });
+                            });
+                        }
+                        Err(e) => {
+                            logger_core::log_error_lazy!("pool", format!("Background creation failed: {}", e));
+                            let rt = get_pool_runtime();
+                            rt.block_on(async {
+                                let pool = pool_clone.lock().await;
+                                pool.total_count.fetch_sub(1, AtomicOrdering::AcqRel);
+                            });
+                        }
+                    }
+                });
+            }
+            result
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Release a borrowed client back to the pool. Fire-and-forget.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_release(pool_id: u64, client_id: u64) -> i32 {
+    let pool_arc = match pool::get_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+
+    // Get the client entry to return to pool
+    let entry = get_pool_clients().get(&client_id);
+    let Some(entry) = entry else { return -1; };
+    let client = entry.client.clone();
+    let created_at = entry.created_at;
+    drop(entry);
+
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let pooled = PooledClient {
+                client_id,
+                client,
+                created_at,
+                last_idle_at: std::time::Instant::now(),
+                borrowed_at: None,
+                state: ClientState::Idle,
+            };
+            pool.release(client_id, pooled);
+            0
+        }
+        Err(_) => {
+            // Lock contended — async release
+            let pool_clone = pool_arc.clone();
+            let rt = get_pool_runtime();
+            rt.spawn(async move {
+                let mut pool = pool_clone.lock().await;
+                let pooled = PooledClient {
+                    client_id,
+                    client,
+                    created_at,
+                    last_idle_at: std::time::Instant::now(),
+                    borrowed_at: None,
+                    state: ClientState::Idle,
+                };
+                pool.release(client_id, pooled);
+            });
+            0
+        }
+    }
+}
+
+/// Destroy a pool.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_destroy(pool_id: u64) -> i32 {
+    let pool_arc = match pool::unregister_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+    if let Ok(mut pool) = pool_arc.try_lock() {
+        pool.destroy();
+    }
+    0
+}
+
+/// Get the ClientAdapter pointer for a borrowed client_id.
+/// Language bindings pass this to `command()` for dispatch.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_get_client_ptr(client_id: u64) -> usize {
+    get_pool_clients()
+        .get(&client_id)
+        .map(|e| e.adapter_ptr)
+        .unwrap_or(0)
+}
+
+/// Query pool metrics. Writes idle/active/total to out pointers.
+///
+/// # Safety
+/// Out pointers must be valid for writing a u32.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn glide_pool_metrics(
+    pool_id: u64,
+    idle_out: *mut u32,
+    active_out: *mut u32,
+    total_out: *mut u32,
+) -> i32 {
+    let pool_arc = match pool::get_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+    match pool_arc.try_lock() {
+        Ok(pool) => {
+            if !idle_out.is_null() { unsafe { *idle_out = pool.idle_count(); } }
+            if !active_out.is_null() { unsafe { *active_out = pool.active_count(); } }
+            if !total_out.is_null() { unsafe { *total_out = pool.total_count.load(AtomicOrdering::Acquire); } }
+            0
+        }
+        Err(_) => -1,
+    }
+}

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -932,6 +932,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1319,6 +1332,7 @@ dependencies = [
  "bytes",
  "criterion",
  "ctor",
+ "dashmap 5.5.3",
  "directories",
  "futures",
  "futures-intrusive",
@@ -2620,7 +2634,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.2.1",
  "dispose",
  "futures",
  "futures-util",

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Valkey GLIDE Maintainers"]
 [dependencies]
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 bytes = "1"
+dashmap = "5"
 futures = "^0.3"
 redis = { path = "./redis-rs/redis", features = [
     "aio",

--- a/glide-core/src/lib.rs
+++ b/glide-core/src/lib.rs
@@ -4,6 +4,7 @@
 include!("generated/mod.rs");
 pub mod client;
 pub mod otel_db_semantics;
+pub mod pool;
 #[cfg(feature = "socket-layer")]
 pub mod rotating_buffer;
 #[cfg(feature = "socket-layer")]

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -62,6 +62,8 @@ pub struct PoolConfig {
     pub idle_timeout: Duration,
     /// Request timeout (used for cleanup: 2×).
     pub request_timeout: Duration,
+    /// Send PING on borrow to verify connection health. Default: false.
+    pub test_on_borrow: bool,
     /// Serialized protobuf ConnectionRequest for background client creation.
     pub connection_request: Vec<u8>,
 }

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -1,0 +1,257 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//! Client-Instance Pool (RFC #5815 Feature 1)
+//!
+//! A shared, cross-language connection pool that manages `GlideClient` instances.
+//! Callers borrow a client via `try_acquire`, use it for commands, and return it
+//! via `release`. The pool handles creation, LIFO reuse, bounded size, background
+//! creation, and idle eviction.
+//!
+//! This module lives in `glide-core` so all language bindings (Java JNI, Python CFFI,
+//! Ruby FFI, Go CGO, Node N-API) share the same Rust implementation.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Language Binding (Java/Python/Ruby/Go/Node)
+//!     │
+//!     ▼ FFI calls (glide_pool_create, try_acquire, release, destroy)
+//! ┌─────────────────────────────────────┐
+//! │  glide-core::pool                   │
+//! │  ┌─────────────────────────────┐    │
+//! │  │ Pool Registry (DashMap)     │    │
+//! │  │  pool_id → Arc<Mutex<Pool>> │    │
+//! │  └─────────────────────────────┘    │
+//! │  ┌─────────────────────────────┐    │
+//! │  │ ClientPool                  │    │
+//! │  │  idle: VecDeque (LIFO)      │    │
+//! │  │  in_use: DashMap            │    │
+//! │  │  config: PoolConfig         │    │
+//! │  └─────────────────────────────┘    │
+//! └─────────────────────────────────────┘
+//! ```
+
+use crate::client::Client as GlideClient;
+use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex as TokioMutex;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POOL STATES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub const POOL_RUNNING: u8 = 0;
+pub const POOL_CLOSING: u8 = 1;
+pub const POOL_CLOSED: u8 = 2;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CONFIGURATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Configuration for a client-instance pool.
+pub struct PoolConfig {
+    /// Maximum number of clients. Must be >= 1.
+    pub max_size: u32,
+    /// Minimum idle clients to pre-warm at creation. Must be <= max_size.
+    pub min_idle: u32,
+    /// Evict idle clients after this duration.
+    pub idle_timeout: Duration,
+    /// Request timeout (used for cleanup: 2×).
+    pub request_timeout: Duration,
+    /// Serialized protobuf ConnectionRequest for background client creation.
+    pub connection_request: Vec<u8>,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POOLED CLIENT ENTRY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Lifecycle state of a pooled client.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ClientState {
+    Idle,
+    InUse,
+}
+
+/// A client managed by the pool.
+pub struct PooledClient {
+    /// Unique ID for this client (used as the handle returned to language bindings).
+    pub client_id: u64,
+    /// The actual Valkey connection.
+    pub client: GlideClient,
+    /// When this client was created.
+    pub created_at: Instant,
+    /// When last returned to idle.
+    pub last_idle_at: Instant,
+    /// When borrowed (for leak detection).
+    pub borrowed_at: Option<Instant>,
+    /// Current state.
+    pub state: ClientState,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CLIENT POOL
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// The client-instance pool. Thread-safe via TokioMutex at the registry level.
+pub struct ClientPool {
+    pub config: PoolConfig,
+    /// LIFO idle stack — most recently returned client is at the back.
+    pub idle: VecDeque<PooledClient>,
+    /// Currently borrowed clients (client_id → placeholder for tracking).
+    pub in_use: DashMap<u64, ()>,
+    /// Counter for unique client_id generation.
+    next_client_id: AtomicU64,
+    /// Current total count (idle + in_use + creating).
+    pub total_count: AtomicU32,
+    /// Pool lifecycle state.
+    pub state: AtomicU8,
+}
+
+impl ClientPool {
+    /// Create a new pool with validated config.
+    pub fn new(config: PoolConfig) -> Result<Self, PoolError> {
+        if config.max_size < 1 {
+            return Err(PoolError::InvalidConfig("max_size must be >= 1".into()));
+        }
+        if config.min_idle > config.max_size {
+            return Err(PoolError::InvalidConfig("min_idle must be <= max_size".into()));
+        }
+        if config.idle_timeout.is_zero() {
+            return Err(PoolError::InvalidConfig("idle_timeout must be > 0".into()));
+        }
+
+        Ok(Self {
+            config,
+            idle: VecDeque::new(),
+            in_use: DashMap::new(),
+            next_client_id: AtomicU64::new(1),
+            total_count: AtomicU32::new(0),
+            state: AtomicU8::new(POOL_RUNNING),
+        })
+    }
+
+    /// Generate a unique client_id.
+    pub fn next_id(&self) -> u64 {
+        self.next_client_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Non-blocking acquire. Returns client_id on success, -1 if no client available.
+    pub fn try_acquire(&mut self) -> i64 {
+        if self.state.load(Ordering::Acquire) != POOL_RUNNING {
+            return -1;
+        }
+
+        // LIFO pop from idle stack
+        if let Some(mut entry) = self.idle.pop_back() {
+            let client_id = entry.client_id;
+            entry.state = ClientState::InUse;
+            entry.borrowed_at = Some(Instant::now());
+            self.in_use.insert(client_id, ());
+            // Re-store the entry — the binding layer will track it via client_id
+            // For the pool we just need to know it's in_use
+            // (The actual PooledClient is not stored in in_use DashMap to avoid
+            // double-ownership; it's tracked by client_id only)
+            return client_id as i64;
+        }
+
+        -1 // No idle client available
+    }
+
+    /// Whether background creation should be triggered (room below max_size).
+    pub fn should_create(&self) -> bool {
+        self.state.load(Ordering::Acquire) == POOL_RUNNING
+            && self.total_count.load(Ordering::Acquire) < self.config.max_size
+    }
+
+    /// Release a client back to the idle pool. Returns false if not found.
+    pub fn release(&mut self, client_id: u64, client: PooledClient) -> bool {
+        self.in_use.remove(&client_id);
+        if self.state.load(Ordering::Acquire) != POOL_RUNNING {
+            self.total_count.fetch_sub(1, Ordering::AcqRel);
+            return true;
+        }
+        let mut entry = client;
+        entry.state = ClientState::Idle;
+        entry.last_idle_at = Instant::now();
+        entry.borrowed_at = None;
+        self.idle.push_back(entry);
+        true
+    }
+
+    /// Destroy the pool — drop all clients.
+    pub fn destroy(&mut self) {
+        self.state.store(POOL_CLOSED, Ordering::Release);
+        self.idle.clear();
+        let keys: Vec<u64> = self.in_use.iter().map(|e| *e.key()).collect();
+        for key in keys {
+            self.in_use.remove(&key);
+        }
+        self.total_count.store(0, Ordering::Release);
+    }
+
+    /// Get idle count.
+    pub fn idle_count(&self) -> u32 {
+        self.idle.len() as u32
+    }
+
+    /// Get active (in-use) count.
+    pub fn active_count(&self) -> u32 {
+        self.in_use.len() as u32
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GLOBAL REGISTRY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Global pool registry: pool_id → Pool instance.
+static POOL_REGISTRY: OnceLock<DashMap<u64, Arc<TokioMutex<ClientPool>>>> = OnceLock::new();
+static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
+
+pub fn get_pool_registry() -> &'static DashMap<u64, Arc<TokioMutex<ClientPool>>> {
+    POOL_REGISTRY.get_or_init(DashMap::new)
+}
+
+/// Register a pool. Returns assigned pool_id.
+pub fn register_pool(pool: ClientPool) -> u64 {
+    let pool_id = NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed);
+    get_pool_registry().insert(pool_id, Arc::new(TokioMutex::new(pool)));
+    pool_id
+}
+
+/// Get a pool by ID (cheap Arc clone).
+pub fn get_pool(pool_id: u64) -> Option<Arc<TokioMutex<ClientPool>>> {
+    get_pool_registry().get(&pool_id).map(|e| e.value().clone())
+}
+
+/// Remove a pool from the registry.
+pub fn unregister_pool(pool_id: u64) -> Option<Arc<TokioMutex<ClientPool>>> {
+    get_pool_registry().remove(&pool_id).map(|(_, v)| v)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ERRORS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug)]
+pub enum PoolError {
+    InvalidConfig(String),
+    PoolClosed,
+    ClientCreationFailed(String),
+}
+
+impl std::fmt::Display for PoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PoolError::InvalidConfig(msg) => write!(f, "Invalid pool config: {}", msg),
+            PoolError::PoolClosed => write!(f, "Pool is closed"),
+            PoolError::ClientCreationFailed(msg) => write!(f, "Client creation failed: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PoolError {}

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -141,13 +141,20 @@ impl ClientPool {
 
     /// Non-blocking acquire. Returns client_id on success.
     /// Returns -1 if pool is closed/closing, -3 if no idle client available.
-    pub fn try_acquire(&mut self) -> i64 {
+    /// Evicts idle connections past idle_timeout before returning.
+    /// Evicted client_ids are appended to `evicted` for caller cleanup.
+    pub fn try_acquire(&mut self, evicted: &mut Vec<u64>) -> i64 {
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
-            return -1; // Pool not running
+            return -1;
         }
 
-        // LIFO pop from idle stack
-        if let Some(mut entry) = self.idle.pop_back() {
+        while let Some(mut entry) = self.idle.pop_back() {
+            let idle_duration = Instant::now().duration_since(entry.last_idle_at);
+            if idle_duration > self.config.idle_timeout {
+                evicted.push(entry.client_id);
+                self.total_count.fetch_sub(1, Ordering::AcqRel);
+                continue;
+            }
             let client_id = entry.client_id;
             entry.state = ClientState::InUse;
             entry.borrowed_at = Some(Instant::now());
@@ -155,7 +162,7 @@ impl ClientPool {
             return client_id as i64;
         }
 
-        -3 // No idle client available (distinct from -1=closed, -2=invalid pool)
+        -3
     }
 
     /// Whether background creation should be triggered (room below max_size).

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -4,8 +4,9 @@
 //!
 //! A shared, cross-language connection pool that manages `GlideClient` instances.
 //! Callers borrow a client via `try_acquire`, use it for commands, and return it
-//! via `release`. The pool handles creation, LIFO reuse, bounded size, background
-//! creation, and idle eviction.
+//! via `release`. The pool handles LIFO reuse and bounded size; background creation
+//! is implemented by the embedding FFI/JNI layer. Idle eviction and health checks
+//! are deferred to follow-up work.
 //!
 //! This module lives in `glide-core` so all language bindings (Java JNI, Python CFFI,
 //! Ruby FFI, Go CGO, Node N-API) share the same Rust implementation.
@@ -103,8 +104,6 @@ pub struct ClientPool {
     pub idle: VecDeque<PooledClient>,
     /// Currently borrowed clients (client_id → placeholder for tracking).
     pub in_use: DashMap<u64, ()>,
-    /// Counter for unique client_id generation.
-    next_client_id: AtomicU64,
     /// Current total count (idle + in_use + creating).
     pub total_count: AtomicU32,
     /// Pool lifecycle state.
@@ -128,21 +127,21 @@ impl ClientPool {
             config,
             idle: VecDeque::new(),
             in_use: DashMap::new(),
-            next_client_id: AtomicU64::new(1),
             total_count: AtomicU32::new(0),
             state: AtomicU8::new(POOL_RUNNING),
         })
     }
 
-    /// Generate a unique client_id.
+    /// Generate a globally unique client_id (unique across all pools).
     pub fn next_id(&self) -> u64 {
-        self.next_client_id.fetch_add(1, Ordering::Relaxed)
+        NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Non-blocking acquire. Returns client_id on success, -1 if no client available.
+    /// Non-blocking acquire. Returns client_id on success.
+    /// Returns -1 if pool is closed/closing, -3 if no idle client available.
     pub fn try_acquire(&mut self) -> i64 {
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
-            return -1;
+            return -1; // Pool not running
         }
 
         // LIFO pop from idle stack
@@ -151,14 +150,10 @@ impl ClientPool {
             entry.state = ClientState::InUse;
             entry.borrowed_at = Some(Instant::now());
             self.in_use.insert(client_id, ());
-            // Re-store the entry — the binding layer will track it via client_id
-            // For the pool we just need to know it's in_use
-            // (The actual PooledClient is not stored in in_use DashMap to avoid
-            // double-ownership; it's tracked by client_id only)
             return client_id as i64;
         }
 
-        -1 // No idle client available
+        -3 // No idle client available (distinct from -1=closed, -2=invalid pool)
     }
 
     /// Whether background creation should be triggered (room below max_size).
@@ -211,6 +206,8 @@ impl ClientPool {
 /// Global pool registry: pool_id → Pool instance.
 static POOL_REGISTRY: OnceLock<DashMap<u64, Arc<TokioMutex<ClientPool>>>> = OnceLock::new();
 static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
+/// Global client_id allocator — ensures uniqueness across all pools.
+static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 
 pub fn get_pool_registry() -> &'static DashMap<u64, Arc<TokioMutex<ClientPool>>> {
     POOL_REGISTRY.get_or_init(DashMap::new)

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -609,6 +609,8 @@ static MOVED_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock:
 static SUBSCRIPTION_OUT_OF_SYNC_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> =
     OnceLock::new();
 static SUBSCRIPTION_LAST_SYNC_GAUGE: OnceLock<opentelemetry::metrics::Gauge<u64>> = OnceLock::new();
+static POOL_HIT_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
+static POOL_MISS_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
 
 /// Singleton instance of GlideOpenTelemetry. Ensures that telemetry setup happens only once across the application.
 static OTEL: OnceCell<RwLock<GlideOpenTelemetry>> = OnceCell::new();
@@ -986,6 +988,24 @@ impl GlideOpenTelemetry {
                 )
             })?;
 
+        // Pool hit counter
+        let _ = POOL_HIT_COUNTER.set(
+            meter
+                .u64_counter("glide.pool.hits")
+                .with_description("Number of pool acquire hits (client found in idle)")
+                .with_unit("1")
+                .build(),
+        );
+
+        // Pool miss counter
+        let _ = POOL_MISS_COUNTER.set(
+            meter
+                .u64_counter("glide.pool.misses")
+                .with_description("Number of pool acquire misses (no idle client)")
+                .with_unit("1")
+                .build(),
+        );
+
         Ok(())
     }
 
@@ -1055,6 +1075,26 @@ impl GlideOpenTelemetry {
                     )
                 })?
                 .add(1, &[]);
+        }
+        Ok(())
+    }
+
+    /// Record a pool acquire hit (client found in idle list).
+    pub fn record_pool_hit() -> Result<(), GlideOTELError> {
+        if GlideOpenTelemetry::is_initialized() {
+            if let Some(counter) = POOL_HIT_COUNTER.get() {
+                counter.add(1, &[]);
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a pool acquire miss (no idle client available).
+    pub fn record_pool_miss() -> Result<(), GlideOTELError> {
+        if GlideOpenTelemetry::is_initialized() {
+            if let Some(counter) = POOL_MISS_COUNTER.get() {
+                counter.add(1, &[]);
+            }
         }
         Ok(())
     }

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -746,6 +746,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1068,6 +1081,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
+ "dashmap 5.5.3",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -1103,7 +1117,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "dashmap",
+ "dashmap 6.2.1",
  "glide-core",
  "jni",
  "log",
@@ -2195,7 +2209,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.2.1",
  "dispose",
  "futures",
  "futures-util",

--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -106,6 +106,44 @@ public class GlideClient extends BaseClient
     }
 
     /**
+     * Creates a GlideClient that wraps an existing native handle from the pool.
+     *
+     * <p>The pool's Rust side creates the actual connection and registers it in
+     * the JNI handle table. This factory wires up the Java command dispatch chain
+     * so that commands flow through the existing native bridge.
+     *
+     * @param nativeHandle the native client handle (same as client_id from pool)
+     * @param maxInflight max inflight requests (0 = use core defaults)
+     * @param requestTimeoutMs request timeout in ms (0 = no Java-side timeout)
+     * @return a fully-functional GlideClient backed by the pool connection
+     */
+    public static GlideClient fromPoolHandle(long nativeHandle, int maxInflight, long requestTimeoutMs) {
+        glide.internal.GlideCoreClient coreClient =
+                new glide.internal.GlideCoreClient(nativeHandle, maxInflight, requestTimeoutMs);
+        glide.managers.CommandManager commandManager = new glide.managers.CommandManager(coreClient);
+        glide.managers.ConnectionManager connectionManager = new glide.managers.ConnectionManager();
+        glide.connectors.handlers.MessageHandler messageHandler =
+                new glide.connectors.handlers.MessageHandler(
+                        java.util.Optional.empty(), java.util.Optional.empty(),
+                        new glide.managers.BaseResponseResolver(pointer -> {
+                            if (pointer == null || pointer == 0) return null;
+                            return glide.ffi.resolvers.GlideValueResolver.valueFromPointer(pointer);
+                        }));
+
+        GlideClient client = new GlideClient(
+                new ClientBuilder(connectionManager, commandManager, messageHandler,
+                        java.util.Optional.empty()));
+
+        try {
+            glide.internal.GlideCoreClient.registerClient(nativeHandle, client);
+        } catch (Throwable t) {
+            // Non-fatal: push delivery won't work but commands will
+        }
+
+        return client;
+    }
+
+    /**
      * Creates a new {@link GlideClient} instance and establishes a connection to a standalone Valkey
      *
      * @param config The configuration options for the client, including server addresses,

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -116,7 +116,20 @@ public class ClientPool implements AutoCloseable {
                 }
 
                 long clientId = GlidePoolResolver.glidePoolTryAcquire(poolId);
-                if (clientId >= 0) return clientId;
+                if (clientId >= 0) {
+                    // test_on_borrow: PING to verify connection health
+                    if (config.isTestOnBorrow()) {
+                        try {
+                            GlideClient client = getClient(clientId);
+                            client.ping().get(2, java.util.concurrent.TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            // Dead connection — release and retry
+                            release(clientId);
+                            continue;
+                        }
+                    }
+                    return clientId;
+                }
                 if (clientId == -2) throw new RuntimeException("Pool was destroyed");
 
                 long remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000;
@@ -137,6 +150,10 @@ public class ClientPool implements AutoCloseable {
     /**
      * Get a usable GlideClient for the given client_id.
      * Cached — no allocation on subsequent calls for the same client_id.
+     *
+     * <p><b>Important:</b> Do NOT call {@code close()} on the returned client.
+     * The pool manages the client's lifecycle. Call {@link #release(long)} instead
+     * to return the client to the pool.
      */
     public GlideClient getClient(long clientId) {
         GlideClient cached = clientCache.get(clientId);

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -85,23 +85,22 @@ public class ClientPool implements AutoCloseable {
     }
 
     /**
-     * Acquire a client_id from the pool with default timeout.
-     *
-     * @return CompletableFuture resolving to a client_id
+     * Acquire a pooled client with default timeout. Returns a pool-aware wrapper
+     * that returns the client to the pool on close() (try-with-resources safe).
      */
-    public CompletableFuture<Long> acquire() {
+    public CompletableFuture<PooledGlideClient> acquire() {
         return acquire(config.getAcquireTimeout());
     }
 
     /**
-     * Acquire a client_id with custom timeout. Retries with exponential backoff.
+     * Acquire a pooled client with custom timeout. Retries with exponential backoff.
      *
-     * @param timeout max wait time
-     * @return CompletableFuture resolving to a client_id
+     * <p>The returned {@link PooledGlideClient} implements AutoCloseable — its close()
+     * returns the client to the pool instead of destroying the native connection.
      */
-    public CompletableFuture<Long> acquire(Duration timeout) {
+    public CompletableFuture<PooledGlideClient> acquire(Duration timeout) {
         if (state.get() != RUNNING) {
-            CompletableFuture<Long> f = new CompletableFuture<>();
+            CompletableFuture<PooledGlideClient> f = new CompletableFuture<>();
             f.completeExceptionally(new ClosingException("Pool is closed"));
             return f;
         }
@@ -128,7 +127,7 @@ public class ClientPool implements AutoCloseable {
                             continue;
                         }
                     }
-                    return clientId;
+                    return new PooledGlideClient(getClient(clientId), ClientPool.this, clientId);
                 }
                 if (clientId == -2) throw new RuntimeException("Pool was destroyed");
 

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -3,6 +3,7 @@ package glide.api.models.pool;
 
 import static connection_request.ConnectionRequestOuterClass.*;
 
+import glide.api.GlideClient;
 import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.BaseClientConfiguration;
 import glide.api.models.configuration.GlideClusterClientConfiguration;
@@ -47,6 +48,8 @@ public class ClientPool implements AutoCloseable {
     private final long poolId;
     private final ClientPoolConfig config;
     private final AtomicInteger state = new AtomicInteger(RUNNING);
+    private final java.util.concurrent.ConcurrentHashMap<Long, GlideClient> clientCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
 
     private ClientPool(long poolId, ClientPoolConfig config) {
         this.poolId = poolId;
@@ -133,14 +136,13 @@ public class ClientPool implements AutoCloseable {
 
     /**
      * Get a usable GlideClient for the given client_id.
-     *
-     * TODO: Requires GlideClient.fromPoolHandle() factory method to wrap
-     * the native handle without creating a new connection. For now, callers
-     * can use the client_id directly with low-level JNI dispatch.
+     * Cached — no allocation on subsequent calls for the same client_id.
      */
-    public Object getClient(long clientId) {
-        throw new UnsupportedOperationException(
-                "getClient() requires GlideClient.fromPoolHandle() — use low-level dispatch for now");
+    public GlideClient getClient(long clientId) {
+        GlideClient cached = clientCache.get(clientId);
+        if (cached != null) return cached;
+        return clientCache.computeIfAbsent(clientId,
+                id -> GlideClient.fromPoolHandle(id, 0, config.getRequestTimeout().toMillis()));
     }
 
     /** Release a client back to the pool. */
@@ -172,6 +174,7 @@ public class ClientPool implements AutoCloseable {
     public void close() {
         if (state.compareAndSet(RUNNING, CLOSED)) {
             GlidePoolResolver.glidePoolDestroy(poolId);
+            clientCache.clear();
         }
     }
 

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -1,0 +1,237 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.pool;
+
+import static connection_request.ConnectionRequestOuterClass.*;
+
+import glide.api.models.configuration.BackoffStrategy;
+import glide.api.models.configuration.BaseClientConfiguration;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.ServerCredentials;
+import glide.api.models.exceptions.ClosingException;
+import glide.ffi.resolvers.GlidePoolResolver;
+import glide.internal.GlideNativeBridge;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Client-instance pool backed by the shared Rust core.
+ *
+ * <p>Callers borrow a client via {@link #acquire()}, use it for commands, and return
+ * it via {@link #release(long)}. The pool handles creation, LIFO reuse, bounded size,
+ * and background client creation.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * ClientPoolConfig config = ClientPoolConfig.builder()
+ *     .maxSize(10)
+ *     .minIdle(2)
+ *     .clientConfig(GlideClientConfiguration.builder()
+ *         .address(NodeAddress.builder().host("localhost").port(6379).build())
+ *         .build())
+ *     .build();
+ *
+ * ClientPool pool = ClientPool.create(config);
+ * long clientId = pool.acquire().get();
+ * GlideClient client = pool.getClient(clientId);
+ * client.set("key", "value").get();
+ * pool.release(clientId);
+ * pool.close();
+ * }</pre>
+ */
+public class ClientPool implements AutoCloseable {
+
+    private static final int RUNNING = 0;
+    private static final int CLOSED = 1;
+
+    private final long poolId;
+    private final ClientPoolConfig config;
+    private final AtomicInteger state = new AtomicInteger(RUNNING);
+
+    private ClientPool(long poolId, ClientPoolConfig config) {
+        this.poolId = poolId;
+        this.config = config;
+    }
+
+    /**
+     * Create a new pool.
+     *
+     * @param config pool configuration
+     * @return the pool (clients are created asynchronously in the background)
+     */
+    public static ClientPool create(ClientPoolConfig config) {
+        config.validate();
+        byte[] connectionRequestBytes = serializeConnectionRequest(config.getClientConfig());
+
+        long poolId = GlidePoolResolver.glidePoolCreate(
+                config.getMaxSize(),
+                config.getMinIdle(),
+                config.getIdleTimeout().toMillis(),
+                config.getRequestTimeout().toMillis(),
+                connectionRequestBytes);
+
+        if (poolId == -1) throw new IllegalArgumentException("Invalid pool configuration");
+        if (poolId < 0) throw new RuntimeException("Pool creation failed: " + poolId);
+
+        return new ClientPool(poolId, config);
+    }
+
+    /** Get the native pool handle. */
+    public long getPoolId() {
+        return poolId;
+    }
+
+    /**
+     * Acquire a client_id from the pool with default timeout.
+     *
+     * @return CompletableFuture resolving to a client_id
+     */
+    public CompletableFuture<Long> acquire() {
+        return acquire(config.getAcquireTimeout());
+    }
+
+    /**
+     * Acquire a client_id with custom timeout. Retries with exponential backoff.
+     *
+     * @param timeout max wait time
+     * @return CompletableFuture resolving to a client_id
+     */
+    public CompletableFuture<Long> acquire(Duration timeout) {
+        if (state.get() != RUNNING) {
+            CompletableFuture<Long> f = new CompletableFuture<>();
+            f.completeExceptionally(new ClosingException("Pool is closed"));
+            return f;
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            long deadlineNanos = System.nanoTime() + timeout.toNanos();
+            long backoffMs = 1;
+
+            while (System.nanoTime() < deadlineNanos) {
+                if (state.get() != RUNNING) {
+                    throw new RuntimeException(new ClosingException("Pool is closed"));
+                }
+
+                long clientId = GlidePoolResolver.glidePoolTryAcquire(poolId);
+                if (clientId >= 0) return clientId;
+                if (clientId == -2) throw new RuntimeException("Pool was destroyed");
+
+                long remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000;
+                long sleepMs = Math.min(backoffMs, Math.max(remainingMs, 0));
+                if (sleepMs <= 0) break;
+                try { Thread.sleep(sleepMs); } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Acquire interrupted", e);
+                }
+                backoffMs = Math.min(backoffMs * 2, 50);
+            }
+
+            throw new RuntimeException(new java.util.concurrent.TimeoutException(
+                    "Pool exhausted: could not acquire within " + timeout));
+        });
+    }
+
+    /**
+     * Get a usable GlideClient for the given client_id.
+     *
+     * TODO: Requires GlideClient.fromPoolHandle() factory method to wrap
+     * the native handle without creating a new connection. For now, callers
+     * can use the client_id directly with low-level JNI dispatch.
+     */
+    public Object getClient(long clientId) {
+        throw new UnsupportedOperationException(
+                "getClient() requires GlideClient.fromPoolHandle() — use low-level dispatch for now");
+    }
+
+    /** Release a client back to the pool. */
+    public void release(long clientId) {
+        GlidePoolResolver.glidePoolRelease(poolId, clientId);
+    }
+
+    /** Get pool metrics. */
+    public int[] getMetrics() {
+        return GlidePoolResolver.glidePoolMetrics(poolId);
+    }
+
+    public int getIdleCount() {
+        int[] m = getMetrics();
+        return m != null ? m[0] : 0;
+    }
+
+    public int getActiveCount() {
+        int[] m = getMetrics();
+        return m != null ? m[1] : 0;
+    }
+
+    public int getTotalCount() {
+        int[] m = getMetrics();
+        return m != null ? m[2] : 0;
+    }
+
+    @Override
+    public void close() {
+        if (state.compareAndSet(RUNNING, CLOSED)) {
+            GlidePoolResolver.glidePoolDestroy(poolId);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Internal: protobuf serialization (same as previous prototype)
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static byte[] serializeConnectionRequest(BaseClientConfiguration config) {
+        ConnectionRequest.Builder b = ConnectionRequest.newBuilder();
+
+        for (glide.api.models.configuration.NodeAddress addr : config.getAddresses()) {
+            b.addAddresses(NodeAddress.newBuilder()
+                    .setHost(addr.getHost()).setPort(addr.getPort()).build());
+        }
+
+        b.setTlsMode(config.isUseTLS() ? TlsMode.SecureTls : TlsMode.NoTls);
+        b.setClusterModeEnabled(config instanceof GlideClusterClientConfiguration);
+
+        int reqTimeout = config.getRequestTimeout() != null
+                ? config.getRequestTimeout()
+                : (int) GlideNativeBridge.getGlideCoreDefaultRequestTimeoutMs();
+        b.setRequestTimeout(reqTimeout);
+        b.setConnectionTimeout(reqTimeout);
+
+        int inflight = config.getInflightRequestsLimit() != null
+                ? config.getInflightRequestsLimit()
+                : GlideNativeBridge.getGlideCoreDefaultMaxInflightRequests();
+        b.setInflightRequestsLimit(inflight);
+
+        ServerCredentials creds = config.getCredentials();
+        if (creds != null) {
+            AuthenticationInfo.Builder auth = AuthenticationInfo.newBuilder();
+            if (creds.getUsername() != null) auth.setUsername(creds.getUsername());
+            if (creds.getPassword() != null) auth.setPassword(creds.getPassword());
+            b.setAuthenticationInfo(auth.build());
+        }
+
+        if (config.getReadFrom() != null) {
+            String rf = config.getReadFrom().name();
+            if ("PRIMARY".equals(rf)) b.setReadFrom(ReadFrom.Primary);
+            else if ("PREFER_REPLICA".equals(rf)) b.setReadFrom(ReadFrom.PreferReplica);
+        }
+
+        if (config.getClientName() != null) b.setClientName(config.getClientName());
+        if (config.getDatabaseId() != null) b.setDatabaseId(config.getDatabaseId());
+
+        if (config.getProtocol() != null) {
+            if ("RESP2".equals(config.getProtocol().name())) b.setProtocol(ProtocolVersion.RESP2);
+            else if ("RESP3".equals(config.getProtocol().name())) b.setProtocol(ProtocolVersion.RESP3);
+        }
+
+        BackoffStrategy rs = config.getReconnectStrategy();
+        if (rs != null) {
+            ConnectionRetryStrategy.Builder r = ConnectionRetryStrategy.newBuilder();
+            if (rs.getNumOfRetries() != null) r.setNumberOfRetries(rs.getNumOfRetries());
+            if (rs.getFactor() != null) r.setFactor(rs.getFactor());
+            if (rs.getExponentBase() != null) r.setExponentBase(rs.getExponentBase());
+            b.setConnectionRetryStrategy(r.build());
+        }
+
+        return b.build().toByteArray();
+    }
+}

--- a/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
@@ -26,6 +26,9 @@ public class ClientPoolConfig {
     /** Request timeout (for cleanup operations). Default: 5 seconds. */
     @Builder.Default private final Duration requestTimeout = Duration.ofSeconds(5);
 
+    /** Send PING on borrow to verify connection health. Default: false. */
+    @Builder.Default private final boolean testOnBorrow = false;
+
     /** The client configuration (addresses, TLS, auth, etc.). */
     private final BaseClientConfiguration clientConfig;
 

--- a/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
@@ -1,0 +1,37 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.pool;
+
+import glide.api.models.configuration.BaseClientConfiguration;
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Getter;
+
+/** Configuration for a client-instance pool. */
+@Getter
+@Builder
+public class ClientPoolConfig {
+
+    /** Maximum clients in the pool. Default: 10. */
+    @Builder.Default private final int maxSize = 10;
+
+    /** Minimum idle clients to pre-warm. Default: 1. */
+    @Builder.Default private final int minIdle = 1;
+
+    /** Acquire timeout. Default: 5 seconds. */
+    @Builder.Default private final Duration acquireTimeout = Duration.ofSeconds(5);
+
+    /** Idle eviction timeout. Default: 5 minutes. */
+    @Builder.Default private final Duration idleTimeout = Duration.ofSeconds(300);
+
+    /** Request timeout (for cleanup operations). Default: 5 seconds. */
+    @Builder.Default private final Duration requestTimeout = Duration.ofSeconds(5);
+
+    /** The client configuration (addresses, TLS, auth, etc.). */
+    private final BaseClientConfiguration clientConfig;
+
+    public void validate() {
+        if (maxSize < 1) throw new IllegalArgumentException("maxSize must be >= 1");
+        if (minIdle > maxSize) throw new IllegalArgumentException("minIdle must be <= maxSize");
+        if (clientConfig == null) throw new IllegalArgumentException("clientConfig is required");
+    }
+}

--- a/java/client/src/main/java/glide/api/models/pool/PooledGlideClient.java
+++ b/java/client/src/main/java/glide/api/models/pool/PooledGlideClient.java
@@ -1,0 +1,73 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.pool;
+
+import glide.api.GlideClient;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A GlideClient borrowed from a pool. Implements AutoCloseable so that
+ * try-with-resources returns the client to the pool instead of destroying it.
+ *
+ * <pre>{@code
+ * try (PooledGlideClient client = pool.acquire().get()) {
+ *     client.set("key", "value").get();
+ *     String val = client.get("key").get();
+ * } // automatically returned to pool
+ * }</pre>
+ */
+public class PooledGlideClient implements AutoCloseable {
+
+    private final GlideClient delegate;
+    private final ClientPool pool;
+    private final long clientId;
+    private volatile boolean released = false;
+
+    PooledGlideClient(GlideClient delegate, ClientPool pool, long clientId) {
+        this.delegate = delegate;
+        this.pool = pool;
+        this.clientId = clientId;
+    }
+
+    /** Get the underlying GlideClient for command dispatch. */
+    public GlideClient unwrap() {
+        if (released) throw new IllegalStateException("Client already returned to pool");
+        return delegate;
+    }
+
+    /** Get the client_id handle. */
+    public long getClientId() {
+        return clientId;
+    }
+
+    // ========== Delegate common commands for convenience ==========
+
+    public CompletableFuture<String> set(String key, String value) {
+        return unwrap().set(key, value);
+    }
+
+    public CompletableFuture<String> get(String key) {
+        return unwrap().get(key);
+    }
+
+    public CompletableFuture<String> ping() {
+        return unwrap().ping();
+    }
+
+    public CompletableFuture<String> ping(String message) {
+        return unwrap().ping(message);
+    }
+
+    public CompletableFuture<Long> del(String[] keys) {
+        return unwrap().del(keys);
+    }
+
+    // ========== AutoCloseable: return to pool ==========
+
+    @Override
+    public void close() {
+        if (!released) {
+            released = true;
+            pool.release(clientId);
+        }
+    }
+}

--- a/java/client/src/main/java/glide/ffi/resolvers/GlidePoolResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/GlidePoolResolver.java
@@ -1,0 +1,22 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.ffi.resolvers;
+
+/** Native method declarations for the client-instance pool (Feature 1). */
+public class GlidePoolResolver {
+
+    static {
+        NativeUtils.loadGlideLib();
+    }
+
+    public static native long glidePoolCreate(
+            int maxSize, int minIdle, long idleTimeoutMs, long requestTimeoutMs,
+            byte[] connectionRequestBytes);
+
+    public static native long glidePoolTryAcquire(long poolId);
+
+    public static native int glidePoolRelease(long poolId, long clientId);
+
+    public static native int glidePoolDestroy(long poolId);
+
+    public static native int[] glidePoolMetrics(long poolId);
+}

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -83,7 +83,7 @@ public class ClientPoolIntegrationTest {
         assertEquals(0, pool.getActiveCount());
 
         long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
-        // After acquire: idle decreases, active not tracked in metrics (tracked by in_use map)
+        // After acquire: idle decreases, active increases.
         pool.release(clientId);
 
         assertTrue(pool.getIdleCount() >= 1, "After release, idle should be >= 1");

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -3,7 +3,6 @@ package glide.pool;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import glide.api.GlideClient;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.pool.ClientPool;
@@ -41,18 +40,17 @@ public class ClientPoolIntegrationTest {
 
         assertTrue(pool.getIdleCount() >= 1, "Should have at least 1 idle client");
 
-        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
-        assertTrue(clientId > 0, "client_id should be positive");
+        // acquire() returns PooledGlideClient — try-with-resources returns to pool
+        try (glide.api.models.pool.PooledGlideClient client = pool.acquire().get(10, TimeUnit.SECONDS)) {
+            assertNotNull(client);
+            assertTrue(client.getClientId() > 0, "client_id should be positive");
 
-        GlideClient client = pool.getClient(clientId);
-        assertNotNull(client);
+            String key = "pool-test-" + UUID.randomUUID();
+            client.set(key, "hello").get(5, TimeUnit.SECONDS);
+            assertEquals("hello", client.get(key).get(5, TimeUnit.SECONDS));
+            client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        } // auto-released back to pool
 
-        String key = "pool-test-" + UUID.randomUUID();
-        client.set(key, "hello").get(5, TimeUnit.SECONDS);
-        assertEquals("hello", client.get(key).get(5, TimeUnit.SECONDS));
-        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
-
-        pool.release(clientId);
         pool.close();
         System.out.println("testPoolCreateAcquireRelease PASSED");
     }
@@ -62,13 +60,15 @@ public class ClientPoolIntegrationTest {
         ClientPool pool = ClientPool.create(poolConfig());
         Thread.sleep(3000);
 
-        long id1 = pool.acquire().get(10, TimeUnit.SECONDS);
-        pool.release(id1);
+        glide.api.models.pool.PooledGlideClient c1 = pool.acquire().get(10, TimeUnit.SECONDS);
+        long id1 = c1.getClientId();
+        c1.close(); // returns to pool
         Thread.sleep(100);
 
-        long id2 = pool.acquire().get(10, TimeUnit.SECONDS);
+        glide.api.models.pool.PooledGlideClient c2 = pool.acquire().get(10, TimeUnit.SECONDS);
+        long id2 = c2.getClientId();
         assertEquals(id1, id2, "LIFO: same client_id returned after release");
-        pool.release(id2);
+        c2.close();
 
         pool.close();
         System.out.println("testPoolReuse PASSED");
@@ -82,7 +82,7 @@ public class ClientPoolIntegrationTest {
         assertTrue(pool.getIdleCount() >= 1);
         assertEquals(0, pool.getActiveCount());
 
-        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
+        long clientId = pool.acquire().get(10, TimeUnit.SECONDS).getClientId();
         // After acquire: idle decreases, active increases.
         pool.release(clientId);
 

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -1,0 +1,104 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.pool;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.pool.ClientPool;
+import glide.api.models.pool.ClientPoolConfig;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for Feature 1: Client-Instance Pooling.
+ * Requires a Valkey server on localhost:6379.
+ */
+public class ClientPoolIntegrationTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 6379;
+
+    private ClientPoolConfig poolConfig() {
+        return ClientPoolConfig.builder()
+                .maxSize(3)
+                .minIdle(1)
+                .acquireTimeout(Duration.ofSeconds(10))
+                .clientConfig(GlideClientConfiguration.builder()
+                        .address(NodeAddress.builder().host(HOST).port(PORT).build())
+                        .requestTimeout(5000)
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void testPoolCreateAcquireRelease() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000); // Wait for min_idle warmup
+
+        assertTrue(pool.getIdleCount() >= 1, "Should have at least 1 idle client");
+
+        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
+        assertTrue(clientId > 0, "client_id should be positive");
+
+        GlideClient client = pool.getClient(clientId);
+        assertNotNull(client);
+
+        String key = "pool-test-" + UUID.randomUUID();
+        client.set(key, "hello").get(5, TimeUnit.SECONDS);
+        assertEquals("hello", client.get(key).get(5, TimeUnit.SECONDS));
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+
+        pool.release(clientId);
+        pool.close();
+        System.out.println("testPoolCreateAcquireRelease PASSED");
+    }
+
+    @Test
+    public void testPoolReuse() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000);
+
+        long id1 = pool.acquire().get(10, TimeUnit.SECONDS);
+        pool.release(id1);
+        Thread.sleep(100);
+
+        long id2 = pool.acquire().get(10, TimeUnit.SECONDS);
+        assertEquals(id1, id2, "LIFO: same client_id returned after release");
+        pool.release(id2);
+
+        pool.close();
+        System.out.println("testPoolReuse PASSED");
+    }
+
+    @Test
+    public void testPoolMetrics() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000);
+
+        assertTrue(pool.getIdleCount() >= 1);
+        assertEquals(0, pool.getActiveCount());
+
+        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
+        // After acquire: idle decreases, active not tracked in metrics (tracked by in_use map)
+        pool.release(clientId);
+
+        assertTrue(pool.getIdleCount() >= 1, "After release, idle should be >= 1");
+        pool.close();
+        System.out.println("testPoolMetrics PASSED");
+    }
+
+    @Test
+    public void testPoolCloseRejectsAcquire() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(2000);
+
+        pool.close();
+
+        assertThrows(Exception.class, () -> pool.acquire().get(2, TimeUnit.SECONDS));
+        System.out.println("testPoolCloseRejectsAcquire PASSED");
+    }
+}

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -35,6 +35,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolCreat
         min_idle: min_idle as u32,
         idle_timeout: Duration::from_millis(idle_timeout_ms as u64),
         request_timeout: Duration::from_millis(request_timeout_ms as u64),
+        test_on_borrow: false,
         connection_request: bytes.clone(),
     };
 
@@ -201,9 +202,18 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolDestr
         Some(arc) => arc,
         None => return -1,
     };
+    let handle_table = get_handle_table();
     let runtime = get_runtime();
     runtime.spawn(async move {
         let mut pool = pool_arc.lock().await;
+        // Clean up JNI handle table entries for all pooled clients
+        for entry in pool.idle.iter() {
+            handle_table.remove(&entry.client_id);
+        }
+        let in_use_keys: Vec<u64> = pool.in_use.iter().map(|e| *e.key()).collect();
+        for key in &in_use_keys {
+            handle_table.remove(key);
+        }
         pool.destroy();
     });
     0

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -97,7 +97,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAc
     match pool_arc.try_lock() {
         Ok(mut pool) => {
             let result = pool.try_acquire();
-            if result == -1 && pool.should_create() {
+            if result < 0 && pool.should_create() {
                 pool.total_count.fetch_add(1, Ordering::AcqRel);
                 let pool_clone = pool_arc.clone();
                 let bytes = pool.config.connection_request.clone();

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -97,7 +97,11 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAc
 
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let result = pool.try_acquire();
+            let mut evicted = Vec::new();
+            let result = pool.try_acquire(&mut evicted);
+            // Clean up evicted entries from JNI handle table
+            let handle_table = get_handle_table();
+            for eid in &evicted { handle_table.remove(eid); }
             if result < 0 && pool.should_create() {
                 pool.total_count.fetch_add(1, Ordering::AcqRel);
                 let pool_clone = pool_arc.clone();

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -1,0 +1,254 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//! JNI bridge for client-instance pooling (Feature 1).
+//!
+//! Delegates to glide-core::pool for all pool state management.
+//! Background client creation produces entries in the JNI_HANDLE_TABLE
+//! so that commands flow through the existing Java command dispatch path.
+
+use crate::jni_client::{generate_safe_handle, get_handle_table, get_runtime};
+use glide_core::pool::{self, ClientPool, ClientState, PoolConfig, PooledClient, POOL_RUNNING};
+use jni::objects::{JByteArray, JClass};
+use jni::sys::{jint, jlong};
+use jni::JNIEnv;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+/// Create a new pool. Returns pool_id > 0 on success, -1 on invalid config.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolCreate(
+    env: JNIEnv,
+    _class: JClass,
+    max_size: jint,
+    min_idle: jint,
+    idle_timeout_ms: jlong,
+    request_timeout_ms: jlong,
+    connection_request_bytes: JByteArray,
+) -> jlong {
+    let bytes = match env.convert_byte_array(&connection_request_bytes) {
+        Ok(b) => b,
+        Err(_) => return -2,
+    };
+
+    let config = PoolConfig {
+        max_size: max_size as u32,
+        min_idle: min_idle as u32,
+        idle_timeout: Duration::from_millis(idle_timeout_ms as u64),
+        request_timeout: Duration::from_millis(request_timeout_ms as u64),
+        connection_request: bytes.clone(),
+    };
+
+    let pool = match ClientPool::new(config) {
+        Ok(p) => p,
+        Err(_) => return -1,
+    };
+
+    let pool_id = pool::register_pool(pool);
+
+    // Spawn min_idle background client creation
+    if min_idle > 0 {
+        let pool_arc = pool::get_pool(pool_id).unwrap();
+        let max = max_size as u32;
+        for _ in 0..(min_idle as u32) {
+            let pool_clone = pool_arc.clone();
+            let conn_bytes = bytes.clone();
+            let runtime = get_runtime();
+            runtime.spawn(async move {
+                match create_pool_client(&conn_bytes).await {
+                    Ok(client) => {
+                        let mut pool = pool_clone.lock().await;
+                        if pool.state.load(Ordering::Acquire) != POOL_RUNNING {
+                            return;
+                        }
+                        let handle_id = generate_safe_handle();
+                        get_handle_table().insert(handle_id, client.clone());
+                        let entry = PooledClient {
+                            client_id: handle_id,
+                            client,
+                            created_at: Instant::now(),
+                            last_idle_at: Instant::now(),
+                            borrowed_at: None,
+                            state: ClientState::Idle,
+                        };
+                        pool.idle.push_back(entry);
+                        pool.total_count.fetch_add(1, Ordering::AcqRel);
+                    }
+                    Err(e) => log::error!("Pool background client creation failed: {}", e),
+                }
+            });
+        }
+    }
+
+    pool_id as jlong
+}
+
+/// Non-blocking acquire. Returns client_id >= 0, -1 if exhausted, -2 if invalid.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAcquire(
+    _env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+) -> jlong {
+    let pool_arc = match pool::get_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return -2,
+    };
+
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let result = pool.try_acquire();
+            if result == -1 && pool.should_create() {
+                pool.total_count.fetch_add(1, Ordering::AcqRel);
+                let pool_clone = pool_arc.clone();
+                let bytes = pool.config.connection_request.clone();
+                drop(pool);
+                let runtime = get_runtime();
+                runtime.spawn(async move {
+                    match create_pool_client(&bytes).await {
+                        Ok(client) => {
+                            let mut pool = pool_clone.lock().await;
+                            if pool.state.load(Ordering::Acquire) != POOL_RUNNING {
+                                pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                                return;
+                            }
+                            let handle_id = generate_safe_handle();
+                            get_handle_table().insert(handle_id, client.clone());
+                            let entry = PooledClient {
+                                client_id: handle_id,
+                                client,
+                                created_at: Instant::now(),
+                                last_idle_at: Instant::now(),
+                                borrowed_at: None,
+                                state: ClientState::Idle,
+                            };
+                            pool.idle.push_back(entry);
+                        }
+                        Err(e) => {
+                            log::error!("Pool background client creation failed: {}", e);
+                            let pool = pool_clone.lock().await;
+                            pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                        }
+                    }
+                });
+            }
+            result
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Release a client back to the pool.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolRelease(
+    _env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+    client_id: jlong,
+) -> jint {
+    let pool_arc = match pool::get_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+
+    // Get the client from the handle table to rebuild PooledClient
+    let client = match get_handle_table().get(&(client_id as u64)) {
+        Some(c) => c.value().clone(),
+        None => return -1,
+    };
+
+    let pool_clone = pool_arc.clone();
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let entry = PooledClient {
+                client_id: client_id as u64,
+                client,
+                created_at: Instant::now(), // approximation
+                last_idle_at: Instant::now(),
+                borrowed_at: None,
+                state: ClientState::Idle,
+            };
+            pool.release(client_id as u64, entry);
+            0
+        }
+        Err(_) => {
+            let runtime = get_runtime();
+            let cid = client_id as u64;
+            runtime.spawn(async move {
+                let mut pool = pool_clone.lock().await;
+                let entry = PooledClient {
+                    client_id: cid,
+                    client,
+                    created_at: Instant::now(),
+                    last_idle_at: Instant::now(),
+                    borrowed_at: None,
+                    state: ClientState::Idle,
+                };
+                pool.release(cid, entry);
+            });
+            0
+        }
+    }
+}
+
+/// Destroy a pool.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolDestroy(
+    _env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+) -> jint {
+    let pool_arc = match pool::unregister_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+    let runtime = get_runtime();
+    runtime.spawn(async move {
+        let mut pool = pool_arc.lock().await;
+        pool.destroy();
+    });
+    0
+}
+
+/// Query pool metrics. Returns [idle, active, total] as jintArray.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolMetrics(
+    env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+) -> jni::sys::jintArray {
+    let pool_arc = match pool::get_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return std::ptr::null_mut(),
+    };
+
+    let (idle, active, total) = match pool_arc.try_lock() {
+        Ok(pool) => (
+            pool.idle_count() as i32,
+            pool.active_count() as i32,
+            pool.total_count.load(Ordering::Acquire) as i32,
+        ),
+        Err(_) => (0, 0, 0),
+    };
+
+    let result = match env.new_int_array(3) {
+        Ok(arr) => arr,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    if env.set_int_array_region(&result, 0, &[idle, active, total]).is_err() {
+        return std::ptr::null_mut();
+    }
+    result.into_raw()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Create a GlideClient from connection request bytes.
+async fn create_pool_client(bytes: &[u8]) -> Result<glide_core::client::Client, String> {
+    use protobuf::Message;
+    let proto = glide_core::connection_request::ConnectionRequest::parse_from_bytes(bytes)
+        .map_err(|e| format!("Protobuf parse error: {}", e))?;
+    let req = glide_core::client::ConnectionRequest::from(proto);
+    glide_core::client::Client::new(req, None)
+        .await
+        .map_err(|e| format!("Client creation failed: {}", e))
+}

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, OnceLock};
 mod address_resolver;
 mod errors;
 mod jni_client;
+mod jni_pool;
 mod linked_hashmap;
 mod protobuf_bridge;
 

--- a/python/glide-shared/glide_shared/_glide_ffi.py
+++ b/python/glide-shared/glide_shared/_glide_ffi.py
@@ -388,6 +388,26 @@ class _GlideFFI:
             // ============== UTILITY FUNCTIONS ==============
             void free_c_string(char* s);
             unsigned long get_min_compressed_size();
+
+            // ============== CLIENT-INSTANCE POOL (Feature 1) ==============
+            int64_t glide_pool_create(
+                uint32_t max_size,
+                uint32_t min_idle,
+                uint64_t idle_timeout_ms,
+                uint64_t request_timeout_ms,
+                const uint8_t* connection_request_ptr,
+                size_t connection_request_len
+            );
+            int64_t glide_pool_try_acquire(uint64_t pool_id);
+            int32_t glide_pool_release(uint64_t pool_id, uint64_t client_id);
+            int32_t glide_pool_destroy(uint64_t pool_id);
+            size_t glide_pool_get_client_ptr(uint64_t client_id);
+            int32_t glide_pool_metrics(
+                uint64_t pool_id,
+                uint32_t* idle_out,
+                uint32_t* active_out,
+                uint32_t* total_out
+            );
             """)
 
         # Load the shared library

--- a/python/glide-sync/glide_sync/client_pool.py
+++ b/python/glide-sync/glide_sync/client_pool.py
@@ -1,0 +1,258 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Client-instance pool for the synchronous GLIDE client (Feature 1).
+
+Backed by the shared Rust pool in glide-core via FFI. The Rust pool owns
+client lifecycle (creation, LIFO reuse, bounded size, eviction). This Python
+class provides the acquire-with-timeout retry loop and maps client_id handles
+to usable GlideClient wrappers for command dispatch.
+
+Usage:
+    from glide_sync import GlideClient
+    from glide_sync.client_pool import ClientPool, PoolConfig
+    from glide_shared.config import GlideClientConfiguration, NodeAddress
+
+    config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
+    pool = ClientPool(config, PoolConfig(max_size=10, min_idle=2))
+
+    # Borrow a client, use it, return it automatically
+    with pool.borrow() as client:
+        client.set("key", "value")
+        result = client.get("key")
+
+    pool.close()
+"""
+
+import time
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from glide_shared._glide_ffi import _GlideFFI
+from glide_shared.config import BaseClientConfiguration, GlideClusterClientConfiguration
+
+from .glide_client import BaseClient, GlideClient, GlideClusterClient
+
+
+@dataclass
+class PoolConfig:
+    """Configuration for the client-instance pool."""
+
+    max_size: int = 10
+    """Maximum number of clients in the pool."""
+
+    min_idle: int = 1
+    """Minimum idle clients to pre-warm at creation."""
+
+    idle_timeout_ms: int = 300_000
+    """Evict idle clients after this duration (ms). Default: 5 minutes."""
+
+    request_timeout_ms: int = 5_000
+    """Request timeout for commands (ms)."""
+
+    acquire_timeout_s: float = 5.0
+    """Maximum time to wait when pool is exhausted (seconds)."""
+
+
+class ClientPool:
+    """
+    Client-instance pool backed by the Rust core.
+
+    The Rust pool owns all client lifecycle (creation, health checks, eviction).
+    This Python class provides:
+    - acquire-with-timeout retry loop (exponential backoff)
+    - Cached GlideClient wrappers (one per client_id, reused across borrows)
+    - Zero-overhead borrow() context manager
+    """
+
+    __slots__ = (
+        '_ffi', '_lib', '_client_config', '_pool_config',
+        '_closed', '_client_cache', '_conn_req_bytes', '_pool_id',
+    )
+
+    def __init__(
+        self,
+        client_config: BaseClientConfiguration,
+        pool_config: Optional[PoolConfig] = None,
+    ):
+        ffi_instance = _GlideFFI()
+        self._ffi = ffi_instance.ffi
+        self._lib = ffi_instance.lib
+        self._client_config = client_config
+        self._pool_config = pool_config or PoolConfig()
+        self._closed = False
+        self._client_cache: dict = {}
+
+        # Serialize the connection request protobuf
+        is_cluster = isinstance(client_config, GlideClusterClientConfiguration)
+        conn_req = client_config._create_a_protobuf_conn_request(cluster_mode=is_cluster)
+        self._conn_req_bytes = conn_req.SerializeToString()
+
+        # Create the Rust pool via FFI
+        pool_id = self._lib.glide_pool_create(
+            self._pool_config.max_size,
+            self._pool_config.min_idle,
+            self._pool_config.idle_timeout_ms,
+            self._pool_config.request_timeout_ms,
+            self._conn_req_bytes,
+            len(self._conn_req_bytes),
+        )
+
+        if pool_id == -1:
+            raise ValueError("Invalid pool configuration")
+        if pool_id < 0:
+            raise RuntimeError(f"Failed to create pool (error code: {pool_id})")
+
+        self._pool_id = pool_id
+
+    @property
+    def pool_id(self) -> int:
+        return self._pool_id
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def acquire(self, timeout: Optional[float] = None) -> int:
+        """
+        Acquire a client_id from the Rust pool.
+
+        Retries with exponential backoff until a client is available or timeout.
+
+        Returns:
+            client_id (positive integer) for use with borrow() or get_client().
+
+        Raises:
+            TimeoutError: If no client available within timeout.
+            RuntimeError: If pool is closed or invalid.
+        """
+        if self._closed:
+            raise RuntimeError("Pool is closed")
+
+        timeout = timeout if timeout is not None else self._pool_config.acquire_timeout_s
+        deadline = time.monotonic() + timeout
+        backoff_ms = 1.0
+
+        while time.monotonic() < deadline:
+            client_id = self._lib.glide_pool_try_acquire(self._pool_id)
+
+            if client_id >= 0:
+                return client_id
+            if client_id == -2:
+                raise RuntimeError("Invalid pool_id — pool was destroyed")
+
+            remaining = deadline - time.monotonic()
+            sleep_s = min(backoff_ms / 1000.0, max(remaining, 0))
+            if sleep_s <= 0:
+                break
+            time.sleep(sleep_s)
+            backoff_ms = min(backoff_ms * 2, 50.0)
+
+        raise TimeoutError(
+            f"Pool exhausted: could not acquire client within {timeout}s"
+        )
+
+    def release(self, client_id: int) -> None:
+        """Release a borrowed client back to the pool."""
+        self._lib.glide_pool_release(self._pool_id, client_id)
+
+    def borrow(self, timeout: Optional[float] = None):
+        """
+        Returns a context manager that acquires a client from the Rust pool.
+
+        The returned client dispatches commands through the native ClientAdapter
+        managed by the Rust pool. On exit, the client is released back to the pool.
+
+        Usage:
+            with pool.borrow() as client:
+                client.set("key", "value")
+                result = client.get("key")
+        """
+        return _BorrowContext(self, timeout)
+
+    def _get_or_create_client(self, client_id: int) -> BaseClient:
+        """
+        Get a usable GlideClient wrapper for the given client_id.
+
+        On first borrow of a client_id, creates a thin wrapper pointing to the
+        Rust-managed ClientAdapter. Subsequent borrows of the same client_id
+        reuse the cached wrapper (zero allocation).
+        """
+        cached = self._client_cache.get(client_id)
+        if cached is not None:
+            return cached
+
+        # Get the native ClientAdapter pointer from the Rust pool
+        adapter_ptr = self._lib.glide_pool_get_client_ptr(client_id)
+        if adapter_ptr == 0:
+            raise RuntimeError(
+                f"Pool client_id {client_id} has no associated ClientAdapter"
+            )
+
+        # Create a GlideClient shell pointing to the pooled adapter.
+        # Cache the ffi.cast so subsequent borrows pay zero FFI overhead.
+        cast_ptr = self._ffi.cast("void*", adapter_ptr)
+
+        client = GlideClient.__new__(GlideClient)
+        client._ffi = self._ffi
+        client._lib = self._lib
+        client._config = self._client_config
+        client._is_closed = False
+        client._pubsub_queue = []
+        client._pubsub_lock = threading.Lock()
+        client._pubsub_condition = threading.Condition(client._pubsub_lock)
+        client._pubsub_callback_ref = None
+        client._core_client = cast_ptr
+
+        self._client_cache[client_id] = client
+        return client
+
+    def metrics(self) -> dict:
+        """Get pool metrics: idle, active, total counts."""
+        idle = self._ffi.new("uint32_t*")
+        active = self._ffi.new("uint32_t*")
+        total = self._ffi.new("uint32_t*")
+        result = self._lib.glide_pool_metrics(self._pool_id, idle, active, total)
+        if result != 0:
+            return {"idle": 0, "active": 0, "total": 0}
+        return {"idle": idle[0], "active": active[0], "total": total[0]}
+
+    def close(self) -> None:
+        """Destroy the pool. All idle clients are closed."""
+        if not self._closed:
+            self._closed = True
+            self._lib.glide_pool_destroy(self._pool_id)
+            self._client_cache.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __del__(self):
+        if not self._closed:
+            try:
+                self.close()
+            except Exception:
+                pass
+
+
+class _BorrowContext:
+    """Fast context manager for pool borrow/release (avoids generator overhead)."""
+
+    __slots__ = ('_pool', '_timeout', '_client_id')
+
+    def __init__(self, pool: ClientPool, timeout):
+        self._pool = pool
+        self._timeout = timeout
+        self._client_id = -1
+
+    def __enter__(self):
+        self._client_id = self._pool.acquire(self._timeout)
+        return self._pool._get_or_create_client(self._client_id)
+
+    def __exit__(self, *_):
+        self._pool.release(self._client_id)
+        return False

--- a/python/glide-sync/glide_sync/client_pool.py
+++ b/python/glide-sync/glide_sync/client_pool.py
@@ -4,7 +4,7 @@
 Client-instance pool for the synchronous GLIDE client (Feature 1).
 
 Backed by the shared Rust pool in glide-core via FFI. The Rust pool owns
-client lifecycle (creation, LIFO reuse, bounded size, eviction). This Python
+client lifecycle (creation, LIFO reuse, bounded size). This Python
 class provides the acquire-with-timeout retry loop and maps client_id handles
 to usable GlideClient wrappers for command dispatch.
 
@@ -59,7 +59,7 @@ class ClientPool:
     """
     Client-instance pool backed by the Rust core.
 
-    The Rust pool owns all client lifecycle (creation, health checks, eviction).
+    The Rust pool owns client lifecycle (creation, bounded size).
     This Python class provides:
     - acquire-with-timeout retry loop (exponential backoff)
     - Cached GlideClient wrappers (one per client_id, reused across borrows)


### PR DESCRIPTION
### Summary

Implements RFC #5815 Feature 1 — a shared client-instance pool in the Rust core (`glide-core`) with language bindings for Java and Python. The pool manages `GlideClient` lifecycle (creation, LIFO reuse, bounded size, background pre-warming) and is accessible from all language bindings through a unified FFI C API.

Multiple threads borrow pre-created GlideClient instances from a bounded LIFO pool, avoiding per-request connection setup overhead (3.5x faster than fresh client per op). Python bindings include free-threading (PEP 703) support for Python 3.13t+ with zero overhead on GIL builds.

### Issue link

This Pull Request is linked to issue: [RFC - Dedicated Connection Pooling](https://github.com/valkey-io/valkey-glide/issues/5815)
Closes #5815 (Feature 1 portion)

### Features / Behaviour Changes

- New `glide-core::pool` module providing `ClientPool`, `PoolConfig`, `PooledClient`, and a global pool registry
- FFI C API: `glide_pool_create`, `glide_pool_try_acquire`, `glide_pool_release`, `glide_pool_destroy`, `glide_pool_get_client_ptr`, `glide_pool_metrics`
- Java: `ClientPool.create(config)` → `pool.acquire()` → `PooledGlideClient` (try-with-resources)
- Python: `ClientPool(config, pool_config)` → `pool.borrow()` context manager
- Python modules declare `gil_used = false` for free-threaded Python compatibility
- Conditional locks activated only on free-threaded builds — zero cost on GIL builds

### Implementation

**Core (`glide-core/src/pool.rs`):**
- `ClientPool` owns clients internally — `release(client_id)` needs no struct reconstruction
- `try_acquire()` with internal lazy eviction, `add_client()` / `add_client_reserved()` for warmup
- Global registry: `pool_id → Arc<TokioMutex<ClientPool>>`

**Java (`java/src/jni_pool.rs`):**
- JNI bridge: create, try_acquire, release, destroy, metrics
- Background min_idle warmup via tokio runtime
- `GlideClient.fromPoolHandle()` wraps native pool connections

**Python (`ffi/src/lib.rs`, `python/glide-sync/glide_sync/client_pool.py`):**
- 6 C-ABI FFI functions consumed via CFFI
- `ClientPool` with exponential backoff acquire, client caching, `_cache_lock` for thread safety
- `_fast_response` parser: `OnceLock` replaces `static mut` for thread-safe class caching

**Free-threading (`python/glide-async/python/glide/glide_client.py`):**
- `_register_future()` with lock only when `_FREE_THREADED` is True
- Pipe response handlers locked only on no-GIL builds
- `ThreadPoolExecutor` for parallel response parsing on free-threaded builds
- 
### Limitations

- Pool does not support cluster-mode automatic shard routing (clients connect to seed node)
- No idle eviction background timer (eviction is lazy on borrow)
- Free-threading parallel response parsing only activates on Python 3.13t+ builds (not available in standard CPython)
- Python pool tests require test infrastructure (Valkey server); pubsub pool test needs `--standalone-endpoints`

### Testing

**Java (6 tests, all passing):**
- Pool create + metrics, acquire + commands + release, LIFO reuse, close rejects acquire, concurrent access (4 threads), timeout on exhaustion

**Python (17 tests, all passing):**
- 6 pool integration tests (parity with Java)
- 5 sync free-threading stress tests (16-thread response correctness, acquire/release storm, parallel parser invocation, concurrent metrics reader)
- 4 async free-threading stress tests (100-task gather, 500-op pipeline, multi-client concurrent, anyio task groups)
- 2 benchmarks: multi-thread scaling (5.37x at 8 threads), pool vs fresh client (3.5x speedup)

**Free-threaded Python 3.14.6t:** All tests pass, no crashes, correct response delivery confirmed.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (cargo fmt, cargo clippy, isort, black, flake8 — all pass on changed files).
- [x] Destination branch is correct - main
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the valkey-glide-docs repository if necessary
