### PR TITLE
Python: Fix flaky test_cluster_batch_route errorstats assertion

### DIFF
--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -746,13 +746,16 @@ class TestBatch:
         protocol: ProtocolVersion,
         is_atomic: bool,
     ):
-        if await check_if_server_version_lt(glide_client, "6.0.0"):
-            pytest.skip("CONFIG RESETSTAT requires redis >= 6.0")
-
-        assert await glide_client.config_resetstat() == OK
-
         key = get_random_string(10)
         value_bytes = b"value"
+
+        # Capture MOVED error counts before the batch to compare afterward.
+        # Other tests running concurrently may leave residual error stats, so
+        # we only check that no NEW MOVED errors were introduced by this batch.
+        pre_error_stats = await glide_client.info(
+            sections=[InfoSection.ERROR_STATS], route=AllNodes()
+        )
+        assert isinstance(pre_error_stats, dict)
 
         batch = ClusterBatch(is_atomic=is_atomic)
         batch.set(key, value_bytes)
@@ -765,18 +768,21 @@ class TestBatch:
         assert results == [OK, value_bytes]
 
         # Check that no MOVED error occurred by inspecting errorstats on all nodes
-        error_stats_dict = await glide_client.info(
+        post_error_stats = await glide_client.info(
             sections=[InfoSection.ERROR_STATS], route=AllNodes()
         )
-        assert isinstance(error_stats_dict, dict)
+        assert isinstance(post_error_stats, dict)
 
-        for node_address, node_info in error_stats_dict.items():
+        for node_address, node_info in post_error_stats.items():
             assert isinstance(node_info, bytes)
-            # Ensure the errorstats section indicates no errors reported for this test
-            # It should only contain the header line.
+            pre_info = pre_error_stats.get(node_address, b"")
+            # Verify no new MOVED errors appeared, which would indicate incorrect
+            # routing. We compare before/after to ignore pre-existing errors from
+            # concurrent tests.
             assert (
-                node_info.strip() == b"# Errorstats"
-            ), f"Node {node_address.decode()} reported errors: {node_info.decode()}"
+                b"errorstat_MOVED" not in node_info
+                or b"errorstat_MOVED" in pre_info
+            ), f"Node {node_address.decode()} reported new MOVED errors after batch: {node_info.decode()}"
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -76,6 +76,16 @@ async def exec_batch(
         )
 
 
+def _moved_error_count(node_info: bytes) -> int:
+    """Return the errorstat_MOVED count from an INFO errorstats section, or 0."""
+    for line in node_info.splitlines():
+        if line.startswith(b"errorstat_MOVED"):
+            _, _, count_field = line.partition(b"count=")
+            if count_field:
+                return int(count_field.split(b",")[0])
+    return 0
+
+
 @pytest.mark.anyio
 class TestBatch:
     @pytest.mark.parametrize("cluster_mode", [True, False])
@@ -777,11 +787,10 @@ class TestBatch:
             assert isinstance(node_info, bytes)
             pre_info = pre_error_stats.get(node_address, b"")
             # Verify no new MOVED errors appeared, which would indicate incorrect
-            # routing. We compare before/after to ignore pre-existing errors from
-            # concurrent tests.
-            assert (
-                b"errorstat_MOVED" not in node_info
-                or b"errorstat_MOVED" in pre_info
+            # routing. We compare the MOVED count before/after so pre-existing
+            # errors from concurrent tests do not mask a new one from this batch.
+            assert _moved_error_count(node_info) <= _moved_error_count(
+                pre_info
             ), f"Node {node_address.decode()} reported new MOVED errors after batch: {node_info.decode()}"
 
     @pytest.mark.parametrize("cluster_mode", [True])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -738,13 +738,16 @@ class TestSyncBatch:
         protocol: ProtocolVersion,
         is_atomic: bool,
     ):
-        if sync_check_if_server_version_lt(glide_sync_client, "6.0.0"):
-            pytest.skip("CONFIG RESETSTAT requires redis >= 6.0")
-
-        assert glide_sync_client.config_resetstat() == OK
-
         key = get_random_string(10)
         value_bytes = b"value"
+
+        # Capture MOVED error counts before the batch to compare afterward.
+        # Other tests running concurrently may leave residual error stats, so
+        # we only check that no NEW MOVED errors were introduced by this batch.
+        pre_error_stats = glide_sync_client.info(
+            sections=[InfoSection.ERROR_STATS], route=AllNodes()
+        )
+        assert isinstance(pre_error_stats, dict)
 
         batch = ClusterBatch(is_atomic=is_atomic)
         batch.set(key, value_bytes)
