### PR TITLE
fix(java): increase ACL subscription metrics polling timeouts on Windows

### DIFF
--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -2938,11 +2938,12 @@ public class PubSubTests {
 
             // Subscribe (will fail due to ACL)
             listeningClient.subscribeLazy(createSet(channel)).get();
-            Thread.sleep(500);
+            Thread.sleep(isWindows() ? 2000 : 500);
 
             // Poll for metric increment
             long outOfSyncCount = initialOutOfSync;
-            for (int i = 0; i < 15; i++) {
+            int maxAttempts = isWindows() ? 25 : 15;
+            for (int i = 0; i < maxAttempts; i++) {
                 Thread.sleep(1000);
                 Map<String, String> stats = listeningClient.getStatistics();
                 outOfSyncCount = Long.parseLong(stats.getOrDefault("subscription_out_of_sync_count", "0"));


### PR DESCRIPTION
### Summary

Fix flaky test `test_subscription_metrics_on_acl_failure_cluster` that fails on Windows CI after ~5.6 seconds by increasing the initial wait and poll loop iterations.

### Issue link

This Pull Request is linked to issue: [test_subscription_metrics_on_acl_failure_cluster on Windows](https://github.com/valkey-io/valkey-glide/issues/6413)
Closes #6413

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** After calling `subscribeLazy`, the test waits only 500ms before starting to poll for the ACL failure metric. On Windows, the subscription attempt, ACL rejection, and metric propagation through the cluster take longer. The test was failing at ~5.6s because the initial 500ms + a few 1-second poll iterations werent enough.

**Fix:**
- Increase initial wait after `subscribeLazy` from 500ms to 2000ms on Windows
- Increase poll loop iterations from 15 to 25 on Windows (total possible wait: 2s + 25s = 27s)

```java
Thread.sleep(isWindows() ? 2000 : 500);
int maxAttempts = isWindows() ? 25 : 15;
```

The test already uses a poll-and-check pattern (not a fixed sleep), so the additional time only applies when the metric hasnt yet been incremented.

### Limitations

None

### Testing

- Compilation verified locally
- Follows existing Windows-specific timeout patterns in PubSubTests
- Full validation requires Windows CI (flakiness is Windows-specific)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release