### PR TITLE
feat(python): Add configurable lib_name and client_info_tag to client config (async + sync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 
 
+* Python: Add configurable `lib_name` to client configuration (async and sync). When set, it is sent via `CLIENT SETINFO LIB-NAME` at connection establishment for library/framework attribution in `CLIENT INFO`/`CLIENT LIST`; when unset, the existing defaults (`GlidePy`/`GlidePySync`) are preserved. Brings parity with the Java `libName` option. ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
 * Go: Add multi-key `MIGRATE` support ([#6293](https://github.com/valkey-io/valkey-glide/pull/6293))
 * Core, Java, Go, Node, Python: Support server-assisted invalidation and add `CLIENT TRACKINGINFO` command ([#5961](https://github.com/valkey-io/valkey-glide/issues/5961))
 * Core, Java, Python, Node, Go: Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands ([#6286](https://github.com/valkey-io/valkey-glide/issues/6286))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Changes
 
 
-* Python: Add configurable `lib_name` and `client_info_tag` to client configuration (async and sync). `lib_name` replaces the library name sent via `CLIENT SETINFO LIB-NAME` (defaults `GlidePy`/`GlidePySync` preserved when unset); `client_info_tag` appends a parenthesized tag while preserving the library identity (e.g. `GlidePy(my-framework:1.2.3)`) for library/framework attribution in `CLIENT INFO`/`CLIENT LIST`. Brings parity with the Java `libName` option. ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
+* Python: Add configurable `lib_name` and `client_info_tag` to client configuration (async and sync). ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
 * Go: Add multi-key `MIGRATE` support ([#6293](https://github.com/valkey-io/valkey-glide/pull/6293))
 * Core, Java, Go, Node, Python: Support server-assisted invalidation and add `CLIENT TRACKINGINFO` command ([#5961](https://github.com/valkey-io/valkey-glide/issues/5961))
 * Core, Java, Python, Node, Go: Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands ([#6286](https://github.com/valkey-io/valkey-glide/issues/6286))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Changes
 
 
-* Python: Add configurable `lib_name` to client configuration (async and sync). When set, it is sent via `CLIENT SETINFO LIB-NAME` at connection establishment for library/framework attribution in `CLIENT INFO`/`CLIENT LIST`; when unset, the existing defaults (`GlidePy`/`GlidePySync`) are preserved. Brings parity with the Java `libName` option. ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
+* Python: Add configurable `lib_name` and `client_info_tag` to client configuration (async and sync). `lib_name` replaces the library name sent via `CLIENT SETINFO LIB-NAME` (defaults `GlidePy`/`GlidePySync` preserved when unset); `client_info_tag` appends a parenthesized tag while preserving the library identity (e.g. `GlidePy(my-framework:1.2.3)`) for library/framework attribution in `CLIENT INFO`/`CLIENT LIST`. Brings parity with the Java `libName` option. ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
 * Go: Add multi-key `MIGRATE` support ([#6293](https://github.com/valkey-io/valkey-glide/pull/6293))
 * Core, Java, Go, Node, Python: Support server-assisted invalidation and add `CLIENT TRACKINGINFO` command ([#5961](https://github.com/valkey-io/valkey-glide/issues/5961))
 * Core, Java, Python, Node, Go: Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands ([#6286](https://github.com/valkey-io/valkey-glide/issues/6286))

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -488,6 +488,10 @@ class BaseClient(CoreCommands):
         # Preserve a user-configured lib_name; otherwise fall back to the async default.
         if not conn_req.lib_name:
             conn_req.lib_name = "GlidePy"
+        # Optionally append a client info tag, preserving the library identity
+        # (e.g. "GlidePy(my-framework:1.2.3)").
+        if config.client_info_tag:
+            conn_req.lib_name = f"{conn_req.lib_name}({config.client_info_tag})"
         conn_req_bytes = conn_req.SerializeToString()
 
         # Create AsyncClient type

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -485,7 +485,9 @@ class BaseClient(CoreCommands):
         conn_req = config._create_a_protobuf_conn_request(
             cluster_mode=isinstance(config, GlideClusterClientConfiguration)
         )
-        conn_req.lib_name = "GlidePy"
+        # Preserve a user-configured lib_name; otherwise fall back to the async default.
+        if not conn_req.lib_name:
+            conn_req.lib_name = "GlidePy"
         conn_req_bytes = conn_req.SerializeToString()
 
         # Create AsyncClient type

--- a/python/glide-shared/glide_shared/config.py
+++ b/python/glide-shared/glide_shared/config.py
@@ -730,6 +730,10 @@ class BaseClientConfiguration:
             command during connection establishment. Useful for identifying a wrapping library or framework in
             ``CLIENT INFO``/``CLIENT LIST`` output. If not set, a client-specific default (e.g. ``GlidePy`` for the
             async client, ``GlidePySync`` for the sync client) is used.
+        client_info_tag (Optional[str]): Optional tag appended to the library name in parentheses
+            (e.g. ``GlidePy(my-framework:1.2.3)``), preserving the underlying GLIDE library identity while
+            attributing a wrapping library or framework in ``CLIENT INFO``/``CLIENT LIST`` output. Applied on top of
+            the default library name or a configured ``lib_name``. Must not contain whitespace.
         protocol (ProtocolVersion): Serialization protocol to be used. If not set, `RESP3` will be used.
         inflight_requests_limit (Optional[int]): The maximum number of concurrent requests allowed to be in-flight
             (sent but not yet completed).
@@ -816,6 +820,7 @@ class BaseClientConfiguration:
         database_id: Optional[int] = None,
         client_name: Optional[str] = None,
         lib_name: Optional[str] = None,
+        client_info_tag: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         inflight_requests_limit: Optional[int] = None,
         client_az: Optional[str] = None,
@@ -835,6 +840,7 @@ class BaseClientConfiguration:
         self.database_id = database_id
         self.client_name = client_name
         self.lib_name = lib_name
+        self.client_info_tag = client_info_tag
         self.protocol = protocol
         self.inflight_requests_limit = inflight_requests_limit
         self.client_az = client_az
@@ -844,6 +850,9 @@ class BaseClientConfiguration:
         self.client_side_cache = client_side_cache
         self.address_resolver = address_resolver
         self.client_circuit_breaker = client_circuit_breaker
+
+        if client_info_tag is not None and any(c.isspace() for c in client_info_tag):
+            raise ValueError("client_info_tag must not contain whitespace characters")
 
         if read_from == ReadFrom.AZ_AFFINITY and not client_az:
             raise ValueError(
@@ -1055,6 +1064,10 @@ class GlideClientConfiguration(BaseClientConfiguration):
         lib_name (Optional[str]): Library name to be used for the client. Will be used with CLIENT SETINFO LIB-NAME command
             during connection establishment. Useful for identifying a wrapping library or framework in
             ``CLIENT INFO``/``CLIENT LIST`` output. If not set, a client-specific default is used.
+        client_info_tag (Optional[str]): Optional tag appended to the library name in parentheses
+            (e.g. ``GlidePy(my-framework:1.2.3)``), preserving the underlying GLIDE library identity while
+            attributing a wrapping library or framework in ``CLIENT INFO``/``CLIENT LIST`` output. Applied on top of
+            the default library name or a configured ``lib_name``. Must not contain whitespace.
         protocol (ProtocolVersion): The version of the RESP protocol to communicate with the server.
         pubsub_subscriptions (Optional[GlideClientConfiguration.PubSubSubscriptions]): Pubsub subscriptions to be used for the
                 client.
@@ -1150,6 +1163,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         database_id: Optional[int] = None,
         client_name: Optional[str] = None,
         lib_name: Optional[str] = None,
+        client_info_tag: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         pubsub_subscriptions: Optional[PubSubSubscriptions] = None,
         inflight_requests_limit: Optional[int] = None,
@@ -1173,6 +1187,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
             database_id=database_id,
             client_name=client_name,
             lib_name=lib_name,
+            client_info_tag=client_info_tag,
             protocol=protocol,
             inflight_requests_limit=inflight_requests_limit,
             client_az=client_az,
@@ -1307,6 +1322,10 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         lib_name (Optional[str]): Library name to be used for the client. Will be used with CLIENT SETINFO LIB-NAME command
             during connection establishment. Useful for identifying a wrapping library or framework in
             ``CLIENT INFO``/``CLIENT LIST`` output. If not set, a client-specific default is used.
+        client_info_tag (Optional[str]): Optional tag appended to the library name in parentheses
+            (e.g. ``GlidePy(my-framework:1.2.3)``), preserving the underlying GLIDE library identity while
+            attributing a wrapping library or framework in ``CLIENT INFO``/``CLIENT LIST`` output. Applied on top of
+            the default library name or a configured ``lib_name``. Must not contain whitespace.
         protocol (ProtocolVersion): The version of the RESP protocol to communicate with the server.
         periodic_checks (Union[PeriodicChecksStatus, PeriodicChecksManualInterval]): Configure the periodic topology checks.
             These checks evaluate changes in the cluster's topology, triggering a slot refresh when detected.
@@ -1399,6 +1418,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         database_id: Optional[int] = None,
         client_name: Optional[str] = None,
         lib_name: Optional[str] = None,
+        client_info_tag: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         periodic_checks: Union[
             PeriodicChecksStatus, PeriodicChecksManualInterval
@@ -1423,6 +1443,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             database_id=database_id,
             client_name=client_name,
             lib_name=lib_name,
+            client_info_tag=client_info_tag,
             protocol=protocol,
             inflight_requests_limit=inflight_requests_limit,
             client_az=client_az,

--- a/python/glide-shared/glide_shared/config.py
+++ b/python/glide-shared/glide_shared/config.py
@@ -726,6 +726,10 @@ class BaseClientConfiguration:
             Must be a non-negative integer.If not set, the client will connect to database 0.
         client_name (Optional[str]): Client name to be used for the client. Will be used with CLIENT SETNAME command
             during connection establishment.
+        lib_name (Optional[str]): Library name to be used for the client. Will be used with CLIENT SETINFO LIB-NAME
+            command during connection establishment. Useful for identifying a wrapping library or framework in
+            ``CLIENT INFO``/``CLIENT LIST`` output. If not set, a client-specific default (e.g. ``GlidePy`` for the
+            async client, ``GlidePySync`` for the sync client) is used.
         protocol (ProtocolVersion): Serialization protocol to be used. If not set, `RESP3` will be used.
         inflight_requests_limit (Optional[int]): The maximum number of concurrent requests allowed to be in-flight
             (sent but not yet completed).
@@ -811,6 +815,7 @@ class BaseClientConfiguration:
         reconnect_strategy: Optional[BackoffStrategy] = None,
         database_id: Optional[int] = None,
         client_name: Optional[str] = None,
+        lib_name: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         inflight_requests_limit: Optional[int] = None,
         client_az: Optional[str] = None,
@@ -829,6 +834,7 @@ class BaseClientConfiguration:
         self.reconnect_strategy = reconnect_strategy
         self.database_id = database_id
         self.client_name = client_name
+        self.lib_name = lib_name
         self.protocol = protocol
         self.inflight_requests_limit = inflight_requests_limit
         self.client_az = client_az
@@ -964,6 +970,8 @@ class BaseClientConfiguration:
 
         if self.client_name:
             request.client_name = self.client_name
+        if self.lib_name:
+            request.lib_name = self.lib_name
         if self.inflight_requests_limit:
             request.inflight_requests_limit = self.inflight_requests_limit
         if self.client_circuit_breaker:
@@ -1044,6 +1052,9 @@ class GlideClientConfiguration(BaseClientConfiguration):
         database_id (Optional[int]): Index of the logical database to connect to.
         client_name (Optional[str]): Client name to be used for the client. Will be used with CLIENT SETNAME command during
             connection establishment.
+        lib_name (Optional[str]): Library name to be used for the client. Will be used with CLIENT SETINFO LIB-NAME command
+            during connection establishment. Useful for identifying a wrapping library or framework in
+            ``CLIENT INFO``/``CLIENT LIST`` output. If not set, a client-specific default is used.
         protocol (ProtocolVersion): The version of the RESP protocol to communicate with the server.
         pubsub_subscriptions (Optional[GlideClientConfiguration.PubSubSubscriptions]): Pubsub subscriptions to be used for the
                 client.
@@ -1138,6 +1149,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
         reconnect_strategy: Optional[BackoffStrategy] = None,
         database_id: Optional[int] = None,
         client_name: Optional[str] = None,
+        lib_name: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         pubsub_subscriptions: Optional[PubSubSubscriptions] = None,
         inflight_requests_limit: Optional[int] = None,
@@ -1160,6 +1172,7 @@ class GlideClientConfiguration(BaseClientConfiguration):
             reconnect_strategy=reconnect_strategy,
             database_id=database_id,
             client_name=client_name,
+            lib_name=lib_name,
             protocol=protocol,
             inflight_requests_limit=inflight_requests_limit,
             client_az=client_az,
@@ -1291,6 +1304,9 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         database_id (Optional[int]): Index of the logical database to connect to.
         client_name (Optional[str]): Client name to be used for the client. Will be used with CLIENT SETNAME command during
             connection establishment.
+        lib_name (Optional[str]): Library name to be used for the client. Will be used with CLIENT SETINFO LIB-NAME command
+            during connection establishment. Useful for identifying a wrapping library or framework in
+            ``CLIENT INFO``/``CLIENT LIST`` output. If not set, a client-specific default is used.
         protocol (ProtocolVersion): The version of the RESP protocol to communicate with the server.
         periodic_checks (Union[PeriodicChecksStatus, PeriodicChecksManualInterval]): Configure the periodic topology checks.
             These checks evaluate changes in the cluster's topology, triggering a slot refresh when detected.
@@ -1382,6 +1398,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         reconnect_strategy: Optional[BackoffStrategy] = None,
         database_id: Optional[int] = None,
         client_name: Optional[str] = None,
+        lib_name: Optional[str] = None,
         protocol: ProtocolVersion = ProtocolVersion.RESP3,
         periodic_checks: Union[
             PeriodicChecksStatus, PeriodicChecksManualInterval
@@ -1405,6 +1422,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             reconnect_strategy=reconnect_strategy,
             database_id=database_id,
             client_name=client_name,
+            lib_name=lib_name,
             protocol=protocol,
             inflight_requests_limit=inflight_requests_limit,
             client_az=client_az,

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -99,7 +99,9 @@ class BaseClient(CoreCommands):
         conn_req = self._config._create_a_protobuf_conn_request(
             cluster_mode=type(self._config) is GlideClusterClientConfiguration
         )
-        conn_req.lib_name = "GlidePySync"
+        # Preserve a user-configured lib_name; otherwise fall back to the sync default.
+        if not conn_req.lib_name:
+            conn_req.lib_name = "GlidePySync"
         conn_req_bytes = conn_req.SerializeToString()
         client_type = self._ffi.new(
             "ClientType*",

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -102,6 +102,10 @@ class BaseClient(CoreCommands):
         # Preserve a user-configured lib_name; otherwise fall back to the sync default.
         if not conn_req.lib_name:
             conn_req.lib_name = "GlidePySync"
+        # Optionally append a client info tag, preserving the library identity
+        # (e.g. "GlidePySync(my-framework:1.2.3)").
+        if self._config.client_info_tag:
+            conn_req.lib_name = f"{conn_req.lib_name}({self._config.client_info_tag})"
         conn_req_bytes = conn_req.SerializeToString()
         client_type = self._ffi.new(
             "ClientType*",

--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -288,6 +288,7 @@ async def create_client(
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
     lib_name: Optional[str] = None,
+    client_info_tag: Optional[str] = None,
 ) -> Union[GlideClient, GlideClusterClient]:
     config = create_client_config(
         request,
@@ -317,6 +318,7 @@ async def create_client(
         read_only=read_only,
         cache=cache,
         lib_name=lib_name,
+        client_info_tag=client_info_tag,
     )
     if cluster_mode:
         return await GlideClusterClient.create(config)

--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -287,6 +287,7 @@ async def create_client(
     client_key_pem: Optional[bytes] = None,
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
+    lib_name: Optional[str] = None,
 ) -> Union[GlideClient, GlideClusterClient]:
     config = create_client_config(
         request,
@@ -315,6 +316,7 @@ async def create_client(
         client_key_pem=client_key_pem,
         read_only=read_only,
         cache=cache,
+        lib_name=lib_name,
     )
     if cluster_mode:
         return await GlideClusterClient.create(config)

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -358,6 +358,19 @@ class TestGlideClients:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_lib_name(self, request, cluster_mode, protocol):
+        glide_client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            lib_name="glide-py(my-framework:1.2.3)",
+        )
+        client_info = await glide_client.custom_command(["CLIENT", "INFO"])
+        assert b"lib-name=glide-py(my-framework:1.2.3)" in client_info
+        await glide_client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_closed_client_raises_error(self, glide_client: TGlideClient):
         await glide_client.close()
         with pytest.raises(ClosingError) as e:

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -371,6 +371,20 @@ class TestGlideClients:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_client_info_tag(self, request, cluster_mode, protocol):
+        glide_client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            client_info_tag="my-framework:1.2.3",
+        )
+        client_info = await glide_client.custom_command(["CLIENT", "INFO"])
+        # The default library identity is preserved and the tag is appended.
+        assert b"lib-name=GlidePy(my-framework:1.2.3)" in client_info
+        await glide_client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_closed_client_raises_error(self, glide_client: TGlideClient):
         await glide_client.close()
         with pytest.raises(ClosingError) as e:

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -385,6 +385,24 @@ class TestGlideClients:
         assert b"lib-name=GlidePy(my-framework:1.2.3)" in client_info
         await glide_client.close()
 
+    @pytest.mark.skip_if_version_below("7.2.0")
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_lib_name_with_client_info_tag(
+        self, request, cluster_mode, protocol
+    ):
+        glide_client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            lib_name="custom-lib",
+            client_info_tag="my-framework:1.2.3",
+        )
+        client_info = await glide_client.custom_command(["CLIENT", "INFO"])
+        # The tag is appended to the configured lib_name override.
+        assert b"lib-name=custom-lib(my-framework:1.2.3)" in client_info
+        await glide_client.close()
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_closed_client_raises_error(self, glide_client: TGlideClient):

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -388,9 +388,7 @@ class TestGlideClients:
     @pytest.mark.skip_if_version_below("7.2.0")
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_lib_name_with_client_info_tag(
-        self, request, cluster_mode, protocol
-    ):
+    async def test_lib_name_with_client_info_tag(self, request, cluster_mode, protocol):
         glide_client = await create_client(
             request,
             cluster_mode=cluster_mode,

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -356,6 +356,7 @@ class TestGlideClients:
         assert b"name=TEST_CLIENT_NAME" in client_info
         await glide_client.close()
 
+    @pytest.mark.skip_if_version_below("7.2.0")
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_lib_name(self, request, cluster_mode, protocol):
@@ -369,6 +370,7 @@ class TestGlideClients:
         assert b"lib-name=glide-py(my-framework:1.2.3)" in client_info
         await glide_client.close()
 
+    @pytest.mark.skip_if_version_below("7.2.0")
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_client_info_tag(self, request, cluster_mode, protocol):

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -240,6 +240,7 @@ def create_sync_client(
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
     lib_name: Optional[str] = None,
+    client_info_tag: Optional[str] = None,
 ) -> TSyncGlideClient:
     # Create sync client
     config = create_sync_client_config(
@@ -270,6 +271,7 @@ def create_sync_client(
         read_only=read_only,
         cache=cache,
         lib_name=lib_name,
+        client_info_tag=client_info_tag,
     )
     if cluster_mode:
         return SyncGlideClusterClient.create(config)

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -239,6 +239,7 @@ def create_sync_client(
     client_key_pem: Optional[bytes] = None,
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
+    lib_name: Optional[str] = None,
 ) -> TSyncGlideClient:
     # Create sync client
     config = create_sync_client_config(
@@ -268,6 +269,7 @@ def create_sync_client(
         client_key_pem=client_key_pem,
         read_only=read_only,
         cache=cache,
+        lib_name=lib_name,
     )
     if cluster_mode:
         return SyncGlideClusterClient.create(config)

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -383,6 +383,19 @@ class TestGlideClients:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_lib_name(self, request, cluster_mode, protocol):
+        glide_sync_client = create_sync_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            lib_name="glide-py(my-framework:1.2.3)",
+        )
+        client_info = glide_sync_client.custom_command(["CLIENT", "INFO"])
+        assert b"lib-name=glide-py(my-framework:1.2.3)" in client_info
+        glide_sync_client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_closed_client_raises_error(self, glide_sync_client: TGlideClient):
         glide_sync_client.close()
         with pytest.raises(ClosingError) as e:

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -413,9 +413,7 @@ class TestGlideClients:
     @pytest.mark.skip_if_version_below("7.2.0")
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    def test_sync_lib_name_with_client_info_tag(
-        self, request, cluster_mode, protocol
-    ):
+    def test_sync_lib_name_with_client_info_tag(self, request, cluster_mode, protocol):
         glide_sync_client = create_sync_client(
             request,
             cluster_mode=cluster_mode,

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -410,6 +410,24 @@ class TestGlideClients:
         assert b"lib-name=GlidePySync(my-framework:1.2.3)" in client_info
         glide_sync_client.close()
 
+    @pytest.mark.skip_if_version_below("7.2.0")
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_lib_name_with_client_info_tag(
+        self, request, cluster_mode, protocol
+    ):
+        glide_sync_client = create_sync_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            lib_name="custom-lib",
+            client_info_tag="my-framework:1.2.3",
+        )
+        client_info = glide_sync_client.custom_command(["CLIENT", "INFO"])
+        # The tag is appended to the configured lib_name override.
+        assert b"lib-name=custom-lib(my-framework:1.2.3)" in client_info
+        glide_sync_client.close()
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_closed_client_raises_error(self, glide_sync_client: TGlideClient):

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -396,6 +396,20 @@ class TestGlideClients:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_client_info_tag(self, request, cluster_mode, protocol):
+        glide_sync_client = create_sync_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+            client_info_tag="my-framework:1.2.3",
+        )
+        client_info = glide_sync_client.custom_command(["CLIENT", "INFO"])
+        # The default library identity is preserved and the tag is appended.
+        assert b"lib-name=GlidePySync(my-framework:1.2.3)" in client_info
+        glide_sync_client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_closed_client_raises_error(self, glide_sync_client: TGlideClient):
         glide_sync_client.close()
         with pytest.raises(ClosingError) as e:

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -381,6 +381,7 @@ class TestGlideClients:
         assert b"name=TEST_CLIENT_NAME" in client_info
         glide_sync_client.close()
 
+    @pytest.mark.skip_if_version_below("7.2.0")
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_lib_name(self, request, cluster_mode, protocol):
@@ -394,6 +395,7 @@ class TestGlideClients:
         assert b"lib-name=glide-py(my-framework:1.2.3)" in client_info
         glide_sync_client.close()
 
+    @pytest.mark.skip_if_version_below("7.2.0")
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_client_info_tag(self, request, cluster_mode, protocol):

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -746,6 +746,7 @@ def create_client_config(
     client_key_pem: Optional[bytes] = None,
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
+    lib_name: Optional[str] = None,
 ) -> Union[GlideClusterClientConfiguration, GlideClientConfiguration]:
     if use_tls is not None:
         use_tls = use_tls
@@ -787,6 +788,7 @@ def create_client_config(
             credentials=credentials,
             database_id=database_id,
             client_name=client_name,
+            lib_name=lib_name,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=cluster_mode_pubsub,
@@ -813,6 +815,7 @@ def create_client_config(
             credentials=credentials,
             database_id=database_id,
             client_name=client_name,
+            lib_name=lib_name,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=standalone_mode_pubsub,
@@ -863,6 +866,7 @@ def create_sync_client_config(
     client_key_pem: Optional[bytes] = None,
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
+    lib_name: Optional[str] = None,
 ) -> Union[SyncGlideClusterClientConfiguration, SyncGlideClientConfiguration]:
     if use_tls is not None:
         use_tls = use_tls
@@ -904,6 +908,7 @@ def create_sync_client_config(
             credentials=credentials,
             database_id=database_id,
             client_name=client_name,
+            lib_name=lib_name,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=cluster_mode_pubsub,
@@ -929,6 +934,7 @@ def create_sync_client_config(
             credentials=credentials,
             database_id=database_id,
             client_name=client_name,
+            lib_name=lib_name,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=standalone_mode_pubsub,

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -747,6 +747,7 @@ def create_client_config(
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
     lib_name: Optional[str] = None,
+    client_info_tag: Optional[str] = None,
 ) -> Union[GlideClusterClientConfiguration, GlideClientConfiguration]:
     if use_tls is not None:
         use_tls = use_tls
@@ -789,6 +790,7 @@ def create_client_config(
             database_id=database_id,
             client_name=client_name,
             lib_name=lib_name,
+            client_info_tag=client_info_tag,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=cluster_mode_pubsub,
@@ -816,6 +818,7 @@ def create_client_config(
             database_id=database_id,
             client_name=client_name,
             lib_name=lib_name,
+            client_info_tag=client_info_tag,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=standalone_mode_pubsub,
@@ -867,6 +870,7 @@ def create_sync_client_config(
     read_only: bool = False,
     cache: Optional[ClientSideCache] = None,
     lib_name: Optional[str] = None,
+    client_info_tag: Optional[str] = None,
 ) -> Union[SyncGlideClusterClientConfiguration, SyncGlideClientConfiguration]:
     if use_tls is not None:
         use_tls = use_tls
@@ -909,6 +913,7 @@ def create_sync_client_config(
             database_id=database_id,
             client_name=client_name,
             lib_name=lib_name,
+            client_info_tag=client_info_tag,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=cluster_mode_pubsub,
@@ -935,6 +940,7 @@ def create_sync_client_config(
             database_id=database_id,
             client_name=client_name,
             lib_name=lib_name,
+            client_info_tag=client_info_tag,
             protocol=protocol,
             request_timeout=request_timeout,
             pubsub_subscriptions=standalone_mode_pubsub,


### PR DESCRIPTION
### Summary

Adds two related client-identification options to the Python client configuration, for **both the async and sync** clients:

1. **`lib_name`** — overrides the `CLIENT SETINFO LIB-NAME` value (parity with the Java client's `libName`). When unset, the existing defaults (`GlidePy` / `GlidePySync`) are preserved.
2. **`client_info_tag`** — appends a parenthesized tag to the resolved library name while **preserving the underlying GLIDE identity**, e.g. `GlidePy(my-framework:1.2.3)`. Follows the ioredis `ioredis(<tag>)` convention.

Closes #6378.

### Motivation

Libraries and frameworks that embed GLIDE often want to identify themselves to the server for **adoption tracking, observability, and debugging**, distinct from the application-level `client_name` (which maps to `CLIENT SETNAME` and is frequently redacted in operational tooling).

`client_info_tag` is the recommended option for framework attribution: it keeps the `GlidePy`/`GlidePySync` token intact so existing GLIDE-level adoption dashboards keep counting these connections, while adding a per-framework breakdown:

```python
config = GlideClusterClientConfiguration(
    addresses=[...],
    client_info_tag="my-framework:1.2.3",   # -> lib-name = GlidePy(my-framework:1.2.3)
)
# or full override:
config = GlideClusterClientConfiguration(addresses=[...], lib_name="custom-name")
```

### What changed

The `lib_name` field already exists in the shared `ConnectionRequest` protobuf (field 19) and is consumed by the Rust core (the Java client sets it today), so this is a **binding-only** change — no proto or Rust-core changes.

- **`glide-shared/glide_shared/config.py`** — add `lib_name` and `client_info_tag` to `BaseClientConfiguration`, `GlideClientConfiguration`, and `GlideClusterClientConfiguration`. `lib_name` is passed through to `request.lib_name` (mirroring `client_name`). `client_info_tag` is validated (no whitespace, matching `CLIENT SETINFO` value constraints) and composed in the client wrappers. Docstrings updated.
- **`glide-async/.../glide_client.py`** and **`glide-sync/.../glide_client.py`** — the wrappers previously hardcoded `conn_req.lib_name = "GlidePy"` / `"GlidePySync"` unconditionally. They now (1) only apply that default when the user did not configure a `lib_name`, and (2) append `(client_info_tag)` to the resolved name when a tag is set. So a full override is honored, the default is preserved when unset, and a tag composes on top of either.
- **Tests** — add `test_lib_name` / `test_client_info_tag` (async) and `test_sync_lib_name` / `test_sync_client_info_tag` (sync), asserting the configured value / appended tag appears in `CLIENT INFO`. Existing tests still cover the untouched defaults. Test helpers thread the new options through.
- **CHANGELOG.md** — entry added under Pending 2.5.

### Behavior matrix

| Config | Resulting `lib-name` (async) |
|---|---|
| _(none)_ | `GlidePy` |
| `client_info_tag="lmcache:1.2"` | `GlidePy(lmcache:1.2)` |
| `lib_name="custom"` | `custom` |
| `lib_name="custom"`, `client_info_tag="lmcache:1.2"` | `custom(lmcache:1.2)` |

(Sync client uses `GlidePySync` as the default identity.)

### Scope notes

- **`LIB-NAME` only.** Java does not expose a `lib_version` setter either; `LIB-VER` remains core-controlled (`GLIDE_VERSION`). This PR intentionally scopes to `lib_name` + tag.
- Node.js has the same gap and could be addressed similarly in a follow-up.

### Testing

- `flake8` passes on all changed files (repo config).
- Added async + sync tests across standalone/cluster and RESP2/RESP3, asserting configured `lib_name` and appended `client_info_tag` appear in `CLIENT INFO`.
- Existing default-value tests continue to assert `GlidePy`/`GlidePySync` when unset.