@@ -757,18 +760,21 @@ class TestSyncBatch:
         assert results == [OK, value_bytes]
 
         # Check that no MOVED error occurred by inspecting errorstats on all nodes
-        error_stats_dict = glide_sync_client.info(
+        post_error_stats = glide_sync_client.info(
             sections=[InfoSection.ERROR_STATS], route=AllNodes()
         )
-        assert isinstance(error_stats_dict, dict)
+        assert isinstance(post_error_stats, dict)
 
-        for node_address, node_info in error_stats_dict.items():
+        for node_address, node_info in post_error_stats.items():
             assert isinstance(node_info, bytes)
-            # Ensure the errorstats section indicates no errors reported for this test
-            # It should only contain the header line.
+            pre_info = pre_error_stats.get(node_address, b"")
+            # Verify no new MOVED errors appeared, which would indicate incorrect
+            # routing. We compare before/after to ignore pre-existing errors from
+            # concurrent tests.
             assert (
-                node_info.strip() == b"# Errorstats"
-            ), f"Node {node_address.decode()} reported errors: {node_info.decode()}"
+                b"errorstat_MOVED" not in node_info
+                or b"errorstat_MOVED" in pre_info
+            ), f"Node {node_address.decode()} reported new MOVED errors after batch: {node_info.decode()}"
 
     @pytest.mark.parametrize("cluster_mode", [True])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -74,6 +74,16 @@ def exec_batch(
         )
 
 
+def _moved_error_count(node_info: bytes) -> int:
+    """Return the errorstat_MOVED count from an INFO errorstats section, or 0."""
+    for line in node_info.splitlines():
+        if line.startswith(b"errorstat_MOVED"):
+            _, _, count_field = line.partition(b"count=")
+            if count_field:
+                return int(count_field.split(b",")[0])
+    return 0
+
+
 @pytest.mark.anyio
 class TestSyncBatch:
     @pytest.mark.parametrize("cluster_mode", [True, False])
@@ -769,11 +779,10 @@ class TestSyncBatch:
             assert isinstance(node_info, bytes)
             pre_info = pre_error_stats.get(node_address, b"")
             # Verify no new MOVED errors appeared, which would indicate incorrect
-            # routing. We compare before/after to ignore pre-existing errors from
-            # concurrent tests.
-            assert (
-                b"errorstat_MOVED" not in node_info
-                or b"errorstat_MOVED" in pre_info
+            # routing. We compare the MOVED count before/after so pre-existing
+            # errors from concurrent tests do not mask a new one from this batch.
+            assert _moved_error_count(node_info) <= _moved_error_count(
+                pre_info
             ), f"Node {node_address.decode()} reported new MOVED errors after batch: {node_info.decode()}"
 
     @pytest.mark.parametrize("cluster_mode", [True])


### PR DESCRIPTION
### Summary
Fix flaky `test_cluster_batch_route` and `test_sync_cluster_batch_route` tests that sporadically fail due to residual error stats from concurrent tests.

### Issue link
This Pull Request is linked to issue: [[Python][Flaky Test] test_cluster_batch_route - AssertionError on Errorstats residual count](https://github.com/valkey-io/valkey-glide/issues/6400)
Closes #6400

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The tests asserted that `INFO ERRORSTATS` on all cluster nodes returns a completely empty section (just `# Errorstats`). When other tests run concurrently, they can generate unrelated errors (e.g., `errorstat_ERR:count=2`) that pollute the error stats on shared cluster nodes, causing the assertion to fail spuriously.

**Fix:** Changed the assertion to only check for `MOVED` errors, which is what the test actually validates (that the batch was correctly routed to the target node without any MOVED redirections). The test now:
1. Captures error stats before the batch operation
2. Runs the batch with explicit slot-based routing
3. Verifies no new `errorstat_MOVED` entries appeared afterward

This approach is immune to unrelated error stats from concurrent tests while still correctly validating routing behavior.

### Limitations
None

### Testing
- Ran both tests 100 times with parallelism of 10 (`--count=100 -n 10 -x`): all 800 runs passed (400 async + 400 sync)
- Verified fix handles the exact failure scenario: deliberately triggered `errorstat_ERR:count=2` on a node and confirmed the test still passes
- Removed the `config_resetstat()` dependency and version check since the fix no longer requires resetting stats

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release