### PR TITLE
fix(core): stop MONITOR from dropping all lines on buffered handshake bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Fix MONITOR dropping all lines when the server packs the first monitor line into the same TCP segment as the `MONITOR` `+OK` reply. `Monitor::into_on_message` discarded the connection decoder's buffered bytes and rebuilt a codec over the bare socket, so it resumed parsing mid-frame, hit a parse error, and terminated the stream before delivering a single line. The framed read buffer is now seeded with the leftover bytes. This also deflakes `test_monitor_start_and_receive_line`. ([#6161](https://github.com/valkey-io/valkey-glide/issues/6161))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 
 ### Changes

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -24,7 +24,7 @@ use futures_util::{
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 #[cfg(feature = "tokio-comp")]
-use tokio_util::codec::Decoder;
+use tokio_util::codec::{Decoder, Framed, FramedParts};
 
 /// Represents a stateful redis TCP connection.
 #[deprecated(note = "aio::Connection is deprecated. Use aio::MultiplexedConnection instead.")]
@@ -380,8 +380,18 @@ where
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection
     pub fn into_on_message<T: FromRedisValue>(self) -> impl Stream<Item = T> {
-        ValueCodec::default()
-            .framed(self.0.con)
+        // The `MONITOR` handshake is parsed through `self.0.decoder`, which reads
+        // from the socket in chunks. Under load the server can pack the first
+        // monitor line(s) into the same TCP segment as the `+OK` handshake reply,
+        // leaving those bytes buffered inside the decoder. If we built the stream's
+        // codec over the bare socket we would discard that buffer, resume parsing
+        // mid-frame, hit a parse error, and terminate the stream before delivering
+        // a single line. Seed the framed read buffer with the leftover bytes so no
+        // already-received monitor line is lost.
+        let leftover = self.0.decoder.buffer();
+        let mut parts = FramedParts::new::<Vec<u8>>(self.0.con, ValueCodec::default());
+        parts.read_buf = bytes::BytesMut::from(leftover);
+        Framed::from_parts(parts)
             .filter_map(|value| {
                 Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
             })

--- a/glide-core/tests/test_monitor.rs
+++ b/glide-core/tests/test_monitor.rs
@@ -72,8 +72,10 @@ mod test_monitor {
             .await
             .unwrap();
 
-        // Generous deadline to tolerate slow/loaded CI; not a behavioral change.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        // The monitor stream is deterministically ready before `new()` returns and no
+        // longer drops the first lines under load (see MonitorClient / redis-rs
+        // `Monitor::into_on_message`), so a modest deadline is sufficient.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
             if lines.lock().unwrap().iter().any(|l| {
                 l.command == "SET" && l.args.first().map(|s| s.as_str()) == Some("monitor_test_key")


### PR DESCRIPTION
## Summary

Properly fixes the still-flaky Rust integration test `test_monitor::test_monitor_start_and_receive_line`.

The prior attempt (#6163) only bumped the test's polling deadline from 5s to 15s. That did not work: the test still fails, and it exhausts the **full** 15s window, which showed the SET line was never arriving at all rather than arriving slowly. This PR fixes the actual source of the lost lines.

Fixes #6161

## Root cause (confirmed by instrumentation, not assumed)

Under concurrent load, the Valkey server can pack the first MONITOR line into the **same TCP segment** as the `MONITOR` `+OK` handshake reply. The redis-rs connection's `combine` decoder reads both when parsing `+OK`, leaving the monitor-line bytes buffered **inside the decoder**.

`Monitor::into_on_message` then discarded that decoder buffer (`self.0.decoder`) and rebuilt a fresh `ValueCodec` over the bare socket (`self.0.con`). The fresh codec resumed parsing mid-frame, hit a `ParseError`, and `FramedRead` terminated the stream. The monitor task saw the stream end (`None`) and exited having delivered **zero lines**, so no amount of waiting could recover.

Instrumentation made this deterministic to observe:
- Every failure: a partial monitor line (e.g. `+... [0 127.0.0.1:...] "CLIENT" "`) left in the decoder buffer, immediately followed by the stream ending and `0 lines captured`.
- Every pass: the decoder buffer was empty (0 bytes).

The failure only reproduces when the three monitor tests run concurrently against the shared server (as in CI), which is why it never surfaces running the single test in isolation.

## Fix

In `glide-core/redis-rs/redis/src/aio/connection.rs`, `Monitor::into_on_message` now seeds the framed read buffer with the decoder's leftover bytes via `FramedParts`, so no already-received monitor line is lost:

```rust
let leftover = self.0.decoder.buffer();
let mut parts = FramedParts::new::<Vec<u8>>(self.0.con, ValueCodec::default());
parts.read_buf = bytes::BytesMut::from(leftover);
Framed::from_parts(parts).filter_map(...)
```

Because the stream is now deterministically live before `MonitorClient::new` returns, the test's 15s crutch is reverted to a modest 5s deadline.

## Verification

- Reproduced the baseline flake: running the full test binary (all three monitor tests concurrently, as CI does) failed **4-11 times per 60-80 runs**. The single test in isolation never failed.
- After the fix: **0 failures / 200 runs**, plus **0 failures / 100 runs under CPU load** (`yes` workers saturating cores).
- redis-rs parser unit tests pass; `monitor_client` parse unit tests pass; all three monitor integration tests pass with the 5s deadline.

## Changes
- `glide-core/redis-rs/redis/src/aio/connection.rs`: seed framed read buffer from the decoder buffer in `Monitor::into_on_message`.
- `glide-core/tests/test_monitor.rs`: revert the 15s crutch to 5s now that the stream is deterministic.
- `CHANGELOG.md`: add a Fixes entry.
