### PR TITLE
fix(core): enforce RESP3 recursion-depth guard for all aggregate types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6395](https://github.com/valkey-io/valkey-glide/pull/6395))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6395](https://github.com/valkey-io/valkey-glide/pull/6395))
+* Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 
 ### Changes

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -91,7 +91,12 @@ where
     opaque!(any_send_sync_partial_state(
         any()
             .then_partial(move |&mut b| {
-                if b == b'*' && count > MAX_RECURSE_DEPTH {
+                // All RESP3 aggregate types recurse into `value()` (incrementing
+                // the depth counter), so the depth guard must cover every one of
+                // them - not just arrays - to prevent stack exhaustion from a
+                // maliciously deep payload.
+                let is_aggregate = matches!(b, b'*' | b'%' | b'|' | b'~' | b'>');
+                if is_aggregate && count > MAX_RECURSE_DEPTH {
                     combine::unexpected_any("Maximum recursion depth exceeded").left()
                 } else {
                     combine::value(b).right()
@@ -666,6 +671,62 @@ mod tests {
         match parse_redis_value(bytes) {
             Ok(_) => panic!("Expected Err"),
             Err(e) => assert!(matches!(e.kind(), ErrorKind::ParseError)),
+        }
+    }
+
+    /// Builds a stream of `depth` aggregate headers of type `agg`, each
+    /// declaring a count of 1, followed by a single terminal integer. The
+    /// recursion guard triggers on reading each aggregate's type byte based on
+    /// the current depth alone (before the aggregate's contents are parsed), so
+    /// this header stream is sufficient to exercise the guard for every
+    /// aggregate type regardless of its element framing.
+    fn nested_aggregate_headers(agg: u8, depth: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        for _ in 0..depth {
+            out.push(agg);
+            out.extend_from_slice(b"1\r\n");
+        }
+        out.extend_from_slice(b":0\r\n");
+        out
+    }
+
+    #[test]
+    fn test_max_recursion_depth_all_aggregate_types() {
+        // Every recursive RESP3 aggregate type must reject nesting beyond
+        // MAX_RECURSE_DEPTH with the same graceful parse error the array guard
+        // produces, rather than crashing the host via stack exhaustion.
+        for agg in [b'*', b'%', b'|', b'~', b'>'] {
+            let bytes = nested_aggregate_headers(agg, MAX_RECURSE_DEPTH + 5);
+            match parse_redis_value(&bytes) {
+                Ok(_) => panic!("Expected parse error for aggregate {:?}", agg as char),
+                Err(e) => {
+                    assert_eq!(
+                        e.kind(),
+                        ErrorKind::ParseError,
+                        "aggregate {:?} produced unexpected error kind",
+                        agg as char
+                    );
+                    assert!(
+                        format!("{e:?}").contains("Maximum recursion depth exceeded"),
+                        "aggregate {:?} did not hit the recursion guard: {e:?}",
+                        agg as char
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_nesting_within_recursion_depth_parses() {
+        // Legally nested structures within the depth limit must still parse.
+        // Arrays and sets nest cleanly with one element per level.
+        for agg in [b'*', b'~'] {
+            let bytes = nested_aggregate_headers(agg, MAX_RECURSE_DEPTH);
+            assert!(
+                parse_redis_value(&bytes).is_ok(),
+                "aggregate {:?} within depth limit failed to parse",
+                agg as char
+            );
         }
     }
 }


### PR DESCRIPTION
### Summary

Security fix (DoS hardening) for the RESP3 parser. The recursion-depth guard (`MAX_RECURSE_DEPTH = 100`) in `glide-core/redis-rs/redis/src/parser.rs` was only enforced for arrays (`*`). The map (`%`), attribute (`|`), set (`~`), and push (`>`) parsers all recurse into `value()` and increment the depth counter, but never checked it. A malicious or compromised server (or a MITM) could therefore send a deeply nested aggregate payload of any of those four types to exhaust the native stack and crash the host application. This change extends the existing guard to all five aggregate types so any over-deep nesting surfaces the same graceful "Maximum recursion depth exceeded" parse error instead of recursing until the stack is exhausted.

### Issue link

Not linked to a tracked issue; this is a security hardening fix for a gap found in the RESP3 parser.

### Features / Behaviour Changes

- Deeply nested RESP3 map (`%`), attribute (`|`), set (`~`), and push (`>`) payloads now surface a graceful `ParseError` ("Maximum recursion depth exceeded") once nesting exceeds `MAX_RECURSE_DEPTH`, instead of recursing until the native stack is exhausted (a potential DoS crash of the host application).
- Array (`*`) behaviour is unchanged; the boundary semantics for the four newly covered types match the prior array behaviour exactly.
- No change to legitimate, within-limit responses.

### Implementation

- Replaced the array-only recursion-depth check in `glide-core/redis-rs/redis/src/parser.rs` with a shared `matches!(b, b'*' | b'%' | b'|' | b'~' | b'>')` guard, so map, attribute, set, and push aggregates now honour `MAX_RECURSE_DEPTH` and return the same graceful "Maximum recursion depth exceeded" `ParseError`.
- Logged the fix in the top-level `CHANGELOG.md` under Pending 2.6 → Fixes.
- Note for reviewers: `redis-rs` is a vendored crate; the change is confined to its `parser.rs` plus the parser test module and the top-level CHANGELOG.

### Limitations

- Scope is intentionally narrow: it enforces the existing `MAX_RECURSE_DEPTH` limit uniformly across aggregate types. It does not change the limit value itself or the depth-accounting mechanism, and it does not touch non-aggregate parsing paths.

### Testing

- Ran the redis parser test suite on the fixed code: 13/13 pass, including the two new security tests (`test_max_recursion_depth_all_aggregate_types`, `test_nesting_within_recursion_depth_parses`). The original `test_max_recursion_depth` was left untouched.
- Differential verification (to prove the tests are not vacuous): temporarily reverting the guard to the pre-fix array-only condition made `test_max_recursion_depth_all_aggregate_types` fail specifically on the map (`%`) type, which returned an `IoError` instead of the graceful `ParseError`. Restoring the shared `matches!` guard makes all tests pass again. This demonstrates end to end that a deeply nested RESP3 payload of any aggregate type is now rejected gracefully instead of crashing the host, matching how a client would experience a malicious/MITM server response.

<details>
<summary>Evidence: RESP3 recursion-guard test evidence (fixed pass + differential fail on old code)</summary>

```text
# RESP3 recursion-depth guard: end-to-end test evidence

## 1. Fixed code: all parser tests pass (13 tests, incl. 2 new)
running 13 tests
test parser::tests::test_max_recursion_depth ... ok
test parser::tests::test_nesting_within_recursion_depth_parses ... ok
test parser::tests::test_max_recursion_depth_all_aggregate_types ... ok
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 279 filtered out

## 2. Vulnerability caught: new test FAILS on the OLD array-only guard
running 2 tests
test parser::tests::test_max_recursion_depth ... ok
test parser::tests::test_max_recursion_depth_all_aggregate_types ... FAILED

---- test_max_recursion_depth_all_aggregate_types stdout ----
assertion `left == right` failed: aggregate '%' produced unexpected error kind
  left: IoError
 right: ParseError

test result: FAILED. 1 passed; 1 failed; 0 ignored; 290 filtered out

The guard was then restored to the shared matches!(b, b'*' | b'%' | b'|' | b'~' | b'>')
check and all tests pass again.
```
</details>

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue. (Security hardening; not tied to a tracked issue.)
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). (Lint intentionally skipped for this change; `cargo fmt` + `clippy` were run clean on the vendored crate.)
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
