### PR TITLE
[CI] Add retry logic to cargo-zigbuild install

### DIFF
--- a/.github/actions/install-zig/action.yml
+++ b/.github/actions/install-zig/action.yml
@@ -25,7 +25,7 @@ runs:
                   sudo apt install -y python3-pip
                   pip3 install ziglang
               fi
-              cargo install --locked cargo-zigbuild
+              for i in 1 2 3; do cargo install --locked cargo-zigbuild && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
 
               # Set environment variable to prevent cargo-zigbuild from auto-detecting malformed targets
               # This will be available for subsequent steps in the workflow


### PR DESCRIPTION
### Summary

Add retry logic to the `cargo install --locked cargo-zigbuild` command in `.github/actions/install-zig/action.yml` to handle transient network/SSL failures during CI.

### Issue link

Closes #6312

### Features / Behaviour Changes

No behaviour changes. This PR fixes CI flakiness only.

### Implementation

**Root cause:** The `cargo install --locked cargo-zigbuild` command fails intermittently due to transient `SSL_ERROR_SYSCALL` errors when downloading crate dependencies from [crates.io](https://crates.io/). There was no retry logic, so a single network hiccup would fail the entire CI job.

**Fix:** Wrap the cargo install command in a retry loop that attempts up to 3 times with a 15-second delay between attempts:

```bash
for i in 1 2 3; do cargo install --locked cargo-zigbuild && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
```

If retries are exhausted it will exit with status 1 to prevent the workflow from continuing.

### Limitations

None

### Testing

This is a CI infrastructure change. The retry logic follows standard shell patterns and has been verified syntactically. The fix is consistent with the approach discussed in #6284 for similar transient network failures.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] ~Commit message has a detailed description of what changed and why.~
- [x] ~Tests are added or updated.~
- [x] ~CHANGELOG.md and documentation files are updated.~
- [x] Linters have been run.
- [x] Destination branch is correct - main or release