### PR TITLE
test(java): deflake config_reset_stat via gossip-immune stat

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -661,24 +661,42 @@ public class CommandTests {
     @MethodSource("getClients")
     @SneakyThrows
     public void config_reset_stat(GlideClusterClient clusterClient) {
-        // Ensure some network activity has occurred to guarantee valueBefore > 0
-        clusterClient.info(new Section[] {STATS}).get();
-        clusterClient.info(new Section[] {STATS}).get();
-
+        // Prior attempts (#4575, #4621, #4668) asserted on "total_net_input_bytes", which counts
+        // every byte the node reads from its sockets, including continuous cluster-bus gossip.
+        // Gossip keeps arriving between RESETSTAT and the re-read, so that counter is not monotonic
+        // on a live cluster node and the "after < before" ordering races (observed 203 vs 100).
+        //
+        // Assert on "total_commands_processed" instead. It is incremented only for client commands
+        // executed on the node; cluster-bus gossip is handled off the command path and never touches
+        // it. We pin all traffic to a single node and deliberately drive a known number of commands
+        // before the reset, so the pre-reset value is a controlled floor and the post-reset value is
+        // just the RESETSTAT + INFO round trip. This is deterministic and gossip-immune, not a tuned
+        // threshold.
         ClusterValue<String> data = clusterClient.info(new Section[] {STATS}).get();
-        // always use the same node address for before and after
-        final String firstNodeAddress = getFirstKeyFromMultiValue(data);
-        String firstNodeInfo = data.getMultiValue().get(firstNodeAddress);
-        long valueBefore = getValueFromInfo(firstNodeInfo, "total_net_input_bytes");
+        // always talk to the same node for the inflation, reset, and both reads
+        final Route route = new ByAddressRoute(getFirstKeyFromMultiValue(data));
 
-        String result = clusterClient.configResetStat().get();
-        assertEquals(OK, result);
+        final int commandCount = 100;
+        for (int i = 0; i < commandCount; i++) {
+            clusterClient.ping(route).get();
+        }
 
-        data = clusterClient.info(new Section[] {STATS}).get();
-        // always use the same node address for before and after
-        firstNodeInfo = data.getMultiValue().get(firstNodeAddress);
-        long valueAfter = getValueFromInfo(firstNodeInfo, "total_net_input_bytes");
+        String nodeInfo = clusterClient.info(new Section[] {STATS}, route).get().getSingleValue();
+        long valueBefore = getValueFromInfo(nodeInfo, "total_commands_processed");
+        assertTrue(
+                valueBefore >= commandCount,
+                () ->
+                        String.format(
+                                "Expected valueBefore (%d) to reflect the %d commands issued",
+                                valueBefore, commandCount));
 
+        assertEquals(OK, clusterClient.configResetStat(route).get());
+
+        nodeInfo = clusterClient.info(new Section[] {STATS}, route).get().getSingleValue();
+        long valueAfter = getValueFromInfo(nodeInfo, "total_commands_processed");
+
+        // After RESETSTAT the only commands processed on the node are the reset itself and this INFO
+        // read, so the counter is a tiny constant far below the inflated pre-reset value.
         assertTrue(
                 valueAfter < valueBefore,
                 () ->

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -403,15 +403,39 @@ public class CommandTests {
     @MethodSource("getClients")
     @SneakyThrows
     public void config_reset_stat(GlideClient regularClient) {
+        // Mirror of the cluster twin (see glide.cluster.CommandTests#config_reset_stat and issue
+        // #4574). Assert on the command-scoped "total_commands_processed" counter rather than
+        // "total_net_input_bytes". Comparing byte counters is fragile: the pre-reset value depends on
+        // whatever traffic preceded it, and the post-reset value already includes the bytes of the
+        // INFO read used to measure it, so the "after < before" ordering is not guaranteed. Instead we
+        // drive a known number of commands before the reset so the pre-reset count is a controlled
+        // floor, then assert the counter dropped afterwards. Deterministic, not a tuned threshold.
+        final int commandCount = 100;
+        for (int i = 0; i < commandCount; i++) {
+            regularClient.ping().get();
+        }
+
         String data = regularClient.info(new Section[] {STATS}).get();
-        long value_before = getValueFromInfo(data, "total_net_input_bytes");
+        long value_before = getValueFromInfo(data, "total_commands_processed");
+        assertTrue(
+                value_before >= commandCount,
+                () ->
+                        String.format(
+                                "Expected value_before (%d) to reflect the %d commands issued",
+                                value_before, commandCount));
 
         String result = regularClient.configResetStat().get();
         assertEquals(OK, result);
 
         data = regularClient.info(new Section[] {STATS}).get();
-        long value_after = getValueFromInfo(data, "total_net_input_bytes");
-        assertTrue(value_after < value_before);
+        long value_after = getValueFromInfo(data, "total_commands_processed");
+        // After RESETSTAT only the reset and this INFO read have been processed, far below the floor.
+        assertTrue(
+                value_after < value_before,
+                () ->
+                        String.format(
+                                "Expected value_after (%d) to be less than value_before (%d)",
+                                value_after, value_before));
     }
 
     @ParameterizedTest(autoCloseArguments = false)


### PR DESCRIPTION
### Issue link

Closes #4574

### Summary

`config_reset_stat` (cluster) and its standalone twin read the INFO STATS metric `total_net_input_bytes`, call `CONFIG RESETSTAT`, re-read, and assert `valueAfter < valueBefore`. On a live cluster node this races: `total_net_input_bytes` counts every byte the node reads from its sockets, including continuous cluster-bus gossip that keeps arriving between the reset and the second read. The counter is not monotonic, so `valueAfter` can exceed `valueBefore` (the issue reports 203 vs 100).

### Why the three prior fixes regressed

This flake has been "fixed" three times and reopened each time:

- **#4575** added warmup INFO calls and dropped the `valueBefore == 0` special case.
- **#4621** only improved the failure message.
- **#4668** pinned both reads to the same node address.

All three kept `total_net_input_bytes` and the accumulated-window `valueAfter < valueBefore` ordering. None removed the dependence on quiescent, monotonic network traffic, which is the actual root cause, so the flake came back.

### What this PR does differently

It stops measuring bytes and measures a command-scoped counter instead: `total_commands_processed`. In Valkey this counter is incremented only inside `call()` on the client command path (`resetServerStats()` zeroes it on `CONFIG RESETSTAT`). Cluster-bus gossip is handled by `clusterProcessPacket`/`clusterCron` and never goes through `call()`, so gossip cannot move this counter.

The test now:

1. Pins all traffic to a single node (`ByAddressRoute`).
2. Deliberately issues a known number of commands (100 PINGs) before the reset, so the pre-reset value is a controlled floor of at least 100.
3. Calls `CONFIG RESETSTAT`, then re-reads. After the reset the only commands processed on the node are the reset itself and the measuring `INFO` read, so the post-reset value is a small single-digit constant, far below the floor.

This is deterministic and gossip-immune. It is not a tuned magic number: the assertion compares an inflated, test-controlled floor against a post-reset value that only reflects the test's own two round trips, with a ~100-command margin. Background client checks (e.g. the periodic topology check) fire on the order of once per minute, far too slow to close a margin of 100 in the millisecond window between the two reads.

The standalone twin applies the mirrored logic (no routing, single server).

### Testing

Ran locally against a self-managed cluster and standalone server:

- `glide.cluster.CommandTests.config_reset_stat` and `glide.standalone.CommandTests.config_reset_stat` pass for both RESP2 and RESP3.
- The cluster test passed 3/3 repeated `--rerun-tasks` runs.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated (n/a: test-only change).
- [x] Destination branch is correct (`main`).
- [x] Considered the change's effect on other clients (test-only, Java integTest; no core or binding changes).