### PR TITLE
feat(java): bypass protobuf serialization for command execution

### DIFF
--- a/java/client/src/main/java/glide/api/models/BaseBatch.java
+++ b/java/client/src/main/java/glide/api/models/BaseBatch.java
@@ -17,6 +17,7 @@ import static command_request.CommandRequestOuterClass.RequestType.BitPos;
 import static command_request.CommandRequestOuterClass.RequestType.ClientGetName;
 import static command_request.CommandRequestOuterClass.RequestType.ClientId;
 import static command_request.CommandRequestOuterClass.RequestType.ClientPause;
+import static command_request.CommandRequestOuterClass.RequestType.ClientTrackingInfo;
 import static command_request.CommandRequestOuterClass.RequestType.ClientUnpause;
 import static command_request.CommandRequestOuterClass.RequestType.ConfigGet;
 import static command_request.CommandRequestOuterClass.RequestType.ConfigResetStat;
@@ -101,6 +102,9 @@ import static command_request.CommandRequestOuterClass.RequestType.LRem;
 import static command_request.CommandRequestOuterClass.RequestType.LSet;
 import static command_request.CommandRequestOuterClass.RequestType.LTrim;
 import static command_request.CommandRequestOuterClass.RequestType.LastSave;
+import static command_request.CommandRequestOuterClass.RequestType.LatencyHistory;
+import static command_request.CommandRequestOuterClass.RequestType.LatencyLatest;
+import static command_request.CommandRequestOuterClass.RequestType.LatencyReset;
 import static command_request.CommandRequestOuterClass.RequestType.Lolwut;
 import static command_request.CommandRequestOuterClass.RequestType.MGet;
 import static command_request.CommandRequestOuterClass.RequestType.MSet;
@@ -240,11 +244,7 @@ import static glide.utils.ArrayTransformUtils.flattenMapToGlideStringArrayValueF
 import static glide.utils.ArrayTransformUtils.flattenNestedArrayToGlideStringArray;
 import static glide.utils.ArrayTransformUtils.mapGeoDataToGlideStringArray;
 
-import command_request.CommandRequestOuterClass.Batch;
-import command_request.CommandRequestOuterClass.Command;
-import command_request.CommandRequestOuterClass.Command.ArgsArray;
 import command_request.CommandRequestOuterClass.RequestType;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import glide.api.commands.StringBaseCommands;
 import glide.api.models.commands.ClientPauseMode;
 import glide.api.models.commands.ExpireOptions;
@@ -322,8 +322,9 @@ import glide.api.models.commands.stream.StreamReadGroupOptions;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
 import glide.api.models.configuration.ReadFrom;
-import glide.managers.CommandManager;
 import glide.utils.ArgsBuilder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
 
@@ -343,8 +344,11 @@ import lombok.NonNull;
  * @param <T> child typing for chaining method calls.
  */
 public abstract class BaseBatch<T extends BaseBatch<T>> {
-    /** Command class to send a single request to Valkey. */
-    protected final Batch.Builder protobufBatch;
+    /** Accumulated commands in this batch. */
+    protected final ArrayList<BatchCommand> commands = new ArrayList<>();
+
+    /** Whether this batch is atomic (transaction) or a pipeline. */
+    protected final boolean isAtomic;
 
     /**
      * Flag whether batch commands may return binary data.<br>
@@ -353,15 +357,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     protected boolean binaryOutput = false;
 
-    /**
-     * Returns the protobuf batch builder. Batch builder is intentionally mutable for command
-     * assembly.
-     */
-    @SuppressFBWarnings(
-            value = "EI_EXPOSE_REP",
-            justification = "Batch builder is intentionally mutable for command assembly")
-    public Batch.Builder getProtobufBatch() {
-        return protobufBatch;
+    /** Returns the list of accumulated batch commands. */
+    public List<BatchCommand> getCommands() {
+        return commands;
+    }
+
+    /** Returns whether this batch is atomic (transaction). */
+    public boolean isAtomic() {
+        return isAtomic;
     }
 
     /** Returns whether batch commands may return binary data. */
@@ -376,7 +379,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     }
 
     protected BaseBatch(boolean isAtomic) {
-        this.protobufBatch = Batch.newBuilder().setIsAtomic(isAtomic);
+        this.isAtomic = isAtomic;
     }
 
     protected abstract T getThis();
@@ -394,7 +397,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T customCommand(ArgType[] args) {
         checkTypeOrThrow(args);
-        protobufBatch.addCommands(buildCommand(CustomCommand, newArgsBuilder().add(args)));
+        addCommand(CustomCommand, newArgsBuilder().add(args));
         return getThis();
     }
 
@@ -409,7 +412,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T echo(@NonNull ArgType message) {
         checkTypeOrThrow(message);
-        protobufBatch.addCommands(buildCommand(Echo, newArgsBuilder().add(message)));
+        addCommand(Echo, newArgsBuilder().add(message));
         return getThis();
     }
 
@@ -420,7 +423,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - A response from the server with a <code>String</code>.
      */
     public T ping() {
-        protobufBatch.addCommands(buildCommand(Ping));
+        addCommand(Ping);
         return getThis();
     }
 
@@ -431,7 +434,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - A response from the server with a <code>String</code>.
      */
     public T reset() {
-        protobufBatch.addCommands(buildCommand(Reset));
+        addCommand(Reset);
         return getThis();
     }
 
@@ -446,7 +449,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T ping(@NonNull ArgType msg) {
         checkTypeOrThrow(msg);
-        protobufBatch.addCommands(buildCommand(Ping, newArgsBuilder().add(msg)));
+        addCommand(Ping, newArgsBuilder().add(msg));
         return getThis();
     }
 
@@ -457,7 +460,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - A <code>String</code> with server info.
      */
     public T info() {
-        protobufBatch.addCommands(buildCommand(Info));
+        addCommand(Info);
         return getThis();
     }
 
@@ -471,7 +474,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - A <code>String</code> containing the requested {@link Section}s.
      */
     public T info(@NonNull Section[] sections) {
-        protobufBatch.addCommands(buildCommand(Info, newArgsBuilder().add(sections)));
+        addCommand(Info, newArgsBuilder().add(sections));
         return getThis();
     }
 
@@ -487,7 +490,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T del(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(Del, newArgsBuilder().add(keys)));
+        addCommand(Del, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -504,7 +507,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T get(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Get, newArgsBuilder().add(key)));
+        addCommand(Get, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -520,7 +523,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T getdel(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(GetDel, newArgsBuilder().add(key)));
+        addCommand(GetDel, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -537,7 +540,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T getex(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(GetEx, newArgsBuilder().add(key)));
+        addCommand(GetEx, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -555,7 +558,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T getex(@NonNull ArgType key, @NonNull GetExOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(GetEx, newArgsBuilder().add(key).add(options.toArgs())));
+        addCommand(GetEx, newArgsBuilder().add(key).add(options.toArgs()));
         return getThis();
     }
 
@@ -571,7 +574,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T set(@NonNull ArgType key, @NonNull ArgType value) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Set, newArgsBuilder().add(key).add(value)));
+        addCommand(Set, newArgsBuilder().add(key).add(value));
         return getThis();
     }
 
@@ -593,8 +596,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T set(
             @NonNull ArgType key, @NonNull ArgType value, @NonNull SetOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(Set, newArgsBuilder().add(key).add(value).add(options.toArgsBinary())));
+        addCommand(Set, newArgsBuilder().add(key).add(value).add(options.toArgsBinary()));
         return getThis();
     }
 
@@ -612,7 +614,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T append(@NonNull ArgType key, @NonNull ArgType value) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Append, newArgsBuilder().add(key).add(value)));
+        addCommand(Append, newArgsBuilder().add(key).add(value));
         return getThis();
     }
 
@@ -630,7 +632,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T mget(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(MGet, newArgsBuilder().add(keys)));
+        addCommand(MGet, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -643,7 +645,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T mset(@NonNull Map<?, ?> keyValueMap) {
         GlideString[] args = flattenMapToGlideStringArray(keyValueMap);
-        protobufBatch.addCommands(buildCommand(MSet, newArgsBuilder().add(args)));
+        addCommand(MSet, newArgsBuilder().add(args));
         return getThis();
     }
 
@@ -658,7 +660,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T msetnx(@NonNull Map<?, ?> keyValueMap) {
         GlideString[] args = flattenMapToGlideStringArray(keyValueMap);
-        protobufBatch.addCommands(buildCommand(MSetNX, newArgsBuilder().add(args)));
+        addCommand(MSetNX, newArgsBuilder().add(args));
         return getThis();
     }
 
@@ -677,7 +679,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T move(ArgType key, long dbIndex) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Move, newArgsBuilder().add(key).add(dbIndex)));
+        addCommand(Move, newArgsBuilder().add(key).add(dbIndex));
         return getThis();
     }
 
@@ -693,7 +695,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T incr(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Incr, newArgsBuilder().add(key)));
+        addCommand(Incr, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -710,7 +712,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T incrBy(@NonNull ArgType key, long amount) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(IncrBy, newArgsBuilder().add(key).add(amount)));
+        addCommand(IncrBy, newArgsBuilder().add(key).add(amount));
         return getThis();
     }
 
@@ -729,7 +731,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T incrByFloat(@NonNull ArgType key, double amount) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(IncrByFloat, newArgsBuilder().add(key).add(amount)));
+        addCommand(IncrByFloat, newArgsBuilder().add(key).add(amount));
         return getThis();
     }
 
@@ -745,7 +747,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T decr(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Decr, newArgsBuilder().add(key)));
+        addCommand(Decr, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -762,7 +764,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T decrBy(@NonNull ArgType key, long amount) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(DecrBy, newArgsBuilder().add(key).add(amount)));
+        addCommand(DecrBy, newArgsBuilder().add(key).add(amount));
         return getThis();
     }
 
@@ -779,7 +781,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T strlen(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Strlen, newArgsBuilder().add(key)));
+        addCommand(Strlen, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -801,8 +803,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T setrange(@NonNull ArgType key, int offset, @NonNull ArgType value) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(SetRange, newArgsBuilder().add(key).add(offset).add(value)));
+        addCommand(SetRange, newArgsBuilder().add(key).add(offset).add(value));
         return getThis();
     }
 
@@ -824,8 +825,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T getrange(@NonNull ArgType key, int start, int end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(GetRange, newArgsBuilder().add(key).add(start).add(end)));
+        addCommand(GetRange, newArgsBuilder().add(key).add(start).add(end));
         return getThis();
     }
 
@@ -842,7 +842,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hget(@NonNull ArgType key, @NonNull ArgType field) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HGet, newArgsBuilder().add(key).add(field)));
+        addCommand(HGet, newArgsBuilder().add(key).add(field));
         return getThis();
     }
 
@@ -859,9 +859,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hset(@NonNull ArgType key, @NonNull Map<ArgType, ArgType> fieldValueMap) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HSet, newArgsBuilder().add(key).add(flattenMapToGlideStringArray(fieldValueMap))));
+        addCommand(HSet, newArgsBuilder().add(key).add(flattenMapToGlideStringArray(fieldValueMap)));
         return getThis();
     }
 
@@ -897,15 +895,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull Map<ArgType, ArgType> fieldValueMap,
             @NonNull HSetExOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HSetEx,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(options.toArgs())
-                                .add(FIELDS_VALKEY_API)
-                                .add(fieldValueMap.size())
-                                .add(flattenMapToGlideStringArray(fieldValueMap))));
+        addCommand(
+                HSetEx,
+                newArgsBuilder()
+                        .add(key)
+                        .add(options.toArgs())
+                        .add(FIELDS_VALKEY_API)
+                        .add(fieldValueMap.size())
+                        .add(flattenMapToGlideStringArray(fieldValueMap)));
         return getThis();
     }
 
@@ -939,15 +936,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T hgetex(
             @NonNull ArgType key, @NonNull ArgType[] fields, @NonNull HGetExOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HGetEx,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(options.toArgs())
-                                .add(FIELDS_VALKEY_API)
-                                .add(fields.length)
-                                .add(fields)));
+        addCommand(
+                HGetEx,
+                newArgsBuilder()
+                        .add(key)
+                        .add(options.toArgs())
+                        .add(FIELDS_VALKEY_API)
+                        .add(fields.length)
+                        .add(fields));
         return getThis();
     }
 
@@ -988,16 +984,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType[] fields,
             @NonNull HashFieldExpirationConditionOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HExpire,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(seconds)
-                                .add(options.toArgs())
-                                .add(FIELDS_VALKEY_API)
-                                .add(fields.length)
-                                .add(fields)));
+        addCommand(
+                HExpire,
+                newArgsBuilder()
+                        .add(key)
+                        .add(seconds)
+                        .add(options.toArgs())
+                        .add(FIELDS_VALKEY_API)
+                        .add(fields.length)
+                        .add(fields));
         return getThis();
     }
 
@@ -1021,10 +1016,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hpersist(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HPersist,
-                        newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields)));
+        addCommand(
+                HPersist, newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields));
         return getThis();
     }
 
@@ -1064,16 +1057,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType[] fields,
             @NonNull HashFieldExpirationConditionOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HPExpire,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(milliseconds)
-                                .add(options.toArgs())
-                                .add(FIELDS_VALKEY_API)
-                                .add(fields.length)
-                                .add(fields)));
+        addCommand(
+                HPExpire,
+                newArgsBuilder()
+                        .add(key)
+                        .add(milliseconds)
+                        .add(options.toArgs())
+                        .add(FIELDS_VALKEY_API)
+                        .add(fields.length)
+                        .add(fields));
         return getThis();
     }
 
@@ -1115,16 +1107,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType[] fields,
             @NonNull HashFieldExpirationConditionOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HExpireAt,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(unixSeconds)
-                                .add(options.toArgs())
-                                .add(FIELDS_VALKEY_API)
-                                .add(fields.length)
-                                .add(fields)));
+        addCommand(
+                HExpireAt,
+                newArgsBuilder()
+                        .add(key)
+                        .add(unixSeconds)
+                        .add(options.toArgs())
+                        .add(FIELDS_VALKEY_API)
+                        .add(fields.length)
+                        .add(fields));
         return getThis();
     }
 
@@ -1168,16 +1159,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType[] fields,
             @NonNull HashFieldExpirationConditionOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HPExpireAt,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(unixMilliseconds)
-                                .add(options.toArgs())
-                                .add(FIELDS_VALKEY_API)
-                                .add(fields.length)
-                                .add(fields)));
+        addCommand(
+                HPExpireAt,
+                newArgsBuilder()
+                        .add(key)
+                        .add(unixMilliseconds)
+                        .add(options.toArgs())
+                        .add(FIELDS_VALKEY_API)
+                        .add(fields.length)
+                        .add(fields));
         return getThis();
     }
 
@@ -1199,9 +1189,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T httl(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HTtl, newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields)));
+        addCommand(
+                HTtl, newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields));
         return getThis();
     }
 
@@ -1223,10 +1212,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hpttl(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HPTtl,
-                        newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields)));
+        addCommand(
+                HPTtl, newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields));
         return getThis();
     }
 
@@ -1249,10 +1236,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hexpiretime(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HExpireTime,
-                        newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields)));
+        addCommand(
+                HExpireTime,
+                newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields));
         return getThis();
     }
 
@@ -1276,10 +1262,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hpexpiretime(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        HPExpireTime,
-                        newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields)));
+        addCommand(
+                HPExpireTime,
+                newArgsBuilder().add(key).add(FIELDS_VALKEY_API).add(fields.length).add(fields));
         return getThis();
     }
 
@@ -1300,8 +1285,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hsetnx(@NonNull ArgType key, @NonNull ArgType field, @NonNull ArgType value) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(HSetNX, newArgsBuilder().add(key).add(field).add(value)));
+        addCommand(HSetNX, newArgsBuilder().add(key).add(field).add(value));
         return getThis();
     }
 
@@ -1320,7 +1304,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hdel(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HDel, newArgsBuilder().add(key).add(fields)));
+        addCommand(HDel, newArgsBuilder().add(key).add(fields));
         return getThis();
     }
 
@@ -1337,7 +1321,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hlen(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HLen, newArgsBuilder().add(key)));
+        addCommand(HLen, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1353,7 +1337,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hvals(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HVals, newArgsBuilder().add(key)));
+        addCommand(HVals, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1373,7 +1357,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hmget(@NonNull ArgType key, @NonNull ArgType[] fields) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HMGet, newArgsBuilder().add(key).add(fields)));
+        addCommand(HMGet, newArgsBuilder().add(key).add(fields));
         return getThis();
     }
 
@@ -1391,7 +1375,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hexists(@NonNull ArgType key, @NonNull ArgType field) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HExists, newArgsBuilder().add(key).add(field)));
+        addCommand(HExists, newArgsBuilder().add(key).add(field));
         return getThis();
     }
 
@@ -1408,7 +1392,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hgetall(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HGetAll, newArgsBuilder().add(key)));
+        addCommand(HGetAll, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1431,8 +1415,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hincrBy(@NonNull ArgType key, @NonNull ArgType field, long amount) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(HIncrBy, newArgsBuilder().add(key).add(field).add(amount)));
+        addCommand(HIncrBy, newArgsBuilder().add(key).add(field).add(amount));
         return getThis();
     }
 
@@ -1456,8 +1439,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hincrByFloat(@NonNull ArgType key, @NonNull ArgType field, double amount) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(HIncrByFloat, newArgsBuilder().add(key).add(field).add(amount)));
+        addCommand(HIncrByFloat, newArgsBuilder().add(key).add(field).add(amount));
         return getThis();
     }
 
@@ -1473,7 +1455,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hkeys(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HKeys, newArgsBuilder().add(key)));
+        addCommand(HKeys, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1491,7 +1473,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hstrlen(@NonNull ArgType key, @NonNull ArgType field) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HStrlen, newArgsBuilder().add(key).add(field)));
+        addCommand(HStrlen, newArgsBuilder().add(key).add(field));
         return getThis();
     }
 
@@ -1508,7 +1490,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hrandfield(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HRandField, newArgsBuilder().add(key)));
+        addCommand(HRandField, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1529,7 +1511,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hrandfieldWithCount(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HRandField, newArgsBuilder().add(key).add(count)));
+        addCommand(HRandField, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -1552,8 +1534,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hrandfieldWithCountWithValues(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(HRandField, newArgsBuilder().add(key).add(count).add(WITH_VALUES_VALKEY_API)));
+        addCommand(HRandField, newArgsBuilder().add(key).add(count).add(WITH_VALUES_VALKEY_API));
         return getThis();
     }
 
@@ -1572,7 +1553,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lpush(@NonNull ArgType key, @NonNull ArgType[] elements) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LPush, newArgsBuilder().add(key).add(elements)));
+        addCommand(LPush, newArgsBuilder().add(key).add(elements));
         return getThis();
     }
 
@@ -1589,7 +1570,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lpop(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LPop, newArgsBuilder().add(key)));
+        addCommand(LPop, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1608,7 +1589,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lpos(@NonNull ArgType key, @NonNull ArgType element) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LPos, newArgsBuilder().add(key).add(element)));
+        addCommand(LPos, newArgsBuilder().add(key).add(element));
         return getThis();
     }
 
@@ -1629,8 +1610,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T lpos(
             @NonNull ArgType key, @NonNull ArgType element, @NonNull LPosOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(LPos, newArgsBuilder().add(key).add(element).add(options.toArgs())));
+        addCommand(LPos, newArgsBuilder().add(key).add(element).add(options.toArgs()));
         return getThis();
     }
 
@@ -1649,9 +1629,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lposCount(@NonNull ArgType key, @NonNull ArgType element, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LPos, newArgsBuilder().add(key).add(element).add(COUNT_VALKEY_API).add(count)));
+        addCommand(LPos, newArgsBuilder().add(key).add(element).add(COUNT_VALKEY_API).add(count));
         return getThis();
     }
 
@@ -1673,15 +1651,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T lposCount(
             @NonNull ArgType key, @NonNull ArgType element, long count, @NonNull LPosOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LPos,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(element)
-                                .add(COUNT_VALKEY_API)
-                                .add(count)
-                                .add(options.toArgs())));
+        addCommand(
+                LPos,
+                newArgsBuilder()
+                        .add(key)
+                        .add(element)
+                        .add(COUNT_VALKEY_API)
+                        .add(count)
+                        .add(options.toArgs()));
         return getThis();
     }
 
@@ -1700,7 +1677,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lpopCount(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LPop, newArgsBuilder().add(key).add(count)));
+        addCommand(LPop, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -1727,7 +1704,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lrange(@NonNull ArgType key, long start, long end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LRange, newArgsBuilder().add(key).add(start).add(end)));
+        addCommand(LRange, newArgsBuilder().add(key).add(start).add(end));
         return getThis();
     }
 
@@ -1750,7 +1727,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lindex(@NonNull ArgType key, long index) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LIndex, newArgsBuilder().add(key).add(index)));
+        addCommand(LIndex, newArgsBuilder().add(key).add(index));
         return getThis();
     }
 
@@ -1778,7 +1755,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T ltrim(@NonNull ArgType key, long start, long end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LTrim, newArgsBuilder().add(key).add(start).add(end)));
+        addCommand(LTrim, newArgsBuilder().add(key).add(start).add(end));
         return getThis();
     }
 
@@ -1795,7 +1772,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T llen(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LLen, newArgsBuilder().add(key)));
+        addCommand(LLen, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1821,8 +1798,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lrem(@NonNull ArgType key, long count, @NonNull ArgType element) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(LRem, newArgsBuilder().add(key).add(count).add(element)));
+        addCommand(LRem, newArgsBuilder().add(key).add(count).add(element));
         return getThis();
     }
 
@@ -1841,7 +1817,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T rpush(@NonNull ArgType key, @NonNull ArgType[] elements) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(RPush, newArgsBuilder().add(key).add(elements)));
+        addCommand(RPush, newArgsBuilder().add(key).add(elements));
         return getThis();
     }
 
@@ -1858,7 +1834,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T rpop(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(RPop, newArgsBuilder().add(key)));
+        addCommand(RPop, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1876,7 +1852,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T rpopCount(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(RPop, newArgsBuilder().add(key).add(count)));
+        addCommand(RPop, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -1896,7 +1872,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sadd(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SAdd, newArgsBuilder().add(key).add(members)));
+        addCommand(SAdd, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -1914,7 +1890,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sismember(@NonNull ArgType key, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SIsMember, newArgsBuilder().add(key).add(member)));
+        addCommand(SIsMember, newArgsBuilder().add(key).add(member));
         return getThis();
     }
 
@@ -1934,7 +1910,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T srem(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SRem, newArgsBuilder().add(key).add(members)));
+        addCommand(SRem, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -1950,7 +1926,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T smembers(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SMembers, newArgsBuilder().add(key)));
+        addCommand(SMembers, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1966,7 +1942,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T scard(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SCard, newArgsBuilder().add(key)));
+        addCommand(SCard, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -1983,7 +1959,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sdiff(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(SDiff, newArgsBuilder().add(keys)));
+        addCommand(SDiff, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -2000,7 +1976,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T smismember(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SMIsMember, newArgsBuilder().add(key).add(members)));
+        addCommand(SMIsMember, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -2017,8 +1993,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sdiffstore(@NonNull ArgType destination, @NonNull ArgType[] keys) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(SDiffStore, newArgsBuilder().add(destination).add(keys)));
+        addCommand(SDiffStore, newArgsBuilder().add(destination).add(keys));
         return getThis();
     }
 
@@ -2039,8 +2014,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T smove(
             @NonNull ArgType source, @NonNull ArgType destination, @NonNull ArgType member) {
         checkTypeOrThrow(source);
-        protobufBatch.addCommands(
-                buildCommand(SMove, newArgsBuilder().add(source).add(destination).add(member)));
+        addCommand(SMove, newArgsBuilder().add(source).add(destination).add(member));
         return getThis();
     }
 
@@ -2057,7 +2031,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sinter(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(SInter, newArgsBuilder().add(keys)));
+        addCommand(SInter, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -2074,8 +2048,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sinterstore(@NonNull ArgType destination, @NonNull ArgType[] keys) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(SInterStore, newArgsBuilder().add(destination).add(keys)));
+        addCommand(SInterStore, newArgsBuilder().add(destination).add(keys));
         return getThis();
     }
 
@@ -2092,8 +2065,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sintercard(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(SInterCard, newArgsBuilder().add(keys.length).add(keys)));
+        addCommand(SInterCard, newArgsBuilder().add(keys.length).add(keys));
         return getThis();
     }
 
@@ -2112,10 +2084,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sintercard(@NonNull ArgType[] keys, long limit) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        SInterCard,
-                        newArgsBuilder().add(keys.length).add(keys).add(SET_LIMIT_VALKEY_API).add(limit)));
+        addCommand(
+                SInterCard,
+                newArgsBuilder().add(keys.length).add(keys).add(SET_LIMIT_VALKEY_API).add(limit));
         return getThis();
     }
 
@@ -2132,8 +2103,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sunionstore(@NonNull ArgType destination, @NonNull ArgType[] keys) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(SUnionStore, newArgsBuilder().add(destination).add(keys)));
+        addCommand(SUnionStore, newArgsBuilder().add(destination).add(keys));
         return getThis();
     }
 
@@ -2151,7 +2121,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T configGet(@NonNull ArgType[] parameters) {
         checkTypeOrThrow(parameters);
-        protobufBatch.addCommands(buildCommand(ConfigGet, newArgsBuilder().add(parameters)));
+        addCommand(ConfigGet, newArgsBuilder().add(parameters));
         return getThis();
     }
 
@@ -2167,8 +2137,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public <ArgType> T configSet(@NonNull Map<ArgType, ArgType> parameters) {
-        protobufBatch.addCommands(
-                buildCommand(ConfigSet, newArgsBuilder().add(flattenMapToGlideStringArray(parameters))));
+        addCommand(ConfigSet, newArgsBuilder().add(flattenMapToGlideStringArray(parameters)));
         return getThis();
     }
 
@@ -2184,7 +2153,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T exists(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(Exists, newArgsBuilder().add(keys)));
+        addCommand(Exists, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -2202,7 +2171,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T unlink(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(Unlink, newArgsBuilder().add(keys)));
+        addCommand(Unlink, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -2226,7 +2195,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T expire(@NonNull ArgType key, long seconds) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Expire, newArgsBuilder().add(key).add(seconds)));
+        addCommand(Expire, newArgsBuilder().add(key).add(seconds));
         return getThis();
     }
 
@@ -2253,8 +2222,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T expire(
             @NonNull ArgType key, long seconds, @NonNull ExpireOptions expireOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(Expire, newArgsBuilder().add(key).add(seconds).add(expireOptions.toArgs())));
+        addCommand(Expire, newArgsBuilder().add(key).add(seconds).add(expireOptions.toArgs()));
         return getThis();
     }
 
@@ -2278,7 +2246,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T expireAt(@NonNull ArgType key, long unixSeconds) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ExpireAt, newArgsBuilder().add(key).add(unixSeconds)));
+        addCommand(ExpireAt, newArgsBuilder().add(key).add(unixSeconds));
         return getThis();
     }
 
@@ -2305,9 +2273,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T expireAt(
             @NonNull ArgType key, long unixSeconds, @NonNull ExpireOptions expireOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ExpireAt, newArgsBuilder().add(key).add(unixSeconds).add(expireOptions.toArgs())));
+        addCommand(ExpireAt, newArgsBuilder().add(key).add(unixSeconds).add(expireOptions.toArgs()));
         return getThis();
     }
 
@@ -2331,7 +2297,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pexpire(@NonNull ArgType key, long milliseconds) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(PExpire, newArgsBuilder().add(key).add(milliseconds)));
+        addCommand(PExpire, newArgsBuilder().add(key).add(milliseconds));
         return getThis();
     }
 
@@ -2358,9 +2324,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T pexpire(
             @NonNull ArgType key, long milliseconds, @NonNull ExpireOptions expireOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        PExpire, newArgsBuilder().add(key).add(milliseconds).add(expireOptions.toArgs())));
+        addCommand(PExpire, newArgsBuilder().add(key).add(milliseconds).add(expireOptions.toArgs()));
         return getThis();
     }
 
@@ -2384,8 +2348,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pexpireAt(@NonNull ArgType key, long unixMilliseconds) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(PExpireAt, newArgsBuilder().add(key).add(unixMilliseconds)));
+        addCommand(PExpireAt, newArgsBuilder().add(key).add(unixMilliseconds));
         return getThis();
     }
 
@@ -2412,10 +2375,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T pexpireAt(
             @NonNull ArgType key, long unixMilliseconds, @NonNull ExpireOptions expireOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        PExpireAt,
-                        newArgsBuilder().add(key).add(unixMilliseconds).add(expireOptions.toArgs())));
+        addCommand(
+                PExpireAt, newArgsBuilder().add(key).add(unixMilliseconds).add(expireOptions.toArgs()));
         return getThis();
     }
 
@@ -2431,7 +2392,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T ttl(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(TTL, newArgsBuilder().add(key)));
+        addCommand(TTL, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2451,7 +2412,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T expiretime(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ExpireTime, newArgsBuilder().add(key)));
+        addCommand(ExpireTime, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2471,7 +2432,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pexpiretime(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(PExpireTime, newArgsBuilder().add(key)));
+        addCommand(PExpireTime, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2482,7 +2443,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command response - The id of the client.
      */
     public T clientId() {
-        protobufBatch.addCommands(buildCommand(ClientId));
+        addCommand(ClientId);
         return getThis();
     }
 
@@ -2494,7 +2455,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     <code>null</code> if no name is assigned.
      */
     public T clientGetName() {
-        protobufBatch.addCommands(buildCommand(ClientGetName));
+        addCommand(ClientGetName);
         return getThis();
     }
 
@@ -2506,8 +2467,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> on success.
      */
     public T clientPause(long timeout) {
-        protobufBatch.addCommands(
-                buildCommand(ClientPause, newArgsBuilder().add(Long.toString(timeout))));
+        addCommand(ClientPause, newArgsBuilder().add(Long.toString(timeout)));
         return getThis();
     }
 
@@ -2520,9 +2480,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> on success.
      */
     public T clientPause(long timeout, @NonNull ClientPauseMode mode) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ClientPause, newArgsBuilder().add(Long.toString(timeout)).add(mode.getValkeyApi())));
+        addCommand(ClientPause, newArgsBuilder().add(Long.toString(timeout)).add(mode.getValkeyApi()));
         return getThis();
     }
 
@@ -2533,7 +2491,20 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> on success.
      */
     public T clientUnpause() {
-        protobufBatch.addCommands(buildCommand(ClientUnpause));
+        addCommand(ClientUnpause);
+        return getThis();
+    }
+
+    /**
+     * Returns information about the current client connection's tracking state.
+     *
+     * @see <a href="https://valkey.io/commands/client-trackinginfo/">valkey.io</a> for details.
+     * @return Command response - A {@link Map} with keys: {@code flags} ({@link java.util.Set} of
+     *     tracking flag strings), {@code redirect} ({@link Long}, {@code -1} if not redirecting), and
+     *     {@code prefixes} ({@code Object[]} of monitored key prefixes).
+     */
+    public T clientTrackingInfo() {
+        addCommand(ClientTrackingInfo);
         return getThis();
     }
 
@@ -2544,7 +2515,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T configRewrite() {
-        protobufBatch.addCommands(buildCommand(ConfigRewrite));
+        addCommand(ConfigRewrite);
         return getThis();
     }
 
