### PR TITLE
Fix flaky test_monitor_start_and_receive_line with canary command

### DIFF
--- a/glide-core/tests/test_monitor.rs
+++ b/glide-core/tests/test_monitor.rs
@@ -45,6 +45,23 @@ mod test_monitor {
         }
     }
 
+    /// Poll `lines` until `predicate` matches at least one entry, or panic after `timeout`.
+    async fn wait_for_line(
+        lines: &Arc<Mutex<Vec<MonitorLine>>>,
+        predicate: impl Fn(&MonitorLine) -> bool,
+        timeout: std::time::Duration,
+        msg: &str,
+    ) {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if lines.lock().unwrap().iter().any(&predicate) {
+                return;
+            }
+            assert!(std::time::Instant::now() < deadline, "{}", msg);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
     #[tokio::test]
     async fn test_monitor_start_and_receive_line() {
         let server_addr = get_shared_server_address(false);
@@ -65,6 +82,24 @@ mod test_monitor {
             .get_multiplexed_async_connection(GlideConnectionOptions::default())
             .await
             .unwrap();
+
+        // Send a canary PING and wait for it to appear in the monitor output.
+        // This ensures the monitor stream is actively receiving before we issue
+        // the SET command we actually want to validate.
+        let _: () = redis::cmd("PING")
+            .arg("monitor_canary")
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+
+        wait_for_line(
+            &lines,
+            |l| l.command == "PING" && l.args.first().map(|s| s.as_str()) == Some("monitor_canary"),
+            std::time::Duration::from_secs(15),
+            "timed out waiting for canary PING line",
+        )
+        .await;
+
         let _: () = redis::cmd("SET")
             .arg("monitor_test_key")
             .arg("monitor_test_val")
@@ -72,20 +107,13 @@ mod test_monitor {
             .await
             .unwrap();
 
-        // Generous deadline to tolerate slow/loaded CI; not a behavioral change.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
-        loop {
-            if lines.lock().unwrap().iter().any(|l| {
-                l.command == "SET" && l.args.first().map(|s| s.as_str()) == Some("monitor_test_key")
-            }) {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "timed out waiting for SET line"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        wait_for_line(
+            &lines,
+            |l| l.command == "SET" && l.args.first().map(|s| s.as_str()) == Some("monitor_test_key"),
+            std::time::Duration::from_secs(15),
+            "timed out waiting for SET line",
+        )
+        .await;
 
         let (args, db, client_addr, timestamp) = {
             let found = lines.lock().unwrap();


### PR DESCRIPTION
### Summary
Fix flaky `test_monitor::test_monitor_start_and_receive_line` test by adding a canary PING command that verifies the monitor stream is actively receiving before issuing the SET command under test.

### Issue link
This Pull Request is linked to issue: [[Rust][Flaky Test] test_monitor_start_and_receive_line](https://github.com/valkey-io/valkey-glide/issues/6390)
Closes #6390

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The test issued a SET command immediately after creating `MonitorClient`, without verifying the monitor stream task was actively polling. On loaded CI machines, the tokio-spawned task may not be scheduled before the SET arrives at the server, causing the monitor to miss the command and time out after 15 seconds.

**Fix:** Before sending the SET command, send a canary `PING monitor_canary` and wait for it to appear in the monitor output. This end-to-end readiness check guarantees the monitor pipeline is operational. Also extracts a reusable `wait_for_line` helper to improve readability and reduce code duplication in the polling loop.

### Limitations
None

### Testing
- Ran the test 100 times in a loop (`for i in $(seq 1 100); do cargo test --test test_monitor test_monitor_start_and_receive_line || exit 1; done`) — all 100 runs passed.
- All other monitor tests continue to pass.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release