### PR TITLE
Core: Isolated Execution Scopes (Feature 2)

### DIFF
--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -746,6 +746,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1074,6 +1087,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
+ "dashmap 5.5.3",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -1107,6 +1121,7 @@ dependencies = [
 name = "glide-ffi"
 version = "0.1.0"
 dependencies = [
+ "dashmap 5.5.3",
  "glide-core",
  "lazy_static",
  "libc",
@@ -2206,7 +2221,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.1.0",
  "dispose",
  "futures",
  "futures-util",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
 libc = "0.2"
+dashmap = "5"
 protobuf = { version = "3", features = [] }
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }
 glide-core = { path = "../glide-core", features = ["proto"] }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5359,11 +5359,11 @@ fn create_pool_client_sync(
     });
     // For sync dispatch to work correctly, we need a background_runtime ref
     // so execute_request can enter its context during block_on.
-    // Clone the pool runtime's handle into a dedicated wrapper.
-    let bg_handle = shared_bg.handle().clone();
+    // Use a minimal single-threaded runtime as the background context.
     let bg_wrapper = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .worker_threads(0) // No actual threads — we just need the Handle
+        .worker_threads(1)
+        .thread_name("glide-pool-bg")
         .build()
         .ok(); // Fallback: if this fails, sync dispatch still works without bg context
 
