### PR TITLE
cd: Fix python and node release workflows

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -274,40 +274,24 @@ jobs:
                   if [[ "$ARCH" == "arm64" ]]; then
                     # Download PyPy for Apple Silicon
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
-                    PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_arm64
-                    PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_arm64
-
-                    echo "Downloading PyPy 3.9 for arm64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
-                    echo "Downloading PyPy 3.10 for arm64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
+                    
+                    
+                    
                     echo "Downloading PyPy 3.11 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
                   elif [[ "$ARCH" == "x86_64" ]]; then
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
-                    PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
-                    PYPY_VERSION_3_9=pypy3.9-v7.3.16-macos_x86_64
-
-                    echo "Downloading PyPy 3.9 for x86_64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
-                    echo "Downloading PyPy 3.10 for x86_64"
-                    curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                    sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
+                    
+                    
+                    
                     echo "Downloading PyPy 3.11 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                   fi
 
-                  echo "/opt/${PYPY_VERSION_3_11}/bin:/opt/${PYPY_VERSION_3_10}/bin:/opt/${PYPY_VERSION_3_9}/bin" >> ${GITHUB_PATH}
+                  echo "/opt/${PYPY_VERSION_3_11}/bin" >> ${GITHUB_PATH}
 
                   sudo chmod -R a+rx /opt/pypy*/bin
                   sudo chmod -R a+rx /opt/pypy*/lib/*.dylib
@@ -324,7 +308,7 @@ jobs:
               with:
                   working-directory: ./python/glide-async
                   target: ${{ matrix.build.TARGET }}
-                  args: --release --strip --out wheels -i ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.9 pypy3.10 pypy3.11' || 'python3.14' }}
+                  args: --release --strip --out wheels -i ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.11' || 'python3.14' }}
                   manylinux: auto
                   container: ${{ matrix.build.CONTAINER != '' && matrix.build.CONTAINER || '2014' }}
                   docker-options: --pull always --rm
@@ -355,41 +339,21 @@ jobs:
                       # Install PyPy
                       if [[ "$ARCH" == "x86_64" ]]; then
                         PYPY_VERSION_3_11=pypy3.11-v7.3.19-linux64
-                        PYPY_VERSION_3_10=pypy3.10-v7.3.19-linux64
-                        PYPY_VERSION_3_9=pypy3.9-v7.3.16-linux64
-
-                        echo "Downloading PyPy 3.9 for x86_64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_9}.tar.bz2"  --exclude="*/bin/python*" -C /opt
-
-                        echo "Downloading PyPy 3.10 for x86_64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
                         echo "Downloading PyPy 3.11 for x86_64"
                         curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                         tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
-                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:/opt/${PYPY_VERSION_3_10}/bin:/opt/${PYPY_VERSION_3_9}/bin:$PATH"
+                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:$PATH"
 
                       elif [[ "$ARCH" == "aarch64" ]]; then
                         PYPY_VERSION_3_11=pypy3.11-v7.3.19-aarch64
-                        PYPY_VERSION_3_10=pypy3.10-v7.3.19-aarch64
-                        PYPY_VERSION_3_9=pypy3.9-v7.3.16-aarch64
-
-                        echo "Downloading PyPy 3.9 for aarch64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_9}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_9}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
-                        echo "Downloading PyPy 3.10 for aarch64"
-                        curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                        tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
                         echo "Downloading PyPy 3.11 for aarch64"
                         curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                         tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
-                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:/opt/${PYPY_VERSION_3_10}/bin:/opt/${PYPY_VERSION_3_9}/bin:$PATH"
+                        export PATH="/opt/${PYPY_VERSION_3_11}/bin:$PATH"
                       else
                         echo "Running on unsupported architecture: $ARCH. Expected one of: ['x86_64', 'aarch64']"
                         exit 1
