### PR TITLE
Fix flaky scriptKill_unkillable test by increasing timeouts

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -133,7 +133,7 @@ public class CommandTests {
 
     private static final String INITIAL_VALUE = "VALUE";
 
-    private static final int SCRIPT_POLL_TIMEOUT_MS = 8000;
+    private static final int SCRIPT_POLL_TIMEOUT_MS = 15000;
     private static final int SCRIPT_POLL_INTERVAL_MS = 500;
 
     private static final List<Arguments> clients = new ArrayList<>();
@@ -3944,7 +3944,7 @@ public class CommandTests {
 
         String key = UUID.randomUUID().toString();
         Route route = new SlotKeyRoute(key, PRIMARY);
-        String code = createLongRunningLuaScript(6, false);
+        String code = createLongRunningLuaScript(12, false);
 
         // Lower lua-time-limit on the target primary so the server starts reporting BUSY (and
         // accepting SCRIPT KILL) shortly after the script begins, instead of after the 5000ms
@@ -3962,10 +3962,10 @@ public class CommandTests {
                 GlideClusterClient testClient =
                         GlideClusterClient.createClient(
                                         commonClusterClientConfig()
-                                                .requestTimeout(10000)
+                                                .requestTimeout(15000)
                                                 .advancedConfiguration(
                                                         AdvancedGlideClusterClientConfiguration.builder()
-                                                                .connectionTimeout(10000)
+                                                                .connectionTimeout(15000)
                                                                 .build())
                                                 .build())
                                 .get()) {


### PR DESCRIPTION
### Summary
Fix flaky `scriptKill_unkillable` cluster test that times out waiting for the "unkillable" error under CI load.

### Issue link
This Pull Request is linked to issue: [[Java][Flaky Test] CommandTests > scriptKill_unkillable (GlideClusterClient)](https://github.com/valkey-io/valkey-glide/issues/6325)
Closes #6325

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** Under CI load, pipeline response latencies of 5.6s were observed. The write script ran for only 6 seconds, which left an extremely narrow window (< 1s after the first poll response arrives) to receive the "unkillable" error. If the script completes before the poll response arrives, SCRIPT KILL returns "NotBusy" instead, and the test times out.

**Fix:**
- Increase the write script duration from 6s to 12s, providing a much wider window for the polling to observe "unkillable"
- Increase `SCRIPT_POLL_TIMEOUT_MS` from 8000ms to 15000ms to give adequate headroom under CI load
- Increase `requestTimeout` and `connectionTimeout` from 10s to 15s to match the longer script duration (consistent with the other script test in the same file that already uses 15s)

### Limitations
None

### Testing
Verified the fix compiles and the changes are consistent with existing patterns in the same test class.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release