### PR TITLE
Fix flaky test_socket_listener assertion failure in standalone mode

### DIFF
--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -44,11 +44,17 @@ pub enum ServerType {
 }
 
 type SharedServer = Lazy<Mutex<Option<RedisServer>>>;
-static SHARED_SERVER: SharedServer =
-    Lazy::new(|| Mutex::new(Some(RedisServer::new(ServerType::Tcp { tls: false }))));
+static SHARED_SERVER: SharedServer = Lazy::new(|| {
+    let server = RedisServer::new(ServerType::Tcp { tls: false });
+    block_on_all(wait_for_server_to_become_ready(&server.get_client_addr()));
+    Mutex::new(Some(server))
+});
 
-static SHARED_TLS_SERVER: SharedServer =
-    Lazy::new(|| Mutex::new(Some(RedisServer::new(ServerType::Tcp { tls: true }))));
+static SHARED_TLS_SERVER: SharedServer = Lazy::new(|| {
+    let server = RedisServer::new(ServerType::Tcp { tls: true });
+    block_on_all(wait_for_server_to_become_ready(&server.get_client_addr()));
+    Mutex::new(Some(server))
+});
 
 static SHARED_SERVER_ADDRESS: Lazy<ConnectionAddr> = Lazy::new(|| {
     SHARED_SERVER


### PR DESCRIPTION
### Summary
Fix race condition in shared test server initialization that caused `test_socket_listener` Standalone tests to fail with assertion `4294967295 != 0`.

### Issue link
This Pull Request is linked to issue: [Rust: test_socket_listener tests flaky in Standalone mode](https://github.com/valkey-io/valkey-glide/issues/6434)
Closes #6434

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** `SHARED_SERVER` and `SHARED_TLS_SERVER` lazy initializers in `glide-core/tests/utilities/mod.rs` spawned redis-server processes without waiting for them to accept connections. When tests ran immediately after initialization, connection attempts would fail with `ConnectionError`, causing the callback index to be returned as `u32::MAX` (4294967295) instead of the expected `0`.

**Fix:** Added `block_on_all(wait_for_server_to_become_ready(...))` calls to both `SHARED_SERVER` and `SHARED_TLS_SERVER` lazy initializers. This ensures the servers are fully ready to accept connections before any test uses them.

### Limitations
None

### Testing
Ran the 14 previously-failing Standalone tests 20 consecutive times with 0 failures.

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release