### PR TITLE
build(deps): update anyhow to 1.0.103 to fix RUSTSEC-2026-0190 (#6364)

### DIFF
--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1193,6 +1193,7 @@ dependencies = [
  "futures",
  "futures-intrusive",
  "http 1.4.0",
+ "libc",
  "logger_core",
  "lz4",
  "nanoid",

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1008,6 +1008,7 @@ dependencies = [
  "futures",
  "futures-intrusive",
  "http 1.4.0",
+ "libc",
  "logger_core",
  "lz4",
  "nanoid",

--- a/ffi/miri-tests/mock-glide-core/Cargo.lock
+++ b/ffi/miri-tests/mock-glide-core/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1008,6 +1008,7 @@ dependencies = [
  "futures",
  "futures-intrusive",
  "http 1.4.0",
+ "libc",
  "logger_core",
  "lz4",
  "nanoid",
@@ -1655,6 +1656,7 @@ dependencies = [
  "glide-core",
  "mock-redis",
  "mock-telemetry",
+ "protobuf",
  "tokio",
 ]
 

--- a/ffi/miri-tests/mock-redis/Cargo.lock
+++ b/ffi/miri-tests/mock-redis/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/glide-core/redis-rs/Cargo.lock
+++ b/glide-core/redis-rs/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/glide-core/telemetry/Cargo.lock
+++ b/glide-core/telemetry/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-stream"

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
This is a cherry pick from main for [build(deps): update anyhow to 1.0.103 to fix RUSTSEC-2026-0190 #6364](https://github.com/valkey-io/valkey-glide/pull/6364)

## Summary

Fixes **RUSTSEC-2026-0190**, an unsoundness advisory in `anyhow` that the repo-wide `lint-rust` CI job (`cargo-deny`) flags on `main`.

`anyhow::Error::downcast_mut()` in versions `< 1.0.103` violates borrow rules and can trigger undefined behavior when a user adds context via `Error::context` and later calls `Error::downcast_mut` on the returned error.

The official fix is to upgrade to `>= 1.0.103`.

## Change

Lockfile-only bump of `anyhow` from `1.0.102` to `1.0.103`, applied via `cargo update -p anyhow` in each of the 11 workspaces that carry their own `Cargo.lock`:

- `python/glide-async/Cargo.lock`
- `java/Cargo.lock`
- `glide-core/Cargo.lock`
- `glide-core/redis-rs/Cargo.lock`
- `glide-core/telemetry/Cargo.lock`
- `ffi/Cargo.lock`
- `ffi/miri-tests/Cargo.lock`
- `ffi/miri-tests/mock-redis/Cargo.lock`
- `ffi/miri-tests/mock-glide-core/Cargo.lock`
- `benchmarks/rust/Cargo.lock`
- `node/rust-client/Cargo.lock`

No `Cargo.toml` version constraints were touched. The diff is `Cargo.lock` files only.

## Validation

`cargo audit` against the RustSec advisory DB, per lockfile:

- **Before** (`anyhow` 1.0.102): `RUSTSEC-2026-0190` fires (`unsound`, `Error::downcast_mut()`).
- **After** (`anyhow` 1.0.103): advisory no longer reported in any of the 11 lockfiles.

## Notes


Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0190