@@ -2557,7 +2528,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T configResetStat() {
-        protobufBatch.addCommands(buildCommand(ConfigResetStat));
+        addCommand(ConfigResetStat);
         return getThis();
     }
 
@@ -2588,7 +2559,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             args.add("CH");
         }
         args.add(flattenMapToGlideStringArrayValueFirst(membersScoresMap));
-        protobufBatch.addCommands(buildCommand(ZAdd, args));
+        addCommand(ZAdd, args);
         return getThis();
     }
 
@@ -2671,15 +2642,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             double increment,
             @NonNull ZAddOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZAdd,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(options.toArgs())
-                                .add("INCR")
-                                .add(increment)
-                                .add(member)));
+        addCommand(
+                ZAdd,
+                newArgsBuilder().add(key).add(options.toArgs()).add("INCR").add(increment).add(member));
         return getThis();
     }
 
@@ -2719,7 +2684,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrem(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZRem, newArgsBuilder().add(key).add(members)));
+        addCommand(ZRem, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -2736,7 +2701,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zcard(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZCard, newArgsBuilder().add(key)));
+        addCommand(ZCard, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2758,7 +2723,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zpopmin(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZPopMin, newArgsBuilder().add(key).add(count)));
+        addCommand(ZPopMin, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -2776,7 +2741,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zpopmin(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZPopMin, newArgsBuilder().add(key)));
+        addCommand(ZPopMin, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2793,7 +2758,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrandmember(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZRandMember, newArgsBuilder().add(key)));
+        addCommand(ZRandMember, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2813,7 +2778,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrandmemberWithCount(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZRandMember, newArgsBuilder().add(key).add(count)));
+        addCommand(ZRandMember, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -2836,9 +2801,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrandmemberWithCountWithScores(ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZRandMember, newArgsBuilder().add(key).add(count).add(WITH_SCORES_VALKEY_API)));
+        addCommand(ZRandMember, newArgsBuilder().add(key).add(count).add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -2859,8 +2822,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zincrby(@NonNull ArgType key, double increment, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(ZIncrBy, newArgsBuilder().add(key).add(increment).add(member)));
+        addCommand(ZIncrBy, newArgsBuilder().add(key).add(increment).add(member));
         return getThis();
     }
 
@@ -2886,7 +2848,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bzpopmin(@NonNull ArgType[] keys, double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(BZPopMin, newArgsBuilder().add(keys).add(timeout)));
+        addCommand(BZPopMin, newArgsBuilder().add(keys).add(timeout));
         return getThis();
     }
 
@@ -2908,7 +2870,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zpopmax(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZPopMax, newArgsBuilder().add(key).add(count)));
+        addCommand(ZPopMax, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -2926,7 +2888,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zpopmax(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZPopMax, newArgsBuilder().add(key)));
+        addCommand(ZPopMax, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -2952,7 +2914,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bzpopmax(@NonNull ArgType[] keys, double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(BZPopMax, newArgsBuilder().add(keys).add(timeout)));
+        addCommand(BZPopMax, newArgsBuilder().add(keys).add(timeout));
         return getThis();
     }
 
@@ -2970,7 +2932,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zscore(@NonNull ArgType key, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZScore, newArgsBuilder().add(key).add(member)));
+        addCommand(ZScore, newArgsBuilder().add(key).add(member));
         return getThis();
     }
 
@@ -2990,7 +2952,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrank(@NonNull ArgType key, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZRank, newArgsBuilder().add(key).add(member)));
+        addCommand(ZRank, newArgsBuilder().add(key).add(member));
         return getThis();
     }
 
@@ -3011,8 +2973,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrankWithScore(@NonNull ArgType key, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(ZRank, newArgsBuilder().add(key).add(member).add(WITH_SCORE_VALKEY_API)));
+        addCommand(ZRank, newArgsBuilder().add(key).add(member).add(WITH_SCORE_VALKEY_API));
         return getThis();
     }
 
@@ -3033,7 +2994,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrevrank(@NonNull ArgType key, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZRevRank, newArgsBuilder().add(key).add(member)));
+        addCommand(ZRevRank, newArgsBuilder().add(key).add(member));
         return getThis();
     }
 
@@ -3055,8 +3016,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrevrankWithScore(@NonNull ArgType key, @NonNull ArgType member) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(ZRevRank, newArgsBuilder().add(key).add(member).add(WITH_SCORE_VALKEY_API)));
+        addCommand(ZRevRank, newArgsBuilder().add(key).add(member).add(WITH_SCORE_VALKEY_API));
         return getThis();
     }
 
@@ -3075,7 +3035,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zmscore(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZMScore, newArgsBuilder().add(key).add(members)));
+        addCommand(ZMScore, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -3095,7 +3055,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zdiff(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(ZDiff, newArgsBuilder().add(keys.length).add(keys)));
+        addCommand(ZDiff, newArgsBuilder().add(keys.length).add(keys));
         return getThis();
     }
 
@@ -3114,9 +3074,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zdiffWithScores(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZDiff, newArgsBuilder().add(keys.length).add(keys).add(WITH_SCORES_VALKEY_API)));
+        addCommand(ZDiff, newArgsBuilder().add(keys.length).add(keys).add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3136,8 +3094,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zdiffstore(@NonNull ArgType destination, @NonNull ArgType[] keys) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(ZDiffStore, newArgsBuilder().add(destination).add(keys.length).add(keys)));
+        addCommand(ZDiffStore, newArgsBuilder().add(destination).add(keys.length).add(keys));
         return getThis();
     }
 
@@ -3163,9 +3120,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T zcount(
             @NonNull ArgType key, @NonNull ScoreRange minScore, @NonNull ScoreRange maxScore) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZCount, newArgsBuilder().add(key).add(minScore.toArgs()).add(maxScore.toArgs())));
+        addCommand(ZCount, newArgsBuilder().add(key).add(minScore.toArgs()).add(maxScore.toArgs()));
         return getThis();
     }
 
@@ -3190,8 +3145,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zremrangebyrank(@NonNull ArgType key, long start, long end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(ZRemRangeByRank, newArgsBuilder().add(key).add(start).add(end)));
+        addCommand(ZRemRangeByRank, newArgsBuilder().add(key).add(start).add(end));
         return getThis();
     }
 
@@ -3222,13 +3176,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull RangeQuery rangeQuery,
             boolean reverse) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZRangeStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(source)
-                                .add(RangeOptions.createZRangeBaseArgs(rangeQuery, reverse, false))));
+        addCommand(
+                ZRangeStore,
+                newArgsBuilder()
+                        .add(destination)
+                        .add(source)
+                        .add(RangeOptions.createZRangeBaseArgs(rangeQuery, reverse, false)));
         return getThis();
     }
 
@@ -3279,9 +3232,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T zremrangebylex(
             @NonNull ArgType key, @NonNull LexRange minLex, @NonNull LexRange maxLex) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZRemRangeByLex, newArgsBuilder().add(key).add(minLex.toArgs()).add(maxLex.toArgs())));
+        addCommand(ZRemRangeByLex, newArgsBuilder().add(key).add(minLex.toArgs()).add(maxLex.toArgs()));
         return getThis();
     }
 
@@ -3307,10 +3258,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T zremrangebyscore(
             @NonNull ArgType key, @NonNull ScoreRange minScore, @NonNull ScoreRange maxScore) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZRemRangeByScore,
-                        newArgsBuilder().add(key).add(minScore.toArgs()).add(maxScore.toArgs())));
+        addCommand(
+                ZRemRangeByScore, newArgsBuilder().add(key).add(minScore.toArgs()).add(maxScore.toArgs()));
         return getThis();
     }
 
@@ -3336,9 +3285,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T zlexcount(
             @NonNull ArgType key, @NonNull LexRange minLex, @NonNull LexRange maxLex) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZLexCount, newArgsBuilder().add(key).add(minLex.toArgs()).add(maxLex.toArgs())));
+        addCommand(ZLexCount, newArgsBuilder().add(key).add(minLex.toArgs()).add(maxLex.toArgs()));
         return getThis();
     }
 
@@ -3365,13 +3312,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull String destination,
             @NonNull KeysOrWeightedKeys keysOrWeightedKeys,
             @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnionStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())));
+        addCommand(
+                ZUnionStore,
+                newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()).add(aggregate.toArgs()));
         return getThis();
     }
 
@@ -3398,13 +3341,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GlideString destination,
             @NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys,
             @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnionStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())));
+        addCommand(
+                ZUnionStore,
+                newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()).add(aggregate.toArgs()));
         return getThis();
     }
 
@@ -3426,9 +3365,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zunionstore(
             @NonNull String destination, @NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnionStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs())));
+        addCommand(ZUnionStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()));
         return getThis();
     }
 
@@ -3450,9 +3387,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zunionstore(
             @NonNull GlideString destination, @NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnionStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs())));
+        addCommand(ZUnionStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()));
         return getThis();
     }
 
@@ -3479,13 +3414,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull String destination,
             @NonNull KeysOrWeightedKeys keysOrWeightedKeys,
             @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInterStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())));
+        addCommand(
+                ZInterStore,
+                newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()).add(aggregate.toArgs()));
         return getThis();
     }
 
@@ -3512,13 +3443,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GlideString destination,
             @NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys,
             @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInterStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())));
+        addCommand(
+                ZInterStore,
+                newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()).add(aggregate.toArgs()));
         return getThis();
     }
 
@@ -3534,8 +3461,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zintercard(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(ZInterCard, newArgsBuilder().add(keys.length).add(keys)));
+        addCommand(ZInterCard, newArgsBuilder().add(keys.length).add(keys));
         return getThis();
     }
 
@@ -3556,10 +3482,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zintercard(@NonNull ArgType[] keys, long limit) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInterCard,
-                        newArgsBuilder().add(keys.length).add(keys).add(LIMIT_VALKEY_API).add(limit)));
+        addCommand(
+                ZInterCard, newArgsBuilder().add(keys.length).add(keys).add(LIMIT_VALKEY_API).add(limit));
         return getThis();
     }
 
@@ -3583,9 +3507,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zinterstore(
             @NonNull String destination, @NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInterStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs())));
+        addCommand(ZInterStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()));
         return getThis();
     }
 
@@ -3609,9 +3531,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zinterstore(
             @NonNull GlideString destination, @NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInterStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs())));
+        addCommand(ZInterStore, newArgsBuilder().add(destination).add(keysOrWeightedKeys.toArgs()));
         return getThis();
     }
 
@@ -3625,7 +3545,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the union.
      */
     public T zunion(@NonNull KeyArray keys) {
-        protobufBatch.addCommands(buildCommand(ZUnion, newArgsBuilder().add(keys.toArgs())));
+        addCommand(ZUnion, newArgsBuilder().add(keys.toArgs()));
         return getThis();
     }
 
@@ -3639,7 +3559,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the union.
      */
     public T zunion(@NonNull KeyArrayBinary keys) {
-        protobufBatch.addCommands(buildCommand(ZUnion, newArgsBuilder().add(keys.toArgs())));
+        addCommand(ZUnion, newArgsBuilder().add(keys.toArgs()));
         return getThis();
     }
 
@@ -3661,13 +3581,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zunionWithScores(
             @NonNull KeysOrWeightedKeys keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnion,
-                        newArgsBuilder()
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())
-                                .add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZUnion,
+                newArgsBuilder()
+                        .add(keysOrWeightedKeys.toArgs())
+                        .add(aggregate.toArgs())
+                        .add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3689,13 +3608,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zunionWithScores(
             @NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnion,
-                        newArgsBuilder()
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())
-                                .add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZUnion,
+                newArgsBuilder()
+                        .add(keysOrWeightedKeys.toArgs())
+                        .add(aggregate.toArgs())
+                        .add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3716,9 +3634,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the union.
      */
     public T zunionWithScores(@NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnion, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZUnion, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3739,9 +3656,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the union.
      */
     public T zunionWithScores(@NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZUnion, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZUnion, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3756,7 +3672,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the intersection.
      */
     public T zinter(@NonNull KeyArray keys) {
-        protobufBatch.addCommands(buildCommand(ZInter, newArgsBuilder().add(keys.toArgs())));
+        addCommand(ZInter, newArgsBuilder().add(keys.toArgs()));
         return getThis();
     }
 
@@ -3771,7 +3687,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the intersection.
      */
     public T zinter(@NonNull KeyArrayBinary keys) {
-        protobufBatch.addCommands(buildCommand(ZInter, newArgsBuilder().add(keys.toArgs())));
+        addCommand(ZInter, newArgsBuilder().add(keys.toArgs()));
         return getThis();
     }
 
@@ -3791,9 +3707,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the intersection.
      */
     public T zinterWithScores(@NonNull KeysOrWeightedKeys keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInter, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZInter, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3813,9 +3728,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The resulting sorted set from the intersection.
      */
     public T zinterWithScores(@NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInter, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZInter, newArgsBuilder().add(keysOrWeightedKeys.toArgs()).add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3837,13 +3751,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zinterWithScores(
             @NonNull KeysOrWeightedKeys keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInter,
-                        newArgsBuilder()
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())
-                                .add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZInter,
+                newArgsBuilder()
+                        .add(keysOrWeightedKeys.toArgs())
+                        .add(aggregate.toArgs())
+                        .add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3865,13 +3778,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public T zinterWithScores(
             @NonNull KeysOrWeightedKeysBinary keysOrWeightedKeys, @NonNull Aggregate aggregate) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZInter,
-                        newArgsBuilder()
-                                .add(keysOrWeightedKeys.toArgs())
-                                .add(aggregate.toArgs())
-                                .add(WITH_SCORES_VALKEY_API)));
+        addCommand(
+                ZInter,
+                newArgsBuilder()
+                        .add(keysOrWeightedKeys.toArgs())
+                        .add(aggregate.toArgs())
+                        .add(WITH_SCORES_VALKEY_API));
         return getThis();
     }
 
@@ -3927,13 +3839,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull Map<ArgType, ArgType> values,
             @NonNull StreamAddOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XAdd,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(options.toArgs())
-                                .add(flattenMapToGlideStringArray(values))));
+        addCommand(
+                XAdd,
+                newArgsBuilder().add(key).add(options.toArgs()).add(flattenMapToGlideStringArray(values)));
         return getThis();
     }
 
@@ -3955,13 +3863,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xadd(
             @NonNull ArgType key, @NonNull ArgType[][] values, @NonNull StreamAddOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XAdd,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(options.toArgs())
-                                .add(flattenNestedArrayToGlideStringArray(values))));
+        addCommand(
+                XAdd,
+                newArgsBuilder()
+                        .add(key)
+                        .add(options.toArgs())
+                        .add(flattenNestedArrayToGlideStringArray(values)));
         return getThis();
     }
 
@@ -3998,12 +3905,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xread(
             @NonNull Map<ArgType, ArgType> keysAndIds, @NonNull StreamReadOptions options) {
         checkTypeOrThrow(keysAndIds);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XRead,
-                        newArgsBuilder()
-                                .add(options.toArgs())
-                                .add(flattenAllKeysFollowedByAllValues(keysAndIds))));
+        addCommand(
+                XRead,
+                newArgsBuilder().add(options.toArgs()).add(flattenAllKeysFollowedByAllValues(keysAndIds)));
         return getThis();
     }
 
@@ -4019,7 +3923,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T xtrim(@NonNull ArgType key, @NonNull StreamTrimOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(XTrim, newArgsBuilder().add(key).add(options.toArgs())));
+        addCommand(XTrim, newArgsBuilder().add(key).add(options.toArgs()));
         return getThis();
     }
 
@@ -4035,7 +3939,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T xlen(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(XLen, newArgsBuilder().add(key)));
+        addCommand(XLen, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -4053,7 +3957,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T xdel(@NonNull ArgType key, @NonNull ArgType[] ids) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(XDel, newArgsBuilder().add(key).add(ids)));
+        addCommand(XDel, newArgsBuilder().add(key).add(ids));
         return getThis();
     }
 
@@ -4086,8 +3990,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xrange(
             @NonNull ArgType key, @NonNull StreamRange start, @NonNull StreamRange end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XRange, newArgsBuilder().add(key).add(StreamRange.toArgs(start, end))));
+        addCommand(XRange, newArgsBuilder().add(key).add(StreamRange.toArgs(start, end)));
         return getThis();
     }
 
@@ -4122,8 +4025,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xrange(
             @NonNull ArgType key, @NonNull StreamRange start, @NonNull StreamRange end, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XRange, newArgsBuilder().add(key).add(StreamRange.toArgs(start, end, count))));
+        addCommand(XRange, newArgsBuilder().add(key).add(StreamRange.toArgs(start, end, count)));
         return getThis();
     }
 
@@ -4158,8 +4060,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xrevrange(
             @NonNull ArgType key, @NonNull StreamRange end, @NonNull StreamRange start) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XRevRange, newArgsBuilder().add(key).add(StreamRange.toArgs(end, start))));
+        addCommand(XRevRange, newArgsBuilder().add(key).add(StreamRange.toArgs(end, start)));
         return getThis();
     }
 
@@ -4196,9 +4097,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xrevrange(
             @NonNull ArgType key, @NonNull StreamRange end, @NonNull StreamRange start, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XRevRange, newArgsBuilder().add(key).add(StreamRange.toArgs(end, start, count))));
+        addCommand(XRevRange, newArgsBuilder().add(key).add(StreamRange.toArgs(end, start, count)));
         return getThis();
     }
 
@@ -4219,8 +4118,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xgroupCreate(
             @NonNull ArgType key, @NonNull ArgType groupName, @NonNull ArgType id) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XGroupCreate, newArgsBuilder().add(key).add(groupName).add(id)));
+        addCommand(XGroupCreate, newArgsBuilder().add(key).add(groupName).add(id));
         return getThis();
     }
 
@@ -4245,9 +4143,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType id,
             @NonNull StreamGroupOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XGroupCreate, newArgsBuilder().add(key).add(groupName).add(id).add(options.toArgs())));
+        addCommand(
+                XGroupCreate, newArgsBuilder().add(key).add(groupName).add(id).add(options.toArgs()));
         return getThis();
     }
 
@@ -4264,8 +4161,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T xgroupDestroy(@NonNull ArgType key, @NonNull ArgType groupName) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XGroupDestroy, newArgsBuilder().add(key).add(groupName)));
+        addCommand(XGroupDestroy, newArgsBuilder().add(key).add(groupName));
         return getThis();
     }
 
@@ -4285,8 +4181,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xgroupCreateConsumer(
             @NonNull ArgType key, @NonNull ArgType group, @NonNull ArgType consumer) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XGroupCreateConsumer, newArgsBuilder().add(key).add(group).add(consumer)));
+        addCommand(XGroupCreateConsumer, newArgsBuilder().add(key).add(group).add(consumer));
         return getThis();
     }
 
@@ -4305,8 +4200,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xgroupDelConsumer(
             @NonNull ArgType key, @NonNull ArgType group, @NonNull ArgType consumer) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XGroupDelConsumer, newArgsBuilder().add(key).add(group).add(consumer)));
+        addCommand(XGroupDelConsumer, newArgsBuilder().add(key).add(group).add(consumer));
         return getThis();
     }
 
@@ -4325,8 +4219,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xgroupSetId(
             @NonNull ArgType key, @NonNull ArgType groupName, @NonNull ArgType id) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(XGroupSetId, newArgsBuilder().add(key).add(groupName).add(id)));
+        addCommand(XGroupSetId, newArgsBuilder().add(key).add(groupName).add(id));
         return getThis();
     }
 
@@ -4347,15 +4240,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T xgroupSetId(
             @NonNull ArgType key, @NonNull ArgType groupName, @NonNull ArgType id, long entriesRead) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XGroupSetId,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(groupName)
-                                .add(id)
-                                .add(ENTRIES_READ_VALKEY_API)
-                                .add(entriesRead)));
+        addCommand(
+                XGroupSetId,
+                newArgsBuilder()
+                        .add(key)
+                        .add(groupName)
+                        .add(id)
+                        .add(ENTRIES_READ_VALKEY_API)
+                        .add(entriesRead));
         return getThis();
     }
 
@@ -4406,12 +4298,11 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType consumer,
             @NonNull StreamReadGroupOptions options) {
         checkTypeOrThrow(group);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XReadGroup,
-                        newArgsBuilder()
-                                .add(options.toArgs(group, consumer))
-                                .add(flattenAllKeysFollowedByAllValues(keysAndIds))));
+        addCommand(
+                XReadGroup,
+                newArgsBuilder()
+                        .add(options.toArgs(group, consumer))
+                        .add(flattenAllKeysFollowedByAllValues(keysAndIds)));
         return getThis();
     }
 
@@ -4429,7 +4320,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T xack(@NonNull ArgType key, @NonNull ArgType group, @NonNull ArgType[] ids) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(XAck, newArgsBuilder().add(key).add(group).add(ids)));
+        addCommand(XAck, newArgsBuilder().add(key).add(group).add(ids));
         return getThis();
     }
 
@@ -4456,7 +4347,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T xpending(@NonNull ArgType key, @NonNull ArgType group) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(XPending, newArgsBuilder().add(key).add(group)));
+        addCommand(XPending, newArgsBuilder().add(key).add(group));
         return getThis();
     }
 
@@ -4551,9 +4442,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             long count,
             @NonNull StreamPendingOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XPending, newArgsBuilder().add(key).add(group).add(options.toArgs(start, end, count))));
+        addCommand(
+                XPending, newArgsBuilder().add(key).add(group).add(options.toArgs(start, end, count)));
         return getThis();
     }
 
@@ -4569,7 +4459,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     </code>.
      */
     public <ArgType> T xinfoStream(@NonNull ArgType key) {
-        protobufBatch.addCommands(buildCommand(XInfoStream, newArgsBuilder().add(key)));
+        addCommand(XInfoStream, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -4585,7 +4475,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     <code>key</code>.
      */
     public <ArgType> T xinfoStreamFull(@NonNull ArgType key) {
-        protobufBatch.addCommands(buildCommand(XInfoStream, newArgsBuilder().add(key).add(FULL)));
+        addCommand(XInfoStream, newArgsBuilder().add(key).add(FULL));
         return getThis();
     }
 
@@ -4603,10 +4493,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     <code>key</code>.
      */
     public <ArgType> T xinfoStreamFull(@NonNull ArgType key, int count) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        XInfoStream,
-                        newArgsBuilder().add(key).add(FULL).add(COUNT).add(Integer.toString(count))));
+        addCommand(
+                XInfoStream, newArgsBuilder().add(key).add(FULL).add(COUNT).add(Integer.toString(count)));
         return getThis();
     }
 
@@ -4631,9 +4519,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             long minIdleTime,
             @NonNull ArgType[] ids) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XClaim, newArgsBuilder().add(key).add(group).add(consumer).add(minIdleTime).add(ids)));
+        addCommand(
+                XClaim, newArgsBuilder().add(key).add(group).add(consumer).add(minIdleTime).add(ids));
         return getThis();
     }
 
@@ -4660,16 +4547,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType[] ids,
             @NonNull StreamClaimOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XClaim,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(group)
-                                .add(consumer)
-                                .add(minIdleTime)
-                                .add(ids)
-                                .add(options.toArgs())));
+        addCommand(
+                XClaim,
+                newArgsBuilder()
+                        .add(key)
+                        .add(group)
+                        .add(consumer)
+                        .add(minIdleTime)
+                        .add(ids)
+                        .add(options.toArgs()));
         return getThis();
     }
 
@@ -4694,16 +4580,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             long minIdleTime,
             @NonNull ArgType[] ids) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XClaim,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(group)
-                                .add(consumer)
-                                .add(minIdleTime)
-                                .add(ids)
-                                .add(JUST_ID_VALKEY_API)));
+        addCommand(
+                XClaim,
+                newArgsBuilder()
+                        .add(key)
+                        .add(group)
+                        .add(consumer)
+                        .add(minIdleTime)
+                        .add(ids)
+                        .add(JUST_ID_VALKEY_API));
         return getThis();
     }
 
@@ -4730,17 +4615,16 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType[] ids,
             @NonNull StreamClaimOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        XClaim,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(group)
-                                .add(consumer)
-                                .add(minIdleTime)
-                                .add(ids)
-                                .add(options.toArgs())
-                                .add(JUST_ID_VALKEY_API)));
+        addCommand(
+                XClaim,
+                newArgsBuilder()
+                        .add(key)
+                        .add(group)
+                        .add(consumer)
+                        .add(minIdleTime)
+                        .add(ids)
+                        .add(options.toArgs())
+                        .add(JUST_ID_VALKEY_API));
         return getThis();
     }
 
@@ -4754,7 +4638,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     represents the attributes of a consumer group for the stream at <code>key</code>.
      */
     public <ArgType> T xinfoGroups(@NonNull ArgType key) {
-        protobufBatch.addCommands(buildCommand(XInfoGroups, newArgsBuilder().add(key)));
+        addCommand(XInfoGroups, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -4770,8 +4654,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     key</code>.
      */
     public <ArgType> T xinfoConsumers(@NonNull ArgType key, @NonNull ArgType groupName) {
-        protobufBatch.addCommands(
-                buildCommand(XInfoConsumers, newArgsBuilder().add(key).add(groupName)));
+        addCommand(XInfoConsumers, newArgsBuilder().add(key).add(groupName));
         return getThis();
     }
 
@@ -4807,10 +4690,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType consumer,
             long minIdleTime,
             @NonNull ArgType start) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        XAutoClaim,
-                        newArgsBuilder().add(key).add(group).add(consumer).add(minIdleTime).add(start)));
+        addCommand(
+                XAutoClaim, newArgsBuilder().add(key).add(group).add(consumer).add(minIdleTime).add(start));
         return getThis();
     }
 
@@ -4848,17 +4729,16 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             long minIdleTime,
             @NonNull ArgType start,
             long count) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        XAutoClaim,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(group)
-                                .add(consumer)
-                                .add(minIdleTime)
-                                .add(start)
-                                .add(READ_COUNT_VALKEY_API)
-                                .add(count)));
+        addCommand(
+                XAutoClaim,
+                newArgsBuilder()
+                        .add(key)
+                        .add(group)
+                        .add(consumer)
+                        .add(minIdleTime)
+                        .add(start)
+                        .add(READ_COUNT_VALKEY_API)
+                        .add(count));
         return getThis();
     }
 
@@ -4894,16 +4774,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType consumer,
             long minIdleTime,
             @NonNull ArgType start) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        XAutoClaim,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(group)
-                                .add(consumer)
-                                .add(minIdleTime)
-                                .add(start)
-                                .add(JUST_ID_VALKEY_API)));
+        addCommand(
+                XAutoClaim,
+                newArgsBuilder()
+                        .add(key)
+                        .add(group)
+                        .add(consumer)
+                        .add(minIdleTime)
+                        .add(start)
+                        .add(JUST_ID_VALKEY_API));
         return getThis();
     }
 
@@ -4941,18 +4820,17 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             long minIdleTime,
             @NonNull ArgType start,
             long count) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        XAutoClaim,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(group)
-                                .add(consumer)
-                                .add(minIdleTime)
-                                .add(start)
-                                .add(READ_COUNT_VALKEY_API)
-                                .add(count)
-                                .add(JUST_ID_VALKEY_API)));
+        addCommand(
+                XAutoClaim,
+                newArgsBuilder()
+                        .add(key)
+                        .add(group)
+                        .add(consumer)
+                        .add(minIdleTime)
+                        .add(start)
+                        .add(READ_COUNT_VALKEY_API)
+                        .add(count)
+                        .add(JUST_ID_VALKEY_API));
         return getThis();
     }
 
@@ -4968,7 +4846,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pttl(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(PTTL, newArgsBuilder().add(key)));
+        addCommand(PTTL, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -4986,7 +4864,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T persist(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Persist, newArgsBuilder().add(key)));
+        addCommand(Persist, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5000,7 +4878,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     </code> format.
      */
     public T time() {
-        protobufBatch.addCommands(buildCommand(Time));
+        addCommand(Time);
         return getThis();
     }
 
@@ -5012,7 +4890,54 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>UNIX TIME</code> of the last DB save executed with success.
      */
     public T lastsave() {
-        protobufBatch.addCommands(buildCommand(LastSave));
+        addCommand(LastSave);
+        return getThis();
+    }
+
+    /**
+     * Returns the latency spike time series for the specified event.
+     *
+     * @see <a href="https://valkey.io/commands/latency-history/">valkey.io</a> for details.
+     * @param event The name of the latency event (e.g., <code>"command"</code>).
+     * @return Command Response - An array of {@link LatencyEntry} for the event, or an empty array if
+     *     the event doesn't exist.
+     */
+    public T latencyHistory(@NonNull String event) {
+        addCommand(LatencyHistory, newArgsBuilder().add(event));
+        return getThis();
+    }
+
+    /**
+     * Reports the latest latency events logged by the server.
+     *
+     * @see <a href="https://valkey.io/commands/latency-latest/">valkey.io</a> for details.
+     * @return Command Response - An array of {@link LatencyEventInfo} for the latest latency events.
+     */
+    public T latencyLatest() {
+        addCommand(LatencyLatest);
+        return getThis();
+    }
+
+    /**
+     * Resets the latency spike time series for all events.
+     *
+     * @see <a href="https://valkey.io/commands/latency-reset/">valkey.io</a> for details.
+     * @return Command Response - The number of event time series that were reset.
+     */
+    public T latencyReset() {
+        addCommand(LatencyReset);
+        return getThis();
+    }
+
+    /**
+     * Resets the latency spike time series for the specified events.
+     *
+     * @see <a href="https://valkey.io/commands/latency-reset/">valkey.io</a> for details.
+     * @param events The names of the latency events to reset.
+     * @return Command Response - The number of event time series that were reset.
+     */
+    public T latencyReset(@NonNull String[] events) {
+        addCommand(LatencyReset, newArgsBuilder().add(events));
         return getThis();
     }
 
@@ -5023,7 +4948,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T flushall() {
-        protobufBatch.addCommands(buildCommand(FlushAll));
+        addCommand(FlushAll);
         return getThis();
     }
 
@@ -5036,7 +4961,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T flushall(FlushMode mode) {
-        protobufBatch.addCommands(buildCommand(FlushAll, newArgsBuilder().add(mode)));
+        addCommand(FlushAll, newArgsBuilder().add(mode));
         return getThis();
     }
 
@@ -5047,7 +4972,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T flushdb() {
-        protobufBatch.addCommands(buildCommand(FlushDB));
+        addCommand(FlushDB);
         return getThis();
     }
 
@@ -5060,7 +4985,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T flushdb(FlushMode mode) {
-        protobufBatch.addCommands(buildCommand(FlushDB, newArgsBuilder().add(mode)));
+        addCommand(FlushDB, newArgsBuilder().add(mode));
         return getThis();
     }
 
@@ -5072,7 +4997,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     version.
      */
     public T lolwut() {
-        protobufBatch.addCommands(buildCommand(Lolwut));
+        addCommand(Lolwut);
         return getThis();
     }
 
@@ -5093,7 +5018,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     version.
      */
     public T lolwut(int @NonNull [] parameters) {
-        protobufBatch.addCommands(buildCommand(Lolwut, newArgsBuilder().add(parameters)));
+        addCommand(Lolwut, newArgsBuilder().add(parameters));
         return getThis();
     }
 
@@ -5107,8 +5032,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     version.
      */
     public T lolwut(int version) {
-        protobufBatch.addCommands(
-                buildCommand(Lolwut, newArgsBuilder().add(VERSION_VALKEY_API).add(version)));
+        addCommand(Lolwut, newArgsBuilder().add(VERSION_VALKEY_API).add(version));
         return getThis();
     }
 
@@ -5129,9 +5053,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     version.
      */
     public T lolwut(int version, int @NonNull [] parameters) {
-        protobufBatch.addCommands(
-                buildCommand(
-                        Lolwut, newArgsBuilder().add(VERSION_VALKEY_API).add(version).add(parameters)));
+        addCommand(Lolwut, newArgsBuilder().add(VERSION_VALKEY_API).add(version).add(parameters));
         return getThis();
     }
 
@@ -5142,7 +5064,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The number of keys in the currently selected database.
      */
     public T dbsize() {
-        protobufBatch.addCommands(buildCommand(DBSize));
+        addCommand(DBSize);
         return getThis();
     }
 
@@ -5158,7 +5080,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T type(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Type, newArgsBuilder().add(key)));
+        addCommand(Type, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5169,7 +5091,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - A random <code>key</code> from the database.
      */
     public T randomKey() {
-        protobufBatch.addCommands(buildCommand(RandomKey));
+        addCommand(RandomKey);
         return getThis();
     }
 
@@ -5187,7 +5109,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T rename(@NonNull ArgType key, @NonNull ArgType newKey) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Rename, newArgsBuilder().add(key).add(newKey)));
+        addCommand(Rename, newArgsBuilder().add(key).add(newKey));
         return getThis();
     }
 
