### PR TITLE
CD: Drop PyPy 3.9/3.10 from PyPI release builds

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -272,16 +272,8 @@ jobs:
                   if [[ "$ARCH" == "arm64" ]]; then
                     # Download PyPy for Apple Silicon
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
-                    PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_arm64
-                    PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_arm64
                     
-                    echo "Downloading PyPy 3.9 for arm64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     
-                    echo "Downloading PyPy 3.10 for arm64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     
                     echo "Downloading PyPy 3.11 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
@@ -289,23 +281,15 @@ jobs:
                     
                   elif [[ "$ARCH" == "x86_64" ]]; then
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
-                    PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
-                    PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_x86_64
                     
-                    echo "Downloading PyPy 3.9 for x86_64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     
-                    echo "Downloading PyPy 3.10 for x86_64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     
                     echo "Downloading PyPy 3.11 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2" 
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                   fi
 
-                  echo "/opt/${PYPY_VERSION_3_11}/bin:/opt/${PYPY_VERSION_3_10}/bin:/opt/${PYPY_VERSION_3_9}/bin" >> ${GITHUB_PATH}
+                  echo "/opt/${PYPY_VERSION_3_11}/bin" >> ${GITHUB_PATH}
 
                   sudo chmod -R a+rx /opt/pypy*/bin
                   sudo chmod -R a+rx /opt/pypy*/lib/*.dylib
@@ -322,7 +306,7 @@ jobs:
               with:
                   working-directory: ./python/glide-async
                   target: ${{ matrix.build.TARGET }}
-                  args: --release --strip --out wheels -i ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.9 pypy3.10 pypy3.11' || 'python3.14' }}
+                  args: --release --strip --out wheels -i ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.11' || 'python3.14' }}
                   manylinux: auto
                   container: ${{ matrix.build.CONTAINER != '' && matrix.build.CONTAINER || '2014' }}
                   docker-options: --pull always --rm
@@ -353,41 +337,21 @@ jobs:
                       # Install PyPy
                       if [[ "$ARCH" == "x86_64" ]]; then
                         PYPY_VERSION_3_11=pypy3.11-v7.3.19-linux64
-                        PYPY_VERSION_3_10=pypy3.10-v7.3.19-linux64
-                        PYPY_VERSION_3_9=pypy3.9-v7.3.16-linux64
-
-                        echo "Downloading PyPy 3.9 for x86_64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_9}.tar.bz2"  --exclude="*/bin/python*" -C /opt
-
-                        echo "Downloading PyPy 3.10 for x86_64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
                         echo "Downloading PyPy 3.11 for x86_64"
                         curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                         tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
-                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:/opt/${PYPY_VERSION_3_10}/bin:/opt/${PYPY_VERSION_3_9}/bin:$PATH"
+                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:$PATH"
 
                       elif [[ "$ARCH" == "aarch64" ]]; then
                         PYPY_VERSION_3_11=pypy3.11-v7.3.19-aarch64
-                        PYPY_VERSION_3_10=pypy3.10-v7.3.19-aarch64
-                        PYPY_VERSION_3_9=pypy3.9-v7.3.16-aarch64
-
-                        echo "Downloading PyPy 3.9 for aarch64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
-                        echo "Downloading PyPy 3.10 for aarch64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
                         echo "Downloading PyPy 3.11 for aarch64"
                         curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                         tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
-                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:/opt/${PYPY_VERSION_3_10}/bin:/opt/${PYPY_VERSION_3_9}/bin:$PATH"
+                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:$PATH"
                       else
                         echo "Running on unsupported architecture: $ARCH. Expected one of: ['x86_64', 'aarch64']"
                         exit 1
@@ -400,7 +364,7 @@ jobs:
                   maturin-version: 0.14.17
                   working-directory: ./python/glide-async
                   target: ${{ matrix.build.TARGET }}
-                  args: --release --strip --out wheels -i  ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.9 pypy3.10 pypy3.11' || 'python3.14' }}
+                  args: --release --strip --out wheels -i  ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.11' || 'python3.14' }}
 
             ### SYNC CLIENT ###
 
@@ -436,7 +400,7 @@ jobs:
                   # we call cibuildwheel from the root folder in order to copy the whole folder tree to the docker
                   ${{ steps.python_cmd.outputs.cmd }} -m cibuildwheel python/glide-sync --output-dir python/glide-sync/wheels
               env:
-                  CIBW_BUILD: ${{ github.event_name != 'pull_request' && 'cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* pp39-* pp310-* pp311-*' || 'cp314-*' }}
+                  CIBW_BUILD: ${{ github.event_name != 'pull_request' && 'cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* pp311-*' || 'cp314-*' }}
                   CIBW_SKIP: "*-musl* *i686* *i386*"
                   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
                   CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
@@ -599,39 +563,39 @@ jobs:
 
                   if [[ "${{ matrix.build.NAMED_OS }}" == "linux" ]]; then
                     if [[ "$ARCH" == "x86_64" ]]; then
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-linux64
-                      echo "Downloading PyPy 3.10 for x86_64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-linux64
+                      echo "Downloading PyPy 3.11 for x86_64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                       
                     elif [[ "$ARCH" == "aarch64" ]]; then
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-aarch64
-                      echo "Downloading PyPy 3.10 for aarch64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-aarch64
+                      echo "Downloading PyPy 3.11 for aarch64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     fi
 
-                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_10}/bin
+                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_11}/bin
 
                   elif [[ "${{ matrix.build.NAMED_OS }}" == "darwin" ]]; then
                     if [[ "$ARCH" == "arm64" ]]; then
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_arm64
-                      echo "Downloading PyPy 3.10 for arm64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
+                      echo "Downloading PyPy 3.11 for arm64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                       
                     else
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
-                      echo "Downloading PyPy 3.10 for x86_64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
+                      echo "Downloading PyPy 3.11 for x86_64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     fi
 
-                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_10}/bin
-                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_10}/lib/*.dylib
+                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_11}/bin
+                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_11}/lib/*.dylib
                   fi
 
-                  echo "/opt/${PYPY_VERSION_3_10}/bin" >> ${GITHUB_PATH}
+                  echo "/opt/${PYPY_VERSION_3_11}/bin" >> ${GITHUB_PATH}
 
             - name: Install engine build dependencies (ephemeral runners)
               if: ${{ contains(matrix.build.RUNNER, 'ephemeral') }}


### PR DESCRIPTION
## What
Stop building PyPy 3.9 and 3.10 wheels in the PyPI CD workflow, keeping only PyPy 3.11.

## Why
The pyo3 0.25 → 0.29 backport (#6322) raised PyO3's minimum supported PyPy version to **3.11**. As a result, the `v2.4.2-rc1` release builds failed across all platforms with:

```
error: the configured PyPy interpreter version (3.9) is lower than PyO3's minimum supported version (3.11)
```

## Changes
- Remove `pypy3.9 pypy3.10` from the async maturin build args (linux + macOS).
- Remove `pp39-* pp310-*` from the sync `cibuildwheel` `CIBW_BUILD` list.
- Drop the PyPy 3.9/3.10 download steps from the build setup.
- Switch the post-publish PyPy RC test from 3.10 to 3.11.

CPython 3.9–3.14 builds are unaffected.