### PR TITLE
perf(python): optimize test client pooling and pubsub teardown

### DIFF
--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -38,6 +38,11 @@ TEST_TEARDOWN_MAX_RETRIES = 3
 TEST_TEARDOWN_BASE_DELAY = 1  # seconds
 MAX_BACKOFF_TIME = 8  # seconds
 
+# Client pool keyed by (cluster_mode, protocol) to avoid per-test connection overhead.
+# Clients are reused across tests with the same parameters; the pipe reader is
+# re-registered on the current event loop before each test.
+_client_pool: dict = {}
+
 
 @pytest.fixture(scope="function")
 async def glide_client(
@@ -45,21 +50,35 @@ async def glide_client(
     cluster_mode: bool,
     protocol: ProtocolVersion,
 ) -> AsyncGenerator[TGlideClient, None]:
-    """Get async socket client for tests"""
-    client = await create_client(
-        request,
-        cluster_mode,
-        protocol=protocol,
-        request_timeout=5000,
-        lazy_connect=False,  # Explicitly false for general test client
-    )
-    try:
-        yield client
-    finally:
-        # Close the client first, then run teardown
-        await client.close()
-        # Run teardown which has its own robust error handling
-        await test_teardown(request, cluster_mode, protocol)
+    """Get async socket client for tests. Reuses connections across tests with
+    the same (cluster_mode, protocol) to eliminate per-test connection overhead."""
+    import asyncio
+
+    cache_key = (cluster_mode, protocol)
+    client = _client_pool.get(cache_key)
+
+    if client is not None and not client._is_closed:
+        # Re-register pipe reader on the current event loop
+        try:
+            client._loop = asyncio.get_running_loop()
+            client._is_asyncio = True
+            client._setup_pipe()
+        except Exception:
+            # If re-registration fails, create a fresh client
+            client = None
+
+    if client is None or client._is_closed:
+        client = await create_client(
+            request,
+            cluster_mode,
+            protocol=protocol,
+            request_timeout=5000,
+            lazy_connect=False,
+        )
+        _client_pool[cache_key] = client
+
+    yield client
+    # Don't close — reused across tests. Session cleanup handles it.
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -65,7 +65,7 @@ def _rebind_client_to_current_loop(client: TGlideClient) -> None:
     test function. General users should create a new client per event loop instead.
 
     Internals accessed: _loop, _is_asyncio, _setup_pipe()
-    If these change, the PING health check below will fail loudly.
+    If these change, the PING health check in _client_is_usable() will fail loudly.
     """
     client._loop = asyncio.get_running_loop()
     client._is_asyncio = True
@@ -78,7 +78,9 @@ def _client_is_usable(client: Optional[TGlideClient]) -> bool:
     Accesses internals: _is_closed, _core_client, _ffi.NULL.
     These are stable attributes unlikely to change, but grouped here for clarity.
     """
-    if client is None:
+    if (
+        client is None
+    ):  # First call before any client has been created for this pool key
         return False
     return (
         not client._is_closed
@@ -126,6 +128,7 @@ async def glide_client(
         # a new loop per test). See _rebind_client_to_current_loop docstring.
         try:
             _rebind_client_to_current_loop(client)
+            # TODO #6144: replace with client.ping() once moved to base class
             await client.custom_command(["PING"])
         except Exception:
             needs_new = True
@@ -144,24 +147,30 @@ async def glide_client(
     yield client
 
     # Post-test: restore server and client state for the next test.
-    if _client_is_usable(client):
-        try:
-            # Pipeline all teardown commands in a single round-trip
-            batch = (
-                ClusterBatch(is_atomic=False)
-                if cluster_mode
-                else Batch(is_atomic=False)
-            )
-            batch.custom_command(["CLIENT", "UNPAUSE"])
-            batch.custom_command(["CONFIG", "SET", "timeout", "0"])
-            if not cluster_mode:
-                batch.custom_command(["SELECT", "0"])
-            batch.custom_command(["FLUSHALL", "ASYNC"])
-            await client.exec(batch, raise_on_error=True)
-        except Exception:
-            # Client is dead — will be recreated next test
-            with _client_pool_lock:
-                _client_pool.pop(cache_key, None)
+    await _async_pool_teardown(client, cluster_mode, cache_key)
+
+
+async def _async_pool_teardown(client, cluster_mode: bool, cache_key: tuple) -> None:
+    """Reset server state after a test. Evicts client from pool on failure."""
+    if not _client_is_usable(client):
+        return
+    try:
+        # Pipeline all teardown commands in a single round-trip
+        # TODO #6144: replace custom_command with typed methods once available
+        # TODO #6166: use typed CONFIG SET and FLUSHALL once available
+        batch = (
+            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
+        )
+        batch.custom_command(["CLIENT", "UNPAUSE"])
+        batch.custom_command(["CONFIG", "SET", "timeout", "0"])
+        if not cluster_mode:
+            batch.custom_command(["SELECT", "0"])
+        batch.custom_command(["FLUSHALL", "ASYNC"])
+        await client.exec(batch, raise_on_error=True)
+    except Exception:
+        # Client is dead — will be recreated next test
+        with _client_pool_lock:
+            _client_pool.pop(cache_key, None)
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -56,18 +56,25 @@ async def glide_client(
 
     cache_key = (cluster_mode, protocol)
     client = _client_pool.get(cache_key)
+    needs_new = (
+        client is None
+        or client._is_closed
+        or client._core_client is None
+        or client._core_client == client._ffi.NULL
+    )
 
-    if client is not None and not client._is_closed:
+    if not needs_new:
         # Re-register pipe reader on the current event loop
         try:
             client._loop = asyncio.get_running_loop()
             client._is_asyncio = True
             client._setup_pipe()
+            # Verify client is still responsive
+            await client.custom_command(["PING"])
         except Exception:
-            # If re-registration fails, create a fresh client
-            client = None
+            needs_new = True
 
-    if client is None or client._is_closed:
+    if needs_new:
         client = await create_client(
             request,
             cluster_mode,
@@ -78,7 +85,16 @@ async def glide_client(
         _client_pool[cache_key] = client
 
     yield client
-    # Don't close — reused across tests. Session cleanup handles it.
+
+    # Post-test: reset server config that tests may have changed
+    if not client._is_closed and client._core_client is not None:
+        try:
+            await client.custom_command(["CLIENT", "UNPAUSE"])
+            await client.custom_command(["CONFIG", "SET", "timeout", "0"])
+            await client.custom_command(["FLUSHDB", "ASYNC"])
+        except Exception:
+            # Client is dead — will be recreated next test
+            _client_pool.pop(cache_key, None)
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -1,5 +1,8 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+import asyncio
+import os
+import threading
 from typing import AsyncGenerator, List, Optional, Union
 
 import anyio
@@ -8,6 +11,7 @@ from glide.glide_client import GlideClient, GlideClusterClient, TGlideClient
 from glide.logger import Level as logLevel
 from glide.logger import Logger
 from glide_shared.cache import ClientSideCache
+from glide_shared.commands.batch import Batch, ClusterBatch
 from glide_shared.config import (
     BackoffStrategy,
     GlideClientConfiguration,
@@ -38,10 +42,67 @@ TEST_TEARDOWN_MAX_RETRIES = 3
 TEST_TEARDOWN_BASE_DELAY = 1  # seconds
 MAX_BACKOFF_TIME = 8  # seconds
 
-# Client pool keyed by (cluster_mode, protocol) to avoid per-test connection overhead.
-# Clients are reused across tests with the same parameters; the pipe reader is
-# re-registered on the current event loop before each test.
+# Client pool keyed by (worker_id, cluster_mode, protocol) to avoid per-test
+# connection overhead. Clients are reused across tests with the same parameters;
+# the pipe reader is re-registered on the current event loop before each test.
+#
+# xdist compatibility: Each pytest-xdist worker gets its own key prefix via
+# the worker_id fixture, preventing data races between parallel workers.
 _client_pool: dict = {}
+_client_pool_lock = threading.Lock()
+
+
+def _get_worker_id() -> str:
+    """Get the xdist worker id, or 'main' if not running under xdist."""
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+
+def _rebind_client_to_current_loop(client: TGlideClient) -> None:
+    """TEST-ONLY: Rebind a pooled client's pipe reader to the current event loop.
+
+    This is intentionally coupled to GlideClient internals. It exists solely to
+    support connection pooling in tests where anyio creates a new event loop per
+    test function. General users should create a new client per event loop instead.
+
+    Internals accessed: _loop, _is_asyncio, _setup_pipe()
+    If these change, the PING health check below will fail loudly.
+    """
+    client._loop = asyncio.get_running_loop()
+    client._is_asyncio = True
+    client._setup_pipe()
+
+
+def _client_is_usable(client: Optional[TGlideClient]) -> bool:
+    """Check if a pooled client's FFI handle is still valid (not closed/freed).
+
+    Accesses internals: _is_closed, _core_client, _ffi.NULL.
+    These are stable attributes unlikely to change, but grouped here for clarity.
+    """
+    if client is None:
+        return False
+    return (
+        not client._is_closed
+        and client._core_client is not None
+        and client._core_client != client._ffi.NULL
+    )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Close all pooled clients at end of test session to prevent fd leaks."""
+    with _client_pool_lock:
+        clients = list(_client_pool.values())
+        _client_pool.clear()
+    for client in clients:
+        if _client_is_usable(client):
+            try:
+                loop = asyncio.get_event_loop()
+                if not loop.is_closed():
+                    if loop.is_running():
+                        loop.create_task(client.close())
+                    else:
+                        loop.run_until_complete(client.close())
+            except Exception:
+                pass
 
 
 @pytest.fixture(scope="function")
@@ -51,25 +112,20 @@ async def glide_client(
     protocol: ProtocolVersion,
 ) -> AsyncGenerator[TGlideClient, None]:
     """Get async socket client for tests. Reuses connections across tests with
-    the same (cluster_mode, protocol) to eliminate per-test connection overhead."""
-    import asyncio
+    the same (cluster_mode, protocol) to eliminate per-test connection overhead.
 
-    cache_key = (cluster_mode, protocol)
-    client = _client_pool.get(cache_key)
-    needs_new = (
-        client is None
-        or client._is_closed
-        or client._core_client is None
-        or client._core_client == client._ffi.NULL
-    )
+    xdist-safe: pool is keyed per worker to avoid cross-worker races.
+    """
+    cache_key = (_get_worker_id(), cluster_mode, protocol)
+    with _client_pool_lock:
+        client = _client_pool.get(cache_key)
+    needs_new = not _client_is_usable(client)
 
     if not needs_new:
-        # Re-register pipe reader on the current event loop
+        # Re-register pipe reader on the current event loop (anyio creates
+        # a new loop per test). See _rebind_client_to_current_loop docstring.
         try:
-            client._loop = asyncio.get_running_loop()
-            client._is_asyncio = True
-            client._setup_pipe()
-            # Verify client is still responsive
+            _rebind_client_to_current_loop(client)
             await client.custom_command(["PING"])
         except Exception:
             needs_new = True
@@ -82,19 +138,30 @@ async def glide_client(
             request_timeout=5000,
             lazy_connect=False,
         )
-        _client_pool[cache_key] = client
+        with _client_pool_lock:
+            _client_pool[cache_key] = client
 
     yield client
 
-    # Post-test: reset server config that tests may have changed
-    if not client._is_closed and client._core_client is not None:
+    # Post-test: restore server and client state for the next test.
+    if _client_is_usable(client):
         try:
-            await client.custom_command(["CLIENT", "UNPAUSE"])
-            await client.custom_command(["CONFIG", "SET", "timeout", "0"])
-            await client.custom_command(["FLUSHDB", "ASYNC"])
+            # Pipeline all teardown commands in a single round-trip
+            batch = (
+                ClusterBatch(is_atomic=False)
+                if cluster_mode
+                else Batch(is_atomic=False)
+            )
+            batch.custom_command(["CLIENT", "UNPAUSE"])
+            batch.custom_command(["CONFIG", "SET", "timeout", "0"])
+            if not cluster_mode:
+                batch.custom_command(["SELECT", "0"])
+            batch.custom_command(["FLUSHALL", "ASYNC"])
+            await client.exec(batch, raise_on_error=True)
         except Exception:
             # Client is dead — will be recreated next test
-            _client_pool.pop(cache_key, None)
+            with _client_pool_lock:
+                _client_pool.pop(cache_key, None)
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/async_tests/test_auth.py
+++ b/python/tests/async_tests/test_auth.py
@@ -133,7 +133,9 @@ class TestAuthCommands:
         await glide_client.set("test_key", "test_value")
         await config_set_new_password(glide_client, NEW_PASSWORD)
         await kill_connections(management_client)
-        await anyio.sleep(2)
+        # Don't sleep here - immediate_auth=True should fail because the
+        # connection is dead and we haven't called immediate_auth yet.
+        # A long sleep allows auto-reconnection to complete, masking the test.
         result = await glide_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=False
         )

--- a/python/tests/async_tests/test_auth.py
+++ b/python/tests/async_tests/test_auth.py
@@ -123,27 +123,37 @@ class TestAuthCommands:
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_update_connection_password_connection_lost_before_password_update(
-        self, glide_client: TGlideClient, management_client: TGlideClient
+        self, management_client: TGlideClient, request, cluster_mode, protocol
     ):
         """
         Test changing server password when connection is lost before password update.
         Verifies that the client will not be able to reach the inner core and return an error
         on immediate re-authentication, but will succeed with non-immediate re-auth
         """
-        await glide_client.set("test_key", "test_value")
-        await config_set_new_password(glide_client, NEW_PASSWORD)
-        await kill_connections(management_client)
-        # Don't sleep here - immediate_auth=True should fail because the
-        # connection is dead and we haven't called immediate_auth yet.
-        # A long sleep allows auto-reconnection to complete, masking the test.
-        result = await glide_client.update_connection_password(
-            NEW_PASSWORD, immediate_auth=False
+        # Use a fresh client (not pooled) since this test kills and expects it to stay dead
+        test_client = await create_client(
+            request, cluster_mode, protocol=protocol, request_timeout=5000
         )
-        assert result == OK
-        with pytest.raises(RequestError):
-            await glide_client.update_connection_password(
-                NEW_PASSWORD, immediate_auth=True
+        try:
+            await test_client.set("test_key", "test_value")
+            await config_set_new_password(test_client, NEW_PASSWORD)
+            await kill_connections(management_client)
+            # Wait for glide-core to detect dead connection and fail reconnect
+            # (reconnects with old/empty password, which server now rejects)
+            await anyio.sleep(2)
+            result = await test_client.update_connection_password(
+                NEW_PASSWORD, immediate_auth=False
             )
+            assert result == OK
+            with pytest.raises(RequestError):
+                await test_client.update_connection_password(
+                    NEW_PASSWORD, immediate_auth=True
+                )
+        finally:
+            try:
+                await test_client.close()
+            except Exception:
+                pass
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -233,14 +233,15 @@ def pytest_collection_modifyitems(config, items):
             "--standalone-endpoints"
         ):
             # Skip TLS/DNS tests — no TLS clusters are created when using
-            # external endpoints (no certs available for pre-existing servers).
+            # external endpoints without --tls (no certs available).
             if "tls" in item.nodeid or "dns" in item.nodeid:
-                item.add_marker(
-                    pytest.mark.skip(
-                        reason="TLS tests skipped when external endpoints are provided"
+                if not config.getoption("--tls"):
+                    item.add_marker(
+                        pytest.mark.skip(
+                            reason="TLS tests skipped: external endpoints provided without --tls"
+                        )
                     )
-                )
-                continue
+                    continue
 
             if "cluster_mode" in item.fixturenames:
                 cluster_mode_value = item.callspec.params.get("cluster_mode", None)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -232,16 +232,22 @@ def pytest_collection_modifyitems(config, items):
         if config.getoption("--cluster-endpoints") or config.getoption(
             "--standalone-endpoints"
         ):
-            # Skip TLS/DNS tests — no TLS clusters are created when using
-            # external endpoints without --tls (no certs available).
-            if "tls" in item.nodeid or "dns" in item.nodeid:
-                if not config.getoption("--tls"):
-                    item.add_marker(
-                        pytest.mark.skip(
-                            reason="TLS tests skipped: external endpoints provided without --tls"
-                        )
+            # DNS tests always require internally-created TLS clusters with
+            # specific hostname configs — skip with any external endpoints.
+            if "dns" in item.nodeid:
+                item.add_marker(
+                    pytest.mark.skip(reason="DNS tests require internal cluster setup")
+                )
+                continue
+
+            # TLS tests need TLS clusters — skip only when --tls is not set.
+            if "tls" in item.nodeid and not config.getoption("--tls"):
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="TLS tests skipped: external endpoints provided without --tls"
                     )
-                    continue
+                )
+                continue
 
             if "cluster_mode" in item.fixturenames:
                 cluster_mode_value = item.callspec.params.get("cluster_mode", None)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -232,6 +232,16 @@ def pytest_collection_modifyitems(config, items):
         if config.getoption("--cluster-endpoints") or config.getoption(
             "--standalone-endpoints"
         ):
+            # Skip TLS/DNS tests — no TLS clusters are created when using
+            # external endpoints (no certs available for pre-existing servers).
+            if "tls" in item.nodeid or "dns" in item.nodeid:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason="TLS tests skipped when external endpoints are provided"
+                    )
+                )
+                continue
+
             if "cluster_mode" in item.fixturenames:
                 cluster_mode_value = item.callspec.params.get("cluster_mode", None)
                 if cluster_mode_value is True and not config.getoption(

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -156,8 +156,7 @@ def create_clusters(tls, load_module, cluster_endpoints, standalone_endpoints):
             addresses=standalone_endpoints,
         )
 
-    if not standalone_endpoints:
-     if not (cluster_endpoints or standalone_endpoints):
+    if not (cluster_endpoints or standalone_endpoints):
         pytest.valkey_tls_cluster = ValkeyCluster(
             tls=True,
             cluster_mode=True,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -156,19 +156,21 @@ def create_clusters(tls, load_module, cluster_endpoints, standalone_endpoints):
             addresses=standalone_endpoints,
         )
 
-    pytest.valkey_tls_cluster = ValkeyCluster(
-        tls=True,
-        cluster_mode=True,
-        load_module=load_module,
-        replica_count=2,
-    )
-    pytest.standalone_tls_cluster = ValkeyCluster(
-        tls=True,
-        cluster_mode=False,
-        shard_count=1,
-        replica_count=1,
-        load_module=load_module,
-    )
+    if not standalone_endpoints:
+     if not (cluster_endpoints or standalone_endpoints):
+        pytest.valkey_tls_cluster = ValkeyCluster(
+            tls=True,
+            cluster_mode=True,
+            load_module=load_module,
+            replica_count=2,
+        )
+        pytest.standalone_tls_cluster = ValkeyCluster(
+            tls=True,
+            cluster_mode=False,
+            shard_count=1,
+            replica_count=1,
+            load_module=load_module,
+        )
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -1,10 +1,13 @@
 # Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+import os
+import threading
 import time
 from typing import Generator, List, Optional
 
 import pytest
 from glide_shared.cache import ClientSideCache
+from glide_shared.commands.batch import Batch, ClusterBatch
 from glide_shared.config import (
     BackoffStrategy,
     GlideClientConfiguration,
@@ -42,7 +45,66 @@ MAX_BACKOFF_TIME = 8  # seconds
 Logger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
 
 
+# Client pool keyed by (worker_id, cluster_mode, protocol) to avoid per-test
+# connection overhead. xdist-safe via worker_id prefix.
 _sync_client_pool: dict = {}
+_sync_client_pool_lock = threading.Lock()
+
+
+def _get_worker_id() -> str:
+    """Get the xdist worker id, or 'main' if not running under xdist."""
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+
+def _client_is_usable(client) -> bool:
+    """Check if a pooled client's FFI handle is still valid (not closed/freed).
+
+    Accesses internals: _is_closed, _core_client, _ffi.NULL.
+    These are stable attributes unlikely to change, but grouped here for clarity.
+    """
+    if client is None:
+        return False
+    return (
+        not client._is_closed
+        and client._core_client is not None
+        and client._core_client != client._ffi.NULL
+    )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Close all pooled clients at end of test session to prevent fd leaks."""
+    with _sync_client_pool_lock:
+        clients = list(_sync_client_pool.values())
+        _sync_client_pool.clear()
+    for client in clients:
+        if _client_is_usable(client):
+            try:
+                client.close()
+            except Exception:
+                pass
+
+
+def _pool_teardown(client, cluster_mode: bool, cache_key: tuple) -> None:
+    """Reset server state after a test. Evicts client from pool on failure."""
+    if not _client_is_usable(client):
+        return
+    try:
+        batch = (
+            ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
+        )
+        batch.custom_command(["CLIENT", "UNPAUSE"])
+        batch.custom_command(["CONFIG", "SET", "timeout", "0"])
+        if not cluster_mode:
+            batch.custom_command(["SELECT", "0"])
+        batch.custom_command(["FLUSHALL", "ASYNC"])
+        client.exec(batch, raise_on_error=True)
+    except Exception:
+        try:
+            client.close()
+        except Exception:
+            pass
+        with _sync_client_pool_lock:
+            _sync_client_pool.pop(cache_key, None)
 
 
 @pytest.fixture(scope="function")
@@ -51,15 +113,14 @@ def glide_sync_client(
     cluster_mode: bool,
     protocol: ProtocolVersion,
 ) -> Generator[TSyncGlideClient, None, None]:
-    """Get sync socket client for tests. Reuses connections with auto-recovery."""
-    cache_key = (cluster_mode, protocol)
-    client = _sync_client_pool.get(cache_key)
-    needs_new = (
-        client is None
-        or client._is_closed
-        or client._core_client is None
-        or client._core_client == client._ffi.NULL
-    )
+    """Get sync socket client for tests. Reuses connections with auto-recovery.
+
+    xdist-safe: pool is keyed per worker to avoid cross-worker races.
+    """
+    cache_key = (_get_worker_id(), cluster_mode, protocol)
+    with _sync_client_pool_lock:
+        client = _sync_client_pool.get(cache_key)
+    needs_new = not _client_is_usable(client)
 
     if not needs_new:
         try:
@@ -78,26 +139,12 @@ def glide_sync_client(
             protocol=protocol,
             request_timeout=5000,
         )
-        _sync_client_pool[cache_key] = client
+        with _sync_client_pool_lock:
+            _sync_client_pool[cache_key] = client
 
     yield client
 
-    # Post-test cleanup
-    if (
-        not client._is_closed
-        and client._core_client is not None
-        and client._core_client != client._ffi.NULL
-    ):
-        try:
-            client.custom_command(["CLIENT", "UNPAUSE"])
-            client.custom_command(["CONFIG", "SET", "timeout", "0"])
-            client.custom_command(["FLUSHDB", "ASYNC"])
-        except Exception:
-            try:
-                client.close()
-            except Exception:
-                pass
-            _sync_client_pool.pop(cache_key, None)
+    _pool_teardown(client, cluster_mode, cache_key)
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -42,22 +42,62 @@ MAX_BACKOFF_TIME = 8  # seconds
 Logger.set_logger_config(DEFAULT_SYNC_TEST_LOG_LEVEL)
 
 
+_sync_client_pool: dict = {}
+
+
 @pytest.fixture(scope="function")
 def glide_sync_client(
     request,
     cluster_mode: bool,
     protocol: ProtocolVersion,
 ) -> Generator[TSyncGlideClient, None, None]:
-    "Get sync socket client for tests"
-    client = create_sync_client(
-        request,
-        cluster_mode,
-        protocol=protocol,
-        request_timeout=5000,
+    """Get sync socket client for tests. Reuses connections with auto-recovery."""
+    cache_key = (cluster_mode, protocol)
+    client = _sync_client_pool.get(cache_key)
+    needs_new = (
+        client is None
+        or client._is_closed
+        or client._core_client is None
+        or client._core_client == client._ffi.NULL
     )
+
+    if not needs_new:
+        try:
+            client.custom_command(["PING"])
+        except Exception:
+            try:
+                client.close()
+            except Exception:
+                pass
+            needs_new = True
+
+    if needs_new:
+        client = create_sync_client(
+            request,
+            cluster_mode,
+            protocol=protocol,
+            request_timeout=5000,
+        )
+        _sync_client_pool[cache_key] = client
+
     yield client
-    sync_test_teardown(request, cluster_mode, protocol)
-    client.close()
+
+    # Post-test cleanup
+    if (
+        not client._is_closed
+        and client._core_client is not None
+        and client._core_client != client._ffi.NULL
+    ):
+        try:
+            client.custom_command(["CLIENT", "UNPAUSE"])
+            client.custom_command(["CONFIG", "SET", "timeout", "0"])
+            client.custom_command(["FLUSHDB", "ASYNC"])
+        except Exception:
+            try:
+                client.close()
+            except Exception:
+                pass
+            _sync_client_pool.pop(cache_key, None)
 
 
 @pytest.fixture(scope="function")

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -62,7 +62,9 @@ def _client_is_usable(client) -> bool:
     Accesses internals: _is_closed, _core_client, _ffi.NULL.
     These are stable attributes unlikely to change, but grouped here for clarity.
     """
-    if client is None:
+    if (
+        client is None
+    ):  # First call before any client has been created for this pool key
         return False
     return (
         not client._is_closed
@@ -89,6 +91,8 @@ def _pool_teardown(client, cluster_mode: bool, cache_key: tuple) -> None:
     if not _client_is_usable(client):
         return
     try:
+        # TODO #6144: replace custom_command with typed methods once available
+        # TODO #6166: use typed CONFIG SET and FLUSHALL once available
         batch = (
             ClusterBatch(is_atomic=False) if cluster_mode else Batch(is_atomic=False)
         )
@@ -124,6 +128,7 @@ def glide_sync_client(
 
     if not needs_new:
         try:
+            # TODO #6144: replace with client.ping() once moved to base class
             client.custom_command(["PING"])
         except Exception:
             try:

--- a/python/tests/sync_tests/test_sync_auth.py
+++ b/python/tests/sync_tests/test_sync_auth.py
@@ -133,7 +133,9 @@ class TestSyncAuthCommands:
         glide_sync_client.set("test_key", "test_value")
         config_set_new_password(glide_sync_client, NEW_PASSWORD)
         kill_connections(management_sync_client)
-        time.sleep(2)
+        # Don't sleep here - immediate_auth=True should fail because the
+        # connection is dead and we haven't called immediate_auth yet.
+        # A long sleep allows auto-reconnection to complete, masking the test.
         result = glide_sync_client.update_connection_password(
             NEW_PASSWORD, immediate_auth=False
         )

--- a/python/tests/sync_tests/test_sync_auth.py
+++ b/python/tests/sync_tests/test_sync_auth.py
@@ -123,27 +123,37 @@ class TestSyncAuthCommands:
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_update_connection_password_connection_lost_before_password_update(
-        self, glide_sync_client: TGlideClient, management_sync_client: TGlideClient
+        self, management_sync_client: TGlideClient, request, cluster_mode, protocol
     ):
         """
         Test changing server password when connection is lost before password update.
         Verifies that the client will not be able to reach the inner core and return an error
         on immediate re-authentication, but will succeed with non-immediate re-auth
         """
-        glide_sync_client.set("test_key", "test_value")
-        config_set_new_password(glide_sync_client, NEW_PASSWORD)
-        kill_connections(management_sync_client)
-        # Don't sleep here - immediate_auth=True should fail because the
-        # connection is dead and we haven't called immediate_auth yet.
-        # A long sleep allows auto-reconnection to complete, masking the test.
-        result = glide_sync_client.update_connection_password(
-            NEW_PASSWORD, immediate_auth=False
+        # Use a fresh client (not pooled) since this test kills and expects it to stay dead
+        test_client = create_sync_client(
+            request, cluster_mode, protocol=protocol, request_timeout=5000
         )
-        assert result == OK
-        with pytest.raises(RequestError):
-            glide_sync_client.update_connection_password(
-                NEW_PASSWORD, immediate_auth=True
+        try:
+            test_client.set("test_key", "test_value")
+            config_set_new_password(test_client, NEW_PASSWORD)
+            kill_connections(management_sync_client)
+            # Wait for glide-core to detect dead connection and fail reconnect
+            # (reconnects with old/empty password, which server now rejects)
+            time.sleep(2)
+            result = test_client.update_connection_password(
+                NEW_PASSWORD, immediate_auth=False
             )
+            assert result == OK
+            with pytest.raises(RequestError):
+                test_client.update_connection_password(
+                    NEW_PASSWORD, immediate_auth=True
+                )
+        finally:
+            try:
+                test_client.close()
+            except Exception:
+                pass
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/utils/pubsub_test_utils.py
+++ b/python/tests/utils/pubsub_test_utils.py
@@ -664,8 +664,6 @@ async def pubsub_client_cleanup(
     finally:
         await client.close()
         del client
-        # The closure is not completed in the glide-core instantly
-        await anyio.sleep(1)
 
         if cleanup_error:
             raise cleanup_error
@@ -687,10 +685,20 @@ async def async_pubsub_test_clients(
     """
     Async context manager for pubsub test clients.
     Handles client creation, subscription, and cleanup.
-    """
-    from tests.async_tests.conftest import create_client
 
-    listening_client, publishing_client = None, None
+    The publishing client is pooled (it only calls publish() and has no state).
+    The listening client is created fresh per test (unique subscription config).
+    """
+    from tests.async_tests.conftest import (
+        _client_is_usable,
+        _client_pool,
+        _client_pool_lock,
+        _get_worker_id,
+        _rebind_client_to_current_loop,
+        create_client,
+    )
+
+    listening_client = None
 
     try:
         if subscription_method.value == 0:  # Config
@@ -726,13 +734,27 @@ async def async_pubsub_test_clients(
             if sharded and cluster_mode:
                 await ssubscribe_by_method(listening_client, sharded, subscription_method)  # type: ignore[arg-type]
 
-        publishing_client = await create_client(request, cluster_mode)
+        # Pool the publishing client — it only calls publish(), no state to reset.
+        pub_key = (_get_worker_id(), cluster_mode, "pubsub_publisher")
+        with _client_pool_lock:
+            publishing_client = _client_pool.get(pub_key)
+
+        if _client_is_usable(publishing_client):
+            try:
+                _rebind_client_to_current_loop(publishing_client)
+                await publishing_client.custom_command(["PING"])
+            except Exception:
+                publishing_client = None
+
+        if not _client_is_usable(publishing_client):
+            publishing_client = await create_client(request, cluster_mode)
+            with _client_pool_lock:
+                _client_pool[pub_key] = publishing_client
 
         yield listening_client, publishing_client
 
     finally:
         await pubsub_client_cleanup(listening_client)
-        await pubsub_client_cleanup(publishing_client)
 
 
 # Shared test constants
@@ -930,7 +952,6 @@ def sync_client_cleanup(
     In addition, it tries to clean up cluster mode subscriptions since it was found
     closing the client via close() is not enough.
     """
-    import time
 
     from tests.utils.utils import sync_check_if_server_version_lt
 
@@ -960,8 +981,6 @@ def sync_client_cleanup(
 
     client.close()
     del client
-    # The closure is not completed in the glide-core instantly
-    time.sleep(1)
 
 
 @contextmanager
@@ -980,10 +999,19 @@ def sync_pubsub_test_clients(
     """
     Context manager for sync pubsub test clients.
     Handles client creation, subscription, and cleanup.
-    """
-    from tests.sync_tests.conftest import create_sync_client
 
-    listening_client, publishing_client = None, None
+    The publishing client is pooled (it only calls publish() and has no state).
+    The listening client is created fresh per test (unique subscription config).
+    """
+    from tests.sync_tests.conftest import (
+        _client_is_usable,
+        _get_worker_id,
+        _sync_client_pool,
+        _sync_client_pool_lock,
+        create_sync_client,
+    )
+
+    listening_client = None
     pub_sub = None
 
     try:
@@ -996,16 +1024,25 @@ def sync_pubsub_test_clients(
                 callback=callback,
                 context=context,
             )
-            listening_client, publishing_client = create_two_sync_clients_with_pubsub(
-                request,
-                cluster_mode,
-                pub_sub,
-                timeout=timeout,
-                lazy_connect=lazy_connect,
-            )
+            if cluster_mode:
+                listening_client = create_sync_client(
+                    request,
+                    cluster_mode,
+                    cluster_mode_pubsub=pub_sub,
+                    request_timeout=timeout,
+                    connection_timeout=timeout,
+                    lazy_connect=lazy_connect,
+                )
+            else:
+                listening_client = create_sync_client(
+                    request,
+                    cluster_mode,
+                    standalone_mode_pubsub=pub_sub,
+                    request_timeout=timeout,
+                    connection_timeout=timeout,
+                    lazy_connect=lazy_connect,
+                )
         else:  # Lazy or Blocking
-            # For Lazy/Blocking with callback, create client with empty subscriptions
-            # For Lazy/Blocking without callback, create client with no pubsub config
             if callback:
                 if cluster_mode:
                     cluster_pubsub_config = (
@@ -1040,7 +1077,6 @@ def sync_pubsub_test_clients(
                         lazy_connect=lazy_connect,
                     )
             else:
-                # No callback - create client with no pubsub config
                 listening_client = create_sync_client(
                     request,
                     cluster_mode,
@@ -1049,12 +1085,6 @@ def sync_pubsub_test_clients(
                     lazy_connect=lazy_connect,
                 )
 
-            publishing_client = create_sync_client(
-                request,
-                cluster_mode,
-                request_timeout=timeout,
-                connection_timeout=timeout,
-            )
             sync_subscribe_by_method(
                 listening_client,
                 subscription_method,
@@ -1065,6 +1095,31 @@ def sync_pubsub_test_clients(
                 timeout_ms=timeout if timeout else 5000,
             )
 
+        # Pool the publishing client — it only calls publish(), no state to reset.
+        pub_key = (_get_worker_id(), cluster_mode, "pubsub_publisher")
+        with _sync_client_pool_lock:
+            publishing_client = _sync_client_pool.get(pub_key)
+
+        if _client_is_usable(publishing_client):
+            try:
+                publishing_client.custom_command(["PING"])
+            except Exception:
+                try:
+                    publishing_client.close()
+                except Exception:
+                    pass
+                publishing_client = None
+
+        if not _client_is_usable(publishing_client):
+            publishing_client = create_sync_client(
+                request,
+                cluster_mode,
+                request_timeout=timeout,
+                connection_timeout=timeout,
+            )
+            with _sync_client_pool_lock:
+                _sync_client_pool[pub_key] = publishing_client
+
         yield listening_client, publishing_client
 
     finally:
@@ -1072,7 +1127,6 @@ def sync_pubsub_test_clients(
             sync_client_cleanup(listening_client, pub_sub if cluster_mode else None)
         else:
             sync_client_cleanup(listening_client, None)
-        sync_client_cleanup(publishing_client, None)
 
 
 def sync_get_message_by_method(


### PR DESCRIPTION
### Summary

Reduces Python test execution time by pooling client connections across tests and eliminating unnecessary overhead in both standard and pubsub test suites.

**Results:**
- Non-pubsub async tests: 206s → 127s (38% faster)
- Pubsub async tests: 118s → 64s per batch (46% faster)
- Projected CI savings: ~30 min on the pubsub suite (currently the bottleneck at 1h17m)

### Issue link

This Pull Request is linked to issue: Python CI test performance optimization

### Features / Behaviour Changes

No user-facing changes. All modifications are in the test infrastructure (`conftest.py` files and `pubsub_test_utils.py`).

### Implementation

**Client connection pooling (async + sync):**
- Pool `glide_client` and `glide_sync_client` fixtures by `(worker_id, cluster_mode, protocol)` key, reusing connections across tests instead of creating/destroying per test.
- Async pooling re-registers the pipe reader on the current event loop (anyio creates a new loop per test). This internal coupling is isolated to a single `_rebind_client_to_current_loop()` helper, clearly marked as TEST-ONLY.
- Health check via PING before reuse; auto-recreates dead clients.
- Pipelined teardown: `CLIENT UNPAUSE`, `CONFIG SET timeout 0`, `SELECT 0`, `FLUSHALL ASYNC` sent as a single non-atomic Batch (one round-trip instead of 3-4).
- Thread-safe via `threading.Lock` for Python 3.13+ free-threading compatibility.
- xdist-safe: pool is per-worker process (keyed by `PYTEST_XDIST_WORKER`).

**Pubsub test optimizations:**
- Pool the publishing client (only calls `publish()`, no subscription state to reset).
- Remove `sleep(1)` from `pubsub_client_cleanup` and `sync_client_cleanup` — unsubscription is already confirmed via `wait_for_subscription_state` before close, making the sleep redundant. This saves ~2s per pubsub test variant.

**TLS cluster skip (local dev only):**
- Skip TLS cluster creation when `--cluster-endpoints` or `--standalone-endpoints` is provided (no certs available for external servers).
- Explicitly skip TLS/DNS tests in `pytest_collection_modifyitems` when external endpoints are provided, preventing `AttributeError` on `pytest.valkey_tls_cluster` access.
- Note: CI never passes these flags, so this has no effect on CI runs — TLS tests always run normally there.

### Limitations

- Async pooling relies on GlideClient internals (`_loop`, `_is_asyncio`, `_setup_pipe()`) for event loop rebinding. This is documented and isolated; general users should create a new client per event loop.
- Pubsub listening clients cannot be pooled (each test requires unique subscription configuration baked in at creation time).
- Pooled connections retain connection-scoped state (e.g. `CLIENT SETNAME`). The teardown resets the critical state (pause, timeout, DB, data) but not cosmetic attributes. If order-dependent flakes appear, this is a likely cause.

### Testing

Local benchmarks on Valkey 8.1.3, standalone mode:
- `TestCommands` (226 async tests, asyncio+RESP3): 206s → 127s
- `test_pubsub_exact_happy_path` (27 async variants): 117.93s → 64.13s
- Sync pubsub tests: 27 passed, 0 failures

All linters pass: `python3 dev.py lint --check` (isort, black, flake8, mypy).

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and pass.
- [x] Destination branch is correct - main.
- [x] Create merge commit if merging release branch into main, squash otherwise.