### PR TITLE
fix(java): use createClientWithRetry in TLS certificate tests

### DIFF
--- a/java/integTest/src/test/java/glide/DnsTest.java
+++ b/java/integTest/src/test/java/glide/DnsTest.java
@@ -95,7 +95,8 @@ public class DnsTest {
                                 .tlsAdvancedConfiguration(tlsConfig)
                                 .build());
             }
-            return GlideClusterClient.createClient(builder.build()).get();
+            GlideClusterClientConfiguration config = builder.build();
+            return createClientWithRetry(() -> GlideClusterClient.createClient(config));
         } else {
             GlideClientConfigurationBuilder<?, ?> builder =
                     GlideClientConfiguration.builder().address(address).useTLS(useTls);
@@ -105,7 +106,8 @@ public class DnsTest {
                 builder.advancedConfiguration(
                         AdvancedGlideClientConfiguration.builder().tlsAdvancedConfiguration(tlsConfig).build());
             }
-            return GlideClient.createClient(builder.build()).get();
+            GlideClientConfiguration config = builder.build();
+            return createClientWithRetry(() -> GlideClient.createClient(config));
         }
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/StandaloneTlsCertificateTest.java
+++ b/java/integTest/src/test/java/glide/standalone/StandaloneTlsCertificateTest.java
@@ -62,7 +62,8 @@ public class StandaloneTlsCertificateTest {
         GlideClientConfiguration config =
                 TestUtilities.createStandaloneConfigWithRootCert(caCert, nodeAddr);
 
-        try (GlideClient client = GlideClient.createClient(config).get()) {
+        try (GlideClient client =
+                TestUtilities.createClientWithRetry(() -> GlideClient.createClient(config))) {
             TestUtilities.assertConnected(client);
         }
     }
@@ -76,7 +77,8 @@ public class StandaloneTlsCertificateTest {
         GlideClientConfiguration config =
                 TestUtilities.createStandaloneConfigWithRootCert(certBundle, nodeAddr);
 
-        try (GlideClient client = GlideClient.createClient(config).get()) {
+        try (GlideClient client =
+                TestUtilities.createClientWithRetry(() -> GlideClient.createClient(config))) {
             TestUtilities.assertConnected(client);
         }
     }


### PR DESCRIPTION
### Summary

Fix flaky TLS certificate tests (`testTlsConnectWithHostnameInCert`, `testStandaloneTlsWithMultipleCertificatesSucceeds`, `testStandaloneTlsWithSelfSignedCertificateSucceeds`) that fail with connection timeouts on Windows CI.

### Issue link

This Pull Request is linked to issue: [TLS certificate tests failing on Windows - Connection timeout](https://github.com/valkey-io/valkey-glide/issues/6410)
Closes #6410

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The TLS tests in `StandaloneTlsCertificateTest` and `DnsTest` use `GlideClient.createClient(config).get()` directly. On Windows, the TLS handshake combined with port-binding delays causes the default ~2-second connection timeout to be exceeded.

**Fix:** Replace direct `.get()` calls with `createClientWithRetry(() -> GlideClient.createClient(config))` in:
- `StandaloneTlsCertificateTest.testStandaloneTlsWithSelfSignedCertificateSucceeds`
- `StandaloneTlsCertificateTest.testStandaloneTlsWithMultipleCertificatesSucceeds`
- `DnsTest.buildClient` (used by `testTlsConnectWithHostnameInCert`)

The retry approach (3 attempts, 1-second backoff) is preferable to globally increasing connection timeouts.

### Limitations

None

### Testing

- Compilation verified locally
- Fix uses established `createClientWithRetry` pattern already validated across the codebase
- Full validation requires Windows CI (flakiness is Windows-specific)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release