### PR TITLE
test(java): make BatchTests client setup resilient to slow CI connects

### DIFF
--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -53,6 +53,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -284,6 +285,57 @@ public class TestUtilities {
                     NodeAddress.builder().host(parts[0]).port(Integer.parseInt(parts[1])).build());
         }
         return builder.useTLS(TLS);
+    }
+
+    /** Number of times {@link #createClientWithRetry} attempts the initial connect. */
+    public static final int MAX_CONNECT_ATTEMPTS = 3;
+
+    /** Backoff between {@link #createClientWithRetry} attempts, in milliseconds. */
+    public static final long CONNECT_RETRY_BACKOFF_MILLIS = 1000;
+
+    /**
+     * Creates a client by issuing fresh {@code createClient} attempts, retrying a bounded number of
+     * times when the initial connect fails transiently.
+     *
+     * <p>Under heavy CI load the server may not be accepting connections yet, so the first {@code
+     * createClient} can fail with e.g. "Connection refused" or "Request timed out" and sink an entire
+     * {@code @BeforeAll} setup before a single command runs. This helper retries the whole {@code
+     * createClient} call ({@value #MAX_CONNECT_ATTEMPTS} attempts, {@value
+     * #CONNECT_RETRY_BACKOFF_MILLIS}ms backoff) to survive that window. See issue #5343.
+     *
+     * <p>Glide's native reconnect strategy ({@code reconnectStrategy} / core {@code
+     * connection_retry_strategy}) is intentionally not used for this: it does retry the initial
+     * connect, but the whole retry loop is bounded by {@code connectionTimeout} (default ~2000ms, see
+     * {@code reconnecting_connection.rs} which wraps the loop in {@code timeout(connection_timeout,
+     * ...)}). Once that elapses {@code createClient} rejects, and the "retry forever" background
+     * reconnect only runs on a connection the awaited future has already abandoned. A server that is
+     * slow to accept for several seconds therefore needs fresh {@code createClient} attempts, each
+     * with a new connection-timeout budget, which is exactly what this helper provides. Matching that
+     * with native config would require globally raising {@code connectionTimeout}, slowing every
+     * other path that uses {@link #commonClientConfig()} / {@link #commonClusterClientConfig()}.
+     *
+     * <p>Only {@link ExecutionException} (a failed connect surfaced from {@code
+     * CompletableFuture.get()}) is retried; an {@link InterruptedException} is intentionally not
+     * retried and propagates.
+     *
+     * @param clientFactory supplies a fresh {@code createClient} future on each attempt
+     * @param <T> the client type produced (e.g. {@code GlideClient} or {@code GlideClusterClient})
+     * @return the connected client
+     */
+    @SneakyThrows
+    public static <T> T createClientWithRetry(Supplier<CompletableFuture<T>> clientFactory) {
+        ExecutionException lastException = null;
+        for (int attempt = 1; attempt <= MAX_CONNECT_ATTEMPTS; attempt++) {
+            try {
+                return clientFactory.get().get();
+            } catch (ExecutionException e) {
+                lastException = e;
+                if (attempt < MAX_CONNECT_ATTEMPTS) {
+                    Thread.sleep(CONNECT_RETRY_BACKOFF_MILLIS);
+                }
+            }
+        }
+        throw lastException;
     }
 
     /**

--- a/java/integTest/src/test/java/glide/cluster/ClusterBatchTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterBatchTests.java
@@ -5,6 +5,7 @@ import static glide.TestConfiguration.SERVER_VERSION;
 import static glide.TestUtilities.assertDeepEquals;
 import static glide.TestUtilities.commonClusterClientConfig;
 import static glide.TestUtilities.concatenateArrays;
+import static glide.TestUtilities.createClientWithRetry;
 import static glide.TestUtilities.generateLuaLibCode;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.GlideString.gs;
@@ -37,7 +38,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -54,14 +54,9 @@ public class ClusterBatchTests {
 
     private static final List<Arguments> clients = new ArrayList<>();
 
-    // Client setup here runs once before the whole parameterized suite. Under heavy CI load the
-    // initial connect can intermittently fail (e.g. "Connection refused" while the server is still
-    // accepting connections, or "Request timed out"), which would fail every parameter set before a
-    // single batch command runs. Retry the connect a bounded number of times so a transient slow or
-    // refused connect does not sink the entire suite. See issue #5343.
-    private static final int MAX_CONNECT_ATTEMPTS = 3;
-    private static final long CONNECT_RETRY_BACKOFF_MILLIS = 1000;
-
+    // Client setup runs once before the whole parameterized suite. Under heavy CI load the initial
+    // connect can fail transiently, so use the shared bounded-retry helper (see its javadoc for why
+    // Glide's native reconnect strategy is not sufficient here). See issue #5343.
     @BeforeAll
     @SneakyThrows
     public static void init() {
@@ -69,22 +64,11 @@ public class ClusterBatchTests {
         clients.add(Arguments.of(Named.of("RESP3", connectWithRetry(ProtocolVersion.RESP3))));
     }
 
-    @SneakyThrows
     private static GlideClusterClient connectWithRetry(ProtocolVersion protocol) {
-        ExecutionException lastException = null;
-        for (int attempt = 1; attempt <= MAX_CONNECT_ATTEMPTS; attempt++) {
-            try {
-                return GlideClusterClient.createClient(
-                                commonClusterClientConfig().requestTimeout(7000).protocol(protocol).build())
-                        .get();
-            } catch (ExecutionException e) {
-                lastException = e;
-                if (attempt < MAX_CONNECT_ATTEMPTS) {
-                    Thread.sleep(CONNECT_RETRY_BACKOFF_MILLIS);
-                }
-            }
-        }
-        throw lastException;
+        return createClientWithRetry(
+                () ->
+                        GlideClusterClient.createClient(
+                                commonClusterClientConfig().requestTimeout(7000).protocol(protocol).build()));
     }
 
     @AfterAll

--- a/java/integTest/src/test/java/glide/cluster/ClusterBatchTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterBatchTests.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -53,29 +54,37 @@ public class ClusterBatchTests {
 
     private static final List<Arguments> clients = new ArrayList<>();
 
+    // Client setup here runs once before the whole parameterized suite. Under heavy CI load the
+    // initial connect can intermittently fail (e.g. "Connection refused" while the server is still
+    // accepting connections, or "Request timed out"), which would fail every parameter set before a
+    // single batch command runs. Retry the connect a bounded number of times so a transient slow or
+    // refused connect does not sink the entire suite. See issue #5343.
+    private static final int MAX_CONNECT_ATTEMPTS = 3;
+    private static final long CONNECT_RETRY_BACKOFF_MILLIS = 1000;
+
     @BeforeAll
     @SneakyThrows
     public static void init() {
-        clients.add(
-                Arguments.of(
-                        Named.of(
-                                "RESP2",
-                                GlideClusterClient.createClient(
-                                                commonClusterClientConfig()
-                                                        .requestTimeout(7000)
-                                                        .protocol(ProtocolVersion.RESP2)
-                                                        .build())
-                                        .get())));
-        clients.add(
-                Arguments.of(
-                        Named.of(
-                                "RESP3",
-                                GlideClusterClient.createClient(
-                                                commonClusterClientConfig()
-                                                        .requestTimeout(7000)
-                                                        .protocol(ProtocolVersion.RESP3)
-                                                        .build())
-                                        .get())));
+        clients.add(Arguments.of(Named.of("RESP2", connectWithRetry(ProtocolVersion.RESP2))));
+        clients.add(Arguments.of(Named.of("RESP3", connectWithRetry(ProtocolVersion.RESP3))));
+    }
+
+    @SneakyThrows
+    private static GlideClusterClient connectWithRetry(ProtocolVersion protocol) {
+        ExecutionException lastException = null;
+        for (int attempt = 1; attempt <= MAX_CONNECT_ATTEMPTS; attempt++) {
+            try {
+                return GlideClusterClient.createClient(
+                                commonClusterClientConfig().requestTimeout(7000).protocol(protocol).build())
+                        .get();
+            } catch (ExecutionException e) {
+                lastException = e;
+                if (attempt < MAX_CONNECT_ATTEMPTS) {
+                    Thread.sleep(CONNECT_RETRY_BACKOFF_MILLIS);
+                }
+            }
+        }
+        throw lastException;
     }
 
     @AfterAll

--- a/java/integTest/src/test/java/glide/standalone/BatchTests.java
+++ b/java/integTest/src/test/java/glide/standalone/BatchTests.java
@@ -4,6 +4,7 @@ package glide.standalone;
 import static glide.TestConfiguration.SERVER_VERSION;
 import static glide.TestUtilities.assertDeepEquals;
 import static glide.TestUtilities.commonClientConfig;
+import static glide.TestUtilities.createClientWithRetry;
 import static glide.TestUtilities.generateLuaLibCode;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.GlideString.gs;
@@ -64,14 +65,9 @@ public class BatchTests {
 
     private static final List<Arguments> clients = new ArrayList<>();
 
-    // Client setup here runs once before the whole parameterized suite. Under heavy CI load the
-    // initial connect can intermittently fail (e.g. "Connection refused" while the server is still
-    // accepting connections, or "Request timed out"), which would fail every parameter set before a
-    // single batch command runs. Retry the connect a bounded number of times so a transient slow or
-    // refused connect does not sink the entire suite. See issue #5343.
-    private static final int MAX_CONNECT_ATTEMPTS = 3;
-    private static final long CONNECT_RETRY_BACKOFF_MILLIS = 1000;
-
+    // Client setup runs once before the whole parameterized suite. Under heavy CI load the initial
+    // connect can fail transiently, so use the shared bounded-retry helper (see its javadoc for why
+    // Glide's native reconnect strategy is not sufficient here). See issue #5343.
     @BeforeAll
     @SneakyThrows
     public static void init() {
@@ -79,22 +75,11 @@ public class BatchTests {
         clients.add(Arguments.of(Named.of("RESP3", connectWithRetry(ProtocolVersion.RESP3))));
     }
 
-    @SneakyThrows
     private static GlideClient connectWithRetry(ProtocolVersion protocol) {
-        ExecutionException lastException = null;
-        for (int attempt = 1; attempt <= MAX_CONNECT_ATTEMPTS; attempt++) {
-            try {
-                return GlideClient.createClient(
-                                commonClientConfig().requestTimeout(7000).protocol(protocol).build())
-                        .get();
-            } catch (ExecutionException e) {
-                lastException = e;
-                if (attempt < MAX_CONNECT_ATTEMPTS) {
-                    Thread.sleep(CONNECT_RETRY_BACKOFF_MILLIS);
-                }
-            }
-        }
-        throw lastException;
+        return createClientWithRetry(
+                () ->
+                        GlideClient.createClient(
+                                commonClientConfig().requestTimeout(7000).protocol(protocol).build()));
     }
 
     @AfterAll

--- a/java/integTest/src/test/java/glide/standalone/BatchTests.java
+++ b/java/integTest/src/test/java/glide/standalone/BatchTests.java
@@ -64,29 +64,37 @@ public class BatchTests {
 
     private static final List<Arguments> clients = new ArrayList<>();
 
+    // Client setup here runs once before the whole parameterized suite. Under heavy CI load the
+    // initial connect can intermittently fail (e.g. "Connection refused" while the server is still
+    // accepting connections, or "Request timed out"), which would fail every parameter set before a
+    // single batch command runs. Retry the connect a bounded number of times so a transient slow or
+    // refused connect does not sink the entire suite. See issue #5343.
+    private static final int MAX_CONNECT_ATTEMPTS = 3;
+    private static final long CONNECT_RETRY_BACKOFF_MILLIS = 1000;
+
     @BeforeAll
     @SneakyThrows
     public static void init() {
-        clients.add(
-                Arguments.of(
-                        Named.of(
-                                "RESP2",
-                                GlideClient.createClient(
-                                                commonClientConfig()
-                                                        .requestTimeout(7000)
-                                                        .protocol(ProtocolVersion.RESP2)
-                                                        .build())
-                                        .get())));
-        clients.add(
-                Arguments.of(
-                        Named.of(
-                                "RESP3",
-                                GlideClient.createClient(
-                                                commonClientConfig()
-                                                        .requestTimeout(7000)
-                                                        .protocol(ProtocolVersion.RESP3)
-                                                        .build())
-                                        .get())));
+        clients.add(Arguments.of(Named.of("RESP2", connectWithRetry(ProtocolVersion.RESP2))));
+        clients.add(Arguments.of(Named.of("RESP3", connectWithRetry(ProtocolVersion.RESP3))));
+    }
+
+    @SneakyThrows
+    private static GlideClient connectWithRetry(ProtocolVersion protocol) {
+        ExecutionException lastException = null;
+        for (int attempt = 1; attempt <= MAX_CONNECT_ATTEMPTS; attempt++) {
+            try {
+                return GlideClient.createClient(
+                                commonClientConfig().requestTimeout(7000).protocol(protocol).build())
+                        .get();
+            } catch (ExecutionException e) {
+                lastException = e;
+                if (attempt < MAX_CONNECT_ATTEMPTS) {
+                    Thread.sleep(CONNECT_RETRY_BACKOFF_MILLIS);
+                }
+            }
+        }
+        throw lastException;
     }
 
     @AfterAll


### PR DESCRIPTION
## Summary

Fixes flaky `[Java] BatchTests > batches with group of commands (...)` and its cluster twin `ClusterBatchTests`.

## Root cause

Both batch suites build their shared clients once in `@BeforeAll init()` via `createClient(...).get()`. Under heavy CI load this initial connect intermittently fails, surfacing as an `ExecutionException` (`ClosingException: Failed to create client - Connection refused` per the reported stack trace, or `Request timed out`). Because setup runs before any batch command executes, a single slow or refused connect fails the entire parameterized set, not just one case.

The failures in #5343 are intermittent and load/timing driven (observed across different OS/engine combinations, transient connection refused / timeout), not a deterministic connect regression.

## Fix (test-only)

Wrap the client connect in a bounded retry (3 attempts, 1s backoff) in both the standalone and cluster batch-test factories, so a transient slow or refused connect during setup no longer sinks the whole suite. A `requestTimeout` bump alone would not address the `Connection refused` case, so a bounded retry is the minimal deterministic fix.

No production/client code is changed.

## Validation

- `./gradlew :integTest:compileTestJava` passes (both files compile).
- `spotlessApply` run on both changed files, no formatting diff remaining.
- The batch tests themselves require a live Valkey server/cluster and run in CI.

Closes #5343