### PR TITLE
ci(dependabot): cover all cargo build roots so shared-dep bumps fan out automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,9 +97,9 @@ updates:
           - "Rust ⚙️"
           - "java ☕"
 
-    # Enable version updates for Cargo (Rust - Python wrapper)
+    # Enable version updates for Cargo (Rust - Python async wrapper)
     - package-ecosystem: "cargo"
-      directory: "/python"
+      directory: "/python/glide-async"
       schedule:
           interval: "weekly"
           day: "monday"
@@ -116,6 +116,141 @@ updates:
           - "dependencies"
           - "Rust ⚙️"
           - "python 🐍"
+
+    # Enable version updates for Cargo (Rust - Python shared)
+    - package-ecosystem: "cargo"
+      directory: "/python/glide-shared"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
+          - "python 🐍"
+
+    # Enable version updates for Cargo (Rust - Node client)
+    - package-ecosystem: "cargo"
+      directory: "/node/rust-client"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
+          - "node 🐢"
+
+    # Enable version updates for Cargo (Rust - FFI / Go & Python sync bindings)
+    - package-ecosystem: "cargo"
+      directory: "/ffi"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
+
+    # Enable version updates for Cargo (Rust - telemetry)
+    - package-ecosystem: "cargo"
+      directory: "/glide-core/telemetry"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
+
+    # Enable version updates for Cargo (Rust - redis-rs vendored fork)
+    - package-ecosystem: "cargo"
+      directory: "/glide-core/redis-rs"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
+
+    # Enable version updates for Cargo (Rust - benchmarks)
+    - package-ecosystem: "cargo"
+      directory: "/benchmarks/rust"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
+
+    # Enable version updates for Cargo (Rust - logger core)
+    - package-ecosystem: "cargo"
+      directory: "/logger_core"
+      schedule:
+          interval: "weekly"
+          day: "monday"
+          time: "09:00"
+      open-pull-requests-limit: 10
+      groups:
+          patch-updates:
+              update-types:
+                  - "patch"
+          minor-updates:
+              update-types:
+                  - "minor"
+      labels:
+          - "dependencies"
+          - "Rust ⚙️"
 
     # Enable version updates for Go modules
     - package-ecosystem: "gomod"


### PR DESCRIPTION
## Motivation

The repo has multiple independent Cargo build roots, each with its own committed `Cargo.lock`. Today `.github/dependabot.yml` declares the `cargo` ecosystem for only three directories: `/glide-core`, `/java`, and `/python`. When an advisory hits a transitive dependency shared across roots (e.g. the recent opentelemetry_sdk bump that touched 11 lockfiles), Dependabot auto-opens PRs for only those roots and the rest get hand-patched.

The `/python` entry is also **broken**: that directory has no `Cargo.toml` (the binding manifest lives in `/python/glide-async`), so Dependabot could not act on it at all.

This PR extends the `cargo` ecosystem to every real Rust build root and fixes the `/python` path, so a shared-dependency or security bump fans out to a per-directory PR automatically.

## Changes

Only `.github/dependabot.yml` is changed. Each new entry mirrors the existing cargo entries exactly (schedule, groups, `open-pull-requests-limit`, labels); only `directory` differs.

Directories now covered (each verified to contain a real `Cargo.toml`/`Cargo.lock` in the tree):

- `/python/glide-async` (corrected from the invalid `/python`)
- `/python/glide-shared`
- `/node/rust-client`
- `/ffi`
- `/glide-core/telemetry`
- `/glide-core/redis-rs`
- `/benchmarks/rust`
- `/logger_core`

Already covered (unchanged): `/glide-core`, `/java`.

## Excluded

The `ffi/miri-tests/*` mock crates are intentionally excluded. They are test-only mocks with lockfiles pinned for miri determinism, not shipped/release roots. Auto-bumping them risks breaking miri runs for no dependency-hygiene benefit. Happy to add them if maintainers prefer.

## Validation

- YAML parses and conforms to the Dependabot v2 schema (every `updates` entry has `package-ecosystem`, `directory`, `schedule`).
- `yamllint` passes.
- Each cargo `directory` was verified to contain a real `Cargo.toml` (`test -f .<dir>/Cargo.toml`).