### PR TITLE
Replace unmaintained iai-callgrind with gungraun (#6209)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,10 +22,6 @@ yanked = "deny"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # bincode is unmaintained but only used as a transitive dev dependency
-    # via iai-callgrind for benchmarking. No security impact.
-    # https://rustsec.org/advisories/RUSTSEC-2025-0141
-    "RUSTSEC-2025-0141"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -79,7 +79,7 @@ which = "8"
 ctor = "0.10"
 redis = { path = "./redis-rs/redis", features = ["tls-rustls-insecure"] }
 rustls = { version = "0.23", features = ["aws-lc-rs"]}
-iai-callgrind = "0.15"
+gungraun = "0.19"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 glide-core = { path = ".", features = [
     "socket-layer",

--- a/glide-core/benches/memory_benchmark.rs
+++ b/glide-core/benches/memory_benchmark.rs
@@ -4,7 +4,7 @@ use glide_core::{
     client::Client,
     connection_request::{ConnectionRequest, NodeAddress, TlsMode},
 };
-use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use gungraun::{library_benchmark, library_benchmark_group, main};
 use redis::{Value, cmd};
 use std::hint::black_box;
 use tokio::runtime::Builder;


### PR DESCRIPTION
Cherrypicking https://github.com/valkey-io/valkey-glide/pull/6209 to `release-2.4`.