@@ -5204,7 +5126,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T renamenx(@NonNull ArgType key, @NonNull ArgType newKey) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(RenameNX, newArgsBuilder().add(key).add(newKey)));
+        addCommand(RenameNX, newArgsBuilder().add(key).add(newKey));
         return getThis();
     }
 
@@ -5230,8 +5152,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType pivot,
             @NonNull ArgType element) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(LInsert, newArgsBuilder().add(key).add(position).add(pivot).add(element)));
+        addCommand(LInsert, newArgsBuilder().add(key).add(position).add(pivot).add(element));
         return getThis();
     }
 
@@ -5256,7 +5177,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T brpop(@NonNull ArgType[] keys, double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(BRPop, newArgsBuilder().add(keys).add(timeout)));
+        addCommand(BRPop, newArgsBuilder().add(keys).add(timeout));
         return getThis();
     }
 
@@ -5274,7 +5195,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lpushx(@NonNull ArgType key, @NonNull ArgType[] elements) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(LPushX, newArgsBuilder().add(key).add(elements)));
+        addCommand(LPushX, newArgsBuilder().add(key).add(elements));
         return getThis();
     }
 
@@ -5292,7 +5213,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T rpushx(@NonNull ArgType key, @NonNull ArgType[] elements) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(RPushX, newArgsBuilder().add(key).add(elements)));
+        addCommand(RPushX, newArgsBuilder().add(key).add(elements));
         return getThis();
     }
 
@@ -5317,7 +5238,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T blpop(@NonNull ArgType[] keys, double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(BLPop, newArgsBuilder().add(keys).add(timeout)));
+        addCommand(BLPop, newArgsBuilder().add(keys).add(timeout));
         return getThis();
     }
 
@@ -5346,12 +5267,11 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zrange(@NonNull ArgType key, @NonNull RangeQuery rangeQuery, boolean reverse) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZRange,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(RangeOptions.createZRangeBaseArgs(rangeQuery, reverse, false))));
+        addCommand(
+                ZRange,
+                newArgsBuilder()
+                        .add(key)
+                        .add(RangeOptions.createZRangeBaseArgs(rangeQuery, reverse, false)));
         return getThis();
     }
 
@@ -5403,12 +5323,11 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T zrangeWithScores(
             @NonNull ArgType key, @NonNull ScoredRangeQuery rangeQuery, boolean reverse) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZRange,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(RangeOptions.createZRangeBaseArgs(rangeQuery, reverse, true))));
+        addCommand(
+                ZRange,
+                newArgsBuilder()
+                        .add(key)
+                        .add(RangeOptions.createZRangeBaseArgs(rangeQuery, reverse, true)));
         return getThis();
     }
 
@@ -5452,8 +5371,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zmpop(@NonNull ArgType[] keys, @NonNull ScoreFilter modifier) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(ZMPop, newArgsBuilder().add(keys.length).add(keys).add(modifier)));
+        addCommand(ZMPop, newArgsBuilder().add(keys.length).add(keys).add(modifier));
         return getThis();
     }
 
@@ -5476,15 +5394,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zmpop(@NonNull ArgType[] keys, @NonNull ScoreFilter modifier, long count) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        ZMPop,
-                        newArgsBuilder()
-                                .add(keys.length)
-                                .add(keys)
-                                .add(modifier)
-                                .add(COUNT_VALKEY_API)
-                                .add(count)));
+        addCommand(
+                ZMPop,
+                newArgsBuilder().add(keys.length).add(keys).add(modifier).add(COUNT_VALKEY_API).add(count));
         return getThis();
     }
 
@@ -5513,9 +5425,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T bzmpop(
             @NonNull ArgType[] keys, @NonNull ScoreFilter modifier, double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BZMPop, newArgsBuilder().add(timeout).add(keys.length).add(keys).add(modifier)));
+        addCommand(BZMPop, newArgsBuilder().add(timeout).add(keys.length).add(keys).add(modifier));
         return getThis();
     }
 
@@ -5546,16 +5456,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T bzmpop(
             @NonNull ArgType[] keys, @NonNull ScoreFilter modifier, double timeout, long count) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BZMPop,
-                        newArgsBuilder()
-                                .add(timeout)
-                                .add(keys.length)
-                                .add(keys)
-                                .add(modifier)
-                                .add(COUNT_VALKEY_API)
-                                .add(count)));
+        addCommand(
+                BZMPop,
+                newArgsBuilder()
+                        .add(timeout)
+                        .add(keys.length)
+                        .add(keys)
+                        .add(modifier)
+                        .add(COUNT_VALKEY_API)
+                        .add(count));
         return getThis();
     }
 
@@ -5580,7 +5489,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pfadd(@NonNull ArgType key, @NonNull ArgType[] elements) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(PfAdd, newArgsBuilder().add(key).add(elements)));
+        addCommand(PfAdd, newArgsBuilder().add(key).add(elements));
         return getThis();
     }
 
@@ -5598,7 +5507,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pfcount(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(PfCount, newArgsBuilder().add(keys)));
+        addCommand(PfCount, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -5617,8 +5526,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pfmerge(@NonNull ArgType destination, @NonNull ArgType[] sourceKeys) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(PfMerge, newArgsBuilder().add(destination).add(sourceKeys)));
+        addCommand(PfMerge, newArgsBuilder().add(destination).add(sourceKeys));
         return getThis();
     }
 
@@ -5635,7 +5543,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T objectEncoding(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ObjectEncoding, newArgsBuilder().add(key)));
+        addCommand(ObjectEncoding, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5653,7 +5561,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T objectFreq(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ObjectFreq, newArgsBuilder().add(key)));
+        addCommand(ObjectFreq, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5669,7 +5577,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T objectIdletime(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ObjectIdleTime, newArgsBuilder().add(key)));
+        addCommand(ObjectIdleTime, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5686,7 +5594,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T objectRefcount(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ObjectRefCount, newArgsBuilder().add(key)));
+        addCommand(ObjectRefCount, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5701,7 +5609,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T touch(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(Touch, newArgsBuilder().add(keys)));
+        addCommand(Touch, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -5722,10 +5630,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T copy(@NonNull ArgType source, @NonNull ArgType destination, boolean replace) {
         checkTypeOrThrow(source);
-        protobufBatch.addCommands(
-                buildCommand(
-                        Copy,
-                        newArgsBuilder().add(source).add(destination).addIf(REPLACE_VALKEY_API, replace)));
+        addCommand(
+                Copy, newArgsBuilder().add(source).add(destination).addIf(REPLACE_VALKEY_API, replace));
         return getThis();
     }
 
@@ -5787,15 +5693,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T copy(
             @NonNull ArgType source, @NonNull ArgType destination, long destinationDB, boolean replace) {
         checkTypeOrThrow(source);
-        protobufBatch.addCommands(
-                buildCommand(
-                        Copy,
-                        newArgsBuilder()
-                                .add(source)
-                                .add(destination)
-                                .add(DB_VALKEY_API)
-                                .add(destinationDB)
-                                .addIf(REPLACE_VALKEY_API, replace)));
+        addCommand(
+                Copy,
+                newArgsBuilder()
+                        .add(source)
+                        .add(destination)
+                        .add(DB_VALKEY_API)
+                        .add(destinationDB)
+                        .addIf(REPLACE_VALKEY_API, replace));
         return getThis();
     }
 
@@ -5812,7 +5717,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T dump(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Dump, newArgsBuilder().add(key)));
+        addCommand(Dump, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5831,7 +5736,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T restore(@NonNull ArgType key, long ttl, @NonNull byte[] value) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Restore, newArgsBuilder().add(key).add(ttl).add(value)));
+        addCommand(Restore, newArgsBuilder().add(key).add(ttl).add(value));
         return getThis();
     }
 
@@ -5856,9 +5761,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull byte[] value,
             @NonNull RestoreOptions restoreOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        Restore, newArgsBuilder().add(key).add(ttl).add(value).add(restoreOptions.toArgs())));
+        addCommand(Restore, newArgsBuilder().add(key).add(ttl).add(value).add(restoreOptions.toArgs()));
         return getThis();
     }
 
@@ -5874,7 +5777,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitcount(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(BitCount, newArgsBuilder().add(key)));
+        addCommand(BitCount, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -5894,7 +5797,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitcount(@NonNull ArgType key, long start) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(BitCount, newArgsBuilder().add(key).add(start)));
+        addCommand(BitCount, newArgsBuilder().add(key).add(start));
         return getThis();
     }
 
@@ -5918,8 +5821,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitcount(@NonNull ArgType key, long start, long end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(BitCount, newArgsBuilder().add(key).add(start).add(end)));
+        addCommand(BitCount, newArgsBuilder().add(key).add(start).add(end));
         return getThis();
     }
 
@@ -5947,8 +5849,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T bitcount(
             @NonNull ArgType key, long start, long end, @NonNull BitmapIndexType options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(BitCount, newArgsBuilder().add(key).add(start).add(end).add(options)));
+        addCommand(BitCount, newArgsBuilder().add(key).add(start).add(end).add(options));
         return getThis();
     }
 
@@ -5974,13 +5875,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull Map<ArgType, GeospatialData> membersToGeospatialData,
             @NonNull GeoAddOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoAdd,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(options.toArgs())
-                                .add(mapGeoDataToGlideStringArray(membersToGeospatialData))));
+        addCommand(
+                GeoAdd,
+                newArgsBuilder()
+                        .add(key)
+                        .add(options.toArgs())
+                        .add(mapGeoDataToGlideStringArray(membersToGeospatialData)));
         return getThis();
     }
 
@@ -6020,7 +5920,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T geopos(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(GeoPos, newArgsBuilder().add(key).add(members)));
+        addCommand(GeoPos, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -6044,10 +5944,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType member2,
             @NonNull GeoUnit geoUnit) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoDist,
-                        newArgsBuilder().add(key).add(member1).add(member2).add(geoUnit.getValkeyAPI())));
+        addCommand(
+                GeoDist, newArgsBuilder().add(key).add(member1).add(member2).add(geoUnit.getValkeyAPI()));
         return getThis();
     }
 
@@ -6068,8 +5966,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T geodist(
             @NonNull ArgType key, @NonNull ArgType member1, @NonNull ArgType member2) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(GeoDist, newArgsBuilder().add(key).add(member1).add(member2)));
+        addCommand(GeoDist, newArgsBuilder().add(key).add(member1).add(member2));
         return getThis();
     }
 
@@ -6088,7 +5985,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T geohash(@NonNull ArgType key, @NonNull ArgType[] members) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(GeoHash, newArgsBuilder().add(key).add(members)));
+        addCommand(GeoHash, newArgsBuilder().add(key).add(members));
         return getThis();
     }
 
@@ -6106,8 +6003,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T functionLoad(@NonNull ArgType libraryCode, boolean replace) {
         checkTypeOrThrow(libraryCode);
-        protobufBatch.addCommands(
-                buildCommand(FunctionLoad, newArgsBuilder().addIf(REPLACE, replace).add(libraryCode)));
+        addCommand(FunctionLoad, newArgsBuilder().addIf(REPLACE, replace).add(libraryCode));
         return getThis();
     }
 
@@ -6120,8 +6016,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - Info about all libraries and their functions.
      */
     public T functionList(boolean withCode) {
-        protobufBatch.addCommands(
-                buildCommand(FunctionList, newArgsBuilder().addIf(WITH_CODE_VALKEY_API, withCode)));
+        addCommand(FunctionList, newArgsBuilder().addIf(WITH_CODE_VALKEY_API, withCode));
         return getThis();
     }
 
@@ -6138,13 +6033,12 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T functionList(@NonNull ArgType libNamePattern, boolean withCode) {
         checkTypeOrThrow(libNamePattern);
-        protobufBatch.addCommands(
-                buildCommand(
-                        FunctionList,
-                        newArgsBuilder()
-                                .add(LIBRARY_NAME_VALKEY_API)
-                                .add(libNamePattern)
-                                .addIf(WITH_CODE_VALKEY_API, withCode)));
+        addCommand(
+                FunctionList,
+                newArgsBuilder()
+                        .add(LIBRARY_NAME_VALKEY_API)
+                        .add(libNamePattern)
+                        .addIf(WITH_CODE_VALKEY_API, withCode));
         return getThis();
     }
 
@@ -6166,9 +6060,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T fcall(
             @NonNull ArgType function, @NonNull ArgType[] keys, @NonNull ArgType[] arguments) {
         checkTypeOrThrow(function);
-        protobufBatch.addCommands(
-                buildCommand(
-                        FCall, newArgsBuilder().add(function).add(keys.length).add(keys).add(arguments)));
+        addCommand(FCall, newArgsBuilder().add(function).add(keys.length).add(keys).add(arguments));
         return getThis();
     }
 
@@ -6206,10 +6098,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T fcallReadOnly(
             @NonNull ArgType function, @NonNull ArgType[] keys, @NonNull ArgType[] arguments) {
         checkTypeOrThrow(function);
-        protobufBatch.addCommands(
-                buildCommand(
-                        FCallReadOnly,
-                        newArgsBuilder().add(function).add(keys.length).add(keys).add(arguments)));
+        addCommand(
+                FCallReadOnly, newArgsBuilder().add(function).add(keys.length).add(keys).add(arguments));
         return getThis();
     }
 
@@ -6242,7 +6132,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     </ul>
      */
     public T functionStats() {
-        protobufBatch.addCommands(buildCommand(FunctionStats));
+        addCommand(FunctionStats);
         return getThis();
     }
 
@@ -6255,7 +6145,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - The serialized payload of all loaded libraries.
      */
     public T functionDump() {
-        protobufBatch.addCommands(buildCommand(FunctionDump));
+        addCommand(FunctionDump);
         return getThis();
     }
 
@@ -6269,7 +6159,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T functionRestore(@NonNull byte[] payload) {
-        protobufBatch.addCommands(buildCommand(FunctionRestore, newArgsBuilder().add(payload)));
+        addCommand(FunctionRestore, newArgsBuilder().add(payload));
         return getThis();
     }
 
@@ -6284,8 +6174,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T functionRestore(@NonNull byte[] payload, @NonNull FunctionRestorePolicy policy) {
-        protobufBatch.addCommands(
-                buildCommand(FunctionRestore, newArgsBuilder().add(payload).add(policy)));
+        addCommand(FunctionRestore, newArgsBuilder().add(payload).add(policy));
         return getThis();
     }
 
@@ -6308,8 +6197,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T setbit(@NonNull ArgType key, long offset, long value) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(SetBit, newArgsBuilder().add(key).add(offset).add(value)));
+        addCommand(SetBit, newArgsBuilder().add(key).add(offset).add(value));
         return getThis();
     }
 
@@ -6327,7 +6215,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T getbit(@NonNull ArgType key, long offset) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(GetBit, newArgsBuilder().add(key).add(offset)));
+        addCommand(GetBit, newArgsBuilder().add(key).add(offset));
         return getThis();
     }
 
@@ -6359,16 +6247,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull Long count,
             double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BLMPop,
-                        newArgsBuilder()
-                                .add(timeout)
-                                .add(keys.length)
-                                .add(keys)
-                                .add(direction)
-                                .add(COUNT_FOR_LIST_VALKEY_API)
-                                .add(count)));
+        addCommand(
+                BLMPop,
+                newArgsBuilder()
+                        .add(timeout)
+                        .add(keys.length)
+                        .add(keys)
+                        .add(direction)
+                        .add(COUNT_FOR_LIST_VALKEY_API)
+                        .add(count));
         return getThis();
     }
 
@@ -6396,9 +6283,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T blmpop(
             @NonNull ArgType[] keys, @NonNull ListDirection direction, double timeout) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BLMPop, newArgsBuilder().add(timeout).add(keys.length).add(keys).add(direction)));
+        addCommand(BLMPop, newArgsBuilder().add(timeout).add(keys.length).add(keys).add(direction));
         return getThis();
     }
 
@@ -6416,7 +6301,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitpos(@NonNull ArgType key, long bit) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(BitPos, newArgsBuilder().add(key).add(bit)));
+        addCommand(BitPos, newArgsBuilder().add(key).add(bit));
         return getThis();
     }
 
@@ -6439,7 +6324,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitpos(@NonNull ArgType key, long bit, long start) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(BitPos, newArgsBuilder().add(key).add(bit).add(start)));
+        addCommand(BitPos, newArgsBuilder().add(key).add(bit).add(start));
         return getThis();
     }
 
@@ -6463,8 +6348,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitpos(@NonNull ArgType key, long bit, long start, long end) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(BitPos, newArgsBuilder().add(key).add(bit).add(start).add(end)));
+        addCommand(BitPos, newArgsBuilder().add(key).add(bit).add(start).add(end));
         return getThis();
     }
 
@@ -6495,9 +6379,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T bitpos(
             @NonNull ArgType key, long bit, long start, long end, @NonNull BitmapIndexType offsetType) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BitPos, newArgsBuilder().add(key).add(bit).add(start).add(end).add(offsetType)));
+        addCommand(BitPos, newArgsBuilder().add(key).add(bit).add(start).add(end).add(offsetType));
         return getThis();
     }
 
@@ -6518,8 +6400,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ArgType destination,
             @NonNull ArgType[] keys) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(BitOp, newArgsBuilder().add(bitwiseOperation).add(destination).add(keys)));
+        addCommand(BitOp, newArgsBuilder().add(bitwiseOperation).add(destination).add(keys));
         return getThis();
     }
 
@@ -6541,15 +6422,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T lmpop(
             @NonNull ArgType[] keys, @NonNull ListDirection direction, @NonNull Long count) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LMPop,
-                        newArgsBuilder()
-                                .add(keys.length)
-                                .add(keys)
-                                .add(direction)
-                                .add(COUNT_FOR_LIST_VALKEY_API)
-                                .add(count)));
+        addCommand(
+                LMPop,
+                newArgsBuilder()
+                        .add(keys.length)
+                        .add(keys)
+                        .add(direction)
+                        .add(COUNT_FOR_LIST_VALKEY_API)
+                        .add(count));
         return getThis();
     }
 
@@ -6568,8 +6448,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lmpop(@NonNull ArgType[] keys, @NonNull ListDirection direction) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(
-                buildCommand(LMPop, newArgsBuilder().add(keys.length).add(keys).add(direction)));
+        addCommand(LMPop, newArgsBuilder().add(keys.length).add(keys).add(direction));
         return getThis();
     }
 
@@ -6589,8 +6468,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lset(@NonNull ArgType key, long index, @NonNull ArgType element) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(LSet, newArgsBuilder().add(key).add(index).add(element)));
+        addCommand(LSet, newArgsBuilder().add(key).add(index).add(element));
         return getThis();
     }
 
@@ -6616,9 +6494,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ListDirection whereFrom,
             @NonNull ListDirection whereTo) {
         checkTypeOrThrow(source);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LMove, newArgsBuilder().add(source).add(destination).add(whereFrom).add(whereTo)));
+        addCommand(LMove, newArgsBuilder().add(source).add(destination).add(whereFrom).add(whereTo));
         return getThis();
     }
 
@@ -6653,15 +6529,9 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull ListDirection whereTo,
             double timeout) {
         checkTypeOrThrow(source);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BLMove,
-                        newArgsBuilder()
-                                .add(source)
-                                .add(destination)
-                                .add(whereFrom)
-                                .add(whereTo)
-                                .add(timeout)));
+        addCommand(
+                BLMove,
+                newArgsBuilder().add(source).add(destination).add(whereFrom).add(whereTo).add(timeout));
         return getThis();
     }
 
@@ -6677,7 +6547,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T srandmember(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SRandMember, newArgsBuilder().add(key)));
+        addCommand(SRandMember, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -6696,7 +6566,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T srandmember(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SRandMember, newArgsBuilder().add(key).add(count)));
+        addCommand(SRandMember, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -6712,7 +6582,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T spop(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SPop, newArgsBuilder().add(key)));
+        addCommand(SPop, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -6731,7 +6601,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T spopCount(@NonNull ArgType key, long count) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SPop, newArgsBuilder().add(key).add(count)));
+        addCommand(SPop, newArgsBuilder().add(key).add(count));
         return getThis();
     }
 
@@ -6766,8 +6636,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T bitfield(@NonNull ArgType key, @NonNull BitFieldSubCommands[] subCommands) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(BitField, newArgsBuilder().add(key).add(createBitFieldArgs(subCommands))));
+        addCommand(BitField, newArgsBuilder().add(key).add(createBitFieldArgs(subCommands)));
         return getThis();
     }
 
@@ -6788,9 +6657,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T bitfieldReadOnly(
             @NonNull ArgType key, @NonNull BitFieldReadOnlySubCommands[] subCommands) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        BitFieldReadOnly, newArgsBuilder().add(key).add(createBitFieldArgs(subCommands))));
+        addCommand(BitFieldReadOnly, newArgsBuilder().add(key).add(createBitFieldArgs(subCommands)));
         return getThis();
     }
 
@@ -6802,7 +6669,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T functionFlush() {
-        protobufBatch.addCommands(buildCommand(FunctionFlush));
+        addCommand(FunctionFlush);
         return getThis();
     }
 
@@ -6816,7 +6683,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command Response - <code>"OK"</code> response on success.
      */
     public T functionFlush(@NonNull FlushMode mode) {
-        protobufBatch.addCommands(buildCommand(FunctionFlush, newArgsBuilder().add(mode)));
+        addCommand(FunctionFlush, newArgsBuilder().add(mode));
         return getThis();
     }
 
@@ -6832,7 +6699,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T functionDelete(@NonNull ArgType libName) {
         checkTypeOrThrow(libName);
-        protobufBatch.addCommands(buildCommand(FunctionDelete, newArgsBuilder().add(libName)));
+        addCommand(FunctionDelete, newArgsBuilder().add(libName));
         return getThis();
     }
 
@@ -6852,7 +6719,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lcs(@NonNull ArgType key1, @NonNull ArgType key2) {
         checkTypeOrThrow(key1);
-        protobufBatch.addCommands(buildCommand(LCS, newArgsBuilder().add(key1).add(key2)));
+        addCommand(LCS, newArgsBuilder().add(key1).add(key2));
         return getThis();
     }
 
@@ -6871,8 +6738,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lcsLen(@NonNull ArgType key1, @NonNull ArgType key2) {
         checkTypeOrThrow(key1);
-        protobufBatch.addCommands(
-                buildCommand(LCS, newArgsBuilder().add(key1).add(key2).add(LEN_VALKEY_API)));
+        addCommand(LCS, newArgsBuilder().add(key1).add(key2).add(LEN_VALKEY_API));
         return getThis();
     }
 
@@ -6888,7 +6754,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T publish(@NonNull ArgType message, @NonNull ArgType channel) {
         checkTypeOrThrow(channel);
-        protobufBatch.addCommands(buildCommand(Publish, newArgsBuilder().add(channel).add(message)));
+        addCommand(Publish, newArgsBuilder().add(channel).add(message));
         return getThis();
     }
 
@@ -6901,7 +6767,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command response - An <code>Array</code> of all active channels.
      */
     public T pubsubChannels() {
-        protobufBatch.addCommands(buildCommand(PubSubChannels));
+        addCommand(PubSubChannels);
         return getThis();
     }
 
@@ -6919,7 +6785,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pubsubChannels(@NonNull ArgType pattern) {
         checkTypeOrThrow(pattern);
-        protobufBatch.addCommands(buildCommand(PubSubChannels, newArgsBuilder().add(pattern)));
+        addCommand(PubSubChannels, newArgsBuilder().add(pattern));
         return getThis();
     }
 
@@ -6938,7 +6804,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      * @return Command response - The number of unique patterns.
      */
     public T pubsubNumPat() {
-        protobufBatch.addCommands(buildCommand(PubSubNumPat));
+        addCommand(PubSubNumPat);
         return getThis();
     }
 
@@ -6957,7 +6823,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T pubsubNumSub(@NonNull ArgType[] channels) {
         checkTypeOrThrow(channels);
-        protobufBatch.addCommands(buildCommand(PubSubNumSub, newArgsBuilder().add(channels)));
+        addCommand(PubSubNumSub, newArgsBuilder().add(channels));
         return getThis();
     }
 
@@ -6973,7 +6839,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sunion(@NonNull ArgType[] keys) {
         checkTypeOrThrow(keys);
-        protobufBatch.addCommands(buildCommand(SUnion, newArgsBuilder().add(keys)));
+        addCommand(SUnion, newArgsBuilder().add(keys));
         return getThis();
     }
 
@@ -7001,8 +6867,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lcsIdx(@NonNull ArgType key1, @NonNull ArgType key2) {
         checkTypeOrThrow(key1);
-        protobufBatch.addCommands(
-                buildCommand(LCS, newArgsBuilder().add(key1).add(key2).add(IDX_COMMAND_STRING)));
+        addCommand(LCS, newArgsBuilder().add(key1).add(key2).add(IDX_COMMAND_STRING));
         return getThis();
     }
 
@@ -7032,15 +6897,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lcsIdx(@NonNull ArgType key1, @NonNull ArgType key2, long minMatchLen) {
         checkTypeOrThrow(key1);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LCS,
-                        newArgsBuilder()
-                                .add(key1)
-                                .add(key2)
-                                .add(IDX_COMMAND_STRING)
-                                .add(MINMATCHLEN_COMMAND_STRING)
-                                .add(minMatchLen)));
+        addCommand(
+                LCS,
+                newArgsBuilder()
+                        .add(key1)
+                        .add(key2)
+                        .add(IDX_COMMAND_STRING)
+                        .add(MINMATCHLEN_COMMAND_STRING)
+                        .add(minMatchLen));
         return getThis();
     }
 
@@ -7069,14 +6933,13 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T lcsIdxWithMatchLen(@NonNull ArgType key1, @NonNull ArgType key2) {
         checkTypeOrThrow(key1);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LCS,
-                        newArgsBuilder()
-                                .add(key1)
-                                .add(key2)
-                                .add(IDX_COMMAND_STRING)
-                                .add(WITHMATCHLEN_COMMAND_STRING)));
+        addCommand(
+                LCS,
+                newArgsBuilder()
+                        .add(key1)
+                        .add(key2)
+                        .add(IDX_COMMAND_STRING)
+                        .add(WITHMATCHLEN_COMMAND_STRING));
         return getThis();
     }
 
@@ -7107,16 +6970,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T lcsIdxWithMatchLen(
             @NonNull ArgType key1, @NonNull ArgType key2, long minMatchLen) {
         checkTypeOrThrow(key1);
-        protobufBatch.addCommands(
-                buildCommand(
-                        LCS,
-                        newArgsBuilder()
-                                .add(key1)
-                                .add(key2)
-                                .add(IDX_COMMAND_STRING)
-                                .add(MINMATCHLEN_COMMAND_STRING)
-                                .add(minMatchLen)
-                                .add(WITHMATCHLEN_COMMAND_STRING)));
+        addCommand(
+                LCS,
+                newArgsBuilder()
+                        .add(key1)
+                        .add(key2)
+                        .add(IDX_COMMAND_STRING)
+                        .add(MINMATCHLEN_COMMAND_STRING)
+                        .add(minMatchLen)
+                        .add(WITHMATCHLEN_COMMAND_STRING));
         return getThis();
     }
 
@@ -7135,7 +6997,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sort(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(Sort, newArgsBuilder().add(key)));
+        addCommand(Sort, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -7158,8 +7020,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sort(@NonNull ArgType key, @NonNull SortOptions sortOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(Sort, newArgsBuilder().add(key).add(sortOptions.toArgs())));
+        addCommand(Sort, newArgsBuilder().add(key).add(sortOptions.toArgs()));
         return getThis();
     }
 
@@ -7178,7 +7039,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sortReadOnly(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SortReadOnly, newArgsBuilder().add(key)));
+        addCommand(SortReadOnly, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -7201,8 +7062,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sortReadOnly(@NonNull ArgType key, @NonNull SortOptions sortOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(SortReadOnly, newArgsBuilder().add(key).add(sortOptions.toArgs())));
+        addCommand(SortReadOnly, newArgsBuilder().add(key).add(sortOptions.toArgs()));
         return getThis();
     }
 
@@ -7224,8 +7084,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sortStore(@NonNull ArgType key, @NonNull ArgType destination) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(Sort, newArgsBuilder().add(key).add(STORE_COMMAND_STRING).add(destination)));
+        addCommand(Sort, newArgsBuilder().add(key).add(STORE_COMMAND_STRING).add(destination));
         return getThis();
     }
 
@@ -7257,14 +7116,13 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T sortStore(
             @NonNull ArgType key, @NonNull ArgType destination, @NonNull SortOptions sortOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        Sort,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(sortOptions.toArgs())
-                                .add(STORE_COMMAND_STRING)
-                                .add(destination)));
+        addCommand(
+                Sort,
+                newArgsBuilder()
+                        .add(key)
+                        .add(sortOptions.toArgs())
+                        .add(STORE_COMMAND_STRING)
+                        .add(destination));
         return getThis();
     }
 
@@ -7297,9 +7155,8 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T geosearch(
             @NonNull ArgType key, @NonNull SearchOrigin searchFrom, @NonNull GeoSearchShape searchBy) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearch, newArgsBuilder().add(key).add(searchFrom.toArgs()).add(searchBy.toArgs())));
+        addCommand(
+                GeoSearch, newArgsBuilder().add(key).add(searchFrom.toArgs()).add(searchBy.toArgs()));
         return getThis();
     }
 
@@ -7337,14 +7194,13 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GeoSearchShape searchBy,
             @NonNull GeoSearchResultOptions resultOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearch,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())
-                                .add(resultOptions.toArgs())));
+        addCommand(
+                GeoSearch,
+                newArgsBuilder()
+                        .add(key)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs())
+                        .add(resultOptions.toArgs()));
         return getThis();
     }
 
@@ -7389,14 +7245,13 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GeoSearchShape searchBy,
             @NonNull GeoSearchOptions options) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearch,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())
-                                .add(options.toArgs())));
+        addCommand(
+                GeoSearch,
+                newArgsBuilder()
+                        .add(key)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs())
+                        .add(options.toArgs()));
         return getThis();
     }
 
