### PR TITLE
CI: fix stale workflow exempt-issue-labels to match repo labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
                   days-before-pr-stale: 60
                   days-before-close: 14
                   days-before-pr-close: 10
-                  exempt-issue-labels: "bug,Users Pain,Epic,User issue,Unatriaged user issue"
+                  exempt-issue-labels: "bug 🐞,Users Pain,Epic ⚡,User issue 🚨,Untriaged user issue"
                   exempt-all-milestones: true
                   operations-per-run: 50
                   labels-to-add-when-unstale: "Unstaled"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Maintainers and experienced contributors review incoming issues to ensure they a
 
 - Once an issue is accepted for work, the `Untriaged user issue` label is removed.
 - If more information is needed, a comment is left requesting clarification and the label stays until the author responds.
-- Issues inactive for 90 days are automatically marked stale and closed after 14 additional days. Issues labeled `bug`, `Users Pain`, `Epic`, `User issue`, or `Unatriaged user issue` are exempt.
+- Issues inactive for 90 days are automatically marked stale and closed after 14 additional days. Issues labeled `bug 🐞`, `Users Pain`, `Epic ⚡`, `User issue 🚨`, or `Untriaged user issue` are exempt.
 
 For the full triage workflow, stale bot behavior, and exempt labels, see the [Triaging Issues Guide](./TRIAGING_ISSUES.md).
 

--- a/TRIAGING_ISSUES.md
+++ b/TRIAGING_ISSUES.md
@@ -56,11 +56,11 @@ The repository uses a [stale bot](.github/workflows/stale.yml) (powered by the `
 
 Issues with any of the following labels are exempt from the stale bot and will not be automatically marked stale or closed:
 
-- `bug`
+- `bug 🐞`
 - `Users Pain`
-- `Epic`
-- `User issue`
-- `Unatriaged user issue`
+- `Epic ⚡`
+- `User issue 🚨`
+- `Untriaged user issue`
 
 > **Note:** Issues with milestones assigned are also exempt from the stale bot.
 


### PR DESCRIPTION
### Summary

The stale workflow's `exempt-issue-labels` no longer matches the repo's actual label names, so issues labeled `bug`, `Epic`, and `User issue` are being auto-closed instead of exempted.

### Issue link

N/A — trivial CI fix.

### Features / Behaviour Changes

Corrects the exempt label names to the current ones (`bug 🐞`, `Epic ⚡`, `User issue 🚨`) and fixes the `Unatriaged` → `Untriaged` typo, so these issues are again exempt from stale auto-close.

### Implementation

One-line change in `.github/workflows/stale.yml`. `actions/stale` matches full label names case-insensitively (no emoji-stripping or substring), so the bare names matched nothing.

### Limitations

Matching stays brittle — renaming a label's emoji would silently break the exemption again.

### Testing

Config-only. Verified against current labels: e.g. auto-closed #4494 (`bug 🐞`) and #4039 (`User issue 🚨`) would now be exempt.

### Checklist

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Destination branch is correct - main or release
