### PR TITLE
Backport pyo3 0.29 upgrade + pytest<9.1 pin for release-2.4 (#6238 & #6268)

### DIFF
--- a/python/dev_requirements.txt
+++ b/python/dev_requirements.txt
@@ -1,7 +1,7 @@
 maturin==1.13.1
 anyio[trio]>=4.9.0
 uvloop
-pytest
+pytest<9.1
 pytest-html
 pytest-timeout
 black >= 24.3.0

--- a/python/glide-async/Cargo.toml
+++ b/python/glide-async/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-pyo3 = { version = "^0.25", features = ["extension-module", "num-bigint"] }
+pyo3 = { version = "^0.29", features = ["extension-module", "num-bigint"] }
 bytes = { version = "^1.8" }
 redis = { path = "../../glide-core/redis-rs/redis", features = [
     "aio",

--- a/python/glide-async/src/lib.rs
+++ b/python/glide-async/src/lib.rs
@@ -15,6 +15,8 @@ use pyo3::Python;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBool, PyBytes, PyDict, PyFloat, PyList, PySet, PyString};
+
+type PyObject = Py<PyAny>;
 use redis::Value;
 use std::collections::HashMap;
 use std::ptr::from_mut;
@@ -35,7 +37,7 @@ pub const DEFAULT_TRACE_SAMPLE_RATE: u32 = DEFAULT_TRACE_SAMPLE_PERCENTAGE;
 /// - `flush_interval_ms`: Optional interval in milliseconds between consecutive exports of telemetry data. If `None`, a default value will be used.
 ///
 /// At least one of traces or metrics must be provided.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct OpenTelemetryConfig {
     /// Optional configuration for exporting trace data. If `None`, trace data will not be exported.
@@ -85,7 +87,7 @@ impl OpenTelemetryConfig {
 /// - `sample_percentage`: The percentage of requests to sample and create a span for, used to measure command duration. If `None`, a default value DEFAULT_TRACE_SAMPLE_RATE will be used.
 ///   Note: There is a tradeoff between sampling percentage and performance. Higher sampling percentages will provide more detailed telemetry data but will impact performance.
 ///   It is recommended to keep this number low (1-5%) in production environments unless you have specific needs for higher sampling rates.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct OpenTelemetryTracesConfig {
     /// The endpoint to which trace data will be exported.
@@ -122,7 +124,7 @@ impl OpenTelemetryTracesConfig {
 ///   - For gRPC: `grpc://host:port`
 ///   - For HTTP: `http://host:port` or `https://host:port`
 ///   - For file exporter: `file:///absolute/path/to/folder/file.json`
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct OpenTelemetryMetricsConfig {
     /// The endpoint to which metrics data will be exported.
@@ -141,7 +143,7 @@ impl OpenTelemetryMetricsConfig {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(PartialEq, Eq, PartialOrd, Clone)]
 pub enum Level {
     Error = 0,
@@ -291,7 +293,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         fn resolve(&self, host: &str, port: u16) -> (String, u16) {
             let callback = Arc::clone(&self.callback);
             let host = host.to_string();
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 match callback.call(py, (host.as_str(), port), None) {
                     Ok(result) => {
                         // Expect a tuple (str, int)
@@ -386,7 +388,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             Telemetry::subscription_last_sync_timestamp().to_string(),
         );
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_dict = PyDict::new(py);
 
             for (key, value) in stats_map {
@@ -413,7 +415,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
             let init_callback = Arc::clone(&init_callback);
             move |socket_path| {
                 let init_callback = Arc::clone(&init_callback);
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     match socket_path {
                         Ok(path) => {
                             let _ = init_callback.call(py, (path, py.None()), None);
@@ -425,7 +427,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
                 });
             }
         });
-        Ok(Python::with_gil(|py| {
+        Ok(Python::attach(|py| {
             "OK".into_pyobject(py)
                 .expect("Expected a proper conversion of 'OK' into a Python string.")
                 .into_any()

--- a/python/glide-shared/Cargo.toml
+++ b/python/glide-shared/Cargo.toml
@@ -8,4 +8,4 @@ name = "_fast_response"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.25", features = ["extension-module"] }
+pyo3 = { version = "^0.29", features = ["extension-module"] }

--- a/python/glide-shared/src/lib.rs
+++ b/python/glide-shared/src/lib.rs
@@ -2,6 +2,8 @@ use pyo3::ffi;
 use pyo3::prelude::*;
 use std::os::raw::c_char;
 
+type PyObject = Py<PyAny>;
+
 /// CommandResponse layout — must match ffi/src/lib.rs `CommandResponse` exactly.
 /// If you change this struct, you must also update the corresponding struct in ffi/src/lib.rs
 /// and the CFFI declarations in python/glide-shared/glide_shared/_glide_ffi.py.
@@ -31,10 +33,8 @@ static mut REQUEST_ERROR_CLASS: *mut ffi::PyObject = std::ptr::null_mut();
 unsafe fn get_request_error_class() -> *mut ffi::PyObject {
     unsafe {
         if REQUEST_ERROR_CLASS.is_null() {
-            let mod_name = ffi::PyUnicode_FromStringAndSize(
-                b"glide_shared.exceptions\0".as_ptr() as *const c_char,
-                23,
-            );
+            let mod_name =
+                ffi::PyUnicode_FromStringAndSize(c"glide_shared.exceptions".as_ptr(), 23);
             if mod_name.is_null() {
                 ffi::PyErr_Clear();
                 return std::ptr::null_mut();
@@ -45,10 +45,7 @@ unsafe fn get_request_error_class() -> *mut ffi::PyObject {
                 ffi::PyErr_Clear();
                 return std::ptr::null_mut();
             }
-            let attr = ffi::PyUnicode_FromStringAndSize(
-                b"RequestError\0".as_ptr() as *const c_char,
-                12,
-            );
+            let attr = ffi::PyUnicode_FromStringAndSize(c"RequestError".as_ptr(), 12);
             if attr.is_null() {
                 ffi::Py_DECREF(module);
                 ffi::PyErr_Clear();
@@ -72,24 +69,39 @@ unsafe fn get_request_error_class() -> *mut ffi::PyObject {
 /// and the CFFI declarations in python/glide-shared/glide_shared/_glide_ffi.py.
 unsafe fn convert(resp: *const CommandResponse) -> *mut ffi::PyObject {
     if resp.is_null() {
-        return unsafe { { let n = ffi::Py_None(); ffi::Py_INCREF(n); n } };
+        return unsafe {
+            {
+                let n = ffi::Py_None();
+                ffi::Py_INCREF(n);
+                n
+            }
+        };
     }
     let r = unsafe { &*resp };
     match r.response_type {
-        0 => unsafe { { let n = ffi::Py_None(); ffi::Py_INCREF(n); n } },
+        0 => unsafe {
+            {
+                let n = ffi::Py_None();
+                ffi::Py_INCREF(n);
+                n
+            }
+        },
         1 => unsafe { ffi::PyLong_FromLongLong(r.int_value) },
         2 => unsafe { ffi::PyFloat_FromDouble(r.float_value) },
         3 => unsafe { ffi::PyBool_FromLong(r.bool_value as std::ffi::c_long) },
-        4 => unsafe {
-            ffi::PyBytes_FromStringAndSize(r.string_value, r.string_value_len as isize)
-        },
+        4 => unsafe { ffi::PyBytes_FromStringAndSize(r.string_value, r.string_value_len as isize) },
         5 => unsafe {
             let len = r.array_value_len as isize;
             let list = ffi::PyList_New(len);
-            if list.is_null() { return std::ptr::null_mut(); }
+            if list.is_null() {
+                return std::ptr::null_mut();
+            }
             for i in 0..len {
                 let item = convert(r.array_value.offset(i));
-                if item.is_null() { ffi::Py_DECREF(list); return std::ptr::null_mut(); }
+                if item.is_null() {
+                    ffi::Py_DECREF(list);
+                    return std::ptr::null_mut();
+                }
                 ffi::PyList_SetItem(list, i, item);
             }
             list
@@ -98,13 +110,22 @@ unsafe fn convert(resp: *const CommandResponse) -> *mut ffi::PyObject {
             // Map — wrapper layout: array_value[i].map_key / .map_value
             let n = r.array_value_len as isize;
             let dict = ffi::PyDict_New();
-            if dict.is_null() { return std::ptr::null_mut(); }
+            if dict.is_null() {
+                return std::ptr::null_mut();
+            }
             for i in 0..n {
                 let wrapper = &*r.array_value.offset(i);
                 let key = convert(wrapper.map_key);
-                if key.is_null() { ffi::Py_DECREF(dict); return std::ptr::null_mut(); }
+                if key.is_null() {
+                    ffi::Py_DECREF(dict);
+                    return std::ptr::null_mut();
+                }
                 let val = convert(wrapper.map_value);
-                if val.is_null() { ffi::Py_DECREF(key); ffi::Py_DECREF(dict); return std::ptr::null_mut(); }
+                if val.is_null() {
+                    ffi::Py_DECREF(key);
+                    ffi::Py_DECREF(dict);
+                    return std::ptr::null_mut();
+                }
                 ffi::PyDict_SetItem(dict, key, val);
                 ffi::Py_DECREF(key);
                 ffi::Py_DECREF(val);
@@ -114,17 +135,22 @@ unsafe fn convert(resp: *const CommandResponse) -> *mut ffi::PyObject {
         7 => unsafe {
             let len = r.sets_value_len as isize;
             let set = ffi::PySet_New(std::ptr::null_mut());
-            if set.is_null() { return std::ptr::null_mut(); }
+            if set.is_null() {
+                return std::ptr::null_mut();
+            }
             for i in 0..len {
                 let item = convert(r.sets_value.offset(i));
-                if item.is_null() { ffi::Py_DECREF(set); return std::ptr::null_mut(); }
+                if item.is_null() {
+                    ffi::Py_DECREF(set);
+                    return std::ptr::null_mut();
+                }
                 ffi::PySet_Add(set, item);
                 ffi::Py_DECREF(item);
             }
             set
         },
         8 => unsafe {
-            let s = ffi::PyUnicode_FromStringAndSize(b"OK\0".as_ptr() as *const c_char, 2);
+            let s = ffi::PyUnicode_FromStringAndSize(c"OK".as_ptr(), 2);
             if !s.is_null() {
                 // Intern so that `result is OK` identity checks pass
                 let mut interned = s;
@@ -142,16 +168,44 @@ unsafe fn convert(resp: *const CommandResponse) -> *mut ffi::PyObject {
                 return ffi::PyBytes_FromStringAndSize(r.string_value, r.string_value_len as isize);
             }
             let msg = ffi::PyUnicode_FromStringAndSize(r.string_value, r.string_value_len as isize);
-            if msg.is_null() { ffi::PyErr_Clear(); return ffi::Py_None(); }
+            if msg.is_null() {
+                ffi::PyErr_Clear();
+                return {
+                    let n = ffi::Py_None();
+                    ffi::Py_INCREF(n);
+                    n
+                };
+            }
             let args = ffi::PyTuple_New(1);
-            if args.is_null() { ffi::Py_DECREF(msg); ffi::PyErr_Clear(); return ffi::Py_None(); }
+            if args.is_null() {
+                ffi::Py_DECREF(msg);
+                ffi::PyErr_Clear();
+                return {
+                    let n = ffi::Py_None();
+                    ffi::Py_INCREF(n);
+                    n
+                };
+            }
             ffi::PyTuple_SetItem(args, 0, msg); // steals ref to msg
             let obj = ffi::PyObject_CallObject(cls, args);
             ffi::Py_DECREF(args);
-            if obj.is_null() { ffi::PyErr_Clear(); return ffi::Py_None(); }
+            if obj.is_null() {
+                ffi::PyErr_Clear();
+                return {
+                    let n = ffi::Py_None();
+                    ffi::Py_INCREF(n);
+                    n
+                };
+            }
             obj
         },
-        _ => unsafe { { let n = ffi::Py_None(); ffi::Py_INCREF(n); n } },
+        _ => unsafe {
+            {
+                let n = ffi::Py_None();
+                ffi::Py_INCREF(n);
+                n
+            }
+        },
     }
 }
 
@@ -165,7 +219,11 @@ fn parse_response(py: Python<'_>, ptr: usize) -> (PyObject, usize) {
     let resp = ptr as *const CommandResponse;
     let arena_ptr = unsafe { (*resp).arena_ptr as usize };
     let raw = unsafe { convert(resp) };
-    let obj = if raw.is_null() { py.None() } else { unsafe { PyObject::from_owned_ptr(py, raw) } };
+    let obj = if raw.is_null() {
+        py.None()
+    } else {
+        unsafe { Bound::from_owned_ptr(py, raw).unbind() }
+    };
     (obj, arena_ptr)
 }
 


### PR DESCRIPTION
Cherrypicking two Python-CI fixes to `release-2.4`:
  
  1. **pyo3 upgrade** — https://github.com/valkey-io/valkey-glide/pull/6238 (commit `cc0fb9e28`).
     Resolves `RUSTSEC-2026-0176` and `RUSTSEC-2026-0177` advisories on `pyo3 0.25.1` that surfaced in `cargo deny` lint after #6318 landed on this branch.
  
  2. **pytest pin** — https://github.com/valkey-io/valkey-glide/pull/6268 (commit `d14dbdb25`).
     Pins `pytest<9.1` in `python/dev_requirements.txt` to avoid the fixture-finalizer assertion bug introduced in pytest 9.1 that breaks Python 3.13 + uvloop/trio backends.
  
  Originally tracked separately as #6319 (pytest pin) and this PR (pyo3 upgrade), but the two are mutually blocking on `release-2.4`'s CI: the pyo3 PR's Python 3.13 tests need the pytest pin to pass, and the pytest pin PR's lint needs the pyo3 fix to pass. Combining them here unblocks both. **#6319 will be closed as superseded once this merges.**