### PR TITLE
Java: Fix flaky pubsub_with_binary test and synchronize PubSubTests callback lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Java: Fix flaky `pubsub_with_binary` test in cluster mode ([#6481](https://github.com/valkey-io/valkey-glide/pull/6481))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 
 ### Changes

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -1681,7 +1681,11 @@ public class PubSubTests {
         waitForCondition(
                 () -> callbackMessages.size() >= 1,
                 MESSAGE_DELIVERY_DELAY,
-                "Timed out waiting for binary message");
+                "Timed out waiting for binary callback message");
+        waitForCondition(
+                () -> listener.getPubSubMessageCount() >= 1,
+                MESSAGE_DELIVERY_DELAY,
+                "Timed out waiting for binary message on listener");
 
         assertEquals(message, listener.tryGetPubSubMessage());
         assertEquals(1, callbackMessages.size());

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -318,6 +318,29 @@ public class PubSubTests {
         fail(message);
     }
 
+    /**
+     * Reports whether the server has confirmed an exact-channel subscription for the client. The
+     * caller must hold a single exact subscription, because a binary channel does not round-trip to
+     * the String keys {@code getActualSubscriptions()} exposes, so a non-empty EXACT set is the way
+     * to recognize it.
+     */
+    private boolean exactSubscriptionConfirmed(BaseClient client, boolean standalone)
+            throws Exception {
+        Set<String> exact =
+                standalone
+                        ? ((GlideClient) client)
+                                .getSubscriptions()
+                                .get()
+                                .getActualSubscriptions()
+                                .get(PubSubChannelMode.EXACT)
+                        : ((GlideClusterClient) client)
+                                .getSubscriptions()
+                                .get()
+                                .getActualSubscriptions()
+                                .get(PubSubClusterChannelMode.EXACT);
+        return exact != null && !exact.isEmpty();
+    }
+
     @AfterEach
     @SneakyThrows
     public void cleanup() {
@@ -1677,9 +1700,14 @@ public class PubSubTests {
                         standalone, subscriptions, Optional.of(callback), Optional.of(callbackMessages));
         BaseClient sender = createClient(standalone);
 
-        // wait for the subscription to register on the server before publishing; cluster pub/sub
-        // gives the client no readiness signal to poll for
-        Thread.sleep(MESSAGE_DELIVERY_DELAY);
+        // Subscriptions are applied on the server asynchronously, so a message published before
+        // the subscription registers is lost. Publish only once both listeners are confirmed.
+        waitForCondition(
+                () ->
+                        exactSubscriptionConfirmed(listener, standalone)
+                                && exactSubscriptionConfirmed(listener2, standalone),
+                MESSAGE_DELIVERY_DELAY,
+                "Timed out waiting for subscription to register on the server");
 
         assertEquals(OK, sender.publish(message.getMessage(), channel).get());
         waitForCondition(

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -1677,15 +1677,17 @@ public class PubSubTests {
                         standalone, subscriptions, Optional.of(callback), Optional.of(callbackMessages));
         BaseClient sender = createClient(standalone);
 
+        Thread.sleep(MESSAGE_DELIVERY_DELAY); // allow subscription propagation in cluster mode
+
         assertEquals(OK, sender.publish(message.getMessage(), channel).get());
         waitForCondition(
                 () -> callbackMessages.size() >= 1,
                 MESSAGE_DELIVERY_DELAY,
-                "Timed out waiting for binary callback message");
+                "Timed out waiting for binary message via callback");
         waitForCondition(
                 () -> listener.getPubSubMessageCount() >= 1,
                 MESSAGE_DELIVERY_DELAY,
-                "Timed out waiting for binary message on listener");
+                "Timed out waiting for binary message via message buffer");
 
         assertEquals(message, listener.tryGetPubSubMessage());
         assertEquals(1, callbackMessages.size());

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -1677,11 +1677,19 @@ public class PubSubTests {
                         standalone, subscriptions, Optional.of(callback), Optional.of(callbackMessages));
         BaseClient sender = createClient(standalone);
 
+        // wait for the subscription to register on the server before publishing; cluster pub/sub
+        // gives the client no readiness signal to poll for
+        Thread.sleep(MESSAGE_DELIVERY_DELAY);
+
         assertEquals(OK, sender.publish(message.getMessage(), channel).get());
         waitForCondition(
                 () -> callbackMessages.size() >= 1,
                 MESSAGE_DELIVERY_DELAY,
-                "Timed out waiting for binary message");
+                "Timed out waiting for binary message via callback");
+        waitForCondition(
+                () -> listener.getPubSubMessageCount() >= 1,
+                MESSAGE_DELIVERY_DELAY,
+                "Timed out waiting for binary message via message buffer");
 
         assertEquals(message, listener.tryGetPubSubMessage());
         assertEquals(1, callbackMessages.size());


### PR DESCRIPTION
### Summary

`glide.PubSubTests.pubsub_with_binary` fails intermittently in cluster mode with `expected binary message but got null`.
This PR fixes that race. It also fixes an unsynchronized cross-thread list that four callback tests in the same file share.

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] glide.PubSubTests.pubsub_with_binary - cluster mode](https://github.com/valkey-io/valkey-glide/issues/6479)
Closes #6479

### Features / Behaviour Changes

None. Every change is inside `java/integTest/src/test/java/glide/PubSubTests.java`, so no shipped client code is touched.

### Implementation

Three separate problems, all in test code.

**Publishing before the server has registered the subscription.**
`pubsub_with_binary` creates two listeners, `listener` on the pull-based API and `listener2` on a callback, then publishes to the channel.
A subscription is applied on the server asynchronously, so a message published before it registers is dropped and reaches neither listener.
The helper `exactSubscriptionConfirmed` polls `getSubscriptions().get().getActualSubscriptions()` and reports whether the server has confirmed an EXACT subscription for a client.
The test waits on that for both listeners before it publishes, which replaces guessing at a delay with a server-confirmed readiness signal.
The helper checks that the EXACT set is non-empty rather than that it contains the channel: this channel is a non-UTF-8 byte sequence and `getActualSubscriptions()` is keyed by `String`, so the channel name does not round-trip. Each client in this test holds exactly one exact subscription, which is what makes the non-empty check unambiguous.

**Reading the pull-based listener before it has the message.**
The callback firing on `listener2` says nothing about `listener`, because in cluster mode the two clients can be connected to different nodes and the pull-side delivery can lag.
So the test waits for the callback list and separately waits for `listener.getPubSubMessageCount() >= 1` before it calls `listener.tryGetPubSubMessage()`.
Both waits use the bounded `waitForCondition` poll already used throughout this file.

**Unsynchronized handoff of the callback message list.**
Four tests pass a list to Glide's message-delivery thread as the callback context and then read it from the JUnit test thread: `pubsub_exact_max_size_message_callback`, `pubsub_sharded_max_size_message_callback`, `pubsub_test_callback_exception`, and `pubsub_with_binary`.
`waitForCondition` calls the condition and then sleeps, and sleeping creates no happens-before edge.
A plain `ArrayList` creates none either, so the appended messages may never become visible to the test thread, or `size()` may count an element whose array slot the reader still sees as null.
Each list is a `Collections.synchronizedList`, so every `add`, `size`, and `get` goes through the wrapper's monitor, which orders the test thread's read after the callback's write.
Every read of these lists is a `size()` or an indexed `get()`, so no external locking for iteration is required.

### Limitations

`pubsub_exact_max_size_message_callback` and `pubsub_sharded_max_size_message_callback` are `@Disabled` under issue #1649, so CI does not exercise the visibility fix in those two tests.

### Testing

Compiled with `./gradlew :integTest:compileTestJava`.

Ran the whole `glide.PubSubTests` class against a local standalone server and a local 6-node cluster on Valkey 9.0.1: 226 tests passed, 0 failed, 9 aborted on `assumeTrue` version gates.
`pubsub_with_binary` and `pubsub_test_callback_exception` were also run on their own and pass in both standalone and cluster mode.

No CHANGELOG entry, because no product behaviour changes.
Formatting was matched to the surrounding style by hand, and the spotless check in CI is the gate for it.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
