### PR TITLE
CD: Retry RC node test install to handle npm propagation race

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -540,7 +540,27 @@ jobs:
             - name: Run utils/node Tests
               working-directory: utils/release-candidate-testing/node
               run: |
-                  npm install @valkey/valkey-glide@${{ needs.get-build-parameters.outputs.npm_tag }} --save
+                  # The platform-specific optional dependency (e.g. @valkey/valkey-glide-linux-x64-gnu)
+                  # can lag behind the base package on the npm registry for a short window right after
+                  # publish. When that happens npm silently skips the optional dependency and the test
+                  # fails with "Cannot find module". Retry the install until the native module resolves.
+                  NPM_TAG="${{ needs.get-build-parameters.outputs.npm_tag }}"
+                  MAX_ATTEMPTS=5
+                  DELAY=15
+                  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+                      rm -rf node_modules package-lock.json
+                      npm install "@valkey/valkey-glide@${NPM_TAG}" --save
+                      if node -e "require('@valkey/valkey-glide')"; then
+                          echo "Native module resolved on attempt ${attempt}."
+                          break
+                      fi
+                      if [ "${attempt}" -eq "${MAX_ATTEMPTS}" ]; then
+                          echo "::error::@valkey/valkey-glide native module still unresolved after ${MAX_ATTEMPTS} attempts."
+                          exit 1
+                      fi
+                      echo "Attempt ${attempt}/${MAX_ATTEMPTS}: native module not resolvable yet (likely npm registry propagation). Retrying in ${DELAY}s..."
+                      sleep "${DELAY}"
+                  done
                   npm run build:utils
                   npm test
 


### PR DESCRIPTION
## What
Add a propagation-aware retry around the install in the post-publish `Run utils/node Tests` step of the NPM CD.

## Why
Right after publish, the platform-specific optional dependency (e.g. `@valkey/valkey-glide-linux-x64-gnu`) can lag behind the base package on the npm registry. When that happens, `npm install` **silently skips** the optional dependency (no error), and the subsequent native-module load fails with:

```
Error: Cannot find module '@valkey/valkey-glide-linux-x64-gnu'
```

This is what failed the node test on `v2.4.2-rc1`. The published artifacts are correct — a clean install resolves fine once the registry has propagated (verified locally under npm 10 and npm 11) — so this is a timing race, not a packaging bug.

## How
Retry `npm install @valkey/valkey-glide@<tag>` (with a clean `node_modules`/lockfile each attempt) until `require('@valkey/valkey-glide')` succeeds, then run `build:utils` and the tests. 5 attempts, 15s backoff.

No auth/secrets involved. The same step is identical on `main`; a matching PR will follow.