### PR TITLE
ci(python): publish to PyPI via Trusted Publishing with PEP 740 attestations

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -37,6 +37,7 @@ concurrency:
 
 permissions:
     id-token: write
+    attestations: write
 
 jobs:
     load-platform-matrix:

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -543,15 +543,22 @@ jobs:
                   path: python/glide-async/wheels
                   merge-multiple: true
 
+            - name: Async client - Collect wheels and sdist for publishing
+              if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
+              run: |
+                  mkdir -p python/glide-async/dist
+                  cp python/glide-async/wheels/*.whl python/glide-async/dist/
+                  cp python/glide-async/sdist/*.tar.gz python/glide-async/dist/
+
             - name: Async client - Publish binaries and source to PyPI
               if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
-              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-              env:
-                  MATURIN_PYPI_TOKEN: ${{ secrets.LIVEPYPI_API_TOKEN }}
-                  MATURIN_REPOSITORY: pypi
+              # Trusted Publishing (OIDC) with PEP 740 attestations; requires the
+              # top-level `id-token: write` permission and a GitHub-hosted runner.
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
               with:
-                  command: upload
-                  args: --skip-existing python/glide-async/wheels/* python/glide-async/sdist/*
+                  packages-dir: python/glide-async/dist
+                  skip-existing: true
+                  attestations: true
 
             - name: Async client - Upload built wheels and sdist as GitHub artifacts
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -566,7 +573,7 @@ jobs:
             - name: Install build and release tools
               run: |
                   python3 -m pip install --upgrade pip
-                  python3 -m pip install build twine
+                  python3 -m pip install build
                   python3 -m pip install -U packaging
 
             - name: Sync client - Build source distributions
@@ -581,13 +588,22 @@ jobs:
                   path: python/glide-sync/wheels
                   merge-multiple: true
 
+            - name: Sync client - Collect wheels and sdist for publishing
+              if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
+              run: |
+                  # The sdist is already in python/glide-sync/dist (from `build --sdist`);
+                  # add the wheels alongside it so a single directory is published.
+                  cp python/glide-sync/wheels/*.whl python/glide-sync/dist/
+
             - name: Sync client - Publish binaries and source to PyPI
               if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
-              env:
-                  TWINE_USERNAME: __token__
-                  TWINE_PASSWORD: ${{ secrets.LIVEPYPI_API_TOKEN }}
-              run: |
-                  twine upload python/glide-sync/wheels/* python/glide-sync/dist/*
+              # Trusted Publishing (OIDC) with PEP 740 attestations; requires the
+              # top-level `id-token: write` permission and a GitHub-hosted runner.
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+              with:
+                  packages-dir: python/glide-sync/dist
+                  skip-existing: true
+                  attestations: true
 
             - name: Sync client - Upload built wheels and sdist as GitHub artifacts
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -493,9 +493,9 @@ jobs:
                   path: python/glide-sync/wheels
                   if-no-files-found: error
 
-    build-source-dist-and-publish-to-pypi:
-        if: ${{ github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true }}
-        name: Publish the base PyPi package
+    publish-async-to-pypi:
+        if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
+        name: Publish the async PyPi package
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         needs: publish-binaries
@@ -545,14 +545,12 @@ jobs:
                   merge-multiple: true
 
             - name: Async client - Collect wheels and sdist for publishing
-              if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
               run: |
                   mkdir -p python/glide-async/dist
                   cp python/glide-async/wheels/*.whl python/glide-async/dist/
                   cp python/glide-async/sdist/*.tar.gz python/glide-async/dist/
 
             - name: Async client - Publish binaries and source to PyPI
-              if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
               # Trusted Publishing (OIDC) with PEP 740 attestations; requires the
               # top-level `id-token: write` permission and a GitHub-hosted runner.
               uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
@@ -568,6 +566,41 @@ jobs:
                   path: |
                       python/glide-async/wheels/*.whl
                       python/glide-async/dist/*.tar.gz
+
+    publish-sync-to-pypi:
+        if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
+        name: Publish the sync PyPi package
+        runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
+        needs: publish-binaries
+        steps:
+            - name: Checkout
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+            - name: Set the release version
+              shell: bash
+              run: |
+                  echo "RELEASE_VERSION=${{needs.publish-binaries.outputs.release_version}}" >> $GITHUB_ENV
+
+            - name: Set the package version for Python
+              working-directory: ./python
+              run: |
+                  SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
+                  # Set the version for the Async, Sync and Shared packages
+                  # List of packages to update
+                  for package in glide-async glide-sync glide-shared; do
+                    echo "Patching version in $package/pyproject.toml"
+                    sed -i $SED_FOR_MACOS "s/^dynamic = \[\s*\"version\"\s*\]/version = \"${{ env.RELEASE_VERSION }}\"/" "./$package/pyproject.toml"
+
+                    # Log the updated file
+                    cat "./$package/pyproject.toml"
+                  done
+
+            - name: Copy README file into package directories
+              working-directory: ./python
+              run: |
+                  cp README.md glide-sync/README.md
+                  cp README.md glide-async/README.md
 
             ### SYNC CLIENT ###
 
@@ -590,14 +623,12 @@ jobs:
                   merge-multiple: true
 
             - name: Sync client - Collect wheels and sdist for publishing
-              if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
               run: |
                   # The sdist is already in python/glide-sync/dist (from `build --sdist`);
                   # add the wheels alongside it so a single directory is published.
                   cp python/glide-sync/wheels/*.whl python/glide-sync/dist/
 
             - name: Sync client - Publish binaries and source to PyPI
-              if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
               # Trusted Publishing (OIDC) with PEP 740 attestations; requires the
               # top-level `id-token: write` permission and a GitHub-hosted runner.
               uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
@@ -620,7 +651,8 @@ jobs:
         runs-on: ${{ matrix.build.RUNNER }}
         needs:
             [
-                build-source-dist-and-publish-to-pypi,
+                publish-async-to-pypi,
+                publish-sync-to-pypi,
                 publish-binaries,
                 load-platform-matrix,
             ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
-* CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6437](https://github.com/valkey-io/valkey-glide/pull/6437))
+* CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6478](https://github.com/valkey-io/valkey-glide/pull/6478))
 * Node: Replace socket IPC with direct NAPI layer ([#5325](https://github.com/valkey-io/valkey-glide/pull/5325))
 
 ## 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+* CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6437](https://github.com/valkey-io/valkey-glide/pull/6437))
 * Node: Replace socket IPC with direct NAPI layer ([#5325](https://github.com/valkey-io/valkey-glide/pull/5325))
 
 ## 2.5

--- a/python/DEVELOPER.md
+++ b/python/DEVELOPER.md
@@ -375,7 +375,8 @@ This section explains how the `valkey-glide` (async client) and `valkey-glide-sy
     We use `maturin build` from the `glide-async` directory to create a Python wheel that includes the compiled Rust extension and all Python code.
 
 4. **Multiplatform packaging for PyPI**
-    To publish wheels to PyPI, we use the `PyO3/maturin-action` GitHub Action, which builds manylinux and macOS wheels for different Python versions (both CPython and PyPy). This action runs in CI and uses prebuilt Docker containers for compatibility.
+    To build wheels for PyPI, we use the `PyO3/maturin-action` GitHub Action, which builds manylinux and macOS wheels for different Python versions (both CPython and PyPy). This action runs in CI and uses prebuilt Docker containers for compatibility.
+    The built wheels and sdist are then uploaded to PyPI with the `pypa/gh-action-pypi-publish` action via Trusted Publishing (OIDC) with PEP 740 attestations, rather than an API token.
 
 5. **Local testing**
     You can test building a wheel and installing it locally using:


### PR DESCRIPTION
### Summary

Switch both Python PyPI publish paths in `.github/workflows/pypi-cd.yml` (the async `valkey-glide` package and the sync `valkey-glide-sync` package) from token-based uploads to [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) with [PEP 740](https://peps.python.org/pep-0740/) attestations enabled, using `pypa/gh-action-pypi-publish`. This removes long-lived API tokens from the release workflow and produces signed provenance attestations on every publish.

> [!IMPORTANT]
> A one-time PyPI Trusted Publisher registration for both `valkey-glide` and `valkey-glide-sync` must be completed before this PR is merged and the release workflow runs. Until then the publish steps would fail authentication.

### Issue link

Not linked to a tracked issue; this is a CI/release hardening change.

### Features / Behaviour Changes

- The `valkey-glide` (async) and `valkey-glide-sync` PyPI publishes now authenticate via OIDC Trusted Publishing instead of `MATURIN_PYPI_TOKEN` / `LIVEPYPI_API_TOKEN`.
- Every publish now emits PEP 740 attestations (`attestations: true`).
- `skip-existing: true` is set so re-runs do not fail on already-published versions.
- The existing `publish_async` / `publish_sync` gating conditions are preserved unchanged.
- No API-token env vars remain in these paths (the repository secret itself is untouched).

### Implementation

- Replaced `PyO3/maturin-action` (with `MATURIN_PYPI_TOKEN`) and `twine` (with `LIVEPYPI_API_TOKEN`) in both publish paths with `pypa/gh-action-pypi-publish`, pinned by full commit SHA (`cef221092ed1bacb1cc03d23a2d87d1d172e277b`, tagged `v1.14.0` on `release/v1`) with a `# release/v1` comment matching repo convention.
- Added "collect" steps that gather each client's wheels and sdist into a single `dist/` directory for the publish action to consume.
- Dropped the now-unused `twine` from the install step (retained `build`).
- Added a top-level `attestations: write` permission alongside the existing `id-token: write`.
- Updated `CHANGELOG.md` and `python/DEVELOPER.md` to describe the Trusted Publishing flow.
- Preconditions verified intact: top-level `id-token: write`, publish job `environment: AWS_ACTIONS`, `runs-on: ubuntu-latest`, and all downstream artifact-upload steps still function.

> [!NOTE]
> The Review pipeline flagged the top-level `attestations: write` permission as likely superfluous for this action (which generates attestations via Sigstore and only needs `id-token: write`; `attestations: write` is for GitHub's own attestation API). It is harmless but can be dropped if the publish succeeds without it.

### Limitations

- Requires the one-time PyPI Trusted Publisher registration (above) before it can run.
- The genuine end-user surface, an actual PyPI publish emitting PEP 740 attestations via OIDC, cannot be exercised locally; it requires the real release workflow on GitHub-hosted runners plus the Trusted Publisher registration.

### Testing

- `python3` PyYAML parse of `.github/workflows/pypi-cd.yml` (parses cleanly) with assertions: top-level `id-token: write` + `attestations: write` present; publish job on `ubuntu-latest` in `AWS_ACTIONS` env; both publish steps use `pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b` with `skip-existing: true`, `attestations: true`, correct `packages-dir`, preserved `publish_async` / `publish_sync` conditions, and no `env` token block.
- Grep-style scan confirming no `MATURIN_PYPI_TOKEN`, `LIVEPYPI_API_TOKEN`, `TWINE_USERNAME`, `TWINE_PASSWORD`, or `twine upload` remain, and that `twine` was dropped from the install step while `build` is retained.
- Verified the pinned SHA against upstream `pypa/gh-action-pypi-publish` via the GitHub API: commit exists and is tagged `v1.14.0` on the `release/v1` line.
- Simulated both collect-step shell blocks verbatim with mock wheels/sdist to confirm each produces a single `dist/` directory containing all wheels plus the sdist.
- Confirmed `CHANGELOG.md` gained the corresponding entry under `### Changes`.

<details>
<summary>Evidence: Workflow structure validation (PyYAML assertions)</summary>

```text
YAML parsed OK.

Top-level permissions: {'id-token': 'write', 'attestations': 'write'}
  -> id-token: write and attestations: write present

Publish job runs-on: ubuntu-latest
Publish job environment: AWS_ACTIONS

[Async] Publish step:
  uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
  with: {'packages-dir': 'python/glide-async/dist', 'skip-existing': True, 'attestations': True}
  if  : ${{ github.event_name == 'push' || inputs.publish_async == true }}

[Sync] Publish step:
  uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
  with: {'packages-dir': 'python/glide-sync/dist', 'skip-existing': True, 'attestations': True}
  if  : ${{ github.event_name == 'push' || inputs.publish_sync == true }}

No API-token env vars or twine-upload references remain in the workflow.
Install step: twine dropped, build retained.

ALL STRUCTURE ASSERTIONS PASSED
```
</details>

<details>
<summary>Evidence: Pinned action SHA verified against upstream (v1.14.0 / release/v1)</summary>

```text
Pinned action in workflow: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
Upstream commit exists: cef221092ed1bacb1cc03d23a2d87d1d172e277b
Committed: 2026-02-18T00:13:16Z
Release tag at this SHA: ['v1.14.0']
```
</details>

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue. (CI/release hardening; not tied to a tracked issue.)
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
