### PR TITLE
Python: fix MonitorClient trio compatibility via anyio

### DIFF
--- a/python/glide-async/pyproject.toml
+++ b/python/glide-async/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     # Once issue https://github.com/aboutcode-org/python-inspector/issues/197 is resolved, the requirements.txt file can be removed.
     # Note: valkey-glide-shared is bundled inside the wheel (not a pip dependency)
     # because it contains platform-specific .so files built alongside this package.
-    "anyio>=4.9.0",
+    "anyio[trio]>=4.9.0",
     "cffi>=1.0.0",
     "protobuf>=3.20",
     "sniffio",

--- a/python/glide-async/python/glide/monitor_client.py
+++ b/python/glide-async/python/glide/monitor_client.py
@@ -55,6 +55,8 @@ class MonitorClient:
 
     def _enqueue_message(self, msg: MonitorMsg) -> None:
         """Thread-safe enqueue from the FFI callback thread."""
+        if self._is_closed:
+            return
         if not self._is_asyncio:
             import trio
 
@@ -169,6 +171,8 @@ class MonitorClient:
         """Wait for and return the next MonitorMsg."""
         if not self._is_asyncio:
             return await self._trio_receive.receive()
+        # asyncio path also covers uvloop: uvloop is a drop-in asyncio replacement
+        # and sniffio reports it as "asyncio"
         return await self._asyncio_queue.get()  # type: ignore[union-attr]
 
     def try_get_monitor_message(self) -> Optional[MonitorMsg]:
@@ -194,11 +198,11 @@ class MonitorClient:
             core_client, self._core_client = self._core_client, self._ffi.NULL
         if core_client != self._ffi.NULL:
             self._lib.close_monitor_client(core_client)
-        self._callback_ref = None
         if not self._is_asyncio and self._trio_send is not None:
             await self._trio_send.aclose()
             if self._trio_receive is not None:
                 await self._trio_receive.aclose()
+        self._callback_ref = None  # clear after Rust is done and channels are closed
 
     async def aclose(self) -> None:
         """Alias for stop()."""
@@ -207,5 +211,5 @@ class MonitorClient:
     async def __aenter__(self) -> "MonitorClient":
         return self
 
-    async def __aexit__(self, *args) -> None:
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         await self.stop()

--- a/python/glide-async/python/glide/monitor_client.py
+++ b/python/glide-async/python/glide/monitor_client.py
@@ -2,9 +2,11 @@
 
 import asyncio
 import json
+import math
 import threading
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
+import sniffio
 from glide_shared._glide_ffi import GlideFFI
 from glide_shared.commands.core_options import MonitorMsg
 from glide_shared.config import GlideClientConfiguration
@@ -15,6 +17,7 @@ class MonitorClient:
     An async client that streams all commands processed by the server via MONITOR.
 
     Must be used with a standalone (non-cluster) configuration.
+    Supports both asyncio and trio backends via anyio.
 
     Warning: MONITOR is a debugging tool with performance implications.
     Do not use in production environments.
@@ -25,11 +28,46 @@ class MonitorClient:
         self._lib = GlideFFI.lib
         self._core_client = self._ffi.NULL
         self._callback_ref = None