@@ -440,7 +404,7 @@ jobs:
                   maturin-version: 0.14.17
                   working-directory: ./python/glide-async
                   target: ${{ matrix.build.TARGET }}
-                  args: --release --strip --out wheels -i  ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.9 pypy3.10 pypy3.11' || 'python3.14' }}
+                  args: --release --strip --out wheels -i  ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.11' || 'python3.14' }}
 
             ### SYNC CLIENT ###
 
@@ -485,7 +449,7 @@ jobs:
                   # we call cibuildwheel from the root folder in order to copy the whole folder tree to the docker
                   ${{ steps.python_cmd.outputs.cmd }} -m cibuildwheel python/glide-sync --output-dir python/glide-sync/wheels
               env:
-                  CIBW_BUILD: ${{ github.event_name != 'pull_request' && 'cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* pp39-* pp310-* pp311-*' || 'cp314-*' }}
+                  CIBW_BUILD: ${{ github.event_name != 'pull_request' && 'cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* pp311-*' || 'cp314-*' }}
                   CIBW_SKIP: "*-musl* *i686* *i386*"
                   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
                   CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
@@ -670,39 +634,39 @@ jobs:
 
                   if [[ "${{ matrix.build.NAMED_OS }}" == "linux" ]]; then
                     if [[ "$ARCH" == "x86_64" ]]; then
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-linux64
-                      echo "Downloading PyPy 3.10 for x86_64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-linux64
+                      echo "Downloading PyPy 3.11 for x86_64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      
                     elif [[ "$ARCH" == "aarch64" ]]; then
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-aarch64
-                      echo "Downloading PyPy 3.10 for aarch64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-aarch64
+                      echo "Downloading PyPy 3.11 for aarch64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     fi
 
-                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_10}/bin
+                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_11}/bin
 
                   elif [[ "${{ matrix.build.NAMED_OS }}" == "darwin" ]]; then
                     if [[ "$ARCH" == "arm64" ]]; then
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_arm64
-                      echo "Downloading PyPy 3.10 for arm64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
-
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
+                      echo "Downloading PyPy 3.11 for arm64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      
                     else
-                      PYPY_VERSION_3_10=pypy3.10-v7.3.19-macos_x86_64
-                      echo "Downloading PyPy 3.10 for x86_64"
-                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_10}.tar.bz2"
-                      sudo tar -xf "${PYPY_VERSION_3_10}.tar.bz2" --exclude="*/bin/python*" -C /opt
+                      PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
+                      echo "Downloading PyPy 3.11 for x86_64"
+                      curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
+                      sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
                     fi
 
