### PR TITLE
fix(java): use createClientWithRetry in failover_to_replica test

### DIFF
--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -14,6 +14,7 @@ import static glide.TestUtilities.checkFunctionStatsBinaryResponse;
 import static glide.TestUtilities.checkFunctionStatsResponse;
 import static glide.TestUtilities.commonClientConfig;
 import static glide.TestUtilities.concatenateArrays;
+import static glide.TestUtilities.createClientWithRetry;
 import static glide.TestUtilities.createLongRunningLuaScript;
 import static glide.TestUtilities.createLuaLibWithLongRunningFunction;
 import static glide.TestUtilities.generateLuaLibCode;
@@ -2259,7 +2260,8 @@ public class CommandTests {
             NodeAddress primaryAddr = standalone.getNodesAddr().get(0);
             GlideClientConfiguration config =
                     GlideClientConfiguration.builder().address(primaryAddr).protocol(protocol).build();
-            try (GlideClient client = GlideClient.createClient(config).get()) {
+            try (GlideClient client =
+                    createClientWithRetry(() -> GlideClient.createClient(config))) {
                 // Verify initial role is master
                 waitForRole(client, "master");
 


### PR DESCRIPTION
### Summary

Fix flaky test `failover_to_replica` that fails with "Connection refused" on Windows CI by using `createClientWithRetry` for client creation after starting a new ValkeyCluster.

### Issue link

This Pull Request is linked to issue: [failover_to_replica - Connection refused on Windows](https://github.com/valkey-io/valkey-glide/issues/6408)
Closes #6408

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The test creates a new standalone ValkeyCluster and immediately tries to connect. On Windows, port binding is slower, so the server may not be ready to accept connections when `GlideClient.createClient(config).get()` is called, resulting in "Connection refused".

**Fix:** Replace direct `.get()` with `createClientWithRetry(() -> GlideClient.createClient(config))` which retries client creation up to 3 times with 1-second backoff. This utility already exists in the codebase (added in PR #5343) for exactly this scenario.

### Limitations

None

### Testing

- Compilation verified locally
- Fix uses established `createClientWithRetry` pattern already validated across the codebase
- Full validation requires Windows CI (flakiness is Windows-specific)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release