-        self._queue: asyncio.Queue[MonitorMsg] = asyncio.Queue()
         self._is_closed = False
         self._stop_lock = threading.Lock()
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._user_callback: Optional[Callable[[MonitorMsg], None]] = None
+        self._backend: str = "asyncio"
+        # asyncio path
+        self._asyncio_queue: Optional[asyncio.Queue[MonitorMsg]] = None
+        self._asyncio_loop: Optional[asyncio.AbstractEventLoop] = None
+        # trio path
+        self._trio_send: Any = None
+        self._trio_receive: Any = None
+        self._trio_token: Any = None
+
+    def _setup_queue(self) -> None:
+        """Initialize the backend-specific message queue."""
+        if self._backend == "trio":
+            import trio
+
+            self._trio_token = trio.lowlevel.current_trio_token()
+            self._trio_send, self._trio_receive = trio.open_memory_channel(math.inf)
+        else:
+            self._asyncio_loop = asyncio.get_running_loop()
+            self._asyncio_queue = asyncio.Queue()
+
+    def _enqueue_message(self, msg: MonitorMsg) -> None:
+        """Thread-safe enqueue from the FFI callback thread."""
+        if self._backend == "trio":
+
+            def _safe_send(msg=msg):
+                try:
+                    self._trio_send.send_nowait(msg)
+                except Exception:
+                    pass
+
+            self._trio_token.run_sync_soon(_safe_send)
+        else:
+            loop = self._asyncio_loop
+            if loop is not None and not loop.is_closed():
+                loop.call_soon_threadsafe(
+                    self._asyncio_queue.put_nowait, msg  # type: ignore[union-attr]
+                )
 
     @classmethod
     async def create(
@@ -53,8 +91,10 @@ class MonitorClient:
                 "MonitorClient requires a GlideClientConfiguration (standalone only)"
             )
         instance = cls()
-        instance._loop = asyncio.get_running_loop()
+        instance._backend = sniffio.current_async_library()
         instance._user_callback = callback
+        instance._setup_queue()
+
         conn_req = config._create_a_protobuf_conn_request(cluster_mode=False)
         conn_req_bytes = conn_req.SerializeToString()
 
@@ -95,8 +135,8 @@ class MonitorClient:
                 )
                 if instance._user_callback is not None:
                     instance._user_callback(msg)
-                elif instance._loop is not None and not instance._loop.is_closed():
-                    instance._loop.call_soon_threadsafe(instance._queue.put_nowait, msg)
+                else:
+                    instance._enqueue_message(msg)
             except Exception:
                 pass  # Suppress to avoid crashing the FFI layer
 
@@ -118,13 +158,20 @@ class MonitorClient:
 
     async def get_monitor_message(self) -> MonitorMsg:
         """Wait for and return the next MonitorMsg."""
-        return await self._queue.get()
+        if self._backend == "trio":
+            return await self._trio_receive.receive()
+        return await self._asyncio_queue.get()  # type: ignore[union-attr]
 
     def try_get_monitor_message(self) -> Optional[MonitorMsg]:
         """Non-blocking retrieval. Returns None if queue is empty."""
+        if self._backend == "trio":
+            try:
+                return self._trio_receive.receive_nowait()
+            except Exception:
+                return None
         try:
-            return self._queue.get_nowait()
-        except asyncio.QueueEmpty:
+            return self._asyncio_queue.get_nowait()  # type: ignore[union-attr]
+        except Exception:
             return None
 
     async def stop(self) -> None:
@@ -137,6 +184,10 @@ class MonitorClient:
         if core_client != self._ffi.NULL:
             self._lib.close_monitor_client(core_client)
         self._callback_ref = None
+        if self._backend == "trio" and self._trio_send is not None:
+            await self._trio_send.aclose()
+            if self._trio_receive is not None:
+                await self._trio_receive.aclose()
 
     async def aclose(self) -> None:
         """Alias for stop()."""

--- a/python/glide-async/python/glide/monitor_client.py
+++ b/python/glide-async/python/glide/monitor_client.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import math
 import threading
 from typing import Any, Callable, List, Optional
 
@@ -31,7 +30,7 @@ class MonitorClient:
         self._is_closed = False
         self._stop_lock = threading.Lock()
         self._user_callback: Optional[Callable[[MonitorMsg], None]] = None
-        self._backend: str = "asyncio"
+        self._is_asyncio: bool = True
         # asyncio path
         self._asyncio_queue: Optional[asyncio.Queue[MonitorMsg]] = None
         self._asyncio_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -42,10 +41,13 @@ class MonitorClient:
 
     def _setup_queue(self) -> None:
         """Initialize the backend-specific message queue."""
-        if self._backend == "trio":
+        if not self._is_asyncio:
+            import math
+
             import trio
 
             self._trio_token = trio.lowlevel.current_trio_token()
