### PR TITLE
fix(node): stabilize CLIENT LIST count in lazy connection test

### DIFF
--- a/node/AGENTS.md
+++ b/node/AGENTS.md
@@ -136,6 +136,22 @@ npm run test:debug -- --testNamePattern="batch"
 npm run test:modules -- --cluster-endpoints=localhost:7000
 ```
 
+### Testing Connection Establishment (Avoid Count-Based CLIENT LIST Assertions)
+
+Do not assert on `CLIENT LIST` connection *counts* to detect whether a specific
+client connected (e.g. baseline + 1). Since the socket-IPC-to-NAPI change,
+`close()` only drops the JS handle and the Rust worker exits later, so
+connections from a preceding test can linger in `CLIENT LIST` when the baseline
+is taken and disappear one poll later, producing a net-zero delta and a flaky
+test. Polling until the count "stabilizes" does not fix this: two matching
+readings only prove stability for one poll window.
+
+Instead, identify the client deterministically by a unique `clientName`
+(passed in the client configuration) and assert `CLIENT LIST` excludes that name
+before the first command and includes it afterwards. See the
+`lazy connection establishes only on first command` test in
+`tests/GlideClient.test.ts` and the pattern in `tests/NodeDiscoveryMode.test.ts`.
+
 ## Contribution Requirements
 
 ### Developer Certificate of Origin (DCO) Signoff REQUIRED

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -2047,9 +2047,7 @@ describe("GlideClient", () => {
                 const stabilizeStart = Date.now();
 
                 while (Date.now() - stabilizeStart < 5000) {
-                    await new Promise((resolve) =>
-                        setTimeout(resolve, 100),
-                    );
+                    await new Promise((resolve) => setTimeout(resolve, 100));
                     const current = await getClientCount();
 
                     if (current === clientsBeforeLazyInit) {

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -2039,7 +2039,25 @@ describe("GlideClient", () => {
                         .length;
                 };
 
-                const clientsBeforeLazyInit = await getClientCount();
+                // Wait for CLIENT LIST to stabilize before taking baseline.
+                // Previous tests may have closed connections that the server
+                // hasn't fully removed yet; polling until the count is stable
+                // ensures stale entries are gone before we measure.
+                let clientsBeforeLazyInit = await getClientCount();
+                const stabilizeStart = Date.now();
+
+                while (Date.now() - stabilizeStart < 5000) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, 100),
+                    );
+                    const current = await getClientCount();
+
+                    if (current === clientsBeforeLazyInit) {
+                        break;
+                    }
+
+                    clientsBeforeLazyInit = current;
+                }
 
                 // Create lazy client
                 const lazyClient = await GlideClient.createClient(

--- a/node/tests/GlideClient.test.ts
+++ b/node/tests/GlideClient.test.ts
@@ -2023,41 +2023,34 @@ describe("GlideClient", () => {
             );
 
             try {
-                // Get initial client count
-                const getClientCount = async (): Promise<number> => {
+                // Identify the lazy client by a unique name rather than by
+                // counting connections. A count-based baseline is racy here:
+                // preceding tests (e.g. the inflight-requests test above) close
+                // their connections asynchronously, so stale entries may linger
+                // in CLIENT LIST when the baseline is taken and then disappear
+                // before the post-command measurement, producing a net-zero
+                // delta. Checking for a unique clientName is deterministic and
+                // immune to concurrent connection churn.
+                const lazyClientName = `lazy_conn_${protocol}_${getRandomKey()}`;
+
+                // Returns true if a connection with the given name is present
+                // in CLIENT LIST.
+                const clientListContains = async (
+                    name: string,
+                ): Promise<boolean> => {
                     const result = await monitoringClient.customCommand([
                         "CLIENT",
                         "LIST",
                     ]);
-                    if (result === null) return 0;
+                    if (result === null) return false;
 
                     const text = Buffer.isBuffer(result)
                         ? result.toString()
                         : String(result);
-                    const lines = text.trim().split("\n");
-                    return lines.filter((line) => line.trim().length > 0)
-                        .length;
+                    return text.includes(`name=${name} `);
                 };
 
-                // Wait for CLIENT LIST to stabilize before taking baseline.
-                // Previous tests may have closed connections that the server
-                // hasn't fully removed yet; polling until the count is stable
-                // ensures stale entries are gone before we measure.
-                let clientsBeforeLazyInit = await getClientCount();
-                const stabilizeStart = Date.now();
-
-                while (Date.now() - stabilizeStart < 5000) {
-                    await new Promise((resolve) => setTimeout(resolve, 100));
-                    const current = await getClientCount();
-
-                    if (current === clientsBeforeLazyInit) {
-                        break;
-                    }
-
-                    clientsBeforeLazyInit = current;
-                }
-
-                // Create lazy client
+                // Create lazy client with a unique name.
                 const lazyClient = await GlideClient.createClient(
                     getClientConfigurationOption(
                         cluster.getAddresses(),
@@ -2065,26 +2058,25 @@ describe("GlideClient", () => {
                         {
                             lazyConnect: true, // Lazy connection
                             requestTimeout: 3000,
+                            clientName: lazyClientName,
                         },
                     ),
                 );
 
                 try {
-                    // Verify no new connections were established
-                    const clientsAfterLazyInit = await getClientCount();
+                    // Verify the lazy client has not connected yet: its name
+                    // must be absent from CLIENT LIST before the first command.
+                    expect(await clientListContains(lazyClientName)).toBe(
+                        false,
+                    );
 
-                    expect(clientsAfterLazyInit).toEqual(clientsBeforeLazyInit);
-
-                    // Send first command with lazy client
+                    // Send first command with lazy client.
                     const pingResponse = await lazyClient.ping();
                     expect(pingResponse).toEqual("PONG");
 
-                    // Check client count after first command
-                    const clientsAfterFirstCommand = await getClientCount();
-
-                    expect(clientsAfterFirstCommand).toEqual(
-                        clientsBeforeLazyInit + 1,
-                    );
+                    // After the first command the connection is established, so
+                    // its name must now appear in CLIENT LIST.
+                    expect(await clientListContains(lazyClientName)).toBe(true);
                 } finally {
                     await lazyClient.close();
                 }


### PR DESCRIPTION
### Summary

Fix the "lazy connection establishes only on first command" test that consistently fails with `Expected: N+1, Received: N` in the nightly full-matrix CI.

### Issue link

This Pull Request is linked to issue: [[Node][Flaky Test] lazy connection establishes only on first command - assertion count mismatch](https://github.com/valkey-io/valkey-glide/issues/6480)
Closes #6480

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root Cause:** The test counted total connections via `CLIENT LIST` and asserted the count increased by exactly 1 after the lazy client's first command. Under CI load, stale connections from preceding tests (e.g., the BLPOP "inflight requests limit" test) could be cleaned up by the server during the test window, producing a net-zero delta (+1 lazy connection, -1 stale cleanup) instead of the expected +1. Node's `close()` drops the handle immediately (`BaseClient.ts:9847`) but the Rust worker only exits later (`lib.rs:1109`), making cleanup timing non-deterministic.

**Fix (deterministic named-client approach):** Replaced the fragile count-based assertion with a deterministic check using a unique `clientName`:
1. Create the lazy client with a unique client name (e.g. `lazy_test_<random>`)
2. Assert `CLIENT LIST` does NOT contain that name before the first command (proves connection not yet established)
3. Call `ping()` (triggers the lazy connection)
4. Assert `CLIENT LIST` DOES contain that name after the command (proves connection was established)

This approach is immune to concurrent connection noise, stale-connection timing, and over-counting. It mirrors the proven pattern already in use at `NodeDiscoveryMode.test.ts:123-145`.

The initial stabilization-loop approach (first commit) was superseded after review feedback identified that it was probabilistic rather than deterministic: two consecutive equal CLIENT LIST counts do not guarantee no further cleanup will occur.

### Limitations

None

### Testing

- 25/25 isolated runs pass (both RESP2 and RESP3 protocols)
- 7/7 runs pass with the preceding BLPOP test included (the specific race trigger)
- PR CI: lint, lint-rust, DCO, and all Node Tests matrix jobs green (10+ checks passing, 0 failed)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run and Prettier has been run.
- [x] Destination branch is correct - main or release