### PR TITLE
feat(ffi): add command_with_route_info entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changes
 
+* Core/FFI: Add `command_with_route_info` FFI entrypoint, accepting routing as a `RouteInfo` C-struct pointer instead of protobuf-encoded bytes — the same mechanism `batch()` already uses. Existing `command`, `command_with_buffer`, `command_with_buffers`, and `invoke_script` are unchanged. ([#6494](https://github.com/valkey-io/valkey-glide/pull/6494))
 * CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6478](https://github.com/valkey-io/valkey-glide/pull/6478))
 * Node: Replace socket IPC with direct NAPI layer ([#5325](https://github.com/valkey-io/valkey-glide/pull/5325))
 * feat(python-sync): add zero-copy buffers to mget ([#6367](https://github.com/valkey-io/valkey-glide/pull/6367))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3030,9 +3030,9 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
     }
 }
 
-/// The underlying command execution implementation. Used by various command 
+/// The underlying command execution implementation. Used by various command
 /// execution API like: [`command_with_buffer`], [`command_with_buffers`],
-/// and [`command_with_route_info`]. It builds and dispatches the command, 
+/// and [`command_with_route_info`]. It builds and dispatches the command,
 /// writing the reply into `response_buffer` when present (a single buffer for
 /// a scalar reply, one buffer per element for an array reply).
 ///
@@ -5586,9 +5586,9 @@ pub unsafe extern "C-unwind" fn close_monitor_client(client_ptr: *const c_void) 
         let _ = unsafe { Box::from_raw(client_ptr as *mut MonitorAdapter) };
     }
 }
-/// Execute a command with routing using a [`RouteInfo`] C-struct pointer 
+/// Execute a command with routing using a [`RouteInfo`] C-struct pointer
 /// instead of protobuf-encoded route bytes.
-/// 
+///
 /// Behaves identically to [`command_with_buffer`] otherwise, including the
 /// buffer-response behavior: when `response_buf` is null, the response flows
 /// through the normal `execute_request` path; when non-null, the response is

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3015,7 +3015,7 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
         Some(ResponseBuffer::Single((response_buf, response_buf_len)))
     };
     unsafe {
-        execute_command_with_buffer_option(
+        execute_command_with_buffer(
             client_adapter_ptr,
             request_id,
             command_type,
@@ -3030,16 +3030,17 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
     }
 }
 
-/// Shared implementation behind [`command_with_buffer`], [`command_with_buffers`],
-/// and [`command_with_route_info`]: builds and dispatches the command, writing
-/// the reply into `buf_option` when present (a single buffer for a scalar
-/// reply, one buffer per element for an array reply).
+/// The underlying command execution implementation. Used by various command 
+/// execution API like: [`command_with_buffer`], [`command_with_buffers`],
+/// and [`command_with_route_info`]. It builds and dispatches the command, 
+/// writing the reply into `response_buffer` when present (a single buffer for
+/// a scalar reply, one buffer per element for an array reply).
 ///
 /// # Safety
 /// `client_adapter_ptr` and `args`/`args_len` follow the same contract as
 /// [`command_with_buffer`]. `route_input` follows the safety contract
 /// documented on [`RouteInput::resolve`]. Any buffers referenced by
-/// `buf_option` must remain valid and writable until the command completes.
+/// `response_buffer` must remain valid and writable until the command completes.
 // Mirrors the C ABI of the FFI entry points it backs, hence the argument count.
 #[allow(clippy::too_many_arguments)]
 unsafe fn execute_command(
@@ -3050,7 +3051,7 @@ unsafe fn execute_command(
     args: *const usize,
     args_len: *const c_ulong,
     route_input: RouteInput,
-    buf_option: Option<ResponseBuffer>,
+    response_buffer: Option<ResponseBuffer>,
     span_ptr: u64,
 ) -> *mut CommandResult {
     let client_adapter = unsafe {
@@ -3149,7 +3150,7 @@ unsafe fn execute_command(
     client_adapter.execute_request_with_buffer(
         request_id,
         async move { client.send_command(&mut cmd, routing_info).await },
-        buf_option,
+        response_buffer,
     )
 }
 
@@ -3157,13 +3158,40 @@ unsafe fn execute_command(
 /// protobuf-encoded `route_bytes`, matching the contract shared by
 /// [`command_with_buffer`] and [`command_with_buffers`].
 ///
+/// # Parameters
+/// - `client_adapter_ptr`: Pointer to the `Arc<ClientAdapter>` obtained from
+///   [`create_client`]. The strong count is incremented so the caller's
+///   original `Arc` remains valid.
+/// - `request_id`: Caller-supplied ID used to correlate the eventual
+///   response (or async callback invocation) with this call.
+/// - `command_type`: Identifies which Valkey/Redis command to run; mapped to
+///   the internal `Cmd` via `command_type.get_command()`.
+/// - `arg_count`: Number of elements in the `args` / `args_len` arrays.
+/// - `args`: Pointer to an array of pointers, each pointing to one command
+///   argument's raw bytes. Caller-owned; must remain valid for the duration
+///   of the call.
+/// - `args_len`: Parallel array giving the byte length of each argument
+///   pointed to by `args`. Must be null iff `args` is null.
+/// - `route_bytes`: Optional protobuf-encoded `Routes` message describing
+///   where to send the command (e.g. specific node, all primaries). Null
+///   means no explicit route (default routing is used).
+/// - `route_bytes_len`: Number of bytes in `route_bytes`; must be `0` when
+///   `route_bytes` is null.
+/// - `response_buffer`: Optional caller-provided buffer(s) for zero-copy
+///   response writing — `Single` for a scalar reply (e.g. GET), `Multi` with
+///   one buffer per element for an array reply (e.g. MGET). When `None`, the
+///   response is heap/arena-allocated and returned normally.
+/// - `span_ptr`: Pointer (as `u64`) to an `Arc<GlideSpan>` OpenTelemetry span
+///   created by `create_otel_span`, or `0` for no tracing. When non-zero, it
+///   is attached to the command so the request is traced.
+///
 /// # Safety
 /// `client_adapter_ptr`, `args`/`args_len`, and `route_bytes` follow the same
-/// contract as [`command_with_buffer`]. Any buffers referenced by `buf_option`
+/// contract as [`command_with_buffer`]. Any buffers referenced by `response_buffer`
 /// must remain valid and writable until the command completes.
 // Mirrors the C ABI of the FFI entry points it backs, hence the argument count.
 #[allow(clippy::too_many_arguments)]
-unsafe fn execute_command_with_buffer_option(
+unsafe fn execute_command_with_buffer(
     client_adapter_ptr: *const c_void,
     request_id: usize,
     command_type: RequestType,
@@ -3172,7 +3200,7 @@ unsafe fn execute_command_with_buffer_option(
     args_len: *const c_ulong,
     route_bytes: *const u8,
     route_bytes_len: usize,
-    buf_option: Option<ResponseBuffer>,
+    response_buffer: Option<ResponseBuffer>,
     span_ptr: u64,
 ) -> *mut CommandResult {
     unsafe {
@@ -3187,7 +3215,7 @@ unsafe fn execute_command_with_buffer_option(
                 route_bytes,
                 route_bytes_len,
             },
-            buf_option,
+            response_buffer,
             span_ptr,
         )
     }
@@ -3246,7 +3274,7 @@ pub unsafe extern "C-unwind" fn command_with_buffers(
             ))
         };
     unsafe {
-        execute_command_with_buffer_option(
+        execute_command_with_buffer(
             client_adapter_ptr,
             request_id,
             command_type,
@@ -5558,10 +5586,9 @@ pub unsafe extern "C-unwind" fn close_monitor_client(client_ptr: *const c_void) 
         let _ = unsafe { Box::from_raw(client_ptr as *mut MonitorAdapter) };
     }
 }
-
-/// [`command_with_buffer`] sibling that takes routing as a [`RouteInfo`]
-/// C-struct pointer instead of protobuf-encoded route bytes.
-///
+/// Execute a command with routing using a [`RouteInfo`] C-struct pointer 
+/// instead of protobuf-encoded route bytes.
+/// 
 /// Behaves identically to [`command_with_buffer`] otherwise, including the
 /// buffer-response behavior: when `response_buf` is null, the response flows
 /// through the normal `execute_request` path; when non-null, the response is

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5577,7 +5577,7 @@ pub unsafe extern "C-unwind" fn close_monitor_client(client_ptr: *const c_void) 
 /// * `arg_count` the number of elements in `args` and `args_len`. It must also not be greater than the max value of a signed pointer-sized integer.
 /// * `arg_count` must be 0 if `args` and `args_len` are null.
 /// * `args` and `args_len` must either be both null or be both not null.
-/// * `route_info` could be `null`, which means no route (equivalent to an unset `route_bytes`); if not `null`, it must be a valid pointer to a [`RouteInfo`] struct for the duration of this call. See the safety documentation of [`create_route`].
+/// * `route_info` could be `null`, which means no route (equivalent to an unset `route_bytes`); if not `null`, it must be a valid pointer to a [`RouteInfo`] struct for the duration of this call.
 /// * When non-null, `response_buf` must point to a writable buffer of at least `response_buf_len` bytes.
 /// * `response_buf_len` must be 0 if `response_buf` is null.
 /// * `span_ptr` is a valid pointer to [`Arc<GlideSpan>`], a span created by [`create_otel_span`] or `0`. The span must be valid until the command is finished.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2912,6 +2912,62 @@ pub unsafe extern "C-unwind" fn command(
     }
 }
 
+/// Where routing info came from across the FFI boundary: legacy protobuf
+/// bytes ([`command_with_buffer`]) or a [`RouteInfo`] C-struct
+/// ([`command_with_route_info`]).
+enum RouteInput {
+    /// Protobuf-encoded `Routes` bytes. Null means no route.
+    ProtobufBytes {
+        route_bytes: *const u8,
+        route_bytes_len: usize,
+    },
+    /// A `RouteInfo` C-struct pointer. Null means no route.
+    RouteInfo(*const RouteInfo),
+}
+
+impl RouteInput {
+    /// Resolves to a [`RoutingInfo`] given a `cmd` is built (needed for
+    /// `AllNodes`/`AllPrimaries` `ResponsePolicy`).
+    ///
+    /// # Safety
+    /// Pointers must be null or valid for their variant. See
+    /// [`create_route`].
+    unsafe fn resolve(self, cmd: &Cmd) -> RedisResult<Option<RoutingInfo>> {
+        match self {
+            RouteInput::ProtobufBytes {
+                route_bytes,
+                route_bytes_len,
+            } => unsafe { Self::resolve_protobuf_bytes(route_bytes, route_bytes_len, cmd) },
+            RouteInput::RouteInfo(route_info) => unsafe { Ok(create_route(route_info, Some(cmd))) },
+        }
+    }
+
+    /// Decodes `route_bytes` as protobuf `Routes` (or defaults when null),
+    /// then converts via [`get_route`].
+    ///
+    /// # Safety
+    /// `route_bytes` must either point to valid `route_bytes_len` bytes or be null.
+    unsafe fn resolve_protobuf_bytes(
+        route_bytes: *const u8,
+        route_bytes_len: usize,
+        cmd: &Cmd,
+    ) -> RedisResult<Option<RoutingInfo>> {
+        let route = if !route_bytes.is_null() {
+            let r_bytes = unsafe { std::slice::from_raw_parts(route_bytes, route_bytes_len) };
+            Routes::parse_from_bytes(r_bytes).map_err(|err| {
+                RedisError::from((
+                    ErrorKind::ClientError,
+                    "Decoding route failed",
+                    err.to_string(),
+                ))
+            })?
+        } else {
+            Routes::default()
+        };
+        get_route(route, Some(cmd))
+    }
+}
+
 /// Executes a command, optionally copying a BulkString response directly into a
 /// caller-provided buffer instead of returning it as a heap-allocated value.
 ///
@@ -2974,26 +3030,26 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
     }
 }
 
-/// Shared implementation behind [`command_with_buffer`] and
-/// [`command_with_buffers`]: builds and dispatches the command, writing the
-/// reply into `buf_option` when present (a single buffer for a scalar reply,
-/// one buffer per element for an array reply).
+/// Shared implementation behind [`command_with_buffer`], [`command_with_buffers`],
+/// and [`command_with_route_info`]: builds and dispatches the command, writing
+/// the reply into `buf_option` when present (a single buffer for a scalar
+/// reply, one buffer per element for an array reply).
 ///
 /// # Safety
-/// `client_adapter_ptr`, `args`/`args_len`, and `route_bytes` follow the same
-/// contract as [`command_with_buffer`]. Any buffers referenced by `buf_option`
-/// must remain valid and writable until the command completes.
+/// `client_adapter_ptr` and `args`/`args_len` follow the same contract as
+/// [`command_with_buffer`]. `route_input` follows the safety contract
+/// documented on [`RouteInput::resolve`]. Any buffers referenced by
+/// `buf_option` must remain valid and writable until the command completes.
 // Mirrors the C ABI of the FFI entry points it backs, hence the argument count.
 #[allow(clippy::too_many_arguments)]
-unsafe fn execute_command_with_buffer_option(
+unsafe fn execute_command(
     client_adapter_ptr: *const c_void,
     request_id: usize,
     command_type: RequestType,
     arg_count: c_ulong,
     args: *const usize,
     args_len: *const c_ulong,
-    route_bytes: *const u8,
-    route_bytes_len: usize,
+    route_input: RouteInput,
     buf_option: Option<ResponseBuffer>,
     span_ptr: u64,
 ) -> *mut CommandResult {
@@ -3080,21 +3136,11 @@ unsafe fn execute_command_with_buffer_option(
         set_db_attributes(span, &cmd, &client_adapter.core.client);
     }
 
-    let route = if !route_bytes.is_null() {
-        let r_bytes = unsafe { std::slice::from_raw_parts(route_bytes, route_bytes_len) };
-        match Routes::parse_from_bytes(r_bytes) {
-            Ok(route) => route,
-            Err(err) => {
-                let err = RedisError::from((
-                    ErrorKind::ClientError,
-                    "Decoding route failed",
-                    err.to_string(),
-                ));
-                return unsafe { client_adapter.handle_redis_error(err, request_id) };
-            }
+    let routing_info = match unsafe { route_input.resolve(&cmd) } {
+        Ok(routing_info) => routing_info,
+        Err(err) => {
+            return unsafe { client_adapter.handle_redis_error(err, request_id) };
         }
-    } else {
-        Routes::default()
     };
 
     // Inflight tracking is handled by send_command() via InflightRequestTracker on Cmd.
@@ -3102,12 +3148,49 @@ unsafe fn execute_command_with_buffer_option(
 
     client_adapter.execute_request_with_buffer(
         request_id,
-        async move {
-            let routing_info = get_route(route, Some(&cmd))?;
-            client.send_command(&mut cmd, routing_info).await
-        },
+        async move { client.send_command(&mut cmd, routing_info).await },
         buf_option,
     )
+}
+
+/// Thin wrapper around [`execute_command`] that resolves routing from
+/// protobuf-encoded `route_bytes`, matching the contract shared by
+/// [`command_with_buffer`] and [`command_with_buffers`].
+///
+/// # Safety
+/// `client_adapter_ptr`, `args`/`args_len`, and `route_bytes` follow the same
+/// contract as [`command_with_buffer`]. Any buffers referenced by `buf_option`
+/// must remain valid and writable until the command completes.
+// Mirrors the C ABI of the FFI entry points it backs, hence the argument count.
+#[allow(clippy::too_many_arguments)]
+unsafe fn execute_command_with_buffer_option(
+    client_adapter_ptr: *const c_void,
+    request_id: usize,
+    command_type: RequestType,
+    arg_count: c_ulong,
+    args: *const usize,
+    args_len: *const c_ulong,
+    route_bytes: *const u8,
+    route_bytes_len: usize,
+    buf_option: Option<ResponseBuffer>,
+    span_ptr: u64,
+) -> *mut CommandResult {
+    unsafe {
+        execute_command(
+            client_adapter_ptr,
+            request_id,
+            command_type,
+            arg_count,
+            args,
+            args_len,
+            RouteInput::ProtobufBytes {
+                route_bytes,
+                route_bytes_len,
+            },
+            buf_option,
+            span_ptr,
+        )
+    }
 }
 
 /// MGET-style variant of [`command_with_buffer`] that writes each element of an
@@ -5473,5 +5556,61 @@ pub unsafe extern "C-unwind" fn close_monitor_client(client_ptr: *const c_void) 
         // Drop calls runtime.block_on(client.stop_async()), ensuring the task
         // has fully exited before the adapter memory is freed.
         let _ = unsafe { Box::from_raw(client_ptr as *mut MonitorAdapter) };
+    }
+}
+
+/// [`command_with_buffer`] sibling that takes routing as a [`RouteInfo`]
+/// C-struct pointer instead of protobuf-encoded route bytes.
+///
+/// Behaves identically to [`command_with_buffer`] otherwise, including the
+/// buffer-response behavior: when `response_buf` is null, the response flows
+/// through the normal `execute_request` path; when non-null, the response is
+/// written directly into the buffer.
+///
+/// # Safety
+///
+/// * `client_adapter_ptr` must not be `null` and must be obtained from the `ConnectionResponse` returned from [`create_client`].
+/// * `client_adapter_ptr` must be able to be safely casted to a valid [`Arc<ClientAdapter>`] via [`Arc::from_raw`]. See the safety documentation of [`std::sync::Arc::from_raw`].
+/// * `request_id` must be a request ID from the foreign language and must be valid until either `success_callback` or `failure_callback` is finished.
+/// * `args` is an optional bytes pointers array. The array must be allocated by the caller and subsequently freed by the caller after this function returns.
+/// * `args_len` is an optional bytes length array. The array must be allocated by the caller and subsequently freed by the caller after this function returns.
+/// * `arg_count` the number of elements in `args` and `args_len`. It must also not be greater than the max value of a signed pointer-sized integer.
+/// * `arg_count` must be 0 if `args` and `args_len` are null.
+/// * `args` and `args_len` must either be both null or be both not null.
+/// * `route_info` could be `null`, which means no route (equivalent to an unset `route_bytes`); if not `null`, it must be a valid pointer to a [`RouteInfo`] struct for the duration of this call. See the safety documentation of [`create_route`].
+/// * When non-null, `response_buf` must point to a writable buffer of at least `response_buf_len` bytes.
+/// * `response_buf_len` must be 0 if `response_buf` is null.
+/// * `span_ptr` is a valid pointer to [`Arc<GlideSpan>`], a span created by [`create_otel_span`] or `0`. The span must be valid until the command is finished.
+/// * This function should only be called with a `client_adapter_ptr` created by [`create_client`], before [`close_client`] was called with the pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn command_with_route_info(
+    client_adapter_ptr: *const c_void,
+    request_id: usize,
+    command_type: RequestType,
+    arg_count: c_ulong,
+    args: *const usize,
+    args_len: *const c_ulong,
+    route_info: *const RouteInfo,
+    response_buf: *mut u8,
+    response_buf_len: usize,
+    span_ptr: u64,
+) -> *mut CommandResult {
+    let buf_option = if response_buf.is_null() {
+        None
+    } else {
+        Some(ResponseBuffer::Single((response_buf, response_buf_len)))
+    };
+    unsafe {
+        execute_command(
+            client_adapter_ptr,
+            request_id,
+            command_type,
+            arg_count,
+            args,
+            args_len,
+            RouteInput::RouteInfo(route_info),
+            buf_option,
+            span_ptr,
+        )
     }
 }

--- a/ffi/tests/ffi_client_tests.rs
+++ b/ffi/tests/ffi_client_tests.rs
@@ -22,18 +22,25 @@ pub(crate) struct AsyncMetrics {
     pub results: HashMap<usize, Result<String, (String, RequestErrorType)>>,
 }
 
+impl AsyncMetrics {
+    fn new() -> Self {
+        Self {
+            success_count: AtomicUsize::new(0),
+            failure_count: AtomicUsize::new(0),
+            results: HashMap::new(),
+        }
+    }
+}
+
 lazy_static! {
-    static ref ASYNC_METRICS: Arc<RwLock<AsyncMetrics>> = Arc::new(RwLock::new(AsyncMetrics {
-        success_count: AtomicUsize::new(0),
-        failure_count: AtomicUsize::new(0),
-        results: HashMap::new(),
-    }));
+    static ref ASYNC_METRICS: Arc<RwLock<AsyncMetrics>> =
+        Arc::new(RwLock::new(AsyncMetrics::new()));
 }
 
 const ASYNC_WRITE_LOCK_ERR: &str = "Failed to aquire ASYNC_METRICS the write lock";
 const ASYNC_READ_LOCK_ERR: &str = "Failed to aquire ASYNC_METRICS the write lock";
 
-/// Success callback function for String responses for the async client
+/// Success callback for the async client.
 extern "C-unwind" fn string_success_callback(index: usize, response_ptr: *const CommandResponse) {
     let mut metrics = ASYNC_METRICS.write().expect(ASYNC_WRITE_LOCK_ERR);
     metrics
@@ -42,7 +49,7 @@ extern "C-unwind" fn string_success_callback(index: usize, response_ptr: *const 
     metrics.success_count.fetch_add(1, Ordering::SeqCst);
 }
 
-/// Failure callback function for the async client
+/// Failure callback for the async client.
 extern "C-unwind" fn failure_callback(
     index: usize,
     err_msg_ptr: *const c_char,
@@ -236,8 +243,179 @@ fn get_async_error(index: usize) -> (String, RequestErrorType) {
     (err_msg.to_string(), err_type.clone())
 }
 
+/// Exercises [`command`] (unrouted): good PING, bad SADD. Sync + async.
+fn test_command(client_ptr: *const c_void, async_client: bool) {
+    // Good command: PING IS_WORKING
+    let good_cmd_idx = 0;
+    let ping_value = b"IS_WORKING";
+    let good_res = execute_command(
+        client_ptr,
+        good_cmd_idx,
+        ping_value,
+        1_u64,
+        RequestType::Ping,
+    );
+    let ping_res = if async_client {
+        assert!(good_res.is_none()); // result should be returned through callback
+        let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
+        assert_eq!(metrics.success_count.load(Ordering::SeqCst), 1);
+        get_async_response(good_cmd_idx)
+    } else {
+        assert!(good_res.is_some());
+        get_sync_response(good_res.unwrap().response)
+    };
+    assert_eq!(ping_res, String::from_utf8_lossy(ping_value));
+    // Bad command: Non existing command args, the server should return with an error: SADD NOTAREALCMD
+    let bad_cmd_idx = 1;
+    let bad_res = execute_command(
+        client_ptr,
+        bad_cmd_idx,
+        b"NOTAREALCMD",
+        1_u64,
+        RequestType::SAdd,
+    );
+    let (err_msg, err_type) = if async_client {
+        assert!(bad_res.is_none()); // result should be returned through callback
+        let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
+        assert_eq!(metrics.failure_count.load(Ordering::SeqCst), 1);
+        get_async_error(bad_cmd_idx)
+    } else {
+        assert!(bad_res.is_some());
+        get_sync_error(bad_res.unwrap().command_error)
+    };
+    assert!(err_msg.contains("wrong number of arguments for 'sadd' command"));
+    assert_eq!(err_type, RequestErrorType::Unspecified);
+}
+
+fn execute_command_with_route_info(
+    client_ptr: *const c_void,
+    index: usize,
+    command_bytes: &[u8],
+    arg_count: u64,
+    command_type: RequestType,
+    route_info: *const RouteInfo,
+) -> Option<Box<CommandResult>> {
+    let command_len = command_bytes.len();
+    let command_vec = [command_bytes.as_ptr()];
+    let command_ptr = command_vec.as_ptr() as *const usize;
+    let args_len = command_len as c_ulong;
+    let args_len_vec = [args_len];
+    let args_len_ptr = args_len_vec.as_ptr();
+
+    let command_res_ptr = unsafe {
+        command_with_route_info(
+            client_ptr,
+            index,
+            command_type,
+            arg_count,
+            command_ptr,
+            args_len_ptr,
+            route_info,
+            std::ptr::null_mut(),
+            0,
+            0,
+        )
+    };
+    if command_res_ptr.is_null() {
+        // If the returned CommandResult pointer is null it means that the Async client is being used.
+        // We shall let the async callback to be called.
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            sleep(Duration::from_millis(1)).await;
+        });
+        None
+    } else {
+        // Sync client, command result returns immediately
+        unsafe { Some(Box::from_raw(command_res_ptr)) }
+    }
+}
+
+/// Exercises [`command_with_route_info`]: good PING, bad SADD, and a
+/// null-route PING, all via `RouteInfo::Random`. Sync + async.
+fn test_command_with_route_info(client_ptr: *const c_void, async_client: bool) {
+    // Route::Random — the only variant guaranteed to be meaningful against
+    // a single-node standalone server. slot_key/hostname are left null
+    // since RouteType::Random doesn't read them.
+    let route_info = RouteInfo {
+        route_type: RouteType::Random,
+        slot_id: 0,
+        slot_key: std::ptr::null(),
+        slot_type: SlotType::Primary,
+        hostname: std::ptr::null(),
+        port: 0,
+    };
+    let route_info_ptr = &route_info as *const RouteInfo;
+
+    // Good command: PING IS_WORKING, routed via RouteInfo instead of route_bytes.
+    let good_cmd_idx = 2;
+    let ping_value = b"IS_WORKING";
+    let good_res = execute_command_with_route_info(
+        client_ptr,
+        good_cmd_idx,
+        ping_value,
+        1_u64,
+        RequestType::Ping,
+        route_info_ptr,
+    );
+    let ping_res = if async_client {
+        assert!(good_res.is_none()); // result should be returned through callback
+        let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
+        assert_eq!(metrics.success_count.load(Ordering::SeqCst), 2);
+        get_async_response(good_cmd_idx)
+    } else {
+        assert!(good_res.is_some());
+        get_sync_response(good_res.unwrap().response)
+    };
+    assert_eq!(ping_res, String::from_utf8_lossy(ping_value));
+
+    // Bad command: Non existing command args, the server should return with an error: SADD NOTAREALCMD
+    let bad_cmd_idx = 3;
+    let bad_res = execute_command_with_route_info(
+        client_ptr,
+        bad_cmd_idx,
+        b"NOTAREALCMD",
+        1_u64,
+        RequestType::SAdd,
+        route_info_ptr,
+    );
+    let (err_msg, err_type) = if async_client {
+        assert!(bad_res.is_none()); // result should be returned through callback
+        let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
+        assert_eq!(metrics.failure_count.load(Ordering::SeqCst), 2);
+        get_async_error(bad_cmd_idx)
+    } else {
+        assert!(bad_res.is_some());
+        get_sync_error(bad_res.unwrap().command_error)
+    };
+    assert!(err_msg.contains("wrong number of arguments for 'sadd' command"));
+    assert_eq!(err_type, RequestErrorType::Unspecified);
+
+    // Null route_info should behave identically to an unrouted command
+    // (mirrors route_bytes = null / route_bytes_len = 0 on the protobuf path).
+    let null_route_cmd_idx = 4;
+    let null_route_res = execute_command_with_route_info(
+        client_ptr,
+        null_route_cmd_idx,
+        ping_value,
+        1_u64,
+        RequestType::Ping,
+        std::ptr::null(),
+    );
+    let null_route_ping_res = if async_client {
+        assert!(null_route_res.is_none());
+        let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
+        assert_eq!(metrics.success_count.load(Ordering::SeqCst), 3);
+        get_async_response(null_route_cmd_idx)
+    } else {
+        assert!(null_route_res.is_some());
+        get_sync_response(null_route_res.unwrap().response)
+    };
+    assert_eq!(null_route_ping_res, String::from_utf8_lossy(ping_value));
+}
+
+/// Test both command entrypoints executions.
 #[rstest]
-fn test_ffi_client_command_execution(#[values(false, true)] async_client: bool) {
+fn test_ffi_client_command_executions(#[values(false, true)] async_client: bool) {
     let server = Server::new();
     let connection_request_bytes = create_connection_request(server.port);
     let connection_request_len = connection_request_bytes.len();
@@ -292,50 +470,15 @@ fn test_ffi_client_command_execution(#[values(false, true)] async_client: bool) 
         );
 
         let client_ptr = response.conn_ptr;
-        // Good command: PING IS_WORKING
-        let good_cmd_idx = 0;
-        let ping_value = b"IS_WORKING";
-        let good_res = execute_command(
-            client_ptr,
-            good_cmd_idx,
-            ping_value,
-            1_u64,
-            RequestType::Ping,
-        );
-        let ping_res = if async_client {
-            assert!(good_res.is_none()); // result should be returned through callback
-            let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
-            assert_eq!(metrics.success_count.load(Ordering::SeqCst), 1);
-            get_async_response(good_cmd_idx)
-        } else {
-            assert!(good_res.is_some());
-            get_sync_response(good_res.unwrap().response)
-        };
-        assert_eq!(ping_res, String::from_utf8_lossy(ping_value));
-        // Bad command: Non existing command args, the server should return with an error: SADD NOTAREALCMD
-        let bad_cmd_idx = 1;
-        let bad_res = execute_command(
-            client_ptr,
-            bad_cmd_idx,
-            b"NOTAREALCMD",
-            1_u64,
-            RequestType::SAdd,
-        );
-        let (err_msg, err_type) = if async_client {
-            assert!(bad_res.is_none()); // result should be returned through callback
-            let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
-            assert_eq!(metrics.failure_count.load(Ordering::SeqCst), 1);
-            get_async_error(bad_cmd_idx)
-        } else {
-            assert!(bad_res.is_some());
-            get_sync_error(bad_res.unwrap().command_error)
-        };
-        assert!(err_msg.contains("wrong number of arguments for 'sadd' command"));
-        assert_eq!(err_type, RequestErrorType::Unspecified);
+
+        test_command(client_ptr, async_client);
+        test_command_with_route_info(client_ptr, async_client);
+
         free_connection_response(response_ptr as *mut ConnectionResponse);
         close_client(client_ptr);
     }
 }
+
 #[test]
 fn test_create_otel_span_with_parent() {
     // Test creating a parent span

--- a/ffi/tests/ffi_client_tests.rs
+++ b/ffi/tests/ffi_client_tests.rs
@@ -22,25 +22,18 @@ pub(crate) struct AsyncMetrics {
     pub results: HashMap<usize, Result<String, (String, RequestErrorType)>>,
 }
 
-impl AsyncMetrics {
-    fn new() -> Self {
-        Self {
-            success_count: AtomicUsize::new(0),
-            failure_count: AtomicUsize::new(0),
-            results: HashMap::new(),
-        }
-    }
-}
-
 lazy_static! {
-    static ref ASYNC_METRICS: Arc<RwLock<AsyncMetrics>> =
-        Arc::new(RwLock::new(AsyncMetrics::new()));
+    static ref ASYNC_METRICS: Arc<RwLock<AsyncMetrics>> = Arc::new(RwLock::new(AsyncMetrics {
+        success_count: AtomicUsize::new(0),
+        failure_count: AtomicUsize::new(0),
+        results: HashMap::new(),
+    }));
 }
 
 const ASYNC_WRITE_LOCK_ERR: &str = "Failed to aquire ASYNC_METRICS the write lock";
 const ASYNC_READ_LOCK_ERR: &str = "Failed to aquire ASYNC_METRICS the write lock";
 
-/// Success callback for the async client.
+/// Success callback function for String responses for the async client
 extern "C-unwind" fn string_success_callback(index: usize, response_ptr: *const CommandResponse) {
     let mut metrics = ASYNC_METRICS.write().expect(ASYNC_WRITE_LOCK_ERR);
     metrics
@@ -49,7 +42,7 @@ extern "C-unwind" fn string_success_callback(index: usize, response_ptr: *const 
     metrics.success_count.fetch_add(1, Ordering::SeqCst);
 }
 
-/// Failure callback for the async client.
+/// Failure callback function for the async client
 extern "C-unwind" fn failure_callback(
     index: usize,
     err_msg_ptr: *const c_char,


### PR DESCRIPTION
### Summary

Adds `command_with_route_info`, a new FFI entrypoint that takes routing as a `RouteInfo` C-struct pointer instead of protobuf-encoded bytes — same mechanism `batch()` already uses. No existing entrypoint signatures change.

### Issue link

Closes https://github.com/valkey-io/valkey-glide-ruby/issues/140

### Features / Behaviour Changes

-   New `command_with_route_info` FFI function, sibling of `command_with_buffer`, resolves routing via `create_route(route_info, Some(&cmd))`.
-   `command`, `command_with_buffer`, `command_with_buffers`, `invoke_script` unchanged.
-   `invoke_script_with_route_info` deferred to a follow-up (not in this PR).

### Implementation

-  New `RouteInput` enum (`ProtobufBytes` / `RouteInfo` variants) shares command-dispatch logic (arg conversion, compression, span setup) between the protobuf and `RouteInfo` paths via `resolve()` / `resolve_protobuf_bytes()` / `resolve_route_info()`, avoiding duplicating that logic for the new entrypoint.
-  Extracted the shared dispatch core (arg conversion, compression, span setup, routing resolution, dispatch) out of `execute_command_with_buffer_option` into `execute_command`. It handles both protobuf and `RouteInfo`. 
-  `execute_command_with_buffer_option` remains as a thin wrapper so `command_with_buffer`/`command_with_buffers` are unchanged.
-  Reuses existing `RouteInfo`/`RouteType`/`SlotType`/`create_route` — all pre-existing, already used by `batch()`.

### Limitations

-   `invoke_script_with_route_info` not included — script invocation still only supports protobuf routing for now.

### Testing

-   New FFI-level test in `ffi_client_tests.rs` exercising `command_with_route_info` end-to-end (good command, error command, null `route_info`) against a live standalone server, sync + async clients.
-   `cargo build`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` all clean.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [ ] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