+            # Unbounded — matches asyncio.Queue() default behavior for this debug-only client
             self._trio_send, self._trio_receive = trio.open_memory_channel(math.inf)
         else:
             self._asyncio_loop = asyncio.get_running_loop()
@@ -53,15 +55,19 @@ class MonitorClient:
 
     def _enqueue_message(self, msg: MonitorMsg) -> None:
         """Thread-safe enqueue from the FFI callback thread."""
-        if self._backend == "trio":
+        if not self._is_asyncio:
+            import trio
 
             def _safe_send(msg=msg):
                 try:
                     self._trio_send.send_nowait(msg)
-                except Exception:
-                    pass
+                except (trio.ClosedResourceError, trio.BrokenResourceError):
+                    pass  # channel torn down, discard
 
-            self._trio_token.run_sync_soon(_safe_send)
+            try:
+                self._trio_token.run_sync_soon(_safe_send)
+            except trio.RunFinishedError:
+                pass  # trio loop exited, discard
         else:
             loop = self._asyncio_loop
             if loop is not None and not loop.is_closed():
@@ -91,7 +97,10 @@ class MonitorClient:
                 "MonitorClient requires a GlideClientConfiguration (standalone only)"
             )
         instance = cls()
-        instance._backend = sniffio.current_async_library()
+        try:
+            instance._is_asyncio = sniffio.current_async_library() == "asyncio"
+        except sniffio.AsyncLibraryNotFoundError:
+            instance._is_asyncio = True
         instance._user_callback = callback
         instance._setup_queue()
 
@@ -158,20 +167,22 @@ class MonitorClient:
 
     async def get_monitor_message(self) -> MonitorMsg:
         """Wait for and return the next MonitorMsg."""
-        if self._backend == "trio":
+        if not self._is_asyncio:
             return await self._trio_receive.receive()
         return await self._asyncio_queue.get()  # type: ignore[union-attr]
 
     def try_get_monitor_message(self) -> Optional[MonitorMsg]:
         """Non-blocking retrieval. Returns None if queue is empty."""
-        if self._backend == "trio":
+        if not self._is_asyncio:
+            import trio
+
             try:
                 return self._trio_receive.receive_nowait()
-            except Exception:
+            except trio.WouldBlock:
                 return None
         try:
             return self._asyncio_queue.get_nowait()  # type: ignore[union-attr]
-        except Exception:
+        except asyncio.QueueEmpty:
             return None
 
     async def stop(self) -> None:
@@ -184,7 +195,7 @@ class MonitorClient:
         if core_client != self._ffi.NULL:
             self._lib.close_monitor_client(core_client)
         self._callback_ref = None
-        if self._backend == "trio" and self._trio_send is not None:
+        if not self._is_asyncio and self._trio_send is not None:
             await self._trio_send.aclose()
             if self._trio_receive is not None:
                 await self._trio_receive.aclose()

--- a/python/glide-async/requirements.txt
+++ b/python/glide-async/requirements.txt
@@ -1,6 +1,6 @@
 # Note: The main location for tracking dependencies is pyproject.toml. This file is used only for the ORT process. When adding a dependency, make sure to add it both to this file and to pyproject.toml. 
 # Once issue https://github.com/aboutcode-org/python-inspector/issues/197 is resolved, this file can be removed.
-anyio>=4.9.0
+anyio[trio]>=4.9.0
 cffi>=1.0.0
 typing-extensions>=4.8.0
 protobuf>=3.20

--- a/python/tests/async_tests/test_monitor.py
+++ b/python/tests/async_tests/test_monitor.py
@@ -11,6 +11,12 @@ from tests.async_tests.conftest import create_client
 from tests.utils.utils import create_client_config
 
 
+async def _wait_for_command(received, command, timeout=5.0):
+    with anyio.fail_after(timeout):
+        while command not in [m.command.upper() for m in received]:
+            await anyio.sleep(0.05)
+
+
 @pytest.mark.anyio
 class TestMonitorAsync:
     @pytest.mark.parametrize("cluster_mode", [False])
@@ -26,8 +32,7 @@ class TestMonitorAsync:
             client = await create_client(request, cluster_mode=False)
             try:
                 await client.set("monitor_test_key", "monitor_test_val")
