### PR TITLE
Fix flaky test_pipeline_all_primary_routing timeout

### DIFF
--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -40,6 +40,15 @@ pub(crate) mod shared_client_tests {
     use utilities::cluster::*;
     use utilities::*;
 
+    /// Explicit pipeline timeout (in milliseconds) used by pipeline tests.
+    ///
+    /// These pipelines include commands that route to all primary nodes (e.g.
+    /// `FLUSHALL`, `DBSIZE`). Under CI load (many tests running in parallel
+    /// against a shared server) these multi-node operations can exceed the
+    /// `DEFAULT_RESPONSE_TIMEOUT` (250ms), causing flaky timeouts. A higher,
+    /// explicit timeout keeps these tests stable without affecting behaviour.
+    const PIPELINE_TEST_TIMEOUT_MS: u32 = 10_000;
+
     #[cfg(feature = "iam_tests")]
     use glide_core::connection_request::{
         AuthenticationInfo, IamCredentials, ServiceType, TlsMode,
@@ -1658,7 +1667,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    Some(10_000),
+                    Some(PIPELINE_TEST_TIMEOUT_MS),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -1722,7 +1731,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     raise_error,
-                    Some(10_000),
+                    Some(PIPELINE_TEST_TIMEOUT_MS),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -1796,7 +1805,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    Some(10_000),
+                    Some(PIPELINE_TEST_TIMEOUT_MS),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2255,7 +2264,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    Some(10_000),
+                    Some(PIPELINE_TEST_TIMEOUT_MS),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2299,7 +2308,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    Some(10_000),
+                    Some(PIPELINE_TEST_TIMEOUT_MS),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2342,15 +2351,14 @@ pub(crate) mod shared_client_tests {
             pipeline.add_command(cmd("FLUSHALL"));
             pipeline.add_command(cmd("DBSIZE")); // AllPrimary cmd + SUM aggregation
 
-            // Execute the pipeline with an explicit timeout to avoid flakiness
-            // under CI load (multi-node routing can exceed default 250ms timeout).
+            // Execute the pipeline.
             let result = test_basics
                 .client
                 .send_pipeline(
                     &pipeline,
                     None,
                     false,
-                    Some(10_000),
+                    Some(PIPELINE_TEST_TIMEOUT_MS),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2407,7 +2415,7 @@ pub(crate) mod shared_client_tests {
                         &pipeline,
                         None,
                         false,
-                        Some(10_000),
+                        Some(PIPELINE_TEST_TIMEOUT_MS),
                         PipelineRetryStrategy {
                             retry_server_error: false,
                             retry_connection_error: false,

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -1658,7 +1658,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -1722,7 +1722,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     raise_error,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -1796,7 +1796,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2255,7 +2255,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2299,7 +2299,7 @@ pub(crate) mod shared_client_tests {
                     &pipeline,
                     None,
                     false,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2342,14 +2342,15 @@ pub(crate) mod shared_client_tests {
             pipeline.add_command(cmd("FLUSHALL"));
             pipeline.add_command(cmd("DBSIZE")); // AllPrimary cmd + SUM aggregation
 
-            // Execute the pipeline.
+            // Execute the pipeline with an explicit timeout to avoid flakiness
+            // under CI load (multi-node routing can exceed default 250ms timeout).
             let result = test_basics
                 .client
                 .send_pipeline(
                     &pipeline,
                     None,
                     false,
-                    None,
+                    Some(10_000),
                     PipelineRetryStrategy {
                         retry_server_error: true,
                         retry_connection_error: false,
@@ -2406,7 +2407,7 @@ pub(crate) mod shared_client_tests {
                         &pipeline,
                         None,
                         false,
-                        None,
+                        Some(10_000),
                         PipelineRetryStrategy {
                             retry_server_error: false,
                             retry_connection_error: false,


### PR DESCRIPTION
### Summary

Fix flaky pipeline test timeouts in `glide-core/tests/test_client.rs` by giving the pipeline tests an explicit, higher-than-default execution timeout.

### Issue link

Closes #6331

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The pipeline tests relied on `DEFAULT_RESPONSE_TIMEOUT` (250ms) for pipeline execution. Several of these pipelines include commands that route to all primary nodes (e.g. `FLUSHALL`, `DBSIZE`). Under CI load (many tests running in parallel against a shared server), these multi-node operations can exceed 250ms, causing intermittent timeouts.

**Fix:** Introduce a single `PIPELINE_TEST_TIMEOUT_MS` constant (10 seconds) with a comment explaining why a higher-than-default timeout is required, and pass `Some(PIPELINE_TEST_TIMEOUT_MS)` to every `send_pipeline` call in the pipeline tests. Centralizing the value in one named constant keeps the timeout consistent across all pipeline tests and documents the rationale in one place.

### Limitations

None

### Testing

- All affected pipeline test variants (`use_cluster=true` and `use_cluster=false`) pass consistently
- Ran the tests in a loop with zero failures
- Code compiles cleanly with `cargo check --tests`, and `cargo fmt --check` and `cargo clippy --tests` pass

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] ~~CHANGELOG.md and documentation files are updated.~~
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