@@ -5472,13 +5472,7 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
 
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let mut evicted = Vec::new();
-            let result = pool.try_acquire(&mut evicted);
-
-            // Clean up evicted entries from POOL_CLIENTS
-            for evicted_id in &evicted {
-                get_pool_clients().remove(evicted_id);
-            }
+            let result = pool.try_acquire();
 
             // Record OTel metrics for pool hit/miss
             if result >= 0 {
@@ -5545,24 +5539,9 @@ pub extern "C" fn glide_pool_release(pool_id: u64, client_id: u64) -> i32 {
         None => return -1,
     };
 
-    // Get the client entry to return to pool
-    let entry = get_pool_clients().get(&client_id);
-    let Some(entry) = entry else { return -1; };
-    let client = entry.client.clone();
-    let created_at = entry.created_at;
-    drop(entry);
-
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let pooled = PooledClient {
-                client_id,
-                client,
-                created_at,
-                last_idle_at: std::time::Instant::now(),
-                borrowed_at: None,
-                state: ClientState::Idle,
-            };
-            pool.release(client_id, pooled);
+            pool.release(client_id);
             0
         }
         Err(_) => {
@@ -5571,15 +5550,7 @@ pub extern "C" fn glide_pool_release(pool_id: u64, client_id: u64) -> i32 {
             let rt = get_pool_runtime();
             rt.spawn(async move {
                 let mut pool = pool_clone.lock().await;
-                let pooled = PooledClient {
-                    client_id,
-                    client,
-                    created_at,
-                    last_idle_at: std::time::Instant::now(),
-                    borrowed_at: None,
-                    state: ClientState::Idle,
-                };
-                pool.release(client_id, pooled);
+                pool.release(client_id);
             });
             0
         }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5462,6 +5462,16 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
     match pool_arc.try_lock() {
         Ok(mut pool) => {
             let result = pool.try_acquire();
+
+            // Record OTel metrics for pool hit/miss
+            if result >= 0 {
+                // Pool hit — client acquired from idle
+                let _ = GlideOpenTelemetry::record_pool_hit();
+            } else {
+                // Pool miss — no idle client available
+                let _ = GlideOpenTelemetry::record_pool_miss();
+            }
+
             if result < 0 && pool.should_create() {
                 // Trigger background creation
                 pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5395,6 +5395,7 @@ pub unsafe extern "C" fn glide_pool_create(
         min_idle,
         idle_timeout: std::time::Duration::from_millis(idle_timeout_ms),
         request_timeout: std::time::Duration::from_millis(request_timeout_ms),
+        test_on_borrow: false,
         connection_request: connection_request.clone(),
     };
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5324,22 +5324,20 @@ fn get_pool_clients() -> &'static dashmap::DashMap<u64, PoolClientEntry> {
 fn create_pool_client_sync(
     connection_request_bytes: &[u8],
 ) -> Result<(usize, glide_core::client::Client), String> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
+    // Each pooled client gets a lightweight current_thread runtime for block_on,
+    // but shares the global POOL_RUNTIME for background I/O (connection drivers,
+    // reconnection). This avoids creating N OS threads for N pooled clients.
+    let main_runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("Runtime creation failed: {}", e))?;
 
-    let bg_runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .worker_threads(1)
-        .thread_name("glide-pool-client")
-        .build()
-        .map_err(|e| format!("BG runtime creation failed: {}", e))?;
+    let shared_bg = get_pool_runtime();
 
-    // Parse and create client on background runtime
+    // Create client on the shared background runtime
     let client = {
-        let _guard = bg_runtime.enter();
-        bg_runtime.block_on(async {
+        let _guard = shared_bg.enter();
+        shared_bg.block_on(async {
             let proto = glide_core::connection_request::ConnectionRequest::parse_from_bytes(
                 connection_request_bytes,
             )
@@ -5351,15 +5349,28 @@ fn create_pool_client_sync(
         })?
     };
 
-    // Build ClientAdapter (sync mode: current_thread main + multi_thread background)
+    // Build ClientAdapter: current_thread for block_on, shared bg for I/O.
+    // Note: background_runtime is None — the shared POOL_RUNTIME handles
+    // spawned tasks. The SyncClient execute_request enters the bg context
+    // via the pool runtime handle stored separately.
     let core = Arc::new(CommandExecutionCore {
         client: client.clone(),
         client_type: ClientType::SyncClient,
     });
+    // For sync dispatch to work correctly, we need a background_runtime ref
+    // so execute_request can enter its context during block_on.
+    // Clone the pool runtime's handle into a dedicated wrapper.
+    let bg_handle = shared_bg.handle().clone();
+    let bg_wrapper = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(0) // No actual threads — we just need the Handle
+        .build()
+        .ok(); // Fallback: if this fails, sync dispatch still works without bg context
+
     let adapter = Arc::new(ClientAdapter {
-        runtime,
+        runtime: main_runtime,
         pipe_client_id: std::sync::atomic::AtomicU64::new(0),
-        background_runtime: Some(bg_runtime),
+        background_runtime: bg_wrapper,
         core,
         pubsub_callback: Arc::new(std::sync::RwLock::new(None)),
     });
@@ -5461,14 +5472,18 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
 
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let result = pool.try_acquire();
+            let mut evicted = Vec::new();
+            let result = pool.try_acquire(&mut evicted);
+
+            // Clean up evicted entries from POOL_CLIENTS
+            for evicted_id in &evicted {
+                get_pool_clients().remove(evicted_id);
+            }
 
             // Record OTel metrics for pool hit/miss
             if result >= 0 {
-                // Pool hit — client acquired from idle
                 let _ = GlideOpenTelemetry::record_pool_hit();
             } else {
-                // Pool miss — no idle client available
                 let _ = GlideOpenTelemetry::record_pool_miss();
             }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5461,7 +5461,7 @@ pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
     match pool_arc.try_lock() {
         Ok(mut pool) => {
             let result = pool.try_acquire();
-            if result == -1 && pool.should_create() {
+            if result < 0 && pool.should_create() {
                 // Trigger background creation
                 pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);
                 let pool_clone = pool_arc.clone();

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5277,3 +5277,334 @@ pub unsafe extern "C-unwind" fn close_monitor_client(client_ptr: *const c_void) 
         let _ = unsafe { Box::from_raw(client_ptr as *mut MonitorAdapter) };
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CLIENT-INSTANCE POOL FFI (Feature 1)
+//
+// These functions expose glide-core's ClientPool to all language bindings.
+// The pool manages GlideClient lifecycle (creation, LIFO reuse, bounded size).
+// Language bindings call these via their FFI mechanism (CFFI, Ruby FFI, JNI, CGO).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+use glide_core::pool::{self, ClientPool, ClientState, PoolConfig, PooledClient, POOL_RUNNING};
+use std::sync::atomic::Ordering as AtomicOrdering;
+
+/// Shared Tokio runtime for pool background operations (client creation, eviction).
+/// All pooled clients share this runtime rather than each getting their own.
+static POOL_RUNTIME: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+
+/// Maps client_id → (ClientAdapter raw pointer, PooledClient).
+/// When a client is acquired, the entry moves here. On release, it moves back to pool.idle.
+static POOL_CLIENTS: std::sync::OnceLock<dashmap::DashMap<u64, PoolClientEntry>> =
+    std::sync::OnceLock::new();
+
+struct PoolClientEntry {
+    adapter_ptr: usize,  // *const ClientAdapter as usize (for command dispatch)
+    client: glide_core::client::Client,
+    created_at: std::time::Instant,
+}
+
+fn get_pool_runtime() -> &'static tokio::runtime::Runtime {
+    POOL_RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("glide-pool")
+            .build()
+            .expect("Failed to create pool runtime")
+    })
+}
+
+fn get_pool_clients() -> &'static dashmap::DashMap<u64, PoolClientEntry> {
+    POOL_CLIENTS.get_or_init(dashmap::DashMap::new)
+}
+
+/// Create a GlideClient + ClientAdapter for the pool.
+/// Runs on a dedicated thread (not inside an existing runtime) to avoid nesting.
+fn create_pool_client_sync(
+    connection_request_bytes: &[u8],
+) -> Result<(usize, glide_core::client::Client), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("Runtime creation failed: {}", e))?;
+
+    let bg_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(1)
+        .thread_name("glide-pool-client")
+        .build()
+        .map_err(|e| format!("BG runtime creation failed: {}", e))?;
+
+    // Parse and create client on background runtime
+    let client = {
+        let _guard = bg_runtime.enter();
+        bg_runtime.block_on(async {
+            let proto = glide_core::connection_request::ConnectionRequest::parse_from_bytes(
+                connection_request_bytes,
+            )
+            .map_err(|e| format!("Protobuf parse error: {}", e))?;
+            let req = glide_core::client::ConnectionRequest::from(proto);
+            glide_core::client::Client::new(req, None)
+                .await
+                .map_err(|e| format!("Client creation failed: {}", e))
+        })?
+    };
+
+    // Build ClientAdapter (sync mode: current_thread main + multi_thread background)
+    let core = Arc::new(CommandExecutionCore {
+        client: client.clone(),
+        client_type: ClientType::SyncClient,
+    });
+    let adapter = Arc::new(ClientAdapter {
+        runtime,
+        pipe_client_id: std::sync::atomic::AtomicU64::new(0),
+        background_runtime: Some(bg_runtime),
+        core,
+        pubsub_callback: Arc::new(std::sync::RwLock::new(None)),
+    });
+    let ptr = Arc::into_raw(adapter) as usize;
+
+    Ok((ptr, client))
+}
+
+/// Create a new client-instance pool.
+///
+/// Spawns `min_idle` background client creation tasks. Returns pool_id (positive)
+/// on success, -1 on invalid config, -2 on other errors.
+///
+/// # Safety
+/// `connection_request_ptr` must point to `connection_request_len` valid bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn glide_pool_create(
+    max_size: u32,
+    min_idle: u32,
+    idle_timeout_ms: u64,
+    request_timeout_ms: u64,
+    connection_request_ptr: *const u8,
+    connection_request_len: usize,
+) -> i64 {
+    let connection_request = if connection_request_ptr.is_null() || connection_request_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(connection_request_ptr, connection_request_len) }.to_vec()
+    };
+
+    let config = PoolConfig {
+        max_size,
+        min_idle,
+        idle_timeout: std::time::Duration::from_millis(idle_timeout_ms),
+        request_timeout: std::time::Duration::from_millis(request_timeout_ms),
+        connection_request: connection_request.clone(),
+    };
+
+    let pool = match ClientPool::new(config) {
+        Ok(p) => p,
+        Err(_) => return -1,
+    };
+
+    let pool_id = pool::register_pool(pool);
+
+    // Spawn min_idle background client creation
+    if min_idle > 0 {
+        let pool_arc = pool::get_pool(pool_id).unwrap();
+        for _ in 0..min_idle {
+            let pool_clone = pool_arc.clone();
+            let bytes = connection_request.clone();
+            std::thread::spawn(move || {
+                match create_pool_client_sync(&bytes) {
+                    Ok((adapter_ptr, client)) => {
+                        let rt = get_pool_runtime();
+                        rt.block_on(async {
+                            let mut pool = pool_clone.lock().await;
+                            if pool.state.load(AtomicOrdering::Acquire) != POOL_RUNNING {
+                                return;
+                            }
+                            let client_id = pool.next_id();
+                            let entry = PooledClient {
+                                client_id,
+                                client: client.clone(),
+                                created_at: std::time::Instant::now(),
+                                last_idle_at: std::time::Instant::now(),
+                                borrowed_at: None,
+                                state: ClientState::Idle,
+                            };
+                            pool.idle.push_back(entry);
+                            pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);
+                            // Store adapter mapping
+                            get_pool_clients().insert(client_id, PoolClientEntry {
+                                adapter_ptr,
+                                client,
+                                created_at: std::time::Instant::now(),
+                            });
+                        });
+                    }
+                    Err(e) => {
+                        logger_core::log_error_lazy!("pool", format!("Background client creation failed: {}", e));
+                    }
+                }
+            });
+        }
+    }
+
+    pool_id as i64
+}
+
+/// Non-blocking acquire. Returns client_id >= 0, -1 if exhausted, -2 if invalid pool.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_try_acquire(pool_id: u64) -> i64 {
+    let pool_arc = match pool::get_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -2,
+    };
+
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let result = pool.try_acquire();
+            if result == -1 && pool.should_create() {
+                // Trigger background creation
+                pool.total_count.fetch_add(1, AtomicOrdering::AcqRel);
+                let pool_clone = pool_arc.clone();
+                let bytes = pool.config.connection_request.clone();
+                drop(pool);
+                std::thread::spawn(move || {
+                    match create_pool_client_sync(&bytes) {
+                        Ok((adapter_ptr, client)) => {
+                            let rt = get_pool_runtime();
+                            rt.block_on(async {
+                                let mut pool = pool_clone.lock().await;
+                                if pool.state.load(AtomicOrdering::Acquire) != POOL_RUNNING {
+                                    pool.total_count.fetch_sub(1, AtomicOrdering::AcqRel);
+                                    return;
+                                }
+                                let client_id = pool.next_id();
+                                let entry = PooledClient {
+                                    client_id,
+                                    client: client.clone(),
+                                    created_at: std::time::Instant::now(),
+                                    last_idle_at: std::time::Instant::now(),
+                                    borrowed_at: None,
+                                    state: ClientState::Idle,
+                                };
+                                pool.idle.push_back(entry);
+                                get_pool_clients().insert(client_id, PoolClientEntry {
+                                    adapter_ptr,
+                                    client,
+                                    created_at: std::time::Instant::now(),
+                                });
+                            });
+                        }
+                        Err(e) => {
+                            logger_core::log_error_lazy!("pool", format!("Background creation failed: {}", e));
+                            let rt = get_pool_runtime();
+                            rt.block_on(async {
+                                let pool = pool_clone.lock().await;
+                                pool.total_count.fetch_sub(1, AtomicOrdering::AcqRel);
+                            });
+                        }
+                    }
+                });
+            }
+            result
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Release a borrowed client back to the pool. Fire-and-forget.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_release(pool_id: u64, client_id: u64) -> i32 {
+    let pool_arc = match pool::get_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+
+    // Get the client entry to return to pool
+    let entry = get_pool_clients().get(&client_id);
+    let Some(entry) = entry else { return -1; };
+    let client = entry.client.clone();
+    let created_at = entry.created_at;
+    drop(entry);
+
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let pooled = PooledClient {
+                client_id,
+                client,
+                created_at,
+                last_idle_at: std::time::Instant::now(),
+                borrowed_at: None,
+                state: ClientState::Idle,
+            };
+            pool.release(client_id, pooled);
+            0
+        }
+        Err(_) => {
+            // Lock contended — async release
+            let pool_clone = pool_arc.clone();
+            let rt = get_pool_runtime();
+            rt.spawn(async move {
+                let mut pool = pool_clone.lock().await;
+                let pooled = PooledClient {
+                    client_id,
+                    client,
+                    created_at,
+                    last_idle_at: std::time::Instant::now(),
+                    borrowed_at: None,
+                    state: ClientState::Idle,
+                };
+                pool.release(client_id, pooled);
+            });
+            0
+        }
+    }
+}
+
+/// Destroy a pool.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_destroy(pool_id: u64) -> i32 {
+    let pool_arc = match pool::unregister_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+    if let Ok(mut pool) = pool_arc.try_lock() {
+        pool.destroy();
+    }
+    0
+}
+
+/// Get the ClientAdapter pointer for a borrowed client_id.
+/// Language bindings pass this to `command()` for dispatch.
+#[unsafe(no_mangle)]
+pub extern "C" fn glide_pool_get_client_ptr(client_id: u64) -> usize {
+    get_pool_clients()
+        .get(&client_id)
+        .map(|e| e.adapter_ptr)
+        .unwrap_or(0)
+}
+
+/// Query pool metrics. Writes idle/active/total to out pointers.
+///
+/// # Safety
+/// Out pointers must be valid for writing a u32.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn glide_pool_metrics(
+    pool_id: u64,
+    idle_out: *mut u32,
+    active_out: *mut u32,
+    total_out: *mut u32,
+) -> i32 {
+    let pool_arc = match pool::get_pool(pool_id) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+    match pool_arc.try_lock() {
+        Ok(pool) => {
+            if !idle_out.is_null() { unsafe { *idle_out = pool.idle_count(); } }
+            if !active_out.is_null() { unsafe { *active_out = pool.active_count(); } }
+            if !total_out.is_null() { unsafe { *total_out = pool.total_count.load(AtomicOrdering::Acquire); } }
+            0
+        }
+        Err(_) => -1,
+    }
+}

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -932,6 +932,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1319,6 +1332,7 @@ dependencies = [
  "bytes",
  "criterion",
  "ctor",
+ "dashmap 5.5.3",
  "directories",
  "futures",
  "futures-intrusive",
@@ -2620,7 +2634,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.2.1",
  "dispose",
  "futures",
  "futures-util",

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Valkey GLIDE Maintainers"]
 [dependencies]
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 bytes = "1"
+dashmap = "5"
 futures = "^0.3"
 redis = { path = "./redis-rs/redis", features = [
     "aio",

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -189,7 +189,13 @@ where
 /// underlying connections maintained for each node in the cluster, as well
 /// as common parameters for connecting to nodes and executing commands.
 #[derive(Clone)]
-pub struct ClusterConnection<C = MultiplexedConnection>(mpsc::Sender<Message<C>>);
+pub struct ClusterConnection<C = MultiplexedConnection> {
+    sender: mpsc::Sender<Message<C>>,
+    /// Direct access to the cluster's slot map for address resolution.
+    /// Used by isolated execution (Feature 2) to determine which node
+    /// to open a scoped connection to.
+    inner_core: Arc<InnerCore<C>>,
+}
 
 impl<C> ClusterConnection<C>
 where
@@ -211,6 +217,7 @@ where
         )
         .await
         .map(|inner| {
+            let inner_core = inner.inner.clone();
             let (tx, mut rx) = mpsc::channel::<Message<_>>(100);
             let stream = async move {
                 let _ = stream::poll_fn(move |cx| rx.poll_recv(cx))
@@ -220,7 +227,7 @@ where
             };
             #[cfg(feature = "tokio-comp")]
             tokio::spawn(stream);
-            ClusterConnection(tx)
+            ClusterConnection { sender: tx, inner_core }
         })
     }
 
@@ -288,7 +295,7 @@ where
         cluster_scan_args: ClusterScanArgs,
     ) -> RedisResult<(ScanStateRC, Vec<Value>)> {
         let (sender, receiver) = oneshot::channel();
-        self.0
+        self.sender
             .send(Message {
                 cmd: CmdArg::ClusterScan { cluster_scan_args },
                 sender,
@@ -322,7 +329,7 @@ where
     ) -> RedisResult<Value> {
         log_trace_lazy!("cluster", "route_command");
         let (sender, receiver) = oneshot::channel();
-        self.0
+        self.sender
             .send(Message {
                 cmd: CmdArg::Cmd {
                     cmd: Arc::new(cmd.clone()),
@@ -367,7 +374,7 @@ where
         pipeline_retry_strategy: Option<PipelineRetryStrategy>,
     ) -> RedisResult<Vec<Value>> {
         let (sender, receiver) = oneshot::channel();
-        self.0
+        self.sender
             .send(Message {
                 cmd: CmdArg::Pipeline {
                     pipeline: Arc::new(pipeline.clone()),
@@ -460,13 +467,22 @@ where
         self.route_operation_request(Operation::GetUsername).await
     }
 
+    /// Get the primary node address for a given hash slot.
+    /// Used by isolated execution to open scoped connections to the correct node.
+    /// Returns None if the slot is not mapped to any known node.
+    pub fn address_for_slot(&self, slot: u16) -> Option<String> {
+        use crate::cluster_routing::{Route, SlotAddr};
+        let route = Route::new(slot, SlotAddr::Master);
+        self.inner_core.conn_lock.read().address_for_route(&route)
+    }
+
     /// Routes an operation request to the appropriate handler.
     async fn route_operation_request(
         &mut self,
         operation_request: Operation,
     ) -> RedisResult<Value> {
         let (sender, receiver) = oneshot::channel();
-        self.0
+        self.sender
             .send(Message {
                 cmd: CmdArg::OperationRequest(operation_request),
                 sender,

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1321,6 +1321,94 @@ impl Client {
         })
     }
 
+    /// Execute a command on a provided dedicated connection (for isolated execution).
+    ///
+    /// Applies the same timeout, decompression, and IAM token refresh logic as
+    /// `send_command`, but routes the command to the given `MultiplexedConnection`
+    /// instead of the client's internal managed connection.
+    ///
+    /// IAM handling: if the token has rotated since the connection was last
+    /// authenticated, sends AUTH with the fresh token before executing the command.
+    /// This ensures scoped connections don't fail mid-transaction due to token expiry.
+    pub async fn send_command_on_connection(
+        &self,
+        cmd: &Cmd,
+        connection: &mut redis::aio::MultiplexedConnection,
+    ) -> RedisResult<Value> {
+        // IAM token refresh: if token rotated, re-authenticate this connection
+        if let Some(iam_manager) = &self.iam_token_manager {
+            if iam_manager.token_changed() {
+                let current_token = iam_manager.get_token().await;
+                if !current_token.is_empty() {
+                    iam_manager.clear_token_changed();
+                    // Re-authenticate the scoped connection with fresh token
+                    let auth_cmd = redis::cmd("AUTH").arg(current_token.as_str()).to_owned();
+                    connection.send_packed_command(&auth_cmd).await?;
+                }
+            }
+        }
+
+        let request_timeout = Some(self.request_timeout);
+
+        // Send with timeout
+        let raw_value = match request_timeout {
+            Some(duration) => {
+                match tokio::time::timeout(duration, connection.send_packed_command(cmd)).await {
+                    Ok(result) => result?,
+                    Err(_) => {
+                        return Err(std::io::Error::from(std::io::ErrorKind::TimedOut).into());
+                    }
+                }
+            }
+            None => connection.send_packed_command(cmd).await?,
+        };
+
+        // Apply decompression if compression is enabled
+        let processed_value = if let Some(ref compression_manager) = self.compression_manager {
+            if let Some(request_type) = extract_request_type_from_cmd(cmd) {
+                match crate::compression::process_response_for_decompression(
+                    raw_value.clone(),
+                    request_type,
+                    Some(compression_manager.as_ref()),
+                ) {
+                    Ok(decompressed) => decompressed,
+                    Err(e) => {
+                        if e.should_propagate() {
+                            return Err(redis::RedisError::from((
+                                redis::ErrorKind::IoError,
+                                "Decompression error",
+                                e.to_string(),
+                            )));
+                        }
+                        raw_value
+                    }
+                }
+            } else {
+                raw_value
+            }
+        } else {
+            raw_value
+        };
+
+        // Type conversion
+        let expected_type = expected_type_for_cmd(cmd);
+        convert_to_expected_type(processed_value, expected_type)
+    }
+
+    /// Get the primary node address for a given hash slot (cluster mode).
+    /// Returns the host:port string for the primary that owns the slot.
+    /// Returns None in standalone mode or if the slot is unmapped.
+    ///
+    /// Used by isolated execution (Feature 2) to open scoped connections
+    /// directly to the correct node, avoiding MOVED redirects.
+    pub async fn address_for_slot(&self, slot: u16) -> Option<String> {
+        let client = self.internal_client.read().await;
+        match &*client {
+            ClientWrapper::Cluster { client } => client.address_for_slot(slot),
+            _ => None,
+        }
+    }
+
     /// Returns the cache hit rate (hits / total requests).
     /// Returns an error if caching is not enabled or metrics are disabled.
     pub fn cache_hit_rate(&self) -> RedisResult<Value> {

--- a/glide-core/src/lib.rs
+++ b/glide-core/src/lib.rs
@@ -5,6 +5,7 @@ include!("generated/mod.rs");
 pub mod client;
 pub mod otel_db_semantics;
 pub mod pool;
+pub mod scope;
 #[cfg(feature = "socket-layer")]
 pub mod rotating_buffer;
 #[cfg(feature = "socket-layer")]

--- a/glide-core/src/lib.rs
+++ b/glide-core/src/lib.rs
@@ -4,6 +4,7 @@
 include!("generated/mod.rs");
 pub mod client;
 pub mod otel_db_semantics;
+pub mod pool;
 #[cfg(feature = "socket-layer")]
 pub mod rotating_buffer;
 #[cfg(feature = "socket-layer")]

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -34,6 +34,7 @@
 
 use crate::client::Client as GlideClient;
 use dashmap::DashMap;
+use redis::aio::MultiplexedConnection;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -261,3 +262,389 @@ impl std::fmt::Display for PoolError {
 }
 
 impl std::error::Error for PoolError {}
+
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// FEATURE 2: ISOLATED EXECUTION (SCOPE POOL)
+//
+// Per-client pool of dedicated connections for operations requiring
+// per-connection server state (WATCH, CLIENT TRACKING, BLPOP, pub/sub).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Tracks per-connection state mutations during a scope borrow.
+/// Used for conditional cleanup on release (zero-cost if clean).
+#[derive(Default)]
+pub struct ConnectionState {
+    pub watch_active: bool,
+    pub multi_active: bool,
+    pub tracking_enabled: bool,
+    pub db_selected: u8,
+    pub client_name_changed: bool,
+    pub subscriptions: Vec<ScopeSubscription>,
+}
+
+impl ConnectionState {
+    pub fn is_clean(&self) -> bool {
+        !self.watch_active
+            && !self.multi_active
+            && !self.tracking_enabled
+            && self.db_selected == 0
+            && !self.client_name_changed
+            && self.subscriptions.is_empty()
+    }
+
+    pub fn has_subscriptions(&self) -> bool {
+        !self.subscriptions.is_empty()
+    }
+}
+
+pub enum ScopeSubscription {
+    Channel(Vec<u8>),
+    Pattern(Vec<u8>),
+    ShardedChannel(Vec<u8>),
+}
+
+/// Update ConnectionState based on a command about to execute.
+pub fn update_state_for_command(state: &mut ConnectionState, cmd: &str, args: &[&[u8]]) {
+    match cmd.to_uppercase().as_str() {
+        "WATCH" => state.watch_active = true,
+        "UNWATCH" => state.watch_active = false,
+        "MULTI" => state.multi_active = true,
+        "EXEC" | "DISCARD" => {
+            state.watch_active = false;
+            state.multi_active = false;
+        }
+        "SELECT" => {
+            if let Some(b) = args.first() {
+                if let Ok(s) = std::str::from_utf8(b) {
+                    if let Ok(db) = s.parse::<u8>() {
+                        state.db_selected = db;
+                    }
+                }
+            }
+        }
+        "CLIENT" => {
+            if args.len() >= 2 {
+                let sub = std::str::from_utf8(args[0]).unwrap_or("").to_uppercase();
+                if sub == "TRACKING" {
+                    let v = std::str::from_utf8(args[1]).unwrap_or("").to_uppercase();
+                    state.tracking_enabled = v == "ON";
+                } else if sub == "SETNAME" {
+                    state.client_name_changed = true;
+                }
+            }
+        }
+        "SUBSCRIBE" | "PSUBSCRIBE" | "SSUBSCRIBE" => {
+            for arg in args {
+                let s = match cmd.to_uppercase().as_str() {
+                    "PSUBSCRIBE" => ScopeSubscription::Pattern(arg.to_vec()),
+                    "SSUBSCRIBE" => ScopeSubscription::ShardedChannel(arg.to_vec()),
+                    _ => ScopeSubscription::Channel(arg.to_vec()),
+                };
+                state.subscriptions.push(s);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Configuration for per-client scope pool.
+pub struct ScopePoolConfig {
+    pub max_total: u32,
+    pub idle_timeout: Duration,
+    pub request_timeout: Duration,
+}
+
+impl Default for ScopePoolConfig {
+    fn default() -> Self {
+        Self {
+            max_total: 64,
+            idle_timeout: Duration::from_secs(30),
+            request_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+/// A dedicated connection for isolated execution.
+///
+/// Cluster mode support:
+/// - `pinned_slot`: set after first command with keys (from key hash slot)
+/// - Subsequent commands must target the same slot or have no keys
+/// - MOVED errors surface to caller (WATCH state can't survive migration)
+pub struct ScopedConnection {
+    pub scope_id: u64,
+    pub connection: redis::aio::MultiplexedConnection,
+    pub created_at: Instant,
+    pub last_idle_at: Instant,
+    pub borrowed_at: Option<Instant>,
+    pub state: ConnectionState,
+    /// In cluster mode: the slot this scope is pinned to after first keyed command.
+    /// None means not yet pinned (no keyed command issued).
+    pub pinned_slot: Option<u16>,
+}
+
+/// Per-client scope pool.
+pub struct ScopePool {
+    pub config: ScopePoolConfig,
+    pub idle: VecDeque<ScopedConnection>,
+    pub in_use: DashMap<u64, ()>,
+    next_scope_id: AtomicU64,
+    pub total_count: AtomicU32,
+    pub state: AtomicU8,
+    pub connection_request_bytes: Vec<u8>,
+    /// The parent client_id that owns this scope pool (for accessing client config).
+    pub parent_client_id: u64,
+}
+
+impl ScopePool {
+    pub fn new(config: ScopePoolConfig, connection_request_bytes: Vec<u8>, parent_client_id: u64) -> Self {
+        Self {
+            config,
+            idle: VecDeque::new(),
+            in_use: DashMap::new(),
+            next_scope_id: AtomicU64::new(1),
+            total_count: AtomicU32::new(0),
+            state: AtomicU8::new(POOL_RUNNING),
+            connection_request_bytes,
+            parent_client_id,
+        }
+    }
+
+    pub fn next_id(&self) -> u64 {
+        self.next_scope_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Non-blocking acquire. Returns scope_id >= 0, -1 if exhausted.
+    pub fn try_acquire(&mut self, registry: &DashMap<u64, ScopeEntry>) -> i64 {
+        if self.state.load(Ordering::Acquire) != POOL_RUNNING {
+            return -1;
+        }
+        if let Some(mut conn) = self.idle.pop_back() {
+            // Evict if idle too long
+            let idle_duration = Instant::now().duration_since(conn.last_idle_at);
+            if idle_duration > self.config.idle_timeout {
+                self.total_count.fetch_sub(1, Ordering::AcqRel);
+                // Try next idle connection (recursive pop)
+                while let Some(mut next) = self.idle.pop_back() {
+                    let d = Instant::now().duration_since(next.last_idle_at);
+                    if d <= self.config.idle_timeout {
+                        let scope_id = next.scope_id;
+                        next.borrowed_at = Some(Instant::now());
+                        next.state = ConnectionState::default();
+                        registry.insert(scope_id, ScopeEntry {
+                            connection: Arc::new(TokioMutex::new(next)),
+                        });
+                        self.in_use.insert(scope_id, ());
+                        return scope_id as i64;
+                    }
+                    self.total_count.fetch_sub(1, Ordering::AcqRel);
+                }
+            } else {
+                let scope_id = conn.scope_id;
+                conn.borrowed_at = Some(Instant::now());
+                conn.state = ConnectionState::default();
+                registry.insert(scope_id, ScopeEntry {
+                    connection: Arc::new(TokioMutex::new(conn)),
+                });
+                self.in_use.insert(scope_id, ());
+                return scope_id as i64;
+            }
+        }
+        if self.total_count.load(Ordering::Acquire) < self.config.max_total {
+            self.total_count.fetch_add(1, Ordering::AcqRel);
+        }
+        -1
+    }
+
+    /// Release a scope. Zero-cost if state is clean.
+    pub fn release(&mut self, scope_id: u64, registry: &DashMap<u64, ScopeEntry>) -> bool {
+        if self.in_use.remove(&scope_id).is_none() {
+            return false;
+        }
+        let entry = registry.remove(&scope_id);
+        let Some((_, entry)) = entry else { return false; };
+
+        if self.state.load(Ordering::Acquire) != POOL_RUNNING {
+            self.total_count.fetch_sub(1, Ordering::AcqRel);
+            return true;
+        }
+
+        match entry.connection.try_lock() {
+            Ok(conn) => {
+                if conn.state.is_clean() {
+                    let idle_conn = ScopedConnection {
+                        scope_id: conn.scope_id,
+                        connection: conn.connection.clone(),
+                        created_at: conn.created_at,
+                        last_idle_at: Instant::now(),
+                        borrowed_at: None,
+                        state: ConnectionState::default(),
+                        pinned_slot: None,
+                    };
+                    drop(conn);
+                    self.idle.push_back(idle_conn);
+                } else {
+                    // Dirty state — spawn async cleanup (UNSUBSCRIBE, DISCARD, etc.)
+                    let conn_arc = entry.connection.clone();
+                    let request_timeout = self.config.request_timeout;
+                    self.total_count.fetch_sub(1, Ordering::AcqRel);
+
+                    tokio::spawn(async move {
+                        let mut guard = conn_arc.lock().await;
+                        let timeout = request_timeout * 2;
+                        let _ = tokio::time::timeout(timeout, async {
+                            if guard.state.has_subscriptions() {
+                                let mut channels = Vec::new();
+                                let mut patterns = Vec::new();
+                                let mut sharded = Vec::new();
+                                for sub in &guard.state.subscriptions {
+                                    match sub {
+                                        ScopeSubscription::Channel(c) => channels.push(c.clone()),
+                                        ScopeSubscription::Pattern(p) => patterns.push(p.clone()),
+                                        ScopeSubscription::ShardedChannel(s) => sharded.push(s.clone()),
+                                    }
+                                }
+                                if !channels.is_empty() {
+                                    let mut cmd = redis::Cmd::new();
+                                    cmd.arg("UNSUBSCRIBE");
+                                    for c in &channels { cmd.arg(c.as_slice()); }
+                                    let _ = guard.connection.send_packed_command(&cmd).await;
+                                }
+                                if !patterns.is_empty() {
+                                    let mut cmd = redis::Cmd::new();
+                                    cmd.arg("PUNSUBSCRIBE");
+                                    for p in &patterns { cmd.arg(p.as_slice()); }
+                                    let _ = guard.connection.send_packed_command(&cmd).await;
+                                }
+                                if !sharded.is_empty() {
+                                    let mut cmd = redis::Cmd::new();
+                                    cmd.arg("SUNSUBSCRIBE");
+                                    for s in &sharded { cmd.arg(s.as_slice()); }
+                                    let _ = guard.connection.send_packed_command(&cmd).await;
+                                }
+                            }
+                            if guard.state.multi_active {
+                                let _ = guard.connection.send_packed_command(
+                                    &redis::Cmd::new().arg("DISCARD")).await;
+                            } else if guard.state.watch_active {
+                                let _ = guard.connection.send_packed_command(
+                                    &redis::Cmd::new().arg("UNWATCH")).await;
+                            }
+                            if guard.state.tracking_enabled {
+                                let _ = guard.connection.send_packed_command(
+                                    &redis::Cmd::new().arg("CLIENT").arg("TRACKING").arg("OFF")).await;
+                            }
+                            if guard.state.db_selected != 0 {
+                                let _ = guard.connection.send_packed_command(
+                                    &redis::Cmd::new().arg("SELECT").arg("0")).await;
+                            }
+                        }).await;
+                    });
+                }
+                true
+            }
+            Err(_) => {
+                self.total_count.fetch_sub(1, Ordering::AcqRel);
+                true
+            }
+        }
+    }
+
+    pub fn destroy(&mut self, registry: &DashMap<u64, ScopeEntry>) {
+        self.state.store(POOL_CLOSED, Ordering::Release);
+        self.idle.clear();
+        let keys: Vec<u64> = self.in_use.iter().map(|e| *e.key()).collect();
+        for key in keys {
+            self.in_use.remove(&key);
+            registry.remove(&key);
+        }
+        self.total_count.store(0, Ordering::Release);
+    }
+}
+
+/// Entry in the global scope registry for command routing.
+pub struct ScopeEntry {
+    pub connection: Arc<TokioMutex<ScopedConnection>>,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SCOPE REGISTRIES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Global scope registry: scope_id → ScopeEntry (for command dispatch).
+static SCOPE_REGISTRY: OnceLock<DashMap<u64, ScopeEntry>> = OnceLock::new();
+
+/// Per-client scope pools: client_id → ScopePool.
+static CLIENT_SCOPE_POOLS: OnceLock<DashMap<u64, Arc<TokioMutex<ScopePool>>>> = OnceLock::new();
+
+pub fn get_scope_registry() -> &'static DashMap<u64, ScopeEntry> {
+    SCOPE_REGISTRY.get_or_init(DashMap::new)
+}
+
+pub fn get_client_scope_pools() -> &'static DashMap<u64, Arc<TokioMutex<ScopePool>>> {
+    CLIENT_SCOPE_POOLS.get_or_init(DashMap::new)
+}
+
+/// Get or create a scope pool for a client (atomic via DashMap entry API).
+pub fn get_or_create_scope_pool(
+    client_id: u64,
+    connection_request_bytes: Vec<u8>,
+) -> Arc<TokioMutex<ScopePool>> {
+    get_client_scope_pools()
+        .entry(client_id)
+        .or_insert_with(|| {
+            Arc::new(TokioMutex::new(ScopePool::new(
+                ScopePoolConfig::default(),
+                connection_request_bytes,
+                client_id,
+            )))
+        })
+        .value()
+        .clone()
+}
+
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CLUSTER SLOT VALIDATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Compute the hash slot for a key (CRC16 mod 16384).
+/// Re-exports redis-rs's slot computation for use by binding layers.
+pub fn slot_for_key(key: &[u8]) -> u16 {
+    redis::cluster_topology::get_slot(key)
+}
+
+/// Validate that a command's keys target the scope's pinned slot.
+/// Returns Ok(slot) if consistent, Err if cross-slot.
+/// If scope has no pinned slot yet, returns the slot from the first key.
+pub fn validate_scope_slot(
+    pinned: Option<u16>,
+    keys: &[&[u8]],
+) -> Result<Option<u16>, String> {
+    if keys.is_empty() {
+        return Ok(pinned); // No keys — no slot constraint
+    }
+
+    let first_slot = slot_for_key(keys[0]);
+
+    // Validate all keys are in the same slot
+    for key in &keys[1..] {
+        let s = slot_for_key(key);
+        if s != first_slot {
+            return Err(format!(
+                "Cross-slot error: key targets slot {} but scope is pinned to slot {}",
+                s, first_slot
+            ));
+        }
+    }
+
+    // Validate against pinned slot
+    match pinned {
+        None => Ok(Some(first_slot)), // First keyed command — pin to this slot
+        Some(p) if p == first_slot => Ok(Some(p)), // Consistent
+        Some(p) => Err(format!(
+            "Cross-slot error: command targets slot {} but scope is pinned to slot {}",
+            first_slot, p
+        )),
+    }
+}

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -35,7 +35,7 @@
 use crate::client::Client as GlideClient;
 use dashmap::DashMap;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex as TokioMutex;
@@ -104,8 +104,8 @@ pub struct ClientPool {
     pub config: PoolConfig,
     /// LIFO idle stack — most recently returned client is at the back.
     pub idle: VecDeque<PooledClient>,
-    /// Currently borrowed clients (client_id → placeholder for tracking).
-    pub in_use: DashMap<u64, ()>,
+    /// Currently borrowed clients (client_id → PooledClient).
+    pub in_use: DashMap<u64, PooledClient>,
     /// Current total count (idle + in_use + creating).
     pub total_count: AtomicU32,
     /// Pool lifecycle state.
@@ -119,7 +119,9 @@ impl ClientPool {
             return Err(PoolError::InvalidConfig("max_size must be >= 1".into()));
         }
         if config.min_idle > config.max_size {
-            return Err(PoolError::InvalidConfig("min_idle must be <= max_size".into()));
+            return Err(PoolError::InvalidConfig(
+                "min_idle must be <= max_size".into(),
+            ));
         }
         if config.idle_timeout.is_zero() {
             return Err(PoolError::InvalidConfig("idle_timeout must be > 0".into()));
@@ -141,9 +143,8 @@ impl ClientPool {
 
     /// Non-blocking acquire. Returns client_id on success.
     /// Returns -1 if pool is closed/closing, -3 if no idle client available.
-    /// Evicts idle connections past idle_timeout before returning.
-    /// Evicted client_ids are appended to `evicted` for caller cleanup.
-    pub fn try_acquire(&mut self, evicted: &mut Vec<u64>) -> i64 {
+    /// Evicts idle connections past idle_timeout internally.
+    pub fn try_acquire(&mut self) -> i64 {
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
             return -1;
         }
@@ -151,14 +152,13 @@ impl ClientPool {
         while let Some(mut entry) = self.idle.pop_back() {
             let idle_duration = Instant::now().duration_since(entry.last_idle_at);
             if idle_duration > self.config.idle_timeout {
-                evicted.push(entry.client_id);
                 self.total_count.fetch_sub(1, Ordering::AcqRel);
                 continue;
             }
             let client_id = entry.client_id;
             entry.state = ClientState::InUse;
             entry.borrowed_at = Some(Instant::now());
-            self.in_use.insert(client_id, ());
+            self.in_use.insert(client_id, entry);
             return client_id as i64;
         }
 
@@ -171,14 +171,52 @@ impl ClientPool {
             && self.total_count.load(Ordering::Acquire) < self.config.max_size
     }
 
-    /// Release a client back to the idle pool. Returns false if not found.
-    pub fn release(&mut self, client_id: u64, client: PooledClient) -> bool {
-        self.in_use.remove(&client_id);
+    /// Add a newly created client to the idle pool. Returns the assigned client_id.
+    /// Increments total_count. Use `add_client_reserved` if the slot was pre-reserved.
+    pub fn add_client(&mut self, client: GlideClient) -> u64 {
+        let client_id = self.next_id();
+        let entry = PooledClient {
+            client_id,
+            client,
+            created_at: Instant::now(),
+            last_idle_at: Instant::now(),
+            borrowed_at: None,
+            state: ClientState::Idle,
+        };
+        self.idle.push_back(entry);
+        self.total_count.fetch_add(1, Ordering::AcqRel);
+        client_id
+    }
+
+    /// Add a newly created client to the idle pool when the caller already
+    /// pre-incremented total_count (e.g., background creation after should_create check).
+    /// Returns the assigned client_id.
+    pub fn add_client_reserved(&mut self, client: GlideClient) -> u64 {
+        let client_id = self.next_id();
+        let entry = PooledClient {
+            client_id,
+            client,
+            created_at: Instant::now(),
+            last_idle_at: Instant::now(),
+            borrowed_at: None,
+            state: ClientState::Idle,
+        };
+        self.idle.push_back(entry);
+        client_id
+    }
+
+    /// Release a client back to the idle pool by client_id.
+    /// Returns false if not found in in_use.
+    pub fn release(&mut self, client_id: u64) -> bool {
+        let entry = self.in_use.remove(&client_id);
+        let Some((_, mut entry)) = entry else {
+            return false;
+        };
+
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
             self.total_count.fetch_sub(1, Ordering::AcqRel);
             return true;
         }
-        let mut entry = client;
         entry.state = ClientState::Idle;
         entry.last_idle_at = Instant::now();
         entry.borrowed_at = None;
@@ -190,10 +228,7 @@ impl ClientPool {
     pub fn destroy(&mut self) {
         self.state.store(POOL_CLOSED, Ordering::Release);
         self.idle.clear();
-        let keys: Vec<u64> = self.in_use.iter().map(|e| *e.key()).collect();
-        for key in keys {
-            self.in_use.remove(&key);
-        }
+        self.in_use.clear();
         self.total_count.store(0, Ordering::Release);
     }
 
@@ -262,7 +297,6 @@ impl std::fmt::Display for PoolError {
 
 impl std::error::Error for PoolError {}
 
-
 // ═══════════════════════════════════════════════════════════════════════════════
 // FEATURE 2: ISOLATED EXECUTION (SCOPE POOL)
 //
@@ -304,6 +338,7 @@ pub enum ScopeSubscription {
 }
 
 /// Update ConnectionState based on a command about to execute.
+#[allow(clippy::collapsible_if)]
 pub fn update_state_for_command(state: &mut ConnectionState, cmd: &str, args: &[&[u8]]) {
     match cmd.to_uppercase().as_str() {
         "WATCH" => state.watch_active = true,
@@ -396,7 +431,11 @@ pub struct ScopePool {
 }
 
 impl ScopePool {
-    pub fn new(config: ScopePoolConfig, connection_request_bytes: Vec<u8>, parent_client_id: u64) -> Self {
+    pub fn new(
+        config: ScopePoolConfig,
+        connection_request_bytes: Vec<u8>,
+        parent_client_id: u64,
+    ) -> Self {
         Self {
             config,
             idle: VecDeque::new(),
@@ -430,9 +469,12 @@ impl ScopePool {
                         let scope_id = next.scope_id;
                         next.borrowed_at = Some(Instant::now());
                         next.state = ConnectionState::default();
-                        registry.insert(scope_id, ScopeEntry {
-                            connection: Arc::new(TokioMutex::new(next)),
-                        });
+                        registry.insert(
+                            scope_id,
+                            ScopeEntry {
+                                connection: Arc::new(TokioMutex::new(next)),
+                            },
+                        );
                         self.in_use.insert(scope_id, ());
                         return scope_id as i64;
                     }
@@ -442,9 +484,12 @@ impl ScopePool {
                 let scope_id = conn.scope_id;
                 conn.borrowed_at = Some(Instant::now());
                 conn.state = ConnectionState::default();
-                registry.insert(scope_id, ScopeEntry {
-                    connection: Arc::new(TokioMutex::new(conn)),
-                });
+                registry.insert(
+                    scope_id,
+                    ScopeEntry {
+                        connection: Arc::new(TokioMutex::new(conn)),
+                    },
+                );
                 self.in_use.insert(scope_id, ());
                 return scope_id as i64;
             }
@@ -456,12 +501,15 @@ impl ScopePool {
     }
 
     /// Release a scope. Zero-cost if state is clean.
+    #[allow(clippy::needless_borrow)]
     pub fn release(&mut self, scope_id: u64, registry: &DashMap<u64, ScopeEntry>) -> bool {
         if self.in_use.remove(&scope_id).is_none() {
             return false;
         }
         let entry = registry.remove(&scope_id);
-        let Some((_, entry)) = entry else { return false; };
+        let Some((_, entry)) = entry else {
+            return false;
+        };
 
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
             self.total_count.fetch_sub(1, Ordering::AcqRel);
@@ -506,44 +554,63 @@ impl ScopePool {
                                     match sub {
                                         ScopeSubscription::Channel(c) => channels.push(c.clone()),
                                         ScopeSubscription::Pattern(p) => patterns.push(p.clone()),
-                                        ScopeSubscription::ShardedChannel(s) => sharded.push(s.clone()),
+                                        ScopeSubscription::ShardedChannel(s) => {
+                                            sharded.push(s.clone())
+                                        }
                                     }
                                 }
                                 if !channels.is_empty() {
                                     let mut cmd = redis::Cmd::new();
                                     cmd.arg("UNSUBSCRIBE");
-                                    for c in &channels { cmd.arg(c.as_slice()); }
+                                    for c in &channels {
+                                        cmd.arg(c.as_slice());
+                                    }
                                     let _ = guard.connection.send_packed_command(&cmd).await;
                                 }
                                 if !patterns.is_empty() {
                                     let mut cmd = redis::Cmd::new();
                                     cmd.arg("PUNSUBSCRIBE");
-                                    for p in &patterns { cmd.arg(p.as_slice()); }
+                                    for p in &patterns {
+                                        cmd.arg(p.as_slice());
+                                    }
                                     let _ = guard.connection.send_packed_command(&cmd).await;
                                 }
                                 if !sharded.is_empty() {
                                     let mut cmd = redis::Cmd::new();
                                     cmd.arg("SUNSUBSCRIBE");
-                                    for s in &sharded { cmd.arg(s.as_slice()); }
+                                    for s in &sharded {
+                                        cmd.arg(s.as_slice());
+                                    }
                                     let _ = guard.connection.send_packed_command(&cmd).await;
                                 }
                             }
                             if guard.state.multi_active {
-                                let _ = guard.connection.send_packed_command(
-                                    &redis::Cmd::new().arg("DISCARD")).await;
+                                let _ = guard
+                                    .connection
+                                    .send_packed_command(&redis::Cmd::new().arg("DISCARD"))
+                                    .await;
                             } else if guard.state.watch_active {
-                                let _ = guard.connection.send_packed_command(
-                                    &redis::Cmd::new().arg("UNWATCH")).await;
+                                let _ = guard
+                                    .connection
+                                    .send_packed_command(&redis::Cmd::new().arg("UNWATCH"))
+                                    .await;
                             }
                             if guard.state.tracking_enabled {
-                                let _ = guard.connection.send_packed_command(
-                                    &redis::Cmd::new().arg("CLIENT").arg("TRACKING").arg("OFF")).await;
+                                let _ = guard
+                                    .connection
+                                    .send_packed_command(
+                                        &redis::Cmd::new().arg("CLIENT").arg("TRACKING").arg("OFF"),
+                                    )
+                                    .await;
                             }
                             if guard.state.db_selected != 0 {
-                                let _ = guard.connection.send_packed_command(
-                                    &redis::Cmd::new().arg("SELECT").arg("0")).await;
+                                let _ = guard
+                                    .connection
+                                    .send_packed_command(&redis::Cmd::new().arg("SELECT").arg("0"))
+                                    .await;
                             }
-                        }).await;
+                        })
+                        .await;
 
                         // If cleanup succeeded and we have a pool reference, return to idle.
                         if cleanup_result.is_ok() {
@@ -642,7 +709,6 @@ pub fn get_or_create_scope_pool(
         .clone()
 }
 
-
 // ═══════════════════════════════════════════════════════════════════════════════
 // CLUSTER SLOT VALIDATION
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -656,10 +722,7 @@ pub fn slot_for_key(key: &[u8]) -> u16 {
 /// Validate that a command's keys target the scope's pinned slot.
 /// Returns Ok(slot) if consistent, Err if cross-slot.
 /// If scope has no pinned slot yet, returns the slot from the first key.
-pub fn validate_scope_slot(
-    pinned: Option<u16>,
-    keys: &[&[u8]],
-) -> Result<Option<u16>, String> {
+pub fn validate_scope_slot(pinned: Option<u16>, keys: &[&[u8]]) -> Result<Option<u16>, String> {
     if keys.is_empty() {
         return Ok(pinned); // No keys — no slot constraint
     }

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -34,7 +34,6 @@
 
 use crate::client::Client as GlideClient;
 use dashmap::DashMap;
-use redis::aio::MultiplexedConnection;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -485,14 +484,20 @@ impl ScopePool {
                     self.idle.push_back(idle_conn);
                 } else {
                     // Dirty state — spawn async cleanup (UNSUBSCRIBE, DISCARD, etc.)
+                    // After successful cleanup, return the connection to the idle pool.
                     let conn_arc = entry.connection.clone();
                     let request_timeout = self.config.request_timeout;
-                    self.total_count.fetch_sub(1, Ordering::AcqRel);
+
+                    // We need the pool Arc to re-insert after cleanup.
+                    // The caller must provide it via the scope pool registry.
+                    let client_id = self.parent_client_id;
+                    let pools = get_client_scope_pools();
+                    let pool_arc = pools.get(&client_id).map(|p| p.value().clone());
 
                     tokio::spawn(async move {
                         let mut guard = conn_arc.lock().await;
                         let timeout = request_timeout * 2;
-                        let _ = tokio::time::timeout(timeout, async {
+                        let cleanup_result = tokio::time::timeout(timeout, async {
                             if guard.state.has_subscriptions() {
                                 let mut channels = Vec::new();
                                 let mut patterns = Vec::new();
@@ -539,6 +544,40 @@ impl ScopePool {
                                     &redis::Cmd::new().arg("SELECT").arg("0")).await;
                             }
                         }).await;
+
+                        // If cleanup succeeded and we have a pool reference, return to idle.
+                        if cleanup_result.is_ok() {
+                            if let Some(pool_arc) = pool_arc {
+                                let idle_conn = ScopedConnection {
+                                    scope_id: guard.scope_id,
+                                    connection: guard.connection.clone(),
+                                    created_at: guard.created_at,
+                                    last_idle_at: Instant::now(),
+                                    borrowed_at: None,
+                                    state: ConnectionState::default(),
+                                    pinned_slot: None,
+                                };
+                                drop(guard);
+
+                                let mut pool = pool_arc.lock().await;
+                                if pool.state.load(Ordering::Acquire) == POOL_RUNNING {
+                                    pool.idle.push_back(idle_conn);
+                                    // total_count was never decremented — connection is back in pool
+                                } else {
+                                    pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                                }
+                            } else {
+                                // No pool reference — discard connection
+                                drop(guard);
+                            }
+                        } else {
+                            // Cleanup timed out — discard the connection
+                            drop(guard);
+                            if let Some(pool_arc) = pool_arc {
+                                let pool = pool_arc.lock().await;
+                                pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                            }
+                        }
                     });
                 }
                 true

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -62,6 +62,8 @@ pub struct PoolConfig {
     pub idle_timeout: Duration,
     /// Request timeout (used for cleanup: 2×).
     pub request_timeout: Duration,
+    /// Send PING on borrow to verify connection health. Default: false.
+    pub test_on_borrow: bool,
     /// Serialized protobuf ConnectionRequest for background client creation.
     pub connection_request: Vec<u8>,
 }

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -1,0 +1,257 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//! Client-Instance Pool (RFC #5815 Feature 1)
+//!
+//! A shared, cross-language connection pool that manages `GlideClient` instances.
+//! Callers borrow a client via `try_acquire`, use it for commands, and return it
+//! via `release`. The pool handles creation, LIFO reuse, bounded size, background
+//! creation, and idle eviction.
+//!
+//! This module lives in `glide-core` so all language bindings (Java JNI, Python CFFI,
+//! Ruby FFI, Go CGO, Node N-API) share the same Rust implementation.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Language Binding (Java/Python/Ruby/Go/Node)
+//!     │
+//!     ▼ FFI calls (glide_pool_create, try_acquire, release, destroy)
+//! ┌─────────────────────────────────────┐
+//! │  glide-core::pool                   │
+//! │  ┌─────────────────────────────┐    │
+//! │  │ Pool Registry (DashMap)     │    │
+//! │  │  pool_id → Arc<Mutex<Pool>> │    │
+//! │  └─────────────────────────────┘    │
+//! │  ┌─────────────────────────────┐    │
+//! │  │ ClientPool                  │    │
+//! │  │  idle: VecDeque (LIFO)      │    │
+//! │  │  in_use: DashMap            │    │
+//! │  │  config: PoolConfig         │    │
+//! │  └─────────────────────────────┘    │
+//! └─────────────────────────────────────┘
+//! ```
+
+use crate::client::Client as GlideClient;
+use dashmap::DashMap;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex as TokioMutex;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POOL STATES
+// ═══════════════════════════════════════════════════════════════════════════════
+
+pub const POOL_RUNNING: u8 = 0;
+pub const POOL_CLOSING: u8 = 1;
+pub const POOL_CLOSED: u8 = 2;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CONFIGURATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Configuration for a client-instance pool.
+pub struct PoolConfig {
+    /// Maximum number of clients. Must be >= 1.
+    pub max_size: u32,
+    /// Minimum idle clients to pre-warm at creation. Must be <= max_size.
+    pub min_idle: u32,
+    /// Evict idle clients after this duration.
+    pub idle_timeout: Duration,
+    /// Request timeout (used for cleanup: 2×).
+    pub request_timeout: Duration,
+    /// Serialized protobuf ConnectionRequest for background client creation.
+    pub connection_request: Vec<u8>,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POOLED CLIENT ENTRY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Lifecycle state of a pooled client.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ClientState {
+    Idle,
+    InUse,
+}
+
+/// A client managed by the pool.
+pub struct PooledClient {
+    /// Unique ID for this client (used as the handle returned to language bindings).
+    pub client_id: u64,
+    /// The actual Valkey connection.
+    pub client: GlideClient,
+    /// When this client was created.
+    pub created_at: Instant,
+    /// When last returned to idle.
+    pub last_idle_at: Instant,
+    /// When borrowed (for leak detection).
+    pub borrowed_at: Option<Instant>,
+    /// Current state.
+    pub state: ClientState,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CLIENT POOL
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// The client-instance pool. Thread-safe via TokioMutex at the registry level.
+pub struct ClientPool {
+    pub config: PoolConfig,
+    /// LIFO idle stack — most recently returned client is at the back.
+    pub idle: VecDeque<PooledClient>,
+    /// Currently borrowed clients (client_id → placeholder for tracking).
+    pub in_use: DashMap<u64, ()>,
+    /// Counter for unique client_id generation.
+    next_client_id: AtomicU64,
+    /// Current total count (idle + in_use + creating).
+    pub total_count: AtomicU32,
+    /// Pool lifecycle state.
+    pub state: AtomicU8,
+}
+
+impl ClientPool {
+    /// Create a new pool with validated config.
+    pub fn new(config: PoolConfig) -> Result<Self, PoolError> {
+        if config.max_size < 1 {
+            return Err(PoolError::InvalidConfig("max_size must be >= 1".into()));
+        }
+        if config.min_idle > config.max_size {
+            return Err(PoolError::InvalidConfig("min_idle must be <= max_size".into()));
+        }
+        if config.idle_timeout.is_zero() {
+            return Err(PoolError::InvalidConfig("idle_timeout must be > 0".into()));
+        }
+
+        Ok(Self {
+            config,
+            idle: VecDeque::new(),
+            in_use: DashMap::new(),
+            next_client_id: AtomicU64::new(1),
+            total_count: AtomicU32::new(0),
+            state: AtomicU8::new(POOL_RUNNING),
+        })
+    }
+
+    /// Generate a unique client_id.
+    pub fn next_id(&self) -> u64 {
+        self.next_client_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Non-blocking acquire. Returns client_id on success, -1 if no client available.
+    pub fn try_acquire(&mut self) -> i64 {
+        if self.state.load(Ordering::Acquire) != POOL_RUNNING {
+            return -1;
+        }
+
+        // LIFO pop from idle stack
+        if let Some(mut entry) = self.idle.pop_back() {
+            let client_id = entry.client_id;
+            entry.state = ClientState::InUse;
+            entry.borrowed_at = Some(Instant::now());
+            self.in_use.insert(client_id, ());
+            // Re-store the entry — the binding layer will track it via client_id
+            // For the pool we just need to know it's in_use
+            // (The actual PooledClient is not stored in in_use DashMap to avoid
+            // double-ownership; it's tracked by client_id only)
+            return client_id as i64;
+        }
+
+        -1 // No idle client available
+    }
+
+    /// Whether background creation should be triggered (room below max_size).
+    pub fn should_create(&self) -> bool {
+        self.state.load(Ordering::Acquire) == POOL_RUNNING
+            && self.total_count.load(Ordering::Acquire) < self.config.max_size
+    }
+
+    /// Release a client back to the idle pool. Returns false if not found.
+    pub fn release(&mut self, client_id: u64, client: PooledClient) -> bool {
+        self.in_use.remove(&client_id);
+        if self.state.load(Ordering::Acquire) != POOL_RUNNING {
+            self.total_count.fetch_sub(1, Ordering::AcqRel);
+            return true;
+        }
+        let mut entry = client;
+        entry.state = ClientState::Idle;
+        entry.last_idle_at = Instant::now();
+        entry.borrowed_at = None;
+        self.idle.push_back(entry);
+        true
+    }
+
+    /// Destroy the pool — drop all clients.
+    pub fn destroy(&mut self) {
+        self.state.store(POOL_CLOSED, Ordering::Release);
+        self.idle.clear();
+        let keys: Vec<u64> = self.in_use.iter().map(|e| *e.key()).collect();
+        for key in keys {
+            self.in_use.remove(&key);
+        }
+        self.total_count.store(0, Ordering::Release);
+    }
+
+    /// Get idle count.
+    pub fn idle_count(&self) -> u32 {
+        self.idle.len() as u32
+    }
+
+    /// Get active (in-use) count.
+    pub fn active_count(&self) -> u32 {
+        self.in_use.len() as u32
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GLOBAL REGISTRY
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Global pool registry: pool_id → Pool instance.
+static POOL_REGISTRY: OnceLock<DashMap<u64, Arc<TokioMutex<ClientPool>>>> = OnceLock::new();
+static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
+
+pub fn get_pool_registry() -> &'static DashMap<u64, Arc<TokioMutex<ClientPool>>> {
+    POOL_REGISTRY.get_or_init(DashMap::new)
+}
+
+/// Register a pool. Returns assigned pool_id.
+pub fn register_pool(pool: ClientPool) -> u64 {
+    let pool_id = NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed);
+    get_pool_registry().insert(pool_id, Arc::new(TokioMutex::new(pool)));
+    pool_id
+}
+
+/// Get a pool by ID (cheap Arc clone).
+pub fn get_pool(pool_id: u64) -> Option<Arc<TokioMutex<ClientPool>>> {
+    get_pool_registry().get(&pool_id).map(|e| e.value().clone())
+}
+
+/// Remove a pool from the registry.
+pub fn unregister_pool(pool_id: u64) -> Option<Arc<TokioMutex<ClientPool>>> {
+    get_pool_registry().remove(&pool_id).map(|(_, v)| v)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ERRORS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug)]
+pub enum PoolError {
+    InvalidConfig(String),
+    PoolClosed,
+    ClientCreationFailed(String),
+}
+
+impl std::fmt::Display for PoolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PoolError::InvalidConfig(msg) => write!(f, "Invalid pool config: {}", msg),
+            PoolError::PoolClosed => write!(f, "Pool is closed"),
+            PoolError::ClientCreationFailed(msg) => write!(f, "Client creation failed: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PoolError {}

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -141,13 +141,20 @@ impl ClientPool {
 
     /// Non-blocking acquire. Returns client_id on success.
     /// Returns -1 if pool is closed/closing, -3 if no idle client available.
-    pub fn try_acquire(&mut self) -> i64 {
+    /// Evicts idle connections past idle_timeout before returning.
+    /// Evicted client_ids are appended to `evicted` for caller cleanup.
+    pub fn try_acquire(&mut self, evicted: &mut Vec<u64>) -> i64 {
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
-            return -1; // Pool not running
+            return -1;
         }
 
-        // LIFO pop from idle stack
-        if let Some(mut entry) = self.idle.pop_back() {
+        while let Some(mut entry) = self.idle.pop_back() {
+            let idle_duration = Instant::now().duration_since(entry.last_idle_at);
+            if idle_duration > self.config.idle_timeout {
+                evicted.push(entry.client_id);
+                self.total_count.fetch_sub(1, Ordering::AcqRel);
+                continue;
+            }
             let client_id = entry.client_id;
             entry.state = ClientState::InUse;
             entry.borrowed_at = Some(Instant::now());
@@ -155,7 +162,7 @@ impl ClientPool {
             return client_id as i64;
         }
 
-        -3 // No idle client available (distinct from -1=closed, -2=invalid pool)
+        -3
     }
 
     /// Whether background creation should be triggered (room below max_size).

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -4,8 +4,9 @@
 //!
 //! A shared, cross-language connection pool that manages `GlideClient` instances.
 //! Callers borrow a client via `try_acquire`, use it for commands, and return it
-//! via `release`. The pool handles creation, LIFO reuse, bounded size, background
-//! creation, and idle eviction.
+//! via `release`. The pool handles LIFO reuse and bounded size; background creation
+//! is implemented by the embedding FFI/JNI layer. Idle eviction and health checks
+//! are deferred to follow-up work.
 //!
 //! This module lives in `glide-core` so all language bindings (Java JNI, Python CFFI,
 //! Ruby FFI, Go CGO, Node N-API) share the same Rust implementation.
@@ -103,8 +104,6 @@ pub struct ClientPool {
     pub idle: VecDeque<PooledClient>,
     /// Currently borrowed clients (client_id → placeholder for tracking).
     pub in_use: DashMap<u64, ()>,
-    /// Counter for unique client_id generation.
-    next_client_id: AtomicU64,
     /// Current total count (idle + in_use + creating).
     pub total_count: AtomicU32,
     /// Pool lifecycle state.
@@ -128,21 +127,21 @@ impl ClientPool {
             config,
             idle: VecDeque::new(),
             in_use: DashMap::new(),
-            next_client_id: AtomicU64::new(1),
             total_count: AtomicU32::new(0),
             state: AtomicU8::new(POOL_RUNNING),
         })
     }
 
-    /// Generate a unique client_id.
+    /// Generate a globally unique client_id (unique across all pools).
     pub fn next_id(&self) -> u64 {
-        self.next_client_id.fetch_add(1, Ordering::Relaxed)
+        NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Non-blocking acquire. Returns client_id on success, -1 if no client available.
+    /// Non-blocking acquire. Returns client_id on success.
+    /// Returns -1 if pool is closed/closing, -3 if no idle client available.
     pub fn try_acquire(&mut self) -> i64 {
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
-            return -1;
+            return -1; // Pool not running
         }
 
         // LIFO pop from idle stack
@@ -151,14 +150,10 @@ impl ClientPool {
             entry.state = ClientState::InUse;
             entry.borrowed_at = Some(Instant::now());
             self.in_use.insert(client_id, ());
-            // Re-store the entry — the binding layer will track it via client_id
-            // For the pool we just need to know it's in_use
-            // (The actual PooledClient is not stored in in_use DashMap to avoid
-            // double-ownership; it's tracked by client_id only)
             return client_id as i64;
         }
 
-        -1 // No idle client available
+        -3 // No idle client available (distinct from -1=closed, -2=invalid pool)
     }
 
     /// Whether background creation should be triggered (room below max_size).
@@ -211,6 +206,8 @@ impl ClientPool {
 /// Global pool registry: pool_id → Pool instance.
 static POOL_REGISTRY: OnceLock<DashMap<u64, Arc<TokioMutex<ClientPool>>>> = OnceLock::new();
 static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
+/// Global client_id allocator — ensures uniqueness across all pools.
+static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 
 pub fn get_pool_registry() -> &'static DashMap<u64, Arc<TokioMutex<ClientPool>>> {
     POOL_REGISTRY.get_or_init(DashMap::new)

--- a/glide-core/src/scope.rs
+++ b/glide-core/src/scope.rs
@@ -1,0 +1,409 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//! Isolated Execution (Feature 2) — Core Logic
+//!
+//! This module contains the language-agnostic core logic for scoped connections:
+//! - Command deserialization (wire format)
+//! - Slot validation and key extraction
+//! - Command execution on a scoped connection (with timeout, decompression, IAM)
+//! - Background connection creation
+//!
+//! Language bindings (Java JNI, Python CFFI, Node N-API, Go CGO) should call
+//! these functions rather than duplicating the logic.
+
+use crate::client::Client;
+use crate::pool::{
+    get_client_scope_pools, get_scope_registry, update_state_for_command, validate_scope_slot,
+};
+use redis::{Cmd, RedisError, RedisResult, Value};
+
+#[cfg(feature = "proto")]
+use crate::pool::{ConnectionState, ScopePool, ScopedConnection, POOL_RUNNING};
+#[cfg(feature = "proto")]
+use std::sync::atomic::Ordering;
+#[cfg(feature = "proto")]
+use std::sync::Arc;
+#[cfg(feature = "proto")]
+use std::time::Instant;
+#[cfg(feature = "proto")]
+use tokio::sync::Mutex as TokioMutex;
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// COMMAND DESERIALIZATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Deserialize a command from the wire format used by language bindings.
+///
+/// Wire format (little-endian):
+///   [4 bytes: cmd_name_len][cmd_name bytes][4 bytes: num_args]
+///   [4 bytes: arg1_len][arg1 bytes]...[4 bytes: argN_len][argN bytes]
+pub fn deserialize_command(bytes: &[u8]) -> Option<(String, Vec<Vec<u8>>)> {
+    if bytes.len() < 4 {
+        return None;
+    }
+    let mut off = 0;
+
+    let cmd_len = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
+    off += 4;
+    if off + cmd_len > bytes.len() {
+        return None;
+    }
+    let cmd = String::from_utf8(bytes[off..off + cmd_len].to_vec()).ok()?;
+    off += cmd_len;
+
+    if off + 4 > bytes.len() {
+        return None;
+    }
+    let num_args = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
+    off += 4;
+
+    let mut args = Vec::with_capacity(num_args);
+    for _ in 0..num_args {
+        if off + 4 > bytes.len() {
+            return None;
+        }
+        let len = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
+        off += 4;
+        if off + len > bytes.len() {
+            return None;
+        }
+        args.push(bytes[off..off + len].to_vec());
+        off += len;
+    }
+
+    Some((cmd, args))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// KEY EXTRACTION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Extract key arguments from a command for slot validation.
+///
+/// Returns references to the argument bytes that represent keys.
+/// Commands with no keys (MULTI, EXEC, PING, etc.) return empty.
+pub fn extract_key_args<'a>(cmd_name: &str, args: &[&'a [u8]]) -> Vec<&'a [u8]> {
+    match cmd_name.to_uppercase().as_str() {
+        // Commands with first arg as key
+        "GET" | "SET" | "DEL" | "INCR" | "DECR" | "INCRBY" | "DECRBY"
+        | "SETNX" | "SETEX" | "PSETEX" | "GETSET" | "GETDEL" | "GETEX"
+        | "APPEND" | "STRLEN" | "TYPE" | "EXISTS" | "EXPIRE" | "EXPIREAT"
+        | "TTL" | "PTTL" | "PERSIST" | "DUMP" | "RESTORE"
+        | "HGET" | "HSET" | "HDEL" | "HLEN" | "HGETALL" | "HMGET" | "HMSET"
+        | "LPUSH" | "RPUSH" | "LPOP" | "RPOP" | "LLEN" | "LRANGE"
+        | "SADD" | "SREM" | "SMEMBERS" | "SCARD" | "SISMEMBER"
+        | "ZADD" | "ZREM" | "ZRANGE" | "ZCARD" | "ZSCORE"
+        | "SUBSCRIBE" | "UNSUBSCRIBE"
+        | "BLPOP" | "BRPOP" | "BLMOVE" => {
+            if !args.is_empty() {
+                vec![args[0]]
+            } else {
+                vec![]
+            }
+        }
+        // WATCH can have multiple keys — all must be in same slot
+        "WATCH" => args.to_vec(),
+        // MGET: all args are keys
+        "MGET" => args.to_vec(),
+        // MSET: keys at even positions (key, value, key, value, ...)
+        "MSET" | "MSETNX" => args.iter().step_by(2).copied().collect(),
+        // Commands with no keys
+        "MULTI" | "EXEC" | "DISCARD" | "UNWATCH" | "PING" | "SELECT"
+        | "AUTH" | "CLIENT" | "INFO" | "DBSIZE" | "FLUSHDB" | "FLUSHALL"
+        | "RESET" | "QUIT" | "COMMAND" | "CONFIG" | "CLUSTER" | "TIME"
+        | "WAIT" | "OBJECT" | "DEBUG" | "SLOWLOG" | "LATENCY" | "MEMORY" => vec![],
+        // Default: assume first arg is a key (safe approximation for unknown commands)
+        _ => {
+            if !args.is_empty() {
+                vec![args[0]]
+            } else {
+                vec![]
+            }
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SCOPE COMMAND EXECUTION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Execute a command on a scoped connection.
+///
+/// This is the core function that all language bindings should call. It handles:
+/// - State tracking (WATCH, MULTI, SELECT, subscriptions, etc.)
+/// - Cluster slot validation (cross-slot errors)
+/// - Command execution via Client::send_command_on_connection (timeout, decompression, IAM)
+/// - Fallback to raw send if no parent client is available
+///
+/// # Arguments
+/// - `scope_id`: The scope identifier (must be currently in-use)
+/// - `cmd_name`: The command name (e.g., "GET", "SET", "WATCH")
+/// - `args`: Command arguments as byte slices
+/// - `client`: Optional reference to the parent Client (for timeout, decompression, IAM)
+///
+/// # Returns
+/// `Ok(Value)` on success, `Err(RedisError)` on failure (including cross-slot errors).
+pub async fn execute_scope_command(
+    scope_id: u64,
+    cmd_name: &str,
+    args: &[Vec<u8>],
+    client: Option<&Client>,
+) -> RedisResult<Value> {
+    let registry = get_scope_registry();
+    let entry = match registry.get(&scope_id) {
+        Some(e) => e.connection.clone(),
+        None => {
+            return Err(RedisError::from((
+                redis::ErrorKind::ClientError,
+                "Invalid scope_id: scope not found in registry",
+            )));
+        }
+    };
+
+    let mut conn = entry.lock().await;
+
+    // State tracking (for conditional cleanup on release)
+    let arg_refs: Vec<&[u8]> = args.iter().map(|a| a.as_slice()).collect();
+    update_state_for_command(&mut conn.state, cmd_name, &arg_refs);
+
+    // Cluster mode: validate slot consistency
+    let key_args = extract_key_args(cmd_name, &arg_refs);
+    if !key_args.is_empty() {
+        match validate_scope_slot(conn.pinned_slot, &key_args) {
+            Ok(new_slot) => {
+                conn.pinned_slot = new_slot;
+            }
+            Err(e) => {
+                return Err(RedisError::from((
+                    redis::ErrorKind::CrossSlot,
+                    "CROSSSLOT",
+                    e,
+                )));
+            }
+        }
+    }
+
+    // Build redis command
+    let mut cmd = Cmd::new();
+    cmd.arg(cmd_name.as_bytes());
+    for arg in args {
+        cmd.arg(arg.as_slice());
+    }
+
+    // Execute via Client (gets timeout, decompression, IAM refresh) or raw fallback
+    match client {
+        Some(c) => c.send_command_on_connection(&cmd, &mut conn.connection).await,
+        None => conn.connection.send_packed_command(&cmd).await,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BACKGROUND CONNECTION CREATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Create a new scope connection in the background and add it to the pool.
+///
+/// This function resolves the target address (cluster-aware via the parent Client,
+/// or falling back to the seed node for standalone mode) and opens a new
+/// MultiplexedConnection.
+///
+/// # Arguments
+/// - `pool`: Arc to the scope pool (locked async)
+/// - `client`: Optional reference to the parent Client (for cluster slot resolution)
+/// - `connection_request_bytes`: Serialized protobuf ConnectionRequest
+#[cfg(feature = "proto")]
+pub async fn create_scope_connection(
+    pool: Arc<TokioMutex<ScopePool>>,
+    client: Option<&Client>,
+    connection_request_bytes: &[u8],
+) {
+    use protobuf::Message as _;
+
+    let proto = match crate::connection_request::ConnectionRequest::parse_from_bytes(
+        connection_request_bytes,
+    ) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let use_tls = proto.tls_mode.value() != 0;
+    let scheme = if use_tls { "rediss" } else { "redis" };
+
+    // Determine target address:
+    // - Cluster mode: use Client::address_for_slot() to get a primary node address
+    // - Standalone mode: fall back to the seed node address from the config
+    let url = {
+        let cluster_addr = match client {
+            Some(c) => c.address_for_slot(0).await,
+            None => None,
+        };
+
+        if let Some(addr) = cluster_addr {
+            // address_for_slot returns "host:port"
+            format!("{}://{}", scheme, addr)
+        } else {
+            // Standalone mode or cluster lookup failed — use seed node
+            let addr = match proto.addresses.first() {
+                Some(a) => a,
+                None => return,
+            };
+            let port = if addr.port == 0 { 6379 } else { addr.port as u16 };
+            format!("{}://{}:{}", scheme, &addr.host, port)
+        }
+    };
+
+    let redis_client = match redis::Client::open(url.as_str()) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let opts = redis::GlideConnectionOptions {
+        push_sender: None,
+        disconnect_notifier: None,
+        discover_az: false,
+        connection_timeout: Some(std::time::Duration::from_secs(5)),
+        connection_retry_strategy: None,
+        tcp_nodelay: true,
+        pubsub_synchronizer: None,
+        iam_token_provider: None,
+    };
+    let conn = match tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        redis_client.get_multiplexed_async_connection(opts),
+    )
+    .await
+    {
+        Ok(Ok(c)) => c,
+        _ => return,
+    };
+
+    let mut pool_guard = pool.lock().await;
+    if pool_guard.state.load(Ordering::Acquire) != POOL_RUNNING {
+        pool_guard.total_count.fetch_sub(1, Ordering::AcqRel);
+        return;
+    }
+    let scope_id = pool_guard.next_id();
+    let entry = ScopedConnection {
+        scope_id,
+        connection: conn,
+        created_at: Instant::now(),
+        last_idle_at: Instant::now(),
+        borrowed_at: None,
+        state: ConnectionState::default(),
+        pinned_slot: None,
+    };
+    pool_guard.idle.push_back(entry);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SCOPE ACQUIRE / RELEASE (NON-BLOCKING WRAPPERS)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Non-blocking scope acquire. Returns scope_id >= 0, -1 if exhausted, -2 if invalid.
+///
+/// If the pool is exhausted but below max capacity, spawns background connection creation.
+/// Language bindings should call this from their FFI layer, passing the client_id,
+/// serialized ConnectionRequest bytes, and a tokio runtime handle for async spawning.
+#[cfg(feature = "proto")]
+pub fn try_acquire_scope(
+    client_id: u64,
+    connection_request_bytes: Vec<u8>,
+    runtime: &tokio::runtime::Handle,
+) -> i64 {
+    let scope_pool =
+        crate::pool::get_or_create_scope_pool(client_id, connection_request_bytes.clone());
+    let registry = get_scope_registry();
+
+    match scope_pool.try_lock() {
+        Ok(mut pool) => {
+            let result = pool.try_acquire(registry);
+            if result >= 0 {
+                let _ = telemetrylib::GlideOpenTelemetry::record_scope_acquire();
+            }
+            if result < 0 && pool.total_count.load(Ordering::Acquire) <= pool.config.max_total {
+                // Spawn background connection creation
+                let pool_clone = scope_pool.clone();
+                let conn_bytes = pool.connection_request_bytes.clone();
+                let parent_client_id = pool.parent_client_id;
+                runtime.spawn(async move {
+                    // Get the parent client for cluster-aware address resolution
+                    let client = get_parent_client(parent_client_id).await;
+                    create_scope_connection(
+                        pool_clone,
+                        client.as_ref(),
+                        &conn_bytes,
+                    )
+                    .await;
+                });
+            }
+            result
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Release a scope back to the pool. Fire-and-forget, non-blocking.
+///
+/// Returns 0 on success, -1 if client not found.
+pub fn release_scope(scope_id: u64, client_id: u64, runtime: &tokio::runtime::Handle) -> i32 {
+    let pools = get_client_scope_pools();
+    let scope_pool = match pools.get(&client_id) {
+        Some(p) => p.value().clone(),
+        None => return -1,
+    };
+    let registry = get_scope_registry();
+
+    let pool_clone = scope_pool.clone();
+    match scope_pool.try_lock() {
+        Ok(mut pool) => {
+            pool.release(scope_id, registry);
+            let _ = telemetrylib::GlideOpenTelemetry::record_scope_release();
+            0
+        }
+        Err(_) => {
+            runtime.spawn(async move {
+                let mut pool = pool_clone.lock().await;
+                pool.release(scope_id, get_scope_registry());
+            });
+            0
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Get the parent Client for a given client_id.
+///
+/// This uses the client registry that each language binding populates.
+/// The registry is in `glide-core::pool` (via the client_scope_pools map)
+/// but the actual Client instances are stored per-binding. This function
+/// is a hook point — language bindings should register their clients in a
+/// shared registry accessible from glide-core.
+///
+/// For now, we use the scope pool's parent_client_id to look up from the
+/// global CLIENT_REGISTRY that language bindings populate.
+#[cfg(feature = "proto")]
+async fn get_parent_client(client_id: u64) -> Option<Client> {
+    let registry = get_client_registry();
+    registry.get(&client_id).map(|e| e.value().clone())
+}
+
+/// Global client registry: client_id → Client.
+/// Language bindings register their Client instances here so that
+/// scope execution can access timeout, decompression, and IAM features.
+static CLIENT_REGISTRY: std::sync::OnceLock<dashmap::DashMap<u64, Client>> =
+    std::sync::OnceLock::new();
+
+pub fn get_client_registry() -> &'static dashmap::DashMap<u64, Client> {
+    CLIENT_REGISTRY.get_or_init(dashmap::DashMap::new)
+}
+
+/// Register a Client in the global registry (called by language bindings after creation).
+pub fn register_client(client_id: u64, client: Client) {
+    get_client_registry().insert(client_id, client);
+}
+
+/// Unregister a Client from the global registry (called on client close).
+pub fn unregister_client(client_id: u64) {
+    get_client_registry().remove(&client_id);
+}

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -611,6 +611,8 @@ static SUBSCRIPTION_OUT_OF_SYNC_COUNTER: OnceLock<opentelemetry::metrics::Counte
 static SUBSCRIPTION_LAST_SYNC_GAUGE: OnceLock<opentelemetry::metrics::Gauge<u64>> = OnceLock::new();
 static POOL_HIT_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
 static POOL_MISS_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
+static SCOPE_ACQUIRE_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
+static SCOPE_RELEASE_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
 
 /// Singleton instance of GlideOpenTelemetry. Ensures that telemetry setup happens only once across the application.
 static OTEL: OnceCell<RwLock<GlideOpenTelemetry>> = OnceCell::new();
@@ -1006,6 +1008,24 @@ impl GlideOpenTelemetry {
                 .build(),
         );
 
+        // Scope acquire counter
+        let _ = SCOPE_ACQUIRE_COUNTER.set(
+            meter
+                .u64_counter("glide.scope.acquires")
+                .with_description("Number of scope connections acquired")
+                .with_unit("1")
+                .build(),
+        );
+
+        // Scope release counter
+        let _ = SCOPE_RELEASE_COUNTER.set(
+            meter
+                .u64_counter("glide.scope.releases")
+                .with_description("Number of scope connections released")
+                .with_unit("1")
+                .build(),
+        );
+
         Ok(())
     }
 
@@ -1093,6 +1113,26 @@ impl GlideOpenTelemetry {
     pub fn record_pool_miss() -> Result<(), GlideOTELError> {
         if GlideOpenTelemetry::is_initialized() {
             if let Some(counter) = POOL_MISS_COUNTER.get() {
+                counter.add(1, &[]);
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a scope connection acquire.
+    pub fn record_scope_acquire() -> Result<(), GlideOTELError> {
+        if GlideOpenTelemetry::is_initialized() {
+            if let Some(counter) = SCOPE_ACQUIRE_COUNTER.get() {
+                counter.add(1, &[]);
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a scope connection release.
+    pub fn record_scope_release() -> Result<(), GlideOTELError> {
+        if GlideOpenTelemetry::is_initialized() {
+            if let Some(counter) = SCOPE_RELEASE_COUNTER.get() {
                 counter.add(1, &[]);
             }
         }

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -609,6 +609,8 @@ static MOVED_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock:
 static SUBSCRIPTION_OUT_OF_SYNC_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> =
     OnceLock::new();
 static SUBSCRIPTION_LAST_SYNC_GAUGE: OnceLock<opentelemetry::metrics::Gauge<u64>> = OnceLock::new();
+static POOL_HIT_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
+static POOL_MISS_COUNTER: OnceLock<opentelemetry::metrics::Counter<u64>> = OnceLock::new();
 
 /// Singleton instance of GlideOpenTelemetry. Ensures that telemetry setup happens only once across the application.
 static OTEL: OnceCell<RwLock<GlideOpenTelemetry>> = OnceCell::new();
@@ -986,6 +988,24 @@ impl GlideOpenTelemetry {
                 )
             })?;
 
+        // Pool hit counter
+        let _ = POOL_HIT_COUNTER.set(
+            meter
+                .u64_counter("glide.pool.hits")
+                .with_description("Number of pool acquire hits (client found in idle)")
+                .with_unit("1")
+                .build(),
+        );
+
+        // Pool miss counter
+        let _ = POOL_MISS_COUNTER.set(
+            meter
+                .u64_counter("glide.pool.misses")
+                .with_description("Number of pool acquire misses (no idle client)")
+                .with_unit("1")
+                .build(),
+        );
+
         Ok(())
     }
 
@@ -1055,6 +1075,26 @@ impl GlideOpenTelemetry {
                     )
                 })?
                 .add(1, &[]);
+        }
+        Ok(())
+    }
+
+    /// Record a pool acquire hit (client found in idle list).
+    pub fn record_pool_hit() -> Result<(), GlideOTELError> {
+        if GlideOpenTelemetry::is_initialized() {
+            if let Some(counter) = POOL_HIT_COUNTER.get() {
+                counter.add(1, &[]);
+            }
+        }
+        Ok(())
+    }
+
+    /// Record a pool acquire miss (no idle client available).
+    pub fn record_pool_miss() -> Result<(), GlideOTELError> {
+        if GlideOpenTelemetry::is_initialized() {
+            if let Some(counter) = POOL_MISS_COUNTER.get() {
+                counter.add(1, &[]);
+            }
         }
         Ok(())
     }

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -746,6 +746,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1068,6 +1081,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
+ "dashmap 5.5.3",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -1103,7 +1117,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "dashmap",
+ "dashmap 6.2.1",
  "glide-core",
  "jni",
  "log",
@@ -2195,7 +2209,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.2.1",
  "dispose",
  "futures",
  "futures-util",

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -30,7 +30,7 @@ configurations {
 }
 
 dependencies {
-    implementation group: 'com.google.protobuf', name:'protobuf-java', version: '4.29.1'
+    implementation group: 'com.google.protobuf', name:'protobuf-java', version: '4.29.6'
 
     shadow group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
 

--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -59,6 +59,7 @@ import glide.api.commands.TransactionsCommands;
 import glide.api.models.Batch;
 import glide.api.models.GlideString;
 import glide.api.models.Transaction;
+import glide.api.models.scope.IsolatedScope;
 import glide.api.models.commands.ClientPauseMode;
 import glide.api.models.commands.FailoverOptions;
 import glide.api.models.commands.FlushMode;
@@ -190,6 +191,52 @@ public class GlideClient extends BaseClient
     public static CompletableFuture<GlideClient> createClient(
             @NonNull GlideClientConfiguration config) {
         return BaseClient.createClient(config, GlideClient::new);
+    }
+
+    /**
+     * Acquire an isolated scope (dedicated connection) for operations requiring
+     * per-connection server state (WATCH/MULTI/EXEC, CLIENT TRACKING, blocking commands).
+     *
+     * <p>The returned {@link IsolatedScope} borrows a connection from the client's internal
+     * scope pool. Commands on the scope bypass the multiplexer. Use try-with-resources
+     * to ensure the scope is returned to the pool.
+     *
+     * @param timeout maximum time to wait for a scope to become available
+     * @return a Future resolving to an {@link IsolatedScope}
+     */
+    public CompletableFuture<IsolatedScope> scopedConnection(@NonNull java.time.Duration timeout) {
+        long clientId = connectionManager.getNativeClientHandle();
+        byte[] connBytes = connectionManager.getConnectionRequestBytes();
+        if (connBytes == null) {
+            CompletableFuture<IsolatedScope> f = new CompletableFuture<>();
+            f.completeExceptionally(new IllegalStateException("Client not connected"));
+            return f;
+        }
+
+        long timeoutMs = timeout.toMillis();
+        long deadline = System.currentTimeMillis() + timeoutMs;
+
+        return CompletableFuture.supplyAsync(() -> {
+            while (true) {
+                long scopeId = glide.ffi.resolvers.GlideScopeResolver.glideScopeTryAcquire(clientId, connBytes);
+                if (scopeId >= 0) {
+                    return new IsolatedScope(scopeId, clientId);
+                }
+                // Pool exhausted — retry with backoff until deadline
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    throw new java.util.concurrent.CompletionException(
+                            new java.util.concurrent.TimeoutException(
+                                    "Timed out waiting for isolated scope (pool exhausted)"));
+                }
+                try {
+                    Thread.sleep(Math.min(10, remaining));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new java.util.concurrent.CompletionException(e);
+                }
+            }
+        });
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -106,6 +106,44 @@ public class GlideClient extends BaseClient
     }
 
     /**
+     * Creates a GlideClient that wraps an existing native handle from the pool.
+     *
+     * <p>The pool's Rust side creates the actual connection and registers it in
+     * the JNI handle table. This factory wires up the Java command dispatch chain
+     * so that commands flow through the existing native bridge.
+     *
+     * @param nativeHandle the native client handle (same as client_id from pool)
+     * @param maxInflight max inflight requests (0 = use core defaults)
+     * @param requestTimeoutMs request timeout in ms (0 = no Java-side timeout)
+     * @return a fully-functional GlideClient backed by the pool connection
+     */
+    public static GlideClient fromPoolHandle(long nativeHandle, int maxInflight, long requestTimeoutMs) {
+        glide.internal.GlideCoreClient coreClient =
+                new glide.internal.GlideCoreClient(nativeHandle, maxInflight, requestTimeoutMs);
+        glide.managers.CommandManager commandManager = new glide.managers.CommandManager(coreClient);
+        glide.managers.ConnectionManager connectionManager = new glide.managers.ConnectionManager();
+        glide.connectors.handlers.MessageHandler messageHandler =
+                new glide.connectors.handlers.MessageHandler(
+                        java.util.Optional.empty(), java.util.Optional.empty(),
+                        new glide.managers.BaseResponseResolver(pointer -> {
+                            if (pointer == null || pointer == 0) return null;
+                            return glide.ffi.resolvers.GlideValueResolver.valueFromPointer(pointer);
+                        }));
+
+        GlideClient client = new GlideClient(
+                new ClientBuilder(connectionManager, commandManager, messageHandler,
+                        java.util.Optional.empty()));
+
+        try {
+            glide.internal.GlideCoreClient.registerClient(nativeHandle, client);
+        } catch (Throwable t) {
+            // Non-fatal: push delivery won't work but commands will
+        }
+
+        return client;
+    }
+
+    /**
      * Creates a new {@link GlideClient} instance and establishes a connection to a standalone Valkey
      *
      * @param config The configuration options for the client, including server addresses,

--- a/java/client/src/main/java/glide/api/GlideClusterClient.java
+++ b/java/client/src/main/java/glide/api/GlideClusterClient.java
@@ -228,6 +228,51 @@ public class GlideClusterClient extends BaseClient
         return BaseClient.createClient(config, GlideClusterClient::new);
     }
 
+    /**
+     * Acquire an isolated scope (dedicated connection) for operations requiring
+     * per-connection server state (WATCH/MULTI/EXEC, CLIENT TRACKING, blocking commands).
+     *
+     * <p>In cluster mode, the scope connection is opened to the primary node for the
+     * relevant slot. The scope is pinned to a single slot after the first keyed command.
+     *
+     * @param timeout maximum time to wait for a scope to become available
+     * @return a Future resolving to an {@link glide.api.models.scope.IsolatedScope}
+     */
+    public CompletableFuture<glide.api.models.scope.IsolatedScope> scopedConnection(
+            @NonNull java.time.Duration timeout) {
+        long clientId = connectionManager.getNativeClientHandle();
+        byte[] connBytes = connectionManager.getConnectionRequestBytes();
+        if (connBytes == null) {
+            CompletableFuture<glide.api.models.scope.IsolatedScope> f = new CompletableFuture<>();
+            f.completeExceptionally(new IllegalStateException("Client not connected"));
+            return f;
+        }
+
+        long timeoutMs = timeout.toMillis();
+        long deadline = System.currentTimeMillis() + timeoutMs;
+
+        return CompletableFuture.supplyAsync(() -> {
+            while (true) {
+                long scopeId = glide.ffi.resolvers.GlideScopeResolver.glideScopeTryAcquire(clientId, connBytes);
+                if (scopeId >= 0) {
+                    return new glide.api.models.scope.IsolatedScope(scopeId, clientId);
+                }
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    throw new java.util.concurrent.CompletionException(
+                            new java.util.concurrent.TimeoutException(
+                                    "Timed out waiting for isolated scope (pool exhausted)"));
+                }
+                try {
+                    Thread.sleep(Math.min(10, remaining));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new java.util.concurrent.CompletionException(e);
+                }
+            }
+        });
+    }
+
     @Override
     public CompletableFuture<ClusterValue<Object>> customCommand(@NonNull String[] args) {
         // TODO if a command returns a map as a single value, ClusterValue misleads user

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -116,7 +116,20 @@ public class ClientPool implements AutoCloseable {
                 }
 
                 long clientId = GlidePoolResolver.glidePoolTryAcquire(poolId);
-                if (clientId >= 0) return clientId;
+                if (clientId >= 0) {
+                    // test_on_borrow: PING to verify connection health
+                    if (config.isTestOnBorrow()) {
+                        try {
+                            GlideClient client = getClient(clientId);
+                            client.ping().get(2, java.util.concurrent.TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            // Dead connection — release and retry
+                            release(clientId);
+                            continue;
+                        }
+                    }
+                    return clientId;
+                }
                 if (clientId == -2) throw new RuntimeException("Pool was destroyed");
 
                 long remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000;
@@ -137,6 +150,10 @@ public class ClientPool implements AutoCloseable {
     /**
      * Get a usable GlideClient for the given client_id.
      * Cached — no allocation on subsequent calls for the same client_id.
+     *
+     * <p><b>Important:</b> Do NOT call {@code close()} on the returned client.
+     * The pool manages the client's lifecycle. Call {@link #release(long)} instead
+     * to return the client to the pool.
      */
     public GlideClient getClient(long clientId) {
         GlideClient cached = clientCache.get(clientId);

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -85,23 +85,22 @@ public class ClientPool implements AutoCloseable {
     }
 
     /**
-     * Acquire a client_id from the pool with default timeout.
-     *
-     * @return CompletableFuture resolving to a client_id
+     * Acquire a pooled client with default timeout. Returns a pool-aware wrapper
+     * that returns the client to the pool on close() (try-with-resources safe).
      */
-    public CompletableFuture<Long> acquire() {
+    public CompletableFuture<PooledGlideClient> acquire() {
         return acquire(config.getAcquireTimeout());
     }
 
     /**
-     * Acquire a client_id with custom timeout. Retries with exponential backoff.
+     * Acquire a pooled client with custom timeout. Retries with exponential backoff.
      *
-     * @param timeout max wait time
-     * @return CompletableFuture resolving to a client_id
+     * <p>The returned {@link PooledGlideClient} implements AutoCloseable — its close()
+     * returns the client to the pool instead of destroying the native connection.
      */
-    public CompletableFuture<Long> acquire(Duration timeout) {
+    public CompletableFuture<PooledGlideClient> acquire(Duration timeout) {
         if (state.get() != RUNNING) {
-            CompletableFuture<Long> f = new CompletableFuture<>();
+            CompletableFuture<PooledGlideClient> f = new CompletableFuture<>();
             f.completeExceptionally(new ClosingException("Pool is closed"));
             return f;
         }
@@ -128,7 +127,7 @@ public class ClientPool implements AutoCloseable {
                             continue;
                         }
                     }
-                    return clientId;
+                    return new PooledGlideClient(getClient(clientId), ClientPool.this, clientId);
                 }
                 if (clientId == -2) throw new RuntimeException("Pool was destroyed");
 

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -3,6 +3,7 @@ package glide.api.models.pool;
 
 import static connection_request.ConnectionRequestOuterClass.*;
 
+import glide.api.GlideClient;
 import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.BaseClientConfiguration;
 import glide.api.models.configuration.GlideClusterClientConfiguration;
@@ -47,6 +48,8 @@ public class ClientPool implements AutoCloseable {
     private final long poolId;
     private final ClientPoolConfig config;
     private final AtomicInteger state = new AtomicInteger(RUNNING);
+    private final java.util.concurrent.ConcurrentHashMap<Long, GlideClient> clientCache =
+            new java.util.concurrent.ConcurrentHashMap<>();
 
     private ClientPool(long poolId, ClientPoolConfig config) {
         this.poolId = poolId;
@@ -133,14 +136,13 @@ public class ClientPool implements AutoCloseable {
 
     /**
      * Get a usable GlideClient for the given client_id.
-     *
-     * TODO: Requires GlideClient.fromPoolHandle() factory method to wrap
-     * the native handle without creating a new connection. For now, callers
-     * can use the client_id directly with low-level JNI dispatch.
+     * Cached — no allocation on subsequent calls for the same client_id.
      */
-    public Object getClient(long clientId) {
-        throw new UnsupportedOperationException(
-                "getClient() requires GlideClient.fromPoolHandle() — use low-level dispatch for now");
+    public GlideClient getClient(long clientId) {
+        GlideClient cached = clientCache.get(clientId);
+        if (cached != null) return cached;
+        return clientCache.computeIfAbsent(clientId,
+                id -> GlideClient.fromPoolHandle(id, 0, config.getRequestTimeout().toMillis()));
     }
 
     /** Release a client back to the pool. */
@@ -172,6 +174,7 @@ public class ClientPool implements AutoCloseable {
     public void close() {
         if (state.compareAndSet(RUNNING, CLOSED)) {
             GlidePoolResolver.glidePoolDestroy(poolId);
+            clientCache.clear();
         }
     }
 

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -1,0 +1,237 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.pool;
+
+import static connection_request.ConnectionRequestOuterClass.*;
+
+import glide.api.models.configuration.BackoffStrategy;
+import glide.api.models.configuration.BaseClientConfiguration;
+import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.ServerCredentials;
+import glide.api.models.exceptions.ClosingException;
+import glide.ffi.resolvers.GlidePoolResolver;
+import glide.internal.GlideNativeBridge;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Client-instance pool backed by the shared Rust core.
+ *
+ * <p>Callers borrow a client via {@link #acquire()}, use it for commands, and return
+ * it via {@link #release(long)}. The pool handles creation, LIFO reuse, bounded size,
+ * and background client creation.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * ClientPoolConfig config = ClientPoolConfig.builder()
+ *     .maxSize(10)
+ *     .minIdle(2)
+ *     .clientConfig(GlideClientConfiguration.builder()
+ *         .address(NodeAddress.builder().host("localhost").port(6379).build())
+ *         .build())
+ *     .build();
+ *
+ * ClientPool pool = ClientPool.create(config);
+ * long clientId = pool.acquire().get();
+ * GlideClient client = pool.getClient(clientId);
+ * client.set("key", "value").get();
+ * pool.release(clientId);
+ * pool.close();
+ * }</pre>
+ */
+public class ClientPool implements AutoCloseable {
+
+    private static final int RUNNING = 0;
+    private static final int CLOSED = 1;
+
+    private final long poolId;
+    private final ClientPoolConfig config;
+    private final AtomicInteger state = new AtomicInteger(RUNNING);
+
+    private ClientPool(long poolId, ClientPoolConfig config) {
+        this.poolId = poolId;
+        this.config = config;
+    }
+
+    /**
+     * Create a new pool.
+     *
+     * @param config pool configuration
+     * @return the pool (clients are created asynchronously in the background)
+     */
+    public static ClientPool create(ClientPoolConfig config) {
+        config.validate();
+        byte[] connectionRequestBytes = serializeConnectionRequest(config.getClientConfig());
+
+        long poolId = GlidePoolResolver.glidePoolCreate(
+                config.getMaxSize(),
+                config.getMinIdle(),
+                config.getIdleTimeout().toMillis(),
+                config.getRequestTimeout().toMillis(),
+                connectionRequestBytes);
+
+        if (poolId == -1) throw new IllegalArgumentException("Invalid pool configuration");
+        if (poolId < 0) throw new RuntimeException("Pool creation failed: " + poolId);
+
+        return new ClientPool(poolId, config);
+    }
+
+    /** Get the native pool handle. */
+    public long getPoolId() {
+        return poolId;
+    }
+
+    /**
+     * Acquire a client_id from the pool with default timeout.
+     *
+     * @return CompletableFuture resolving to a client_id
+     */
+    public CompletableFuture<Long> acquire() {
+        return acquire(config.getAcquireTimeout());
+    }
+
+    /**
+     * Acquire a client_id with custom timeout. Retries with exponential backoff.
+     *
+     * @param timeout max wait time
+     * @return CompletableFuture resolving to a client_id
+     */
+    public CompletableFuture<Long> acquire(Duration timeout) {
+        if (state.get() != RUNNING) {
+            CompletableFuture<Long> f = new CompletableFuture<>();
+            f.completeExceptionally(new ClosingException("Pool is closed"));
+            return f;
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            long deadlineNanos = System.nanoTime() + timeout.toNanos();
+            long backoffMs = 1;
+
+            while (System.nanoTime() < deadlineNanos) {
+                if (state.get() != RUNNING) {
+                    throw new RuntimeException(new ClosingException("Pool is closed"));
+                }
+
+                long clientId = GlidePoolResolver.glidePoolTryAcquire(poolId);
+                if (clientId >= 0) return clientId;
+                if (clientId == -2) throw new RuntimeException("Pool was destroyed");
+
+                long remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000;
+                long sleepMs = Math.min(backoffMs, Math.max(remainingMs, 0));
+                if (sleepMs <= 0) break;
+                try { Thread.sleep(sleepMs); } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Acquire interrupted", e);
+                }
+                backoffMs = Math.min(backoffMs * 2, 50);
+            }
+
+            throw new RuntimeException(new java.util.concurrent.TimeoutException(
+                    "Pool exhausted: could not acquire within " + timeout));
+        });
+    }
+
+    /**
+     * Get a usable GlideClient for the given client_id.
+     *
+     * TODO: Requires GlideClient.fromPoolHandle() factory method to wrap
+     * the native handle without creating a new connection. For now, callers
+     * can use the client_id directly with low-level JNI dispatch.
+     */
+    public Object getClient(long clientId) {
+        throw new UnsupportedOperationException(
+                "getClient() requires GlideClient.fromPoolHandle() — use low-level dispatch for now");
+    }
+
+    /** Release a client back to the pool. */
+    public void release(long clientId) {
+        GlidePoolResolver.glidePoolRelease(poolId, clientId);
+    }
+
+    /** Get pool metrics. */
+    public int[] getMetrics() {
+        return GlidePoolResolver.glidePoolMetrics(poolId);
+    }
+
+    public int getIdleCount() {
+        int[] m = getMetrics();
+        return m != null ? m[0] : 0;
+    }
+
+    public int getActiveCount() {
+        int[] m = getMetrics();
+        return m != null ? m[1] : 0;
+    }
+
+    public int getTotalCount() {
+        int[] m = getMetrics();
+        return m != null ? m[2] : 0;
+    }
+
+    @Override
+    public void close() {
+        if (state.compareAndSet(RUNNING, CLOSED)) {
+            GlidePoolResolver.glidePoolDestroy(poolId);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Internal: protobuf serialization (same as previous prototype)
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static byte[] serializeConnectionRequest(BaseClientConfiguration config) {
+        ConnectionRequest.Builder b = ConnectionRequest.newBuilder();
+
+        for (glide.api.models.configuration.NodeAddress addr : config.getAddresses()) {
+            b.addAddresses(NodeAddress.newBuilder()
+                    .setHost(addr.getHost()).setPort(addr.getPort()).build());
+        }
+
+        b.setTlsMode(config.isUseTLS() ? TlsMode.SecureTls : TlsMode.NoTls);
+        b.setClusterModeEnabled(config instanceof GlideClusterClientConfiguration);
+
+        int reqTimeout = config.getRequestTimeout() != null
+                ? config.getRequestTimeout()
+                : (int) GlideNativeBridge.getGlideCoreDefaultRequestTimeoutMs();
+        b.setRequestTimeout(reqTimeout);
+        b.setConnectionTimeout(reqTimeout);
+
+        int inflight = config.getInflightRequestsLimit() != null
+                ? config.getInflightRequestsLimit()
+                : GlideNativeBridge.getGlideCoreDefaultMaxInflightRequests();
+        b.setInflightRequestsLimit(inflight);
+
+        ServerCredentials creds = config.getCredentials();
+        if (creds != null) {
+            AuthenticationInfo.Builder auth = AuthenticationInfo.newBuilder();
+            if (creds.getUsername() != null) auth.setUsername(creds.getUsername());
+            if (creds.getPassword() != null) auth.setPassword(creds.getPassword());
+            b.setAuthenticationInfo(auth.build());
+        }
+
+        if (config.getReadFrom() != null) {
+            String rf = config.getReadFrom().name();
+            if ("PRIMARY".equals(rf)) b.setReadFrom(ReadFrom.Primary);
+            else if ("PREFER_REPLICA".equals(rf)) b.setReadFrom(ReadFrom.PreferReplica);
+        }
+
+        if (config.getClientName() != null) b.setClientName(config.getClientName());
+        if (config.getDatabaseId() != null) b.setDatabaseId(config.getDatabaseId());
+
+        if (config.getProtocol() != null) {
+            if ("RESP2".equals(config.getProtocol().name())) b.setProtocol(ProtocolVersion.RESP2);
+            else if ("RESP3".equals(config.getProtocol().name())) b.setProtocol(ProtocolVersion.RESP3);
+        }
+
+        BackoffStrategy rs = config.getReconnectStrategy();
+        if (rs != null) {
+            ConnectionRetryStrategy.Builder r = ConnectionRetryStrategy.newBuilder();
+            if (rs.getNumOfRetries() != null) r.setNumberOfRetries(rs.getNumOfRetries());
+            if (rs.getFactor() != null) r.setFactor(rs.getFactor());
+            if (rs.getExponentBase() != null) r.setExponentBase(rs.getExponentBase());
+            b.setConnectionRetryStrategy(r.build());
+        }
+
+        return b.build().toByteArray();
+    }
+}

--- a/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
@@ -26,6 +26,9 @@ public class ClientPoolConfig {
     /** Request timeout (for cleanup operations). Default: 5 seconds. */
     @Builder.Default private final Duration requestTimeout = Duration.ofSeconds(5);
 
+    /** Send PING on borrow to verify connection health. Default: false. */
+    @Builder.Default private final boolean testOnBorrow = false;
+
     /** The client configuration (addresses, TLS, auth, etc.). */
     private final BaseClientConfiguration clientConfig;
 

--- a/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPoolConfig.java
@@ -1,0 +1,37 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.pool;
+
+import glide.api.models.configuration.BaseClientConfiguration;
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Getter;
+
+/** Configuration for a client-instance pool. */
+@Getter
+@Builder
+public class ClientPoolConfig {
+
+    /** Maximum clients in the pool. Default: 10. */
+    @Builder.Default private final int maxSize = 10;
+
+    /** Minimum idle clients to pre-warm. Default: 1. */
+    @Builder.Default private final int minIdle = 1;
+
+    /** Acquire timeout. Default: 5 seconds. */
+    @Builder.Default private final Duration acquireTimeout = Duration.ofSeconds(5);
+
+    /** Idle eviction timeout. Default: 5 minutes. */
+    @Builder.Default private final Duration idleTimeout = Duration.ofSeconds(300);
+
+    /** Request timeout (for cleanup operations). Default: 5 seconds. */
+    @Builder.Default private final Duration requestTimeout = Duration.ofSeconds(5);
+
+    /** The client configuration (addresses, TLS, auth, etc.). */
+    private final BaseClientConfiguration clientConfig;
+
+    public void validate() {
+        if (maxSize < 1) throw new IllegalArgumentException("maxSize must be >= 1");
+        if (minIdle > maxSize) throw new IllegalArgumentException("minIdle must be <= maxSize");
+        if (clientConfig == null) throw new IllegalArgumentException("clientConfig is required");
+    }
+}

--- a/java/client/src/main/java/glide/api/models/pool/PooledGlideClient.java
+++ b/java/client/src/main/java/glide/api/models/pool/PooledGlideClient.java
@@ -1,0 +1,73 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.pool;
+
+import glide.api.GlideClient;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A GlideClient borrowed from a pool. Implements AutoCloseable so that
+ * try-with-resources returns the client to the pool instead of destroying it.
+ *
+ * <pre>{@code
+ * try (PooledGlideClient client = pool.acquire().get()) {
+ *     client.set("key", "value").get();
+ *     String val = client.get("key").get();
+ * } // automatically returned to pool
+ * }</pre>
+ */
+public class PooledGlideClient implements AutoCloseable {
+
+    private final GlideClient delegate;
+    private final ClientPool pool;
+    private final long clientId;
+    private volatile boolean released = false;
+
+    PooledGlideClient(GlideClient delegate, ClientPool pool, long clientId) {
+        this.delegate = delegate;
+        this.pool = pool;
+        this.clientId = clientId;
+    }
+
+    /** Get the underlying GlideClient for command dispatch. */
+    public GlideClient unwrap() {
+        if (released) throw new IllegalStateException("Client already returned to pool");
+        return delegate;
+    }
+
+    /** Get the client_id handle. */
+    public long getClientId() {
+        return clientId;
+    }
+
+    // ========== Delegate common commands for convenience ==========
+
+    public CompletableFuture<String> set(String key, String value) {
+        return unwrap().set(key, value);
+    }
+
+    public CompletableFuture<String> get(String key) {
+        return unwrap().get(key);
+    }
+
+    public CompletableFuture<String> ping() {
+        return unwrap().ping();
+    }
+
+    public CompletableFuture<String> ping(String message) {
+        return unwrap().ping(message);
+    }
+
+    public CompletableFuture<Long> del(String[] keys) {
+        return unwrap().del(keys);
+    }
+
+    // ========== AutoCloseable: return to pool ==========
+
+    @Override
+    public void close() {
+        if (!released) {
+            released = true;
+            pool.release(clientId);
+        }
+    }
+}

--- a/java/client/src/main/java/glide/api/models/scope/IsolatedScope.java
+++ b/java/client/src/main/java/glide/api/models/scope/IsolatedScope.java
@@ -1,0 +1,102 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.scope;
+
+import glide.ffi.resolvers.GlideScopeResolver;
+import glide.internal.AsyncRegistry;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A borrowed dedicated connection for operations requiring per-connection state.
+ *
+ * <p>Commands bypass the multiplexer and execute on a single TCP connection.
+ * Enables WATCH/MULTI/EXEC, CLIENT TRACKING, blocking commands, and pub/sub
+ * without interference from other callers.
+ *
+ * <p><b>Thread Safety:</b> A single IsolatedScope is NOT thread-safe (serial execution).
+ * Multiple threads should each acquire their own scope via {@code client.scopedConnection()}.
+ *
+ * <pre>{@code
+ * try (IsolatedScope scope = client.scopedConnection().get()) {
+ *     scope.watch("counter").get();
+ *     String val = scope.get("counter").get();
+ *     scope.multi().get();
+ *     scope.set("counter", String.valueOf(Integer.parseInt(val) + 1)).get();
+ *     scope.exec().get();
+ * }
+ * }</pre>
+ */
+public class IsolatedScope implements AutoCloseable {
+
+    private final long scopeId;
+    private final long clientId;
+    private final AtomicBoolean released = new AtomicBoolean(false);
+
+    public IsolatedScope(long scopeId, long clientId) {
+        this.scopeId = scopeId;
+        this.clientId = clientId;
+    }
+
+    public long getScopeId() {
+        if (released.get()) throw new IllegalStateException("Scope released");
+        return scopeId;
+    }
+
+    public boolean isReleased() { return released.get(); }
+
+    // ========== Commands ==========
+
+    public CompletableFuture<String> watch(String... keys) { return cmd("WATCH", keys); }
+    public CompletableFuture<String> unwatch() { return cmd("UNWATCH"); }
+    public CompletableFuture<String> multi() { return cmd("MULTI"); }
+    public CompletableFuture<String> exec() { return cmd("EXEC"); }
+    public CompletableFuture<String> discard() { return cmd("DISCARD"); }
+    public CompletableFuture<String> get(String key) { return cmd("GET", key); }
+    public CompletableFuture<String> set(String key, String value) { return cmd("SET", key, value); }
+    public CompletableFuture<String> incr(String key) { return cmd("INCR", key); }
+    public CompletableFuture<String> ping() { return cmd("PING"); }
+    public CompletableFuture<String> select(int db) { return cmd("SELECT", String.valueOf(db)); }
+
+    public CompletableFuture<String> cmd(String command, String... args) {
+        if (released.get()) {
+            CompletableFuture<String> f = new CompletableFuture<>();
+            f.completeExceptionally(new IllegalStateException("Scope released"));
+            return f;
+        }
+
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        long callbackId = AsyncRegistry.register(future, 0, clientId, 0);
+
+        byte[] bytes = serialize(command, args);
+        int result = GlideScopeResolver.glideScopeExecute(scopeId, bytes, callbackId);
+
+        if (result == -1) future.completeExceptionally(new IllegalStateException("Invalid scope"));
+        else if (result == -2) future.completeExceptionally(new IllegalArgumentException("Serialize failed"));
+
+        return future.thenApply(r -> r == null ? null : r.toString());
+    }
+
+    @Override
+    public void close() {
+        if (released.compareAndSet(false, true)) {
+            GlideScopeResolver.glideScopeRelease(scopeId, clientId);
+        }
+    }
+
+    static byte[] serialize(String command, String... args) {
+        byte[] cmdBytes = command.getBytes(StandardCharsets.UTF_8);
+        int size = 4 + cmdBytes.length + 4;
+        byte[][] argBytes = new byte[args.length][];
+        for (int i = 0; i < args.length; i++) {
+            argBytes[i] = args[i].getBytes(StandardCharsets.UTF_8);
+            size += 4 + argBytes[i].length;
+        }
+        ByteBuffer buf = ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putInt(cmdBytes.length).put(cmdBytes).putInt(args.length);
+        for (byte[] a : argBytes) buf.putInt(a.length).put(a);
+        return buf.array();
+    }
+}

--- a/java/client/src/main/java/glide/api/models/scope/IsolatedScope.java
+++ b/java/client/src/main/java/glide/api/models/scope/IsolatedScope.java
@@ -60,6 +60,11 @@ public class IsolatedScope implements AutoCloseable {
     public CompletableFuture<String> ping() { return cmd("PING"); }
     public CompletableFuture<String> select(int db) { return cmd("SELECT", String.valueOf(db)); }
 
+    /** Execute an arbitrary command on this scope. */
+    public CompletableFuture<String> executeCommand(String command, String... args) {
+        return cmd(command, args);
+    }
+
     public CompletableFuture<String> cmd(String command, String... args) {
         if (released.get()) {
             CompletableFuture<String> f = new CompletableFuture<>();

--- a/java/client/src/main/java/glide/ffi/resolvers/GlidePoolResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/GlidePoolResolver.java
@@ -1,0 +1,22 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.ffi.resolvers;
+
+/** Native method declarations for the client-instance pool (Feature 1). */
+public class GlidePoolResolver {
+
+    static {
+        NativeUtils.loadGlideLib();
+    }
+
+    public static native long glidePoolCreate(
+            int maxSize, int minIdle, long idleTimeoutMs, long requestTimeoutMs,
+            byte[] connectionRequestBytes);
+
+    public static native long glidePoolTryAcquire(long poolId);
+
+    public static native int glidePoolRelease(long poolId, long clientId);
+
+    public static native int glidePoolDestroy(long poolId);
+
+    public static native int[] glidePoolMetrics(long poolId);
+}

--- a/java/client/src/main/java/glide/ffi/resolvers/GlideScopeResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/GlideScopeResolver.java
@@ -1,0 +1,11 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.ffi.resolvers;
+
+/** Native method declarations for isolated execution (Feature 2 scopes). */
+public class GlideScopeResolver {
+    static { NativeUtils.loadGlideLib(); }
+
+    public static native long glideScopeTryAcquire(long clientId, byte[] connectionRequestBytes);
+    public static native int glideScopeRelease(long scopeId, long clientId);
+    public static native int glideScopeExecute(long scopeId, byte[] commandBytes, long callbackId);
+}

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -51,6 +51,8 @@ public class ConnectionManager {
     private int requestTimeoutMs = 5000;
     private ServerCredentials credentials;
     private volatile boolean isClosed = false;
+    /** Serialized protobuf ConnectionRequest bytes (stored for scope pool creation). */
+    private volatile byte[] connectionRequestBytes;
 
     /**
      * Connect to Valkey using the native bridge.
@@ -492,6 +494,7 @@ public class ConnectionManager {
                         // Build and serialize to bytes
                         ConnectionRequest request = requestBuilder.build();
                         byte[] requestBytes = request.toByteArray();
+                        this.connectionRequestBytes = requestBytes;
 
                         // Get the address resolver (may be null if not configured)
                         // The resolver is passed directly to native code which stores it as a global reference
@@ -577,6 +580,11 @@ public class ConnectionManager {
     /** Get request timeout setting. */
     public int getRequestTimeoutMs() {
         return requestTimeoutMs;
+    }
+
+    /** Get the serialized ConnectionRequest bytes for scope pool creation. */
+    public byte[] getConnectionRequestBytes() {
+        return connectionRequestBytes;
     }
 
     /** Check if the connection is closed. */

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -379,6 +379,13 @@ tasks.register('modulesTest', Test) {
     }
 }
 
+tasks.register('scopeTest', Test) {
+    filter {
+        includeTestsMatching 'glide.scope.*'
+    }
+    finalizedBy jacocoTestReport, jacocoTestCoverageVerification
+}
+
 // Configure Java 8 testing if enabled
 if (project.hasProperty('testJava8') && project.testJava8 == 'true') {
     tasks.named('test', Test).configure {

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -103,4 +103,78 @@ public class ClientPoolIntegrationTest {
         assertThrows(Exception.class, () -> pool.acquire().get(2, TimeUnit.SECONDS));
         System.out.println("testPoolCloseRejectsAcquire PASSED");
     }
+
+    @Test
+    public void testPoolConcurrentAccess() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000);
+
+        int numThreads = 4;
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(numThreads);
+        java.util.concurrent.atomic.AtomicInteger successCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicInteger errorCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadIdx = t;
+            new Thread(() -> {
+                try (glide.api.models.pool.PooledGlideClient client =
+                        pool.acquire().get(15, TimeUnit.SECONDS)) {
+                    String key = "pool-concurrent-" + threadIdx + "-" + UUID.randomUUID();
+                    client.set(key, "thread-" + threadIdx).get(5, TimeUnit.SECONDS);
+                    String val = client.get(key).get(5, TimeUnit.SECONDS);
+                    assertEquals("thread-" + threadIdx, val);
+                    client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    System.err.println("Thread " + threadIdx + " error: " + e);
+                    errorCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS), "All threads should finish");
+        assertEquals(numThreads, successCount.get(),
+                "All threads should succeed. Errors: " + errorCount.get());
+
+        pool.close();
+        System.out.println("testPoolConcurrentAccess PASSED");
+    }
+
+    @Test
+    public void testPoolTimeoutOnExhaustion() throws Exception {
+        ClientPoolConfig exhaustConfig = ClientPoolConfig.builder()
+                .maxSize(1)
+                .minIdle(1)
+                .acquireTimeout(Duration.ofSeconds(10))
+                .clientConfig(GlideClientConfiguration.builder()
+                        .address(NodeAddress.builder()
+                                .host(TestConfiguration.STANDALONE_HOSTS[0].split(":")[0])
+                                .port(Integer.parseInt(TestConfiguration.STANDALONE_HOSTS[0].split(":")[1]))
+                                .build())
+                        .requestTimeout(5000)
+                        .build())
+                .build();
+
+        ClientPool pool = ClientPool.create(exhaustConfig);
+        Thread.sleep(3000);
+
+        // Acquire the only client
+        glide.api.models.pool.PooledGlideClient held = pool.acquire().get(10, TimeUnit.SECONDS);
+
+        // Second acquire should time out (short timeout)
+        try {
+            pool.acquire(Duration.ofMillis(500)).get(2, TimeUnit.SECONDS);
+            fail("Should have thrown TimeoutException");
+        } catch (java.util.concurrent.ExecutionException e) {
+            assertTrue(e.getCause() instanceof java.util.concurrent.TimeoutException
+                    || e.getCause().getMessage().contains("exhausted"),
+                    "Expected timeout, got: " + e.getCause());
+        }
+
+        held.close();
+        pool.close();
+        System.out.println("testPoolTimeoutOnExhaustion PASSED");
+    }
 }

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -3,6 +3,7 @@ package glide.pool;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import glide.TestConfiguration;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.pool.ClientPool;
@@ -14,20 +15,21 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests for Feature 1: Client-Instance Pooling.
- * Requires a Valkey server on localhost:6379.
+ * Requires a Valkey server (uses test infrastructure endpoints).
  */
 public class ClientPoolIntegrationTest {
 
-    private static final String HOST = "localhost";
-    private static final int PORT = 6379;
-
     private ClientPoolConfig poolConfig() {
+        String hostPort = TestConfiguration.STANDALONE_HOSTS[0];
+        String[] parts = hostPort.split(":");
+        String host = parts[0];
+        int port = Integer.parseInt(parts[1]);
         return ClientPoolConfig.builder()
                 .maxSize(3)
                 .minIdle(1)
                 .acquireTimeout(Duration.ofSeconds(10))
                 .clientConfig(GlideClientConfiguration.builder()
-                        .address(NodeAddress.builder().host(HOST).port(PORT).build())
+                        .address(NodeAddress.builder().host(host).port(port).build())
                         .requestTimeout(5000)
                         .build())
                 .build();

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -83,7 +83,7 @@ public class ClientPoolIntegrationTest {
         assertEquals(0, pool.getActiveCount());
 
         long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
-        // After acquire: idle decreases, active not tracked in metrics (tracked by in_use map)
+        // After acquire: idle decreases, active increases.
         pool.release(clientId);
 
         assertTrue(pool.getIdleCount() >= 1, "After release, idle should be >= 1");

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -3,7 +3,6 @@ package glide.pool;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import glide.api.GlideClient;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.pool.ClientPool;
@@ -41,18 +40,17 @@ public class ClientPoolIntegrationTest {
 
         assertTrue(pool.getIdleCount() >= 1, "Should have at least 1 idle client");
 
-        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
-        assertTrue(clientId > 0, "client_id should be positive");
+        // acquire() returns PooledGlideClient — try-with-resources returns to pool
+        try (glide.api.models.pool.PooledGlideClient client = pool.acquire().get(10, TimeUnit.SECONDS)) {
+            assertNotNull(client);
+            assertTrue(client.getClientId() > 0, "client_id should be positive");
 
-        GlideClient client = pool.getClient(clientId);
-        assertNotNull(client);
+            String key = "pool-test-" + UUID.randomUUID();
+            client.set(key, "hello").get(5, TimeUnit.SECONDS);
+            assertEquals("hello", client.get(key).get(5, TimeUnit.SECONDS));
+            client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        } // auto-released back to pool
 
-        String key = "pool-test-" + UUID.randomUUID();
-        client.set(key, "hello").get(5, TimeUnit.SECONDS);
-        assertEquals("hello", client.get(key).get(5, TimeUnit.SECONDS));
-        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
-
-        pool.release(clientId);
         pool.close();
         System.out.println("testPoolCreateAcquireRelease PASSED");
     }
@@ -62,13 +60,15 @@ public class ClientPoolIntegrationTest {
         ClientPool pool = ClientPool.create(poolConfig());
         Thread.sleep(3000);
 
-        long id1 = pool.acquire().get(10, TimeUnit.SECONDS);
-        pool.release(id1);
+        glide.api.models.pool.PooledGlideClient c1 = pool.acquire().get(10, TimeUnit.SECONDS);
+        long id1 = c1.getClientId();
+        c1.close(); // returns to pool
         Thread.sleep(100);
 
-        long id2 = pool.acquire().get(10, TimeUnit.SECONDS);
+        glide.api.models.pool.PooledGlideClient c2 = pool.acquire().get(10, TimeUnit.SECONDS);
+        long id2 = c2.getClientId();
         assertEquals(id1, id2, "LIFO: same client_id returned after release");
-        pool.release(id2);
+        c2.close();
 
         pool.close();
         System.out.println("testPoolReuse PASSED");
@@ -82,7 +82,7 @@ public class ClientPoolIntegrationTest {
         assertTrue(pool.getIdleCount() >= 1);
         assertEquals(0, pool.getActiveCount());
 
-        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
+        long clientId = pool.acquire().get(10, TimeUnit.SECONDS).getClientId();
         // After acquire: idle decreases, active increases.
         pool.release(clientId);
 

--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -1,0 +1,104 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.pool;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.pool.ClientPool;
+import glide.api.models.pool.ClientPoolConfig;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for Feature 1: Client-Instance Pooling.
+ * Requires a Valkey server on localhost:6379.
+ */
+public class ClientPoolIntegrationTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 6379;
+
+    private ClientPoolConfig poolConfig() {
+        return ClientPoolConfig.builder()
+                .maxSize(3)
+                .minIdle(1)
+                .acquireTimeout(Duration.ofSeconds(10))
+                .clientConfig(GlideClientConfiguration.builder()
+                        .address(NodeAddress.builder().host(HOST).port(PORT).build())
+                        .requestTimeout(5000)
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void testPoolCreateAcquireRelease() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000); // Wait for min_idle warmup
+
+        assertTrue(pool.getIdleCount() >= 1, "Should have at least 1 idle client");
+
+        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
+        assertTrue(clientId > 0, "client_id should be positive");
+
+        GlideClient client = pool.getClient(clientId);
+        assertNotNull(client);
+
+        String key = "pool-test-" + UUID.randomUUID();
+        client.set(key, "hello").get(5, TimeUnit.SECONDS);
+        assertEquals("hello", client.get(key).get(5, TimeUnit.SECONDS));
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+
+        pool.release(clientId);
+        pool.close();
+        System.out.println("testPoolCreateAcquireRelease PASSED");
+    }
+
+    @Test
+    public void testPoolReuse() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000);
+
+        long id1 = pool.acquire().get(10, TimeUnit.SECONDS);
+        pool.release(id1);
+        Thread.sleep(100);
+
+        long id2 = pool.acquire().get(10, TimeUnit.SECONDS);
+        assertEquals(id1, id2, "LIFO: same client_id returned after release");
+        pool.release(id2);
+
+        pool.close();
+        System.out.println("testPoolReuse PASSED");
+    }
+
+    @Test
+    public void testPoolMetrics() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(3000);
+
+        assertTrue(pool.getIdleCount() >= 1);
+        assertEquals(0, pool.getActiveCount());
+
+        long clientId = pool.acquire().get(10, TimeUnit.SECONDS);
+        // After acquire: idle decreases, active not tracked in metrics (tracked by in_use map)
+        pool.release(clientId);
+
+        assertTrue(pool.getIdleCount() >= 1, "After release, idle should be >= 1");
+        pool.close();
+        System.out.println("testPoolMetrics PASSED");
+    }
+
+    @Test
+    public void testPoolCloseRejectsAcquire() throws Exception {
+        ClientPool pool = ClientPool.create(poolConfig());
+        Thread.sleep(2000);
+
+        pool.close();
+
+        assertThrows(Exception.class, () -> pool.acquire().get(2, TimeUnit.SECONDS));
+        System.out.println("testPoolCloseRejectsAcquire PASSED");
+    }
+}

--- a/java/integTest/src/test/java/glide/scope/IsolatedScopeBenchmark.java
+++ b/java/integTest/src/test/java/glide/scope/IsolatedScopeBenchmark.java
@@ -1,0 +1,343 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.scope;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import glide.TestConfiguration;
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.scope.IsolatedScope;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Benchmarks and correctness tests for WATCH/MULTI/EXEC with IsolatedScope.
+ *
+ * Demonstrates:
+ * 1. Performance: IsolatedScope vs creating a fresh client per transaction
+ * 2. Correctness: Optimistic concurrency control (OCC) with concurrent writers
+ *
+ * Requires a Valkey server (uses test infrastructure endpoints).
+ */
+public class IsolatedScopeBenchmark {
+
+    private GlideClientConfiguration getConfig() {
+        String hostPort = TestConfiguration.STANDALONE_HOSTS[0];
+        String[] parts = hostPort.split(":");
+        String host = parts[0];
+        int port = Integer.parseInt(parts[1]);
+        return GlideClientConfiguration.builder()
+                .address(NodeAddress.builder().host(host).port(port).build())
+                .requestTimeout(5000)
+                .build();
+    }
+
+    // ========== Performance Benchmark ==========
+
+    @Test
+    public void benchmarkWatchTransaction() throws Exception {
+        final int ITERATIONS = 100;
+
+        System.out.println("\n=== WATCH/MULTI/EXEC Performance Benchmark ===");
+        System.out.println("Iterations: " + ITERATIONS);
+        System.out.println("Each iteration: WATCH → GET → MULTI → SET(val+1) → EXEC");
+        System.out.println();
+
+        GlideClient sharedClient = GlideClient.createClient(getConfig()).get(10, TimeUnit.SECONDS);
+        String counterKey = "bench-watch-" + UUID.randomUUID();
+        sharedClient.set(counterKey, "0").get(5, TimeUnit.SECONDS);
+
+        // --- Scenario A: Fresh client per transaction (old workaround) ---
+        System.out.println("--- Scenario A: Fresh client per WATCH transaction ---");
+        System.out.println("    (Only way to do WATCH before Feature 2 — creates TCP connection each time)");
+
+        long scenarioAStart = System.nanoTime();
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            GlideClient txClient = GlideClient.createClient(getConfig()).get(10, TimeUnit.SECONDS);
+            txClient.customCommand(new String[]{"WATCH", counterKey}).get(5, TimeUnit.SECONDS);
+            String val = txClient.get(counterKey).get(5, TimeUnit.SECONDS);
+            txClient.customCommand(new String[]{"MULTI"}).get(5, TimeUnit.SECONDS);
+            txClient.set(counterKey, String.valueOf(Integer.parseInt(val) + 1)).get(5, TimeUnit.SECONDS);
+            txClient.customCommand(new String[]{"EXEC"}).get(5, TimeUnit.SECONDS);
+            txClient.close();
+        }
+
+        long scenarioAElapsed = System.nanoTime() - scenarioAStart;
+        double scenarioAMs = scenarioAElapsed / 1_000_000.0;
+        double scenarioAPerOp = scenarioAMs / ITERATIONS;
+
+        String valAfterA = sharedClient.get(counterKey).get(5, TimeUnit.SECONDS);
+        System.out.printf("    Total: %.1f ms%n", scenarioAMs);
+        System.out.printf("    Per transaction: %.2f ms%n", scenarioAPerOp);
+        System.out.printf("    Counter: %s (expected: %d)%n", valAfterA, ITERATIONS);
+        System.out.println();
+
+        // Reset counter
+        sharedClient.set(counterKey, "0").get(5, TimeUnit.SECONDS);
+
+        // --- Scenario B: IsolatedScope (Feature 2) ---
+        System.out.println("--- Scenario B: IsolatedScope from pool ---");
+        System.out.println("    (Borrow dedicated connection, WATCH safely, return to pool)");
+
+        // Warm up the scope pool
+        IsolatedScope warmup = sharedClient.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+        warmup.ping().get(5, TimeUnit.SECONDS);
+        warmup.close();
+        Thread.sleep(100);
+
+        long scenarioBStart = System.nanoTime();
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            try (IsolatedScope scope = sharedClient.scopedConnection(Duration.ofSeconds(10))
+                    .get(10, TimeUnit.SECONDS)) {
+                scope.watch(counterKey).get(5, TimeUnit.SECONDS);
+                String val = scope.get(counterKey).get(5, TimeUnit.SECONDS);
+                scope.multi().get(5, TimeUnit.SECONDS);
+                scope.set(counterKey, String.valueOf(Integer.parseInt(val) + 1)).get(5, TimeUnit.SECONDS);
+                scope.exec().get(5, TimeUnit.SECONDS);
+            }
+        }
+
+        long scenarioBElapsed = System.nanoTime() - scenarioBStart;
+        double scenarioBMs = scenarioBElapsed / 1_000_000.0;
+        double scenarioBPerOp = scenarioBMs / ITERATIONS;
+
+        String valAfterB = sharedClient.get(counterKey).get(5, TimeUnit.SECONDS);
+        System.out.printf("    Total: %.1f ms%n", scenarioBMs);
+        System.out.printf("    Per transaction: %.2f ms%n", scenarioBPerOp);
+        System.out.printf("    Counter: %s (expected: %d)%n", valAfterB, ITERATIONS);
+        System.out.println();
+
+        // --- Breakdown: per-command latency on warmed scope ---
+        System.out.println("--- Breakdown: per-command latency (warmed, no acquire/release) ---");
+        sharedClient.set(counterKey, "0").get(5, TimeUnit.SECONDS);
+        IsolatedScope breakdownScope = sharedClient.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+        // Warmup JIT on this scope
+        for (int i = 0; i < 20; i++) {
+            breakdownScope.ping().get(5, TimeUnit.SECONDS);
+        }
+
+        int cmdIterations = 100;
+        long cmdStart = System.nanoTime();
+        for (int i = 0; i < cmdIterations; i++) {
+            breakdownScope.watch(counterKey).get(5, TimeUnit.SECONDS);
+            breakdownScope.get(counterKey).get(5, TimeUnit.SECONDS);
+            breakdownScope.multi().get(5, TimeUnit.SECONDS);
+            breakdownScope.set(counterKey, String.valueOf(i)).get(5, TimeUnit.SECONDS);
+            breakdownScope.exec().get(5, TimeUnit.SECONDS);
+        }
+        long cmdElapsed = System.nanoTime() - cmdStart;
+        double cmdMs = cmdElapsed / 1_000_000.0;
+        double perTxMs = cmdMs / cmdIterations;
+        double perCmdMs = perTxMs / 5.0;
+        breakdownScope.close();
+
+        System.out.printf("    %d transactions (5 cmds each) on held scope: %.1f ms total%n", cmdIterations, cmdMs);
+        System.out.printf("    Per transaction (no acquire/release): %.2f ms%n", perTxMs);
+        System.out.printf("    Per command: %.2f ms%n", perCmdMs);
+        System.out.printf("    Acquire/release overhead per tx: ~%.2f ms%n", scenarioBPerOp - perTxMs);
+        System.out.println();
+
+        // --- Summary ---
+        System.out.println("=== Summary ===");
+        System.out.printf("    Fresh client per tx:  %.2f ms/tx%n", scenarioAPerOp);
+        System.out.printf("    IsolatedScope:        %.2f ms/tx%n", scenarioBPerOp);
+        System.out.printf("    Speedup:              %.1fx%n", scenarioAPerOp / scenarioBPerOp);
+        System.out.println();
+
+        // Cleanup
+        sharedClient.del(new String[]{counterKey}).get(5, TimeUnit.SECONDS);
+        sharedClient.close();
+    }
+
+    // ========== OCC Correctness Tests ==========
+
+    /**
+     * Demonstrates correct optimistic concurrency control:
+     * Multiple threads increment a counter using WATCH/MULTI/EXEC.
+     * With OCC, some transactions will abort (EXEC returns null) and must retry.
+     * The final counter value must equal the total number of successful increments.
+     */
+    @Test
+    public void testOCCConcurrentIncrement() throws Exception {
+        System.out.println("\n=== OCC Test: Concurrent counter increment ===");
+
+        GlideClient client = GlideClient.createClient(getConfig()).get(10, TimeUnit.SECONDS);
+        String counterKey = "occ-counter-" + UUID.randomUUID();
+        client.set(counterKey, "0").get(5, TimeUnit.SECONDS);
+
+        int numThreads = 5;
+        int incrementsPerThread = 20;
+        int expectedFinal = numThreads * incrementsPerThread;
+
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numThreads);
+        AtomicInteger totalAttempts = new AtomicInteger(0);
+        AtomicInteger totalAborts = new AtomicInteger(0);
+        AtomicInteger totalSuccess = new AtomicInteger(0);
+
+        // Pre-warm the scope pool with enough connections
+        for (int i = 0; i < numThreads; i++) {
+            IsolatedScope w = client.scopedConnection(Duration.ofSeconds(10)).get(10, TimeUnit.SECONDS);
+            w.ping().get(5, TimeUnit.SECONDS);
+            w.close();
+        }
+        Thread.sleep(200);
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadIdx = t;
+            new Thread(() -> {
+                try {
+                    startGate.await(); // All threads start together
+
+                    for (int i = 0; i < incrementsPerThread; i++) {
+                        boolean committed = false;
+                        while (!committed) {
+                            totalAttempts.incrementAndGet();
+
+                            try (IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(10))
+                                    .get(10, TimeUnit.SECONDS)) {
+
+                                scope.watch(counterKey).get(5, TimeUnit.SECONDS);
+                                String val = scope.get(counterKey).get(5, TimeUnit.SECONDS);
+                                int current = Integer.parseInt(val);
+
+                                scope.multi().get(5, TimeUnit.SECONDS);
+                                scope.set(counterKey, String.valueOf(current + 1))
+                                        .get(5, TimeUnit.SECONDS);
+                                String execResult = scope.exec().get(5, TimeUnit.SECONDS);
+
+                                if (execResult != null && !execResult.isEmpty()
+                                        && !execResult.equals("null")) {
+                                    committed = true;
+                                    totalSuccess.incrementAndGet();
+                                } else {
+                                    // Transaction aborted — another thread modified the key
+                                    totalAborts.incrementAndGet();
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    System.err.println("Thread " + threadIdx + " fatal error: " + e);
+                    e.printStackTrace();
+                } finally {
+                    doneLatch.countDown();
+                }
+            }, "OCC-Thread-" + t).start();
+        }
+
+        // Release all threads simultaneously
+        startGate.countDown();
+
+        assertTrue(doneLatch.await(60, TimeUnit.SECONDS), "All threads should finish within 60s");
+
+        // Verify the counter is exactly correct
+        String finalVal = client.get(counterKey).get(5, TimeUnit.SECONDS);
+        int finalCount = Integer.parseInt(finalVal);
+
+        System.out.printf("    Threads: %d, Increments/thread: %d%n", numThreads, incrementsPerThread);
+        System.out.printf("    Expected final counter: %d%n", expectedFinal);
+        System.out.printf("    Actual final counter:   %d%n", finalCount);
+        System.out.printf("    Total attempts:         %d%n", totalAttempts.get());
+        System.out.printf("    Successful commits:     %d%n", totalSuccess.get());
+        System.out.printf("    Aborted (retried):      %d%n", totalAborts.get());
+        System.out.printf("    Abort rate:             %.1f%%%n",
+                100.0 * totalAborts.get() / totalAttempts.get());
+        System.out.println();
+
+        assertEquals(expectedFinal, finalCount,
+                "Counter must equal exactly " + expectedFinal + " — OCC guarantees correctness");
+        assertEquals(expectedFinal, totalSuccess.get(),
+                "Total successful commits must equal expected increments");
+
+        // Cleanup
+        client.del(new String[]{counterKey}).get(5, TimeUnit.SECONDS);
+        client.close();
+
+        System.out.println("OCC concurrent increment test PASSED!");
+        System.out.println("    (Contention caused " + totalAborts.get() + " retries across "
+                + totalAttempts.get() + " attempts — OCC working correctly)");
+    }
+
+    /**
+     * Demonstrates that WATCH correctly detects external modification.
+     * Thread A watches a key, Thread B modifies it, Thread A's EXEC fails.
+     */
+    @Test
+    public void testOCCConflictDetection() throws Exception {
+        System.out.println("\n=== OCC Test: Conflict detection ===");
+
+        GlideClient client = GlideClient.createClient(getConfig()).get(10, TimeUnit.SECONDS);
+        String key = "occ-conflict-" + UUID.randomUUID();
+        client.set(key, "original").get(5, TimeUnit.SECONDS);
+
+        CountDownLatch aWatched = new CountDownLatch(1);
+        CountDownLatch bModified = new CountDownLatch(1);
+        AtomicInteger aExecResult = new AtomicInteger(-1); // -1=pending, 0=aborted, 1=committed
+
+        // Thread A: WATCH, read, wait for B to modify, then MULTI/EXEC
+        new Thread(() -> {
+            try (IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(10))
+                    .get(10, TimeUnit.SECONDS)) {
+
+                scope.watch(key).get(5, TimeUnit.SECONDS);
+                String val = scope.get(key).get(5, TimeUnit.SECONDS);
+                assertEquals("original", val);
+
+                // Signal that we've watched
+                aWatched.countDown();
+
+                // Wait for Thread B to modify the key
+                bModified.await(10, TimeUnit.SECONDS);
+
+                // Now try to commit — should FAIL because Thread B modified the key
+                scope.multi().get(5, TimeUnit.SECONDS);
+                scope.set(key, "from-thread-a").get(5, TimeUnit.SECONDS);
+                String execResult = scope.exec().get(5, TimeUnit.SECONDS);
+
+                if (execResult == null || execResult.isEmpty() || execResult.equals("null")) {
+                    aExecResult.set(0); // Aborted (expected!)
+                } else {
+                    aExecResult.set(1); // Committed (would be a bug)
+                }
+            } catch (Exception e) {
+                System.err.println("Thread A error: " + e);
+            }
+        }, "OCC-A").start();
+
+        // Thread B: wait for A to WATCH, then modify the key
+        aWatched.await(10, TimeUnit.SECONDS);
+
+        // Modify the watched key through the shared multiplexed client
+        client.set(key, "modified-by-b").get(5, TimeUnit.SECONDS);
+        bModified.countDown();
+
+        // Wait for Thread A to finish
+        Thread.sleep(2000);
+
+        // Verify: Thread A's EXEC must have been aborted
+        assertEquals(0, aExecResult.get(),
+                "Thread A's EXEC should be ABORTED because Thread B modified the watched key");
+
+        // Verify: the key has Thread B's value (Thread A's write was rejected)
+        String finalVal = client.get(key).get(5, TimeUnit.SECONDS);
+        assertEquals("modified-by-b", finalVal,
+                "Key should have Thread B's value since Thread A's transaction was aborted");
+
+        // Cleanup
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        client.close();
+
+        System.out.println("OCC conflict detection test PASSED!");
+        System.out.println("    (WATCH correctly detected external modification → EXEC aborted)");
+    }
+}

--- a/java/integTest/src/test/java/glide/scope/IsolatedScopeIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/scope/IsolatedScopeIntegrationTest.java
@@ -1,0 +1,299 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.scope;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import glide.TestConfiguration;
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.scope.IsolatedScope;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for Feature 2: Isolated Execution.
+ * Tests WATCH/MULTI/EXEC, scope isolation, and zero-cost release.
+ * Requires a Valkey server (uses test infrastructure endpoints).
+ */
+public class IsolatedScopeIntegrationTest {
+
+    private GlideClientConfiguration getTestClientConfig() {
+        String hostPort = TestConfiguration.STANDALONE_HOSTS[0];
+        String[] parts = hostPort.split(":");
+        String host = parts[0];
+        int port = Integer.parseInt(parts[1]);
+        return GlideClientConfiguration.builder()
+                .address(NodeAddress.builder().host(host).port(port).build())
+                .requestTimeout(5000)
+                .build();
+    }
+
+    @Test
+    public void testScopeAcquireAndBasicCommands() throws Exception {
+        System.out.println("\n=== Test: Scope acquire and basic commands ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+
+        // Acquire an isolated scope
+        IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+        assertNotNull(scope);
+        assertFalse(scope.isReleased());
+
+        // Execute basic commands on the scope
+        String key = "scope-test-" + UUID.randomUUID();
+        String result = scope.set(key, "hello").get(5, TimeUnit.SECONDS);
+        assertNotNull(result);
+
+        String value = scope.get(key).get(5, TimeUnit.SECONDS);
+        assertEquals("hello", value);
+
+        String pingResult = scope.ping().get(5, TimeUnit.SECONDS);
+        assertEquals("PONG", pingResult);
+
+        // Release the scope
+        scope.close();
+        assertTrue(scope.isReleased());
+
+        // Cleanup
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        client.close();
+
+        System.out.println("Scope acquire and basic commands test PASSED!");
+    }
+
+    @Test
+    public void testWatchMultiExecSuccess() throws Exception {
+        System.out.println("\n=== Test: WATCH/MULTI/EXEC success ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+        String key = "watch-test-" + UUID.randomUUID();
+        client.set(key, "10").get(5, TimeUnit.SECONDS);
+
+        try (IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS)) {
+
+            // WATCH the key
+            String watchResult = scope.watch(key).get(5, TimeUnit.SECONDS);
+            assertEquals("OK", watchResult);
+
+            // Read the value
+            String val = scope.get(key).get(5, TimeUnit.SECONDS);
+            assertEquals("10", val);
+
+            // Start transaction
+            String multiResult = scope.multi().get(5, TimeUnit.SECONDS);
+            assertEquals("OK", multiResult);
+
+            // Queue a SET
+            scope.set(key, String.valueOf(Integer.parseInt(val) + 1)).get(5, TimeUnit.SECONDS);
+
+            // Execute — should succeed since no one modified the key
+            String execResult = scope.exec().get(5, TimeUnit.SECONDS);
+            assertNotNull(execResult, "EXEC should succeed (no conflict)");
+        }
+
+        // Verify the value was updated
+        String finalVal = client.get(key).get(5, TimeUnit.SECONDS);
+        assertEquals("11", finalVal);
+
+        // Cleanup
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        client.close();
+
+        System.out.println("WATCH/MULTI/EXEC success test PASSED!");
+    }
+
+    @Test
+    public void testScopeIsolation() throws Exception {
+        System.out.println("\n=== Test: Scope isolation (two scopes don't interfere) ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+        String key = "isolation-test-" + UUID.randomUUID();
+        client.set(key, "100").get(5, TimeUnit.SECONDS);
+
+        // Acquire two independent scopes
+        IsolatedScope scope1 = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+        IsolatedScope scope2 = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+
+        // Both scopes should have different scope IDs (different connections)
+        assertNotEquals(scope1.getScopeId(), scope2.getScopeId(),
+                "Two scopes should use different connections");
+
+        // Both can WATCH the same key independently
+        scope1.watch(key).get(5, TimeUnit.SECONDS);
+        scope2.watch(key).get(5, TimeUnit.SECONDS);
+
+        // Both can read
+        String val1 = scope1.get(key).get(5, TimeUnit.SECONDS);
+        String val2 = scope2.get(key).get(5, TimeUnit.SECONDS);
+        assertEquals("100", val1);
+        assertEquals("100", val2);
+
+        // Scope1 commits a transaction
+        scope1.multi().get(5, TimeUnit.SECONDS);
+        scope1.set(key, "101").get(5, TimeUnit.SECONDS);
+        String exec1 = scope1.exec().get(5, TimeUnit.SECONDS);
+        assertNotNull(exec1, "Scope1 EXEC should succeed");
+
+        // Scope2's WATCH should now fail because key was modified
+        scope2.multi().get(5, TimeUnit.SECONDS);
+        scope2.set(key, "200").get(5, TimeUnit.SECONDS);
+        String exec2 = scope2.exec().get(5, TimeUnit.SECONDS);
+        // exec2 should be null (WATCH aborted) or empty
+
+        scope1.close();
+        scope2.close();
+
+        // Final value should be from scope1 (101)
+        String finalVal = client.get(key).get(5, TimeUnit.SECONDS);
+        assertEquals("101", finalVal, "Only scope1's transaction should have committed");
+
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        client.close();
+
+        System.out.println("Scope isolation test PASSED!");
+    }
+
+    @Test
+    public void testZeroCostRelease() throws Exception {
+        System.out.println("\n=== Test: Zero-cost release (no cleanup for clean state) ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+        String key = "zerocost-" + UUID.randomUUID();
+
+        // Acquire, do only GET/SET (no state mutations), release
+        long startNanos = System.nanoTime();
+
+        try (IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS)) {
+            scope.set(key, "value").get(5, TimeUnit.SECONDS);
+            scope.get(key).get(5, TimeUnit.SECONDS);
+        }
+        // scope.close() called by try-with-resources — should be instantaneous
+
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
+        System.out.println("  Scope lifecycle (acquire + SET + GET + release): " + elapsedMs + " ms");
+
+        // Cleanup
+        client.del(new String[]{key}).get(5, TimeUnit.SECONDS);
+        client.close();
+
+        System.out.println("Zero-cost release test PASSED!");
+    }
+
+    @Test
+    public void testScopeReuse() throws Exception {
+        System.out.println("\n=== Test: Scope reuse (LIFO — same connection returned) ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+
+        // First borrow
+        IsolatedScope scope1 = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+        long scopeId1 = scope1.getScopeId();
+        scope1.ping().get(5, TimeUnit.SECONDS);
+        scope1.close();
+
+        // Give the pool a moment to process the release
+        Thread.sleep(100);
+
+        // Second borrow — should get the same connection back (LIFO)
+        IsolatedScope scope2 = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+        long scopeId2 = scope2.getScopeId();
+        scope2.close();
+
+        assertEquals(scopeId1, scopeId2, "LIFO reuse: same scope_id should be returned");
+
+        client.close();
+        System.out.println("Scope reuse test PASSED!");
+    }
+
+    @Test
+    public void testScopeCloseIdempotent() throws Exception {
+        System.out.println("\n=== Test: Scope close is idempotent ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+
+        IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(10))
+                .get(10, TimeUnit.SECONDS);
+
+        // Close multiple times — should not throw
+        scope.close();
+        scope.close();
+        scope.close();
+
+        assertTrue(scope.isReleased());
+
+        // Using scope after close should throw
+        assertThrows(IllegalStateException.class, scope::getScopeId);
+
+        client.close();
+        System.out.println("Scope close idempotent test PASSED!");
+    }
+
+    @Test
+    public void testConcurrentScopeAcquisition() throws Exception {
+        System.out.println("\n=== Test: Concurrent scope acquisition from single client ===");
+
+        GlideClient client = GlideClient.createClient(getTestClientConfig()).get(10, TimeUnit.SECONDS);
+
+        int numThreads = 8;
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger errorCount = new AtomicInteger(0);
+        ConcurrentHashMap<Long, Boolean> scopeIds = new ConcurrentHashMap<>();
+
+        for (int t = 0; t < numThreads; t++) {
+            final int threadIdx = t;
+            new Thread(() -> {
+                try {
+                    // Each thread acquires its own scope
+                    IsolatedScope scope = client.scopedConnection(Duration.ofSeconds(15))
+                            .get(15, TimeUnit.SECONDS);
+
+                    // Record scope_id
+                    scopeIds.put(scope.getScopeId(), true);
+
+                    // Do some work on the scope
+                    String key = "concurrent-scope-" + threadIdx + "-" + UUID.randomUUID();
+                    scope.set(key, "thread-" + threadIdx).get(5, TimeUnit.SECONDS);
+                    String val = scope.get(key).get(5, TimeUnit.SECONDS);
+                    assertEquals("thread-" + threadIdx, val);
+
+                    // Clean up key via scope
+                    scope.executeCommand("DEL", key).get(5, TimeUnit.SECONDS);
+                    scope.close();
+
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    System.err.println("Thread " + threadIdx + " error: " + e);
+                    e.printStackTrace();
+                    errorCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS), "All threads should finish within 30s");
+        assertEquals(numThreads, successCount.get(),
+                "All " + numThreads + " threads should succeed. Errors: " + errorCount.get());
+
+        System.out.println("  Unique scope_ids observed: " + scopeIds.size()
+                + " (may be < " + numThreads + " due to LIFO reuse)");
+
+        client.close();
+        System.out.println("Concurrent scope acquisition test PASSED! "
+                + numThreads + "/" + numThreads + " threads succeeded with unique scopes.");
+    }
+}

--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -208,6 +208,9 @@ pub async fn ensure_client_for_handle(handle_id: u64) -> Result<GlideClient> {
         let client = create_glide_client(cfg, Some(tx)).await?;
         table.insert(handle_id, client.clone());
 
+        // Register in the glide-core scope registry for scope command execution
+        glide_core::scope::register_client(handle_id, client.clone());
+
         // Always spawn push notification handler
         let jvm_arc = JVM.get().cloned();
         let handle_for_java = handle_id as jlong;

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -6,13 +6,13 @@
 //! Background client creation produces entries in the JNI_HANDLE_TABLE
 //! so that commands flow through the existing Java command dispatch path.
 
-use crate::jni_client::{generate_safe_handle, get_handle_table, get_runtime};
-use glide_core::pool::{self, ClientPool, ClientState, PoolConfig, PooledClient, POOL_RUNNING};
+use crate::jni_client::{get_handle_table, get_runtime};
+use glide_core::pool::{self, ClientPool, PoolConfig, POOL_RUNNING};
 use jni::objects::{JByteArray, JClass};
 use jni::sys::{jint, jlong};
 use jni::JNIEnv;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Create a new pool. Returns pool_id > 0 on success, -1 on invalid config.
 #[unsafe(no_mangle)]
@@ -49,7 +49,6 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolCreat
     // Spawn min_idle background client creation
     if min_idle > 0 {
         let pool_arc = pool::get_pool(pool_id).unwrap();
-        let max = max_size as u32;
         for _ in 0..(min_idle as u32) {
             let pool_clone = pool_arc.clone();
             let conn_bytes = bytes.clone();
@@ -61,18 +60,12 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolCreat
                         if pool.state.load(Ordering::Acquire) != POOL_RUNNING {
                             return;
                         }
-                        let handle_id = generate_safe_handle();
-                        get_handle_table().insert(handle_id, client.clone());
-                        let entry = PooledClient {
-                            client_id: handle_id,
-                            client,
-                            created_at: Instant::now(),
-                            last_idle_at: Instant::now(),
-                            borrowed_at: None,
-                            state: ClientState::Idle,
-                        };
-                        pool.idle.push_back(entry);
-                        pool.total_count.fetch_add(1, Ordering::AcqRel);
+                        // add_client returns the assigned client_id
+                        let client_id = pool.add_client(client.clone());
+                        // Also register in JNI handle table for command dispatch
+                        get_handle_table().insert(client_id, client.clone());
+                        // Register in scope client registry too
+                        glide_core::scope::register_client(client_id, client);
                     }
                     Err(e) => log::error!("Pool background client creation failed: {}", e),
                 }
@@ -97,11 +90,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAc
 
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let mut evicted = Vec::new();
-            let result = pool.try_acquire(&mut evicted);
-            // Clean up evicted entries from JNI handle table
-            let handle_table = get_handle_table();
-            for eid in &evicted { handle_table.remove(eid); }
+            let result = pool.try_acquire();
             if result < 0 && pool.should_create() {
                 pool.total_count.fetch_add(1, Ordering::AcqRel);
                 let pool_clone = pool_arc.clone();
@@ -116,17 +105,9 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAc
                                 pool.total_count.fetch_sub(1, Ordering::AcqRel);
                                 return;
                             }
-                            let handle_id = generate_safe_handle();
-                            get_handle_table().insert(handle_id, client.clone());
-                            let entry = PooledClient {
-                                client_id: handle_id,
-                                client,
-                                created_at: Instant::now(),
-                                last_idle_at: Instant::now(),
-                                borrowed_at: None,
-                                state: ClientState::Idle,
-                            };
-                            pool.idle.push_back(entry);
+                            let client_id = pool.add_client_reserved(client.clone());
+                            get_handle_table().insert(client_id, client.clone());
+                            glide_core::scope::register_client(client_id, client);
                         }
                         Err(e) => {
                             log::error!("Pool background client creation failed: {}", e);
@@ -155,24 +136,10 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolRelea
         None => return -1,
     };
 
-    // Get the client from the handle table to rebuild PooledClient
-    let client = match get_handle_table().get(&(client_id as u64)) {
-        Some(c) => c.value().clone(),
-        None => return -1,
-    };
-
     let pool_clone = pool_arc.clone();
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let entry = PooledClient {
-                client_id: client_id as u64,
-                client,
-                created_at: Instant::now(), // approximation
-                last_idle_at: Instant::now(),
-                borrowed_at: None,
-                state: ClientState::Idle,
-            };
-            pool.release(client_id as u64, entry);
+            pool.release(client_id as u64);
             0
         }
         Err(_) => {
@@ -180,15 +147,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolRelea
             let cid = client_id as u64;
             runtime.spawn(async move {
                 let mut pool = pool_clone.lock().await;
-                let entry = PooledClient {
-                    client_id: cid,
-                    client,
-                    created_at: Instant::now(),
-                    last_idle_at: Instant::now(),
-                    borrowed_at: None,
-                    state: ClientState::Idle,
-                };
-                pool.release(cid, entry);
+                pool.release(cid);
             });
             0
         }
@@ -213,10 +172,11 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolDestr
         // Clean up JNI handle table entries for all pooled clients
         for entry in pool.idle.iter() {
             handle_table.remove(&entry.client_id);
+            glide_core::scope::unregister_client(entry.client_id);
         }
-        let in_use_keys: Vec<u64> = pool.in_use.iter().map(|e| *e.key()).collect();
-        for key in &in_use_keys {
-            handle_table.remove(key);
+        for entry in pool.in_use.iter() {
+            handle_table.remove(entry.key());
+            glide_core::scope::unregister_client(*entry.key());
         }
         pool.destroy();
     });

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -35,6 +35,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolCreat
         min_idle: min_idle as u32,
         idle_timeout: Duration::from_millis(idle_timeout_ms as u64),
         request_timeout: Duration::from_millis(request_timeout_ms as u64),
+        test_on_borrow: false,
         connection_request: bytes.clone(),
     };
 
@@ -201,9 +202,18 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolDestr
         Some(arc) => arc,
         None => return -1,
     };
+    let handle_table = get_handle_table();
     let runtime = get_runtime();
     runtime.spawn(async move {
         let mut pool = pool_arc.lock().await;
+        // Clean up JNI handle table entries for all pooled clients
+        for entry in pool.idle.iter() {
+            handle_table.remove(&entry.client_id);
+        }
+        let in_use_keys: Vec<u64> = pool.in_use.iter().map(|e| *e.key()).collect();
+        for key in &in_use_keys {
+            handle_table.remove(key);
+        }
         pool.destroy();
     });
     0

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -97,7 +97,7 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAc
     match pool_arc.try_lock() {
         Ok(mut pool) => {
             let result = pool.try_acquire();
-            if result == -1 && pool.should_create() {
+            if result < 0 && pool.should_create() {
                 pool.total_count.fetch_add(1, Ordering::AcqRel);
                 let pool_clone = pool_arc.clone();
                 let bytes = pool.config.connection_request.clone();

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -97,7 +97,11 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAc
 
     match pool_arc.try_lock() {
         Ok(mut pool) => {
-            let result = pool.try_acquire();
+            let mut evicted = Vec::new();
+            let result = pool.try_acquire(&mut evicted);
+            // Clean up evicted entries from JNI handle table
+            let handle_table = get_handle_table();
+            for eid in &evicted { handle_table.remove(eid); }
             if result < 0 && pool.should_create() {
                 pool.total_count.fetch_add(1, Ordering::AcqRel);
                 let pool_clone = pool_arc.clone();

--- a/java/src/jni_pool.rs
+++ b/java/src/jni_pool.rs
@@ -1,0 +1,254 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//! JNI bridge for client-instance pooling (Feature 1).
+//!
+//! Delegates to glide-core::pool for all pool state management.
+//! Background client creation produces entries in the JNI_HANDLE_TABLE
+//! so that commands flow through the existing Java command dispatch path.
+
+use crate::jni_client::{generate_safe_handle, get_handle_table, get_runtime};
+use glide_core::pool::{self, ClientPool, ClientState, PoolConfig, PooledClient, POOL_RUNNING};
+use jni::objects::{JByteArray, JClass};
+use jni::sys::{jint, jlong};
+use jni::JNIEnv;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+/// Create a new pool. Returns pool_id > 0 on success, -1 on invalid config.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolCreate(
+    env: JNIEnv,
+    _class: JClass,
+    max_size: jint,
+    min_idle: jint,
+    idle_timeout_ms: jlong,
+    request_timeout_ms: jlong,
+    connection_request_bytes: JByteArray,
+) -> jlong {
+    let bytes = match env.convert_byte_array(&connection_request_bytes) {
+        Ok(b) => b,
+        Err(_) => return -2,
+    };
+
+    let config = PoolConfig {
+        max_size: max_size as u32,
+        min_idle: min_idle as u32,
+        idle_timeout: Duration::from_millis(idle_timeout_ms as u64),
+        request_timeout: Duration::from_millis(request_timeout_ms as u64),
+        connection_request: bytes.clone(),
+    };
+
+    let pool = match ClientPool::new(config) {
+        Ok(p) => p,
+        Err(_) => return -1,
+    };
+
+    let pool_id = pool::register_pool(pool);
+
+    // Spawn min_idle background client creation
+    if min_idle > 0 {
+        let pool_arc = pool::get_pool(pool_id).unwrap();
+        let max = max_size as u32;
+        for _ in 0..(min_idle as u32) {
+            let pool_clone = pool_arc.clone();
+            let conn_bytes = bytes.clone();
+            let runtime = get_runtime();
+            runtime.spawn(async move {
+                match create_pool_client(&conn_bytes).await {
+                    Ok(client) => {
+                        let mut pool = pool_clone.lock().await;
+                        if pool.state.load(Ordering::Acquire) != POOL_RUNNING {
+                            return;
+                        }
+                        let handle_id = generate_safe_handle();
+                        get_handle_table().insert(handle_id, client.clone());
+                        let entry = PooledClient {
+                            client_id: handle_id,
+                            client,
+                            created_at: Instant::now(),
+                            last_idle_at: Instant::now(),
+                            borrowed_at: None,
+                            state: ClientState::Idle,
+                        };
+                        pool.idle.push_back(entry);
+                        pool.total_count.fetch_add(1, Ordering::AcqRel);
+                    }
+                    Err(e) => log::error!("Pool background client creation failed: {}", e),
+                }
+            });
+        }
+    }
+
+    pool_id as jlong
+}
+
+/// Non-blocking acquire. Returns client_id >= 0, -1 if exhausted, -2 if invalid.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolTryAcquire(
+    _env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+) -> jlong {
+    let pool_arc = match pool::get_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return -2,
+    };
+
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let result = pool.try_acquire();
+            if result == -1 && pool.should_create() {
+                pool.total_count.fetch_add(1, Ordering::AcqRel);
+                let pool_clone = pool_arc.clone();
+                let bytes = pool.config.connection_request.clone();
+                drop(pool);
+                let runtime = get_runtime();
+                runtime.spawn(async move {
+                    match create_pool_client(&bytes).await {
+                        Ok(client) => {
+                            let mut pool = pool_clone.lock().await;
+                            if pool.state.load(Ordering::Acquire) != POOL_RUNNING {
+                                pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                                return;
+                            }
+                            let handle_id = generate_safe_handle();
+                            get_handle_table().insert(handle_id, client.clone());
+                            let entry = PooledClient {
+                                client_id: handle_id,
+                                client,
+                                created_at: Instant::now(),
+                                last_idle_at: Instant::now(),
+                                borrowed_at: None,
+                                state: ClientState::Idle,
+                            };
+                            pool.idle.push_back(entry);
+                        }
+                        Err(e) => {
+                            log::error!("Pool background client creation failed: {}", e);
+                            let pool = pool_clone.lock().await;
+                            pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                        }
+                    }
+                });
+            }
+            result
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Release a client back to the pool.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolRelease(
+    _env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+    client_id: jlong,
+) -> jint {
+    let pool_arc = match pool::get_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+
+    // Get the client from the handle table to rebuild PooledClient
+    let client = match get_handle_table().get(&(client_id as u64)) {
+        Some(c) => c.value().clone(),
+        None => return -1,
+    };
+
+    let pool_clone = pool_arc.clone();
+    match pool_arc.try_lock() {
+        Ok(mut pool) => {
+            let entry = PooledClient {
+                client_id: client_id as u64,
+                client,
+                created_at: Instant::now(), // approximation
+                last_idle_at: Instant::now(),
+                borrowed_at: None,
+                state: ClientState::Idle,
+            };
+            pool.release(client_id as u64, entry);
+            0
+        }
+        Err(_) => {
+            let runtime = get_runtime();
+            let cid = client_id as u64;
+            runtime.spawn(async move {
+                let mut pool = pool_clone.lock().await;
+                let entry = PooledClient {
+                    client_id: cid,
+                    client,
+                    created_at: Instant::now(),
+                    last_idle_at: Instant::now(),
+                    borrowed_at: None,
+                    state: ClientState::Idle,
+                };
+                pool.release(cid, entry);
+            });
+            0
+        }
+    }
+}
+
+/// Destroy a pool.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolDestroy(
+    _env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+) -> jint {
+    let pool_arc = match pool::unregister_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return -1,
+    };
+    let runtime = get_runtime();
+    runtime.spawn(async move {
+        let mut pool = pool_arc.lock().await;
+        pool.destroy();
+    });
+    0
+}
+
+/// Query pool metrics. Returns [idle, active, total] as jintArray.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlidePoolResolver_glidePoolMetrics(
+    env: JNIEnv,
+    _class: JClass,
+    pool_id: jlong,
+) -> jni::sys::jintArray {
+    let pool_arc = match pool::get_pool(pool_id as u64) {
+        Some(arc) => arc,
+        None => return std::ptr::null_mut(),
+    };
+
+    let (idle, active, total) = match pool_arc.try_lock() {
+        Ok(pool) => (
+            pool.idle_count() as i32,
+            pool.active_count() as i32,
+            pool.total_count.load(Ordering::Acquire) as i32,
+        ),
+        Err(_) => (0, 0, 0),
+    };
+
+    let result = match env.new_int_array(3) {
+        Ok(arr) => arr,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    if env.set_int_array_region(&result, 0, &[idle, active, total]).is_err() {
+        return std::ptr::null_mut();
+    }
+    result.into_raw()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Create a GlideClient from connection request bytes.
+async fn create_pool_client(bytes: &[u8]) -> Result<glide_core::client::Client, String> {
+    use protobuf::Message;
+    let proto = glide_core::connection_request::ConnectionRequest::parse_from_bytes(bytes)
+        .map_err(|e| format!("Protobuf parse error: {}", e))?;
+    let req = glide_core::client::ConnectionRequest::from(proto);
+    glide_core::client::Client::new(req, None)
+        .await
+        .map_err(|e| format!("Client creation failed: {}", e))
+}

--- a/java/src/jni_scope.rs
+++ b/java/src/jni_scope.rs
@@ -1,0 +1,299 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+//! JNI bridge for isolated execution (Feature 2 scopes).
+
+use crate::jni_client::{complete_callback, get_runtime, JVM};
+use glide_core::pool::{
+    get_or_create_scope_pool, get_scope_registry, update_state_for_command, POOL_RUNNING,
+};
+use jni::objects::{JByteArray, JClass};
+use jni::sys::{jint, jlong};
+use jni::JNIEnv;
+use protobuf::Message;
+use redis::Cmd;
+use std::sync::atomic::Ordering;
+
+/// Acquire a scope from the client's internal connection pool.
+/// Returns scope_id >= 0, -1 if exhausted, -2 if invalid.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeTryAcquire(
+    env: JNIEnv,
+    _class: JClass,
+    client_id: jlong,
+    connection_request_bytes: JByteArray,
+) -> jlong {
+    let bytes = match env.convert_byte_array(&connection_request_bytes) {
+        Ok(b) => b,
+        Err(_) => return -2,
+    };
+
+    let scope_pool = get_or_create_scope_pool(client_id as u64, bytes.clone());
+    let registry = get_scope_registry();
+
+    match scope_pool.try_lock() {
+        Ok(mut pool) => {
+            let result = pool.try_acquire(registry);
+            if result >= 0 { let _ = telemetrylib::GlideOpenTelemetry::record_scope_acquire(); }
+            if result < 0 && pool.total_count.load(Ordering::Acquire) <= pool.config.max_total {
+                // Spawn background scope connection creation
+                let pool_clone = scope_pool.clone();
+                let conn_bytes = pool.connection_request_bytes.clone();
+                let runtime = get_runtime();
+                runtime.spawn(async move {
+                    // Create a new MultiplexedConnection
+                    let proto = match glide_core::connection_request::ConnectionRequest::parse_from_bytes(&conn_bytes) {
+                        Ok(p) => p,
+                        Err(_) => return,
+                    };
+                    let addr = match proto.addresses.first() {
+                        Some(a) => a,
+                        None => return,
+                    };
+                    let port = if addr.port == 0 { 6379 } else { addr.port as u16 };
+                    let use_tls = proto.tls_mode.value() != 0;
+                    let scheme = if use_tls { "rediss" } else { "redis" };
+                    let url = format!("{}://{}:{}", scheme, &addr.host, port);
+                    let client = match redis::Client::open(url.as_str()) {
+                        Ok(c) => c,
+                        Err(_) => return,
+                    };
+                    let opts = redis::GlideConnectionOptions {
+                        push_sender: None,
+                        disconnect_notifier: None,
+                        discover_az: false,
+                        connection_timeout: Some(std::time::Duration::from_secs(5)),
+                        connection_retry_strategy: None,
+                        tcp_nodelay: true,
+                        pubsub_synchronizer: None,
+                        iam_token_provider: None,
+                    };
+                    let conn = match tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        client.get_multiplexed_async_connection(opts),
+                    ).await {
+                        Ok(Ok(c)) => c,
+                        _ => return,
+                    };
+
+                    let mut pool = pool_clone.lock().await;
+                    if pool.state.load(Ordering::Acquire) != glide_core::pool::POOL_RUNNING {
+                        pool.total_count.fetch_sub(1, Ordering::AcqRel);
+                        return;
+                    }
+                    let scope_id = pool.next_id();
+                    let entry = glide_core::pool::ScopedConnection {
+                        scope_id,
+                        connection: conn,
+                        created_at: std::time::Instant::now(),
+                        last_idle_at: std::time::Instant::now(),
+                        borrowed_at: None,
+                        state: glide_core::pool::ConnectionState::default(),
+                        pinned_slot: None,
+                    };
+                    pool.idle.push_back(entry);
+                });
+            }
+            result
+        }
+        Err(_) => -1,
+    }
+}
+
+/// Release a scope back to the pool. Fire-and-forget.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeRelease(
+    _env: JNIEnv,
+    _class: JClass,
+    scope_id: jlong,
+    client_id: jlong,
+) -> jint {
+    let pools = glide_core::pool::get_client_scope_pools();
+    let scope_pool = match pools.get(&(client_id as u64)) {
+        Some(p) => p.value().clone(),
+        None => return -1,
+    };
+    let registry = get_scope_registry();
+
+    let pool_clone = scope_pool.clone();
+    match scope_pool.try_lock() {
+        Ok(mut pool) => {
+            pool.release(scope_id as u64, registry);
+            let _ = telemetrylib::GlideOpenTelemetry::record_scope_release();
+            0
+        }
+        Err(_) => {
+            let runtime = get_runtime();
+            let sid = scope_id as u64;
+            runtime.spawn(async move {
+                let mut pool = pool_clone.lock().await;
+                pool.release(sid, get_scope_registry());
+            });
+            0
+        }
+    }
+}
+
+/// Execute a command on a scoped connection.
+///
+/// Applies timeout enforcement (same as the main client path) but bypasses
+/// the multiplexer to target the dedicated scoped connection. Compression and
+/// OTel integration require access to the Client's config which would need a
+/// larger refactor to Client internals (adding a connection override parameter
+/// to execute_command_owned). For standalone mode, compression is applied at
+/// the binding layer if configured.
+///
+/// TODO(production): Refactor Client::execute_command_owned to accept an optional
+/// connection override, so scope commands get compression + OTel + circuit breaker
+/// automatically without duplicating logic here.
+///
+/// TODO(cluster): Resolve target node from key hash slot, handle MOVED/ASK.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeExecute(
+    env: JNIEnv,
+    _class: JClass,
+    scope_id: jlong,
+    command_bytes: JByteArray,
+    callback_id: jlong,
+) -> jint {
+    let bytes = match env.convert_byte_array(&command_bytes) {
+        Ok(b) => b,
+        Err(_) => return -2,
+    };
+
+    let (cmd_name, args) = match deserialize_command(&bytes) {
+        Some(p) => p,
+        None => return -2,
+    };
+
+    let registry = get_scope_registry();
+    let entry = match registry.get(&(scope_id as u64)) {
+        Some(e) => e.connection.clone(),
+        None => return -1,
+    };
+
+    let runtime = get_runtime();
+    let jvm = JVM.get().unwrap().clone();
+
+    runtime.spawn(async move {
+        let mut conn = entry.lock().await;
+
+        // State tracking (for conditional cleanup on release)
+        let arg_refs: Vec<&[u8]> = args.iter().map(|a| a.as_slice()).collect();
+        update_state_for_command(&mut conn.state, &cmd_name, &arg_refs);
+
+        // Cluster mode: validate slot consistency
+        // Commands like WATCH, GET, SET have keys — validate they target the same slot.
+        // Commands like MULTI, EXEC, DISCARD, PING have no keys — always allowed.
+        let key_args = extract_key_args(&cmd_name, &arg_refs);
+        if !key_args.is_empty() {
+            match glide_core::pool::validate_scope_slot(conn.pinned_slot, &key_args) {
+                Ok(new_slot) => {
+                    conn.pinned_slot = new_slot;
+                }
+                Err(e) => {
+                    let err = redis::RedisError::from((
+                        redis::ErrorKind::CrossSlot,
+                        "CROSSSLOT",
+                        e,
+                    ));
+                    complete_callback(jvm, callback_id, Err(err), false);
+                    return;
+                }
+            }
+        }
+
+        // Build redis command
+        let mut cmd = Cmd::new();
+        cmd.arg(cmd_name.as_bytes());
+        for arg in &args {
+            cmd.arg(arg.as_slice());
+        }
+
+        // Use Client::send_command_on_connection for timeout + decompression.
+        // Get the parent client from handle table using the scope pool's stored client_id.
+        let result = {
+            let handle_table = crate::jni_client::get_handle_table();
+            // Look up the parent client that owns this scope pool
+            let pools = glide_core::pool::get_client_scope_pools();
+            let parent_id = pools.iter()
+                .find(|e| e.value().try_lock().map(|p| p.in_use.contains_key(&(scope_id as u64))).unwrap_or(false))
+                .map(|e| *e.key());
+
+            if let Some(pid) = parent_id {
+                if let Some(client_entry) = handle_table.get(&pid) {
+                    let client = client_entry.value();
+                    client.send_command_on_connection(&cmd, &mut conn.connection).await
+                } else {
+                    conn.connection.send_packed_command(&cmd).await
+                }
+            } else {
+                conn.connection.send_packed_command(&cmd).await
+            }
+        };
+
+        complete_callback(jvm, callback_id, result, false);
+    });
+
+    0
+}
+
+fn deserialize_command(bytes: &[u8]) -> Option<(String, Vec<Vec<u8>>)> {
+    if bytes.len() < 4 { return None; }
+    let mut off = 0;
+
+    let cmd_len = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
+    off += 4;
+    if off + cmd_len > bytes.len() { return None; }
+    let cmd = String::from_utf8(bytes[off..off + cmd_len].to_vec()).ok()?;
+    off += cmd_len;
+
+    if off + 4 > bytes.len() { return None; }
+    let num_args = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
+    off += 4;
+
+    let mut args = Vec::with_capacity(num_args);
+    for _ in 0..num_args {
+        if off + 4 > bytes.len() { return None; }
+        let len = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
+        off += 4;
+        if off + len > bytes.len() { return None; }
+        args.push(bytes[off..off + len].to_vec());
+        off += len;
+    }
+
+    Some((cmd, args))
+}
+
+
+/// Extract key arguments from a command for slot validation.
+/// Returns the args that are keys (for slot computation).
+/// Commands with no keys (MULTI, EXEC, PING, etc.) return empty.
+fn extract_key_args<'a>(cmd_name: &str, args: &[&'a [u8]]) -> Vec<&'a [u8]> {
+    match cmd_name.to_uppercase().as_str() {
+        // Commands with keys as first N arguments
+        "GET" | "SET" | "DEL" | "INCR" | "DECR" | "INCRBY" | "DECRBY"
+        | "SETNX" | "SETEX" | "PSETEX" | "GETSET" | "GETDEL" | "GETEX"
+        | "APPEND" | "STRLEN" | "TYPE" | "EXISTS" | "EXPIRE" | "EXPIREAT"
+        | "TTL" | "PTTL" | "PERSIST" | "DUMP" | "RESTORE"
+        | "HGET" | "HSET" | "HDEL" | "HLEN" | "HGETALL" | "HMGET" | "HMSET"
+        | "LPUSH" | "RPUSH" | "LPOP" | "RPOP" | "LLEN" | "LRANGE"
+        | "SADD" | "SREM" | "SMEMBERS" | "SCARD" | "SISMEMBER"
+        | "ZADD" | "ZREM" | "ZRANGE" | "ZCARD" | "ZSCORE"
+        | "SUBSCRIBE" | "UNSUBSCRIBE" => {
+            // First arg is the key
+            if !args.is_empty() { vec![args[0]] } else { vec![] }
+        }
+        // WATCH can have multiple keys — all must be in same slot
+        "WATCH" => args.to_vec(),
+        // MGET / MSET / DEL with multiple keys
+        "MGET" => args.to_vec(),
+        "MSET" => args.iter().step_by(2).copied().collect(), // keys at even positions
+        // Commands with no keys
+        "MULTI" | "EXEC" | "DISCARD" | "UNWATCH" | "PING" | "SELECT"
+        | "AUTH" | "CLIENT" | "INFO" | "DBSIZE" | "FLUSHDB" | "FLUSHALL" => vec![],
+        // Default: assume first arg is a key (safe approximation)
+        _ => {
+            if !args.is_empty() { vec![args[0]] } else { vec![] }
+        }
+    }
+}

--- a/java/src/jni_scope.rs
+++ b/java/src/jni_scope.rs
@@ -1,17 +1,14 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 //! JNI bridge for isolated execution (Feature 2 scopes).
+//!
+//! This is a thin adapter that converts JNI types and delegates all logic
+//! to `glide_core::scope` for cross-language reuse.
 
 use crate::jni_client::{complete_callback, get_runtime, JVM};
-use glide_core::pool::{
-    get_or_create_scope_pool, get_scope_registry, update_state_for_command, POOL_RUNNING,
-};
 use jni::objects::{JByteArray, JClass};
 use jni::sys::{jint, jlong};
 use jni::JNIEnv;
-use protobuf::Message;
-use redis::Cmd;
-use std::sync::atomic::Ordering;
 
 /// Acquire a scope from the client's internal connection pool.
 /// Returns scope_id >= 0, -1 if exhausted, -2 if invalid.
@@ -27,76 +24,8 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeTry
         Err(_) => return -2,
     };
 
-    let scope_pool = get_or_create_scope_pool(client_id as u64, bytes.clone());
-    let registry = get_scope_registry();
-
-    match scope_pool.try_lock() {
-        Ok(mut pool) => {
-            let result = pool.try_acquire(registry);
-            if result >= 0 { let _ = telemetrylib::GlideOpenTelemetry::record_scope_acquire(); }
-            if result < 0 && pool.total_count.load(Ordering::Acquire) <= pool.config.max_total {
-                // Spawn background scope connection creation
-                let pool_clone = scope_pool.clone();
-                let conn_bytes = pool.connection_request_bytes.clone();
-                let runtime = get_runtime();
-                runtime.spawn(async move {
-                    // Create a new MultiplexedConnection
-                    let proto = match glide_core::connection_request::ConnectionRequest::parse_from_bytes(&conn_bytes) {
-                        Ok(p) => p,
-                        Err(_) => return,
-                    };
-                    let addr = match proto.addresses.first() {
-                        Some(a) => a,
-                        None => return,
-                    };
-                    let port = if addr.port == 0 { 6379 } else { addr.port as u16 };
-                    let use_tls = proto.tls_mode.value() != 0;
-                    let scheme = if use_tls { "rediss" } else { "redis" };
-                    let url = format!("{}://{}:{}", scheme, &addr.host, port);
-                    let client = match redis::Client::open(url.as_str()) {
-                        Ok(c) => c,
-                        Err(_) => return,
-                    };
-                    let opts = redis::GlideConnectionOptions {
-                        push_sender: None,
-                        disconnect_notifier: None,
-                        discover_az: false,
-                        connection_timeout: Some(std::time::Duration::from_secs(5)),
-                        connection_retry_strategy: None,
-                        tcp_nodelay: true,
-                        pubsub_synchronizer: None,
-                        iam_token_provider: None,
-                    };
-                    let conn = match tokio::time::timeout(
-                        std::time::Duration::from_secs(5),
-                        client.get_multiplexed_async_connection(opts),
-                    ).await {
-                        Ok(Ok(c)) => c,
-                        _ => return,
-                    };
-
-                    let mut pool = pool_clone.lock().await;
-                    if pool.state.load(Ordering::Acquire) != glide_core::pool::POOL_RUNNING {
-                        pool.total_count.fetch_sub(1, Ordering::AcqRel);
-                        return;
-                    }
-                    let scope_id = pool.next_id();
-                    let entry = glide_core::pool::ScopedConnection {
-                        scope_id,
-                        connection: conn,
-                        created_at: std::time::Instant::now(),
-                        last_idle_at: std::time::Instant::now(),
-                        borrowed_at: None,
-                        state: glide_core::pool::ConnectionState::default(),
-                        pinned_slot: None,
-                    };
-                    pool.idle.push_back(entry);
-                });
-            }
-            result
-        }
-        Err(_) => -1,
-    }
+    let runtime = get_runtime();
+    glide_core::scope::try_acquire_scope(client_id as u64, bytes, runtime.handle())
 }
 
 /// Release a scope back to the pool. Fire-and-forget.
@@ -107,46 +36,11 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeRel
     scope_id: jlong,
     client_id: jlong,
 ) -> jint {
-    let pools = glide_core::pool::get_client_scope_pools();
-    let scope_pool = match pools.get(&(client_id as u64)) {
-        Some(p) => p.value().clone(),
-        None => return -1,
-    };
-    let registry = get_scope_registry();
-
-    let pool_clone = scope_pool.clone();
-    match scope_pool.try_lock() {
-        Ok(mut pool) => {
-            pool.release(scope_id as u64, registry);
-            let _ = telemetrylib::GlideOpenTelemetry::record_scope_release();
-            0
-        }
-        Err(_) => {
-            let runtime = get_runtime();
-            let sid = scope_id as u64;
-            runtime.spawn(async move {
-                let mut pool = pool_clone.lock().await;
-                pool.release(sid, get_scope_registry());
-            });
-            0
-        }
-    }
+    let runtime = get_runtime();
+    glide_core::scope::release_scope(scope_id as u64, client_id as u64, runtime.handle())
 }
 
 /// Execute a command on a scoped connection.
-///
-/// Applies timeout enforcement (same as the main client path) but bypasses
-/// the multiplexer to target the dedicated scoped connection. Compression and
-/// OTel integration require access to the Client's config which would need a
-/// larger refactor to Client internals (adding a connection override parameter
-/// to execute_command_owned). For standalone mode, compression is applied at
-/// the binding layer if configured.
-///
-/// TODO(production): Refactor Client::execute_command_owned to accept an optional
-/// connection override, so scope commands get compression + OTel + circuit breaker
-/// automatically without duplicating logic here.
-///
-/// TODO(cluster): Resolve target node from key hash slot, handle MOVED/ASK.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeExecute(
     env: JNIEnv,
@@ -160,140 +54,50 @@ pub extern "system" fn Java_glide_ffi_resolvers_GlideScopeResolver_glideScopeExe
         Err(_) => return -2,
     };
 
-    let (cmd_name, args) = match deserialize_command(&bytes) {
+    let (cmd_name, args) = match glide_core::scope::deserialize_command(&bytes) {
         Some(p) => p,
         None => return -2,
     };
 
-    let registry = get_scope_registry();
-    let entry = match registry.get(&(scope_id as u64)) {
-        Some(e) => e.connection.clone(),
-        None => return -1,
-    };
+    // Verify scope exists before spawning
+    let registry = glide_core::pool::get_scope_registry();
+    if registry.get(&(scope_id as u64)).is_none() {
+        return -1;
+    }
 
     let runtime = get_runtime();
     let jvm = JVM.get().unwrap().clone();
+    let sid = scope_id as u64;
 
     runtime.spawn(async move {
-        let mut conn = entry.lock().await;
-
-        // State tracking (for conditional cleanup on release)
-        let arg_refs: Vec<&[u8]> = args.iter().map(|a| a.as_slice()).collect();
-        update_state_for_command(&mut conn.state, &cmd_name, &arg_refs);
-
-        // Cluster mode: validate slot consistency
-        // Commands like WATCH, GET, SET have keys — validate they target the same slot.
-        // Commands like MULTI, EXEC, DISCARD, PING have no keys — always allowed.
-        let key_args = extract_key_args(&cmd_name, &arg_refs);
-        if !key_args.is_empty() {
-            match glide_core::pool::validate_scope_slot(conn.pinned_slot, &key_args) {
-                Ok(new_slot) => {
-                    conn.pinned_slot = new_slot;
-                }
-                Err(e) => {
-                    let err = redis::RedisError::from((
-                        redis::ErrorKind::CrossSlot,
-                        "CROSSSLOT",
-                        e,
-                    ));
-                    complete_callback(jvm, callback_id, Err(err), false);
-                    return;
-                }
-            }
-        }
-
-        // Build redis command
-        let mut cmd = Cmd::new();
-        cmd.arg(cmd_name.as_bytes());
-        for arg in &args {
-            cmd.arg(arg.as_slice());
-        }
-
-        // Use Client::send_command_on_connection for timeout + decompression.
-        // Get the parent client from handle table using the scope pool's stored client_id.
-        let result = {
-            let handle_table = crate::jni_client::get_handle_table();
-            // Look up the parent client that owns this scope pool
+        // Get the parent client for timeout/decompression/IAM
+        let client_registry = glide_core::scope::get_client_registry();
+        let client = {
+            // Find parent client_id via the scope pool that owns this scope
             let pools = glide_core::pool::get_client_scope_pools();
-            let parent_id = pools.iter()
-                .find(|e| e.value().try_lock().map(|p| p.in_use.contains_key(&(scope_id as u64))).unwrap_or(false))
+            let parent_id = pools
+                .iter()
+                .find(|e| {
+                    e.value()
+                        .try_lock()
+                        .map(|p| p.in_use.contains_key(&sid))
+                        .unwrap_or(false)
+                })
                 .map(|e| *e.key());
 
-            if let Some(pid) = parent_id {
-                if let Some(client_entry) = handle_table.get(&pid) {
-                    let client = client_entry.value();
-                    client.send_command_on_connection(&cmd, &mut conn.connection).await
-                } else {
-                    conn.connection.send_packed_command(&cmd).await
-                }
-            } else {
-                conn.connection.send_packed_command(&cmd).await
-            }
+            parent_id.and_then(|pid| client_registry.get(&pid).map(|e| e.value().clone()))
         };
+
+        let result = glide_core::scope::execute_scope_command(
+            sid,
+            &cmd_name,
+            &args,
+            client.as_ref(),
+        )
+        .await;
 
         complete_callback(jvm, callback_id, result, false);
     });
 
     0
-}
-
-fn deserialize_command(bytes: &[u8]) -> Option<(String, Vec<Vec<u8>>)> {
-    if bytes.len() < 4 { return None; }
-    let mut off = 0;
-
-    let cmd_len = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
-    off += 4;
-    if off + cmd_len > bytes.len() { return None; }
-    let cmd = String::from_utf8(bytes[off..off + cmd_len].to_vec()).ok()?;
-    off += cmd_len;
-
-    if off + 4 > bytes.len() { return None; }
-    let num_args = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
-    off += 4;
-
-    let mut args = Vec::with_capacity(num_args);
-    for _ in 0..num_args {
-        if off + 4 > bytes.len() { return None; }
-        let len = u32::from_le_bytes(bytes[off..off + 4].try_into().ok()?) as usize;
-        off += 4;
-        if off + len > bytes.len() { return None; }
-        args.push(bytes[off..off + len].to_vec());
-        off += len;
-    }
-
-    Some((cmd, args))
-}
-
-
-/// Extract key arguments from a command for slot validation.
-/// Returns the args that are keys (for slot computation).
-/// Commands with no keys (MULTI, EXEC, PING, etc.) return empty.
-fn extract_key_args<'a>(cmd_name: &str, args: &[&'a [u8]]) -> Vec<&'a [u8]> {
-    match cmd_name.to_uppercase().as_str() {
-        // Commands with keys as first N arguments
-        "GET" | "SET" | "DEL" | "INCR" | "DECR" | "INCRBY" | "DECRBY"
-        | "SETNX" | "SETEX" | "PSETEX" | "GETSET" | "GETDEL" | "GETEX"
-        | "APPEND" | "STRLEN" | "TYPE" | "EXISTS" | "EXPIRE" | "EXPIREAT"
-        | "TTL" | "PTTL" | "PERSIST" | "DUMP" | "RESTORE"
-        | "HGET" | "HSET" | "HDEL" | "HLEN" | "HGETALL" | "HMGET" | "HMSET"
-        | "LPUSH" | "RPUSH" | "LPOP" | "RPOP" | "LLEN" | "LRANGE"
-        | "SADD" | "SREM" | "SMEMBERS" | "SCARD" | "SISMEMBER"
-        | "ZADD" | "ZREM" | "ZRANGE" | "ZCARD" | "ZSCORE"
-        | "SUBSCRIBE" | "UNSUBSCRIBE" => {
-            // First arg is the key
-            if !args.is_empty() { vec![args[0]] } else { vec![] }
-        }
-        // WATCH can have multiple keys — all must be in same slot
-        "WATCH" => args.to_vec(),
-        // MGET / MSET / DEL with multiple keys
-        "MGET" => args.to_vec(),
-        "MSET" => args.iter().step_by(2).copied().collect(), // keys at even positions
-        // Commands with no keys
-        "MULTI" | "EXEC" | "DISCARD" | "UNWATCH" | "PING" | "SELECT"
-        | "AUTH" | "CLIENT" | "INFO" | "DBSIZE" | "FLUSHDB" | "FLUSHALL" => vec![],
-        // Default: assume first arg is a key (safe approximation)
-        _ => {
-            if !args.is_empty() { vec![args[0]] } else { vec![] }
-        }
-    }
 }

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1608,6 +1608,9 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_closeClient(
 
         // DashMap operations are sync and lock-free
         if let Some((_, client)) = handle_table.remove(&handle_id) {
+            // Unregister from the scope client registry
+            glide_core::scope::unregister_client(handle_id);
+
             // Schedule async cleanup
             let runtime = get_runtime();
             runtime.spawn(async move {

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -31,6 +31,7 @@ mod address_resolver;
 mod errors;
 mod jni_client;
 mod jni_pool;
+mod jni_scope;
 mod linked_hashmap;
 mod protobuf_bridge;
 

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, OnceLock};
 mod address_resolver;
 mod errors;
 mod jni_client;
+mod jni_pool;
 mod linked_hashmap;
 mod protobuf_bridge;
 

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -142,6 +142,18 @@ _pipe_remainder: bytes = b""
 _FRAME_STRUCT = struct.Struct("=QQQQ")  # Pre-compiled for hot path
 _PUBSUB_SENTINEL = 0xFFFFFFFFFFFFFFFF  # request_id sentinel for pubsub frames
 
+# Free-threading support: detect no-GIL builds and create a thread pool
+# for parallel response parsing when GIL is disabled.
+_FREE_THREADED: bool = hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+_response_thread_pool = None
+if _FREE_THREADED:
+    from concurrent.futures import ThreadPoolExecutor
+
+    _response_thread_pool = ThreadPoolExecutor(
+        max_workers=min(os.cpu_count() or 4, 8),
+        thread_name_prefix="glide-resp-parser",
+    )
+
 
 def _free_orphaned_frame(request_id, response_ptr, arena_or_err):
     """Free resources from a pipe frame whose client has been closed."""
@@ -200,7 +212,11 @@ def _handle_pipe_success(client, request_id, response_ptr, arena_or_err):
     finally:
         if arena_or_err:
             client._lib.free_response_arena(client._ffi.cast("void*", arena_or_err))
-    fut = client._pending_futures.pop(request_id, None)
+    if _FREE_THREADED:
+        with client._lock:
+            fut = client._pending_futures.pop(request_id, None)
+    else:
+        fut = client._pending_futures.pop(request_id, None)
     if fut is not None and not fut.done():
         _resolve_future(fut, result, client)
 
@@ -225,7 +241,11 @@ def _handle_pipe_error(client, request_id, arena_or_err):
         finally:
             client._lib.free_pipe_error_string(client._ffi.cast("char*", err_ptr))
     exc = get_request_error_class(error_type)(msg)
-    fut = client._pending_futures.pop(request_id, None)
+    if _FREE_THREADED:
+        with client._lock:
+            fut = client._pending_futures.pop(request_id, None)
+    else:
+        fut = client._pending_futures.pop(request_id, None)
     if fut is not None and not fut.done():
         _resolve_future(fut, exc, client)
 
@@ -276,10 +296,10 @@ def _drain_stale_pipe_frames():
             break
 
 
-def _on_async_pipe_readable() -> None:
-    # TODO(free-threading): When sys._is_gil_enabled() is False, dispatch frames
-    # to a thread pool for parallel response parsing across cores. Currently
-    # responses are parsed serially on the event loop thread.
+def _on_async_pipe_readable() -> None:  # noqa: C901
+    # Free-threading optimization: when GIL is disabled, dispatch response parsing
+    # to a thread pool for parallel execution across cores. With GIL enabled,
+    # parse serially on the event loop thread (thread pool overhead not worth it).
     global _pipe_remainder
     try:
         data = os.read(_async_pipe_read_fd, 32 * 512)
@@ -312,9 +332,19 @@ def _on_async_pipe_readable() -> None:
             _free_orphaned_frame(request_id, response_ptr, arena_or_err)
             continue
         if response_ptr != 0:
-            _handle_pipe_success(client, request_id, response_ptr, arena_or_err)
+            if _FREE_THREADED and _response_thread_pool is not None:
+                _response_thread_pool.submit(
+                    _handle_pipe_success, client, request_id, response_ptr, arena_or_err
+                )
+            else:
+                _handle_pipe_success(client, request_id, response_ptr, arena_or_err)
         else:
-            _handle_pipe_error(client, request_id, arena_or_err)
+            if _FREE_THREADED and _response_thread_pool is not None:
+                _response_thread_pool.submit(
+                    _handle_pipe_error, client, request_id, arena_or_err
+                )
+            else:
+                _handle_pipe_error(client, request_id, arena_or_err)
     if offset < len(data):
         _pipe_remainder = data[offset:]
 
@@ -502,6 +532,14 @@ class BaseClient(CoreCommands):
     def _get_callback_id(self) -> int:
         return next(self._callback_id_gen)
 
+    def _register_future(self, callback_id: int, fut: "TFuture") -> None:
+        """Register a pending future (thread-safe for free-threading)."""
+        if _FREE_THREADED:
+            with self._lock:
+                self._pending_futures[callback_id] = fut
+        else:
+            self._pending_futures[callback_id] = fut
+
     def _complete_pubsub_futures_safe(self):
         """Complete pending pubsub futures with available messages. Must hold _pubsub_lock."""
         loop = self._loop
@@ -584,7 +622,7 @@ class BaseClient(CoreCommands):
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
 
-        self._pending_futures[callback_id] = fut
+        self._register_future(callback_id, fut)
 
         c_args, c_lengths, buffers = self._to_c_strings(args)
 
@@ -646,7 +684,7 @@ class BaseClient(CoreCommands):
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
 
-        self._pending_futures[callback_id] = fut
+        self._register_future(callback_id, fut)
 
         span = 0
         if OpenTelemetry.should_sample():
@@ -694,7 +732,7 @@ class BaseClient(CoreCommands):
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
 
-        self._pending_futures[callback_id] = fut
+        self._register_future(callback_id, fut)
 
         if keys is None:
             keys = []
@@ -764,7 +802,7 @@ class BaseClient(CoreCommands):
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
 
-        self._pending_futures[callback_id] = fut
+        self._register_future(callback_id, fut)
 
         c_password = (
             self._ffi.new("char[]", password.encode(ENCODING))
@@ -793,7 +831,7 @@ class BaseClient(CoreCommands):
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
 
-        self._pending_futures[callback_id] = fut
+        self._register_future(callback_id, fut)
 
         self._lib.refresh_iam_token(
             self._core_client,
@@ -918,7 +956,7 @@ class GlideClusterClient(BaseClient, ClusterCommands):
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
 
-        self._pending_futures[callback_id] = fut
+        self._register_future(callback_id, fut)
 
         # Build scan args
         args = []

--- a/python/glide-async/src/lib.rs
+++ b/python/glide-async/src/lib.rs
@@ -231,7 +231,7 @@ impl Script {
 }
 
 /// A Python module implemented in Rust.
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<Level>()?;
     m.add_class::<Script>()?;

--- a/python/glide-shared/glide_shared/_glide_ffi.py
+++ b/python/glide-shared/glide_shared/_glide_ffi.py
@@ -388,6 +388,26 @@ class _GlideFFI:
             // ============== UTILITY FUNCTIONS ==============
             void free_c_string(char* s);
             unsigned long get_min_compressed_size();
+
+            // ============== CLIENT-INSTANCE POOL (Feature 1) ==============
+            int64_t glide_pool_create(
+                uint32_t max_size,
+                uint32_t min_idle,
+                uint64_t idle_timeout_ms,
+                uint64_t request_timeout_ms,
+                const uint8_t* connection_request_ptr,
+                size_t connection_request_len
+            );
+            int64_t glide_pool_try_acquire(uint64_t pool_id);
+            int32_t glide_pool_release(uint64_t pool_id, uint64_t client_id);
+            int32_t glide_pool_destroy(uint64_t pool_id);
+            size_t glide_pool_get_client_ptr(uint64_t client_id);
+            int32_t glide_pool_metrics(
+                uint64_t pool_id,
+                uint32_t* idle_out,
+                uint32_t* active_out,
+                uint32_t* total_out
+            );
             """)
 
         # Load the shared library

--- a/python/glide-shared/src/lib.rs
+++ b/python/glide-shared/src/lib.rs
@@ -27,41 +27,45 @@ struct CommandResponse {
 }
 
 /// Cached reference to glide_shared.exceptions.RequestError class.
-static mut REQUEST_ERROR_CLASS: *mut ffi::PyObject = std::ptr::null_mut();
+/// Wrapped for Send+Sync safety — the pointer is valid for the process lifetime.
+struct PyClassPtr(*mut ffi::PyObject);
+unsafe impl Sync for PyClassPtr {}
+unsafe impl Send for PyClassPtr {}
+
+static REQUEST_ERROR_CLASS: std::sync::OnceLock<PyClassPtr> = std::sync::OnceLock::new();
 
 /// Get (and cache) the RequestError class from glide_shared.exceptions.
 unsafe fn get_request_error_class() -> *mut ffi::PyObject {
-    unsafe {
-        if REQUEST_ERROR_CLASS.is_null() {
+    REQUEST_ERROR_CLASS.get_or_init(|| {
+        unsafe {
             let mod_name =
                 ffi::PyUnicode_FromStringAndSize(c"glide_shared.exceptions".as_ptr(), 23);
             if mod_name.is_null() {
                 ffi::PyErr_Clear();
-                return std::ptr::null_mut();
+                return PyClassPtr(std::ptr::null_mut());
             }
             let module = ffi::PyImport_Import(mod_name);
             ffi::Py_DECREF(mod_name);
             if module.is_null() {
                 ffi::PyErr_Clear();
-                return std::ptr::null_mut();
+                return PyClassPtr(std::ptr::null_mut());
             }
             let attr = ffi::PyUnicode_FromStringAndSize(c"RequestError".as_ptr(), 12);
             if attr.is_null() {
                 ffi::Py_DECREF(module);
                 ffi::PyErr_Clear();
-                return std::ptr::null_mut();
+                return PyClassPtr(std::ptr::null_mut());
             }
             let cls = ffi::PyObject_GetAttr(module, attr);
             ffi::Py_DECREF(attr);
             ffi::Py_DECREF(module);
             if cls.is_null() {
                 ffi::PyErr_Clear();
-                return std::ptr::null_mut();
+                return PyClassPtr(std::ptr::null_mut());
             }
-            REQUEST_ERROR_CLASS = cls; // keep one reference
+            PyClassPtr(cls)
         }
-        REQUEST_ERROR_CLASS
-    }
+    }).0
 }
 
 /// Response type values — must match ffi/src/lib.rs `ResponseType` enum exactly.
@@ -227,7 +231,7 @@ fn parse_response(py: Python<'_>, ptr: usize) -> (PyObject, usize) {
     (obj, arena_ptr)
 }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn _fast_response(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_response, m)?)?;
     Ok(())

--- a/python/glide-sync/glide_sync/__init__.py
+++ b/python/glide-sync/glide_sync/__init__.py
@@ -172,6 +172,7 @@ from glide_shared import (
     json_batch,
 )
 
+from .client_pool import ClientPool, PoolConfig
 from .glide_client import GlideClient, GlideClusterClient, TGlideClient
 from .logger import Level as LogLevel
 from .logger import Logger
@@ -190,6 +191,9 @@ __all__ = [
     "TGlideClient",
     "GlideClient",
     "GlideClusterClient",
+    # Pool
+    "ClientPool",
+    "PoolConfig",
     # Internal utilities
     "get_min_compressed_size",
     "Batch",

--- a/python/glide-sync/glide_sync/client_pool.py
+++ b/python/glide-sync/glide_sync/client_pool.py
@@ -24,15 +24,15 @@ Usage:
     pool.close()
 """
 
-import time
 import threading
+import time
 from dataclasses import dataclass
 from typing import Optional
 
 from glide_shared._glide_ffi import _GlideFFI
 from glide_shared.config import BaseClientConfiguration, GlideClusterClientConfiguration
 
-from .glide_client import BaseClient, GlideClient, GlideClusterClient
+from .glide_client import BaseClient, GlideClient
 
 
 @dataclass
@@ -67,8 +67,15 @@ class ClientPool:
     """
 
     __slots__ = (
-        '_ffi', '_lib', '_client_config', '_pool_config',
-        '_closed', '_client_cache', '_conn_req_bytes', '_pool_id',
+        "_ffi",
+        "_lib",
+        "_client_config",
+        "_pool_config",
+        "_closed",
+        "_client_cache",
+        "_conn_req_bytes",
+        "_pool_id",
+        "_cache_lock",
     )
 
     def __init__(
@@ -83,10 +90,14 @@ class ClientPool:
         self._pool_config = pool_config or PoolConfig()
         self._closed = False
         self._client_cache: dict = {}
+        # Lock for _client_cache under free-threading (concurrent get_or_create_client)
+        self._cache_lock = threading.Lock()
 
         # Serialize the connection request protobuf
         is_cluster = isinstance(client_config, GlideClusterClientConfiguration)
-        conn_req = client_config._create_a_protobuf_conn_request(cluster_mode=is_cluster)
+        conn_req = client_config._create_a_protobuf_conn_request(
+            cluster_mode=is_cluster
+        )
         self._conn_req_bytes = conn_req.SerializeToString()
 
         # Create the Rust pool via FFI
@@ -130,7 +141,9 @@ class ClientPool:
         if self._closed:
             raise RuntimeError("Pool is closed")
 
-        timeout = timeout if timeout is not None else self._pool_config.acquire_timeout_s
+        timeout = (
+            timeout if timeout is not None else self._pool_config.acquire_timeout_s
+        )
         deadline = time.monotonic() + timeout
         backoff_ms = 1.0
 
@@ -183,30 +196,36 @@ class ClientPool:
         if cached is not None:
             return cached
 
-        # Get the native ClientAdapter pointer from the Rust pool
-        adapter_ptr = self._lib.glide_pool_get_client_ptr(client_id)
-        if adapter_ptr == 0:
-            raise RuntimeError(
-                f"Pool client_id {client_id} has no associated ClientAdapter"
-            )
+        with self._cache_lock:
+            # Double-check after acquiring lock
+            cached = self._client_cache.get(client_id)
+            if cached is not None:
+                return cached
 
-        # Create a GlideClient shell pointing to the pooled adapter.
-        # Cache the ffi.cast so subsequent borrows pay zero FFI overhead.
-        cast_ptr = self._ffi.cast("void*", adapter_ptr)
+            # Get the native ClientAdapter pointer from the Rust pool
+            adapter_ptr = self._lib.glide_pool_get_client_ptr(client_id)
+            if adapter_ptr == 0:
+                raise RuntimeError(
+                    f"Pool client_id {client_id} has no associated ClientAdapter"
+                )
 
-        client = GlideClient.__new__(GlideClient)
-        client._ffi = self._ffi
-        client._lib = self._lib
-        client._config = self._client_config
-        client._is_closed = False
-        client._pubsub_queue = []
-        client._pubsub_lock = threading.Lock()
-        client._pubsub_condition = threading.Condition(client._pubsub_lock)
-        client._pubsub_callback_ref = None
-        client._core_client = cast_ptr
+            # Create a GlideClient shell pointing to the pooled adapter.
+            cast_ptr = self._ffi.cast("void*", adapter_ptr)
 
-        self._client_cache[client_id] = client
-        return client
+            client = GlideClient.__new__(GlideClient)  # type: ignore[type-abstract]
+            client._ffi = self._ffi
+            client._lib = self._lib
+            client._config = self._client_config
+            client._is_closed = False
+            client._pubsub_queue = []
+            client._pubsub_lock = threading.Lock()
+            client._pubsub_condition = threading.Condition(client._pubsub_lock)
+            client._pubsub_callback_ref = None
+            client._client_lock = threading.Lock()
+            client._core_client = cast_ptr
+
+            self._client_cache[client_id] = client
+            return client
 
     def metrics(self) -> dict:
         """Get pool metrics: idle, active, total counts."""
@@ -242,7 +261,7 @@ class ClientPool:
 class _BorrowContext:
     """Fast context manager for pool borrow/release (avoids generator overhead)."""
 
-    __slots__ = ('_pool', '_timeout', '_client_id')
+    __slots__ = ("_pool", "_timeout", "_client_id")
 
     def __init__(self, pool: ClientPool, timeout):
         self._pool = pool

--- a/python/glide-sync/glide_sync/client_pool.py
+++ b/python/glide-sync/glide_sync/client_pool.py
@@ -1,0 +1,258 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Client-instance pool for the synchronous GLIDE client (Feature 1).
+
+Backed by the shared Rust pool in glide-core via FFI. The Rust pool owns
+client lifecycle (creation, LIFO reuse, bounded size, eviction). This Python
+class provides the acquire-with-timeout retry loop and maps client_id handles
+to usable GlideClient wrappers for command dispatch.
+
+Usage:
+    from glide_sync import GlideClient
+    from glide_sync.client_pool import ClientPool, PoolConfig
+    from glide_shared.config import GlideClientConfiguration, NodeAddress
+
+    config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
+    pool = ClientPool(config, PoolConfig(max_size=10, min_idle=2))
+
+    # Borrow a client, use it, return it automatically
+    with pool.borrow() as client:
+        client.set("key", "value")
+        result = client.get("key")
+
+    pool.close()
+"""
+
+import time
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from glide_shared._glide_ffi import _GlideFFI
+from glide_shared.config import BaseClientConfiguration, GlideClusterClientConfiguration
+
+from .glide_client import BaseClient, GlideClient, GlideClusterClient
+
+
+@dataclass
+class PoolConfig:
+    """Configuration for the client-instance pool."""
+
+    max_size: int = 10
+    """Maximum number of clients in the pool."""
+
+    min_idle: int = 1
+    """Minimum idle clients to pre-warm at creation."""
+
+    idle_timeout_ms: int = 300_000
+    """Evict idle clients after this duration (ms). Default: 5 minutes."""
+
+    request_timeout_ms: int = 5_000
+    """Request timeout for commands (ms)."""
+
+    acquire_timeout_s: float = 5.0
+    """Maximum time to wait when pool is exhausted (seconds)."""
+
+
+class ClientPool:
+    """
+    Client-instance pool backed by the Rust core.
+
+    The Rust pool owns all client lifecycle (creation, health checks, eviction).
+    This Python class provides:
+    - acquire-with-timeout retry loop (exponential backoff)
+    - Cached GlideClient wrappers (one per client_id, reused across borrows)
+    - Zero-overhead borrow() context manager
+    """
+
+    __slots__ = (
+        '_ffi', '_lib', '_client_config', '_pool_config',
+        '_closed', '_client_cache', '_conn_req_bytes', '_pool_id',
+    )
+
+    def __init__(
+        self,
+        client_config: BaseClientConfiguration,
+        pool_config: Optional[PoolConfig] = None,
+    ):
+        ffi_instance = _GlideFFI()
+        self._ffi = ffi_instance.ffi
+        self._lib = ffi_instance.lib
+        self._client_config = client_config
+        self._pool_config = pool_config or PoolConfig()
+        self._closed = False
+        self._client_cache: dict = {}
+
+        # Serialize the connection request protobuf
+        is_cluster = isinstance(client_config, GlideClusterClientConfiguration)
+        conn_req = client_config._create_a_protobuf_conn_request(cluster_mode=is_cluster)
+        self._conn_req_bytes = conn_req.SerializeToString()
+
+        # Create the Rust pool via FFI
+        pool_id = self._lib.glide_pool_create(
+            self._pool_config.max_size,
+            self._pool_config.min_idle,
+            self._pool_config.idle_timeout_ms,
+            self._pool_config.request_timeout_ms,
+            self._conn_req_bytes,
+            len(self._conn_req_bytes),
+        )
+
+        if pool_id == -1:
+            raise ValueError("Invalid pool configuration")
+        if pool_id < 0:
+            raise RuntimeError(f"Failed to create pool (error code: {pool_id})")
+
+        self._pool_id = pool_id
+
+    @property
+    def pool_id(self) -> int:
+        return self._pool_id
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def acquire(self, timeout: Optional[float] = None) -> int:
+        """
+        Acquire a client_id from the Rust pool.
+
+        Retries with exponential backoff until a client is available or timeout.
+
+        Returns:
+            client_id (positive integer) for use with borrow() or get_client().
+
+        Raises:
+            TimeoutError: If no client available within timeout.
+            RuntimeError: If pool is closed or invalid.
+        """
+        if self._closed:
+            raise RuntimeError("Pool is closed")
+
+        timeout = timeout if timeout is not None else self._pool_config.acquire_timeout_s
+        deadline = time.monotonic() + timeout
+        backoff_ms = 1.0
+
+        while time.monotonic() < deadline:
+            client_id = self._lib.glide_pool_try_acquire(self._pool_id)
+
+            if client_id >= 0:
+                return client_id
+            if client_id == -2:
+                raise RuntimeError("Invalid pool_id — pool was destroyed")
+
+            remaining = deadline - time.monotonic()
+            sleep_s = min(backoff_ms / 1000.0, max(remaining, 0))
+            if sleep_s <= 0:
+                break
+            time.sleep(sleep_s)
+            backoff_ms = min(backoff_ms * 2, 50.0)
+
+        raise TimeoutError(
+            f"Pool exhausted: could not acquire client within {timeout}s"
+        )
+
+    def release(self, client_id: int) -> None:
+        """Release a borrowed client back to the pool."""
+        self._lib.glide_pool_release(self._pool_id, client_id)
+
+    def borrow(self, timeout: Optional[float] = None):
+        """
+        Returns a context manager that acquires a client from the Rust pool.
+
+        The returned client dispatches commands through the native ClientAdapter
+        managed by the Rust pool. On exit, the client is released back to the pool.
+
+        Usage:
+            with pool.borrow() as client:
+                client.set("key", "value")
+                result = client.get("key")
+        """
+        return _BorrowContext(self, timeout)
+
+    def _get_or_create_client(self, client_id: int) -> BaseClient:
+        """
+        Get a usable GlideClient wrapper for the given client_id.
+
+        On first borrow of a client_id, creates a thin wrapper pointing to the
+        Rust-managed ClientAdapter. Subsequent borrows of the same client_id
+        reuse the cached wrapper (zero allocation).
+        """
+        cached = self._client_cache.get(client_id)
+        if cached is not None:
+            return cached
+
+        # Get the native ClientAdapter pointer from the Rust pool
+        adapter_ptr = self._lib.glide_pool_get_client_ptr(client_id)
+        if adapter_ptr == 0:
+            raise RuntimeError(
+                f"Pool client_id {client_id} has no associated ClientAdapter"
+            )
+
+        # Create a GlideClient shell pointing to the pooled adapter.
+        # Cache the ffi.cast so subsequent borrows pay zero FFI overhead.
+        cast_ptr = self._ffi.cast("void*", adapter_ptr)
+
+        client = GlideClient.__new__(GlideClient)
+        client._ffi = self._ffi
+        client._lib = self._lib
+        client._config = self._client_config
+        client._is_closed = False
+        client._pubsub_queue = []
+        client._pubsub_lock = threading.Lock()
+        client._pubsub_condition = threading.Condition(client._pubsub_lock)
+        client._pubsub_callback_ref = None
+        client._core_client = cast_ptr
+
+        self._client_cache[client_id] = client
+        return client
+
+    def metrics(self) -> dict:
+        """Get pool metrics: idle, active, total counts."""
+        idle = self._ffi.new("uint32_t*")
+        active = self._ffi.new("uint32_t*")
+        total = self._ffi.new("uint32_t*")
+        result = self._lib.glide_pool_metrics(self._pool_id, idle, active, total)
+        if result != 0:
+            return {"idle": 0, "active": 0, "total": 0}
+        return {"idle": idle[0], "active": active[0], "total": total[0]}
+
+    def close(self) -> None:
+        """Destroy the pool. All idle clients are closed."""
+        if not self._closed:
+            self._closed = True
+            self._lib.glide_pool_destroy(self._pool_id)
+            self._client_cache.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __del__(self):
+        if not self._closed:
+            try:
+                self.close()
+            except Exception:
+                pass
+
+
+class _BorrowContext:
+    """Fast context manager for pool borrow/release (avoids generator overhead)."""
+
+    __slots__ = ('_pool', '_timeout', '_client_id')
+
+    def __init__(self, pool: ClientPool, timeout):
+        self._pool = pool
+        self._timeout = timeout
+        self._client_id = -1
+
+    def __enter__(self):
+        self._client_id = self._pool.acquire(self._timeout)
+        return self._pool._get_or_create_client(self._client_id)
+
+    def __exit__(self, *_):
+        self._pool.release(self._client_id)
+        return False

--- a/python/glide-sync/glide_sync/client_pool.py
+++ b/python/glide-sync/glide_sync/client_pool.py
@@ -4,7 +4,7 @@
 Client-instance pool for the synchronous GLIDE client (Feature 1).
 
 Backed by the shared Rust pool in glide-core via FFI. The Rust pool owns
-client lifecycle (creation, LIFO reuse, bounded size, eviction). This Python
+client lifecycle (creation, LIFO reuse, bounded size). This Python
 class provides the acquire-with-timeout retry loop and maps client_id handles
 to usable GlideClient wrappers for command dispatch.
 
@@ -59,7 +59,7 @@ class ClientPool:
     """
     Client-instance pool backed by the Rust core.
 
-    The Rust pool owns all client lifecycle (creation, health checks, eviction).
+    The Rust pool owns client lifecycle (creation, bounded size).
     This Python class provides:
     - acquire-with-timeout retry loop (exponential backoff)
     - Cached GlideClient wrappers (one per client_id, reused across borrows)

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -72,6 +72,10 @@ class BaseClient(CoreCommands):
         self._pubsub_lock = threading.Lock()
         self._pubsub_condition = threading.Condition(self._pubsub_lock)
         self._pubsub_callback_ref = None  # Keep callback alive
+        # Lock protecting _core_client and _is_closed for free-threading safety.
+        # Under GIL builds this is a no-op (GIL serializes access).
+        # Under free-threaded builds this prevents use-after-free on concurrent close.
+        self._client_lock = threading.Lock()
 
         self._is_closed: bool = False
 
@@ -977,13 +981,14 @@ class BaseClient(CoreCommands):
         return self._handle_cmd_result(result)
 
     def close(self) -> None:
-        if not self._is_closed:
-            self._is_closed = True
-            with self._pubsub_condition:
-                self._pubsub_condition.notify_all()
-            self._lib.close_client(self._core_client)
-            self._core_client = self._ffi.NULL
-            self._pubsub_callback_ref = None
+        with self._client_lock:
+            if not self._is_closed:
+                self._is_closed = True
+                with self._pubsub_condition:
+                    self._pubsub_condition.notify_all()
+                self._lib.close_client(self._core_client)
+                self._core_client = self._ffi.NULL
+                self._pubsub_callback_ref = None
 
     def __enter__(self) -> Self:
         return self

--- a/python/tests/async_tests/test_async_freethreading.py
+++ b/python/tests/async_tests/test_async_freethreading.py
@@ -1,0 +1,159 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Free-threading stress tests for the asynchronous GLIDE client.
+
+Tests exercise concurrent access patterns that validate thread safety of
+_pending_futures and response parsing under free-threaded Python builds.
+"""
+
+import sys
+import uuid
+
+import anyio
+import pytest
+from glide.glide_client import GlideClient
+from glide_shared.config import (
+    GlideClientConfiguration,
+    NodeAddress,
+    ProtocolVersion,
+)
+
+
+def is_free_threaded() -> bool:
+    if hasattr(sys, "_is_gil_enabled"):
+        return not sys._is_gil_enabled()
+    return False
+
+
+def _get_config(request) -> GlideClientConfiguration:
+    host = request.config.getoption("--host", default="localhost")
+    port = int(request.config.getoption("--port", default="6379"))
+    return GlideClientConfiguration(
+        addresses=[NodeAddress(host, port)],
+        request_timeout=5000,
+        protocol=ProtocolVersion.RESP3,
+    )
+
+
+@pytest.mark.anyio
+class TestAsyncFreeThreading:
+    """Stress tests for async client free-threading safety."""
+
+    async def test_concurrent_commands_single_client(self, request):
+        """
+        Many concurrent commands on the same client — exercises _pending_futures
+        dict under high concurrency.
+        """
+        config = _get_config(request)
+        client = await GlideClient.create(config)
+        try:
+            num_tasks = 100
+            errors = []
+
+            async def worker(task_id):
+                key = f"async-ft-{task_id}-{uuid.uuid4().hex[:8]}"
+                expected = f"val-{task_id}"
+                try:
+                    await client.set(key, expected)
+                    result = await client.get(key)
+                    actual = result.decode() if isinstance(result, bytes) else result
+                    if actual != expected:
+                        errors.append(
+                            f"Task {task_id}: expected '{expected}', got '{actual}'"
+                        )
+                    await client.delete([key])
+                except Exception as e:
+                    errors.append(f"Task {task_id}: {type(e).__name__}: {e}")
+
+            async with anyio.create_task_group() as tg:
+                for i in range(num_tasks):
+                    tg.start_soon(worker, i)
+
+            assert not errors, "Errors:\n" + "\n".join(errors[:10])
+        finally:
+            await client.close()
+
+    async def test_high_concurrency_pipeline(self, request):
+        """
+        Fire 500 commands without sequential awaiting — tests _pending_futures
+        map under high entry count.
+        """
+        config = _get_config(request)
+        client = await GlideClient.create(config)
+        try:
+            num_ops = 500
+            keys = [f"async-pipe-{i}-{uuid.uuid4().hex[:6]}" for i in range(num_ops)]
+            results = [None] * num_ops
+
+            # Fire all SETs concurrently
+            async with anyio.create_task_group() as tg:
+                for i, k in enumerate(keys):
+                    tg.start_soon(client.set, k, f"v{i}")
+
+            # Fire all GETs concurrently, collect results
+            async def get_and_store(idx, key):
+                results[idx] = await client.get(key)
+
+            async with anyio.create_task_group() as tg:
+                for i, k in enumerate(keys):
+                    tg.start_soon(get_and_store, i, k)
+
+            # Verify correctness (no response cross-contamination)
+            for i, result in enumerate(results):
+                val = result.decode() if isinstance(result, bytes) else result
+                assert val == f"v{i}", f"Key {keys[i]}: expected 'v{i}', got '{val}'"
+
+            await client.delete(keys)
+        finally:
+            await client.close()
+
+    async def test_multiple_clients_concurrent(self, request):
+        """
+        Multiple async clients operating concurrently — exercises the shared
+        pipe reader's _client_registry lookups under concurrent access.
+        """
+        config = _get_config(request)
+        num_clients = 4
+        ops_per_client = 50
+        errors = []
+
+        clients = [await GlideClient.create(config) for _ in range(num_clients)]
+        try:
+
+            async def client_worker(client_idx, client):
+                for i in range(ops_per_client):
+                    key = f"multi-client-{client_idx}-{i}"
+                    expected = f"c{client_idx}-{i}"
+                    try:
+                        await client.set(key, expected)
+                        result = await client.get(key)
+                        actual = (
+                            result.decode() if isinstance(result, bytes) else result
+                        )
+                        if actual != expected:
+                            errors.append(
+                                f"Client {client_idx} op {i}: expected '{expected}', got '{actual}'"
+                            )
+                            return
+                        await client.delete([key])
+                    except Exception as e:
+                        errors.append(f"Client {client_idx} op {i}: {e}")
+                        return
+
+            async with anyio.create_task_group() as tg:
+                for i, c in enumerate(clients):
+                    tg.start_soon(client_worker, i, c)
+
+            assert not errors, "Errors:\n" + "\n".join(errors[:10])
+        finally:
+            for c in clients:
+                await c.close()
+
+    async def test_info_free_threading_status(self):
+        """Report free-threading status (always passes)."""
+        ft = is_free_threaded()
+        print(f"\n  Free-threaded Python: {ft}")
+        print(f"  Python version: {sys.version}")
+        if hasattr(sys, "_is_gil_enabled"):
+            print(f"  GIL enabled: {sys._is_gil_enabled()}")

--- a/python/tests/sync_tests/test_sync_freethreading.py
+++ b/python/tests/sync_tests/test_sync_freethreading.py
@@ -1,0 +1,231 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Free-threading stress tests for the synchronous GLIDE client.
+
+These tests exercise high-contention parallel access patterns that would
+crash or produce incorrect results on a free-threaded Python build (3.13t+)
+if the native extensions or client code have data races.
+
+On a GIL-enabled build, these tests verify correctness (the GIL serializes
+access, so races can't manifest). On a free-threaded build, they validate
+true thread safety.
+"""
+
+import sys
+import threading
+import time
+import uuid
+
+import pytest
+from glide_shared.config import GlideClientConfiguration, NodeAddress
+from glide_sync.client_pool import ClientPool, PoolConfig
+
+
+def get_config(request) -> GlideClientConfiguration:
+    host = request.config.getoption("--host", default="localhost")
+    port = int(request.config.getoption("--port", default="6379"))
+    return GlideClientConfiguration(
+        addresses=[NodeAddress(host, port)],
+        request_timeout=5000,
+    )
+
+
+def is_free_threaded() -> bool:
+    """Check if running on a free-threaded (no-GIL) Python build."""
+    if hasattr(sys, "_is_gil_enabled"):
+        return not sys._is_gil_enabled()
+    return False
+
+
+class TestFreeThreading:
+    """
+    Stress tests for free-threading safety.
+    These exercise parallel access patterns that would crash without
+    proper synchronization in the native layer.
+    """
+
+    @pytest.fixture
+    def pool(self, request):
+        config = get_config(request)
+        p = ClientPool(
+            config, PoolConfig(max_size=8, min_idle=4, acquire_timeout_s=15.0)
+        )
+        time.sleep(4)  # Wait for min_idle warmup
+        yield p
+        p.close()
+
+    def test_parallel_commands_same_pool(self, pool):
+        """
+        16 threads, each doing 50 SET/GET cycles through the pool.
+        Validates no response cross-contamination under parallel execution.
+        """
+        num_threads = 16
+        ops_per_thread = 50
+        errors = []
+        success_count = threading.atomic(0) if hasattr(threading, "atomic") else [0]
+        lock = threading.Lock()
+
+        def worker(thread_id):
+            for i in range(ops_per_thread):
+                key = f"ft-stress-{thread_id}-{i}-{uuid.uuid4().hex[:8]}"
+                expected_value = f"val-{thread_id}-{i}"
+                try:
+                    with pool.borrow() as client:
+                        client.set(key, expected_value)
+                        result = client.get(key)
+                        # Verify response correctness — the critical check
+                        actual = (
+                            result.decode() if isinstance(result, bytes) else result
+                        )
+                        if actual != expected_value:
+                            errors.append(
+                                f"Thread {thread_id} op {i}: expected '{expected_value}', "
+                                f"got '{actual}' (RESPONSE CORRUPTION)"
+                            )
+                            return
+                        client.delete([key])
+                except Exception as e:
+                    errors.append(f"Thread {thread_id} op {i}: {type(e).__name__}: {e}")
+                    return
+
+            with lock:
+                if isinstance(success_count, list):
+                    success_count[0] += 1
+
+        threads = [
+            threading.Thread(target=worker, args=(t,), name=f"ft-worker-{t}")
+            for t in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        assert not errors, "Free-threading errors:\n" + "\n".join(errors[:10])
+        expected = num_threads
+        actual = success_count[0] if isinstance(success_count, list) else success_count
+        assert actual == expected, f"Only {actual}/{expected} threads completed"
+
+    def test_parallel_pool_acquire_release_storm(self, pool):
+        """
+        Rapid acquire/release without doing commands — stresses the pool's
+        lock contention and atomic operations under true parallelism.
+        """
+        num_threads = 16
+        cycles_per_thread = 100
+        errors = []
+
+        def worker(thread_id):
+            for i in range(cycles_per_thread):
+                try:
+                    client_id = pool.acquire(timeout=10.0)
+                    # Minimal hold time — maximizes contention
+                    pool.release(client_id)
+                except Exception as e:
+                    errors.append(f"Thread {thread_id} cycle {i}: {e}")
+                    return
+
+        threads = [
+            threading.Thread(target=worker, args=(t,)) for t in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        assert not errors, "Pool contention errors:\n" + "\n".join(errors[:10])
+
+    def test_response_parser_parallel_invocation(self, pool):
+        """
+        Multiple threads calling commands simultaneously — exercises the
+        _fast_response parser's OnceLock-cached RequestError class lookup
+        under parallel access.
+        """
+        num_threads = 8
+        ops_per_thread = 100
+        errors = []
+
+        def worker(thread_id):
+            with pool.borrow() as client:
+                for i in range(ops_per_thread):
+                    try:
+                        key = f"parser-{thread_id}-{i}"
+                        client.set(key, str(i))
+                        val = client.get(key)
+                        actual = int(val) if val else -1
+                        if actual != i:
+                            errors.append(
+                                f"Thread {thread_id}: expected {i}, got {actual}"
+                            )
+                            return
+                        client.delete([key])
+                    except Exception as e:
+                        errors.append(f"Thread {thread_id} op {i}: {e}")
+                        return
+
+        threads = [
+            threading.Thread(target=worker, args=(t,)) for t in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        assert not errors, "Parser parallel errors:\n" + "\n".join(errors[:10])
+
+    def test_concurrent_pool_metrics(self, pool):
+        """
+        One thread hammering metrics() while others do acquire/release.
+        metrics() reads pool state without mutation — under free-threading,
+        this validates that concurrent readers don't crash.
+        """
+        stop_event = threading.Event()
+        errors = []
+        metrics_calls = [0]
+
+        def metrics_reader():
+            while not stop_event.is_set():
+                try:
+                    m = pool.metrics()
+                    assert "idle" in m
+                    assert "active" in m
+                    assert "total" in m
+                    metrics_calls[0] += 1
+                except Exception as e:
+                    errors.append(f"Metrics reader: {e}")
+                    return
+
+        def pool_user(thread_id):
+            for _ in range(50):
+                try:
+                    with pool.borrow() as client:
+                        client.set(f"metrics-test-{thread_id}", "x")
+                        client.get(f"metrics-test-{thread_id}")
+                        client.delete([f"metrics-test-{thread_id}"])
+                except Exception as e:
+                    errors.append(f"Pool user {thread_id}: {e}")
+                    return
+
+        reader = threading.Thread(target=metrics_reader)
+        workers = [threading.Thread(target=pool_user, args=(t,)) for t in range(4)]
+
+        reader.start()
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=30)
+        stop_event.set()
+        reader.join(timeout=5)
+
+        assert not errors, "Errors:\n" + "\n".join(errors[:10])
+        assert metrics_calls[0] > 0, "Metrics reader should have run"
+
+    def test_info_free_threading_status(self):
+        """Report whether we're running on a free-threaded build."""
+        ft = is_free_threaded()
+        print(f"\n  Free-threaded Python: {ft}")
+        print(f"  Python version: {sys.version}")
+        if hasattr(sys, "_is_gil_enabled"):
+            print(f"  GIL enabled: {sys._is_gil_enabled()}")
+        # This test always passes — it's informational

--- a/python/tests/sync_tests/test_sync_pool.py
+++ b/python/tests/sync_tests/test_sync_pool.py
@@ -1,0 +1,117 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Integration tests for Feature 1: Client-Instance Pooling (Python sync client).
+Requires a Valkey server (uses test infrastructure endpoints).
+"""
+
+import threading
+import time
+import uuid
+
+import pytest
+from glide_shared.config import GlideClientConfiguration, NodeAddress
+from glide_sync.client_pool import ClientPool, PoolConfig
+
+
+def get_standalone_config(request) -> GlideClientConfiguration:
+    """Build a GlideClientConfiguration using the test server endpoints."""
+    # The test infrastructure passes endpoints via pytest options
+    host = request.config.getoption("--host", default="localhost")
+    port = int(request.config.getoption("--port", default="6379"))
+    return GlideClientConfiguration(
+        addresses=[NodeAddress(host, port)],
+        request_timeout=5000,
+    )
+
+
+class TestClientPool:
+    """Tests for the ClientPool class backed by glide-core::pool via FFI."""
+
+    @pytest.fixture
+    def pool(self, request):
+        """Create a pool for each test, close on teardown."""
+        config = get_standalone_config(request)
+        pool_config = PoolConfig(max_size=5, min_idle=1, acquire_timeout_s=10.0)
+        p = ClientPool(config, pool_config)
+        # Wait for min_idle warmup
+        time.sleep(3)
+        yield p
+        p.close()
+
+    def test_pool_create_and_metrics(self, pool):
+        """Pool creates successfully and reports metrics."""
+        metrics = pool.metrics()
+        assert metrics["idle"] >= 1, f"Expected at least 1 idle, got {metrics}"
+        assert metrics["total"] >= 1, f"Expected total >= 1, got {metrics}"
+        assert not pool.is_closed
+
+    def test_pool_borrow_and_commands(self, pool):
+        """Borrow a client, run commands, auto-release."""
+        key = f"pool-py-test-{uuid.uuid4()}"
+        with pool.borrow() as client:
+            client.set(key, "hello")
+            result = client.get(key)
+            assert result == b"hello" or result == "hello"
+            client.delete([key])
+
+    def test_pool_reuse(self, pool):
+        """LIFO reuse: same client_id returned after release."""
+        id1 = pool.acquire()
+        pool.release(id1)
+        time.sleep(0.1)
+        id2 = pool.acquire()
+        pool.release(id2)
+        assert id1 == id2, f"Expected LIFO reuse: {id1} != {id2}"
+
+    def test_pool_close_rejects_acquire(self, request):
+        """Closed pool raises on acquire."""
+        config = get_standalone_config(request)
+        p = ClientPool(config, PoolConfig(max_size=2, min_idle=0))
+        p.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            p.acquire()
+
+    def test_pool_concurrent_access(self, pool):
+        """Multiple threads can borrow and use clients concurrently."""
+        num_threads = 4
+        results = [None] * num_threads
+        errors = []
+
+        def worker(idx):
+            try:
+                with pool.borrow() as client:
+                    key = f"concurrent-py-{idx}-{uuid.uuid4()}"
+                    client.set(key, f"thread-{idx}")
+                    val = client.get(key)
+                    assert val == f"thread-{idx}".encode() or val == f"thread-{idx}"
+                    client.delete([key])
+                    results[idx] = True
+            except Exception as e:
+                errors.append((idx, e))
+                results[idx] = False
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, f"Thread errors: {errors}"
+        assert all(results), f"Not all threads succeeded: {results}"
+
+    def test_pool_timeout_on_exhaustion(self, request):
+        """Pool raises TimeoutError when exhausted within timeout."""
+        config = get_standalone_config(request)
+        p = ClientPool(config, PoolConfig(max_size=1, min_idle=1, acquire_timeout_s=1.0))
+        time.sleep(3)  # warmup
+
+        # Acquire the only client
+        client_id = p.acquire()
+
+        # Second acquire should time out
+        with pytest.raises(TimeoutError):
+            p.acquire(timeout=0.5)
+
+        p.release(client_id)
+        p.close()

--- a/python/tests/sync_tests/test_sync_pool_benchmark.py
+++ b/python/tests/sync_tests/test_sync_pool_benchmark.py
@@ -1,0 +1,163 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Benchmark: Free-threading + Pooling throughput test.
+
+Measures throughput of SET/GET operations under increasing thread counts
+to demonstrate parallelism gains from pool + free-threading.
+
+On GIL builds: threads add overhead (context switching) without parallelism.
+On free-threaded builds: threads enable true parallelism, throughput scales.
+
+Run with: pytest tests/sync_tests/test_sync_pool_benchmark.py -v -s
+"""
+
+import sys
+import threading
+import time
+
+
+import pytest
+from glide_shared.config import GlideClientConfiguration, NodeAddress
+from glide_sync import GlideClient
+from glide_sync.client_pool import ClientPool, PoolConfig
+
+
+def get_config(request) -> GlideClientConfiguration:
+    host = request.config.getoption("--host", default="localhost")
+    port = int(request.config.getoption("--port", default="6379"))
+    return GlideClientConfiguration(
+        addresses=[NodeAddress(host, port)],
+        request_timeout=5000,
+    )
+
+
+class TestPoolBenchmark:
+    """Throughput benchmarks for pool + free-threading."""
+
+    @pytest.fixture
+    def pool(self, request):
+        config = get_config(request)
+        p = ClientPool(config, PoolConfig(max_size=8, min_idle=4))
+        time.sleep(4)
+        yield p
+        p.close()
+
+    def test_benchmark_single_vs_multi_thread(self, pool):
+        """
+        Compare throughput: 1 thread vs N threads with pooling.
+
+        On GIL builds: multi-thread adds overhead, ~1x or worse.
+        On free-threaded builds: near-linear scaling expected.
+        """
+        ops_per_thread = 500
+        is_ft = hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+        print(f"\n{'='*60}")
+        print("  Pool + Free-threading Throughput Benchmark")
+        print(f"  Free-threaded: {is_ft}")
+        print(f"  Python: {sys.version.split()[0]}")
+        print(f"  Ops per thread: {ops_per_thread}")
+        print(f"{'='*60}\n")
+
+        results = {}
+
+        for num_threads in [1, 2, 4, 8]:
+            errors = []
+
+            def worker(thread_id, ops):
+                for i in range(ops):
+                    try:
+                        with pool.borrow() as client:
+                            key = f"bench-{thread_id}-{i}"
+                            client.set(key, "x" * 100)
+                            client.get(key)
+                            client.delete([key])
+                    except Exception as e:
+                        errors.append(str(e))
+                        return
+
+            start = time.perf_counter()
+            threads = [
+                threading.Thread(target=worker, args=(t, ops_per_thread))
+                for t in range(num_threads)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=60)
+            elapsed = time.perf_counter() - start
+
+            total_ops = num_threads * ops_per_thread * 3  # SET + GET + DEL
+            throughput = total_ops / elapsed
+            results[num_threads] = throughput
+
+            print(
+                f"  {num_threads:2d} threads: "
+                f"{throughput:,.0f} ops/s  "
+                f"({elapsed:.2f}s, {total_ops} ops)"
+                f"{'  ⚠️ errors: ' + str(len(errors)) if errors else ''}"
+            )
+
+        print("\n  Scaling:")
+        baseline = results[1]
+        for n, tput in results.items():
+            print(f"    {n} threads: {tput/baseline:.2f}x vs single-thread")
+
+        print("\n  Note: On GIL builds, expect ~1x scaling (GIL serializes).")
+        print("  On free-threaded (3.13t+), expect near-linear scaling.")
+        print(f"{'='*60}\n")
+
+    def test_benchmark_pool_vs_fresh_client(self, request):
+        """
+        Compare: borrowing from pool vs creating fresh client per operation.
+        Pool should always be faster regardless of GIL/free-threading.
+        """
+        config = get_config(request)
+        pool = ClientPool(config, PoolConfig(max_size=4, min_idle=2))
+        time.sleep(3)
+
+        iterations = 50
+
+        print(f"\n{'='*60}")
+        print("  Pool vs Fresh Client Benchmark")
+        print(f"  Iterations: {iterations}")
+        print(f"{'='*60}\n")
+
+        # Scenario A: Fresh client per operation
+        start = time.perf_counter()
+        for i in range(iterations):
+            client = GlideClient.create(config)
+            key = f"fresh-{i}"
+            client.set(key, "hello")
+            client.get(key)
+            client.delete([key])
+            client.close()
+        fresh_elapsed = time.perf_counter() - start
+
+        # Scenario B: Pool borrow per operation
+        start = time.perf_counter()
+        for i in range(iterations):
+            with pool.borrow() as client:
+                key = f"pooled-{i}"
+                client.set(key, "hello")
+                client.get(key)
+                client.delete([key])
+        pool_elapsed = time.perf_counter() - start
+
+        pool.close()
+
+        fresh_per_op = fresh_elapsed / iterations * 1000
+        pool_per_op = pool_elapsed / iterations * 1000
+        speedup = fresh_elapsed / pool_elapsed
+
+        print(f"  Fresh client per op: {fresh_per_op:.2f} ms/op")
+        print(f"  Pool borrow per op:  {pool_per_op:.2f} ms/op")
+        print(f"  Speedup:             {speedup:.1f}x")
+        print(f"{'='*60}\n")
+
+        # Pool should always be faster
+        assert speedup > 1.0, (
+            f"Pool should be faster than fresh client. "
+            f"Got {speedup:.2f}x (pool: {pool_per_op:.2f}ms, fresh: {fresh_per_op:.2f}ms)"
+        )

--- a/python/tests/sync_tests/test_sync_pool_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pool_pubsub.py
@@ -1,0 +1,140 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+PubSub integration tests for client pool under concurrent access.
+Validates that pubsub messages are delivered correctly when multiple
+threads share a pool and subscribe/publish concurrently.
+"""
+
+import threading
+import time
+import uuid
+
+
+from glide_shared.config import GlideClientConfiguration, NodeAddress
+from glide_sync import GlideClient
+from glide_sync.client_pool import ClientPool, PoolConfig
+
+
+def get_config(request) -> GlideClientConfiguration:
+    host = request.config.getoption("--host", default="localhost")
+    port = int(request.config.getoption("--port", default="6379"))
+    return GlideClientConfiguration(
+        addresses=[NodeAddress(host, port)],
+        request_timeout=5000,
+    )
+
+
+class TestPoolPubSub:
+    """PubSub tests with pooled clients under concurrent access."""
+
+    def test_publish_from_pool(self, request):
+        """Pool clients can publish messages."""
+        config = get_config(request)
+        pool = ClientPool(config, PoolConfig(max_size=3, min_idle=1))
+        time.sleep(3)
+
+        channel = f"test-channel-{uuid.uuid4().hex[:8]}"
+        try:
+            with pool.borrow() as client:
+                # PUBLISH returns number of subscribers (0 if none)
+                result = client.custom_command(["PUBLISH", channel, "hello"])
+                # Just verify it doesn't crash — 0 subscribers expected
+                assert result is not None or result == 0
+        finally:
+            pool.close()
+
+    def test_concurrent_publish(self, request):
+        """Multiple threads publishing through pooled clients concurrently."""
+        config = get_config(request)
+        pool = ClientPool(config, PoolConfig(max_size=4, min_idle=2))
+        time.sleep(3)
+
+        channel = f"concurrent-pub-{uuid.uuid4().hex[:8]}"
+        num_threads = 4
+        msgs_per_thread = 20
+        errors = []
+
+        def publisher(thread_id):
+            for i in range(msgs_per_thread):
+                try:
+                    with pool.borrow() as client:
+                        client.custom_command(
+                            ["PUBLISH", channel, f"msg-{thread_id}-{i}"]
+                        )
+                except Exception as e:
+                    errors.append(f"Thread {thread_id} msg {i}: {e}")
+                    return
+
+        threads = [
+            threading.Thread(target=publisher, args=(t,)) for t in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, "Publish errors:\n" + "\n".join(errors[:10])
+        pool.close()
+
+    def test_pool_with_subscriber_client(self, request):
+        """
+        One thread subscribes via a dedicated client, others publish via pool.
+        Validates messages arrive correctly under concurrent pool usage.
+        """
+        config = get_config(request)
+        pool = ClientPool(config, PoolConfig(max_size=3, min_idle=1))
+        time.sleep(3)
+
+        channel = f"sub-test-{uuid.uuid4().hex[:8]}"
+        received_messages = []
+        subscriber_ready = threading.Event()
+        stop_event = threading.Event()
+
+        # Create a dedicated subscriber client (not from pool)
+        sub_client = GlideClient.create(config)
+
+        def subscriber():
+            try:
+                sub_client.custom_command(["SUBSCRIBE", channel])
+                subscriber_ready.set()
+                # Poll for messages with timeout
+                deadline = time.monotonic() + 10
+                while not stop_event.is_set() and time.monotonic() < deadline:
+                    msg = sub_client.try_get_pubsub_message()
+                    if msg is not None:
+                        received_messages.append(msg)
+                    else:
+                        time.sleep(0.01)
+            except Exception:
+                pass
+
+        sub_thread = threading.Thread(target=subscriber)
+        sub_thread.start()
+        subscriber_ready.wait(timeout=5)
+        time.sleep(0.5)  # Give subscription time to register on server
+
+        # Publish from pool
+        num_messages = 5
+        for i in range(num_messages):
+            with pool.borrow() as client:
+                client.custom_command(["PUBLISH", channel, f"pooled-{i}"])
+
+        # Wait for messages
+        time.sleep(2)
+        stop_event.set()
+        sub_thread.join(timeout=5)
+
+        # Cleanup
+        try:
+            sub_client.custom_command(["UNSUBSCRIBE", channel])
+        except Exception:
+            pass
+        sub_client.close()
+        pool.close()
+
+        # Verify at least some messages arrived
+        # (timing-sensitive, so we check > 0 rather than exact count)
+        assert (
+            len(received_messages) > 0
+        ), f"Expected messages on channel {channel}, got none"


### PR DESCRIPTION
## Summary

Implements RFC #5815 Feature 2 -- isolated execution scopes that allow a borrowed pool client to be pinned to a specific slot/node for multi-command workflows (transactions, WATCH/MULTI/EXEC, Lua scripting) without blocking other pool consumers.

Builds on Feature 1 (Client Connection Pooling, PR #6328).

## Issue link

This Pull Request is linked to issue: [RFC - Dedicated Connection Pooling](https://github.com/valkey-io/valkey-glide/issues/5815)
Closes #5815 (Feature 2 portion)

## Features / Behaviour Changes
* New `glide-core::scope` module providing `IsolatedScope` with slot-pinned execution
* `address_for_slot` wiring in core for deterministic node routing
* Scope-aware acquire: client is reserved for the scope duration, returned to idle on drop
* Java: `IsolatedScope` API with integration tests and benchmarks
* Pool API simplification across Java and Python

## Implementation

**Core (`glide-core/src/scope.rs`):**
* `IsolatedScope` wraps a pooled client with slot affinity
* Deterministic routing: commands within a scope always go to the same node
* Automatic return-to-idle on scope exit (Drop impl)

**Java:**
* `IsolatedScopeIntegrationTest` -- full lifecycle tests
* `IsolatedScopeBenchmark` -- performance characterization
* Scope core refactor for cleaner separation

**Python:**
* Pool API simplification (Feature 1 refinements)
* Free-threading support maintained

## Testing
* Java integration tests for isolated scope lifecycle
* Java benchmark for scope overhead characterization
* Python pool tests updated for API simplification
* Free-threading tests remain passing

## Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Make sure to update the documentation in the valkey-glide-docs repository if necessary.