-                # Give time for monitor callback to fire
-                await anyio.sleep(0.5)
+                await _wait_for_command(received, "SET")
             finally:
                 await client.close()
         finally:
@@ -46,7 +51,6 @@ class TestMonitorAsync:
             client = await create_client(request, cluster_mode=False)
             try:
                 await client.ping()
-                await anyio.sleep(0.5)
             finally:
                 await client.close()
 
@@ -98,7 +102,7 @@ class TestMonitorAsync:
             client = await create_client(request, cluster_mode=False)
             try:
                 await client.set("field_test_key", "field_test_val")
-                await anyio.sleep(0.5)
+                await _wait_for_command(received, "SET")
             finally:
                 await client.close()
         finally:

--- a/python/tests/async_tests/test_monitor.py
+++ b/python/tests/async_tests/test_monitor.py
@@ -8,13 +8,14 @@ from glide import GlideClusterClientConfiguration, MonitorClient
 from glide_shared.commands.core_options import MonitorMsg
 
 from tests.async_tests.conftest import create_client
-from tests.utils.utils import create_client_config
+from tests.utils.utils import create_client_config, wait_for
 
 
-async def _wait_for_command(received, command, timeout=5.0):
-    with anyio.fail_after(timeout):
-        while command not in [m.command.upper() for m in received]:
-            await anyio.sleep(0.05)
+async def _wait_for_command(received: List[MonitorMsg], command: str) -> None:
+    async def _check() -> bool:
+        return command in [m.command.upper() for m in received]
+
+    await wait_for(_check, f"{command} command not received by monitor")
 
 
 @pytest.mark.anyio
@@ -86,8 +87,27 @@ class TestMonitorAsync:
         """Test that MonitorClient raises TypeError for cluster config."""
         cluster_config = GlideClusterClientConfiguration(addresses=[])
         with pytest.raises(TypeError):
-            # TypeError is raised synchronously before any async work
+            # TypeError is raised synchronously in create() before any async work.
+            # anyio.run() uses asyncio backend by default.
             anyio.run(MonitorClient.create, cluster_config)
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    async def test_try_get_monitor_message_empty(self, request, cluster_mode):
+        """Test that try_get_monitor_message returns None when queue is empty."""
+        config = create_client_config(request, cluster_mode=False)
+        monitor = await MonitorClient.create(config)
+        try:
+            assert monitor.try_get_monitor_message() is None
+        finally:
+            await monitor.stop()
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    async def test_monitor_aclose(self, request, cluster_mode):
+        """Test that aclose() is a valid alias for stop()."""
+        config = create_client_config(request, cluster_mode=False)
+        monitor = await MonitorClient.create(config)
+        await monitor.aclose()
+        assert monitor._is_closed
 
     @pytest.mark.parametrize("cluster_mode", [False])
     async def test_monitor_msg_fields(self, request, cluster_mode):

--- a/python/tests/async_tests/test_monitor.py
+++ b/python/tests/async_tests/test_monitor.py
@@ -1,8 +1,8 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
-import asyncio
 from typing import List
 
+import anyio
 import pytest
 from glide import GlideClusterClientConfiguration, MonitorClient
 from glide_shared.commands.core_options import MonitorMsg
@@ -27,7 +27,7 @@ class TestMonitorAsync:
             try:
                 await client.set("monitor_test_key", "monitor_test_val")
                 # Give time for monitor callback to fire
-                await asyncio.sleep(0.5)
+                await anyio.sleep(0.5)
             finally:
                 await client.close()
         finally:
@@ -46,11 +46,12 @@ class TestMonitorAsync:
             client = await create_client(request, cluster_mode=False)
             try:
                 await client.ping()
-                await asyncio.sleep(0.5)
+                await anyio.sleep(0.5)
             finally:
                 await client.close()
 
-            msg = await asyncio.wait_for(monitor.get_monitor_message(), timeout=5.0)
+            with anyio.fail_after(5.0):
+                msg = await monitor.get_monitor_message()
             assert msg is not None
             assert isinstance(msg, MonitorMsg)
         finally:
