### PR TITLE
fix(ci): pin cargo-deny to 0.19.9 to fix lint-rust after 0.20 CLI change

### DIFF
--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -43,7 +43,7 @@ runs:
           shell: bash
 
         - run: |
-              cargo install --locked cargo-deny
+              cargo install --locked cargo-deny@0.19.9
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/redis-rs.yml
+++ b/.github/workflows/redis-rs.yml
@@ -84,7 +84,7 @@ jobs:
               run: |
                   cargo fmt --all -- --check
                   cargo clippy -- -D warnings
-                  cargo install --locked cargo-deny
+                  cargo install --locked cargo-deny@0.19.9
                   cargo deny check all --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev all
               working-directory: ./glide-core/redis-rs/redis
 


### PR DESCRIPTION
## Summary

The `lint-rust` and `redis-rs-CI` jobs install `cargo-deny` unpinned (`cargo install --locked cargo-deny`), which now resolves to 0.20.x. cargo-deny 0.20 ([EmbarkStudios/cargo-deny#881](https://github.com/EmbarkStudios/cargo-deny/pull/881)) moved the `-c/--config` flag from the `check` subcommand to the global/root position. This makes the workflows' existing `cargo deny check --config <path>` invocation exit code 2 (usage error), failing `lint-rust` on `main` and every Rust-touching PR.

This PR pins `cargo-deny` to `0.19.9` (the last release compatible with the existing invocation syntax) in both call sites:
- `.github/workflows/lint-rust/action.yml`
- `.github/workflows/redis-rs.yml`

No invocation syntax is changed; the `check --config` form remains as-is.

## Verification

- Installed `cargo-deny@0.19.9` locally and ran the exact lint-rust step (`cargo deny check --config <repo-root>/deny.toml`) from `node/rust-client`: exits 0, all checks pass (advisories/bans/licenses/sources ok).
- The key success signal is the `lint-rust` CI job going green on this PR.
