### PR TITLE
fix(java): add retry logic to createDedicatedClient for Windows

### DIFF
--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -138,30 +138,33 @@ public class TestUtilities {
                                 .collect(Collectors.toList());
             }
 
-            return GlideClusterClient.createClient(
-                            GlideClusterClientConfiguration.builder()
-                                    .addresses(seedNodes)
-                                    .requestTimeout(2000)
-                                    .lazyConnect(lazyConnect)
-                                    // Explicitly set no credentials for dedicated clusters to avoid
-                                    // authentication issues from environment or global state
-                                    .credentials(null)
-                                    .build())
-                    .get();
+            final List<NodeAddress> finalSeedNodes = seedNodes;
+            return createClientWithRetry(
+                    () ->
+                            GlideClusterClient.createClient(
+                                    GlideClusterClientConfiguration.builder()
+                                            .addresses(finalSeedNodes)
+                                            .requestTimeout(2000)
+                                            .lazyConnect(lazyConnect)
+                                            // Explicitly set no credentials for dedicated clusters to avoid
+                                            // authentication issues from environment or global state
+                                            .credentials(null)
+                                            .build()));
         } else {
             List<NodeAddress> nodeAddresses =
                     addresses != null ? addresses : valkeyCluster.getNodesAddr();
 
-            return GlideClient.createClient(
-                            GlideClientConfiguration.builder()
-                                    .addresses(nodeAddresses)
-                                    .requestTimeout(2000)
-                                    .lazyConnect(lazyConnect)
-                                    // Explicitly set no credentials for dedicated clusters to avoid
-                                    // authentication issues from environment or global state
-                                    .credentials(null)
-                                    .build())
-                    .get();
+            return createClientWithRetry(
+                    () ->
+                            GlideClient.createClient(
+                                    GlideClientConfiguration.builder()
+                                            .addresses(nodeAddresses)
+                                            .requestTimeout(2000)
+                                            .lazyConnect(lazyConnect)
+                                            // Explicitly set no credentials for dedicated clusters to avoid
+                                            // authentication issues from environment or global state
+                                            .credentials(null)
+                                            .build()));
         }
     }
 


### PR DESCRIPTION
### Summary

Fix flaky test `test_lazy_connection_establishes_on_first_command` that fails with "Connection refused" on Windows CI by adding retry logic to the `createDedicatedClient` utility method.

### Issue link

This Pull Request is linked to issue: [test_lazy_connection_establishes_on_first_command - Connection refused on Windows](https://github.com/valkey-io/valkey-glide/issues/6409)
Closes #6409

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** `createDedicatedClient` in TestUtilities calls `.get()` directly on the client creation future. When a test spins up a fresh `ValkeyCluster` and immediately calls `createDedicatedClient`, the server may not yet be accepting connections on Windows due to slower port binding.

**Fix:** Wrap the `GlideClient.createClient(...)` and `GlideClusterClient.createClient(...)` calls inside `createDedicatedClient` with `createClientWithRetry`, which retries up to 3 times with 1-second backoff. This is the same utility already used elsewhere in the codebase for handling transient connection failures during test setup.

This fix benefits all tests that use `createDedicatedClient`, not just the specific test in this issue.

### Limitations

None

### Testing

- Compilation verified locally
- Fix uses established `createClientWithRetry` pattern already validated across the codebase
- Full validation requires Windows CI (flakiness is Windows-specific)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release