### PR TITLE
Fix clientSideCache_set_and_get flaky test by polling for cache hit

### DIFF
--- a/java/integTest/src/test/java/glide/ClientSideCacheTests.java
+++ b/java/integTest/src/test/java/glide/ClientSideCacheTests.java
@@ -642,11 +642,15 @@ public class ClientSideCacheTests {
         // First GET: cache miss, populates cache
         assertEquals(value, client.get(key).get());
 
-        // Second GET: served from local cache
-        assertEquals(value, client.get(key).get());
-
-        // Verify caching was actually used by checking metrics
-        assertTrue(client.getCacheHitRate().get() > 0, "Expected cache hit rate > 0 after second GET");
+        // Poll until a cache hit is observed. With server-assisted caching on cluster
+        // clients, CLIENT TRACKING may not be fully active on all connections immediately,
+        // so the first GET(s) may be misses until tracking is established.
+        waitFor(
+                () -> {
+                    assertEquals(value, client.get(key).get());
+                    return client.getCacheHitRate().get() > 0;
+                },
+                "Expected cache hit rate > 0 after GET");
     }
 
     @ParameterizedTest(autoCloseArguments = true)


### PR DESCRIPTION
### Summary
Fix flaky `clientSideCache_set_and_get` test by replacing the immediate cache hit rate assertion with a polling loop that waits for CLIENT TRACKING to be fully active on cluster connections.

### Issue link
This Pull Request is linked to issue: [Java Flaky Test ClientSideCacheTests.clientSideCache_set_and_get (GlideClusterClient)](https://github.com/valkey-io/valkey-glide/issues/6295)
Closes #6295

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** With server-assisted caching (`CLIENT TRACKING`) on a `GlideClusterClient`, the tracking subscription may not be fully active on all cluster connections immediately after client creation. If the first GET executes before tracking is established on its connection, the response is not cached. The subsequent GET is also a miss since there is no cache entry, causing the `getCacheHitRate() > 0` assertion to fail.

**Fix:** Replace the single GET + assertion with a polling loop using the existing `waitFor` utility (10s timeout, 100ms interval). The loop repeatedly calls GET and checks the hit rate. Once CLIENT TRACKING is established and a response is cached, the next GET will be a cache hit and the rate will become > 0.

### Limitations
None

### Testing
Test was run 100 consecutive times locally with 0 failures (previously failed in CI on aarch64 with GlideClusterClient, engine version 9.0).

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