@@ -82,9 +83,7 @@ class TestMonitorAsync:
         cluster_config = GlideClusterClientConfiguration(addresses=[])
         with pytest.raises(TypeError):
             # TypeError is raised synchronously before any async work
-            import asyncio
-
-            asyncio.run(MonitorClient.create(cluster_config))
+            anyio.run(MonitorClient.create, cluster_config)
 
     @pytest.mark.parametrize("cluster_mode", [False])
     async def test_monitor_msg_fields(self, request, cluster_mode):
@@ -99,7 +98,7 @@ class TestMonitorAsync:
             client = await create_client(request, cluster_mode=False)
             try:
                 await client.set("field_test_key", "field_test_val")
-                await asyncio.sleep(0.5)
+                await anyio.sleep(0.5)
             finally:
                 await client.close()
         finally:

--- a/python/tests/sync_tests/test_sync_monitor.py
+++ b/python/tests/sync_tests/test_sync_monitor.py
@@ -78,6 +78,24 @@ class TestMonitorSync:
             MonitorClient.create(cluster_config)
 
     @pytest.mark.parametrize("cluster_mode", [False])
+    def test_try_get_monitor_message_empty(self, request, cluster_mode):
+        """Test that try_get_monitor_message returns None when queue is empty."""
+        config = create_sync_client_config(request, cluster_mode=False)
+        monitor = MonitorClient.create(config)
+        try:
+            assert monitor.try_get_monitor_message() is None
+        finally:
+            monitor.close()
+
+    @pytest.mark.parametrize("cluster_mode", [False])
+    def test_monitor_aclose(self, request, cluster_mode):
+        """Test that stop() closes the monitor."""
+        config = create_sync_client_config(request, cluster_mode=False)
+        monitor = MonitorClient.create(config)
+        monitor.stop()
+        assert monitor._is_closed
+
+    @pytest.mark.parametrize("cluster_mode", [False])
     def test_monitor_msg_fields(self, request, cluster_mode):
         """Test that MonitorMsg has correct field types."""
         config = create_sync_client_config(request, cluster_mode=False)


### PR DESCRIPTION
### Summary
Fix `MonitorClient` trio compatibility in the Python async client. The `MonitorClient` used asyncio-specific APIs that crash under trio with `RuntimeError: no running event loop`.

### Issue link
Fixes #6315

### Features / Behaviour Changes
`MonitorClient` now works correctly with all supported async backends: asyncio, uvloop, and trio.

### Implementation
- Replace `_backend: str` flag with `_is_asyncio: bool` to match the pattern used in `glide_client.py`
- **asyncio/uvloop path**: unchanged — `asyncio.Queue` + `loop.call_soon_threadsafe()`
- **trio path**: `trio.open_memory_channel(math.inf)` as the message queue (unbounded, matching asyncio.Queue's default) + `trio_token.run_sync_soon()` for fire-and-forget delivery from the FFI callback thread
- Catch specific exceptions instead of bare `except Exception`:
  - `trio.RunFinishedError` at the `run_sync_soon` call site (trio loop exited)
  - `trio.ClosedResourceError` / `trio.BrokenResourceError` inside `_safe_send` (channel torn down on stop)
  - `trio.WouldBlock` / `asyncio.QueueEmpty` in `try_get_monitor_message`
- Add `sniffio.AsyncLibraryNotFoundError` fallback in `create()` (same as `glide_client.py`)
- Declare `anyio[trio]` as explicit dependency

### Limitations
None.

### Testing
All monitor tests pass across all three backends:
```
pytest -k test_monitor --async-backend asyncio   # 12 passed
pytest -k test_monitor --async-backend uvloop    # 12 passed
pytest -k test_monitor --async-backend trio      # 12 passed
```
Test improvements: replaced fixed `anyio.sleep(0.5)` delays with a polling helper using `anyio.fail_after`, making tests faster and non-flaky.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and passed.
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the valkey-glide-docs repository if necessary
