### PR TITLE
fix(python): pin pytest<9.1 to fix fixture finalizer assertion errors (#6268)

### DIFF
--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,7 +1,7 @@
 maturin==1.13.1
 anyio[trio]>=4.9.0
 uvloop
-pytest
+pytest<9.1
 pytest-html
 pytest-timeout
 black >= 24.3.0


### PR DESCRIPTION
Cherrypicking https://github.com/valkey-io/valkey-glide/pull/6268 to `release-2.4`.