-                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_10}/bin
-                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_10}/lib/*.dylib
+                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_11}/bin
+                    sudo chmod -R a+rx /opt/${PYPY_VERSION_3_11}/lib/*.dylib
                   fi
 
-                  echo "/opt/${PYPY_VERSION_3_10}/bin" >> ${GITHUB_PATH}
+                  echo "/opt/${PYPY_VERSION_3_11}/bin" >> ${GITHUB_PATH}
 
             - name: Install engine build dependencies (ephemeral runners)
               if: ${{ contains(matrix.build.RUNNER, 'ephemeral') }}

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -274,18 +274,14 @@ jobs:
                   if [[ "$ARCH" == "arm64" ]]; then
                     # Download PyPy for Apple Silicon
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_arm64
-                    
-                    
-                    
+
                     echo "Downloading PyPy 3.11 for arm64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
 
                   elif [[ "$ARCH" == "x86_64" ]]; then
                     PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
-                    
-                    
-                    
+
                     echo "Downloading PyPy 3.11 for x86_64"
                     curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                     sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
@@ -369,7 +365,7 @@ jobs:
                       # maturin-action will later build a separate async wheel per interpreter,
                       # and each wheel bundles all .so files from the include glob.
                       # Python will load the one matching its ABI at runtime.
-                      maturin build --release --out /tmp/glide_shared_wheels -i python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.9 pypy3.10 pypy3.11 2>/dev/null || \
+                      maturin build --release --out /tmp/glide_shared_wheels -i python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.11 2>/dev/null || \
                       maturin build --release --out /tmp/glide_shared_wheels -i python3.14
                       for WHEEL in /tmp/glide_shared_wheels/*.whl; do
                         unzip -jo "$WHEEL" "glide_shared/_fast_response*.so" -d ../glide-async/python/glide_shared/ 2>/dev/null || true
@@ -392,7 +388,7 @@ jobs:
                   cd python/glide-shared
                   pip install maturin
                   maturin build --release --target ${{ matrix.build.TARGET }} --out /tmp/glide_shared_wheels \
-                    -i ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.9 pypy3.10 pypy3.11' || 'python3.14' }}
+                    -i ${{ github.event_name != 'pull_request' && 'python3.9 python3.10 python3.11 python3.12 python3.13 python3.14 pypy3.11' || 'python3.14' }}
                   for WHEEL in /tmp/glide_shared_wheels/*.whl; do
                     unzip -jo "$WHEEL" "glide_shared/_fast_response*.so" -d ../glide-async/python/glide_shared/ 2>/dev/null || true
                   done
@@ -638,7 +634,7 @@ jobs:
                       echo "Downloading PyPy 3.11 for x86_64"
                       curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                       sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                      
+
                     elif [[ "$ARCH" == "aarch64" ]]; then
                       PYPY_VERSION_3_11=pypy3.11-v7.3.19-aarch64
                       echo "Downloading PyPy 3.11 for aarch64"
@@ -654,7 +650,7 @@ jobs:
                       echo "Downloading PyPy 3.11 for arm64"
                       curl -LO "https://downloads.python.org/pypy/${PYPY_VERSION_3_11}.tar.bz2"
                       sudo tar -xf "${PYPY_VERSION_3_11}.tar.bz2" --exclude="*/bin/python*" -C /opt
-                      
+
                     else
                       PYPY_VERSION_3_11=pypy3.11-v7.3.19-macos_x86_64
                       echo "Downloading PyPy 3.11 for x86_64"

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -14,6 +14,7 @@
             },
             "devDependencies": {
                 "@jest/globals": "29",
+                "@napi-rs/cli": "^2.18.4",
                 "@types/jest": "29",
                 "@types/minimist": "1",
                 "@types/node": "24",
@@ -1099,6 +1100,23 @@
             },
             "engines": {
                 "node": ">=v12.0.0"
+            }
+        },
+        "node_modules/@napi-rs/cli": {
+            "version": "2.18.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.18.4.tgz",
+            "integrity": "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "napi": "scripts/index.js"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
             }
         },
         "node_modules/@pkgjs/parseargs": {

--- a/node/package.json
+++ b/node/package.json
@@ -86,6 +86,7 @@
     },
     "devDependencies": {
         "@jest/globals": "29",
+        "@napi-rs/cli": "^2.18.4",
         "@types/jest": "29",
         "@types/minimist": "1",
         "@types/node": "24",


### PR DESCRIPTION
### Summary

This PR fixes the following issues with the Node and Python release build
- [9c62600](https://github.com/valkey-io/valkey-glide/pull/6363/commits/9c6260077a170321f82a5a734f81b8737226e2cb) [97ffcb3](https://github.com/valkey-io/valkey-glide/pull/6363/commits/97ffcb3437e29d412c039b6e75e538cc078e549b): Forward port fixes to python workflows from #6330 
- [a0dab85](https://github.com/valkey-io/valkey-glide/pull/6363/commits/a0dab8502cb638d12f8ca13bfce9bbcbfe629792): Added napi to node dependencies. Regression from [#5859](https://github.com/valkey-io/valkey-glide/pull/5859/changes#diff-d82fbe1e66dd8b4d402dbfe77afd4797282eaa290459f5a4bd71e941f835ce71L228-R228).