@@ -7444,15 +7299,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GeoSearchOptions options,
             @NonNull GeoSearchResultOptions resultOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearch,
-                        newArgsBuilder()
-                                .add(key)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())
-                                .add(options.toArgs())
-                                .add(resultOptions.toArgs())));
+        addCommand(
+                GeoSearch,
+                newArgsBuilder()
+                        .add(key)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs())
+                        .add(options.toArgs())
+                        .add(resultOptions.toArgs()));
         return getThis();
     }
 
@@ -7492,14 +7346,13 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull SearchOrigin searchFrom,
             @NonNull GeoSearchShape searchBy) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearchStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(source)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())));
+        addCommand(
+                GeoSearchStore,
+                newArgsBuilder()
+                        .add(destination)
+                        .add(source)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs()));
         return getThis();
     }
 
@@ -7542,15 +7395,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GeoSearchShape searchBy,
             @NonNull GeoSearchResultOptions resultOptions) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearchStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(source)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())
-                                .add(resultOptions.toArgs())));
+        addCommand(
+                GeoSearchStore,
+                newArgsBuilder()
+                        .add(destination)
+                        .add(source)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs())
+                        .add(resultOptions.toArgs()));
         return getThis();
     }
 
@@ -7592,15 +7444,14 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GeoSearchShape searchBy,
             @NonNull GeoSearchStoreOptions options) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearchStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(source)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())
-                                .add(options.toArgs())));
+        addCommand(
+                GeoSearchStore,
+                newArgsBuilder()
+                        .add(destination)
+                        .add(source)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs())
+                        .add(options.toArgs()));
         return getThis();
     }
 
@@ -7645,16 +7496,15 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
             @NonNull GeoSearchStoreOptions options,
             @NonNull GeoSearchResultOptions resultOptions) {
         checkTypeOrThrow(destination);
-        protobufBatch.addCommands(
-                buildCommand(
-                        GeoSearchStore,
-                        newArgsBuilder()
-                                .add(destination)
-                                .add(source)
-                                .add(searchFrom.toArgs())
-                                .add(searchBy.toArgs())
-                                .add(options.toArgs())
-                                .add(resultOptions.toArgs())));
+        addCommand(
+                GeoSearchStore,
+                newArgsBuilder()
+                        .add(destination)
+                        .add(source)
+                        .add(searchFrom.toArgs())
+                        .add(searchBy.toArgs())
+                        .add(options.toArgs())
+                        .add(resultOptions.toArgs()));
         return getThis();
     }
 
@@ -7674,7 +7524,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T sscan(@NonNull ArgType key, @NonNull ArgType cursor) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(SScan, newArgsBuilder().add(key).add(cursor)));
+        addCommand(SScan, newArgsBuilder().add(key).add(cursor));
         return getThis();
     }
 
@@ -7696,8 +7546,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T sscan(
             @NonNull ArgType key, @NonNull ArgType cursor, @NonNull SScanOptions sScanOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(SScan, newArgsBuilder().add(key).add(cursor).add(sScanOptions.toArgs())));
+        addCommand(SScan, newArgsBuilder().add(key).add(cursor).add(sScanOptions.toArgs()));
         return getThis();
     }
 
@@ -7719,7 +7568,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T zscan(@NonNull ArgType key, @NonNull ArgType cursor) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ZScan, newArgsBuilder().add(key).add(cursor)));
+        addCommand(ZScan, newArgsBuilder().add(key).add(cursor));
         return getThis();
     }
 
@@ -7745,8 +7594,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T zscan(
             @NonNull ArgType key, @NonNull ArgType cursor, @NonNull ZScanOptions zScanOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(ZScan, newArgsBuilder().add(key).add(cursor).add(zScanOptions.toArgs())));
+        addCommand(ZScan, newArgsBuilder().add(key).add(cursor).add(zScanOptions.toArgs()));
         return getThis();
     }
 
@@ -7768,7 +7616,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      */
     public <ArgType> T hscan(@NonNull ArgType key, @NonNull ArgType cursor) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(HScan, newArgsBuilder().add(key).add(cursor)));
+        addCommand(HScan, newArgsBuilder().add(key).add(cursor));
         return getThis();
     }
 
@@ -7794,8 +7642,7 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
     public <ArgType> T hscan(
             @NonNull ArgType key, @NonNull ArgType cursor, @NonNull HScanOptions hScanOptions) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(
-                buildCommand(HScan, newArgsBuilder().add(key).add(cursor).add(hScanOptions.toArgs())));
+        addCommand(HScan, newArgsBuilder().add(key).add(cursor).add(hScanOptions.toArgs()));
         return getThis();
     }
 
