### PR TITLE
Fix flaky test_pipeline_all_primary_routing timeout

### DIFF
--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -2342,14 +2342,15 @@ pub(crate) mod shared_client_tests {
             pipeline.add_command(cmd("FLUSHALL"));
             pipeline.add_command(cmd("DBSIZE")); // AllPrimary cmd + SUM aggregation
 
-            // Execute the pipeline.
+            // Execute the pipeline with an explicit timeout to avoid flakiness
+            // under CI load (FLUSHALL/DBSIZE route to all primaries and can be slow).
             let result = test_basics
                 .client
                 .send_pipeline(
                     &pipeline,
                     None,
                     false,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,


### PR DESCRIPTION
### Summary
Fix flaky `test_pipeline_all_primary_routing::use_cluster_2_false` test timeout by providing an explicit 10-second pipeline timeout.

### Issue link
This Pull Request is linked to issue: [[Rust][Flaky Test] test_pipeline_all_primary_routing::use_cluster_2_false](https://github.com/valkey-io/valkey-glide/issues/6331)
Closes #6331

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The test relies on `DEFAULT_RESPONSE_TIMEOUT` (250ms) for pipeline execution. The pipeline contains `FLUSHALL` and `DBSIZE` commands that route to all primary nodes. Under CI load (97+ parallel tests on shared server), these multi-node operations can exceed 250ms.

**Fix:** Pass an explicit 10-second timeout (`Some(10_000)`) to `send_pipeline`, consistent with other pipeline tests in the same file that use explicit timeouts (e.g., `test_pipeline_timeout` uses `Some(3000)`).

### Limitations
None

### Testing
- Both test variants (`use_cluster=true` and `use_cluster=false`) pass consistently
- Ran the test 20 times in a loop with zero failures
- Code compiles cleanly with `cargo check --tests`

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release