### PR TITLE
Go: allow committing vendored module by removing shipped .gitignore

### DIFF
--- a/.github/workflows/go-cd.yml
+++ b/.github/workflows/go-cd.yml
@@ -232,6 +232,13 @@ jobs:
                   RELEASE_VERSION=${{ needs.validate-release-version.outputs.RELEASE_VERSION }}
                   git config user.name github-actions
                   git config user.email github-actions@github.com
+                  # Remove go/.gitignore from the released module. 'go mod vendor'
+                  # copies this file into the consumer's vendor/ tree, where its
+                  # rules (*.pb.go, rustbin/, lib.h) cause git to silently drop the
+                  # generated artifacts we force-add below when the consumer commits
+                  # vendor/. This tag commit is never merged back to main, so main
+                  # keeps its .gitignore for development. See issue #6437.
+                  rm -f $GITHUB_WORKSPACE/go/.gitignore
                   git add -f go
                   git status
                   git commit -m "Automated commit from GitHub Actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
+* Go: Remove `.gitignore` from the released module so consumers who commit `vendor/` keep the generated artifacts (`internal/protobuf/*.pb.go`, `rustbin/**`, `lib.h`) ([#6441](https://github.com/valkey-io/valkey-glide/pull/6441))
 
 ### Changes
 


### PR DESCRIPTION
### Summary

The Go client does not work reliably for consumers that run `go mod vendor` **and commit the `vendor/` directory into VCS**. The released module ships a module-root `.gitignore` (`go/.gitignore`) that `go mod vendor` copies into the consumer's vendor tree. When the consumer commits `vendor/`, git honors that nested `.gitignore` and silently drops the generated artifacts that the release process force-adds (`internal/protobuf/*.pb.go`, `rustbin/**`, `lib.h`). A teammate who later checks out the repo without re-running `go mod vendor` gets an incomplete vendor tree and the build fails.

This PR removes `go/.gitignore` from the released module in the CD workflow so the published module can be vendored and committed as-is.

### Issue link

This Pull Request is linked to issue: [[Inquiry] Is valkey-glide meant to work on go vendor mode?](https://github.com/valkey-io/valkey-glide/issues/6437)
Closes #6437

### Features / Behaviour Changes

- The released Go module (`github.com/valkey-io/valkey-glide/go/v2@<version>`) no longer contains a `.gitignore` file.
- Consumers can now run `go mod vendor` and commit `vendor/` to their VCS without the generated artifacts being stripped by git. No manual post-vendor cleanup is required going forward.
- No change to development on `main`: the release step operates only on the tag commit, which is never merged back, so `go/.gitignore` is retained for day-to-day development.

### Implementation

Single change in `.github/workflows/go-cd.yml`, job `commit-auto-gen-files-with-tag`, step `Commit and push tag`. A `rm -f $GITHUB_WORKSPACE/go/.gitignore` is added immediately before `git add -f go`:

```yaml
git config user.name github-actions
git config user.email github-actions@github.com
# Remove go/.gitignore from the released module. 'go mod vendor'
# copies this file into the consumer's vendor/ tree, where its
# rules (*.pb.go, rustbin/, lib.h) cause git to silently drop the
# generated artifacts we force-add below when the consumer commits
# vendor/. This tag commit is never merged back to main, so main
# keeps its .gitignore for development. See issue #6437.
rm -f $GITHUB_WORKSPACE/go/.gitignore
git add -f go
```

**Why this is the correct layer:** The release job already force-adds the generated files with `git add -f go` so they land in the published module. The remaining problem is purely the presence of the ignore rules inside the shipped module. Deleting the file on the tag commit is the minimal, self-contained fix and needs no changes to consumers.

**Root cause detail (for reviewers):** `go mod vendor` copies non-`.go` files it does not recognize on the assumption they may be build inputs (`cmd/go/internal/modcmd/vendor.go` → `matchPotentialSourceFile` returns `true` for unknown files; `copyDir` applies no dotfile exclusion). Because the module root `go/` is an imported package (`github.com/valkey-io/valkey-glide/go/v2`), its `.gitignore` is copied verbatim into `vendor/github.com/valkey-io/valkey-glide/go/v2/.gitignore`, then re-applied by git on the consumer side.

**Relation to prior work:** PR #5071 (issue #4721) made `go mod vendor` *include* the `rustbin/` platform directories via `doc.go`/`tools.go` markers and force-adds. That fixed module contents but left the shipped `.gitignore`, which re-ignores those files downstream on commit. This PR closes that gap.

### Limitations

- The fix applies to future releases produced by the CD workflow. Already-published versions still contain `.gitignore`; for those, consumers can use the workaround: run `go mod vendor` then `rm -f vendor/github.com/valkey-io/valkey-glide/go/v2/.gitignore` before committing `vendor/` (this restores both `internal/protobuf/*.pb.go` and `rustbin/**`).
- No change to non-vendor workflows (module-cache builds), which were already unaffected.

### Testing

Reproduced and verified the root cause and fix against the published `v2.4.2` module:

- After `go mod vendor`: `internal/protobuf/*.pb.go` and the nested `.gitignore` are both present in the vendor tree.
- `git add -A` + `git ls-files` shows the `.pb.go` files are NOT tracked; `git check-ignore -v` attributes this to `vendor/.../go/v2/.gitignore:2:*.pb.go` (and `:19:rustbin/` for the native libs).
- Removing the nested `.gitignore` and re-running `git add -A` results in the `internal/protobuf/*.pb.go` and `rustbin/**` files being tracked — confirming the module-level fix resolves the issue.
- The reporter's [sample project](https://github.com/severedsea/valkey-glide-go-vendor-ignore) was checked out and its committed vendor tree is missing `internal/protobuf/`, matching the reported failure.
- YAML validity of `go-cd.yml` confirmed after the edit.

The change is limited to the CD workflow; it will be exercised end-to-end on the next Go release.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated. <!-- N/A - CI/release workflow change; validated manually against v2.4.2 as described in Testing -->
-   [ ] CHANGELOG.md and documentation files are updated. <!-- add a CHANGELOG entry under the pending release section if required by maintainers -->
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). <!-- N/A for a workflow YAML change; YAML validated -->
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
