### PR TITLE
fix(java): increase MESSAGE_DELIVERY_DELAY for PubSub on Windows

### DIFF
--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -305,7 +305,7 @@ public class PubSubTests {
     /** Other clients used in a test. */
     private final List<BaseClient> senders = new ArrayList<>();
 
-    private static final int MESSAGE_DELIVERY_DELAY = 500; // ms
+    private static final int MESSAGE_DELIVERY_DELAY = isWindows() ? 1500 : 500; // ms
 
     @AfterEach
     @SneakyThrows


### PR DESCRIPTION
### Summary

Fix flaky PubSub test `pattern_many_channels` (Lazy subscribe, Sync read, cluster mode) that fails on Windows by increasing `MESSAGE_DELIVERY_DELAY` for Windows.

### Issue link

This Pull Request is linked to issue: [PubSub pattern_many_channels - Lazy subscribe failure on Windows](https://github.com/valkey-io/valkey-glide/issues/6412)
Closes #6412

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** `MESSAGE_DELIVERY_DELAY` is 500ms which is insufficient on Windows for lazy pattern subscriptions to fully propagate in cluster mode before messages are published. Messages published before the subscription is ready are lost.

**Fix:** Increase `MESSAGE_DELIVERY_DELAY` from 500ms to 1500ms on Windows using the existing `isWindows()` conditional pattern:
```java
private static final int MESSAGE_DELIVERY_DELAY = isWindows() ? 1500 : 500; // ms
```

This follows the same pattern already used for `REQUEST_TIMEOUT` and `SUBSCRIBE_TIMEOUT` in PubSubTests which are tripled for Windows (5000ms -> 15000ms).

PubSub subscription propagation inherently requires a time-based wait since there is no way to poll for a "subscription ready" state.

### Limitations

None

### Testing

- Compilation verified locally
- Follows existing Windows timeout scaling pattern in PubSubTests
- Full validation requires Windows CI (flakiness is Windows-specific)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release