### PR TITLE
Node: Add OTel span creation for script invocation (EVALSHA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changes
 
+* Node: Add OpenTelemetry span creation for script invocations (`EVALSHA`) so `invokeScript`/`invokeScriptWithRoute` calls appear in traces with DB semantic convention attributes and respect parent span context ([#5599](https://github.com/valkey-io/valkey-glide/issues/5599))
 * Java: implement MONITOR command ([#6187](https://github.com/valkey-io/valkey-glide/pull/6187))
 * Node: Add GlideMonitorClient for MONITOR command ([#6212](https://github.com/valkey-io/valkey-glide/pull/6212))
 * Python: implement MONITOR command for sync and async clients ([#6132](https://github.com/valkey-io/valkey-glide/pull/6132))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1343,6 +1343,34 @@ export class BaseClient {
         }
     }
 
+    /**
+     * @internal
+     * Creates an OpenTelemetry span for a command if OpenTelemetry is enabled
+     * and the request is selected for sampling. When a parent span context is
+     * available it is propagated so the span is linked to the parent trace.
+     *
+     * @param commandName - The span name (e.g. the request type or `"EVALSHA"`).
+     * @returns A pointer to the created span as a `Long`, or `null` when no span
+     *     was created (OpenTelemetry disabled or request not sampled).
+     */
+    protected createCommandSpanPtr(commandName: string): Long | null {
+        if (!OpenTelemetry.shouldSample()) {
+            return null;
+        }
+
+        const parentCtx = OpenTelemetry.getParentSpanContext();
+        const pair = parentCtx
+            ? createOtelSpanWithTraceContext(
+                  commandName,
+                  parentCtx.traceId,
+                  parentCtx.spanId,
+                  parentCtx.traceFlags,
+                  parentCtx.traceState,
+              )
+            : createLeakedOtelSpan(commandName);
+        return new Long(pair[0], pair[1]);
+    }
+
     private dropCommandSpan(spanPtr: number | Long | null | undefined) {
         if (spanPtr === null || spanPtr === undefined) return;
 
@@ -1494,26 +1522,12 @@ export class BaseClient {
         const route = this.toProtobufRoute(options?.route);
         const callbackIndex = this.getCallbackIndex();
         const basePromise = new Promise<T>((resolve, reject) => {
-            // Create a span only if the OpenTelemetry is enabled and measure statistics only according to the requests percentage configuration
-            let spanPtr: Long | null = null;
-
-            if (OpenTelemetry.shouldSample()) {
-                const commandName =
-                    command instanceof command_request.Command
-                        ? command_request.RequestType[command.requestType]
-                        : "Batch";
-                const parentCtx = OpenTelemetry.getParentSpanContext();
-                const pair = parentCtx
-                    ? createOtelSpanWithTraceContext(
-                          commandName,
-                          parentCtx.traceId,
-                          parentCtx.spanId,
-                          parentCtx.traceFlags,
-                          parentCtx.traceState,
-                      )
-                    : createLeakedOtelSpan(commandName);
-                spanPtr = new Long(pair[0], pair[1]);
-            }
+            // Create a span only if OpenTelemetry is enabled and the request is sampled.
+            const commandName =
+                command instanceof command_request.Command
+                    ? command_request.RequestType[command.requestType]
+                    : "Batch";
+            const spanPtr = this.createCommandSpanPtr(commandName);
 
             this.promiseCallbackFunctions[callbackIndex] = [
                 resolve,
@@ -1659,6 +1673,8 @@ export class BaseClient {
 
         return new Promise<T>((resolve, reject) => {
             const callbackIdx = this.getCallbackIndex();
+            // Create a span only if OpenTelemetry is enabled and the request is sampled.
+            const spanPtr = this.createCommandSpanPtr("EVALSHA");
             this.promiseCallbackFunctions[callbackIdx] = [
                 resolve,
                 reject,
@@ -1668,6 +1684,7 @@ export class BaseClient {
                 new command_request.CommandRequest({
                     callbackIdx,
                     scriptInvocation: command,
+                    rootSpanPtr: spanPtr,
                 }),
                 (message: command_request.CommandRequest, writer: Writer) => {
                     command_request.CommandRequest.encodeDelimited(

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -2274,6 +2274,8 @@ export class GlideClusterClient extends BaseClient {
 
         return new Promise<T>((resolve, reject) => {
             const callbackIdx = this.getCallbackIndex();
+            // Create a span only if OpenTelemetry is enabled and the request is sampled.
+            const spanPtr = this.createCommandSpanPtr("EVALSHA");
             this.promiseCallbackFunctions[callbackIdx] = [
                 resolve,
                 reject,
@@ -2284,6 +2286,7 @@ export class GlideClusterClient extends BaseClient {
                     callbackIdx,
                     scriptInvocation: command,
                     route: this.toProtobufRoute(options?.route),
+                    rootSpanPtr: spanPtr,
                 }),
                 (message: command_request.CommandRequest, writer: Writer) => {
                     command_request.CommandRequest.encodeDelimited(

--- a/node/tests/OpenTelemetry.test.ts
+++ b/node/tests/OpenTelemetry.test.ts
@@ -14,6 +14,7 @@ import {
     ProtocolVersion,
     GlideSpanContext,
     GlideOpenTelemetryConfig,
+    Script,
 } from "../build-ts";
 import {
     flushAndCloseClient,
@@ -70,6 +71,52 @@ function readAndParseSpanFile(path: string): {
         spans,
         spanNames,
     };
+}
+
+/**
+ * Finds the first span with the given name in a parsed span file and returns
+ * the value of one of its `span_attributes` entries.
+ *
+ * The file exporter serializes attributes as an array of single-key objects,
+ * e.g. `span_attributes: [{ "db.operation.name": "EVALSHA" }, ...]`.
+ *
+ * @param spans - The raw span lines from {@link readAndParseSpanFile}.
+ * @param spanName - The span name to look for (e.g. `"EVALSHA"`).
+ * @param attributeKey - The attribute key to extract (e.g. `"db.operation.name"`).
+ * @returns The attribute value, or `undefined` if the span/attribute is absent.
+ */
+function getSpanAttribute(
+    spans: string[],
+    spanName: string,
+    attributeKey: string,
+): string | undefined {
+    for (const line of spans) {
+        let spanJson: Record<string, unknown>;
+
+        try {
+            spanJson = JSON.parse(line);
+        } catch {
+            continue;
+        }
+
+        if (spanJson.name !== spanName) {
+            continue;
+        }
+
+        const attributes = spanJson.span_attributes;
+
+        if (!Array.isArray(attributes)) {
+            continue;
+        }
+
+        for (const attr of attributes) {
+            if (attr && typeof attr === "object" && attributeKey in attr) {
+                return (attr as Record<string, string>)[attributeKey];
+            }
+        }
+    }
+
+    return undefined;
 }
 
 const TIMEOUT = 50000;
@@ -501,6 +548,137 @@ describe("OpenTelemetry GlideClusterClient", () => {
         },
         TIMEOUT,
     );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `GlideClusterClient test script invocation span_%p`,
+        async (protocol) => {
+            await teardown_otel_test();
+
+            client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+            });
+
+            const script = new Script("return 'OTel script span'");
+            const result = await client.invokeScript(script);
+            expect(result).toEqual("OTel script span");
+
+            // Wait for spans to be flushed to file
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            // Read the span file and check that the EVALSHA span was created
+            // with the expected DB semantic convention attributes.
+            const { spans, spanNames } = readAndParseSpanFile(
+                VALID_ENDPOINT_TRACES,
+            );
+
+            expect(spanNames).toContain("EVALSHA");
+            expect(
+                getSpanAttribute(spans, "EVALSHA", "db.operation.name"),
+            ).toBe("EVALSHA");
+        },
+        TIMEOUT,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `GlideClusterClient test script invocation with route span_%p`,
+        async (protocol) => {
+            await teardown_otel_test();
+
+            client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+            });
+
+            const script = new Script("return 'OTel routed script span'");
+            const result = await client.invokeScriptWithRoute(script, {
+                route: "allPrimaries",
+            });
+            expect(result).toBeDefined();
+
+            // Wait for spans to be flushed to file
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            // Read the span file and check that the EVALSHA span was created
+            // with the expected DB semantic convention attributes.
+            const { spans, spanNames } = readAndParseSpanFile(
+                VALID_ENDPOINT_TRACES,
+            );
+
+            expect(spanNames).toContain("EVALSHA");
+            expect(
+                getSpanAttribute(spans, "EVALSHA", "db.operation.name"),
+            ).toBe("EVALSHA");
+        },
+        TIMEOUT,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `GlideClusterClient test script invocation span memory leak_%p`,
+        async (protocol) => {
+            if (global.gc) {
+                global.gc(); // Run garbage collection
+            }
+
+            const startMemory = process.memoryUsage().heapUsed;
+
+            client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+            });
+
+            const script = new Script("return ARGV[1]");
+
+            // Execute many script invocations sequentially - each should
+            // create and clean up its span.
+            for (let i = 0; i < 100; i++) {
+                await client.invokeScript(script, { args: [`value_${i}`] });
+            }
+
+            // Force GC and check memory
+            if (global.gc) {
+                global.gc();
+            }
+
+            const endMemory = process.memoryUsage().heapUsed;
+
+            expect(endMemory).toBeLessThan(startMemory * 1.1); // Allow 10% growth
+        },
+        TIMEOUT,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `GlideClusterClient test failed script invocation still creates span_%p`,
+        async (protocol) => {
+            await teardown_otel_test();
+
+            client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+            });
+
+            // A script that raises an error - the span must still be created
+            // and cleaned up on the error path.
+            const script = new Script("return redis.error_reply('boom')");
+            await expect(client.invokeScript(script)).rejects.toThrow();
+
+            // Wait for spans to be flushed to file
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            const { spanNames } = readAndParseSpanFile(VALID_ENDPOINT_TRACES);
+
+            expect(spanNames).toContain("EVALSHA");
+        },
+        TIMEOUT,
+    );
 });
 
 //standalone tests
@@ -565,6 +743,45 @@ describe("OpenTelemetry GlideClient", () => {
             const endMemory = process.memoryUsage().heapUsed;
 
             expect(endMemory).toBeLessThan(startMemory * 1.1); // Allow small fluctuations
+        },
+        TIMEOUT,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `GlideClient test script invocation span_%p`,
+        async (protocol) => {
+            // OpenTelemetry.init is global per-process and runs in the cluster
+            // describe's beforeAll. Ensure 100% sampling here since the
+            // standalone block does not manage the sample percentage itself.
+            OpenTelemetry.setSamplePercentage(100);
+
+            // Drain any stale spans from previous tests.
+            if (fs.existsSync(VALID_ENDPOINT_TRACES)) {
+                fs.unlinkSync(VALID_ENDPOINT_TRACES);
+            }
+
+            client = await GlideClient.createClient({
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    protocol,
+                ),
+            });
+
+            const script = new Script("return 'OTel standalone script span'");
+            const result = await client.invokeScript(script);
+            expect(result).toEqual("OTel standalone script span");
+
+            // Wait for spans to be flushed to file
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            const { spans, spanNames } = readAndParseSpanFile(
+                VALID_ENDPOINT_TRACES,
+            );
+
+            expect(spanNames).toContain("EVALSHA");
+            expect(
+                getSpanAttribute(spans, "EVALSHA", "db.operation.name"),
+            ).toBe("EVALSHA");
         },
         TIMEOUT,
     );
@@ -1063,6 +1280,74 @@ describe("OpenTelemetry parent span context propagation", () => {
 
                 if (spanJson.name === "Set" || spanJson.name === "Get") {
                     expect(spanJson.parent_span_id).toBe("0000000000000000");
+                }
+            }
+        },
+        TIMEOUT,
+    );
+
+    it(
+        "EVALSHA script spans inherit trace_id and parent_span_id from provided context",
+        async () => {
+            const parentTraceId = "0af7651916cd43dd8448eb211c80319c";
+            const parentSpanId = "b7ad6b7169203331";
+            const parentTraceFlags = 1;
+
+            OpenTelemetry.setParentSpanContextProvider(() => ({
+                traceId: parentTraceId,
+                spanId: parentSpanId,
+                traceFlags: parentTraceFlags,
+            }));
+
+            OpenTelemetry.setSamplePercentage(100);
+
+            // Drain any stale spans from previous tests.
+            if (fs.existsSync(VALID_ENDPOINT_TRACES)) {
+                fs.unlinkSync(VALID_ENDPOINT_TRACES);
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 200));
+
+            if (fs.existsSync(VALID_ENDPOINT_TRACES)) {
+                fs.unlinkSync(VALID_ENDPOINT_TRACES);
+            }
+
+            client = await GlideClusterClient.createClient({
+                ...getClientConfigurationOption(
+                    cluster.getAddresses(),
+                    ProtocolVersion.RESP3,
+                ),
+            });
+
+            const script = new Script("return 'OTel parent ctx script'");
+            const result = await client.invokeScript(script);
+            expect(result).toEqual("OTel parent ctx script");
+
+            // Wait for spans to be flushed to file
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+
+            const { spans, spanNames } = readAndParseSpanFile(
+                VALID_ENDPOINT_TRACES,
+            );
+
+            // Verify the EVALSHA span was created
+            expect(spanNames).toContain("EVALSHA");
+
+            // Verify the EVALSHA span inherits the parent trace context
+            for (const line of spans) {
+                let spanJson: Record<string, unknown>;
+
+                try {
+                    spanJson = JSON.parse(line);
+                } catch {
+                    continue;
+                }
+
+                if (spanJson.name === "EVALSHA") {
+                    expect(spanJson.trace_id).toBe(parentTraceId);
+                    expect(spanJson.parent_span_id).toBe(parentSpanId);
+                    expect(spanJson.span_id).toBeDefined();
+                    expect(spanJson.span_id).not.toBe(parentSpanId);
                 }
             }
         },


### PR DESCRIPTION
### Summary

The Node.js client created OpenTelemetry spans for regular commands (`createWritePromise`) but **not** for script invocations. `invokeScript` (EVALSHA) and `invokeScriptWithRoute` produced no spans at all, so script execution was completely invisible in OTel traces — a gap compared to regular commands.

This PR makes the script-invocation paths create an `EVALSHA` span (respecting parent span context) and propagate it to the core, so EVALSHA calls now appear in traces with the same DB semantic convention attributes (`db.operation.name=EVALSHA`, `db.query.text`, `server.address`, etc.) as regular commands.

### Issue link

This Pull Request is linked to issue: [(OpenTelemetry) Node.js: Add OTel span creation for script invocation (EVALSHA)](https://github.com/valkey-io/valkey-glide/issues/5599)
Closes #5599

### Features / Behaviour Changes

- `GlideClient.invokeScript` / `GlideClusterClient.invokeScript` now create an `EVALSHA` OpenTelemetry span when sampling is enabled.
- `GlideClusterClient.invokeScriptWithRoute` likewise creates an `EVALSHA` span.
- Script spans respect the configured parent span context (inherit `trace_id` / `parent_span_id`) and carry DB semantic convention attributes set by the core.

### Implementation

- **`node/src/BaseClient.ts`**: Extracted the span-creation logic from `createWritePromise` into a shared `protected createCommandSpanPtr(commandName)` helper (returns a `Long` pointer or `null` when OTel is disabled/not sampled). `createScriptInvocationPromise` now calls it with `"EVALSHA"` and sets the result as `rootSpanPtr` on the `CommandRequest`.
- **`node/src/GlideClusterClient.ts`**: `createScriptInvocationWithRoutePromise` now does the same.
- **No core/Rust changes needed.** The socket IPC path already handles script spans: `socket_listener.rs` reconstructs the span from `root_span_ptr` and applies the DB attributes via `set_db_script_attributes`. The span is dropped on every response (success and error) in `processResponse` via `dropCommandSpan(message.rootSpanPtr)` — the same lifecycle as regular commands.

This mirrors the established regular-command pattern; the only missing piece for scripts was the client setting `rootSpanPtr` on the request.

### Limitations

- This PR covers the **Node.js** client only (socket IPC path). The FFI clients (Go, Python Sync) were addressed separately in #5579.
- Spans for in-flight requests that never receive a response (e.g. the client is closed mid-request) are not explicitly dropped — this is a pre-existing behavior shared by all commands, not specific to scripts.

### Testing

Added OpenTelemetry integration tests in `node/tests/OpenTelemetry.test.ts`:
- Cluster `invokeScript` creates an `EVALSHA` span with `db.operation.name=EVALSHA`.
- Cluster `invokeScriptWithRoute` creates an `EVALSHA` span with `db.operation.name=EVALSHA`.
- Standalone (`GlideClient`) `invokeScript` creates an `EVALSHA` span with `db.operation.name=EVALSHA`.
- `EVALSHA` span inherits `trace_id` / `parent_span_id` from a provided parent context.
- A failing script still creates (and cleans up) its `EVALSHA` span.
- Script-invocation span memory-leak test (100 sequential invocations, heap growth < 10%).

All OpenTelemetry tests pass locally against a local Valkey cluster + standalone. `tsc` typecheck, ESLint, and Prettier all pass.

### Checklist

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run and Prettier has been run.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
