### PR TITLE
fix(java): use createClientWithRetry in AZ affinity tests

### DIFF
--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -82,13 +82,13 @@ public class ConnectionTests {
 
     @SneakyThrows
     public GlideClusterClient createAzTestClient(String az) {
-        return GlideClusterClient.createClient(
-                        azClusterClientConfig()
-                                .readFrom(ReadFrom.AZ_AFFINITY)
-                                .clientAZ(az)
-                                .requestTimeout(2000)
-                                .build())
-                .get();
+        GlideClusterClientConfiguration config =
+                azClusterClientConfig()
+                        .readFrom(ReadFrom.AZ_AFFINITY)
+                        .clientAZ(az)
+                        .requestTimeout(2000)
+                        .build();
+        return createClientWithRetry(() -> GlideClusterClient.createClient(config));
     }
 
     @SneakyThrows
@@ -221,8 +221,10 @@ public class ConnectionTests {
         int nGetCalls = 3;
         String getCmdstat = String.format("cmdstat_get:calls=%d", nGetCalls);
 
+        GlideClusterClientConfiguration configSetConfig =
+                azClusterClientConfig().requestTimeout(2000).build();
         GlideClusterClient configSetClient =
-                GlideClusterClient.createClient(azClusterClientConfig().requestTimeout(2000).build()).get();
+                createClientWithRetry(() -> GlideClusterClient.createClient(configSetConfig));
 
         // reset availability zone for all nodes
         configSetClient.configSet(Collections.singletonMap("availability-zone", ""), ALL_NODES).get();


### PR DESCRIPTION
### Summary

Fix flaky AZ affinity tests (`test_routing_with_az_affinity_strategy_to_1_replica` and `test_az_affinity_non_existing_az`) that fail with ~2.5s connection timeouts on Windows CI.

### Issue link

This Pull Request is linked to issue: [AZ affinity routing tests failing on Windows](https://github.com/valkey-io/valkey-glide/issues/6411)
Closes #6411

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The AZ affinity tests use `GlideClusterClient.createClient(azClusterClientConfig().requestTimeout(2000).build()).get()` which times out at exactly 2000ms on Windows because the server is not ready to accept connections after cluster setup.

**Fix:** 
- Modified `createAzTestClient` to use `createClientWithRetry` instead of direct `.get()`
- Modified the inline `configSetClient` creation in `test_routing_with_az_affinity_strategy_to_1_replica` to also use `createClientWithRetry`

The retry approach (3 attempts, 1-second backoff) allows the server enough time to complete port binding on Windows.

### Limitations

None

### Testing

- Compilation verified locally
- Fix uses established `createClientWithRetry` pattern already validated across the codebase
- Full validation requires Windows CI (flakiness is Windows-specific)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release