### PR TITLE
ci: fix cargo-deny CLI flag order for v0.20+

### DIFF
--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -44,7 +44,7 @@ runs:
 
         - run: |
               cargo install --locked cargo-deny
-              cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
+              cargo deny --config ${GITHUB_WORKSPACE}/deny.toml check
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash
 

--- a/.github/workflows/redis-rs.yml
+++ b/.github/workflows/redis-rs.yml
@@ -85,7 +85,7 @@ jobs:
                   cargo fmt --all -- --check
                   cargo clippy -- -D warnings
                   cargo install --locked cargo-deny
-                  cargo deny check all --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev all
+                  cargo deny --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev check all
               working-directory: ./glide-core/redis-rs/redis
 
             - name: Test

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -549,7 +549,7 @@ where
                 {
                     // Last key reached; add the path argument index for each route and break
                     let path_idx = curr_arg_idx + 1;
-                    for (_, arg_indices) in routes.iter_mut() {
+                    for arg_indices in routes.values_mut() {
                         arg_indices.push(path_idx);
                     }
                     break;

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -160,12 +160,11 @@ impl<'a, T: FromRedisValue + 'a> AsyncIterInner<'a, T> {
             if let Some(v) = self.batch.next() {
                 return Some(v);
             };
-            if let Some(cursor) = self.cmd.cursor {
+            {
+                let cursor = self.cmd.cursor?;
                 if cursor == 0 {
                     return None;
                 }
-            } else {
-                return None;
             }
 
             let rv = self.con.req_packed_command(&self.cmd).await.ok()?;

--- a/glide-core/src/pubsub/mock.rs
+++ b/glide-core/src/pubsub/mock.rs
@@ -656,7 +656,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut channels: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -686,7 +686,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut patterns: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -725,7 +725,7 @@ impl MockPubSubBroker {
 
         for channel in &channels {
             let mut count = 0i64;
-            for (_, client_data) in clients.iter() {
+            for client_data in clients.values() {
                 let actual = client_data
                     .synchronizer
                     .actual_subscriptions
@@ -754,7 +754,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut channels: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -803,7 +803,7 @@ impl MockPubSubBroker {
 
         for channel in &channels {
             let mut count = 0i64;
-            for (_, client_data) in clients.iter() {
+            for client_data in clients.values() {
                 let actual = client_data
                     .synchronizer
                     .actual_subscriptions

--- a/glide-core/src/pubsub/synchronizer.rs
+++ b/glide-core/src/pubsub/synchronizer.rs
@@ -724,7 +724,7 @@ impl PubSubSynchronizer for GlidePubSubSynchronizer {
         } else {
             // For regular subscriptions (Exact/Pattern), remove from ALL addresses.
             // These are not slot-bound, and the server's unsubscribe is authoritative.
-            for (_, addr_subs) in current_by_addr.iter_mut() {
+            for addr_subs in current_by_addr.values_mut() {
                 if let Some(existing) = addr_subs.get_mut(&subscription_type) {
                     for channel in &channels {
                         existing.remove(channel);


### PR DESCRIPTION
### Summary

1. cargo-deny v0.20 moved --config and --exclude-dev from subcommand flags to global flags
2. Rust 1.97 clippy added for_kv_map lint — use .values() / .values_mut() instead of iterating with (_, v)
3. Rust 1.97 clippy added question_mark lint — simplify if let Some / else return None to ?

### Issue link

N/A — CI hotfix