@@ -7813,32 +7660,23 @@ public abstract class BaseBatch<T extends BaseBatch<T>> {
      *     context of the current connection.
      */
     public T wait(long numReplicas, long timeout) {
-        protobufBatch.addCommands(buildCommand(Wait, newArgsBuilder().add(numReplicas).add(timeout)));
+        addCommand(Wait, newArgsBuilder().add(numReplicas).add(timeout));
         return getThis();
     }
 
-    /** Build protobuf {@link Command} object for given command and arguments. */
-    protected Command buildCommand(RequestType requestType) {
-        return buildCommand(requestType, emptyArgs());
+    /** Add a command with no arguments. */
+    protected void addCommand(RequestType requestType) {
+        commands.add(new BatchCommand(requestType.getNumber(), new byte[0][]));
     }
 
-    /** Build protobuf {@link Command} object for given command and arguments. */
-    protected Command buildCommand(RequestType requestType, ArgsArray args) {
-        return Command.newBuilder().setRequestType(requestType).setArgsArray(args).build();
-    }
-
-    /** Build protobuf {@link Command} object for given command and arguments. */
-    protected Command buildCommand(RequestType requestType, ArgsBuilder argsBuilder) {
-        final Command.Builder builder = Command.newBuilder();
-        builder.setRequestType(requestType);
-        CommandManager.populateCommandWithArgs(argsBuilder.toArray(), builder);
-        return builder.build();
-    }
-
-    /** Build protobuf {@link ArgsArray} object for empty arguments. */
-    protected ArgsArray emptyArgs() {
-        ArgsArray.Builder commandArgs = ArgsArray.newBuilder();
-        return commandArgs.build();
+    /** Add a command with pre-built args. */
+    protected void addCommand(RequestType requestType, ArgsBuilder argsBuilder) {
+        GlideString[] glideArgs = argsBuilder.toArray();
+        byte[][] args = new byte[glideArgs.length][];
+        for (int i = 0; i < glideArgs.length; i++) {
+            args[i] = glideArgs[i].getBytes();
+        }
+        commands.add(new BatchCommand(requestType.getNumber(), args));
     }
 
     /** Helper function for creating generic type ("ArgType") array */

--- a/java/client/src/main/java/glide/api/models/Batch.java
+++ b/java/client/src/main/java/glide/api/models/Batch.java
@@ -81,7 +81,7 @@ public class Batch extends BaseBatch<Batch> {
      * @return Command Response - A simple <code>OK</code> response.
      */
     public Batch select(long index) {
-        protobufBatch.addCommands(buildCommand(Select, newArgsBuilder().add(index)));
+        addCommand(Select, newArgsBuilder().add(index));
         return this;
     }
 
@@ -98,7 +98,7 @@ public class Batch extends BaseBatch<Batch> {
      */
     public <ArgType> Batch scan(@NonNull ArgType cursor) {
         checkTypeOrThrow(cursor);
-        protobufBatch.addCommands(buildCommand(Scan, newArgsBuilder().add(cursor)));
+        addCommand(Scan, newArgsBuilder().add(cursor));
         return this;
     }
 
@@ -116,8 +116,7 @@ public class Batch extends BaseBatch<Batch> {
      */
     public <ArgType> Batch scan(@NonNull ArgType cursor, @NonNull ScanOptions options) {
         checkTypeOrThrow(cursor);
-        protobufBatch.addCommands(
-                buildCommand(Scan, newArgsBuilder().add(cursor).add(options.toArgs())));
+        addCommand(Scan, newArgsBuilder().add(cursor).add(options.toArgs()));
         return this;
     }
 }

--- a/java/client/src/main/java/glide/api/models/BatchCommand.java
+++ b/java/client/src/main/java/glide/api/models/BatchCommand.java
@@ -1,0 +1,21 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models;
+
+/** Plain data container for a single command in a batch (pipeline/transaction). */
+public final class BatchCommand {
+    private final int requestType;
+    private final byte[][] args;
+
+    public BatchCommand(int requestType, byte[][] args) {
+        this.requestType = requestType;
+        this.args = args;
+    }
+
+    public int getRequestType() {
+        return requestType;
+    }
+
+    public byte[][] getArgs() {
+        return args;
+    }
+}

--- a/java/client/src/main/java/glide/api/models/ClusterBatch.java
+++ b/java/client/src/main/java/glide/api/models/ClusterBatch.java
@@ -122,7 +122,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
             return super.publish(message, channel);
         }
         checkTypeOrThrow(channel);
-        protobufBatch.addCommands(buildCommand(SPublish, newArgsBuilder().add(channel).add(message)));
+        addCommand(SPublish, newArgsBuilder().add(channel).add(message));
         return getThis();
     }
 
@@ -140,7 +140,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      */
     public <ArgType> ClusterBatch pubsubShardNumSub(@NonNull ArgType[] channels) {
         checkTypeOrThrow(channels);
-        protobufBatch.addCommands(buildCommand(PubSubShardNumSub, newArgsBuilder().add(channels)));
+        addCommand(PubSubShardNumSub, newArgsBuilder().add(channels));
         return getThis();
     }
 
@@ -151,7 +151,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - An <code>Array</code> of all active shard channels.
      */
     public ClusterBatch pubsubShardChannels() {
-        protobufBatch.addCommands(buildCommand(PubSubShardChannels));
+        addCommand(PubSubShardChannels);
         return getThis();
     }
 
@@ -166,7 +166,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      */
     public <ArgType> ClusterBatch pubsubShardChannels(@NonNull ArgType pattern) {
         checkTypeOrThrow(pattern);
-        protobufBatch.addCommands(buildCommand(PubSubShardChannels, newArgsBuilder().add(pattern)));
+        addCommand(PubSubShardChannels, newArgsBuilder().add(pattern));
         return getThis();
     }
 
@@ -179,7 +179,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterMeet(@NonNull String host, long port) {
-        protobufBatch.addCommands(buildCommand(ClusterMeet, newArgsBuilder().add(host).add(port)));
+        addCommand(ClusterMeet, newArgsBuilder().add(host).add(port));
         return getThis();
     }
 
@@ -190,7 +190,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - A <code>String</code> containing cluster state information.
      */
     public ClusterBatch clusterInfo() {
-        protobufBatch.addCommands(buildCommand(ClusterInfo));
+        addCommand(ClusterInfo);
         return getThis();
     }
 
@@ -202,7 +202,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterForget(@NonNull String nodeId) {
-        protobufBatch.addCommands(buildCommand(ClusterForget, newArgsBuilder().add(nodeId)));
+        addCommand(ClusterForget, newArgsBuilder().add(nodeId));
         return getThis();
     }
 
@@ -213,7 +213,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - A <code>String</code> containing node information.
      */
     public ClusterBatch clusterNodes() {
-        protobufBatch.addCommands(buildCommand(ClusterNodes));
+        addCommand(ClusterNodes);
         return getThis();
     }
 
@@ -225,7 +225,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterReplicate(@NonNull String nodeId) {
-        protobufBatch.addCommands(buildCommand(ClusterReplicate, newArgsBuilder().add(nodeId)));
+        addCommand(ClusterReplicate, newArgsBuilder().add(nodeId));
         return getThis();
     }
 
@@ -237,7 +237,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - An <code>array</code> of shard information maps.
      */
     public ClusterBatch clusterShards() {
-        protobufBatch.addCommands(buildCommand(ClusterShards));
+        addCommand(ClusterShards);
         return getThis();
     }
 
@@ -249,7 +249,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - An array of replica node information strings.
      */
     public ClusterBatch clusterReplicas(@NonNull String nodeId) {
-        protobufBatch.addCommands(buildCommand(ClusterReplicas, newArgsBuilder().add(nodeId)));
+        addCommand(ClusterReplicas, newArgsBuilder().add(nodeId));
         return getThis();
     }
 
@@ -261,7 +261,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - An <code>array</code> of link information maps.
      */
     public ClusterBatch clusterLinks() {
-        protobufBatch.addCommands(buildCommand(ClusterLinks));
+        addCommand(ClusterLinks);
         return getThis();
     }
 
@@ -274,8 +274,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - The number of active failure reports.
      */
     public ClusterBatch clusterCountFailureReports(@NonNull String nodeId) {
-        protobufBatch.addCommands(
-                buildCommand(ClusterCountFailureReports, newArgsBuilder().add(nodeId)));
+        addCommand(ClusterCountFailureReports, newArgsBuilder().add(nodeId));
         return getThis();
     }
 
@@ -286,7 +285,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - A <code>String</code> containing the node ID.
      */
     public ClusterBatch clusterMyId() {
-        protobufBatch.addCommands(buildCommand(ClusterMyId));
+        addCommand(ClusterMyId);
         return getThis();
     }
 
@@ -297,7 +296,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterFailover() {
-        protobufBatch.addCommands(buildCommand(ClusterFailover));
+        addCommand(ClusterFailover);
         return getThis();
     }
 
@@ -309,8 +308,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterFailover(@NonNull ClusterFailoverOptions options) {
-        protobufBatch.addCommands(
-                buildCommand(ClusterFailover, newArgsBuilder().add(options.toArgs())));
+        addCommand(ClusterFailover, newArgsBuilder().add(options.toArgs()));
         return getThis();
     }
 
@@ -323,8 +321,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterSetSlot(long slot, @NonNull ClusterSetSlotOptions options) {
-        protobufBatch.addCommands(
-                buildCommand(ClusterSetslot, newArgsBuilder().add(slot).add(options.toArgs())));
+        addCommand(ClusterSetslot, newArgsBuilder().add(slot).add(options.toArgs()));
         return getThis();
     }
 
@@ -335,7 +332,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>BUMPED</code> or <code>STILL</code>.
      */
     public ClusterBatch clusterBumpEpoch() {
-        protobufBatch.addCommands(buildCommand(ClusterBumpEpoch));
+        addCommand(ClusterBumpEpoch);
         return getThis();
     }
 
@@ -347,8 +344,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterSetConfigEpoch(long configEpoch) {
-        protobufBatch.addCommands(
-                buildCommand(ClusterSetConfigEpoch, newArgsBuilder().add(configEpoch)));
+        addCommand(ClusterSetConfigEpoch, newArgsBuilder().add(configEpoch));
         return getThis();
     }
 
@@ -359,7 +355,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterFlushSlots() {
-        protobufBatch.addCommands(buildCommand(ClusterFlushSlots));
+        addCommand(ClusterFlushSlots);
         return getThis();
     }
 
@@ -370,7 +366,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterReset() {
-        protobufBatch.addCommands(buildCommand(ClusterReset));
+        addCommand(ClusterReset);
         return getThis();
     }
 
@@ -382,7 +378,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterReset(@NonNull ClusterResetOptions options) {
-        protobufBatch.addCommands(buildCommand(ClusterReset, newArgsBuilder().add(options.toArgs())));
+        addCommand(ClusterReset, newArgsBuilder().add(options.toArgs()));
         return getThis();
     }
 
@@ -393,7 +389,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch readonly() {
-        protobufBatch.addCommands(buildCommand(ReadOnly));
+        addCommand(ReadOnly);
         return getThis();
     }
 
@@ -404,7 +400,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch readwrite() {
-        protobufBatch.addCommands(buildCommand(ReadWrite));
+        addCommand(ReadWrite);
         return getThis();
     }
 
@@ -415,7 +411,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch asking() {
-        protobufBatch.addCommands(buildCommand(Asking));
+        addCommand(Asking);
         return getThis();
     }
 
@@ -426,7 +422,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>OK</code> on success.
      */
     public ClusterBatch clusterSaveConfig() {
-        protobufBatch.addCommands(buildCommand(ClusterSaveConfig));
+        addCommand(ClusterSaveConfig);
         return getThis();
     }
 
@@ -439,8 +435,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - An array of keys in the slot.
      */
     public ClusterBatch clusterGetKeysInSlot(long slot, long count) {
-        protobufBatch.addCommands(
-                buildCommand(ClusterGetKeysInSlot, newArgsBuilder().add(slot).add(count)));
+        addCommand(ClusterGetKeysInSlot, newArgsBuilder().add(slot).add(count));
         return getThis();
     }
 
@@ -452,7 +447,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - A <code>String</code> containing the shard ID.
      */
     public ClusterBatch clusterMyShardId() {
-        protobufBatch.addCommands(buildCommand(ClusterMyShardId));
+        addCommand(ClusterMyShardId);
         return getThis();
     }
 
@@ -465,7 +460,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      */
     public <ArgType> ClusterBatch clusterKeySlot(@NonNull ArgType key) {
         checkTypeOrThrow(key);
-        protobufBatch.addCommands(buildCommand(ClusterKeySlot, newArgsBuilder().add(key)));
+        addCommand(ClusterKeySlot, newArgsBuilder().add(key));
         return getThis();
     }
 
@@ -477,7 +472,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - The number of keys in the specified slot.
      */
     public ClusterBatch clusterCountKeysInSlot(long slot) {
-        protobufBatch.addCommands(buildCommand(ClusterCountKeysInSlot, newArgsBuilder().add(slot)));
+        addCommand(ClusterCountKeysInSlot, newArgsBuilder().add(slot));
         return getThis();
     }
 
@@ -489,7 +484,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>"OK"</code> if the slots were successfully assigned.
      */
     public ClusterBatch clusterAddSlots(long[] slots) {
-        protobufBatch.addCommands(buildCommand(ClusterAddSlots, newArgsBuilder().add(slots)));
+        addCommand(ClusterAddSlots, newArgsBuilder().add(slots));
         return getThis();
     }
 
@@ -503,7 +498,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>"OK"</code> if the slot ranges were successfully assigned.
      */
     public ClusterBatch clusterAddSlotsRange(long[][] slotRanges) {
-        protobufBatch.addCommands(buildCommand(ClusterAddSlotsRange, newArgsBuilder().add(slotRanges)));
+        addCommand(ClusterAddSlotsRange, newArgsBuilder().add(slotRanges));
         return getThis();
     }
 
@@ -515,7 +510,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>"OK"</code> if the slots were successfully removed.
      */
     public ClusterBatch clusterDelSlots(long[] slots) {
-        protobufBatch.addCommands(buildCommand(ClusterDelSlots, newArgsBuilder().add(slots)));
+        addCommand(ClusterDelSlots, newArgsBuilder().add(slots));
         return getThis();
     }
 
@@ -529,7 +524,7 @@ public class ClusterBatch extends BaseBatch<ClusterBatch> {
      * @return Command response - <code>"OK"</code> if the slot ranges were successfully removed.
      */
     public ClusterBatch clusterDelSlotsRange(long[][] slotRanges) {
-        protobufBatch.addCommands(buildCommand(ClusterDelSlotsRange, newArgsBuilder().add(slotRanges)));
+        addCommand(ClusterDelSlotsRange, newArgsBuilder().add(slotRanges));
         return getThis();
     }
 }

--- a/java/client/src/main/java/glide/internal/GlideCoreClient.java
+++ b/java/client/src/main/java/glide/internal/GlideCoreClient.java
@@ -183,24 +183,21 @@ public class GlideCoreClient implements AutoCloseable {
 
     // ==================== COMMAND EXECUTION METHODS ====================
 
-    /**
-     * Execute binary command asynchronously using raw protobuf bytes (for compatibility with
-     * CommandManager)
-     */
-    public CompletableFuture<Object> executeBinaryCommandAsync(byte[] requestBytes) {
-        return executeBinaryCommandAsyncInternal(requestBytes, this.requestTimeoutMillis);
-    }
-
-    /**
-     * Execute binary command asynchronously without Java-side timeout. Used for blocking commands
-     * (BLPOP, BRPOP, etc.) where the command has its own timeout that Rust handles.
-     */
-    public CompletableFuture<Object> executeBinaryCommandAsyncNoTimeout(byte[] requestBytes) {
-        return executeBinaryCommandAsyncInternal(requestBytes, 0);
-    }
-
-    private CompletableFuture<Object> executeBinaryCommandAsyncInternal(
-            byte[] requestBytes, long timeoutMs) {
+    /** Execute batch asynchronously. */
+    public CompletableFuture<Object> executeBatchDirect(
+            int[] requestTypes,
+            byte[][][] args,
+            boolean isAtomic,
+            boolean raiseOnError,
+            int timeout,
+            boolean retryServerError,
+            boolean retryConnectionError,
+            boolean hasRoute,
+            int routeType,
+            String routeParam,
+            boolean expectUtf8Response,
+            long timeoutMs,
+            long spanPtr) {
         try {
             long handle = nativeClientHandle.get();
             if (handle == 0) {
@@ -210,7 +207,6 @@ public class GlideCoreClient implements AutoCloseable {
                 return future;
             }
 
-            // Create future and register it with the async registry
             CompletableFuture<Object> future = new CompletableFuture<>();
             long correlationId;
             try {
@@ -220,95 +216,21 @@ public class GlideCoreClient implements AutoCloseable {
                 return future;
             }
 
-            // Execute binary command directly using protobuf bytes
-            GlideNativeBridge.executeBinaryCommandAsync(handle, requestBytes, correlationId);
-
-            return future;
-
-        } catch (Exception e) {
-            CompletableFuture<Object> future = new CompletableFuture<>();
-            future.completeExceptionally(e);
-            return future;
-        }
-    }
-
-    /**
-     * Execute command asynchronously using raw protobuf bytes (for compatibility with CommandManager)
-     */
-    public CompletableFuture<Object> executeCommandAsync(byte[] requestBytes) {
-        return executeCommandAsyncInternal(requestBytes, this.requestTimeoutMillis);
-    }
-
-    /**
-     * Execute command asynchronously without Java-side timeout. Used for blocking commands (BLPOP,
-     * BRPOP, etc.) where the command has its own timeout that Rust handles.
-     */
-    public CompletableFuture<Object> executeCommandAsyncNoTimeout(byte[] requestBytes) {
-        return executeCommandAsyncInternal(requestBytes, 0);
-    }
-
-    private CompletableFuture<Object> executeCommandAsyncInternal(
-            byte[] requestBytes, long timeoutMs) {
-        try {
-            long handle = nativeClientHandle.get();
-            if (handle == 0) {
-                CompletableFuture<Object> future = new CompletableFuture<>();
-                future.completeExceptionally(
-                        new glide.api.models.exceptions.ClosingException("Client is closed"));
-                return future;
-            }
-
-            // Create future and register it with the async registry
-            CompletableFuture<Object> future = new CompletableFuture<>();
-            long correlationId;
-            try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle, timeoutMs);
-            } catch (glide.api.models.exceptions.RequestException e) {
-                future.completeExceptionally(e);
-                return future;
-            }
-
-            // Execute command directly using protobuf bytes
-            GlideNativeBridge.executeCommandAsync(handle, requestBytes, correlationId);
-
-            return future;
-
-        } catch (Exception e) {
-            CompletableFuture<Object> future = new CompletableFuture<>();
-            future.completeExceptionally(e);
-            return future;
-        }
-    }
-
-    /** Execute batch asynchronously using raw protobuf bytes. */
-    public CompletableFuture<Object> executeBatchAsync(
-            byte[] batchRequestBytes, boolean expectUtf8Response, Integer timeoutOverrideMs) {
-        try {
-            long handle = nativeClientHandle.get();
-            if (handle == 0) {
-                CompletableFuture<Object> future = new CompletableFuture<>();
-                future.completeExceptionally(
-                        new glide.api.models.exceptions.ClosingException("Client is closed"));
-                return future;
-            }
-
-            // Create future and register it with the async registry
-            CompletableFuture<Object> future = new CompletableFuture<>();
-            long correlationId;
-            long timeoutMs =
-                    timeoutOverrideMs != null && timeoutOverrideMs > 0
-                            ? timeoutOverrideMs
-                            : this.requestTimeoutMillis;
-            try {
-                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle, timeoutMs);
-            } catch (glide.api.models.exceptions.RequestException e) {
-                future.completeExceptionally(e);
-                return future;
-            }
-
-            // Execute batch directly
-            GlideNativeBridge.executeBatchAsync(
-                    handle, batchRequestBytes, expectUtf8Response, correlationId);
+            GlideNativeBridge.executeBatchDirect(
+                    handle,
+                    correlationId,
+                    requestTypes,
+                    args,
+                    isAtomic,
+                    raiseOnError,
+                    timeout,
+                    retryServerError,
+                    retryConnectionError,
+                    hasRoute,
+                    routeType,
+                    routeParam,
+                    expectUtf8Response,
+                    spanPtr);
 
             return future;
 
@@ -433,6 +355,54 @@ public class GlideCoreClient implements AutoCloseable {
 
         GlideNativeBridge.getCacheMetrics(handle, correlationId, metricsType.getNumber());
         return future;
+    }
+
+    /** Execute command asynchronously. Passes requestType, args, and routing directly via JNI. */
+    public CompletableFuture<Object> executeCommandDirect(
+            int requestType,
+            byte[][] args,
+            boolean hasRoute,
+            int routeType,
+            String routeParam,
+            boolean expectUtf8Response,
+            long timeoutMs,
+            long spanPtr) {
+        try {
+            long handle = nativeClientHandle.get();
+            if (handle == 0) {
+                CompletableFuture<Object> future = new CompletableFuture<>();
+                future.completeExceptionally(
+                        new glide.api.models.exceptions.ClosingException("Client is closed"));
+                return future;
+            }
+
+            CompletableFuture<Object> future = new CompletableFuture<>();
+            long correlationId;
+            try {
+                correlationId = AsyncRegistry.register(future, this.maxInflightRequests, handle, timeoutMs);
+            } catch (glide.api.models.exceptions.RequestException e) {
+                future.completeExceptionally(e);
+                return future;
+            }
+
+            GlideNativeBridge.executeCommandDirect(
+                    handle,
+                    correlationId,
+                    requestType,
+                    args != null ? args : EMPTY_2D_BYTE_ARRAY,
+                    hasRoute,
+                    routeType,
+                    routeParam,
+                    expectUtf8Response,
+                    spanPtr);
+
+            return future;
+
+        } catch (Exception e) {
+            CompletableFuture<Object> future = new CompletableFuture<>();
+            future.completeExceptionally(e);
+            return future;
+        }
     }
 
     /** Execute script via native invoke_script path */

--- a/java/client/src/main/java/glide/internal/GlideCoreClient.java
+++ b/java/client/src/main/java/glide/internal/GlideCoreClient.java
@@ -183,8 +183,8 @@ public class GlideCoreClient implements AutoCloseable {
 
     // ==================== COMMAND EXECUTION METHODS ====================
 
-    /** Execute batch asynchronously. */
-    public CompletableFuture<Object> executeBatchDirect(
+    /** Execute a batch of commands asynchronously via JNI. */
+    public CompletableFuture<Object> executeBatchAsync(
             int[] requestTypes,
             byte[][][] args,
             boolean isAtomic,
@@ -216,7 +216,7 @@ public class GlideCoreClient implements AutoCloseable {
                 return future;
             }
 
-            GlideNativeBridge.executeBatchDirect(
+            GlideNativeBridge.executeBatchAsync(
                     handle,
                     correlationId,
                     requestTypes,
@@ -357,8 +357,8 @@ public class GlideCoreClient implements AutoCloseable {
         return future;
     }
 
-    /** Execute command asynchronously. Passes requestType, args, and routing directly via JNI. */
-    public CompletableFuture<Object> executeCommandDirect(
+    /** Execute a single command asynchronously via JNI. */
+    public CompletableFuture<Object> executeCommandAsync(
             int requestType,
             byte[][] args,
             boolean hasRoute,
@@ -385,7 +385,7 @@ public class GlideCoreClient implements AutoCloseable {
                 return future;
             }
 
-            GlideNativeBridge.executeCommandDirect(
+            GlideNativeBridge.executeCommandAsync(
                     handle,
                     correlationId,
                     requestType,
@@ -405,7 +405,7 @@ public class GlideCoreClient implements AutoCloseable {
         }
     }
 
-    /** Execute script via native invoke_script path */
+    /** Execute a script asynchronously via JNI. */
     public CompletableFuture<Object> executeScriptAsync(
             String hash,
             byte[][] keys,

--- a/java/client/src/main/java/glide/internal/GlideNativeBridge.java
+++ b/java/client/src/main/java/glide/internal/GlideNativeBridge.java
@@ -38,17 +38,50 @@ public class GlideNativeBridge {
     public static native long createClient(
             byte[] connectionRequestBytes, AddressResolver addressResolver);
 
-    /** Execute command asynchronously */
-    public static native void executeCommandAsync(
-            long clientPtr, byte[] requestBytes, long callbackId);
+    /**
+     * Execute command asynchronously. Passes command parameters directly via JNI to avoid
+     * serialize/deserialize overhead.
+     */
+    public static native void executeCommandDirect(
+            long clientPtr,
+            long callbackId,
+            int requestType,
+            byte[][] args,
+            boolean hasRoute,
+            int routeType,
+            String routeParam,
+            boolean expectUtf8Response,
+            long spanPtr);
 
-    /** Execute binary command with mixed String/byte[] arguments asynchronously */
-    public static native void executeBinaryCommandAsync(
-            long clientPtr, byte[] requestBytes, long callbackId);
-
-    /** Execute batch (pipeline/transaction) asynchronously */
-    public static native void executeBatchAsync(
-            long clientPtr, byte[] batchRequestBytes, boolean expectUtf8Response, long callbackId);
+    /**
+     * Execute batch asynchronously. Passes batch commands directly via JNI arrays.
+     *
+     * @param requestTypes array of request type integers, one per command
+     * @param args 3D byte array: args[cmdIndex][argIndex] = byte[] argument
+     * @param isAtomic whether this is a transaction (atomic) or pipeline
+     * @param raiseOnError whether to raise on individual command errors
+     * @param timeout batch timeout in ms (0 = no timeout)
+     * @param retryServerError whether to retry on server errors
+     * @param retryConnectionError whether to retry on connection errors
+     * @param hasRoute whether routing is specified
+     * @param routeType route type int
+     * @param routeParam route parameter string
+     */
+    public static native void executeBatchDirect(
+            long clientPtr,
+            long callbackId,
+            int[] requestTypes,
+            byte[][][] args,
+            boolean isAtomic,
+            boolean raiseOnError,
+            int timeout,
+            boolean retryServerError,
+            boolean retryConnectionError,
+            boolean hasRoute,
+            int routeType,
+            String routeParam,
+            boolean expectUtf8Response,
+            long spanPtr);
 
     /** Update the connection password with optional immediate authentication. */
     public static native void updateConnectionPassword(

--- a/java/client/src/main/java/glide/internal/GlideNativeBridge.java
+++ b/java/client/src/main/java/glide/internal/GlideNativeBridge.java
@@ -38,9 +38,7 @@ public class GlideNativeBridge {
     public static native long createClient(
             byte[] connectionRequestBytes, AddressResolver addressResolver);
 
-    /**
-     * Execute a single command asynchronously, passing parameters directly via JNI.
-     */
+    /** Execute a single command asynchronously, passing parameters directly via JNI. */
     public static native void executeCommandAsync(
             long clientPtr,
             long callbackId,

--- a/java/client/src/main/java/glide/internal/GlideNativeBridge.java
+++ b/java/client/src/main/java/glide/internal/GlideNativeBridge.java
@@ -39,10 +39,9 @@ public class GlideNativeBridge {
             byte[] connectionRequestBytes, AddressResolver addressResolver);
 
     /**
-     * Execute command asynchronously. Passes command parameters directly via JNI to avoid
-     * serialize/deserialize overhead.
+     * Execute a single command asynchronously, passing parameters directly via JNI.
      */
-    public static native void executeCommandDirect(
+    public static native void executeCommandAsync(
             long clientPtr,
             long callbackId,
             int requestType,
@@ -54,7 +53,7 @@ public class GlideNativeBridge {
             long spanPtr);
 
     /**
-     * Execute batch asynchronously. Passes batch commands directly via JNI arrays.
+     * Execute a batch of commands asynchronously, passing parameters directly via JNI.
      *
      * @param requestTypes array of request type integers, one per command
      * @param args 3D byte array: args[cmdIndex][argIndex] = byte[] argument
@@ -67,7 +66,7 @@ public class GlideNativeBridge {
      * @param routeType route type int
      * @param routeParam route parameter string
      */
-    public static native void executeBatchDirect(
+    public static native void executeBatchAsync(
             long clientPtr,
             long callbackId,
             int[] requestTypes,

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -141,7 +141,7 @@ public class CommandManager {
             RequestType requestType,
             String[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectCommand(requestType, stringsToBytes(arguments), null, true, responseHandler);
+        return submitCommandAsync(requestType, stringsToBytes(arguments), null, true, responseHandler);
     }
 
     /** GlideString args expect binary response. */
@@ -149,7 +149,7 @@ public class CommandManager {
             RequestType requestType,
             GlideString[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 requestType, glideStringsToBytes(arguments), null, false, responseHandler);
     }
 
@@ -159,7 +159,7 @@ public class CommandManager {
             GlideString[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler,
             boolean expectUtf8Response) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 requestType, glideStringsToBytes(arguments), null, expectUtf8Response, responseHandler);
     }
 
@@ -170,7 +170,7 @@ public class CommandManager {
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler,
             boolean expectUtf8Response) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 requestType, glideStringsToBytes(arguments), route, expectUtf8Response, responseHandler);
     }
 
@@ -180,7 +180,7 @@ public class CommandManager {
             String[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 requestType, stringsToBytes(arguments), route, true, responseHandler);
     }
 
@@ -190,7 +190,7 @@ public class CommandManager {
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 requestType, glideStringsToBytes(arguments), route, false, responseHandler);
     }
 
@@ -203,7 +203,7 @@ public class CommandManager {
             RequestType requestType,
             String[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectBlockingCommand(
+        return submitBlockingCommandAsync(
                 requestType, stringsToBytes(arguments), null, true, responseHandler);
     }
 
@@ -212,7 +212,7 @@ public class CommandManager {
             RequestType requestType,
             GlideString[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectBlockingCommand(
+        return submitBlockingCommandAsync(
                 requestType, glideStringsToBytes(arguments), null, false, responseHandler);
     }
 
@@ -222,7 +222,7 @@ public class CommandManager {
             String[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectBlockingCommand(
+        return submitBlockingCommandAsync(
                 requestType, stringsToBytes(arguments), route, true, responseHandler);
     }
 
@@ -232,7 +232,7 @@ public class CommandManager {
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectBlockingCommand(
+        return submitBlockingCommandAsync(
                 requestType, glideStringsToBytes(arguments), route, false, responseHandler);
     }
 
@@ -245,10 +245,10 @@ public class CommandManager {
             String[] arguments, GlideExceptionCheckedFunction<Response, T> responseHandler) {
         byte[][] args = stringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitDirectBlockingCommand(
+            return submitBlockingCommandAsync(
                     RequestType.CustomCommand, args, null, true, responseHandler);
         }
-        return submitDirectCommand(RequestType.CustomCommand, args, null, true, responseHandler);
+        return submitCommandAsync(RequestType.CustomCommand, args, null, true, responseHandler);
     }
 
     /** Submit a custom command with GlideString args, detecting if it's a blocking command. */
@@ -256,10 +256,10 @@ public class CommandManager {
             GlideString[] arguments, GlideExceptionCheckedFunction<Response, T> responseHandler) {
         byte[][] args = glideStringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitDirectBlockingCommand(
+            return submitBlockingCommandAsync(
                     RequestType.CustomCommand, args, null, false, responseHandler);
         }
-        return submitDirectCommand(RequestType.CustomCommand, args, null, false, responseHandler);
+        return submitCommandAsync(RequestType.CustomCommand, args, null, false, responseHandler);
     }
 
     /** Submit a custom command with route, detecting if it's a blocking command. */
@@ -267,10 +267,10 @@ public class CommandManager {
             String[] arguments, Route route, GlideExceptionCheckedFunction<Response, T> responseHandler) {
         byte[][] args = stringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitDirectBlockingCommand(
+            return submitBlockingCommandAsync(
                     RequestType.CustomCommand, args, route, true, responseHandler);
         }
-        return submitDirectCommand(RequestType.CustomCommand, args, route, true, responseHandler);
+        return submitCommandAsync(RequestType.CustomCommand, args, route, true, responseHandler);
     }
 
     /** Submit a custom command with route and GlideString args, detecting if it's blocking. */
@@ -280,10 +280,10 @@ public class CommandManager {
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
         byte[][] args = glideStringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitDirectBlockingCommand(
+            return submitBlockingCommandAsync(
                     RequestType.CustomCommand, args, route, false, responseHandler);
         }
-        return submitDirectCommand(RequestType.CustomCommand, args, route, false, responseHandler);
+        return submitCommandAsync(RequestType.CustomCommand, args, route, false, responseHandler);
     }
 
     /** Check if a custom command is a blocking command by inspecting the first argument. */
@@ -305,7 +305,7 @@ public class CommandManager {
     /** Specialized path for ObjectEncoding with GlideString args but textual response. */
     public <T> CompletableFuture<T> submitObjectEncoding(
             GlideString[] arguments, GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 RequestType.ObjectEncoding, glideStringsToBytes(arguments), null, true, responseHandler);
     }
 
@@ -314,7 +314,7 @@ public class CommandManager {
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitDirectCommand(
+        return submitCommandAsync(
                 RequestType.ObjectEncoding, glideStringsToBytes(arguments), route, true, responseHandler);
     }
 
@@ -326,7 +326,7 @@ public class CommandManager {
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
         boolean expectUtf8Response = !batch.isBinaryOutput();
         int timeout = options.map(BaseBatchOptions::getTimeout).orElse(0);
-        return submitBatchDirect(
+        return submitBatchAsync(
                 batch, raiseOnError, timeout, false, false, null, expectUtf8Response, responseHandler);
     }
 
@@ -480,7 +480,7 @@ public class CommandManager {
             }
             route = opts.getRoute();
         }
-        return submitBatchDirect(
+        return submitBatchAsync(
                 batch,
                 raiseOnError,
                 timeout,
@@ -688,8 +688,8 @@ public class CommandManager {
                         });
     }
 
-    /** Core command submission via JNI. */
-    protected <T> CompletableFuture<T> submitDirectCommand(
+    /** Submit a command asynchronously via JNI. */
+    protected <T> CompletableFuture<T> submitCommandAsync(
             RequestType requestType,
             byte[][] args,
             Route route,
@@ -712,7 +712,7 @@ public class CommandManager {
             }
 
             CompletableFuture<Object> jniFuture =
-                    coreClient.executeCommandDirect(
+                    coreClient.executeCommandAsync(
                             requestType.getNumber(),
                             args,
                             routeArgs.hasRoute,
@@ -733,8 +733,8 @@ public class CommandManager {
         }
     }
 
-    /** Blocking command submission via JNI (timeout=0, Rust handles timeout). */
-    protected <T> CompletableFuture<T> submitDirectBlockingCommand(
+    /** Submit a blocking command asynchronously via JNI (timeout=0, Rust handles timeout). */
+    protected <T> CompletableFuture<T> submitBlockingCommandAsync(
             RequestType requestType,
             byte[][] args,
             Route route,
@@ -757,7 +757,7 @@ public class CommandManager {
             }
 
             CompletableFuture<Object> jniFuture =
-                    coreClient.executeCommandDirect(
+                    coreClient.executeCommandAsync(
                             requestType.getNumber(),
                             args,
                             routeArgs.hasRoute,
@@ -942,8 +942,8 @@ public class CommandManager {
 
     // Removed blocking command detection - Rust handles all timeout logic
 
-    /** Submit batch directly to JNI. */
-    private <T> CompletableFuture<T> submitBatchDirect(
+    /** Submit a batch of commands asynchronously via JNI. */
+    private <T> CompletableFuture<T> submitBatchAsync(
             BaseBatch<?> batch,
             boolean raiseOnError,
             int timeout,
@@ -982,7 +982,7 @@ public class CommandManager {
             }
 
             return coreClient
-                    .executeBatchDirect(
+                    .executeBatchAsync(
                             requestTypes,
                             allArgs,
                             isAtomic,

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -1,19 +1,12 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.UnsafeByteOperations;
-import command_request.CommandRequestOuterClass;
 import command_request.CommandRequestOuterClass.CacheMetricsType;
-import command_request.CommandRequestOuterClass.Command;
-import command_request.CommandRequestOuterClass.Command.ArgsArray;
-import command_request.CommandRequestOuterClass.CommandRequest;
 import command_request.CommandRequestOuterClass.RequestType;
-import command_request.CommandRequestOuterClass.Routes;
-import command_request.CommandRequestOuterClass.SimpleRoutes;
-import command_request.CommandRequestOuterClass.SlotTypes;
 import glide.api.OpenTelemetry;
+import glide.api.models.BaseBatch;
 import glide.api.models.Batch;
+import glide.api.models.BatchCommand;
 import glide.api.models.ClusterBatch;
 import glide.api.models.GlideString;
 import glide.api.models.Script;
@@ -30,6 +23,7 @@ import glide.api.models.configuration.RequestRoutingConfiguration.SlotIdRoute;
 import glide.api.models.configuration.RequestRoutingConfiguration.SlotKeyRoute;
 import glide.api.models.exceptions.ClosingException;
 import glide.api.models.exceptions.RequestException;
+import glide.ffi.resolvers.ClusterScanCursorResolver;
 import glide.ffi.resolvers.OpenTelemetryResolver;
 import glide.internal.GlideCoreClient;
 import glide.utils.BufferUtils;
@@ -37,7 +31,9 @@ import glide.utils.Java8Utils;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -140,119 +136,104 @@ public class CommandManager {
         String getCursorId();
     }
 
-    /** Build a command and submit it. */
+    /** String args expect UTF-8 response. */
     public <T> CompletableFuture<T> submitNewCommand(
             RequestType requestType,
             String[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments);
-        return submitCommandToJni(
-                command, responseHandler, false, true); // String arguments -> expect UTF-8 response
+        return submitDirectCommand(requestType, stringsToBytes(arguments), null, true, responseHandler);
     }
 
-    /** Build a command and submit it. */
+    /** GlideString args expect binary response. */
     public <T> CompletableFuture<T> submitNewCommand(
             RequestType requestType,
             GlideString[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments);
-        return submitCommandToJni(
-                command, responseHandler, true, false); // GlideString arguments -> expect binary response
+        return submitDirectCommand(
+                requestType, glideStringsToBytes(arguments), null, false, responseHandler);
     }
 
-    /** Build a command with explicit response type expectation. */
+    /** Submit a command with explicit response type expectation. */
     public <T> CompletableFuture<T> submitNewCommandWithResponseType(
             RequestType requestType,
             GlideString[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler,
             boolean expectUtf8Response) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments);
-        return submitCommandToJni(
-                command, responseHandler, true, expectUtf8Response); // Override response expectation
+        return submitDirectCommand(
+                requestType, glideStringsToBytes(arguments), null, expectUtf8Response, responseHandler);
     }
 
-    /** Build a command with route and explicit response type expectation. */
+    /** Submit a command with route and explicit response type expectation. */
     public <T> CompletableFuture<T> submitNewCommandWithResponseType(
             RequestType requestType,
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler,
             boolean expectUtf8Response) {
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments, route);
-        return submitCommandToJni(command, responseHandler, true, expectUtf8Response);
+        return submitDirectCommand(
+                requestType, glideStringsToBytes(arguments), route, expectUtf8Response, responseHandler);
     }
 
-    /** Build a command and submit it. */
+    /** Submit a command with route. String args expect UTF-8 response. */
     public <T> CompletableFuture<T> submitNewCommand(
             RequestType requestType,
             String[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments, route);
-        return submitCommandToJni(
-                command, responseHandler, false, true); // String arguments -> expect UTF-8 response
+        return submitDirectCommand(
+                requestType, stringsToBytes(arguments), route, true, responseHandler);
     }
 
-    /** Build a command and submit it. */
+    /** Submit a command with route. GlideString args expect binary response. */
     public <T> CompletableFuture<T> submitNewCommand(
             RequestType requestType,
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments, route);
-        return submitCommandToJni(
-                command, responseHandler, true, false); // GlideString arguments -> expect binary response
+        return submitDirectCommand(
+                requestType, glideStringsToBytes(arguments), route, false, responseHandler);
     }
 
     // ==================== BLOCKING COMMAND METHODS ====================
     // These methods skip Java-side timeout because blocking commands (BLPOP, BRPOP, etc.)
     // have their own timeout in the command arguments, which Rust handles correctly.
 
-    /** Build a blocking command and submit it (no Java-side timeout). */
+    /** Submit a blocking command (no Java-side timeout). */
     public <T> CompletableFuture<T> submitBlockingCommand(
             RequestType requestType,
             String[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments);
-        return submitBlockingCommandToJni(command, responseHandler, false, true);
+        return submitDirectBlockingCommand(
+                requestType, stringsToBytes(arguments), null, true, responseHandler);
     }
 
-    /** Build a blocking command and submit it (no Java-side timeout). */
+    /** Submit a blocking command (no Java-side timeout). */
     public <T> CompletableFuture<T> submitBlockingCommand(
             RequestType requestType,
             GlideString[] arguments,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments);
-        return submitBlockingCommandToJni(command, responseHandler, true, false);
+        return submitDirectBlockingCommand(
+                requestType, glideStringsToBytes(arguments), null, false, responseHandler);
     }
 
-    /** Build a blocking command with route and submit it (no Java-side timeout). */
+    /** Submit a blocking command with route (no Java-side timeout). */
     public <T> CompletableFuture<T> submitBlockingCommand(
             RequestType requestType,
             String[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments, route);
-        return submitBlockingCommandToJni(command, responseHandler, false, true);
+        return submitDirectBlockingCommand(
+                requestType, stringsToBytes(arguments), route, true, responseHandler);
     }
 
-    /** Build a blocking command with route and submit it (no Java-side timeout). */
+    /** Submit a blocking command with route (no Java-side timeout). */
     public <T> CompletableFuture<T> submitBlockingCommand(
             RequestType requestType,
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(requestType, arguments, route);
-        return submitBlockingCommandToJni(command, responseHandler, true, false);
+        return submitDirectBlockingCommand(
+                requestType, glideStringsToBytes(arguments), route, false, responseHandler);
     }
 
     // ==================== CUSTOM COMMAND METHODS ====================
@@ -262,35 +243,34 @@ public class CommandManager {
     /** Submit a custom command, detecting if it's a blocking command. */
     public <T> CompletableFuture<T> submitCustomCommand(
             String[] arguments, GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(RequestType.CustomCommand, arguments);
+        byte[][] args = stringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitBlockingCommandToJni(command, responseHandler, false, true);
+            return submitDirectBlockingCommand(
+                    RequestType.CustomCommand, args, null, true, responseHandler);
         }
-        return submitCommandToJni(command, responseHandler, false, true);
+        return submitDirectCommand(RequestType.CustomCommand, args, null, true, responseHandler);
     }
 
     /** Submit a custom command with GlideString args, detecting if it's a blocking command. */
     public <T> CompletableFuture<T> submitCustomCommand(
             GlideString[] arguments, GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command = prepareCommandRequest(RequestType.CustomCommand, arguments);
+        byte[][] args = glideStringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitBlockingCommandToJni(command, responseHandler, true, false);
+            return submitDirectBlockingCommand(
+                    RequestType.CustomCommand, args, null, false, responseHandler);
         }
-        return submitCommandToJni(command, responseHandler, true, false);
+        return submitDirectCommand(RequestType.CustomCommand, args, null, false, responseHandler);
     }
 
     /** Submit a custom command with route, detecting if it's a blocking command. */
     public <T> CompletableFuture<T> submitCustomCommand(
             String[] arguments, Route route, GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command =
-                prepareCommandRequest(RequestType.CustomCommand, arguments, route);
+        byte[][] args = stringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitBlockingCommandToJni(command, responseHandler, false, true);
+            return submitDirectBlockingCommand(
+                    RequestType.CustomCommand, args, route, true, responseHandler);
         }
-        return submitCommandToJni(command, responseHandler, false, true);
+        return submitDirectCommand(RequestType.CustomCommand, args, route, true, responseHandler);
     }
 
     /** Submit a custom command with route and GlideString args, detecting if it's blocking. */
@@ -298,13 +278,12 @@ public class CommandManager {
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-
-        CommandRequest.Builder command =
-                prepareCommandRequest(RequestType.CustomCommand, arguments, route);
+        byte[][] args = glideStringsToBytes(arguments);
         if (isBlockingCustomCommand(arguments)) {
-            return submitBlockingCommandToJni(command, responseHandler, true, false);
+            return submitDirectBlockingCommand(
+                    RequestType.CustomCommand, args, route, false, responseHandler);
         }
-        return submitCommandToJni(command, responseHandler, true, false);
+        return submitDirectCommand(RequestType.CustomCommand, args, route, false, responseHandler);
     }
 
     /** Check if a custom command is a blocking command by inspecting the first argument. */
@@ -326,8 +305,8 @@ public class CommandManager {
     /** Specialized path for ObjectEncoding with GlideString args but textual response. */
     public <T> CompletableFuture<T> submitObjectEncoding(
             GlideString[] arguments, GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        CommandRequest.Builder command = prepareCommandRequest(RequestType.ObjectEncoding, arguments);
-        return submitCommandToJni(command, responseHandler, true, true);
+        return submitDirectCommand(
+                RequestType.ObjectEncoding, glideStringsToBytes(arguments), null, true, responseHandler);
     }
 
     /** Specialized path for ObjectEncoding with route. */
@@ -335,21 +314,20 @@ public class CommandManager {
             GlideString[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        CommandRequest.Builder command =
-                prepareCommandRequest(RequestType.ObjectEncoding, arguments, route);
-        return submitCommandToJni(command, responseHandler, true, true);
+        return submitDirectCommand(
+                RequestType.ObjectEncoding, glideStringsToBytes(arguments), route, true, responseHandler);
     }
 
-    /** Build a Batch and submit it. */
+    /** Submit a Batch. */
     public <T> CompletableFuture<T> submitNewBatch(
             Batch batch,
             boolean raiseOnError,
             Optional<BatchOptions> options,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        CommandRequest.Builder command = prepareCommandRequest(batch, raiseOnError, options);
         boolean expectUtf8Response = !batch.isBinaryOutput();
-        Integer timeoutOverride = options.map(BaseBatchOptions::getTimeout).orElse(null);
-        return submitBatchToJni(command, responseHandler, expectUtf8Response, timeoutOverride);
+        int timeout = options.map(BaseBatchOptions::getTimeout).orElse(0);
+        return submitBatchDirect(
+                batch, raiseOnError, timeout, false, false, null, expectUtf8Response, responseHandler);
     }
 
     /** Build a Script (by hash) request to send to Valkey. */
@@ -383,7 +361,7 @@ public class CommandManager {
                             expectUtf8Response);
 
             return jniFuture
-                    .thenApply(result -> createDirectResponse(result, expectUtf8Response))
+                    .thenApply(result -> buildResponseFromJniResult(result, expectUtf8Response))
                     .thenApply(response -> applyHandlerWithCleanup(response, responseHandler))
                     .exceptionally(this::exceptionHandler);
         } catch (Exception e) {
@@ -413,7 +391,7 @@ public class CommandManager {
                     script.getBinaryOutput() == null || !script.getBinaryOutput();
 
             // Map Route to simple route tuple via centralized helper
-            ScriptRouteArgs routeArgs = computeScriptRouteArgs(route);
+            DirectRouteArgs routeArgs = computeRouteArgs(route);
 
             CompletableFuture<Object> jniFuture =
                     coreClient.executeScriptAsync(
@@ -426,7 +404,7 @@ public class CommandManager {
                             expectUtf8Response);
 
             return jniFuture
-                    .thenApply(result -> createDirectResponse(result, expectUtf8Response))
+                    .thenApply(result -> buildResponseFromJniResult(result, expectUtf8Response))
                     .thenApply(response -> applyHandlerWithCleanup(response, responseHandler))
                     .exceptionally(this::exceptionHandler);
         } catch (Exception e) {
@@ -436,60 +414,81 @@ public class CommandManager {
         }
     }
 
-    /** Lightweight container for script routing arguments. */
-    private static final class ScriptRouteArgs {
+    /** Lightweight container for direct routing arguments. */
+    private static final class DirectRouteArgs {
         final boolean hasRoute;
         final int routeType;
         final String routeParam;
 
-        ScriptRouteArgs(boolean hasRoute, int routeType, String routeParam) {
+        DirectRouteArgs(boolean hasRoute, int routeType, String routeParam) {
             this.hasRoute = hasRoute;
             this.routeType = routeType;
             this.routeParam = routeParam;
         }
     }
 
-    /** Centralized mapping from RouteInfo to script routing tuple. */
-    private ScriptRouteArgs computeScriptRouteArgs(Route route) {
+    /** Centralized mapping from Route to direct routing tuple. */
+    private static DirectRouteArgs computeRouteArgs(Route route) {
         if (route == null) {
-            return new ScriptRouteArgs(false, 0, null);
+            return new DirectRouteArgs(false, 0, null);
         }
         if (route instanceof SimpleMultiNodeRoute) {
-            return new ScriptRouteArgs(true, ((SimpleMultiNodeRoute) route).getOrdinal(), null);
+            return new DirectRouteArgs(true, ((SimpleMultiNodeRoute) route).getOrdinal(), null);
         }
         if (route instanceof SimpleSingleNodeRoute) {
-            return new ScriptRouteArgs(true, ((SimpleSingleNodeRoute) route).getOrdinal(), null);
+            return new DirectRouteArgs(true, ((SimpleSingleNodeRoute) route).getOrdinal(), null);
         }
         if (route instanceof SlotKeyRoute) {
             int routeType = ((SlotKeyRoute) route).getSlotType().ordinal();
             String routeParam = ((SlotKeyRoute) route).getSlotKey();
-            return new ScriptRouteArgs(true, routeType, routeParam);
+            return new DirectRouteArgs(true, routeType, routeParam);
         }
         if (route instanceof SlotIdRoute) {
-            int routeType = ((SlotIdRoute) route).getSlotType().ordinal();
+            // Offset by 100 to distinguish from SlotKeyRoute on the native side
+            int routeType = 100 + ((SlotIdRoute) route).getSlotType().ordinal();
             String routeParam = Integer.toString(((SlotIdRoute) route).getSlotId());
-            return new ScriptRouteArgs(true, routeType, routeParam);
+            return new DirectRouteArgs(true, routeType, routeParam);
         }
         if (route instanceof ByAddressRoute) {
             String hostPort =
                     ((ByAddressRoute) route).getHost() + ":" + ((ByAddressRoute) route).getPort();
-            return new ScriptRouteArgs(true, -1, hostPort); // -1 => ByAddress special case
+            return new DirectRouteArgs(true, -1, hostPort);
         }
         throw new RequestException(
-                String.format(
-                        "Unsupported route type for script invocation: %s", route.getClass().getSimpleName()));
+                String.format("Unknown type of route: %s", route.getClass().getSimpleName()));
     }
 
-    /** Build a Cluster Batch and submit it. */
+    /** Submit a Cluster Batch. */
     public <T> CompletableFuture<T> submitNewBatch(
             ClusterBatch batch,
             boolean raiseOnError,
             Optional<ClusterBatchOptions> options,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        CommandRequest.Builder command = prepareCommandRequest(batch, raiseOnError, options);
         boolean expectUtf8Response = !batch.isBinaryOutput();
-        Integer timeoutOverride = options.map(BaseBatchOptions::getTimeout).orElse(null);
-        return submitBatchToJni(command, responseHandler, expectUtf8Response, timeoutOverride);
+        int timeout = options.map(BaseBatchOptions::getTimeout).orElse(0);
+        boolean retryServerError = false;
+        boolean retryConnectionError = false;
+        Route route = null;
+        if (options.isPresent()) {
+            ClusterBatchOptions opts = options.get();
+            if (opts.getRetryStrategy() != null) {
+                if (batch.isAtomic()) {
+                    throw new RequestException("Retry strategy is not supported for atomic batches.");
+                }
+                retryServerError = opts.getRetryStrategy().isRetryServerError();
+                retryConnectionError = opts.getRetryStrategy().isRetryConnectionError();
+            }
+            route = opts.getRoute();
+        }
+        return submitBatchDirect(
+                batch,
+                raiseOnError,
+                timeout,
+                retryServerError,
+                retryConnectionError,
+                route,
+                expectUtf8Response,
+                responseHandler);
     }
 
     private static byte[][] toByteMatrix(List<GlideString> values) {
@@ -553,9 +552,7 @@ public class CommandManager {
                                 if (result == null) {
                                     normalized =
                                             new Object[] {
-                                                glide.ffi.resolvers.ClusterScanCursorResolver
-                                                        .getFinishedCursorHandleConstant(),
-                                                new Object[0]
+                                                ClusterScanCursorResolver.getFinishedCursorHandleConstant(), new Object[0]
                                             };
                                 } else {
                                     // Normalize cluster scan result: ensure cursor is String and
@@ -571,8 +568,7 @@ public class CommandManager {
                                         T fallback =
                                                 (T)
                                                         new Object[] {
-                                                            glide.ffi.resolvers.ClusterScanCursorResolver
-                                                                    .getFinishedCursorHandleConstant(),
+                                                            ClusterScanCursorResolver.getFinishedCursorHandleConstant(),
                                                             new Object[0]
                                                         };
                                         return fallback;
@@ -606,7 +602,7 @@ public class CommandManager {
         Object cursorObj = arr[0];
         String cursor;
         if (cursorObj instanceof byte[]) {
-            cursor = new String((byte[]) cursorObj, java.nio.charset.StandardCharsets.UTF_8);
+            cursor = new String((byte[]) cursorObj, StandardCharsets.UTF_8);
         } else {
             cursor = String.valueOf(cursorObj);
         }
@@ -619,7 +615,7 @@ public class CommandManager {
                 // Convert any stray byte[] to UTF-8 Strings
                 for (int i = 0; i < items.length; i++) {
                     if (items[i] instanceof byte[]) {
-                        items[i] = new String((byte[]) items[i], java.nio.charset.StandardCharsets.UTF_8);
+                        items[i] = new String((byte[]) items[i], StandardCharsets.UTF_8);
                     }
                 }
                 return new Object[] {cursor, items};
@@ -627,7 +623,7 @@ public class CommandManager {
                 // Binary path: convert byte[] to GlideString for nice toString()
                 for (int i = 0; i < items.length; i++) {
                     if (items[i] instanceof byte[]) {
-                        items[i] = glide.api.models.GlideString.gs((byte[]) items[i]);
+                        items[i] = GlideString.gs((byte[]) items[i]);
                     }
                 }
                 return new Object[] {cursor, items};
@@ -692,23 +688,13 @@ public class CommandManager {
                         });
     }
 
-    /** Take a command request and submit it (backward compatibility). */
-    protected <T> CompletableFuture<T> submitCommandToJni(
-            CommandRequest.Builder command,
-            GlideExceptionCheckedFunction<Response, T> responseHandler,
-            boolean binaryMode) {
-        // For backward compatibility, default expectUtf8Response based on binaryMode
-        // binaryMode=true means GlideString args, expect binary response
-        // binaryMode=false means String args, expect UTF-8 response
-        return submitCommandToJni(command, responseHandler, binaryMode, !binaryMode);
-    }
-
-    /** Take a command request and submit it. */
-    protected <T> CompletableFuture<T> submitCommandToJni(
-            CommandRequest.Builder command,
-            GlideExceptionCheckedFunction<Response, T> responseHandler,
-            boolean binaryMode,
-            boolean expectUtf8Response) {
+    /** Core command submission via JNI. */
+    protected <T> CompletableFuture<T> submitDirectCommand(
+            RequestType requestType,
+            byte[][] args,
+            Route route,
+            boolean expectUtf8Response,
+            GlideExceptionCheckedFunction<Response, T> responseHandler) {
 
         if (!coreClient.isConnected()) {
             CompletableFuture<T> errorFuture = new CompletableFuture<T>();
@@ -718,16 +704,23 @@ public class CommandManager {
         }
 
         try {
-            // Serialize the protobuf command request
-            byte[] requestBytes = command.build().toByteArray();
+            DirectRouteArgs routeArgs = computeRouteArgs(route);
 
-            // Execute via JNI - returns converted Java objects directly
-            // No need to wrap in Response since JNI already provides the final object
-            // Use binary or UTF-8 mode based on expected response type, not argument type
+            long spanPtr = 0;
+            if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
+                spanPtr = OpenTelemetryResolver.createLeakedOtelSpan(requestType.name());
+            }
+
             CompletableFuture<Object> jniFuture =
-                    expectUtf8Response
-                            ? coreClient.executeCommandAsync(requestBytes) // Force UTF-8 conversion
-                            : coreClient.executeBinaryCommandAsync(requestBytes); // Allow binary conversion
+                    coreClient.executeCommandDirect(
+                            requestType.getNumber(),
+                            args,
+                            routeArgs.hasRoute,
+                            routeArgs.routeType,
+                            routeArgs.routeParam,
+                            expectUtf8Response,
+                            coreClient.getRequestTimeoutMillis(),
+                            spanPtr);
 
             return jniFuture
                     .thenApply(result -> buildResponseFromJniResult(result, expectUtf8Response))
@@ -740,15 +733,13 @@ public class CommandManager {
         }
     }
 
-    /**
-     * Submit a blocking command to JNI without Java-side timeout. Blocking commands (BLPOP, BRPOP,
-     * etc.) have their own timeout in the command arguments, which Rust handles correctly.
-     */
-    protected <T> CompletableFuture<T> submitBlockingCommandToJni(
-            CommandRequest.Builder command,
-            GlideExceptionCheckedFunction<Response, T> responseHandler,
-            boolean binaryMode,
-            boolean expectUtf8Response) {
+    /** Blocking command submission via JNI (timeout=0, Rust handles timeout). */
+    protected <T> CompletableFuture<T> submitDirectBlockingCommand(
+            RequestType requestType,
+            byte[][] args,
+            Route route,
+            boolean expectUtf8Response,
+            GlideExceptionCheckedFunction<Response, T> responseHandler) {
 
         if (!coreClient.isConnected()) {
             CompletableFuture<T> errorFuture = new CompletableFuture<T>();
@@ -758,14 +749,23 @@ public class CommandManager {
         }
 
         try {
-            // Serialize the protobuf command request
-            byte[] requestBytes = command.build().toByteArray();
+            DirectRouteArgs routeArgs = computeRouteArgs(route);
 
-            // Execute via JNI WITHOUT Java-side timeout - Rust handles blocking command timeout
+            long spanPtr = 0;
+            if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
+                spanPtr = OpenTelemetryResolver.createLeakedOtelSpan(requestType.name());
+            }
+
             CompletableFuture<Object> jniFuture =
-                    expectUtf8Response
-                            ? coreClient.executeCommandAsyncNoTimeout(requestBytes)
-                            : coreClient.executeBinaryCommandAsyncNoTimeout(requestBytes);
+                    coreClient.executeCommandDirect(
+                            requestType.getNumber(),
+                            args,
+                            routeArgs.hasRoute,
+                            routeArgs.routeType,
+                            routeArgs.routeParam,
+                            expectUtf8Response,
+                            0,
+                            spanPtr);
 
             return jniFuture
                     .thenApply(result -> buildResponseFromJniResult(result, expectUtf8Response))
@@ -807,7 +807,7 @@ public class CommandManager {
         dup.order(ByteOrder.BIG_ENDIAN);
         dup.rewind();
         if (dup.remaining() == 0) {
-            return expectUtf8Response ? "" : glide.api.models.GlideString.gs(new byte[0]);
+            return expectUtf8Response ? "" : GlideString.gs(new byte[0]);
         }
         byte marker = dup.get();
         dup.rewind();
@@ -824,7 +824,7 @@ public class CommandManager {
         } else {
             byte[] bytes = new byte[dup.remaining()];
             dup.get(bytes);
-            return glide.api.models.GlideString.gs(bytes);
+            return GlideString.gs(bytes);
         }
     }
 
@@ -885,7 +885,7 @@ public class CommandManager {
      * @throws IllegalArgumentException if the buffer format is invalid or contains out-of-bounds
      *     values
      */
-    private java.util.LinkedHashMap<Object, Object> deserializeByteBufferMap(
+    private LinkedHashMap<Object, Object> deserializeByteBufferMap(
             ByteBuffer buffer, boolean expectUtf8) {
         buffer.order(ByteOrder.BIG_ENDIAN);
         buffer.rewind();
@@ -907,8 +907,7 @@ public class CommandManager {
 
         // Use reasonable initial capacity to avoid huge upfront allocation
         // The actual elements will be validated one-by-one against buffer bounds
-        java.util.LinkedHashMap<Object, Object> map =
-                new java.util.LinkedHashMap<>(Math.min(count, 1024));
+        LinkedHashMap<Object, Object> map = new LinkedHashMap<>(Math.min(count, 1024));
 
         for (int i = 0; i < count; i++) {
             requireBufferBytes(buffer, 4, "key length at entry " + i);
@@ -921,7 +920,7 @@ public class CommandManager {
             } else {
                 byte[] kbytes = new byte[klen];
                 buffer.get(kbytes);
-                key = glide.api.models.GlideString.gs(kbytes);
+                key = GlideString.gs(kbytes);
             }
 
             requireBufferBytes(buffer, 4, "value length at entry " + i);
@@ -934,7 +933,7 @@ public class CommandManager {
             } else {
                 byte[] vbytes = new byte[vlen];
                 buffer.get(vbytes);
-                val = glide.api.models.GlideString.gs(vbytes);
+                val = GlideString.gs(vbytes);
             }
             map.put(key, val);
         }
@@ -943,12 +942,16 @@ public class CommandManager {
 
     // Removed blocking command detection - Rust handles all timeout logic
 
-    /** Submit batch request via JNI. */
-    protected <T> CompletableFuture<T> submitBatchToJni(
-            CommandRequest.Builder command,
-            GlideExceptionCheckedFunction<Response, T> responseHandler,
+    /** Submit batch directly to JNI. */
+    private <T> CompletableFuture<T> submitBatchDirect(
+            BaseBatch<?> batch,
+            boolean raiseOnError,
+            int timeout,
+            boolean retryServerError,
+            boolean retryConnectionError,
+            Route route,
             boolean expectUtf8Response,
-            Integer timeoutOverrideMs) {
+            GlideExceptionCheckedFunction<Response, T> responseHandler) {
 
         if (!coreClient.isConnected()) {
             CompletableFuture<T> errorFuture = new CompletableFuture<T>();
@@ -958,15 +961,42 @@ public class CommandManager {
         }
 
         try {
-            // Serialize the protobuf batch request
-            byte[] requestBytes = command.build().toByteArray();
+            // Extract commands directly from BaseBatch
+            List<BatchCommand> batchCommands = batch.getCommands();
+            int cmdCount = batchCommands.size();
+            int[] requestTypes = new int[cmdCount];
+            byte[][][] allArgs = new byte[cmdCount][][];
+            for (int i = 0; i < cmdCount; i++) {
+                BatchCommand cmd = batchCommands.get(i);
+                requestTypes[i] = cmd.getRequestType();
+                allArgs[i] = cmd.getArgs();
+            }
 
-            // Execute via JNI and convert response
-            // Stage 1: Convert JNI result to Response
-            // Stage 2: Apply response handler with cleanup on exception
+            boolean isAtomic = batch.isAtomic();
+            DirectRouteArgs routeArgs = computeRouteArgs(route);
+            long timeoutMs = timeout > 0 ? timeout : coreClient.getRequestTimeoutMillis();
+
+            long spanPtr = 0;
+            if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
+                spanPtr = OpenTelemetryResolver.createLeakedOtelSpan("Batch");
+            }
+
             return coreClient
-                    .executeBatchAsync(requestBytes, expectUtf8Response, timeoutOverrideMs)
-                    .thenApply(result -> convertJniToProtobufResponse(result, expectUtf8Response))
+                    .executeBatchDirect(
+                            requestTypes,
+                            allArgs,
+                            isAtomic,
+                            raiseOnError,
+                            timeout,
+                            retryServerError,
+                            retryConnectionError,
+                            routeArgs.hasRoute,
+                            routeArgs.routeType,
+                            routeArgs.routeParam,
+                            expectUtf8Response,
+                            timeoutMs,
+                            spanPtr)
+                    .thenApply(result -> buildResponseFromJniResult(result, expectUtf8Response))
                     .thenApply(response -> applyHandlerWithCleanup(response, responseHandler))
                     .exceptionally(this::exceptionHandler);
         } catch (Exception e) {
@@ -989,110 +1019,6 @@ public class CommandManager {
 
         // This shouldn't happen if isFinished() is true
         return null;
-    }
-
-    /**
-     * Convert JNI result to protobuf Response format. This bridges the gap between JNI responses and
-     * the expected protobuf Response.
-     */
-    private Response convertJniToProtobufResponse(Object jniResult, boolean expectUtf8Response) {
-        Response.Builder builder = Response.newBuilder();
-
-        if (jniResult == null) {
-            // Null response - set pointer to 0
-            builder.setRespPointer(0L);
-        } else if ("OK".equals(jniResult)) {
-            // OK constant response
-            builder.setConstantResponse(ConstantResponse.OK);
-        } else if (jniResult instanceof ByteBuffer) {
-            // DirectByteBuffer from JNI. Could be a serialized array/map or a large bulk string.
-            ByteBuffer buffer = (ByteBuffer) jniResult;
-            ByteBuffer dup = buffer.duplicate();
-            dup.rewind();
-            Object toStore;
-            if (dup.remaining() > 0) {
-                byte marker = dup.get();
-                if (marker == '*') {
-                    dup.rewind();
-                    toStore = deserializeByteBufferArray(dup, expectUtf8Response);
-                } else if (marker == '%') {
-                    dup.rewind();
-                    toStore = deserializeByteBufferMap(dup, expectUtf8Response);
-                } else {
-                    dup.rewind();
-                    if (expectUtf8Response) {
-                        toStore = BufferUtils.decodeUtf8(dup);
-                    } else {
-                        byte[] bytes = new byte[dup.remaining()];
-                        dup.get(bytes);
-                        toStore = glide.api.models.GlideString.gs(bytes);
-                    }
-                }
-            } else {
-                toStore = expectUtf8Response ? "" : glide.api.models.GlideString.gs(new byte[0]);
-            }
-            long objectId = JniResponseRegistry.storeObject(toStore);
-            builder.setRespPointer(objectId);
-        } else {
-            // Store the object in the registry and get its ID
-            // This allows BaseResponseResolver to retrieve it correctly
-            long objectId = JniResponseRegistry.storeObject(jniResult);
-            builder.setRespPointer(objectId);
-        }
-
-        return builder.build();
-    }
-
-    /**
-     * Create a direct Response from a JNI result object. Since JNI now returns converted Java objects
-     * directly (not pointers), we store the object in a temporary registry and pass an ID.
-     */
-    private Response createDirectResponse(Object jniResult, boolean expectUtf8Response) {
-        Response.Builder builder = Response.newBuilder();
-
-        if (jniResult == null) {
-            // Null response - no pointer needed
-            builder.setRespPointer(0L);
-        } else if ("OK".equals(jniResult)) {
-            // OK constant response
-            builder.setConstantResponse(ConstantResponse.OK);
-        } else if (jniResult instanceof ByteBuffer) {
-            // DirectByteBuffer from JNI. Could be serialized array/map or large bulk string.
-            ByteBuffer buffer = (ByteBuffer) jniResult;
-            ByteBuffer dup = buffer.duplicate();
-            dup.rewind();
-            Object toStore;
-            if (dup.remaining() > 0) {
-                byte marker = dup.get();
-                if (marker == '*') {
-                    dup.rewind();
-                    toStore = deserializeByteBufferArray(dup, expectUtf8Response);
-                } else if (marker == '%') {
-                    dup.rewind();
-                    toStore = deserializeByteBufferMap(dup, expectUtf8Response);
-                } else {
-                    dup.rewind();
-                    if (expectUtf8Response) {
-                        toStore = BufferUtils.decodeUtf8(dup);
-                    } else {
-                        byte[] bytes = new byte[dup.remaining()];
-                        dup.get(bytes);
-                        toStore = glide.api.models.GlideString.gs(bytes);
-                    }
-                }
-            } else {
-                toStore = expectUtf8Response ? "" : glide.api.models.GlideString.gs(new byte[0]);
-            }
-            long objectId = JniResponseRegistry.storeObject(toStore);
-            builder.setRespPointer(objectId);
-        } else {
-            // Store the Java object and get an ID for it
-            // This ID will be used to retrieve the object in valueFromPointer
-            long objectId = JniResponseRegistry.storeObject(jniResult);
-            builder.setRespPointer(objectId);
-        }
-
-        return builder.build();
     }
 
     /**
@@ -1148,7 +1074,7 @@ public class CommandManager {
                         } else {
                             byte[] data = new byte[bulkLen];
                             buffer.get(data);
-                            result[i] = glide.api.models.GlideString.gs(data);
+                            result[i] = GlideString.gs(data);
                         }
                     }
                     break;
@@ -1193,7 +1119,7 @@ public class CommandManager {
                     } else {
                         byte[] complexData = new byte[complexLen];
                         buffer.get(complexData);
-                        result[i] = glide.api.models.GlideString.gs(complexData);
+                        result[i] = GlideString.gs(complexData);
                     }
                     break;
 
@@ -1220,291 +1146,33 @@ public class CommandManager {
     // Command preparation methods (copied from original CommandManager)
     // ============================================================================
 
-    /** Build a protobuf command request object with routing options. */
-    protected CommandRequest.Builder prepareCommandRequest(
-            RequestType requestType, String[] arguments, Route route) {
-        final Command.Builder commandBuilder = Command.newBuilder();
-        populateCommandWithArgs(arguments, commandBuilder);
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan(requestType.name());
+    /** Convert String[] to byte[][] for direct JNI passing. */
+    private static byte[][] stringsToBytes(String[] arguments) {
+        if (arguments == null || arguments.length == 0) {
+            return GlideCoreClient.EMPTY_2D_BYTE_ARRAY;
         }
-
-        CommandRequest.Builder builder =
-                CommandRequest.newBuilder()
-                        .setSingleCommand(commandBuilder.setRequestType(requestType).build());
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-
-        return prepareCommandRequestRoute(builder, route);
-    }
-
-    /** Build a protobuf command request object with routing options. */
-    protected CommandRequest.Builder prepareCommandRequest(
-            RequestType requestType, GlideString[] arguments, Route route) {
-        final Command.Builder commandBuilder = Command.newBuilder();
-        populateCommandWithArgs(arguments, commandBuilder);
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan(requestType.name());
-        }
-
-        CommandRequest.Builder builder =
-                CommandRequest.newBuilder()
-                        .setSingleCommand(commandBuilder.setRequestType(requestType).build());
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-
-        return prepareCommandRequestRoute(builder, route);
-    }
-
-    /** Build a protobuf Batch request object. */
-    protected CommandRequest.Builder prepareCommandRequest(
-            Batch batch, boolean raiseOnError, Optional<BatchOptions> options) {
-        CommandRequest.Builder builder = CommandRequest.newBuilder();
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan("Batch");
-        }
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-
-        if (options.isPresent()) {
-            BatchOptions opts = options.get();
-            CommandRequestOuterClass.Batch.Builder batchBuilder =
-                    prepareCommandRequestBatchOptions(batch.getProtobufBatch(), opts);
-            builder.setBatch(batchBuilder.setRaiseOnError(raiseOnError).build());
-        } else {
-            builder.setBatch(batch.getProtobufBatch().setRaiseOnError(raiseOnError).build());
-        }
-
-        return builder;
-    }
-
-    /** Build a protobuf Batch request object with options. */
-    protected CommandRequest.Builder prepareCommandRequest(
-            ClusterBatch batch, boolean raiseOnError, Optional<ClusterBatchOptions> options) {
-
-        CommandRequest.Builder builder = CommandRequest.newBuilder();
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan("Batch");
-        }
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-
-        if (options.isPresent()) {
-            ClusterBatchOptions opts = options.get();
-            CommandRequestOuterClass.Batch.Builder batchBuilder =
-                    prepareCommandRequestBatchOptions(batch.getProtobufBatch(), opts);
-
-            if (opts.getRetryStrategy() != null) {
-                if (batchBuilder.getIsAtomic()) {
-                    throw new RequestException("Retry strategy is not supported for atomic batches.");
-                }
-                batchBuilder.setRetryServerError(opts.getRetryStrategy().isRetryServerError());
-                batchBuilder.setRetryConnectionError(opts.getRetryStrategy().isRetryConnectionError());
-            }
-
-            builder.setBatch(batchBuilder.setRaiseOnError(raiseOnError).build());
-
-            if (opts.getRoute() != null) {
-                return prepareCommandRequestRoute(builder, opts.getRoute());
-            }
-        } else {
-            builder.setBatch(batch.getProtobufBatch().setRaiseOnError(raiseOnError).build());
-        }
-
-        return builder;
-    }
-
-    /** Build a protobuf cursor scan request. */
-    protected CommandRequest.Builder prepareCursorRequest(
-            @NonNull ClusterScanCursor cursor, @NonNull ScanOptions options) {
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan("ClusterScan");
-        }
-
-        CommandRequestOuterClass.ClusterScan.Builder clusterScanBuilder =
-                CommandRequestOuterClass.ClusterScan.newBuilder();
-
-        if (cursor != ClusterScanCursor.INITIAL_CURSOR_INSTANCE) {
-            if (cursor instanceof ClusterScanCursorDetail) {
-                clusterScanBuilder.setCursor(((ClusterScanCursorDetail) cursor).getCursorHandle());
-            } else {
-                throw new IllegalArgumentException("Illegal cursor submitted.");
-            }
-        }
-
-        if (options.getMatchPattern() != null) {
-            clusterScanBuilder.setMatchPattern(ByteString.copyFrom(options.getMatchPattern().getBytes()));
-        }
-
-        if (options.getCount() != null) {
-            clusterScanBuilder.setCount(options.getCount());
-        }
-
-        if (options.getType() != null) {
-            clusterScanBuilder.setObjectType(options.getType().getNativeName());
-        }
-
-        if (options.getAllowNonCoveredSlots() != null) {
-            clusterScanBuilder.setAllowNonCoveredSlots(options.getAllowNonCoveredSlots());
-        }
-
-        CommandRequest.Builder builder =
-                CommandRequest.newBuilder().setClusterScan(clusterScanBuilder.build());
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-
-        return builder;
-    }
-
-    /** Build a protobuf command request object. */
-    protected CommandRequest.Builder prepareCommandRequest(
-            RequestType requestType, String[] arguments) {
-        final Command.Builder commandBuilder = Command.newBuilder();
-        populateCommandWithArgs(arguments, commandBuilder);
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan(requestType.name());
-        }
-
-        CommandRequest.Builder builder =
-                CommandRequest.newBuilder()
-                        .setSingleCommand(commandBuilder.setRequestType(requestType).build());
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-        return builder;
-    }
-
-    /** Build a protobuf command request object. */
-    protected CommandRequest.Builder prepareCommandRequest(
-            RequestType requestType, GlideString[] arguments) {
-        final Command.Builder commandBuilder = Command.newBuilder();
-        populateCommandWithArgs(arguments, commandBuilder);
-
-        long spanPtr = 0;
-        if (OpenTelemetry.isInitialized() && OpenTelemetry.shouldSample()) {
-            spanPtr = OpenTelemetryResolver.createLeakedOtelSpan(requestType.name());
-        }
-
-        CommandRequest.Builder builder =
-                CommandRequest.newBuilder()
-                        .setSingleCommand(commandBuilder.setRequestType(requestType).build());
-
-        if (spanPtr != 0) {
-            builder.setRootSpanPtr(spanPtr);
-        }
-
-        return builder;
-    }
-
-    private CommandRequestOuterClass.Batch.Builder prepareCommandRequestBatchOptions(
-            CommandRequestOuterClass.Batch.Builder batchBuilder, BaseBatchOptions options) {
-        if (options.getTimeout() != null) {
-            batchBuilder.setTimeout(options.getTimeout());
-        }
-        return batchBuilder;
-    }
-
-    private CommandRequest.Builder prepareCommandRequestRoute(
-            CommandRequest.Builder builder, Route route) {
-
-        if (route instanceof SimpleMultiNodeRoute) {
-            builder.setRoute(
-                    Routes.newBuilder()
-                            .setSimpleRoutes(SimpleRoutes.forNumber(((SimpleMultiNodeRoute) route).getOrdinal()))
-                            .build());
-        } else if (route instanceof SimpleSingleNodeRoute) {
-            builder.setRoute(
-                    Routes.newBuilder()
-                            .setSimpleRoutes(SimpleRoutes.forNumber(((SimpleSingleNodeRoute) route).getOrdinal()))
-                            .build());
-        } else if (route instanceof SlotIdRoute) {
-            builder.setRoute(
-                    Routes.newBuilder()
-                            .setSlotIdRoute(
-                                    CommandRequestOuterClass.SlotIdRoute.newBuilder()
-                                            .setSlotId(((SlotIdRoute) route).getSlotId())
-                                            .setSlotType(
-                                                    SlotTypes.forNumber(((SlotIdRoute) route).getSlotType().ordinal()))));
-        } else if (route instanceof SlotKeyRoute) {
-            builder.setRoute(
-                    Routes.newBuilder()
-                            .setSlotKeyRoute(
-                                    CommandRequestOuterClass.SlotKeyRoute.newBuilder()
-                                            .setSlotKey(((SlotKeyRoute) route).getSlotKey())
-                                            .setSlotType(
-                                                    SlotTypes.forNumber(((SlotKeyRoute) route).getSlotType().ordinal()))));
-        } else if (route instanceof ByAddressRoute) {
-            builder.setRoute(
-                    Routes.newBuilder()
-                            .setByAddressRoute(
-                                    CommandRequestOuterClass.ByAddressRoute.newBuilder()
-                                            .setHost(((ByAddressRoute) route).getHost())
-                                            .setPort(((ByAddressRoute) route).getPort())));
-        } else {
-            throw new RequestException(
-                    String.format("Unknown type of route: %s", route.getClass().getSimpleName()));
-        }
-        return builder;
-    }
-
-    /** Add the given set of arguments to the output Command.Builder. */
-    public static <ArgType> void populateCommandWithArgs(
-            ArgType[] arguments, Command.Builder outputBuilder) {
-        ArgsArray.Builder commandArgs = ArgsArray.newBuilder();
-        for (ArgType value : arguments) {
-            appendArgument(commandArgs, value);
-        }
-        outputBuilder.setArgsArray(commandArgs);
-    }
-
-    /** Add the given set of arguments to the output Command.Builder. */
-    private static void populateCommandWithArgs(
-            GlideString[] arguments, Command.Builder outputBuilder) {
-        ArgsArray.Builder commandArgs = ArgsArray.newBuilder();
-        for (GlideString argument : arguments) {
-            if (argument == null) {
+        byte[][] result = new byte[arguments.length][];
+        for (int i = 0; i < arguments.length; i++) {
+            if (arguments[i] == null) {
                 throw new NullPointerException("Argument cannot be null");
             }
-            commandArgs.addArgs(UnsafeByteOperations.unsafeWrap(argument.getBytes()));
+            result[i] = arguments[i].getBytes(StandardCharsets.UTF_8);
         }
-        outputBuilder.setArgsArray(commandArgs);
+        return result;
     }
 
-    private static void appendArgument(ArgsArray.Builder commandArgs, Object value) {
-        if (value instanceof GlideString) {
-            commandArgs.addArgs(UnsafeByteOperations.unsafeWrap(((GlideString) value).getBytes()));
-        } else if (value instanceof byte[]) {
-            commandArgs.addArgs(UnsafeByteOperations.unsafeWrap((byte[]) value));
-        } else if (value instanceof String) {
-            commandArgs.addArgs(ByteString.copyFromUtf8((String) value));
-        } else {
-            if (value == null) {
+    /** Convert GlideString[] to byte[][] for direct JNI passing. */
+    private static byte[][] glideStringsToBytes(GlideString[] arguments) {
+        if (arguments == null || arguments.length == 0) {
+            return GlideCoreClient.EMPTY_2D_BYTE_ARRAY;
+        }
+        byte[][] result = new byte[arguments.length][];
+        for (int i = 0; i < arguments.length; i++) {
+            if (arguments[i] == null) {
                 throw new NullPointerException("Argument cannot be null");
             }
-            commandArgs.addArgs(ByteString.copyFromUtf8(value.toString()));
+            result[i] = arguments[i].getBytes();
         }
+        return result;
     }
 }

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -180,8 +180,7 @@ public class CommandManager {
             String[] arguments,
             Route route,
             GlideExceptionCheckedFunction<Response, T> responseHandler) {
-        return submitCommandAsync(
-                requestType, stringsToBytes(arguments), route, true, responseHandler);
+        return submitCommandAsync(requestType, stringsToBytes(arguments), route, true, responseHandler);
     }
 
     /** Submit a command with route. GlideString args expect binary response. */

--- a/java/client/src/main/java/glide/managers/JniResponseRegistry.java
+++ b/java/client/src/main/java/glide/managers/JniResponseRegistry.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Registry for storing Java objects returned from JNI calls. This allows us to pass object IDs
- * through the Response protobuf instead of trying to pass Rust pointers that would become invalid.
+ * through the Response wrapper instead of trying to pass Rust pointers that would become invalid.
  *
  * <p>Objects are stored temporarily and must be retrieved via {@link #retrieveAndRemove(long)} or
  * cleaned up via {@link #remove(long)} to prevent memory leaks. The registry includes monitoring to
@@ -39,7 +39,7 @@ public class JniResponseRegistry {
 
     /**
      * Store a Java object and return its ID. This is used when JNI returns a converted Java object
-     * that needs to be passed through the Response protobuf.
+     * that needs to be passed through the Response wrapper.
      *
      * <p>IMPORTANT: The caller is responsible for ensuring the object is eventually removed via
      * {@link #retrieveAndRemove(long)} or {@link #remove(long)}. Failure to do so will cause memory

--- a/java/client/src/test/java/glide/api/GlideClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClusterClientTest.java
@@ -91,7 +91,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import command_request.CommandRequestOuterClass.CommandRequest;
+import command_request.CommandRequestOuterClass.RequestType;
 import glide.api.models.ClusterBatch;
 import glide.api.models.ClusterValue;
 import glide.api.models.GlideString;
@@ -329,19 +329,22 @@ public class GlideClusterClientTest {
         }
 
         @Override
-        protected <T> CompletableFuture<T> submitCommandToJni(
-                CommandRequest.Builder command,
-                GlideExceptionCheckedFunction<Response, T> responseHandler,
-                boolean binaryMode) {
+        protected <T> CompletableFuture<T> submitDirectCommand(
+                RequestType requestType,
+                byte[][] args,
+                Route route,
+                boolean expectUtf8Response,
+                GlideExceptionCheckedFunction<Response, T> responseHandler) {
             return CompletableFuture.supplyAsync(() -> responseHandler.apply(response));
         }
 
         @Override
-        protected <T> CompletableFuture<T> submitCommandToJni(
-                CommandRequest.Builder command,
-                GlideExceptionCheckedFunction<Response, T> responseHandler,
-                boolean binaryMode,
-                boolean expectUtf8Response) {
+        protected <T> CompletableFuture<T> submitDirectBlockingCommand(
+                RequestType requestType,
+                byte[][] args,
+                Route route,
+                boolean expectUtf8Response,
+                GlideExceptionCheckedFunction<Response, T> responseHandler) {
             return CompletableFuture.supplyAsync(() -> responseHandler.apply(response));
         }
     }

--- a/java/client/src/test/java/glide/api/GlideClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/GlideClusterClientTest.java
@@ -329,7 +329,7 @@ public class GlideClusterClientTest {
         }
 
         @Override
-        protected <T> CompletableFuture<T> submitDirectCommand(
+        protected <T> CompletableFuture<T> submitCommandAsync(
                 RequestType requestType,
                 byte[][] args,
                 Route route,
@@ -339,7 +339,7 @@ public class GlideClusterClientTest {
         }
 
         @Override
-        protected <T> CompletableFuture<T> submitDirectBlockingCommand(
+        protected <T> CompletableFuture<T> submitBlockingCommandAsync(
                 RequestType requestType,
                 byte[][] args,
                 Route route,

--- a/java/client/src/test/java/glide/api/models/BatchTests.java
+++ b/java/client/src/test/java/glide/api/models/BatchTests.java
@@ -255,11 +255,9 @@ import static glide.api.models.commands.stream.StreamTrimOptions.TRIM_EXACT_VALK
 import static glide.api.models.commands.stream.StreamTrimOptions.TRIM_MINID_VALKEY_API;
 import static glide.api.models.commands.stream.XInfoStreamOptions.COUNT;
 import static glide.api.models.commands.stream.XInfoStreamOptions.FULL;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.protobuf.ByteString;
-import command_request.CommandRequestOuterClass.Command;
-import command_request.CommandRequestOuterClass.Command.ArgsArray;
 import command_request.CommandRequestOuterClass.RequestType;
 import glide.api.models.commands.ClientPauseMode;
 import glide.api.models.commands.ConditionalChange;
@@ -344,7 +342,7 @@ public class BatchTests {
     @ParameterizedTest
     @MethodSource("getBatchBuilders")
     public void batch_builds_protobuf_request(BaseBatch<?> batch) {
-        List<Pair<RequestType, ArgsArray>> results = new LinkedList<>();
+        List<Pair<RequestType, byte[][]>> results = new LinkedList<>();
 
         batch.get("key");
         results.add(Pair.of(Get, buildArgs("key")));
@@ -1704,23 +1702,22 @@ public class BatchTests {
         batch.wait(1L, 1000L);
         results.add(Pair.of(Wait, buildArgs("1", "1000")));
 
-        command_request.CommandRequestOuterClass.Batch protobufbatch = batch.getProtobufBatch().build();
+        java.util.List<BatchCommand> batchCommands = batch.getCommands();
 
-        for (int idx = 0; idx < protobufbatch.getCommandsCount(); idx++) {
-            Command protobuf = protobufbatch.getCommands(idx);
+        for (int idx = 0; idx < batchCommands.size(); idx++) {
+            BatchCommand cmd = batchCommands.get(idx);
 
-            assertEquals(results.get(idx).getLeft(), protobuf.getRequestType());
-            assertEquals(
-                    results.get(idx).getRight().getArgsCount(), protobuf.getArgsArray().getArgsCount());
-            assertEquals(results.get(idx).getRight(), protobuf.getArgsArray());
+            assertEquals(results.get(idx).getLeft().getNumber(), cmd.getRequestType());
+            byte[][] expectedArgs = results.get(idx).getRight();
+            assertArrayEquals(expectedArgs, cmd.getArgs());
         }
     }
 
-    static ArgsArray buildArgs(String... args) {
-        ArgsArray.Builder builder = ArgsArray.newBuilder();
-        for (String arg : args) {
-            builder.addArgs(ByteString.copyFromUtf8(arg));
+    static byte[][] buildArgs(String... args) {
+        byte[][] result = new byte[args.length][];
+        for (int i = 0; i < args.length; i++) {
+            result[i] = args[i].getBytes(java.nio.charset.StandardCharsets.UTF_8);
         }
-        return builder.build();
+        return result;
     }
 }

--- a/java/client/src/test/java/glide/api/models/ClusterBatchTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterBatchTests.java
@@ -11,10 +11,9 @@ import static glide.api.models.commands.SortBaseOptions.ALPHA_COMMAND_STRING;
 import static glide.api.models.commands.SortBaseOptions.LIMIT_COMMAND_STRING;
 import static glide.api.models.commands.SortBaseOptions.OrderBy.ASC;
 import static glide.api.models.commands.SortBaseOptions.STORE_COMMAND_STRING;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import command_request.CommandRequestOuterClass.Command;
-import command_request.CommandRequestOuterClass.Command.ArgsArray;
 import command_request.CommandRequestOuterClass.RequestType;
 import glide.api.models.commands.SortBaseOptions;
 import glide.api.models.commands.SortOptions;
@@ -30,7 +29,7 @@ public class ClusterBatchTests {
     @ValueSource(booleans = {true, false})
     public void cluster_batch_builds_protobuf_request(boolean isAtomic) {
         ClusterBatch batch = new ClusterBatch(isAtomic);
-        List<Pair<RequestType, ArgsArray>> results = new LinkedList<>();
+        List<Pair<RequestType, byte[][]>> results = new LinkedList<>();
 
         batch.publish("msg", "ch1", true);
         results.add(Pair.of(SPublish, buildArgs("ch1", "msg")));
@@ -91,15 +90,12 @@ public class ClusterBatchTests {
                                 STORE_COMMAND_STRING,
                                 "key2")));
 
-        command_request.CommandRequestOuterClass.Batch protobufBatch = batch.getProtobufBatch().build();
+        java.util.List<BatchCommand> batchCommands = batch.getCommands();
 
-        for (int idx = 0; idx < protobufBatch.getCommandsCount(); idx++) {
-            Command protobuf = protobufBatch.getCommands(idx);
-
-            assertEquals(results.get(idx).getLeft(), protobuf.getRequestType());
-            assertEquals(
-                    results.get(idx).getRight().getArgsCount(), protobuf.getArgsArray().getArgsCount());
-            assertEquals(results.get(idx).getRight(), protobuf.getArgsArray());
+        for (int idx = 0; idx < batchCommands.size(); idx++) {
+            BatchCommand cmd = batchCommands.get(idx);
+            assertEquals(results.get(idx).getLeft().getNumber(), cmd.getRequestType());
+            assertArrayEquals(results.get(idx).getRight(), cmd.getArgs());
         }
     }
 }

--- a/java/client/src/test/java/glide/api/models/StandaloneBatchTests.java
+++ b/java/client/src/test/java/glide/api/models/StandaloneBatchTests.java
@@ -21,9 +21,10 @@ import static glide.api.models.commands.scan.BaseScanOptions.COUNT_OPTION_STRING
 import static glide.api.models.commands.scan.BaseScanOptions.MATCH_OPTION_STRING;
 import static glide.api.models.commands.scan.ScanOptions.ObjectType.ZSET;
 import static glide.api.models.commands.scan.ScanOptions.TYPE_OPTION_STRING;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import command_request.CommandRequestOuterClass;
+import command_request.CommandRequestOuterClass.RequestType;
 import glide.api.models.commands.SortOptions;
 import glide.api.models.commands.scan.ScanOptions;
 import java.util.Arrays;
@@ -37,8 +38,7 @@ public class StandaloneBatchTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void standalone_batch_commands(boolean isAtomic) {
-        List<Pair<CommandRequestOuterClass.RequestType, CommandRequestOuterClass.Command.ArgsArray>>
-                results = new LinkedList<>();
+        List<Pair<RequestType, byte[][]>> results = new LinkedList<>();
         Batch batch = new Batch(isAtomic);
 
         batch.select(5L);
@@ -198,15 +198,12 @@ public class StandaloneBatchTests {
                                 TYPE_OPTION_STRING,
                                 ZSET.toString())));
 
-        command_request.CommandRequestOuterClass.Batch protobufBatch = batch.getProtobufBatch().build();
+        java.util.List<BatchCommand> batchCommands = batch.getCommands();
 
-        for (int idx = 0; idx < protobufBatch.getCommandsCount(); idx++) {
-            CommandRequestOuterClass.Command protobuf = protobufBatch.getCommands(idx);
-
-            assertEquals(results.get(idx).getLeft(), protobuf.getRequestType());
-            assertEquals(
-                    results.get(idx).getRight().getArgsCount(), protobuf.getArgsArray().getArgsCount());
-            assertEquals(results.get(idx).getRight(), protobuf.getArgsArray());
+        for (int idx = 0; idx < batchCommands.size(); idx++) {
+            BatchCommand cmd = batchCommands.get(idx);
+            assertEquals(results.get(idx).getLeft().getNumber(), cmd.getRequestType());
+            assertArrayEquals(results.get(idx).getRight(), cmd.getArgs());
         }
     }
 }

--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -1,5 +1,5 @@
 //! JNI client management infrastructure extracted from JNI-java implementation
-//! This module provides direct JNI calls to glide-core while preserving protobuf serialization
+//! This module provides direct JNI calls to glide-core
 
 use anyhow::Result;
 use dashmap::DashMap;

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2,7 +2,6 @@
 
 use glide_core::client::FINISHED_SCAN_CURSOR;
 use glide_core::errors::error_message;
-use logger_core::log_warn_lazy;
 // Protocol constants for Java (defined directly since we don't use socket layer)
 const TYPE_HASH: &str = "hash";
 const TYPE_LIST: &str = "list";
@@ -31,11 +30,10 @@ mod address_resolver;
 mod errors;
 mod jni_client;
 mod linked_hashmap;
-mod protobuf_bridge;
+mod routing;
 
 use errors::{FFIError, handle_errors, run_ffi};
 use jni_client::*;
-use protobuf_bridge::*;
 
 use crate::address_resolver::JavaAddressResolver;
 /// Process command arguments for compression, matching the socket_listener pattern.
@@ -165,38 +163,6 @@ fn complete_callback_with_error_on_caller(env: &mut JNIEnv, callback_id: jlong, 
     }
 }
 
-/// Parse request bytes into a CommandRequest, completing the callback with an error on failure.
-/// Returns `Some(request)` on success, `None` if an error occurred (callback already completed).
-fn parse_request_bytes(
-    env: &mut JNIEnv,
-    request_bytes: &JByteArray,
-    callback_id: jlong,
-) -> Option<protobuf_bridge::CommandRequest> {
-    let raw_bytes = match env.convert_byte_array(request_bytes) {
-        Ok(b) => b,
-        Err(e) => {
-            let msg = format!("Failed to read request bytes: {e}");
-            complete_callback_with_error_on_caller(env, callback_id, &msg);
-            return None;
-        }
-    };
-
-    if raw_bytes.is_empty() {
-        complete_callback_with_error_on_caller(env, callback_id, "Empty request bytes");
-        return None;
-    }
-
-    match protobuf_bridge::parse_command_request(&raw_bytes) {
-        Ok(r) => Some(r),
-        Err(e) => {
-            let msg = format!("Failed to parse command request: {e}");
-            complete_callback_with_error_on_caller(env, callback_id, &msg);
-            None
-        }
-    }
-}
-
-/// Get the JVM Arc, falling back to the cached static if env.get_java_vm() fails.
 /// Completes the callback with an error if both fail.
 fn get_jvm_or_complete_error(
     env: &mut JNIEnv,
@@ -214,246 +180,6 @@ fn get_jvm_or_complete_error(
             }
         },
     }
-}
-
-// Internal helper: execute a parsed CommandRequest and complete Java callback
-async fn execute_command_request_and_complete(
-    handle_id: u64,
-    command_request: protobuf_bridge::CommandRequest,
-    callback_id: jlong,
-    jvm: std::sync::Arc<jni::JavaVM>,
-    expect_utf8: bool,
-) {
-    let result: Result<redis::Value, redis::RedisError> = async {
-        let mut client = jni_client::ensure_client_for_handle(handle_id)
-            .await
-            .map_err(|e| {
-                redis::RedisError::from((
-                    redis::ErrorKind::ClientError,
-                    "Client not found",
-                    e.to_string(),
-                ))
-            })?;
-
-        let root_span_ptr_opt = command_request.root_span_ptr;
-        match &command_request.command {
-            Some(protobuf_bridge::command_request::Command::SingleCommand(command)) => {
-                let mut cmd = protobuf_bridge::create_valkey_command(command).map_err(|e| {
-                    redis::RedisError::from((
-                        redis::ErrorKind::ClientError,
-                        "Failed to create command",
-                        e.to_string(),
-                    ))
-                })?;
-
-                // Apply compression to command arguments if compression is enabled
-                // This also validates that the command is compatible with compression
-                // Note: We intentionally keep these as separate if statements for clarity:
-                // - First check: is compression enabled?
-                // - Second check: did compression processing fail?
-                // - Third check: is it an incompatible command error?
-                #[allow(clippy::collapsible_if)]
-                if client.is_compression_enabled() {
-                    if let Err(e) = process_command_for_compression(&mut cmd, &client) {
-                        // Incompatible command errors should be returned to the user
-                        if e.is_incompatible_command() {
-                            return Err(redis::RedisError::from((
-                                redis::ErrorKind::ClientError,
-                                "Incompatible command with compression",
-                                e.to_string(),
-                            )));
-                        }
-                        // For other compression errors, log and continue
-                        log_warn_lazy!(
-                            "compression",
-                            format!("Compression processing failed: {e}, continuing with original command")
-                        );
-                    }
-                }
-
-                // Compute routing
-                let route_box = command_request.route.0;
-                let routing = if let Some(route_box) = route_box {
-                    protobuf_bridge::get_route(*route_box, Some(&cmd)).map_err(|e| {
-                        redis::RedisError::from((
-                            redis::ErrorKind::ClientError,
-                            "Routing error",
-                            e.to_string(),
-                        ))
-                    })?
-                } else {
-                    None
-                };
-
-                let send_start = std::time::Instant::now();
-                let exec = client.send_command(&mut cmd, routing).await;
-                let send_elapsed = send_start.elapsed();
-                if send_elapsed > std::time::Duration::from_secs(1) {
-                    logger_core::log_warn_rate_limited!(
-                        "jni_command",
-                        5,
-                        format!(
-                            "send_command took {:?} for callback_id={}",
-                            send_elapsed, callback_id
-                        )
-                    );
-                }
-
-                if let Some(root_span_ptr) = root_span_ptr_opt
-                    && root_span_ptr != 0
-                {
-                    match unsafe {
-                        glide_core::GlideOpenTelemetry::span_from_pointer(root_span_ptr)
-                    } {
-                        Ok(span) => {
-                            span.end();
-                            unsafe {
-                                std::sync::Arc::from_raw(
-                                    root_span_ptr as *const glide_core::GlideSpan,
-                                );
-                            }
-                        }
-                        Err(err) => {
-                            log_warn_lazy!(
-                                "otel",
-                                format!("Failed to finalize OpenTelemetry span: pointer={}, error={}", root_span_ptr, err)
-                            );
-                        }
-                    }
-                }
-                exec
-            }
-            Some(protobuf_bridge::command_request::Command::Batch(batch)) => {
-                // Build pipeline
-                let mut pipeline = redis::Pipeline::with_capacity(batch.commands.len());
-                if batch.is_atomic {
-                    pipeline.atomic();
-                }
-                for c in &batch.commands {
-                    let mut valkey_cmd = protobuf_bridge::create_valkey_command(c).map_err(|e| {
-                        redis::RedisError::from((
-                            redis::ErrorKind::ClientError,
-                            "Failed to create batch command",
-                            e.to_string(),
-                        ))
-                    })?;
-                    // Apply compression to each command in the batch
-                    // This also validates that the command is compatible with compression
-                    #[allow(clippy::collapsible_if)]
-                    if client.is_compression_enabled() {
-                        if let Err(e) = process_command_for_compression(&mut valkey_cmd, &client) {
-                            // Incompatible command errors should be returned to the user
-                            if e.is_incompatible_command() {
-                                return Err(redis::RedisError::from((
-                                    redis::ErrorKind::ClientError,
-                                    "Incompatible command with compression",
-                                    e.to_string(),
-                                )));
-                            }
-                            // For other compression errors, log and continue
-                            log_warn_lazy!("compression", format!("Compression processing failed for batch command: {e}, continuing with original"));
-                        }
-                    }
-                    pipeline.add_command(valkey_cmd);
-                }
-
-                // Routing for batch
-                let route_box = command_request.route.0;
-                let routing = if let Some(route_box) = route_box {
-                    protobuf_bridge::get_route(*route_box, None).map_err(|e| {
-                        redis::RedisError::from((
-                            redis::ErrorKind::ClientError,
-                            "Routing error",
-                            e.to_string(),
-                        ))
-                    })?
-                } else {
-                    None
-                };
-
-                // Child span as per previous behavior
-                let mut send_batch_span: Option<glide_core::GlideSpan> = None;
-                if let Some(root_span_ptr) = root_span_ptr_opt
-                    && root_span_ptr != 0
-                    && let Ok(root_span) =
-                        unsafe { glide_core::GlideOpenTelemetry::span_from_pointer(root_span_ptr) }
-                    && let Ok(child) = root_span.add_span("send_batch")
-                {
-                    send_batch_span = Some(child);
-                }
-
-                let exec_res = if batch.is_atomic {
-                    client
-                        .send_transaction(
-                            &pipeline,
-                            routing,
-                            batch.timeout,
-                            batch.raise_on_error.unwrap_or(true),
-                        )
-                        .await
-                } else {
-                    client
-                        .send_pipeline(
-                            &pipeline,
-                            routing,
-                            batch.raise_on_error.unwrap_or(true),
-                            batch.timeout,
-                            redis::PipelineRetryStrategy {
-                                retry_server_error: batch.retry_server_error.unwrap_or(false),
-                                retry_connection_error: batch
-                                    .retry_connection_error
-                                    .unwrap_or(false),
-                            },
-                        )
-                        .await
-                };
-
-                if let Some(child) = send_batch_span.as_ref() {
-                    child.end();
-                }
-                if let Some(root_span_ptr) = root_span_ptr_opt
-                    && root_span_ptr != 0
-                {
-                    match unsafe {
-                        glide_core::GlideOpenTelemetry::span_from_pointer(root_span_ptr)
-                    } {
-                        Ok(root_span) => {
-                            root_span.end();
-                            unsafe {
-                                std::sync::Arc::from_raw(
-                                    root_span_ptr as *const glide_core::GlideSpan,
-                                );
-                            }
-                        }
-                        Err(err) => {
-                            log_warn_lazy!(
-                                "otel",
-                                format!("Failed to finalize OpenTelemetry span: pointer={}, error={}", root_span_ptr, err)
-                            );
-                        }
-                    }
-                }
-
-                // Process batch response for decompression if compression is enabled
-                match exec_res {
-                    Ok(value) => glide_core::compression::try_decompress_batch_response(
-                        value,
-                        client.compression_manager().as_deref(),
-                    )
-                    .map_err(|e| redis::RedisError::from((redis::ErrorKind::IoError, "Decompression error", e.to_string()))),
-                    Err(e) => Err(e),
-                }
-            }
-            _ => Err(redis::RedisError::from((
-                redis::ErrorKind::ClientError,
-                "Unsupported command type",
-            ))),
-        }
-    }
-    .await;
-
-    let binary_mode = !expect_utf8;
-    jni_client::complete_callback(jvm, callback_id, result, binary_mode);
 }
 
 /// Configuration for OpenTelemetry integration in the Java client.
@@ -1529,70 +1255,6 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_createClient(
     .unwrap_or(0)
 }
 
-/// Execute Valkey command asynchronously using protobuf with FFI-imported routing.
-#[unsafe(no_mangle)]
-pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandAsync(
-    mut env: JNIEnv,
-    _class: JClass,
-    client_ptr: jlong,
-    request_bytes: JByteArray,
-    callback_id: jlong,
-) {
-    run_ffi(|| {
-        let Some(command_request) = parse_request_bytes(&mut env, &request_bytes, callback_id)
-        else {
-            return Some(());
-        };
-        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeCommandAsync")
-        else {
-            return Some(());
-        };
-
-        let handle_id = client_ptr as u64;
-
-        // Synchronous inflight check: reject immediately if at capacity.
-        // This prevents Java threads from parking on futures that would be
-        // rejected asynchronously, avoiding thread explosion under memory pressure.
-        {
-            let handle_table = jni_client::get_handle_table();
-            if let Some(client_ref) = handle_table.get(&handle_id) {
-                if client_ref.available_inflight_count() <= 0 {
-                    drop(client_ref);
-                    jni_client::complete_error_sync(
-                        &mut env,
-                        callback_id,
-                        "Client reached maximum inflight requests",
-                        0,
-                    );
-                    return Some(());
-                }
-                // Synchronous circuit breaker check: reject immediately if core is unhealthy.
-                if !client_ref.is_circuit_breaker_healthy() {
-                    drop(client_ref);
-                    jni_client::complete_error_sync(
-                        &mut env,
-                        callback_id,
-                        "Client circuit breaker is open - core unhealthy",
-                        4,
-                    );
-                    return Some(());
-                }
-            }
-        }
-
-        get_runtime().spawn(execute_command_request_and_complete(
-            handle_id,
-            command_request,
-            callback_id,
-            jvm,
-            true, // executeCommandAsync expects UTF-8 decoding
-        ));
-
-        Some(())
-    })
-    .unwrap_or(())
-}
-
 /// Close client and release resources.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_glide_internal_GlideNativeBridge_closeClient(
@@ -1707,242 +1369,349 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_markTimedOut(
     jni_client::mark_callback_timed_out(callback_id);
 }
 
-/// Execute a batch (pipeline/transaction) asynchronously using FFI-imported logic
+/// Execute a batch (pipeline/transaction) asynchronously.
+/// Takes command data directly via JNI arrays.
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchAsync(
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
     mut env: JNIEnv,
     _class: JClass,
     client_ptr: jlong,
-    batch_request_bytes: JByteArray,
+    callback_id: jlong,
+    request_types: jni::objects::JIntArray,
+    args: JObjectArray, // byte[][][]
+    is_atomic: jni::sys::jboolean,
+    raise_on_error: jni::sys::jboolean,
+    timeout: jint,
+    retry_server_error: jni::sys::jboolean,
+    retry_connection_error: jni::sys::jboolean,
+    has_route: jni::sys::jboolean,
+    route_type: jint,
+    route_param: JString,
     expect_utf8: jni::sys::jboolean,
-    callback_id: jlong,
+    span_ptr: jlong,
 ) {
     run_ffi(|| {
-            let Some(command_request) =
-                parse_request_bytes(&mut env, &batch_request_bytes, callback_id)
-            else {
-                return Some(());
-            };
-
-            // Extract optional root span pointer from the request (if provided by Java)
-            let root_span_ptr_opt = command_request.root_span_ptr;
-            let route = command_request.route.0.map(|r| *r);
-
-            // Extract the batch from the command request (take ownership to avoid clone)
-            let batch = match command_request.command {
-                Some(command_request::Command::Batch(batch)) => batch,
-                _ => {
-                    complete_callback_with_error_on_caller(
-                        &mut env,
-                        callback_id,
-                        "Expected batch command in request",
-                    );
-                    return Some(());
-                }
-            };
-
-            let handle_id = client_ptr as u64;
-            let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeBatchAsync")
-            else {
-                return Some(());
-            };
-
-            get_runtime().spawn(async move {
-                let client_result = ensure_client_for_handle(handle_id).await;
-                match client_result {
-                    Ok(mut client) => {
-                        // Execute batch using existing FFI methodology
-                        let result: Result<redis::Value, redis::RedisError> = async {
-                            // If we have a root span, create a child span named "send_batch" to match expectations
-                            let mut send_batch_span: Option<glide_core::GlideSpan> = None;
-                            if let Some(root_span_ptr) = root_span_ptr_opt
-                                && root_span_ptr != 0
-                                && let Ok(root_span) = unsafe {
-                                    glide_core::GlideOpenTelemetry::span_from_pointer(root_span_ptr)
-                                }
-                                && let Ok(child) = root_span.add_span("send_batch")
-                            {
-                                send_batch_span = Some(child);
-                            }
-                            // Create pipeline using existing FFI approach
-                            let mut pipeline =
-                                redis::Pipeline::with_capacity(batch.commands.len());
-                            if batch.is_atomic {
-                                pipeline.atomic();
-                            }
-
-                            // Add commands to pipeline using existing bridge logic
-                            for cmd in &batch.commands {
-                                let mut valkey_cmd = match protobuf_bridge::create_valkey_command(cmd) {
-                                    Ok(cmd) => cmd,
-                                    Err(e) => {
-                                        return Err(redis::RedisError::from((
-                                            redis::ErrorKind::ClientError,
-                                            "Failed to create batch command",
-                                            e.to_string(),
-                                        )));
-                                    }
-                                };
-                                // Apply compression to each command in the batch
-                                // This also validates that the command is compatible with compression
-                                #[allow(clippy::collapsible_if)]
-                                if client.is_compression_enabled() {
-                                    if let Err(e) = process_command_for_compression(&mut valkey_cmd, &client) {
-                                        // Incompatible command errors should be returned to the user
-                                        if e.is_incompatible_command() {
-                                            return Err(redis::RedisError::from((
-                                                redis::ErrorKind::ClientError,
-                                                "Incompatible command with compression",
-                                                e.to_string(),
-                                            )));
-                                        }
-                                        // For other compression errors, log and continue
-                                        log_warn_lazy!("compression", format!("Compression processing failed for batch command: {e}, continuing with original"));
-                                    }
-                                }
-                                pipeline.add_command(valkey_cmd);
-                            }
-
-                            // Get routing using FFI approach
-                            let route = route.unwrap_or_default();
-                            let routing = protobuf_bridge::get_route(route, None).map_err(|e| {
-                                    redis::RedisError::from((
-                                        redis::ErrorKind::ClientError,
-                                        "Routing error",
-                                        e.to_string(),
-                                    ))
-                                })?;
-
-                            // Execute using existing client methods
-                            let exec_res = if batch.is_atomic {
-                                client
-                                    .send_transaction(
-                                        &pipeline,
-                                        routing,
-                                        batch.timeout,
-                                        batch.raise_on_error.unwrap_or(true),
-                                    )
-                                    .await
-                            } else {
-                                client
-                                    .send_pipeline(
-                                        &pipeline,
-                                        routing,
-                                        batch.raise_on_error.unwrap_or(true),
-                                        batch.timeout,
-                                        redis::PipelineRetryStrategy {
-                                            retry_server_error: batch
-                                                .retry_server_error
-                                                .unwrap_or(false),
-                                            retry_connection_error: batch
-                                                .retry_connection_error
-                                                .unwrap_or(false),
-                                        },
-                                    )
-                                    .await
-                            };
-
-                            // End child span if created
-                            if let Some(child) = send_batch_span.as_ref() {
-                                child.end();
-                            }
-                            // End and drop the root span if provided
-                            if let Some(root_span_ptr) = root_span_ptr_opt
-                                && root_span_ptr != 0
-                            {
-                                match unsafe {
-                                    glide_core::GlideOpenTelemetry::span_from_pointer(root_span_ptr)
-                                } {
-                                    Ok(root_span) => {
-                                        root_span.end();
-                                        unsafe {
-                                            std::sync::Arc::from_raw(
-                                                root_span_ptr as *const glide_core::GlideSpan,
-                                            );
-                                        }
-                                    }
-                                    Err(err) => {
-                                        log_warn_lazy!(
-                                            "otel",
-                                            format!("Failed to finalize OpenTelemetry span: pointer={}, error={}", root_span_ptr, err)
-                                        );
-                                    }
-                                }
-                            }
-
-                            // Process batch response for decompression if compression is enabled
-                            match exec_res {
-                                Ok(value) => {
-                                    if client.is_compression_enabled() {
-                                        if let Some(manager) = client.compression_manager() {
-                                            match glide_core::compression::decompress_batch_response(
-                                                value.clone(),
-                                                manager.as_ref(),
-                                            ) {
-                                                Ok(decompressed) => Ok(decompressed),
-                                                Err(e) => {
-                                                    log_warn_lazy!(
-                                                        "compression",
-                                                        format!("Failed to decompress batch response: {}, returning original", e)
-                                                    );
-                                                    Ok(value)
-                                                }
-                                            }
-                                        } else {
-                                            Ok(value)
-                                        }
-                                    } else {
-                                        Ok(value)
-                                    }
-                                }
-                                Err(e) => Err(e),
-                            }
-                        }
-                        .await;
-
-                        let binary_mode = expect_utf8 == 0;
-                        complete_callback(jvm, callback_id, result, binary_mode);
-                    }
-                    Err(err) => {
-                        let error = Err(redis::RedisError::from((
-                            redis::ErrorKind::ClientError,
-                            "Client not found",
-                            err.to_string(),
-                        )));
-                        let binary_mode = expect_utf8 == 0;
-                        complete_callback(jvm, callback_id, error, binary_mode);
-                    }
-                }
-            });
-
-            Some(())
-        },
-    ).unwrap_or(())
-}
-
-/// Execute a binary command asynchronously
-#[unsafe(no_mangle)]
-pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBinaryCommandAsync(
-    mut env: JNIEnv,
-    _class: JClass,
-    client_ptr: jlong,
-    request_bytes: JByteArray,
-    callback_id: jlong,
-) {
-    run_ffi(|| {
-        let Some(command_request) = parse_request_bytes(&mut env, &request_bytes, callback_id)
-        else {
-            return Some(());
-        };
-        let Some(jvm) =
-            get_jvm_or_complete_error(&mut env, callback_id, "executeBinaryCommandAsync")
+        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeBatchDirect")
         else {
             return Some(());
         };
 
         let handle_id = client_ptr as u64;
 
-        // Synchronous inflight check (same as executeCommandAsync)
+        // Extract request types
+        let cmd_count = match env.get_array_length(&request_types) {
+            Ok(len) => len as usize,
+            Err(e) => {
+                jni_client::complete_error_sync(
+                    &mut env,
+                    callback_id,
+                    &format!("Failed to get request types length: {e}"),
+                    0,
+                );
+                return Some(());
+            }
+        };
+        let mut req_types = vec![0i32; cmd_count];
+        if let Err(e) = env.get_int_array_region(&request_types, 0, &mut req_types) {
+            jni_client::complete_error_sync(
+                &mut env,
+                callback_id,
+                &format!("Failed to read request types: {e}"),
+                0,
+            );
+            return Some(());
+        }
+
+        // Extract args: byte[][][] -> Vec<Vec<Vec<u8>>>
+        let all_args: Result<Vec<Vec<Vec<u8>>>, FFIError> = (|| {
+            let mut result = Vec::with_capacity(cmd_count);
+            for i in 0..cmd_count {
+                let cmd_args_obj = env.get_object_array_element(&args, i as i32)?;
+                let cmd_args_array = JObjectArray::from(cmd_args_obj);
+                let arg_count = env.get_array_length(&cmd_args_array)? as usize;
+                let mut cmd_args = Vec::with_capacity(arg_count);
+                for j in 0..arg_count {
+                    let arg_obj = env.get_object_array_element(&cmd_args_array, j as i32)?;
+                    let arg_bytes = env.convert_byte_array(JByteArray::from(arg_obj))?;
+                    cmd_args.push(arg_bytes);
+                }
+                result.push(cmd_args);
+            }
+            Ok(result)
+        })();
+
+        let all_args = match all_args {
+            Ok(a) => a,
+            Err(e) => {
+                jni_client::complete_error_sync(
+                    &mut env,
+                    callback_id,
+                    &format!("Failed to extract batch args: {e}"),
+                    0,
+                );
+                return Some(());
+            }
+        };
+
+        let is_atomic_bool = is_atomic != 0;
+        let raise_on_error_bool = raise_on_error != 0;
+        let timeout_val = if timeout > 0 {
+            Some(timeout as u32)
+        } else {
+            None
+        };
+        let retry_server = retry_server_error != 0;
+        let retry_connection = retry_connection_error != 0;
+        let expect_utf8_bool = expect_utf8 != 0;
+
+        // Extract route parameters
+        let has_route_bool = has_route != 0;
+        let route_type_val: i32 = route_type;
+        let route_param_str: Option<String> = if !route_param.is_null() {
+            match env.get_string(&route_param) {
+                Ok(s) => Some(s.into()),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
+        get_runtime().spawn(async move {
+            let client_result = jni_client::ensure_client_for_handle(handle_id).await;
+            match client_result {
+                Ok(mut client) => {
+                    // Create "send_batch" child span for OTel tracing
+                    let mut send_batch_span: Option<glide_core::GlideSpan> = None;
+                    if span_ptr != 0
+                        && let Ok(root_span) = unsafe {
+                            glide_core::GlideOpenTelemetry::span_from_pointer(span_ptr as u64)
+                        }
+                        && let Ok(child) = root_span.add_span("send_batch")
+                    {
+                        send_batch_span = Some(child);
+                    }
+
+                    let result: Result<redis::Value, redis::RedisError> = async {
+                        // Build pipeline directly from arrays
+                        let mut pipeline = redis::Pipeline::with_capacity(cmd_count);
+                        if is_atomic_bool {
+                            pipeline.atomic();
+                        }
+                        if let Some(ref child) = send_batch_span {
+                            pipeline.set_pipeline_span(Some(child.clone()));
+                        }
+
+                        for (i, rt) in req_types.iter().enumerate() {
+                            let proto_rt = protobuf::EnumOrUnknown::<
+                                glide_core::command_request::RequestType,
+                            >::from_i32(*rt);
+                            let request_type: glide_core::request_type::RequestType =
+                                proto_rt.into();
+                            let Some(mut cmd) = request_type.get_command() else {
+                                return Err(redis::RedisError::from((
+                                    redis::ErrorKind::ClientError,
+                                    "Invalid request type in batch",
+                                    format!("request_type={}", rt),
+                                )));
+                            };
+                            for arg in &all_args[i] {
+                                cmd.arg(arg.as_slice());
+                            }
+                            // Apply compression
+                            #[allow(clippy::collapsible_if)]
+                            if client.is_compression_enabled() {
+                                if let Err(e) = process_command_for_compression(&mut cmd, &client) {
+                                    if e.is_incompatible_command() {
+                                        return Err(redis::RedisError::from((
+                                            redis::ErrorKind::ClientError,
+                                            "Incompatible command with compression",
+                                            e.to_string(),
+                                        )));
+                                    }
+                                }
+                            }
+                            pipeline.add_command(cmd);
+                        }
+
+                        // Compute routing
+                        let routing = if has_route_bool {
+                            use glide_core::command_request::{
+                                ByAddressRoute, Routes, SimpleRoutes, SlotIdRoute, SlotKeyRoute,
+                                SlotTypes,
+                            };
+                            use protobuf::EnumOrUnknown;
+                            let mut routes = Routes::default();
+                            if route_type_val >= 0 && route_param_str.is_none() {
+                                let simple = match route_type_val {
+                                    0 => SimpleRoutes::AllNodes,
+                                    1 => SimpleRoutes::AllPrimaries,
+                                    _ => SimpleRoutes::Random,
+                                };
+                                routes.set_simple_routes(simple);
+                            } else if route_type_val >= 100 && route_param_str.is_some() {
+                                // SlotIdRoute: routeType 100+ (offset by 100 from SlotKeyRoute)
+                                let slot_type = match route_type_val - 100 {
+                                    1 => SlotTypes::Replica,
+                                    _ => SlotTypes::Primary,
+                                };
+                                let param_str = route_param_str.as_deref().unwrap_or_default();
+                                if let Ok(slot_id) = param_str.parse::<i32>() {
+                                    routes.set_slot_id_route(SlotIdRoute {
+                                        slot_type: EnumOrUnknown::new(slot_type),
+                                        slot_id,
+                                        ..Default::default()
+                                    });
+                                }
+                            } else if route_type_val >= 0 && route_param_str.is_some() {
+                                // SlotKeyRoute: routeType 0-1
+                                let slot_type = match route_type_val {
+                                    1 => SlotTypes::Replica,
+                                    _ => SlotTypes::Primary,
+                                };
+                                let param_str = route_param_str.as_deref().unwrap_or_default();
+                                if !param_str.is_empty() {
+                                    routes.set_slot_key_route(SlotKeyRoute {
+                                        slot_type: EnumOrUnknown::new(slot_type),
+                                        slot_key: param_str.into(),
+                                        ..Default::default()
+                                    });
+                                }
+                            } else if route_type_val < 0 && route_param_str.is_some() {
+                                let param_str = route_param_str.as_deref().unwrap_or_default();
+                                if let Some((host, port_str)) = param_str.split_once(':')
+                                    && let Ok(port) = port_str.parse::<i32>()
+                                {
+                                    routes.set_by_address_route(ByAddressRoute {
+                                        host: host.to_string().into(),
+                                        port,
+                                        ..Default::default()
+                                    });
+                                }
+                            }
+                            routing::get_route(routes, None).map_err(|e| {
+                                redis::RedisError::from((
+                                    redis::ErrorKind::ClientError,
+                                    "Routing error",
+                                    e.to_string(),
+                                ))
+                            })?
+                        } else {
+                            None
+                        };
+
+                        // Execute
+                        let exec_res = if is_atomic_bool {
+                            client
+                                .send_transaction(
+                                    &pipeline,
+                                    routing,
+                                    timeout_val,
+                                    raise_on_error_bool,
+                                )
+                                .await
+                        } else {
+                            client
+                                .send_pipeline(
+                                    &pipeline,
+                                    routing,
+                                    raise_on_error_bool,
+                                    timeout_val,
+                                    redis::PipelineRetryStrategy {
+                                        retry_server_error: retry_server,
+                                        retry_connection_error: retry_connection,
+                                    },
+                                )
+                                .await
+                        };
+
+                        // Decompress if needed
+                        match exec_res {
+                            Ok(value) => {
+                                if client.is_compression_enabled() {
+                                    if let Some(manager) = client.compression_manager() {
+                                        glide_core::compression::decompress_batch_response(
+                                            value.clone(),
+                                            manager.as_ref(),
+                                        )
+                                        .or(Ok(value))
+                                    } else {
+                                        Ok(value)
+                                    }
+                                } else {
+                                    Ok(value)
+                                }
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                    .await;
+
+                    // End send_batch child span
+                    if let Some(ref child) = send_batch_span {
+                        child.end();
+                    }
+
+                    // End OpenTelemetry root span if one was created
+                    if span_ptr != 0
+                        && let Ok(span) = unsafe {
+                            glide_core::GlideOpenTelemetry::span_from_pointer(span_ptr as u64)
+                        }
+                    {
+                        span.end();
+                        unsafe {
+                            std::sync::Arc::from_raw(span_ptr as *const glide_core::GlideSpan);
+                        }
+                    }
+
+                    complete_callback(jvm, callback_id, result, !expect_utf8_bool);
+                }
+                Err(err) => {
+                    complete_callback(
+                        jvm,
+                        callback_id,
+                        Err(redis::RedisError::from((
+                            redis::ErrorKind::ClientError,
+                            "Client not found",
+                            err.to_string(),
+                        ))),
+                        !expect_utf8_bool,
+                    );
+                }
+            }
+        });
+
+        Some(())
+    })
+    .unwrap_or(())
+}
+
+/// Execute a binary command asynchronously
+/// Execute a Valkey command asynchronously.
+/// Takes command parameters directly via JNI: requestType as int, args as byte[][],
+/// and routing as primitives.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandDirect(
+    mut env: JNIEnv,
+    _class: JClass,
+    client_ptr: jlong,
+    callback_id: jlong,
+    request_type: jint,
+    args: JObjectArray,
+    has_route: jni::sys::jboolean,
+    route_type: jint,
+    route_param: JString,
+    expect_utf8: jni::sys::jboolean,
+    span_ptr: jlong,
+) {
+    run_ffi(|| {
+        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeCommandDirect")
+        else {
+            return Some(());
+        };
+
+        let handle_id = client_ptr as u64;
+
+        // Synchronous inflight check
         {
             let handle_table = jni_client::get_handle_table();
             if let Some(client_ref) = handle_table.get(&handle_id) {
@@ -1969,13 +1738,175 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBinaryComman
             }
         }
 
-        get_runtime().spawn(execute_command_request_and_complete(
-            handle_id,
-            command_request,
-            callback_id,
-            jvm,
-            false, // binary entrypoint expects binary decoding
-        ));
+        // Extract args from byte[][]
+        let args_vec: Result<Vec<Vec<u8>>, FFIError> = (|| {
+            if args.is_null() {
+                return Ok(Vec::new());
+            }
+            let length = env.get_array_length(&args)? as usize;
+            let mut args_data = Vec::with_capacity(length);
+            for i in 0..length {
+                let arg_obj = env.get_object_array_element(&args, i as i32)?;
+                let arg_bytes = env.convert_byte_array(JByteArray::from(arg_obj))?;
+                args_data.push(arg_bytes);
+            }
+            Ok(args_data)
+        })();
+
+        let args_data = match args_vec {
+            Ok(a) => a,
+            Err(e) => {
+                jni_client::complete_error_sync(
+                    &mut env,
+                    callback_id,
+                    &format!("Failed to extract command args: {e}"),
+                    0,
+                );
+                return Some(());
+            }
+        };
+
+        // Extract route parameters
+        let has_route_bool = has_route != 0;
+        let route_type_val: i32 = route_type;
+        let route_param_str: Option<String> = if !route_param.is_null() {
+            match env.get_string(&route_param) {
+                Ok(s) => Some(s.into()),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
+        let expect_utf8_bool = expect_utf8 != 0;
+
+        get_runtime().spawn(async move {
+            let result: Result<redis::Value, redis::RedisError> = async {
+                let mut client = jni_client::ensure_client_for_handle(handle_id)
+                    .await
+                    .map_err(|e| {
+                        redis::RedisError::from((
+                            redis::ErrorKind::ClientError,
+                            "Client not found",
+                            e.to_string(),
+                        ))
+                    })?;
+
+                // Build redis::Cmd directly from requestType int and args
+                let proto_request_type = protobuf::EnumOrUnknown::<
+                    glide_core::command_request::RequestType,
+                >::from_i32(request_type);
+                let rt: glide_core::request_type::RequestType = proto_request_type.into();
+                let Some(mut cmd) = rt.get_command() else {
+                    return Err(redis::RedisError::from((
+                        redis::ErrorKind::ClientError,
+                        "Invalid request type",
+                        format!("request_type={}", request_type),
+                    )));
+                };
+                for arg in &args_data {
+                    cmd.arg(arg.as_slice());
+                }
+
+                // Apply compression
+                #[allow(clippy::collapsible_if)]
+                if client.is_compression_enabled() {
+                    if let Err(e) = process_command_for_compression(&mut cmd, &client) {
+                        if e.is_incompatible_command() {
+                            return Err(redis::RedisError::from((
+                                redis::ErrorKind::ClientError,
+                                "Incompatible command with compression",
+                                e.to_string(),
+                            )));
+                        }
+                    }
+                }
+
+                // Compute routing
+                let routing = if has_route_bool {
+                    use glide_core::command_request::{
+                        ByAddressRoute, Routes, SimpleRoutes, SlotIdRoute, SlotKeyRoute, SlotTypes,
+                    };
+                    use protobuf::EnumOrUnknown;
+                    let mut routes = Routes::default();
+                    if route_type_val >= 0 && route_param_str.is_none() {
+                        let simple = match route_type_val {
+                            0 => SimpleRoutes::AllNodes,
+                            1 => SimpleRoutes::AllPrimaries,
+                            _ => SimpleRoutes::Random,
+                        };
+                        routes.set_simple_routes(simple);
+                    } else if route_type_val >= 100 && route_param_str.is_some() {
+                        // SlotIdRoute: routeType 100+ (offset by 100 from SlotKeyRoute)
+                        let slot_type = match route_type_val - 100 {
+                            1 => SlotTypes::Replica,
+                            _ => SlotTypes::Primary,
+                        };
+                        let param_str = route_param_str.as_deref().unwrap_or_default();
+                        if let Ok(slot_id) = param_str.parse::<i32>() {
+                            let s = SlotIdRoute {
+                                slot_type: EnumOrUnknown::new(slot_type),
+                                slot_id,
+                                ..Default::default()
+                            };
+                            routes.set_slot_id_route(s);
+                        }
+                    } else if route_type_val >= 0 && route_param_str.is_some() {
+                        // SlotKeyRoute: routeType 0-1
+                        let slot_type = match route_type_val {
+                            1 => SlotTypes::Replica,
+                            _ => SlotTypes::Primary,
+                        };
+                        let param_str = route_param_str.as_deref().unwrap_or_default();
+                        if !param_str.is_empty() {
+                            let s = SlotKeyRoute {
+                                slot_type: EnumOrUnknown::new(slot_type),
+                                slot_key: param_str.into(),
+                                ..Default::default()
+                            };
+                            routes.set_slot_key_route(s);
+                        }
+                    } else if route_type_val < 0 && route_param_str.is_some() {
+                        let param_str = route_param_str.as_deref().unwrap_or_default();
+                        if let Some((host, port_str)) = param_str.split_once(':')
+                            && let Ok(port) = port_str.parse::<i32>()
+                        {
+                            let s = ByAddressRoute {
+                                host: host.to_string().into(),
+                                port,
+                                ..Default::default()
+                            };
+                            routes.set_by_address_route(s);
+                        }
+                    }
+                    routing::get_route(routes, Some(&cmd)).map_err(|e| {
+                        redis::RedisError::from((
+                            redis::ErrorKind::ClientError,
+                            "Routing error",
+                            e.to_string(),
+                        ))
+                    })?
+                } else {
+                    None
+                };
+
+                client.send_command(&mut cmd, routing).await
+            }
+            .await;
+
+            // End OpenTelemetry span if one was created
+            if span_ptr != 0
+                && let Ok(span) =
+                    unsafe { glide_core::GlideOpenTelemetry::span_from_pointer(span_ptr as u64) }
+            {
+                span.end();
+                unsafe {
+                    std::sync::Arc::from_raw(span_ptr as *const glide_core::GlideSpan);
+                }
+            }
+
+            complete_callback(jvm, callback_id, result, !expect_utf8_bool);
+        });
 
         Some(())
     })
@@ -2139,13 +2070,12 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeScriptAsync(
                                 _ => SimpleRoutes::Random,
                             };
                             routes.set_simple_routes(simple);
-                        } else if route_type_val >= 0 && route_param_str.is_some() {
-                            // Slot routes with slot type
-                            let slot_type = match route_type_val {
+                        } else if route_type_val >= 100 && route_param_str.is_some() {
+                            // SlotIdRoute: routeType 100+ (offset by 100)
+                            let slot_type = match route_type_val - 100 {
                                 1 => SlotTypes::Replica,
                                 _ => SlotTypes::Primary,
                             };
-                            // Try to parse param as integer slot id; if fails, treat as slot key
                             let param_str = route_param_str.unwrap_or_default();
                             if let Ok(slot_id) = param_str.parse::<i32>() {
                                 let s = SlotIdRoute {
@@ -2154,7 +2084,15 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeScriptAsync(
                                     ..Default::default()
                                 };
                                 routes.set_slot_id_route(s);
-                            } else if !param_str.is_empty() {
+                            }
+                        } else if route_type_val >= 0 && route_param_str.is_some() {
+                            // SlotKeyRoute: routeType 0-1
+                            let slot_type = match route_type_val {
+                                1 => SlotTypes::Replica,
+                                _ => SlotTypes::Primary,
+                            };
+                            let param_str = route_param_str.unwrap_or_default();
+                            if !param_str.is_empty() {
                                 let s = SlotKeyRoute {
                                     slot_type: EnumOrUnknown::new(slot_type),
                                     slot_key: param_str.into(),
@@ -2177,7 +2115,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeScriptAsync(
                             }
                         }
 
-                        match protobuf_bridge::get_route(routes, None) {
+                        match routing::get_route(routes, None) {
                             Ok(r) => r,
                             Err(e) => {
                                 complete_callback(
@@ -2204,7 +2142,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeScriptAsync(
                         for a in &args_data {
                             route_cmd.arg(a.as_slice());
                         }
-                        match protobuf_bridge::get_route(Default::default(), Some(&route_cmd)) {
+                        match routing::get_route(Default::default(), Some(&route_cmd)) {
                             Ok(r) => r,
                             Err(e) => {
                                 complete_callback(

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1534,70 +1534,19 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
                         }
 
                         // Compute routing
-                        let routing = if has_route_bool {
-                            use glide_core::command_request::{
-                                ByAddressRoute, Routes, SimpleRoutes, SlotIdRoute, SlotKeyRoute,
-                                SlotTypes,
-                            };
-                            use protobuf::EnumOrUnknown;
-                            let mut routes = Routes::default();
-                            if route_type_val >= 0 && route_param_str.is_none() {
-                                let simple = match route_type_val {
-                                    0 => SimpleRoutes::AllNodes,
-                                    1 => SimpleRoutes::AllPrimaries,
-                                    _ => SimpleRoutes::Random,
-                                };
-                                routes.set_simple_routes(simple);
-                            } else if route_type_val >= 100 && route_param_str.is_some() {
-                                // SlotIdRoute: routeType 100+ (offset by 100 from SlotKeyRoute)
-                                let slot_type = match route_type_val - 100 {
-                                    1 => SlotTypes::Replica,
-                                    _ => SlotTypes::Primary,
-                                };
-                                let param_str = route_param_str.as_deref().unwrap_or_default();
-                                if let Ok(slot_id) = param_str.parse::<i32>() {
-                                    routes.set_slot_id_route(SlotIdRoute {
-                                        slot_type: EnumOrUnknown::new(slot_type),
-                                        slot_id,
-                                        ..Default::default()
-                                    });
-                                }
-                            } else if route_type_val >= 0 && route_param_str.is_some() {
-                                // SlotKeyRoute: routeType 0-1
-                                let slot_type = match route_type_val {
-                                    1 => SlotTypes::Replica,
-                                    _ => SlotTypes::Primary,
-                                };
-                                let param_str = route_param_str.as_deref().unwrap_or_default();
-                                if !param_str.is_empty() {
-                                    routes.set_slot_key_route(SlotKeyRoute {
-                                        slot_type: EnumOrUnknown::new(slot_type),
-                                        slot_key: param_str.into(),
-                                        ..Default::default()
-                                    });
-                                }
-                            } else if route_type_val < 0 && route_param_str.is_some() {
-                                let param_str = route_param_str.as_deref().unwrap_or_default();
-                                if let Some((host, port_str)) = param_str.split_once(':')
-                                    && let Ok(port) = port_str.parse::<i32>()
-                                {
-                                    routes.set_by_address_route(ByAddressRoute {
-                                        host: host.to_string().into(),
-                                        port,
-                                        ..Default::default()
-                                    });
-                                }
-                            }
-                            routing::get_route(routes, None).map_err(|e| {
-                                redis::RedisError::from((
-                                    redis::ErrorKind::ClientError,
-                                    "Routing error",
-                                    e.to_string(),
-                                ))
-                            })?
-                        } else {
-                            None
-                        };
+                        let routing = routing::resolve_routing_from_params(
+                            has_route_bool,
+                            route_type_val,
+                            route_param_str.as_deref(),
+                            None,
+                        )
+                        .map_err(|e| {
+                            redis::RedisError::from((
+                                redis::ErrorKind::ClientError,
+                                "Routing error",
+                                e.to_string(),
+                            ))
+                        })?;
 
                         // Execute
                         let exec_res = if is_atomic_bool {
@@ -1629,11 +1578,20 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
                             Ok(value) => {
                                 if client.is_compression_enabled() {
                                     if let Some(manager) = client.compression_manager() {
-                                        glide_core::compression::decompress_batch_response(
+                                        match glide_core::compression::decompress_batch_response(
                                             value.clone(),
                                             manager.as_ref(),
-                                        )
-                                        .or(Ok(value))
+                                        ) {
+                                            Ok(decompressed) => Ok(decompressed),
+                                            Err(e) => {
+                                                logger_core::log_warn_rate_limited!(
+                                                    "compression",
+                                                    5,
+                                                    format!("Failed to decompress batch response: {}, returning original", e)
+                                                );
+                                                Ok(value)
+                                            }
+                                        }
                                     } else {
                                         Ok(value)
                                     }
@@ -1685,7 +1643,6 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
     .unwrap_or(())
 }
 
-/// Execute a binary command asynchronously
 /// Execute a Valkey command asynchronously.
 /// Takes command parameters directly via JNI: requestType as int, args as byte[][],
 /// and routing as primitives.
@@ -1823,72 +1780,19 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandDirec
                 }
 
                 // Compute routing
-                let routing = if has_route_bool {
-                    use glide_core::command_request::{
-                        ByAddressRoute, Routes, SimpleRoutes, SlotIdRoute, SlotKeyRoute, SlotTypes,
-                    };
-                    use protobuf::EnumOrUnknown;
-                    let mut routes = Routes::default();
-                    if route_type_val >= 0 && route_param_str.is_none() {
-                        let simple = match route_type_val {
-                            0 => SimpleRoutes::AllNodes,
-                            1 => SimpleRoutes::AllPrimaries,
-                            _ => SimpleRoutes::Random,
-                        };
-                        routes.set_simple_routes(simple);
-                    } else if route_type_val >= 100 && route_param_str.is_some() {
-                        // SlotIdRoute: routeType 100+ (offset by 100 from SlotKeyRoute)
-                        let slot_type = match route_type_val - 100 {
-                            1 => SlotTypes::Replica,
-                            _ => SlotTypes::Primary,
-                        };
-                        let param_str = route_param_str.as_deref().unwrap_or_default();
-                        if let Ok(slot_id) = param_str.parse::<i32>() {
-                            let s = SlotIdRoute {
-                                slot_type: EnumOrUnknown::new(slot_type),
-                                slot_id,
-                                ..Default::default()
-                            };
-                            routes.set_slot_id_route(s);
-                        }
-                    } else if route_type_val >= 0 && route_param_str.is_some() {
-                        // SlotKeyRoute: routeType 0-1
-                        let slot_type = match route_type_val {
-                            1 => SlotTypes::Replica,
-                            _ => SlotTypes::Primary,
-                        };
-                        let param_str = route_param_str.as_deref().unwrap_or_default();
-                        if !param_str.is_empty() {
-                            let s = SlotKeyRoute {
-                                slot_type: EnumOrUnknown::new(slot_type),
-                                slot_key: param_str.into(),
-                                ..Default::default()
-                            };
-                            routes.set_slot_key_route(s);
-                        }
-                    } else if route_type_val < 0 && route_param_str.is_some() {
-                        let param_str = route_param_str.as_deref().unwrap_or_default();
-                        if let Some((host, port_str)) = param_str.split_once(':')
-                            && let Ok(port) = port_str.parse::<i32>()
-                        {
-                            let s = ByAddressRoute {
-                                host: host.to_string().into(),
-                                port,
-                                ..Default::default()
-                            };
-                            routes.set_by_address_route(s);
-                        }
-                    }
-                    routing::get_route(routes, Some(&cmd)).map_err(|e| {
-                        redis::RedisError::from((
-                            redis::ErrorKind::ClientError,
-                            "Routing error",
-                            e.to_string(),
-                        ))
-                    })?
-                } else {
-                    None
-                };
+                let routing = routing::resolve_routing_from_params(
+                    has_route_bool,
+                    route_type_val,
+                    route_param_str.as_deref(),
+                    Some(&cmd),
+                )
+                .map_err(|e| {
+                    redis::RedisError::from((
+                        redis::ErrorKind::ClientError,
+                        "Routing error",
+                        e.to_string(),
+                    ))
+                })?;
 
                 client.send_command(&mut cmd, routing).await
             }
@@ -2055,67 +1959,12 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeScriptAsync(
                 Ok(mut client) => {
                     // Determine routing: explicit route if provided, otherwise infer from keys via EVALSHA-shaped command
                     let routing_info = if has_route_bool {
-                        use glide_core::command_request::{
-                            ByAddressRoute, Routes, SimpleRoutes, SlotIdRoute, SlotKeyRoute,
-                            SlotTypes,
-                        };
-                        use protobuf::EnumOrUnknown;
-                        let mut routes = Routes::default();
-                        // Build route based on route_type/route_param
-                        // SimpleRoutes
-                        if route_type_val >= 0 && route_param_str.is_none() {
-                            let simple = match route_type_val {
-                                0 => SimpleRoutes::AllNodes,
-                                1 => SimpleRoutes::AllPrimaries,
-                                _ => SimpleRoutes::Random,
-                            };
-                            routes.set_simple_routes(simple);
-                        } else if route_type_val >= 100 && route_param_str.is_some() {
-                            // SlotIdRoute: routeType 100+ (offset by 100)
-                            let slot_type = match route_type_val - 100 {
-                                1 => SlotTypes::Replica,
-                                _ => SlotTypes::Primary,
-                            };
-                            let param_str = route_param_str.unwrap_or_default();
-                            if let Ok(slot_id) = param_str.parse::<i32>() {
-                                let s = SlotIdRoute {
-                                    slot_type: EnumOrUnknown::new(slot_type),
-                                    slot_id,
-                                    ..Default::default()
-                                };
-                                routes.set_slot_id_route(s);
-                            }
-                        } else if route_type_val >= 0 && route_param_str.is_some() {
-                            // SlotKeyRoute: routeType 0-1
-                            let slot_type = match route_type_val {
-                                1 => SlotTypes::Replica,
-                                _ => SlotTypes::Primary,
-                            };
-                            let param_str = route_param_str.unwrap_or_default();
-                            if !param_str.is_empty() {
-                                let s = SlotKeyRoute {
-                                    slot_type: EnumOrUnknown::new(slot_type),
-                                    slot_key: param_str.into(),
-                                    ..Default::default()
-                                };
-                                routes.set_slot_key_route(s);
-                            }
-                        } else if route_type_val < 0 && route_param_str.is_some() {
-                            // ByAddressRoute encoded with route_type = -1 and host:port in route_param
-                            let param_str = route_param_str.unwrap_or_default();
-                            if let Some((host, port_str)) = param_str.split_once(':')
-                                && let Ok(port) = port_str.parse::<i32>()
-                            {
-                                let s = ByAddressRoute {
-                                    host: host.to_string().into(),
-                                    port,
-                                    ..Default::default()
-                                };
-                                routes.set_by_address_route(s);
-                            }
-                        }
-
-                        match routing::get_route(routes, None) {
+                        match routing::resolve_routing_from_params(
+                            true,
+                            route_type_val,
+                            route_param_str.as_deref(),
+                            None,
+                        ) {
                             Ok(r) => r,
                             Err(e) => {
                                 complete_callback(

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1372,7 +1372,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_markTimedOut(
 /// Execute a batch (pipeline/transaction) asynchronously.
 /// Takes command data directly via JNI arrays.
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchAsync(
     mut env: JNIEnv,
     _class: JClass,
     client_ptr: jlong,
@@ -1391,7 +1391,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
     span_ptr: jlong,
 ) {
     run_ffi(|| {
-        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeBatchDirect")
+        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeBatchAsync")
         else {
             return Some(());
         };
@@ -1647,7 +1647,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeBatchDirect(
 /// Takes command parameters directly via JNI: requestType as int, args as byte[][],
 /// and routing as primitives.
 #[unsafe(no_mangle)]
-pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandDirect(
+pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandAsync(
     mut env: JNIEnv,
     _class: JClass,
     client_ptr: jlong,
@@ -1661,7 +1661,7 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeCommandDirec
     span_ptr: jlong,
 ) {
     run_ffi(|| {
-        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeCommandDirect")
+        let Some(jvm) = get_jvm_or_complete_error(&mut env, callback_id, "executeCommandAsync")
         else {
             return Some(());
         };

--- a/java/src/routing.rs
+++ b/java/src/routing.rs
@@ -6,8 +6,82 @@ use redis::cluster_routing::{ResponsePolicy, Routable};
 use redis::{Cmd, RedisError, RedisResult};
 
 pub use glide_core::command_request::Routes;
-use glide_core::command_request::SimpleRoutes;
-use glide_core::command_request::SlotTypes;
+use glide_core::command_request::{
+    ByAddressRoute, SimpleRoutes, SlotIdRoute, SlotKeyRoute, SlotTypes,
+};
+use protobuf::EnumOrUnknown;
+
+/// Resolves routing from the JNI primitive encoding used by Java's `computeRouteArgs()`.
+///
+/// The encoding convention from Java:
+/// - `route_type >= 0` with `route_param = None` → SimpleRoutes (0=AllNodes, 1=AllPrimaries, else Random)
+/// - `route_type >= 100` with `route_param = Some(slot_id_str)` → SlotIdRoute (offset by 100)
+/// - `route_type >= 0` with `route_param = Some(slot_key)` → SlotKeyRoute
+/// - `route_type < 0` with `route_param = Some("host:port")` → ByAddressRoute
+pub(crate) fn resolve_routing_from_params(
+    has_route: bool,
+    route_type: i32,
+    route_param: Option<&str>,
+    cmd: Option<&Cmd>,
+) -> RedisResult<Option<RoutingInfo>> {
+    if !has_route {
+        return Ok(None);
+    }
+
+    let mut routes = Routes::default();
+
+    if route_type >= 0 && route_param.is_none() {
+        // SimpleRoutes: no param means multi-node or random
+        let simple = match route_type {
+            0 => SimpleRoutes::AllNodes,
+            1 => SimpleRoutes::AllPrimaries,
+            _ => SimpleRoutes::Random,
+        };
+        routes.set_simple_routes(simple);
+    } else if route_type >= 100 && route_param.is_some() {
+        // SlotIdRoute: routeType 100+ (offset by 100 from SlotKeyRoute)
+        let slot_type = match route_type - 100 {
+            1 => SlotTypes::Replica,
+            _ => SlotTypes::Primary,
+        };
+        let param_str = route_param.unwrap_or_default();
+        if let Ok(slot_id) = param_str.parse::<i32>() {
+            routes.set_slot_id_route(SlotIdRoute {
+                slot_type: EnumOrUnknown::new(slot_type),
+                slot_id,
+                ..Default::default()
+            });
+        }
+    } else if route_type >= 0 && route_param.is_some() {
+        // SlotKeyRoute: routeType 0-1
+        let slot_type = match route_type {
+            1 => SlotTypes::Replica,
+            _ => SlotTypes::Primary,
+        };
+        let param_str = route_param.unwrap_or_default();
+        if !param_str.is_empty() {
+            routes.set_slot_key_route(SlotKeyRoute {
+                slot_type: EnumOrUnknown::new(slot_type),
+                slot_key: param_str.into(),
+                ..Default::default()
+            });
+        }
+    } else if route_type < 0 && route_param.is_some() {
+        // ByAddressRoute: route_type = -1, param = "host:port"
+        let param_str = route_param.unwrap_or_default();
+        if let Some((host, port_str)) = param_str.split_once(':')
+            && let Ok(port) = port_str.parse::<i32>()
+        {
+            routes.set_by_address_route(ByAddressRoute {
+                host: host.to_string().into(),
+                port,
+                ..Default::default()
+            });
+        }
+    }
+
+    get_route(routes, cmd)
+}
 
 fn get_slot_addr(slot_type: &protobuf::EnumOrUnknown<SlotTypes>) -> Result<SlotAddr, RedisError> {
     slot_type

--- a/java/src/routing.rs
+++ b/java/src/routing.rs
@@ -1,68 +1,13 @@
-//! Protobuf bridge for JNI - reuses existing glide-core protobuf parsing logic
-//! This is a surgical change that just parses protobuf and delegates to existing functions
+//! Route resolution - converts route parameters to redis RoutingInfo
 
-use anyhow::{Result, anyhow};
-use protobuf::Message;
 use redis::cluster_routing::RoutingInfo;
 use redis::cluster_routing::{MultipleNodeRoutingInfo, Route, SingleNodeRoutingInfo, SlotAddr};
 use redis::cluster_routing::{ResponsePolicy, Routable};
 use redis::{Cmd, RedisError, RedisResult};
 
-// Reuse existing protobuf types from glide-core (no wrapper types needed)
+pub use glide_core::command_request::Routes;
 use glide_core::command_request::SimpleRoutes;
 use glide_core::command_request::SlotTypes;
-pub use glide_core::command_request::{Command, CommandRequest, Routes, command_request};
-
-/// Parse CommandRequest from protobuf bytes (using existing protobuf parsing)
-pub fn parse_command_request(bytes: &[u8]) -> Result<CommandRequest> {
-    CommandRequest::parse_from_bytes(bytes)
-        .map_err(|e| anyhow!("Failed to parse CommandRequest protobuf: {}", e))
-}
-
-/// Since socket_listener functions are private, we'll need to access the core request_type logic
-/// This reuses the same pattern as socket_listener but makes it accessible for JNI
-pub fn create_valkey_command(command: &Command) -> Result<redis::Cmd> {
-    // Get the command using the same logic as socket_listener
-    let request_type: glide_core::request_type::RequestType = command.request_type.into();
-    let Some(mut cmd) = request_type.get_command() else {
-        return Err(anyhow!(
-            "Received invalid request type: {:?}",
-            command.request_type
-        ));
-    };
-
-    // Add arguments using the same logic as socket_listener
-    match &command.args {
-        Some(glide_core::command_request::command::Args::ArgsArray(args_vec)) => {
-            for arg in args_vec.args.iter() {
-                cmd.arg(arg.as_ref());
-            }
-        }
-        Some(glide_core::command_request::command::Args::ArgsVecPointer(pointer)) => {
-            let res = unsafe { *Box::from_raw(*pointer as *mut Vec<bytes::Bytes>) };
-            for arg in res {
-                cmd.arg(arg.as_ref());
-            }
-        }
-        None => {
-            return Err(anyhow!(
-                "Failed to get request arguments, no arguments are set"
-            ));
-        }
-        // Handle any other cases that might be added to the enum
-        Some(_) => {
-            return Err(anyhow!("Unsupported argument type"));
-        }
-    };
-
-    if cmd.args_iter().next().is_none() {
-        return Err(anyhow!(
-            "Received command without a command name or arguments"
-        ));
-    }
-
-    Ok(cmd)
-}
 
 fn get_slot_addr(slot_type: &protobuf::EnumOrUnknown<SlotTypes>) -> Result<SlotAddr, RedisError> {
     slot_type
@@ -88,7 +33,7 @@ fn get_slot_addr(slot_type: &protobuf::EnumOrUnknown<SlotTypes>) -> Result<SlotA
 ///
 /// # Parameters
 ///
-/// * `route`: The protobuf Routes message to convert.
+/// * `route`: The Routes message to convert.
 /// * `cmd`: Optional command used to determine the response policy for multi-node routes.
 ///
 /// # Returns


### PR DESCRIPTION
### Summary

Eliminate protobuf serialization/deserialization from the entire Java client command execution path (single commands and batches) at the JNI boundary. Commands are now passed directly as primitive arrays (int requestType + byte[][] args) instead of being serialized to protobuf bytes, copied across JNI, and deserialized on the Rust side.

### Issue link

N/A — performance optimization, no linked issue.

### Features / Behaviour Changes

No user-facing API changes. This is a transparent performance optimization that reduces CPU and memory overhead for every command executed through the Java client.

### Implementation

**Single commands:** `submitNewCommand` converts `String[]`/`GlideString[]` directly to `byte[][]` and calls `executeCommandDirect` JNI, which takes `int requestType`, `byte[][] args`, and routing primitives. Rust builds `redis::Cmd` directly from these.

**Batch commands:** `submitNewBatch` extracts `int[] requestTypes` + `byte[][][] args` from the new `BatchCommand` POD class and calls `executeBatchDirect` JNI. Rust builds the `redis::Pipeline` directly.

**BaseBatch refactoring:** Replaced `Batch.Builder protobufBatch` with `ArrayList<BatchCommand>` where `BatchCommand` is a simple `int requestType` + `byte[][] args` container. The 310+ `protobufBatch.addCommands(buildCommand(...))` calls were replaced with `addCommand(...)`.

**Rust cleanup:** Renamed `protobuf_bridge.rs` to `routing.rs` (only `get_route` remains). Removed `executeCommandAsync`, `executeBinaryCommandAsync`, `executeBatchAsync`, `parse_request_bytes`, and `execute_command_request_and_complete`.

### Limitations

- Protobuf is still used for connection setup (`ConnectionRequest`) since that is a one-time operation.
- The `RequestType` enum values (integers) are still defined by the protobuf `.proto` file, but no protobuf serialization occurs at runtime for commands.

### Testing

- All existing unit tests pass (`./gradlew :client:test` — BUILD SUCCESSFUL)
- `BatchTests`, `ClusterBatchTests`, `StandaloneBatchTests` updated to verify `BatchCommand` POD data instead of protobuf `Command` objects
- `GlideClusterClientTest` updated for new `submitDirectCommand` override pattern
- Rust builds clean (`cargo build` — no errors or warnings)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary