### PR TITLE
feat(python-sync): add zero-copy buffers to mget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changes
 
 * Node: Replace socket IPC with direct NAPI layer ([#5325](https://github.com/valkey-io/valkey-glide/pull/5325))
+* feat(python-sync): add zero-copy buffers to mget ([#6367](https://github.com/valkey-io/valkey-glide/pull/6367))
+* Python: Add configurable `lib_name` and `client_info_tag` to client configuration (async and sync). ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
 
 ## 2.5
 
@@ -22,8 +24,6 @@
 
 ### Changes
 
-
-* Python: Add configurable `lib_name` and `client_info_tag` to client configuration (async and sync). ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
 * Go: Add multi-key `MIGRATE` support ([#6293](https://github.com/valkey-io/valkey-glide/pull/6293))
 * Core, Java, Go, Node, Python: Support server-assisted invalidation and add `CLIENT TRACKINGINFO` command ([#5961](https://github.com/valkey-io/valkey-glide/issues/5961))
 * Core, Java, Python, Node, Go: Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands ([#6286](https://github.com/valkey-io/valkey-glide/issues/6286))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -243,10 +243,26 @@ pub enum ResponseType {
     Error = 9,
 }
 
-/// A Send-safe wrapper around a raw buffer pointer and length.
-/// The caller guarantees the buffer remains valid for the duration of the FFI call.
-struct ResponseBuffer(*mut u8, usize);
+/// A Send-safe wrapper around caller-provided response buffers.
+/// The caller guarantees the buffers remain valid for the duration of the FFI call.
+enum ResponseBuffer {
+    /// One caller buffer for a scalar reply (e.g. GET into a buffer). Stored
+    /// inline so the common single-buffer path does not allocate.
+    Single((*mut u8, usize)),
+    /// One buffer per top-level array element (e.g. MGET into buffers).
+    Multi(Vec<(*mut u8, usize)>),
+}
 unsafe impl Send for ResponseBuffer {}
+impl ResponseBuffer {
+    /// The buffers as a slice, consumed positionally by the arena builder
+    /// (array element `i` -> buffer `i`; a scalar uses the first entry).
+    fn as_slice(&self) -> &[(*mut u8, usize)] {
+        match self {
+            ResponseBuffer::Single(buf) => std::slice::from_ref(buf),
+            ResponseBuffer::Multi(bufs) => bufs.as_slice(),
+        }
+    }
+}
 
 /// Success callback that is called when a command succeeds.
 ///
@@ -817,7 +833,8 @@ impl ClientAdapter {
                     self.runtime.spawn(async move {
                         match request_future.await {
                             Ok(value) => {
-                                let buf = response_buf.map(|rb| (rb.0, rb.1));
+                                let buf: &[(*mut u8, usize)] =
+                                    response_buf.as_ref().map(|rb| rb.as_slice()).unwrap_or(&[]);
                                 match valkey_value_to_arena_response(value, buf) {
                                     Ok((root_ptr, arena_ptr)) => {
                                         if let Some(w) = ASYNC_PIPE.get() {
@@ -903,7 +920,8 @@ impl ClientAdapter {
     ) -> *mut CommandResult {
         match result {
             Ok(value) => {
-                let buf = response_buf.map(|rb| (rb.0, rb.1));
+                let buf: &[(*mut u8, usize)] =
+                    response_buf.as_ref().map(|rb| rb.as_slice()).unwrap_or(&[]);
                 if let Some(success_callback) = success_callback {
                     // Stack fast-path for simple types: avoids arena allocation.
                     // Only used when the caller opts in (allow_stack_response=true),
@@ -2610,22 +2628,23 @@ impl ResponseArena {
     }
 
     /// Build the response tree into the arena. Returns index of the root node.
-    fn build(
-        &mut self,
-        value: Value,
-        response_buf: Option<(*mut u8, usize)>,
-    ) -> RedisResult<usize> {
+    fn build(&mut self, value: Value, bufs: &[(*mut u8, usize)]) -> RedisResult<usize> {
         let idx = self.alloc_node();
-        self.build_into(idx, value, response_buf)?;
+        self.build_into(idx, value, bufs)?;
         Ok(idx)
     }
 
     /// Build a value into a pre-allocated node at the given index.
+    ///
+    /// `bufs` carries caller-owned response buffers consumed positionally: a
+    /// scalar value uses `bufs[0]`; an `Array` distributes `bufs[i]` to child
+    /// `i`, enabling zero-copy multi-key reads (e.g. MGET-into-buffers). An
+    /// empty slice means "no caller buffer" (normal heap-allocated response).
     fn build_into(
         &mut self,
         idx: usize,
         value: Value,
-        response_buf: Option<(*mut u8, usize)>,
+        bufs: &[(*mut u8, usize)],
     ) -> RedisResult<()> {
         match value {
             Value::Nil => {}
@@ -2651,25 +2670,29 @@ impl ResponseArena {
                 self.nodes[idx].string_value_len = len;
             }
             Value::BulkString(data) => {
-                let data = if let Some((buf, buf_len)) = response_buf {
-                    if data.len() > buf_len {
-                        return Err(RedisError::from((
-                            ErrorKind::ClientError,
-                            "Value size exceeds buffer capacity",
-                            format!(
-                                "value is {} bytes but buffer is {} bytes",
-                                data.len(),
-                                buf_len
-                            ),
-                        )));
-                    }
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
-                    }
-                    data.len().to_string().into_bytes()
-                } else {
-                    data
-                };
+                // Use the caller buffer only when a non-null destination was
+                // provided; a null entry falls back to a normal heap response
+                // (avoids writing through a null/invalid pointer).
+                let data =
+                    if let Some(&(buf, buf_len)) = bufs.first().filter(|&&(p, _)| !p.is_null()) {
+                        if data.len() > buf_len {
+                            return Err(RedisError::from((
+                                ErrorKind::ClientError,
+                                "Value size exceeds buffer capacity",
+                                format!(
+                                    "value is {} bytes but buffer is {} bytes",
+                                    data.len(),
+                                    buf_len
+                                ),
+                            )));
+                        }
+                        unsafe {
+                            std::ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
+                        }
+                        data.len().to_string().into_bytes()
+                    } else {
+                        data
+                    };
                 let (ptr, len) = self.store_string(data);
                 self.nodes[idx].response_type = ResponseType::String;
                 self.nodes[idx].string_value = ptr;
@@ -2688,10 +2711,13 @@ impl ResponseArena {
                 for _ in 0..child_count {
                     self.alloc_node();
                 }
-                // Build each child; descendants go after all child slots
+                // Build each child; descendants go after all child slots.
+                // Distribute caller buffers positionally so each element of an
+                // MGET-style response is written into its own buffer.
                 for (i, item) in arr.into_iter().enumerate() {
                     let ci = child_start + i;
-                    self.build_into(ci, item, None)?;
+                    let child_bufs = bufs.get(i).map(core::slice::from_ref).unwrap_or(&[]);
+                    self.build_into(ci, item, child_bufs)?;
                 }
                 self.nodes[idx].response_type = ResponseType::Array;
                 self.nodes[idx].array_value_len = child_count as c_long;
@@ -2707,9 +2733,9 @@ impl ResponseArena {
                 }
                 for (i, (k, v)) in map.into_iter().enumerate() {
                     let ki = self.nodes.len();
-                    self.build(k, None)?;
+                    self.build(k, &[])?;
                     let vi = self.nodes.len();
-                    self.build(v, None)?;
+                    self.build(v, &[])?;
                     // Pointers fixed up in finalize() along with array_value
                     self.nodes[wrapper_start + i].map_key = ki as *mut CommandResponse;
                     self.nodes[wrapper_start + i].map_value = vi as *mut CommandResponse;
@@ -2726,7 +2752,7 @@ impl ResponseArena {
                 }
                 for (i, item) in arr.into_iter().enumerate() {
                     let ci = child_start + i;
-                    self.build_into(ci, item, None)?;
+                    self.build_into(ci, item, &[])?;
                 }
                 self.nodes[idx].response_type = ResponseType::Sets;
                 self.nodes[idx].sets_value_len = child_count as c_long;
@@ -2768,7 +2794,7 @@ impl ResponseArena {
                 self.nodes[vk].string_value_len = len;
                 // values value (array)
                 let vv = self.nodes.len();
-                self.build(Value::Array(data), None)?;
+                self.build(Value::Array(data), &[])?;
                 self.nodes[w1].map_key = vk as *mut CommandResponse;
                 self.nodes[w1].map_value = vv as *mut CommandResponse;
 
@@ -2821,10 +2847,10 @@ impl ResponseArena {
 /// The arena_ptr must be freed with `free_response_arena`.
 fn valkey_value_to_arena_response(
     value: Value,
-    response_buf: Option<(*mut u8, usize)>,
+    bufs: &[(*mut u8, usize)],
 ) -> RedisResult<(*mut CommandResponse, *mut ResponseArena)> {
     let mut arena = ResponseArena::from_pool(&value);
-    arena.build(value, response_buf)?;
+    arena.build(value, bufs)?;
     Ok(arena.finalize())
 }
 
@@ -2925,6 +2951,50 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
     route_bytes_len: usize,
     response_buf: *mut u8,
     response_buf_len: usize,
+    span_ptr: u64,
+) -> *mut CommandResult {
+    let buf_option = if response_buf.is_null() {
+        None
+    } else {
+        Some(ResponseBuffer::Single((response_buf, response_buf_len)))
+    };
+    unsafe {
+        execute_command_with_buffer_option(
+            client_adapter_ptr,
+            request_id,
+            command_type,
+            arg_count,
+            args,
+            args_len,
+            route_bytes,
+            route_bytes_len,
+            buf_option,
+            span_ptr,
+        )
+    }
+}
+
+/// Shared implementation behind [`command_with_buffer`] and
+/// [`command_with_buffers`]: builds and dispatches the command, writing the
+/// reply into `buf_option` when present (a single buffer for a scalar reply,
+/// one buffer per element for an array reply).
+///
+/// # Safety
+/// `client_adapter_ptr`, `args`/`args_len`, and `route_bytes` follow the same
+/// contract as [`command_with_buffer`]. Any buffers referenced by `buf_option`
+/// must remain valid and writable until the command completes.
+// Mirrors the C ABI of the FFI entry points it backs, hence the argument count.
+#[allow(clippy::too_many_arguments)]
+unsafe fn execute_command_with_buffer_option(
+    client_adapter_ptr: *const c_void,
+    request_id: usize,
+    command_type: RequestType,
+    arg_count: c_ulong,
+    args: *const usize,
+    args_len: *const c_ulong,
+    route_bytes: *const u8,
+    route_bytes_len: usize,
+    buf_option: Option<ResponseBuffer>,
     span_ptr: u64,
 ) -> *mut CommandResult {
     let client_adapter = unsafe {
@@ -3030,12 +3100,6 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
     // Inflight tracking is handled by send_command() via InflightRequestTracker on Cmd.
     let mut client = client_adapter.core.client.clone();
 
-    let buf_option = if response_buf.is_null() {
-        None
-    } else {
-        Some(ResponseBuffer(response_buf, response_buf_len))
-    };
-
     client_adapter.execute_request_with_buffer(
         request_id,
         async move {
@@ -3044,6 +3108,74 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
         },
         buf_option,
     )
+}
+
+/// MGET-style variant of [`command_with_buffer`] that writes each element of an
+/// array response into its own caller-provided buffer (zero-copy multi-key GET).
+///
+/// `response_bufs` / `response_buf_lens` are parallel arrays of
+/// `response_buf_count` writable buffers; element `i` of the array response is
+/// copied into buffer `i`. A `Nil` element (e.g. a missing key) leaves its
+/// buffer untouched and is reported as a null response. The command response
+/// carries the number of bytes written per element instead of the value bytes.
+///
+/// Intended for commands whose reply is a flat array of bulk strings (e.g.
+/// `MGET`) or a scalar bulk string. If an element's value is larger than its
+/// buffer, the whole command fails with a client error. A null buffer entry, or
+/// fewer buffers than reply elements, makes the affected elements fall back to a
+/// normal heap-allocated response (no zero-copy) rather than erroring.
+///
+/// # Safety
+/// Same contract as [`command_with_buffer`]. When non-null, `response_bufs` and
+/// `response_buf_lens` must each point to `response_buf_count` valid entries.
+/// Each buffer must remain valid and writable until the command **completes**:
+/// for sync clients that is until this call returns; for async clients it is
+/// until the success/failure callback fires (the copy happens off-thread).
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn command_with_buffers(
+    client_adapter_ptr: *const c_void,
+    request_id: usize,
+    command_type: RequestType,
+    arg_count: c_ulong,
+    args: *const usize,
+    args_len: *const c_ulong,
+    route_bytes: *const u8,
+    route_bytes_len: usize,
+    response_bufs: *const *mut u8,
+    response_buf_lens: *const usize,
+    response_buf_count: usize,
+    span_ptr: u64,
+) -> *mut CommandResult {
+    // Collect the caller's per-element buffers into a single owned Vec, consumed
+    // positionally by the arena builder (element i -> buffer i). Both parallel
+    // arrays must be non-null; otherwise the request runs without buffers.
+    let buf_option =
+        if response_bufs.is_null() || response_buf_lens.is_null() || response_buf_count == 0 {
+            None
+        } else {
+            let ptrs = unsafe { std::slice::from_raw_parts(response_bufs, response_buf_count) };
+            let lens = unsafe { std::slice::from_raw_parts(response_buf_lens, response_buf_count) };
+            Some(ResponseBuffer::Multi(
+                ptrs.iter()
+                    .zip(lens.iter())
+                    .map(|(&p, &l)| (p, l))
+                    .collect(),
+            ))
+        };
+    unsafe {
+        execute_command_with_buffer_option(
+            client_adapter_ptr,
+            request_id,
+            command_type,
+            arg_count,
+            args,
+            args_len,
+            route_bytes,
+            route_bytes_len,
+            buf_option,
+            span_ptr,
+        )
+    }
 }
 
 /// Creates a heap-allocated `CommandResult` containing a `CommandError`.
@@ -3555,7 +3687,7 @@ pub unsafe extern "C-unwind" fn get_cache_metrics(
         || (cid != 0 && ASYNC_PIPE.get().is_some());
     if is_pipe_or_sync {
         match result {
-            Ok(value) => match valkey_value_to_arena_response(value, None) {
+            Ok(value) => match valkey_value_to_arena_response(value, &[]) {
                 Ok((root_ptr, arena_ptr)) => Box::into_raw(Box::new(CommandResult {
                     response: root_ptr,
                     command_error: std::ptr::null_mut(),

--- a/python/glide-shared/glide_shared/_glide_ffi.py
+++ b/python/glide-shared/glide_shared/_glide_ffi.py
@@ -142,6 +142,21 @@ class _GlideFFI:
                 uint64_t span_ptr
             );
 
+            CommandResult* command_with_buffers(
+                const void* client_adapter_ptr,
+                uintptr_t request_id,
+                int command_type,
+                unsigned long arg_count,
+                const size_t *args,
+                const unsigned long* args_len,
+                const unsigned char* route_bytes,
+                size_t route_bytes_len,
+                uint8_t** response_bufs,
+                size_t* response_buf_lens,
+                size_t response_buf_count,
+                uint64_t span_ptr
+            );
+
             CommandResult* invoke_script(
                 const void* client_adapter_ptr,
                 uintptr_t request_id,

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -424,12 +424,22 @@ class BaseClient(CoreCommands):
         finally:
             self._lib.free_command_result(command_result)
 
+    @staticmethod
+    def _validate_response_buffers(response_buffers: List[memoryview]) -> None:
+        """Each buffer for a multi-value read must be writable and contiguous."""
+        for mv in response_buffers:
+            if mv.readonly:
+                raise TypeError("response_buffers entries must be writable")
+            if not mv.c_contiguous:
+                raise TypeError("response_buffers entries must be C-contiguous")
+
     def _execute_command(
         self,
         request_type: RequestType.ValueType,  # type: ignore[override]
         args: List[TEncodable],
         route: Optional[Route] = None,
         response_buffer: Optional[memoryview] = None,
+        response_buffers: Optional[List[memoryview]] = None,
     ) -> TResult:
         if self._is_closed:
             raise ClosingError(
@@ -443,6 +453,8 @@ class BaseClient(CoreCommands):
                 raise TypeError("response_buffer must be writable")
             if not response_buffer.c_contiguous:
                 raise TypeError("response_buffer must be C-contiguous")
+        if response_buffers is not None:
+            self._validate_response_buffers(response_buffers)
 
         # Create span if OpenTelemetry is configured and sampling indicates we should trace
         from .opentelemetry import OpenTelemetry
@@ -463,30 +475,53 @@ class BaseClient(CoreCommands):
             # Route bytes should be kept alive in the scope of the FFI call
             route_ptr, route_len, route_bytes = self._to_c_route_ptr_and_len(route)
 
-            buf_ptr = (
-                self._ffi.from_buffer(response_buffer)
-                if response_buffer
-                else self._ffi.NULL
-            )
-            # Capacity must be expressed in bytes, not elements. ``len()`` on a
-            # memoryview returns the element count (``shape[0]``), which equals
-            # the byte count only for itemsize-1 formats (e.g. "B"). For any
-            # itemsize > 1 view (e.g. "I"/"Q"/float) it under-reports capacity,
-            # causing the FFI to spuriously reject values that actually fit.
-            buf_len = response_buffer.nbytes if response_buffer else 0
-            result = self._lib.command_with_buffer(
-                client_adapter_ptr,
-                0,
-                request_type,
-                len(args),
-                c_args,
-                c_lengths,
-                route_ptr,
-                route_len,
-                buf_ptr,
-                buf_len,
-                span,
-            )
+            if response_buffers is not None:
+                # One writable buffer per top-level array element (e.g. mget):
+                # each value is copied straight into its caller-owned buffer.
+                # The from_buffer cdata must stay alive for the call, so keep
+                # the list referenced until command_with_buffers returns.
+                target_ptrs = [self._ffi.from_buffer(mv) for mv in response_buffers]
+                target_bufs = self._ffi.new("uint8_t*[]", target_ptrs)
+                target_lens = self._ffi.new(
+                    "size_t[]", [mv.nbytes for mv in response_buffers]
+                )
+                result = self._lib.command_with_buffers(
+                    client_adapter_ptr,
+                    0,
+                    request_type,
+                    len(args),
+                    c_args,
+                    c_lengths,
+                    route_ptr,
+                    route_len,
+                    target_bufs,
+                    target_lens,
+                    len(response_buffers),
+                    span,
+                )
+            else:
+                buf_ptr = (
+                    self._ffi.from_buffer(response_buffer)
+                    if response_buffer
+                    else self._ffi.NULL
+                )
+                # Capacity must be expressed in bytes, not elements. ``len()`` on
+                # a memoryview returns the element count (``shape[0]``), which
+                # equals the byte count only for itemsize-1 formats (e.g. "B").
+                buf_len = response_buffer.nbytes if response_buffer else 0
+                result = self._lib.command_with_buffer(
+                    client_adapter_ptr,
+                    0,
+                    request_type,
+                    len(args),
+                    c_args,
+                    c_lengths,
+                    route_ptr,
+                    route_len,
+                    buf_ptr,
+                    buf_len,
+                    span,
+                )
         finally:
             # Drop span if it was created
             if span != 0:

--- a/python/glide-sync/glide_sync/sync_commands/core.py
+++ b/python/glide-sync/glide_sync/sync_commands/core.py
@@ -82,6 +82,7 @@ class CoreCommands(Protocol):
         args: List[TEncodable],
         route: Optional[Route] = ...,
         response_buffer: Optional[memoryview] = ...,
+        response_buffers: Optional[List[memoryview]] = ...,
     ) -> TResult: ...
 
     def _execute_batch(
@@ -763,7 +764,11 @@ class CoreCommands(Protocol):
             self._execute_command(RequestType.Move, [key, str(db_index)]),
         )
 
-    def mget(self, keys: List[TEncodable]) -> List[Optional[bytes]]:
+    def mget(
+        self,
+        keys: List[TEncodable],
+        buffers: Optional[List[memoryview]] = None,
+    ) -> List[Optional[bytes]]:
         """
         Retrieve the values of multiple keys.
 
@@ -780,19 +785,38 @@ class CoreCommands(Protocol):
 
         Args:
             keys (List[TEncodable]): A list of keys to retrieve values for.
+            buffers (Optional[List[memoryview]]): Optional writable, C-contiguous
+                buffers, one per key, to receive the values without an
+                intermediate allocation (zero-copy). When given, value ``i`` is
+                written into ``buffers[i]`` and the buffer must be large enough to
+                hold it. Must have the same length as ``keys``. When omitted,
+                ``mget`` allocates and returns ``bytes`` as before.
 
         Returns:
-            List[Optional[bytes]]: A list of values corresponding to the provided keys. If a key is not found,
-            its corresponding value in the list will be None.
+            List[Optional[bytes]]:
+                Without buffers: a list of values corresponding to the provided
+                keys. If a key is not found, its element is None.
+
+                With buffers: each found value is copied into its buffer instead
+                of being allocated, and the corresponding element is the number
+                of bytes written as a byte string (e.g. b'4096'); a missing key
+                is still None. This matches the single-key get(key, buffer=...)
+                convention, so read value i from buffers[i][:int(result[i])].
 
         Examples:
             >>> client.set("key1", "value1")
             >>> client.set("key2", "value2")
             >>> client.mget(["key1", "key2"])
                 [b'value1' , b'value2']
+            >>> bufs = [memoryview(bytearray(64)) for _ in range(2)]
+            >>> client.mget(["key1", "key2"], buffers=bufs)
+                [b'6', b'6']  # 6 bytes written into each buffer; bytes(bufs[0][:6]) == b'value1'
         """
+        if buffers is not None and len(buffers) != len(keys):
+            raise ValueError("buffers must have the same length as keys")
         return cast(
-            List[Optional[bytes]], self._execute_command(RequestType.MGet, keys)
+            List[Optional[bytes]],
+            self._execute_command(RequestType.MGet, keys, response_buffers=buffers),
         )
 
     def decr(self, key: TEncodable) -> int:

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -671,6 +671,146 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers(self, glide_sync_client: TGlideClient):
+        """Test mget with buffers writes each value into its own buffer."""
+        tag = get_random_string(6)
+        keys = [f"{{{tag}}}:{i}" for i in range(3)]
+        values = [os.urandom(100), os.urandom(257), os.urandom(4096)]
+        for k, v in zip(keys, values):
+            assert glide_sync_client.set(k, v) == OK
+
+        bufs = [memoryview(bytearray(4096)) for _ in range(3)]
+        result = glide_sync_client.mget(keys, buffers=bufs)
+        assert result == [b"100", b"257", b"4096"]
+        for buf, val in zip(bufs, values):
+            assert bytes(buf[: len(val)]) == val
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers_missing_key(self, glide_sync_client: TGlideClient):
+        """Test mget with buffers reports a missing key as None."""
+        tag = get_random_string(6)
+        present, missing = f"{{{tag}}}:p", f"{{{tag}}}:m"
+        data = os.urandom(64)
+        assert glide_sync_client.set(present, data) == OK
+
+        bufs = [memoryview(bytearray(256)) for _ in range(2)]
+        result = glide_sync_client.mget([present, missing], buffers=bufs)
+        assert result == [b"64", None]
+        assert bytes(bufs[0][:64]) == data
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers_larger_buffer(
+        self, glide_sync_client: TGlideClient
+    ):
+        """Test mget with buffers larger than the values."""
+        tag = get_random_string(6)
+        keys = [f"{{{tag}}}:{i}" for i in range(2)]
+        values = [os.urandom(10), os.urandom(200)]
+        for k, v in zip(keys, values):
+            assert glide_sync_client.set(k, v) == OK
+
+        bufs = [memoryview(bytearray(4096)) for _ in range(2)]
+        result = glide_sync_client.mget(keys, buffers=bufs)
+        assert result == [b"10", b"200"]
+        for buf, val in zip(bufs, values):
+            assert bytes(buf[: len(val)]) == val
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers_readonly_raises(
+        self, glide_sync_client: TGlideClient
+    ):
+        """Test mget with buffers rejects a read-only buffer entry."""
+        tag = get_random_string(6)
+        keys = [f"{{{tag}}}:{i}" for i in range(2)]
+        bufs = [memoryview(bytearray(64)), memoryview(b"\x00" * 64)]
+        with pytest.raises(TypeError):
+            glide_sync_client.mget(keys, buffers=bufs)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers_too_small_raises(
+        self, glide_sync_client: TGlideClient
+    ):
+        """Test mget with buffers raises when a value exceeds its buffer."""
+        tag = get_random_string(6)
+        keys = [f"{{{tag}}}:{i}" for i in range(2)]
+        assert glide_sync_client.set(keys[0], os.urandom(16)) == OK
+        assert glide_sync_client.set(keys[1], os.urandom(256)) == OK
+
+        bufs = [memoryview(bytearray(64)), memoryview(bytearray(64))]
+        with pytest.raises(RequestError, match="exceeds buffer capacity"):
+            glide_sync_client.mget(keys, buffers=bufs)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_buffers_length_mismatch_raises(
+        self, glide_sync_client: TGlideClient
+    ):
+        """Test mget rejects a buffers list whose length differs from keys."""
+        tag = get_random_string(6)
+        keys = [f"{{{tag}}}:{i}" for i in range(2)]
+        with pytest.raises(ValueError):
+            glide_sync_client.mget(keys, buffers=[memoryview(bytearray(8))])
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers_cross_slot(self, glide_sync_client: TGlideClient):
+        """Test mget with buffers where keys map to different cluster slots.
+
+        A multi-slot MGET is split per slot and the per-slot responses are
+        recombined into the original key order, so ``buffers[i]`` must still
+        receive the value of ``keys[i]``. Distinct hash tags force the keys
+        onto different slots; distinct value sizes make any mis-mapping show
+        up in the returned byte counts as well as the buffer contents.
+        """
+        suffix = get_random_string(6)
+        keys = [f"{{abc}}:{suffix}", f"{{zxy}}:{suffix}", f"{{lkn}}:{suffix}"]
+        values = [os.urandom(64), os.urandom(257), os.urandom(1024)]
+        for k, v in zip(keys, values):
+            assert glide_sync_client.set(k, v) == OK
+
+        bufs = [memoryview(bytearray(2048)) for _ in range(3)]
+        result = glide_sync_client.mget(keys, buffers=bufs)
+        assert result == [b"64", b"257", b"1024"]
+        for buf, val in zip(bufs, values):
+            assert bytes(buf[: len(val)]) == val
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_mget_into_buffers_non_byte_format(
+        self, glide_sync_client: TGlideClient
+    ):
+        """Regression: per-buffer capacity is byte-based, not element-based.
+
+        Same contract as ``test_sync_get_into_buffer_non_byte_format`` (#6310)
+        for the multi-buffer path: a memoryview with ``itemsize > 1`` has
+        ``len()`` (element count) smaller than ``nbytes`` (byte capacity). Each
+        value below is 4096 bytes and each buffer is 1024 ``uint32`` elements
+        == 4096 bytes, so it fits exactly; capacity computed with ``len()``
+        would spuriously reject it.
+        """
+        tag = get_random_string(6)
+        keys = [f"{{{tag}}}:{i}" for i in range(2)]
+        values = [os.urandom(4096), os.urandom(4096)]
+        for k, v in zip(keys, values):
+            assert glide_sync_client.set(k, v) == OK
+
+        arrs = [array.array("I", [0] * 1024) for _ in range(2)]
+        bufs = [memoryview(a) for a in arrs]
+        for buf, val in zip(bufs, values):
+            assert len(buf) < len(val)  # element count under-reports capacity
+            assert buf.nbytes == len(val)
+
+        result = glide_sync_client.mget(keys, buffers=bufs)
+        assert result == [b"4096", b"4096"]
+        for buf, val in zip(bufs, values):
+            assert buf.cast("B")[:4096] == val
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_set_get_with_bytearray_and_memoryview(
         self, glide_sync_client: TGlideClient
     ):

--- a/python/tests/test_api_consistency.py
+++ b/python/tests/test_api_consistency.py
@@ -79,6 +79,15 @@ EXCLUDED_TESTS = {
         "test_sync_get_into_buffer_readonly_raises",
         "test_sync_get_into_buffer_too_small_raises",
         "test_sync_get_into_buffer_non_byte_format",
+        # mget() with buffers - sync-only FFI path, no async equivalent
+        "test_sync_mget_into_buffers",
+        "test_sync_mget_into_buffers_missing_key",
+        "test_sync_mget_into_buffers_larger_buffer",
+        "test_sync_mget_into_buffers_readonly_raises",
+        "test_sync_mget_into_buffers_too_small_raises",
+        "test_sync_mget_buffers_length_mismatch_raises",
+        "test_sync_mget_into_buffers_non_byte_format",
+        "test_sync_mget_into_buffers_cross_slot",
         # Script invocation span — async tracked in #5601
         "test_sync_span_script_invocation",
     ],


### PR DESCRIPTION
### Summary

`mget` allocates a fresh `bytes` object per value. For large multi-key reads (KV-cache blobs, embeddings) that per-value allocation and copy is the main client-side cost. This adds an optional `buffers` argument to the sync `mget` so values are read straight into caller-owned buffers with no intermediate allocation.

### Issue link

No existing issue. Happy to open one if you would prefer to discuss the API first.

### Features / Behaviour Changes

- `mget(keys, buffers=[...])` on the sync client. `buffers` must be writable, C-contiguous, and the same length as `keys`.
- Additive and opt-in. `mget(keys)` is unchanged and still returns `bytes`.
- With `buffers`, value `i` is written into `buffers[i]` and the returned element is the number of bytes written, or `None` for a missing key. Same convention as the existing `get(key, buffer=...)`.

### Implementation

- New FFI entry point `command_with_buffers`, parallel to `command_with_buffer`, taking one `(ptr, len)` pair per top-level array element (`uint8_t** response_bufs`, `size_t* response_buf_lens`, `size_t response_buf_count`).
- `ResponseBuffer` now holds a slice of buffers. The arena builder threads that slice through `build`/`build_into`: a top-level `Array` hands `buffers[i]` to element `i`; a `BulkString` with a buffer is size-checked and copied into it; `Nil` and elements without a buffer are left untouched. Scalars use the first buffer, matching the single-buffer path.
- Python: `_execute_command` gains `response_buffers`; `mget` passes it through. The single-buffer path is untouched.

### Testing

- `cargo build` clean on `main`.
- Sync client built via `dev.py` and run against Valkey 9.1: `mget(keys, buffers)` returns `[b'100', b'257', b'4096', None]` for three present keys and one missing, the buffers hold the exact values, plain `mget(keys)` is unchanged, and a `buffers`/`keys` length mismatch raises `ValueError`.

### Limitations

- Sync client only. The async client is not covered here.
- One buffer per top-level element; nested arrays are not buffered.
- The caller sizes each buffer to hold its value; an undersized buffer is rejected.
