### PR TITLE
style(node): reconcile union-type formatting with pinned Prettier

### DIFF
--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -530,9 +530,7 @@ export type ReturnTypeXinfoStream = Record<
  * See {@link ReturnTypeXinfoStream}.
  */
 export type StreamEntries =
-    | GlideString
-    | number
-    | (GlideString | number | GlideString[])[][];
+    GlideString | number | (GlideString | number | GlideString[])[][];
 
 /**
  * @internal
@@ -1166,8 +1164,7 @@ export interface PubSubMsg {
  */
 type BaseOptions = RouteOption & DecoderOption;
 type WritePromiseOptions =
-    | BaseOptions
-    | (BaseOptions & (ClusterBatchOptions | BatchOptions));
+    BaseOptions | (BaseOptions & (ClusterBatchOptions | BatchOptions));
 
 /**
  * Base client interface for GLIDE
@@ -9556,8 +9553,7 @@ export class BaseClient {
 
         // Build a protobuf AuthenticationInfo
         let authenticationInfo:
-            | connection_request.IAuthenticationInfo
-            | undefined;
+            connection_request.IAuthenticationInfo | undefined;
 
         if (creds) {
             if ("iamConfig" in creds) {
@@ -9600,8 +9596,7 @@ export class BaseClient {
         }
 
         const protocol = options.protocol as
-            | connection_request.ProtocolVersion
-            | undefined;
+            connection_request.ProtocolVersion | undefined;
 
         // Validate that clientAz is set when using AZ affinity strategies
         if (

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -14,12 +14,7 @@ const LEVEL = new Map<LevelOptions | undefined, Level | undefined>([
     [undefined, undefined],
 ]);
 export type LevelOptions =
-    | "error"
-    | "warn"
-    | "info"
-    | "debug"
-    | "trace"
-    | "off";
+    "error" | "warn" | "info" | "debug" | "trace" | "off";
 
 /**
  * A singleton class that allows logging which is consistent with logs from the internal GLIDE core.

--- a/node/tests/PubSubTestUtilities.ts
+++ b/node/tests/PubSubTestUtilities.ts
@@ -53,8 +53,7 @@ export function parseActualSubscriptions(result: unknown): {
 } {
     // Result format: ["desired", [{key, value}, ...], "actual", [{key, value}, ...]]
     const actualArray = (result as unknown[])?.[3] as
-        | SubscriptionEntry[]
-        | undefined;
+        SubscriptionEntry[] | undefined;
 
     if (!Array.isArray(actualArray)) {
         return { exact: [], pattern: [], sharded: [] };


### PR DESCRIPTION
### Summary

The repo's `lint` CI job runs `prettier --check` over the whole `node/` tree, and three committed files had drifted from the pinned Prettier version and now fail the check:

- `node/src/BaseClient.ts`
- `node/src/Logger.ts`
- `node/tests/PubSubTestUtilities.ts`

This is not caused by any recent change. The repo pins `"prettier": "3"` (a floating minor), and a newer 3.x minor (resolving to 3.9.x via `npm ci`) changed a union-type formatting rule: it now collapses short leading-`|` union types onto one line (e.g. `type X =\n    | A\n    | B;` becomes `type X = A | B;`). As a result `main` itself is red on the `lint` job, and every PR that touches the node tree (for example dependabot #6465) inherits the failure.

### Issue link

Not linked to a tracked issue; this is CI/formatting hygiene.

### Features / Behaviour Changes

- No behaviour or API change. This is a formatting-only change to bring three committed TypeScript files back in line with the repo's pinned Prettier, turning the `lint` CI job green on `main` and on every node-touching PR.

### Implementation

- Reformatted exactly the three affected files by running Prettier's own writer (`prettier --write`) with the repo's pinned formatter, rather than hand-editing.
- The diff is confined to those three files and contains only union-type line reflows (+6 / -17); no logic or semantic change.
- Reviewers: the change is purely whitespace/formatting; the intent is simply to reconcile committed sources with the pinned Prettier so the `lint` job stops failing tree-wide.

### Limitations

- Narrow by design: it only reformats the three files that currently fail `prettier --check`. It does not tighten the loose `"prettier": "3"` pin, so future minor Prettier releases could reintroduce similar drift; pinning Prettier to an exact version would be a separate follow-up.

### Testing

- Reproduced the failure with the pinned Prettier (`npm ci` at repo root, resolving Prettier 3.9.x): `npx prettier --check node benchmarks/node benchmarks/utilities` flagged exactly the three files above under `node/`, with the other two folders already clean.
- Applied the fix via `prettier --write` on those three files, then re-ran `npx prettier --check` on all three folders: all clean.
- Confirmed the `lint` CI job is green on this PR head. The only remaining red checks (`Node Tests - EngineVersion 6.2`) are a pre-existing `tests/Dns.test.ts` TLS failure (`cluster_manager.py --tls start` infrastructure error) that also fails on the current `main` HEAD and is unrelated to this formatting-only change.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue. (CI/formatting hygiene; not tied to a tracked issue.)
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated. (Formatting-only change; no test changes applicable.)
-   [ ] CHANGELOG.md and documentation files are updated. (Internal CI hygiene; no user-facing change to log.)
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
