### PR TITLE
perf(core): reduce GET/MGET/SET hot-path copies (buffer slicing + vectored send)

### DIFF
--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -574,12 +574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,9 +909,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "file-rotate"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
 dependencies = [
  "chrono",
  "flate2",
@@ -1197,20 +1191,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1569,27 +1557,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1703,11 +1696,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2270,8 +2263,8 @@ dependencies = [
  "rustls-platform-verifier",
  "ryu",
  "socket2",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "telemetrylib",
  "tokio",
  "tokio-retry2 0.5.8",
@@ -2461,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2666,6 +2659,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,9 +2716,9 @@ checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -2726,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3509,20 +3518,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3531,7 +3531,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3545,40 +3545,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3588,21 +3567,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3618,21 +3585,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3642,21 +3597,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/docs/zero-copy-benchmarks.md
+++ b/docs/zero-copy-benchmarks.md
@@ -1,0 +1,111 @@
+# Zero-Copy Initiative — Benchmark Analysis
+
+Measured impact of the reduced-copy receive path and the vectored/zero-copy
+send path. **Terminology:** the receive side is *reduced-copy* (reaches the
+one-copy floor: kernel read buffer → caller); the send side via `arg_shared` is
+*true zero-copy* (owned `Bytes` → socket, no userspace copy); plain `arg` send
+is reduced to one copy.
+
+## Methodology
+
+- **Baseline:** upstream `main` at the branch point, built identically.
+- **Server:** valkey-server 8.1.3, loopback (127.0.0.1). Loopback means the
+  kernel `send`/`recv` copy and TCP dominate wall-clock at large value sizes, so
+  **instructions retired** (via `perf stat`) is reported as the primary
+  *client-CPU* signal where wall-clock is noisy.
+- **Harnesses (in `glide-core/redis-rs/redis`):**
+  - Micro: `benches/bench_zerocopy.rs` (criterion) — decodes RESP frames through
+    the production `ValueCodec` path.
+  - E2e receive/send: `examples/zc_e2e.rs` — pipelined GET/MGET/SET through a
+    real `MultiplexedConnection`.
+  - E2e sync send: `examples/zc_sync_set.rs` — single blocking connection, tight
+    SET loop (low-noise, single-threaded).
+- **Repetition:** 3+ alternating baseline/modified runs; high-variance cells are
+  flagged.
+
+## Receive — decode micro-benchmark (`ValueCodec`)
+
+Mean decode time vs baseline (negative = faster). The receive change replaces a
+per-bulk-string `Vec` alloc + `memcpy` with a slice of one frame buffer.
+
+| Shape | Δ time |
+|-------|--------|
+| single GET 64 B | −47…−56% |
+| single GET 1 KB | −31…−37% |
+| single GET 16 KB | −9…−16% |
+| single GET 256 KB | −70…−95% (high variance) |
+| MGET 1000×64 B | −71% |
+| MGET 1000×1 KB | −71…−76% |
+| MGET 100×16 KB | −51…−59% |
+| pipeline 100×1 KB | −28% |
+| pipeline 100×16 KB | ~flat…−36% (high variance) |
+
+**Reading it:** multi-element responses (MGET) win most — one alloc+copy per
+element is eliminated, so allocator pressure drops sharply. Single small GETs
+win from the removed allocation; large single GETs are dominated by the one
+remaining copy so the % swings with noise.
+
+## Receive — end-to-end (`MultiplexedConnection`)
+
+Throughput and client CPU vs baseline (via `perf stat task-clock`).
+
+| Workload | Throughput | Client CPU |
+|----------|-----------|------------|
+| MGET 100×1 KB | **+1.9×** | −50% |
+| MGET 100×16 KB | +12…+32% | **−60…−70%** |
+| single GET 16 KB | parity | parity |
+| single GET 256 KB | parity | −0…−8% |
+
+MGET is the headline: at 100×1 KB the client is CPU-bound on
+per-element alloc/copy, so removing it nearly doubles throughput. Single GET is
+server/loopback-bound, so client-CPU savings don't move throughput.
+
+## Send — sync SET (`zc_sync_set`, instructions retired)
+
+Single-threaded, low-noise. Instruction count is the clean client-CPU signal.
+
+| Value size | baseline | plain `arg` | `arg_shared` |
+|------------|----------|-------------|--------------|
+| 256 KB | 629 M | **381 M (−39%)** | **103 M (−84%)** |
+| 16 KB | 642 M | ~flat | 509 M (−21%) |
+| 1 KB (< 4 KB inline threshold) | 979 M | 953 M (−3%) | inlined (n/a) |
+
+- `arg` (borrowed slice): payload copied **once** into an owned `Bytes`, then
+  vectored to the socket — the packing + framed-buffer copies are gone (3 → 1).
+- `arg_shared` (caller owns `Bytes`): **zero** userspace payload copies.
+- Below the 4 KB threshold the segmented/vectored path is gated off, so small
+  commands take the original contiguous path (no regression).
+
+## Send — end-to-end SET (`zc_e2e`)
+
+| Workload | Throughput | Client CPU |
+|----------|-----------|------------|
+| SET 256 KB via `arg_shared` | **+3.2×** | **−78%** |
+| SET 256 KB via plain `arg` | wall noisy | −42% instructions |
+| SET 16 KB | +3…+7% | ~parity |
+
+## What does NOT improve (honest limits)
+
+- The kernel↔userspace `recv`/`send` copy remains — it is the one-copy floor and
+  only disappears with `io_uring` registered buffers (out of scope).
+- Single small GET/SET end-to-end throughput is server/loopback-bound; the win
+  is client-CPU, visible under CPU-bound multiplexed load, not in these
+  round-trip numbers.
+- Socket-listener bindings (Node, python-async) re-serialize responses into
+  protobuf, re-copying; the parser win still applies in front of that layer but
+  the end-to-end binding win awaits protobuf removal.
+- Compression forces an owned buffer on both sides.
+
+## Reproduction
+
+```bash
+cd glide-core/redis-rs/redis
+# micro
+cargo bench --bench bench_zerocopy --features tokio-comp -- codec
+# e2e (needs a server on :6399)
+cargo build --release --example zc_e2e --example zc_sync_set --features tokio-comp
+perf stat -e task-clock,instructions -- \
+  ./target/release/examples/zc_e2e 6399 mgetv 16384 20000 64
+perf stat -e instructions -- \
+  ./target/release/examples/zc_sync_set 6399 arg_shared 262144 20000
+```

--- a/docs/zero-copy-initiative.md
+++ b/docs/zero-copy-initiative.md
@@ -1,0 +1,212 @@
+# Zero-Copy Initiative — glide-core / redis-rs
+
+Reducing per-value memory copies on the client hot path, on both the receive
+(GET/MGET) and send (SET) sides, by teaching the vendored `redis-rs` to slice
+the connection buffers instead of copying payloads.
+
+- **Status:** implemented on a feature branch; benchmarked; all unit +
+  integration tests passing.
+- **Scope:** `glide-core/redis-rs/redis` (parser, `Value`, `Cmd`, connections),
+  `ffi` (response arena, arg handling). No language-binding API changes
+  required for the core win.
+
+---
+
+## 1. Motivation
+
+Prior work (PRs #5492 / #5493) added a "zero-copy" buffered GET/SET API to the
+Python-sync binding. Tracing the actual data path showed those paths were
+**reduced-copy, not zero-copy**: they removed the arena allocation and the
+binding-side (Rust→Python) copy, but the vendored `redis-rs` still copied every
+payload at least once — because its contract forced owned buffers:
+
+- **Receive:** the `combine` RESP parser builds `Value::BulkString(Vec<u8>)` by
+  `to_vec()`-ing the payload out of the socket read buffer (one alloc + memcpy
+  **per bulk string**), then the FFI copied that `Vec` again into the caller
+  buffer/arena.
+- **Send:** a `SET` value was copied up to three times after leaving the
+  binding — into `Cmd.data`, into the packed RESP `Vec`, and into the framed
+  write buffer — before reaching the kernel.
+
+This initiative removes those copies structurally.
+
+### Copy budget (256 KB value, before → after)
+
+| Path | Before (userspace copies) | After |
+|------|---------------------------|-------|
+| GET / MGET receive (per value) | 2 (parser `to_vec` + arena/binding) | **1** (read buffer → caller) |
+| GET via buffered API | 2 | **1** |
+| SET send (borrowed slice) | 3 (+1 if compressed) | **1** |
+| SET send (`arg_shared` / owned `Bytes`) | 3 | **0** |
+
+The kernel↔userspace `recv`/`send` copy is the remaining floor and is out of
+scope (it only disappears with `io_uring` registered buffers).
+
+---
+
+## 2. Design
+
+Three phases, ordered by win-per-risk. Phases 1–2 are implemented; Phase 3 is
+deliberately deferred (see §6).
+
+### Phase 1 — Receive side: `Value::BulkString(Bytes)`
+
+`Value::BulkString(Vec<u8>)` → `Value::BulkString(bytes::Bytes)`. `Bytes` is a
+refcounted view, so bulk-string payloads can be **slices of the connection read
+buffer** with no per-value allocation or memcpy.
+
+The `combine` streaming parser cannot produce zero-copy slices — it only sees
+borrowed `&[u8]` and must own partial frames that straddle socket reads. So the
+async hot path (`ValueCodec`, used by `MultiplexedConnection`) uses a new,
+purpose-built decoder:
+
+1. **Scan** the read buffer for one complete top-level frame *without consuming
+   anything* (walks type bytes + length headers only; payload bytes are skipped
+   by length). Returns `None` if the frame is incomplete → wait for more data.
+2. **Extract** the complete frame:
+   - Frames ≤ 64 KB: one bulk `memcpy` into an owned `Bytes` (keeps the codec's
+     `BytesMut` **unshared** so tokio keeps reusing its read allocation).
+   - Frames > 64 KB: `split_to(len).freeze()` takes the allocation zero-copy
+     (copying hundreds of KB costs more than losing one buffer's reuse).
+3. **Parse** the `Value` tree by slicing bulk-string payloads directly out of
+   that one frame `Bytes` — zero copies, zero allocations per element.
+
+The sync `parse_redis_value` path keeps `combine` (copies into `Bytes`); it is
+not the production hot path.
+
+The **frame scanner is resumable** (`ScanState`: resume offset + a
+remaining-children stack), persisted in `ValueCodec` across `decode` calls, so a
+large multi-element frame arriving over many reads is scanned once
+(O(elements)) instead of restarting from offset 0 every read
+(O(reads × elements)).
+
+**FFI arena** (`ResponseArena`) stores `Bytes` instead of `Vec<u8>`, so
+non-buffered GET/MGET responses hand the refcounted read-buffer slice straight
+to the binding — one copy end-to-end instead of two.
+
+### Phase 2 — Send side: shared args + vectored writes
+
+- `Cmd` args are stored as `StoredArg` = `Inline(offset) | Shared(Bytes) |
+  Cursor`. Args larger than `SHARED_ARG_INLINE_MAX` (4 KB) — via the new
+  `Cmd::arg_shared(Bytes)` or automatically in `write_arg` — are held
+  out-of-line as refcounted `Bytes`, never copied into the command buffer.
+- `SegmentedBytes` represents a packed command as a sequence of byte segments:
+  framing + small inline args coalesce into contiguous segments; large shared
+  payloads are their own zero-copy segments. `get_packed_segments()` is
+  **byte-identical on the wire** to `get_packed_command()` (unit-tested).
+- `MultiplexedConnection` splits its stream: `FramedRead` keeps the zero-copy
+  decode; writes go through a new `VectoredSink` that queues segments and
+  submits them with `poll_write_vectored` (512 KB backpressure watermark, ≤64
+  iovecs/syscall). Payload segments go from the caller's allocation straight to
+  the socket.
+- The sync `Connection` and async single `Connection` gained the same vectored
+  send path (`write_vectored` loops handling partial writes).
+
+**Gating:** commands with no out-of-line payload
+(`Cmd::has_out_of_line_args() == false`) take the original contiguous
+pack-and-write path — the segmented/vectored machinery is only paid when a
+large shared payload can actually skip a copy (avoids a measured +10%
+small-command regression).
+
+---
+
+## 3. Safety
+
+- **Buffer pinning:** a `Bytes` slice keeps its whole underlying read chunk
+  alive. Fine for request/response (dropped promptly), dangerous for retained
+  values. `Value::detach_buffers()` deep-copies, and is applied at the
+  client-side cache insert so cached values never pin network buffers. The FFI
+  arena pins only until the binding frees the response.
+- **Recursion guard:** the new iterative scanner enforces the same
+  `MAX_RECURSE_DEPTH` as the recursive parser (depth = scan stack length),
+  covered by codec-path tests for every RESP3 aggregate type.
+- **Partial writes:** all vectored writers advance the `IoSlice` cursor until
+  fully drained and treat a 0-byte write as `WriteZero`.
+- **Wire-format equivalence:** `get_packed_segments` is asserted byte-identical
+  to `get_packed_command` across simple/cursor/fenced/interleaved cases.
+
+---
+
+## 4. Benchmarks
+
+Environment: valkey-server 8.1.3 on loopback; `perf stat`. Micro-benchmarks via
+`glide-core/redis-rs/redis/benches/bench_zerocopy.rs`; e2e via the
+`zc_e2e` / `zc_sync_set` examples. Baseline = upstream `main` at the branch
+point.
+
+### Receive — decode micro-bench (mean time, vs baseline)
+
+| Shape | Change |
+|-------|--------|
+| Single GET 64 B / 1 KB / 16 KB / 256 KB | −56% / −37% / −9% / −95% |
+| MGET 1000×64 B / 1000×1 KB / 100×16 KB | −71% / −71% / −51% |
+| Pipeline 100×1 KB / 100×16 KB | −28% / ~flat |
+
+### Receive — end-to-end (throughput / client CPU, vs baseline)
+
+| Workload | Throughput | Client CPU |
+|----------|-----------|------------|
+| MGET 100×16 KB | +12–32% | **−60…−70%** |
+| MGET 100×1 KB | **+1.9×** | −50% |
+| Single GET 16 KB / 256 KB | parity | parity … −8% |
+
+### Send — sync `SET` (instructions retired, vs baseline; low-noise single-thread)
+
+| Value size | baseline | `arg` | `arg_shared` |
+|------------|----------|-------|--------------|
+| 256 KB | 629M | **381M (−39%)** | **103M (−84%)** |
+| 16 KB | 642M | ~flat | 509M (−21%) |
+| 1 KB (below threshold) | 979M | 953M (−2.6%) | inlined |
+
+### Send — async `SET` (e2e, vs baseline)
+
+| Workload | Throughput | Client CPU |
+|----------|-----------|------------|
+| SET 256 KB via `arg_shared` | **+3.2×** | **−78%** |
+| SET 256 KB via plain `arg` | (noisy wall) | −42% instructions |
+| SET 16 KB | +3–7% | ~parity |
+
+Profiles confirm the parser `to_vec` and the send-side packing/encode copies
+are gone; the remaining dominant cost is the kernel `recv`/`send` copy (the
+Phase 3 floor).
+
+---
+
+## 5. Testing
+
+- `redis` lib: 299 unit tests (incl. new segmented-packing and codec
+  recursion-guard tests).
+- Parser correctness: `partial_io_parse` (combine path) + new
+  `codec_chunked_parse` quickcheck — the zero-copy codec must decode
+  identically under arbitrary socket chunking.
+- Connection integration (live server): `test_basic` 57 (sync send path),
+  `test_async` 32 (async single-conn send path).
+- `glide-core`: 150 lib tests. `ffi`: 60 tests incl. live-server e2e through
+  the arena + vectored send.
+
+---
+
+## 6. Not done / follow-ups
+
+- **Phase 3 (true zero-copy receive):** parse RESP payloads directly from the
+  socket into pre-registered caller buffers, bypassing the read-buffer staging
+  copy. High complexity (bifurcates the multiplexer read loop); Phase 1 already
+  reaches the one-copy floor, so gated on a profile showing the staging copy
+  matters.
+- **Sync pipeline** (`ConnectionLike::req_packed_commands`) takes an
+  already-packed `&[u8]` at the trait boundary, so it stays contiguous;
+  vectoring it needs a trait-wide signature change.
+- **Socket-listener bindings** (Node, python-async) still serialize responses
+  into protobuf, which re-copies. The parser win still applies in front of it;
+  full end-to-end benefit needs the protobuf-removal initiative.
+- **Compression** forces an owned buffer on both sides regardless.
+
+---
+
+## 7. Commit map
+
+| Area | Commits |
+|------|---------|
+| Benches (harness) | decode micro-bench, codec-path benches |
+| Phase 1 receive | `Value::BulkString(Bytes)` + zero-copy frame codec; hybrid frame extraction; resumable scanner; FFI arena `Bytes` |
+| Phase 2 send | `arg_shared` + `SegmentedBytes`; `VectoredSink`; FFI `arg_shared` wiring; auto-share + scratch reserve; sync/async-single vectored send; shared-arg gating |

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
 name = "glide-ffi"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "glide-core",
  "lazy_static",
  "libc",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Valkey GLIDE Maintainers"]
 crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
+bytes = "1"
 libc = "0.2"
 protobuf = { version = "3", features = [] }
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2558,7 +2558,13 @@ pub struct ResponseArena {
     /// All CommandResponse nodes. Index 0 is the root.
     nodes: Vec<CommandResponse>,
     /// Owned string buffers (kept alive until arena is freed).
-    strings: Vec<Vec<u8>>,
+    ///
+    /// Held as [`bytes::Bytes`] so `BulkString` payloads — zero-copy slices
+    /// of the connection read buffer — can be stored without a `to_vec()`
+    /// copy. NOTE: while the arena is alive it pins the read-buffer chunks
+    /// its slices came from; bindings free the arena promptly after
+    /// materializing values, keeping that window short.
+    strings: Vec<bytes::Bytes>,
 }
 
 const MAX_ARENA_POOL_SIZE: usize = 16;
@@ -2620,7 +2626,9 @@ impl ResponseArena {
     }
 
     /// Store a string buffer, returning (ptr, len) for the CommandResponse fields.
-    fn store_string(&mut self, data: Vec<u8>) -> (*mut c_char, c_long) {
+    /// Accepts anything convertible to `Bytes`; `Vec<u8>` converts zero-copy.
+    fn store_string(&mut self, data: impl Into<bytes::Bytes>) -> (*mut c_char, c_long) {
+        let data = data.into();
         let ptr = data.as_ptr() as *mut c_char;
         let len = data.len() as c_long;
         self.strings.push(data);
@@ -2689,9 +2697,11 @@ impl ResponseArena {
                         unsafe {
                             std::ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
                         }
-                        data.len().to_string().into_bytes()
+                        bytes::Bytes::from(data.len().to_string().into_bytes())
                     } else {
-                        data.to_vec()
+                        // Zero-copy: the arena keeps the refcounted slice of
+                        // the read buffer alive; no payload copy.
+                        data
                     };
                 let (ptr, len) = self.store_string(data);
                 self.nodes[idx].response_type = ResponseType::String;
@@ -2773,7 +2783,7 @@ impl ResponseArena {
 
                 // kind key
                 let ki = self.alloc_node();
-                let (ptr, len) = self.store_string(b"kind".to_vec());
+                let (ptr, len) = self.store_string(bytes::Bytes::from_static(b"kind"));
                 self.nodes[ki].response_type = ResponseType::String;
                 self.nodes[ki].string_value = ptr;
                 self.nodes[ki].string_value_len = len;
@@ -2788,7 +2798,7 @@ impl ResponseArena {
 
                 // values key
                 let vk = self.alloc_node();
-                let (ptr, len) = self.store_string(b"values".to_vec());
+                let (ptr, len) = self.store_string(bytes::Bytes::from_static(b"values"));
                 self.nodes[vk].response_type = ResponseType::String;
                 self.nodes[vk].string_value = ptr;
                 self.nodes[vk].string_value_len = len;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1206,7 +1206,7 @@ fn extract_pubsub_data(push_msg: &redis::PushInfo) -> (Vec<u8>, Vec<u8>, Option<
         .iter()
         .filter_map(|v| {
             if let Value::BulkString(s) = v {
-                Some(s.as_slice())
+                Some(s.as_ref())
             } else {
                 None
             }
@@ -1246,7 +1246,7 @@ unsafe fn process_push_notification(
             let Value::BulkString(str) = v else {
                 unreachable!()
             };
-            let (ptr, len) = convert_vec_to_pointer(str.clone());
+            let (ptr, len) = convert_vec_to_pointer(str.to_vec());
             (ptr, len)
         })
         .collect();
@@ -2691,7 +2691,7 @@ impl ResponseArena {
                         }
                         data.len().to_string().into_bytes()
                     } else {
-                        data
+                        data.to_vec()
                     };
                 let (ptr, len) = self.store_string(data);
                 self.nodes[idx].response_type = ResponseType::String;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3047,6 +3047,31 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
 /// a scalar reply, one buffer per element for an array reply).
 ///
 /// # Safety
+/// Append a caller-provided argument to `cmd` with minimal copying.
+///
+/// Large payloads are copied ONCE at the FFI boundary into a refcounted
+/// `Bytes` (the caller's buffer is only guaranteed to live until this call
+/// returns) and then written to the socket zero-copy via vectored I/O —
+/// instead of being copied again at packing and encode time. Small args are
+/// inlined as before.
+fn append_cmd_arg(cmd: &mut Cmd, arg: &[u8]) {
+    if arg.len() > redis::SHARED_ARG_INLINE_MAX {
+        cmd.arg_shared(bytes::Bytes::copy_from_slice(arg));
+    } else {
+        cmd.arg(arg);
+    }
+}
+
+/// Like [`append_cmd_arg`] for owned buffers (compressed args): `Vec<u8>` to
+/// `Bytes` conversion is zero-copy, so large args are never copied at all.
+fn append_cmd_arg_owned(cmd: &mut Cmd, arg: Vec<u8>) {
+    if arg.len() > redis::SHARED_ARG_INLINE_MAX {
+        cmd.arg_shared(bytes::Bytes::from(arg));
+    } else {
+        cmd.arg(arg);
+    }
+}
+
 /// `client_adapter_ptr` and `args`/`args_len` follow the same contract as
 /// [`command_with_buffer`]. `route_input` follows the safety contract
 /// documented on [`RouteInput::resolve`]. Any buffers referenced by
@@ -3128,14 +3153,14 @@ unsafe fn execute_command(
             return unsafe { client_adapter.handle_redis_error(err, request_id) };
         }
 
-        // Use the compressed arguments
-        for command_arg in &owned_args {
-            cmd.arg(command_arg);
+        // Use the compressed arguments (owned: Vec->Bytes is zero-copy)
+        for command_arg in owned_args {
+            append_cmd_arg_owned(&mut cmd, command_arg);
         }
     } else {
         // Use the original arguments
         for command_arg in &arg_vec {
-            cmd.arg(command_arg);
+            append_cmd_arg(&mut cmd, command_arg);
         }
     }
 
@@ -4222,14 +4247,14 @@ pub(crate) unsafe fn create_cmd(
             return Err(format!("Compression failed: {}", err));
         }
 
-        // Use the compressed arguments
-        for command_arg in &owned_args {
-            cmd.arg(command_arg);
+        // Use the compressed arguments (owned: Vec->Bytes is zero-copy)
+        for command_arg in owned_args {
+            append_cmd_arg_owned(&mut cmd, command_arg);
         }
     } else {
         // Use the original arguments
         for command_arg in &arg_vec {
-            cmd.arg(command_arg);
+            append_cmd_arg(&mut cmd, command_arg);
         }
     }
 

--- a/glide-core/benches/memory_benchmark.rs
+++ b/glide-core/benches/memory_benchmark.rs
@@ -66,8 +66,8 @@ fn send_and_receive_messages() {
         assert!(
             result
                 == Value::Array(vec![
-                    Value::BulkString(b"foo".to_vec()),
-                    Value::BulkString(b"bar".to_vec())
+                    Value::BulkString(b"foo".to_vec().into()),
+                    Value::BulkString(b"bar".to_vec().into())
                 ])
         )
     });
@@ -94,8 +94,8 @@ fn lots_of_messages() {
             assert!(
                 result
                     == Value::Array(vec![
-                        Value::BulkString(b"foo".to_vec()),
-                        Value::BulkString(b"bar".to_vec())
+                        Value::BulkString(b"foo".to_vec().into()),
+                        Value::BulkString(b"bar".to_vec().into())
                     ])
             )
         }

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -167,6 +167,10 @@ harness = false
 required-features = ["tokio-comp"]
 
 [[bench]]
+name = "bench_zerocopy"
+harness = false
+
+[[bench]]
 name = "bench_cluster"
 harness = false
 required-features = ["cluster"]

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -44,7 +44,7 @@ url = "2"
 combine = { version = "4", default-features = false, features = ["std"] }
 
 # Only needed for AIO
-bytes = { version = "1", optional = true }
+bytes = { version = "1" }
 futures-util = { version = "0.3", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
@@ -99,7 +99,6 @@ default = [
     "tls-rustls-insecure",
 ]
 aio = [
-    "bytes",
     "pin-project-lite",
     "futures-util",
     "futures-util/alloc",

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -121,6 +121,8 @@ keep-alive = ["socket2"]
 sentinel = ["rand"]
 
 [dev-dependencies]
+bytes = "1"
+tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.9"
 socket2 = "0.6"
 fnv = "1"
@@ -169,6 +171,7 @@ required-features = ["tokio-comp"]
 [[bench]]
 name = "bench_zerocopy"
 harness = false
+required-features = ["tokio-comp"]
 
 [[bench]]
 name = "bench_cluster"

--- a/glide-core/redis-rs/redis/benches/bench_basic.rs
+++ b/glide-core/redis-rs/redis/benches/bench_basic.rs
@@ -259,7 +259,7 @@ fn bench_decode(c: &mut Criterion) {
         Value::SimpleString("testing".to_string()),
         Value::Array(vec![]),
         Value::Nil,
-        Value::BulkString(vec![b'a'; 10]),
+        Value::BulkString(vec![b'a'; 10].into()),
         Value::Int(7512182390),
     ]);
 

--- a/glide-core/redis-rs/redis/benches/bench_zerocopy.rs
+++ b/glide-core/redis-rs/redis/benches/bench_zerocopy.rs
@@ -1,0 +1,75 @@
+//! Focused parser decode benchmark for the zero-copy (Phase 1) work.
+//!
+//! Measures `parse_redis_value` on bulk-string-heavy RESP payloads across a
+//! range of value sizes and array cardinalities. This isolates the cost that
+//! Phase 1 targets: the per-bulk-string `to_vec()` allocation + memcpy in the
+//! parser. Self-contained (manual RESP encoding), needs no server.
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use redis::parse_redis_value;
+
+/// Encode a single RESP bulk string: `$<len>\r\n<payload>\r\n`.
+fn encode_bulk(payload: &[u8], out: &mut Vec<u8>) {
+    out.push(b'$');
+    out.extend_from_slice(payload.len().to_string().as_bytes());
+    out.extend_from_slice(b"\r\n");
+    out.extend_from_slice(payload);
+    out.extend_from_slice(b"\r\n");
+}
+
+/// Encode a RESP array header: `*<count>\r\n`.
+fn encode_array_header(count: usize, out: &mut Vec<u8>) {
+    out.push(b'*');
+    out.extend_from_slice(count.to_string().as_bytes());
+    out.extend_from_slice(b"\r\n");
+}
+
+/// A single bulk string of `size` bytes (the single-GET shape).
+fn single_bulk(size: usize) -> Vec<u8> {
+    let payload = vec![b'x'; size];
+    let mut out = Vec::new();
+    encode_bulk(&payload, &mut out);
+    out
+}
+
+/// An array of `count` bulk strings each `size` bytes (the MGET/HGETALL shape).
+fn array_of_bulks(count: usize, size: usize) -> Vec<u8> {
+    let payload = vec![b'x'; size];
+    let mut out = Vec::new();
+    encode_array_header(count, &mut out);
+    for _ in 0..count {
+        encode_bulk(&payload, &mut out);
+    }
+    out
+}
+
+fn bench_single_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_single_get");
+    for size in [64usize, 1024, 16 * 1024, 256 * 1024] {
+        let input = single_bulk(size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| parse_redis_value(input).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_mget_array(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_mget_array");
+    // (count, value_size): small values dominated by alloc count; large by memcpy.
+    for (count, size) in [(1000usize, 64usize), (1000, 1024), (100, 16 * 1024)] {
+        let input = array_of_bulks(count, size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{count}x{size}")),
+            &input,
+            |b, input| {
+                b.iter(|| parse_redis_value(input).unwrap());
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_single_get, bench_mget_array);
+criterion_main!(benches);

--- a/glide-core/redis-rs/redis/benches/bench_zerocopy.rs
+++ b/glide-core/redis-rs/redis/benches/bench_zerocopy.rs
@@ -4,8 +4,12 @@
 //! range of value sizes and array cardinalities. This isolates the cost that
 //! Phase 1 targets: the per-bulk-string `to_vec()` allocation + memcpy in the
 //! parser. Self-contained (manual RESP encoding), needs no server.
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use redis::parse_redis_value;
+
+use bytes::BytesMut;
+use redis::ValueCodec;
+use tokio_util::codec::Decoder;
 
 /// Encode a single RESP bulk string: `$<len>\r\n<payload>\r\n`.
 fn encode_bulk(payload: &[u8], out: &mut Vec<u8>) {
@@ -71,5 +75,89 @@ fn bench_mget_array(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_single_get, bench_mget_array);
+/// Decode via the async `ValueCodec` path — this is the path the multiplexed
+/// connection uses in production, and where the zero-copy change lands.
+/// `iter_batched` keeps the buffer refill out of the timed region.
+fn codec_decode_all(mut buf: BytesMut) -> usize {
+    let mut codec = ValueCodec::default();
+    let mut n = 0;
+    while let Some(item) = codec.decode(&mut buf).unwrap() {
+        item.unwrap();
+        n += 1;
+    }
+    n
+}
+
+fn bench_codec_single_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_single_get");
+    for size in [64usize, 1024, 16 * 1024, 256 * 1024] {
+        let input = single_bulk(size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter_batched(
+                || BytesMut::from(&input[..]),
+                |buf| assert_eq!(codec_decode_all(buf), 1),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_codec_mget_array(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_mget_array");
+    for (count, size) in [(1000usize, 64usize), (1000, 1024), (100, 16 * 1024)] {
+        let input = array_of_bulks(count, size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{count}x{size}")),
+            &input,
+            |b, input| {
+                b.iter_batched(
+                    || BytesMut::from(&input[..]),
+                    |buf| assert_eq!(codec_decode_all(buf), 1),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Pipelined shape: many independent single-GET replies in one read buffer,
+/// decoded frame by frame (how a pipelined burst actually hits the codec).
+fn bench_codec_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_pipeline");
+    for (count, size) in [(100usize, 1024usize), (100, 16 * 1024)] {
+        let one = single_bulk(size);
+        let input: Vec<u8> = one
+            .iter()
+            .cycle()
+            .take(one.len() * count)
+            .copied()
+            .collect();
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{count}x{size}")),
+            &input,
+            |b, input| {
+                b.iter_batched(
+                    || BytesMut::from(&input[..]),
+                    |buf| assert_eq!(codec_decode_all(buf), count),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single_get,
+    bench_mget_array,
+    bench_codec_single_get,
+    bench_codec_mget_array,
+    bench_codec_pipeline
+);
 criterion_main!(benches);

--- a/glide-core/redis-rs/redis/examples/zc_e2e.rs
+++ b/glide-core/redis-rs/redis/examples/zc_e2e.rs
@@ -1,0 +1,90 @@
+//! Clean e2e receive-path benchmark: pipelined GET / MGET against a live
+//! server through MultiplexedConnection. No workload generation in the hot
+//! loop — isolates client receive-path CPU.
+//!
+//! Usage: zc_e2e <port> <mode:get|mget> <value_size> <total_ops> <pipeline_depth>
+use futures::future::join_all;
+use redis::{aio::MultiplexedConnection, AsyncCommands, Client};
+use std::time::Instant;
+
+async fn get_conn(port: u16) -> MultiplexedConnection {
+    let client = Client::open(format!("redis://127.0.0.1:{port}")).unwrap();
+    client
+        .get_multiplexed_tokio_connection(redis::GlideConnectionOptions::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let port: u16 = args[1].parse().unwrap();
+    let mode = args[2].clone();
+    let size: usize = args[3].parse().unwrap();
+    let total_ops: usize = args[4].parse().unwrap();
+    let depth: usize = args[5].parse().unwrap();
+
+    let mut conn = get_conn(port).await;
+    let payload = vec![b'x'; size];
+
+    // Preload keys.
+    let nkeys = 100usize;
+    for i in 0..nkeys {
+        let _: () = conn.set(format!("zc:{i}"), &payload).await.unwrap();
+    }
+    let mget_keys: Vec<String> = (0..nkeys).map(|i| format!("zc:{i}")).collect();
+
+    let start = Instant::now();
+    let mut done = 0usize;
+    while done < total_ops {
+        let batch = depth.min(total_ops - done);
+        let futs = (0..batch).map(|j| {
+            let mut c = conn.clone();
+            let mode = &mode;
+            let keys = &mget_keys;
+            async move {
+                match mode.as_str() {
+                    "get" => {
+                        let v: Vec<u8> = c.get(format!("zc:{}", j % 100)).await.unwrap();
+                        assert_eq!(v.len(), size);
+                    }
+                    // Consume the raw Value (glide-core's actual pattern: it
+                    // reads BulkString bytes in place, no Vec conversion).
+                    "getv" => {
+                        let mut cmd = redis::cmd("GET");
+                        cmd.arg(format!("zc:{}", j % 100));
+                        let v = c.send_packed_command(&cmd).await.unwrap();
+                        match v {
+                            redis::Value::BulkString(b) => assert_eq!(b.len(), size),
+                            other => panic!("unexpected {other:?}"),
+                        }
+                    }
+                    "mgetv" => {
+                        let mut cmd = redis::cmd("MGET");
+                        for k in keys {
+                            cmd.arg(k);
+                        }
+                        let v = c.send_packed_command(&cmd).await.unwrap();
+                        match v {
+                            redis::Value::Array(items) => assert_eq!(items.len(), keys.len()),
+                            other => panic!("unexpected {other:?}"),
+                        }
+                    }
+                    "mget" => {
+                        let vs: Vec<Vec<u8>> = c.mget(keys).await.unwrap();
+                        assert_eq!(vs.len(), keys.len());
+                    }
+                    _ => panic!("bad mode"),
+                }
+            }
+        });
+        join_all(futs).await;
+        done += batch;
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "mode={mode} size={size} ops={total_ops} depth={depth} elapsed={:.3}s ops_per_sec={:.0}",
+        elapsed.as_secs_f64(),
+        total_ops as f64 / elapsed.as_secs_f64()
+    );
+}

--- a/glide-core/redis-rs/redis/examples/zc_e2e.rs
+++ b/glide-core/redis-rs/redis/examples/zc_e2e.rs
@@ -26,6 +26,7 @@ async fn main() {
 
     let mut conn = get_conn(port).await;
     let payload = vec![b'x'; size];
+    let shared_payload = bytes::Bytes::from(payload.clone());
 
     // Preload keys.
     let nkeys = 100usize;
@@ -42,6 +43,8 @@ async fn main() {
             let mut c = conn.clone();
             let mode = &mode;
             let keys = &mget_keys;
+            let shared_payload = &shared_payload;
+            let payload = &payload;
             async move {
                 match mode.as_str() {
                     "get" => {
@@ -73,6 +76,21 @@ async fn main() {
                     "mget" => {
                         let vs: Vec<Vec<u8>> = c.mget(keys).await.unwrap();
                         assert_eq!(vs.len(), keys.len());
+                    }
+                    // SET via the plain arg() path (payload copied into Cmd).
+                    "set" => {
+                        let mut cmd = redis::cmd("SET");
+                        cmd.arg(format!("zc:{}", j % 100)).arg(&payload[..]);
+                        let v = c.send_packed_command(&cmd).await.unwrap();
+                        assert_eq!(v, redis::Value::Okay);
+                    }
+                    // SET via arg_shared (zero-copy send for large payloads).
+                    "setv" => {
+                        let mut cmd = redis::cmd("SET");
+                        cmd.arg(format!("zc:{}", j % 100));
+                        cmd.arg_shared(shared_payload.clone());
+                        let v = c.send_packed_command(&cmd).await.unwrap();
+                        assert_eq!(v, redis::Value::Okay);
                     }
                     _ => panic!("bad mode"),
                 }

--- a/glide-core/redis-rs/redis/examples/zc_sync_set.rs
+++ b/glide-core/redis-rs/redis/examples/zc_sync_set.rs
@@ -1,0 +1,49 @@
+//! Sync (blocking) connection SET throughput/CPU benchmark.
+//!
+//! Isolates the sync `Connection::req_command` send path: single blocking
+//! connection, SET of a fixed-size payload in a tight loop. No pipelining —
+//! each SET is one request/response round trip, so this measures the
+//! per-command send cost (where the vectored/zero-copy send lands).
+//!
+//! Usage: zc_sync_set <port> <mode:arg|shared> <value_size> <total_ops>
+use redis::ConnectionLike;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let port: u16 = args[1].parse().unwrap();
+    let mode = args[2].clone();
+    let size: usize = args[3].parse().unwrap();
+    let total_ops: usize = args[4].parse().unwrap();
+
+    let client = redis::Client::open(format!("redis://127.0.0.1:{port}")).unwrap();
+    let mut con = client.get_connection(None).unwrap();
+
+    let payload = vec![b'x'; size];
+    let shared = bytes::Bytes::from(payload.clone());
+
+    let start = Instant::now();
+    for i in 0..total_ops {
+        let mut cmd = redis::cmd("SET");
+        cmd.arg(format!("zc:{}", i % 100));
+        match mode.as_str() {
+            // Plain arg() — large payloads auto-share inside write_arg.
+            "arg" => {
+                cmd.arg(&payload[..]);
+            }
+            // Explicit arg_shared — zero-copy from the caller's Bytes.
+            "shared" => {
+                cmd.arg_shared(shared.clone());
+            }
+            _ => panic!("bad mode"),
+        }
+        let v = con.req_command(&cmd).unwrap();
+        assert_eq!(v, redis::Value::Okay);
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "sync-set mode={mode} size={size} ops={total_ops} elapsed={:.3}s ops_per_sec={:.0}",
+        elapsed.as_secs_f64(),
+        total_ops as f64 / elapsed.as_secs_f64()
+    );
+}

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -23,6 +23,34 @@ use futures_util::{
 };
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
+
+/// Write all segments of a packed command to an async stream using vectored
+/// I/O, so large shared payloads ([`crate::cmd::SegmentedBytes`]) go straight
+/// to the socket without being copied into an intermediate buffer. Handles
+/// partial writes by advancing the `IoSlice` cursor.
+async fn write_all_segments_async<W>(
+    con: &mut W,
+    segments: &crate::cmd::SegmentedBytes,
+) -> RedisResult<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    use std::io::IoSlice;
+    let segs = segments.segments().collect::<Vec<_>>();
+    let mut slices: Vec<IoSlice> = segs.iter().map(|s| IoSlice::new(s)).collect();
+    let mut remaining = &mut slices[..];
+    while !remaining.is_empty() {
+        let n = con.write_vectored(remaining).await?;
+        if n == 0 {
+            return Err(RedisError::from(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "failed to write whole command",
+            )));
+        }
+        IoSlice::advance_slices(&mut remaining, n);
+    }
+    Ok(())
+}
 #[cfg(feature = "tokio-comp")]
 use tokio_util::codec::Decoder;
 
@@ -179,8 +207,7 @@ where
                 self.exit_pubsub().await?;
             }
             self.buf.clear();
-            cmd.write_packed_command(&mut self.buf);
-            self.con.write_all(&self.buf).await?;
+            write_all_segments_async(&mut self.con, &cmd.get_packed_segments()).await?;
             if cmd.is_no_response() {
                 return Ok(Value::Nil);
             }
@@ -207,8 +234,7 @@ where
             }
 
             self.buf.clear();
-            cmd.write_packed_pipeline(&mut self.buf);
-            self.con.write_all(&self.buf).await?;
+            write_all_segments_async(&mut self.con, &cmd.get_packed_pipeline_segments()).await?;
 
             let mut first_err = None;
 

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -207,7 +207,12 @@ where
                 self.exit_pubsub().await?;
             }
             self.buf.clear();
-            write_all_segments_async(&mut self.con, &cmd.get_packed_segments()).await?;
+            if cmd.has_out_of_line_args() {
+                write_all_segments_async(&mut self.con, &cmd.get_packed_segments()).await?;
+            } else {
+                cmd.write_packed_command(&mut self.buf);
+                self.con.write_all(&self.buf).await?;
+            }
             if cmd.is_no_response() {
                 return Ok(Value::Nil);
             }
@@ -234,7 +239,13 @@ where
             }
 
             self.buf.clear();
-            write_all_segments_async(&mut self.con, &cmd.get_packed_pipeline_segments()).await?;
+            if cmd.commands().iter().any(|c| c.has_out_of_line_args()) {
+                write_all_segments_async(&mut self.con, &cmd.get_packed_pipeline_segments())
+                    .await?;
+            } else {
+                cmd.write_packed_pipeline(&mut self.buf);
+                self.con.write_all(&self.buf).await?;
+            }
 
             let mut first_err = None;
 

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -27,7 +27,8 @@ use std::pin::Pin;
 /// Write all segments of a packed command to an async stream using vectored
 /// I/O, so large shared payloads ([`crate::cmd::SegmentedBytes`]) go straight
 /// to the socket without being copied into an intermediate buffer. Handles
-/// partial writes by advancing the `IoSlice` cursor.
+/// partial writes by advancing a `(segment, offset)` cursor (MSRV-compatible,
+/// avoids the 1.81 `IoSlice::advance_slices`).
 async fn write_all_segments_async<W>(
     con: &mut W,
     segments: &crate::cmd::SegmentedBytes,
@@ -36,18 +37,35 @@ where
     W: AsyncWrite + Unpin,
 {
     use std::io::IoSlice;
+    const MAX_SLICES: usize = 64;
     let segs = segments.segments().collect::<Vec<_>>();
-    let mut slices: Vec<IoSlice> = segs.iter().map(|s| IoSlice::new(s)).collect();
-    let mut remaining = &mut slices[..];
-    while !remaining.is_empty() {
-        let n = con.write_vectored(remaining).await?;
+    let mut idx = 0;
+    let mut offset = 0;
+    while idx < segs.len() {
+        let end = std::cmp::min(idx + MAX_SLICES, segs.len());
+        let mut slices: Vec<IoSlice> = Vec::with_capacity(end - idx);
+        slices.push(IoSlice::new(&segs[idx][offset..]));
+        for seg in &segs[idx + 1..end] {
+            slices.push(IoSlice::new(seg));
+        }
+        let mut n = con.write_vectored(&slices).await?;
         if n == 0 {
             return Err(RedisError::from(std::io::Error::new(
                 std::io::ErrorKind::WriteZero,
                 "failed to write whole command",
             )));
         }
-        IoSlice::advance_slices(&mut remaining, n);
+        while n > 0 {
+            let remaining = segs[idx].len() - offset;
+            if n >= remaining {
+                n -= remaining;
+                idx += 1;
+                offset = 0;
+            } else {
+                offset += n;
+                n = 0;
+            }
+        }
     }
     Ok(())
 }

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -37,6 +37,173 @@ use tokio_util::codec::Decoder;
 // Default connection timeout in ms
 const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2000);
 
+/// Flush-directly threshold for the vectored sink's queued bytes. Above this,
+/// `poll_ready` applies backpressure by flushing before accepting more items.
+const VECTORED_SINK_HIGH_WATERMARK: usize = 512 * 1024;
+/// Max iovec entries per `write_vectored` call (typical kernel UIO_MAXIOV is
+/// 1024; 64 keeps the stack array small while amortizing syscalls well).
+const MAX_WRITE_SLICES: usize = 64;
+
+pin_project! {
+    /// Send-side zero-copy sink: queues the segments of packed commands and
+    /// writes them with vectored I/O. Large shared payloads
+    /// ([`crate::cmd::SegmentedBytes`]) go from the caller's allocation
+    /// straight to the socket without ever being copied into a write buffer.
+    struct VectoredSink<W> {
+        #[pin]
+        writer: W,
+        queue: VecDeque<bytes::Bytes>,
+        queued_bytes: usize,
+    }
+}
+
+impl<W> VectoredSink<W> {
+    fn new(writer: W) -> Self {
+        VectoredSink {
+            writer,
+            queue: VecDeque::new(),
+            queued_bytes: 0,
+        }
+    }
+}
+
+impl<W: AsyncWrite> VectoredSink<W> {
+    /// Drive queued segments into the writer. Completes when the queue is
+    /// empty and the writer is flushed.
+    fn poll_flush_queue(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context,
+    ) -> Poll<Result<(), RedisError>> {
+        let mut this = self.project();
+        loop {
+            if this.queue.is_empty() {
+                return this
+                    .writer
+                    .as_mut()
+                    .poll_flush(cx)
+                    .map_err(RedisError::from);
+            }
+            let mut slices = [std::io::IoSlice::new(&[]); MAX_WRITE_SLICES];
+            let mut n = 0;
+            for seg in this.queue.iter().take(MAX_WRITE_SLICES) {
+                slices[n] = std::io::IoSlice::new(seg);
+                n += 1;
+            }
+            match ready!(this.writer.as_mut().poll_write_vectored(cx, &slices[..n])) {
+                Ok(0) => {
+                    return Poll::Ready(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write queued segments to socket",
+                    ))));
+                }
+                Ok(mut written) => {
+                    *this.queued_bytes -= written;
+                    while written > 0 {
+                        let front = this.queue.front_mut().expect("queue can't be empty");
+                        if written >= front.len() {
+                            written -= front.len();
+                            this.queue.pop_front();
+                        } else {
+                            bytes::Buf::advance(front, written);
+                            written = 0;
+                        }
+                    }
+                }
+                Err(err) => return Poll::Ready(Err(err.into())),
+            }
+        }
+    }
+}
+
+impl<W: AsyncWrite> Sink<crate::cmd::SegmentedBytes> for VectoredSink<W> {
+    type Error = RedisError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        if self.queued_bytes <= VECTORED_SINK_HIGH_WATERMARK {
+            return Poll::Ready(Ok(()));
+        }
+        // Backpressure: drain before accepting more.
+        self.poll_flush_queue(cx)
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: crate::cmd::SegmentedBytes,
+    ) -> Result<(), Self::Error> {
+        let this = self.project();
+        for segment in item.into_segments() {
+            if !segment.is_empty() {
+                *this.queued_bytes += segment.len();
+                this.queue.push_back(segment);
+            }
+        }
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.poll_flush_queue(cx)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context,
+    ) -> Poll<Result<(), Self::Error>> {
+        ready!(self.as_mut().poll_flush_queue(cx))?;
+        self.project()
+            .writer
+            .poll_shutdown(cx)
+            .map_err(RedisError::from)
+    }
+}
+
+pin_project! {
+    /// Combines the decode stream (read half) and the vectored sink (write
+    /// half) back into one `Stream + Sink` object for [`Pipeline::new`].
+    struct SplitSinkStream<R, W> {
+        #[pin]
+        read: R,
+        #[pin]
+        write: W,
+    }
+}
+
+impl<R, W> Stream for SplitSinkStream<R, W>
+where
+    R: Stream<Item = RedisResult<Value>>,
+{
+    type Item = RedisResult<Value>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
+        self.project().read.poll_next(cx)
+    }
+}
+
+impl<R, W> Sink<crate::cmd::SegmentedBytes> for SplitSinkStream<R, W>
+where
+    W: Sink<crate::cmd::SegmentedBytes, Error = RedisError>,
+{
+    type Error = RedisError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.project().write.poll_ready(cx)
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: crate::cmd::SegmentedBytes,
+    ) -> Result<(), Self::Error> {
+        self.project().write.start_send(item)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.project().write.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.project().write.poll_close(cx)
+    }
+}
+
 // Senders which the result of a single request are sent through
 type PipelineOutput = oneshot::Sender<RedisResult<Value>>;
 
@@ -799,7 +966,7 @@ where
 /// on the same underlying connection (tcp/unix socket).
 #[derive(Clone)]
 pub struct MultiplexedConnection {
-    pipeline: Pipeline<Vec<u8>>,
+    pipeline: Pipeline<crate::cmd::SegmentedBytes>,
     db: i64,
     response_timeout: Duration,
     protocol: ProtocolVersion,
@@ -849,9 +1016,13 @@ impl MultiplexedConnection {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
-        let codec = ValueCodec::default()
-            .framed(stream)
+        let (read_half, write_half) = ::tokio::io::split(stream);
+        let read_stream = tokio_util::codec::FramedRead::new(read_half, ValueCodec::default())
             .and_then(|msg| async move { msg });
+        let codec = SplitSinkStream {
+            read: read_stream,
+            write: VectoredSink::new(write_half),
+        };
         let (mut pipeline, driver) = Pipeline::new(
             codec,
             glide_connection_options.disconnect_notifier,
@@ -921,7 +1092,7 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_single(
-                cmd.get_packed_command(),
+                cmd.get_packed_segments(),
                 timeout,
                 cmd.is_fenced(),
                 cmd.is_blocking(),
@@ -962,7 +1133,7 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_recv(
-                cmd.get_packed_pipeline(),
+                cmd.get_packed_pipeline_segments(),
                 Some(offset + count),
                 self.response_timeout,
                 cmd.is_atomic(),
@@ -1014,7 +1185,9 @@ impl MultiplexedConnection {
     }
 
     /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
-    pub(crate) fn builder(pipeline: Pipeline<Vec<u8>>) -> MultiplexedConnectionBuilder {
+    pub(crate) fn builder(
+        pipeline: Pipeline<crate::cmd::SegmentedBytes>,
+    ) -> MultiplexedConnectionBuilder {
         MultiplexedConnectionBuilder::new(pipeline)
     }
 
@@ -1029,7 +1202,7 @@ impl MultiplexedConnection {
 
 /// A builder for creating `MultiplexedConnection` instances.
 pub struct MultiplexedConnectionBuilder {
-    pipeline: Pipeline<Vec<u8>>,
+    pipeline: Pipeline<crate::cmd::SegmentedBytes>,
     db: Option<i64>,
     response_timeout: Option<Duration>,
     push_manager: Option<PushManager>,
@@ -1043,7 +1216,7 @@ pub struct MultiplexedConnectionBuilder {
 
 impl MultiplexedConnectionBuilder {
     /// Creates a new builder with the required pipeline
-    pub(crate) fn new(pipeline: Pipeline<Vec<u8>>) -> Self {
+    pub(crate) fn new(pipeline: Pipeline<crate::cmd::SegmentedBytes>) -> Self {
         Self {
             pipeline,
             db: None,

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -31,8 +31,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::task::{self, Poll};
 use std::time::Duration;
-#[cfg(feature = "tokio-comp")]
-use tokio_util::codec::Decoder;
 
 // Default connection timeout in ms
 const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2000);

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -1627,7 +1627,7 @@ mod tests {
         // If poll_read is called during poll_ready (the fix), this response will be
         // delivered to cmd1_handle. If not (the bug), cmd1_handle will hang.
         resp_tx
-            .try_send(Ok(Value::BulkString(b"response1".to_vec())))
+            .try_send(Ok(Value::BulkString(b"response1".to_vec().into())))
             .expect("Failed to inject response");
 
         // Wait for command #1 to complete — with the bug, this times out
@@ -1640,7 +1640,7 @@ mod tests {
 
         match result {
             Ok(Ok(Ok(value))) => {
-                assert_eq!(value, Value::BulkString(b"response1".to_vec()));
+                assert_eq!(value, Value::BulkString(b"response1".to_vec().into()));
             }
             Ok(Ok(Err(e))) => {
                 panic!("Command 1 returned error: {:?}", e);

--- a/glide-core/redis-rs/redis/src/cache/glide_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/glide_cache.rs
@@ -579,6 +579,9 @@ impl<S: EvictionStrategy + 'static> GlideCache for GlideCacheImpl<S> {
     }
 
     fn insert(&self, key: Vec<u8>, key_type: CachedKeyType, value: Value) {
+        // Cached values outlive the request; deep-copy so they don't pin the
+        // connection read buffers their BulkStrings were zero-copy sliced from.
+        let value = value.detach_buffers();
         let entry_size = calculate_entry_size(&key, &value);
 
         if self.core.entry_too_big(entry_size) {
@@ -811,7 +814,7 @@ mod tests {
     #[test]
     fn test_cache_entry_not_expired_no_ttl() {
         let entry = CacheEntry::new(
-            Value::BulkString(b"test".to_vec()),
+            Value::BulkString(b"test".to_vec().into()),
             CachedKeyType::String,
             None,
             100,
@@ -821,7 +824,7 @@ mod tests {
     #[test]
     fn test_cache_entry_not_expired_with_future_ttl() {
         let entry = CacheEntry::new(
-            Value::BulkString(b"test".to_vec()),
+            Value::BulkString(b"test".to_vec().into()),
             CachedKeyType::String,
             Some(Instant::now() + Duration::from_secs(60)),
             100,
@@ -832,7 +835,7 @@ mod tests {
     #[test]
     fn test_cache_entry_expired() {
         let entry = CacheEntry::new(
-            Value::BulkString(b"test".to_vec()),
+            Value::BulkString(b"test".to_vec().into()),
             CachedKeyType::String,
             Some(Instant::now() - Duration::from_secs(1)),
             100,
@@ -983,7 +986,7 @@ mod tests {
     fn test_value_size_bulk_string() {
         let data = b"hello world".to_vec();
         let data_len = data.len();
-        let value = Value::BulkString(data);
+        let value = Value::BulkString(data.into());
         let size = calculate_value_size(&value);
         assert_eq!(size, std::mem::size_of::<Value>() + data_len);
     }

--- a/glide-core/redis-rs/redis/src/cache/lfu_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/lfu_cache.rs
@@ -220,12 +220,12 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         let result = cache.get(b"key1", CachedKeyType::String);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec()));
+        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec().into()));
     }
 
     #[test]
@@ -243,7 +243,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         // Request with wrong type
@@ -262,16 +262,16 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         );
 
         let result = cache.get(b"key1", CachedKeyType::String);
-        assert_eq!(result.unwrap(), Value::BulkString(b"value2".to_vec()));
+        assert_eq!(result.unwrap(), Value::BulkString(b"value2".to_vec().into()));
         assert_eq!(cache.entry_count(), 1);
     }
 
@@ -284,7 +284,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 1);
 
@@ -313,7 +313,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         // Should exist before TTL expires
@@ -339,7 +339,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"val1".to_vec()),
+            Value::BulkString(b"val1".to_vec().into()),
         ); // Entry size ~60B
         cache.get(b"key1", CachedKeyType::String); // freq = 2
         cache.get(b"key1", CachedKeyType::String); // freq = 3
@@ -349,14 +349,14 @@ mod tests {
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"val2".to_vec()),
+            Value::BulkString(b"val2".to_vec().into()),
         );
 
         // Insert key3 to trigger eviction
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"val3".to_vec()),
+            Value::BulkString(b"val3".to_vec().into()),
         );
 
         // key1 should survive (high frequency)
@@ -377,13 +377,13 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v1".to_vec()),
+            Value::BulkString(b"v1".to_vec().into()),
         ); // Entry size ~60B
         sleep(Duration::from_millis(10)); // Ensure different timestamps
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v2".to_vec()),
+            Value::BulkString(b"v2".to_vec().into()),
         ); // Entry size ~60B
 
         // Both have frequency 1, key1 is older
@@ -392,7 +392,7 @@ mod tests {
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v3".to_vec()),
+            Value::BulkString(b"v3".to_vec().into()),
         );
 
         // key2 should survive (newer), key1 should be evicted (older)
@@ -406,7 +406,7 @@ mod tests {
         let cache = new_lfu_cache(make_config(100));
 
         // Try to insert entry larger than max cache size
-        let large_value = Value::BulkString(vec![0u8; 200]);
+        let large_value = Value::BulkString(vec![0u8; 200].into());
         cache.insert(b"large".to_vec(), CachedKeyType::String, large_value);
 
         // Should not be inserted
@@ -423,7 +423,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         // Simulate hits
@@ -445,12 +445,12 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         );
 
         cache.invalidate(b"key1");
@@ -467,17 +467,17 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v1".to_vec()),
+            Value::BulkString(b"v1".to_vec().into()),
         );
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v2".to_vec()),
+            Value::BulkString(b"v2".to_vec().into()),
         );
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v3".to_vec()),
+            Value::BulkString(b"v3".to_vec().into()),
         );
 
         cache.flush_all();
@@ -494,19 +494,19 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         ); // Entry size ~60B
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         ); // Entry size ~60B
 
         // This insert should trigger eviction
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value3".to_vec()),
+            Value::BulkString(b"value3".to_vec().into()),
         );
 
         let metrics = cache.metrics().unwrap();
@@ -588,7 +588,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v1".to_vec()),
+            Value::BulkString(b"v1".to_vec().into()),
         );
 
         // Access multiple times
@@ -613,14 +613,14 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v1".to_vec()),
+            Value::BulkString(b"v1".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 1);
 
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v2".to_vec()),
+            Value::BulkString(b"v2".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 2);
 

--- a/glide-core/redis-rs/redis/src/cache/lfu_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/lfu_cache.rs
@@ -225,7 +225,10 @@ mod tests {
 
         let result = cache.get(b"key1", CachedKeyType::String);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec().into()));
+        assert_eq!(
+            result.unwrap(),
+            Value::BulkString(b"value1".to_vec().into())
+        );
     }
 
     #[test]
@@ -271,7 +274,10 @@ mod tests {
         );
 
         let result = cache.get(b"key1", CachedKeyType::String);
-        assert_eq!(result.unwrap(), Value::BulkString(b"value2".to_vec().into()));
+        assert_eq!(
+            result.unwrap(),
+            Value::BulkString(b"value2".to_vec().into())
+        );
         assert_eq!(cache.entry_count(), 1);
     }
 

--- a/glide-core/redis-rs/redis/src/cache/lru_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/lru_cache.rs
@@ -95,7 +95,10 @@ mod tests {
 
         let result = cache.get(b"key1", CachedKeyType::String);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec().into()));
+        assert_eq!(
+            result.unwrap(),
+            Value::BulkString(b"value1".to_vec().into())
+        );
     }
 
     #[test]
@@ -141,7 +144,10 @@ mod tests {
         );
 
         let result = cache.get(b"key1", CachedKeyType::String);
-        assert_eq!(result.unwrap(), Value::BulkString(b"value2".to_vec().into()));
+        assert_eq!(
+            result.unwrap(),
+            Value::BulkString(b"value2".to_vec().into())
+        );
         assert_eq!(cache.entry_count(), 1);
     }
 

--- a/glide-core/redis-rs/redis/src/cache/lru_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/lru_cache.rs
@@ -90,12 +90,12 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         let result = cache.get(b"key1", CachedKeyType::String);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec()));
+        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec().into()));
     }
 
     #[test]
@@ -113,7 +113,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         // Request with wrong type
@@ -132,16 +132,16 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         );
 
         let result = cache.get(b"key1", CachedKeyType::String);
-        assert_eq!(result.unwrap(), Value::BulkString(b"value2".to_vec()));
+        assert_eq!(result.unwrap(), Value::BulkString(b"value2".to_vec().into()));
         assert_eq!(cache.entry_count(), 1);
     }
 
@@ -154,7 +154,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 1);
 
@@ -183,7 +183,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         // Should exist before TTL expires
@@ -209,14 +209,14 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"val1".to_vec()),
+            Value::BulkString(b"val1".to_vec().into()),
         ); // Entry size ~60B
 
         // Insert key2 (now key1 is older)
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"val2".to_vec()),
+            Value::BulkString(b"val2".to_vec().into()),
         );
 
         // Access key1 to make it most recently used
@@ -226,7 +226,7 @@ mod tests {
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"val3".to_vec()),
+            Value::BulkString(b"val3".to_vec().into()),
         );
 
         // key1 should survive (most recently used)
@@ -244,7 +244,7 @@ mod tests {
         let cache = new_lru_cache(make_config(100));
 
         // Try to insert entry larger than max cache size
-        let large_value = Value::BulkString(vec![0u8; 200]);
+        let large_value = Value::BulkString(vec![0u8; 200].into());
         cache.insert(b"large".to_vec(), CachedKeyType::String, large_value);
 
         // Should not be inserted
@@ -261,7 +261,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
 
         // Simulate hits
@@ -283,12 +283,12 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         );
 
         cache.invalidate(b"key1");
@@ -305,17 +305,17 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v1".to_vec()),
+            Value::BulkString(b"v1".to_vec().into()),
         );
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v2".to_vec()),
+            Value::BulkString(b"v2".to_vec().into()),
         );
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v3".to_vec()),
+            Value::BulkString(b"v3".to_vec().into()),
         );
 
         cache.flush_all();
@@ -332,18 +332,18 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         ); // Entry size ~60B
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         );
         // This should trigger eviction
         cache.insert(
             b"key3".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value3".to_vec()),
+            Value::BulkString(b"value3".to_vec().into()),
         );
 
         let metrics = cache.metrics().unwrap();
@@ -374,14 +374,14 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v1".to_vec()),
+            Value::BulkString(b"v1".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 1);
 
         cache.insert(
             b"key2".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"v2".to_vec()),
+            Value::BulkString(b"v2".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 2);
 

--- a/glide-core/redis-rs/redis/src/cache/mod.rs
+++ b/glide-core/redis-rs/redis/src/cache/mod.rs
@@ -386,7 +386,10 @@ mod tests {
 
         let result = cache.get(b"key1", CachedKeyType::String);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec().into()));
+        assert_eq!(
+            result.unwrap(),
+            Value::BulkString(b"value1".to_vec().into())
+        );
 
         cache.invalidate(b"key1");
         assert_eq!(cache.entry_count(), 0);

--- a/glide-core/redis-rs/redis/src/cache/mod.rs
+++ b/glide-core/redis-rs/redis/src/cache/mod.rs
@@ -380,13 +380,13 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
         );
         assert_eq!(cache.entry_count(), 1);
 
         let result = cache.get(b"key1", CachedKeyType::String);
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec()));
+        assert_eq!(result.unwrap(), Value::BulkString(b"value1".to_vec().into()));
 
         cache.invalidate(b"key1");
         assert_eq!(cache.entry_count(), 0);
@@ -406,7 +406,7 @@ mod tests {
             cache.insert(
                 format!("key{i}").into_bytes(),
                 CachedKeyType::String,
-                crate::Value::BulkString(format!("val{i}").into_bytes()),
+                crate::Value::BulkString(format!("val{i}").into_bytes().into()),
             );
         }
 
@@ -432,7 +432,7 @@ mod tests {
                     c.insert(
                         key.into_bytes(),
                         CachedKeyType::String,
-                        crate::Value::BulkString(b"new_val".to_vec()),
+                        crate::Value::BulkString(b"new_val".to_vec().into()),
                     );
                 }
             }));
@@ -505,7 +505,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            crate::Value::BulkString(b"val".to_vec()),
+            crate::Value::BulkString(b"val".to_vec().into()),
         );
         let result = query_cache_metric(cache_id, CacheMetricType::EntryCount);
         assert_eq!(result.unwrap(), crate::Value::Int(1));
@@ -552,7 +552,7 @@ mod tests {
         cache.insert(
             b"key1".to_vec(),
             CachedKeyType::String,
-            crate::Value::BulkString(b"val".to_vec()),
+            crate::Value::BulkString(b"val".to_vec().into()),
         );
         cache.increment_miss();
         cache.increment_hit();

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -696,7 +696,7 @@ where
                 let results = results
                     .into_iter()
                     .map(|result| {
-                        result.map(|(addr, val)| (Value::BulkString(addr.as_bytes().to_vec()), val))
+                        result.map(|(addr, val)| (Value::BulkString(addr.as_bytes().to_vec().into()), val))
                     })
                     .collect::<RedisResult<Vec<_>>>()?;
                 Ok(Value::Map(results))

--- a/glide-core/redis-rs/redis/src/cluster.rs
+++ b/glide-core/redis-rs/redis/src/cluster.rs
@@ -696,7 +696,9 @@ where
                 let results = results
                     .into_iter()
                     .map(|result| {
-                        result.map(|(addr, val)| (Value::BulkString(addr.as_bytes().to_vec().into()), val))
+                        result.map(|(addr, val)| {
+                            (Value::BulkString(addr.as_bytes().to_vec().into()), val)
+                        })
                     })
                     .collect::<RedisResult<Vec<_>>>()?;
                 Ok(Value::Map(results))

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2354,7 +2354,7 @@ where
                             "No address provided for response in Special or None response policy",
                         ))),
                     };
-                    pairs.push((Value::BulkString(key_bytes), value));
+                    pairs.push((Value::BulkString(key_bytes.into()), value));
                 }
                 Ok(Value::Map(pairs))
             }
@@ -4545,7 +4545,7 @@ mod pipeline_routing_tests {
             ],
             vec![(
                 Some("node3".to_string()),
-                Value::BulkString(b"unchanged".to_vec()),
+                Value::BulkString(b"unchanged".to_vec().into()),
             )],
             vec![
                 (Some("node1".to_string()), Value::Int(5)),
@@ -4581,7 +4581,7 @@ mod pipeline_routing_tests {
             responses,
             vec![
                 Value::Int(10),
-                Value::BulkString(b"unchanged".to_vec()),
+                Value::BulkString(b"unchanged".to_vec().into()),
                 Value::Int(5)
             ],
             "{responses:?}"
@@ -4675,7 +4675,7 @@ mod pipeline_routing_tests {
             ],
             vec![(
                 Some("node3".to_string()),
-                Value::BulkString(b"unchanged".to_vec()),
+                Value::BulkString(b"unchanged".to_vec().into()),
             )],
         ];
         let mut response_policies = HashMap::new();
@@ -4701,7 +4701,7 @@ mod pipeline_routing_tests {
                     kind: ServerErrorKind::Moved,
                     detail: Some("An error was signalled by the server: 127.0.0.1".to_string()),
                 }),
-                Value::BulkString(b"unchanged".to_vec()),
+                Value::BulkString(b"unchanged".to_vec().into()),
             ]
         );
     }

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -257,7 +257,7 @@ pub fn aggregate_array(values: Vec<Value>, op: ArrayAggregateOp) -> RedisResult<
 }
 /// Aggregate array responses into a single map.
 pub fn combine_map_results(values: Vec<Value>) -> RedisResult<Value> {
-    let mut map: HashMap<Vec<u8>, i64> = HashMap::new();
+    let mut map: HashMap<bytes::Bytes, i64> = HashMap::new();
 
     for value in values {
         match value {
@@ -1964,8 +1964,8 @@ mod tests_routing {
         // For example `MGET foo bar baz {baz}baz2 {bar}bar2 {foo}foo2`
         let res1 = Value::Array(vec![Value::Nil, Value::Okay]);
         let res2 = Value::Array(vec![
-            Value::BulkString("1".as_bytes().to_vec()),
-            Value::BulkString("4".as_bytes().to_vec()),
+            Value::BulkString("1".as_bytes().to_vec().into()),
+            Value::BulkString("4".as_bytes().to_vec().into()),
         ]);
         let res3 = Value::Array(vec![Value::SimpleString("2".to_string()), Value::Int(3)]);
         let results = super::combine_and_sort_array_results(
@@ -1982,10 +1982,10 @@ mod tests_routing {
             results.unwrap(),
             Value::Array(vec![
                 Value::SimpleString("2".to_string()),
-                Value::BulkString("1".as_bytes().to_vec()),
+                Value::BulkString("1".as_bytes().to_vec().into()),
                 Value::Nil,
                 Value::Okay,
-                Value::BulkString("4".as_bytes().to_vec()),
+                Value::BulkString("4".as_bytes().to_vec().into()),
                 Value::Int(3),
             ])
         );
@@ -1995,7 +1995,7 @@ mod tests_routing {
     fn test_combining_results_into_single_array_key_value_paires() {
         // For example `MSET foo bar foo2 bar2 {foo}foo3 bar3`
         let res1 = Value::Array(vec![Value::Okay]);
-        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec()), Value::Nil]);
+        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec().into()), Value::Nil]);
         let results = super::combine_and_sort_array_results(
             vec![res1, res2],
             &[
@@ -2008,7 +2008,7 @@ mod tests_routing {
         assert_eq!(
             results.unwrap(),
             Value::Array(vec![
-                Value::BulkString("1".as_bytes().to_vec()),
+                Value::BulkString("1".as_bytes().to_vec().into()),
                 Value::Okay,
                 Value::Nil
             ])
@@ -2019,7 +2019,7 @@ mod tests_routing {
     fn test_combining_results_into_single_array_keys_and_path() {
         // For example `JSON.MGET foo bar {foo}foo2 $.a`
         let res1 = Value::Array(vec![Value::Okay]);
-        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec()), Value::Nil]);
+        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec().into()), Value::Nil]);
         let results = super::combine_and_sort_array_results(
             vec![res1, res2],
             &[
@@ -2032,7 +2032,7 @@ mod tests_routing {
         assert_eq!(
             results.unwrap(),
             Value::Array(vec![
-                Value::BulkString("1".as_bytes().to_vec()),
+                Value::BulkString("1".as_bytes().to_vec().into()),
                 Value::Nil,
                 Value::Okay,
             ])
@@ -2043,7 +2043,7 @@ mod tests_routing {
     fn test_combining_results_into_single_array_key_with_two_arg_triples() {
         // For example `JSON.MSET foo $.a bar foo2 $.f.a bar2 {foo}foo3 $.f bar3`
         let res1 = Value::Array(vec![Value::Okay]);
-        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec()), Value::Nil]);
+        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec().into()), Value::Nil]);
         let results = super::combine_and_sort_array_results(
             vec![res1, res2],
             &[
@@ -2056,7 +2056,7 @@ mod tests_routing {
         assert_eq!(
             results.unwrap(),
             Value::Array(vec![
-                Value::BulkString("1".as_bytes().to_vec()),
+                Value::BulkString("1".as_bytes().to_vec().into()),
                 Value::Okay,
                 Value::Nil
             ])
@@ -2071,23 +2071,23 @@ mod tests_routing {
 
         let input = vec![
             Value::Array(vec![
-                Value::BulkString(b"key1".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
                 Value::Int(5),
-                Value::BulkString(b"key2".to_vec()),
+                Value::BulkString(b"key2".to_vec().into()),
                 Value::Int(10),
             ]),
             Value::Array(vec![
-                Value::BulkString(b"key1".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
                 Value::Int(3),
-                Value::BulkString(b"key3".to_vec()),
+                Value::BulkString(b"key3".to_vec().into()),
                 Value::Int(15),
             ]),
         ];
         let result = super::combine_map_results(input).unwrap();
         let mut expected = vec![
-            (Value::BulkString(b"key1".to_vec()), Value::Int(8)),
-            (Value::BulkString(b"key2".to_vec()), Value::Int(10)),
-            (Value::BulkString(b"key3".to_vec()), Value::Int(15)),
+            (Value::BulkString(b"key1".to_vec().into()), Value::Int(8)),
+            (Value::BulkString(b"key2".to_vec().into()), Value::Int(10)),
+            (Value::BulkString(b"key3".to_vec().into()), Value::Int(15)),
         ];
         expected.sort_unstable_by(|a, b| match (&a.0, &b.0) {
             (Value::BulkString(a_bytes), Value::BulkString(b_bytes)) => a_bytes.cmp(b_bytes),

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -1995,7 +1995,10 @@ mod tests_routing {
     fn test_combining_results_into_single_array_key_value_paires() {
         // For example `MSET foo bar foo2 bar2 {foo}foo3 bar3`
         let res1 = Value::Array(vec![Value::Okay]);
-        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec().into()), Value::Nil]);
+        let res2 = Value::Array(vec![
+            Value::BulkString("1".as_bytes().to_vec().into()),
+            Value::Nil,
+        ]);
         let results = super::combine_and_sort_array_results(
             vec![res1, res2],
             &[
@@ -2019,7 +2022,10 @@ mod tests_routing {
     fn test_combining_results_into_single_array_keys_and_path() {
         // For example `JSON.MGET foo bar {foo}foo2 $.a`
         let res1 = Value::Array(vec![Value::Okay]);
-        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec().into()), Value::Nil]);
+        let res2 = Value::Array(vec![
+            Value::BulkString("1".as_bytes().to_vec().into()),
+            Value::Nil,
+        ]);
         let results = super::combine_and_sort_array_results(
             vec![res1, res2],
             &[
@@ -2043,7 +2049,10 @@ mod tests_routing {
     fn test_combining_results_into_single_array_key_with_two_arg_triples() {
         // For example `JSON.MSET foo $.a bar foo2 $.f.a bar2 {foo}foo3 $.f bar3`
         let res1 = Value::Array(vec![Value::Okay]);
-        let res2 = Value::Array(vec![Value::BulkString("1".as_bytes().to_vec().into()), Value::Nil]);
+        let res2 = Value::Array(vec![
+            Value::BulkString("1".as_bytes().to_vec().into()),
+            Value::Nil,
+        ]);
         let results = super::combine_and_sort_array_results(
             vec![res1, res2],
             &[

--- a/glide-core/redis-rs/redis/src/cluster_topology.rs
+++ b/glide-core/redis-rs/redis/src/cluster_topology.rs
@@ -429,7 +429,7 @@ mod tests {
             .iter()
             .map(|(host, port)| {
                 Value::Array(vec![
-                    Value::BulkString(host.as_bytes().to_vec()),
+                    Value::BulkString(host.as_bytes().to_vec().into()),
                     Value::Int(*port as i64),
                 ])
             })
@@ -455,9 +455,9 @@ mod tests {
             .iter()
             .map(|(host, port, metadata)| {
                 let mut node_vec = vec![
-                    Value::BulkString(host.as_bytes().to_vec()),
+                    Value::BulkString(host.as_bytes().to_vec().into()),
                     Value::Int(*port as i64),
-                    Value::BulkString(b"node-id-placeholder".to_vec()), // node ID
+                    Value::BulkString(b"node-id-placeholder".to_vec().into()), // node ID
                 ];
 
                 if let Some(meta) = metadata {
@@ -467,8 +467,8 @@ mod tests {
                                 .iter()
                                 .flat_map(|(k, v)| {
                                     vec![
-                                        Value::BulkString(k.as_bytes().to_vec()),
-                                        Value::BulkString(v.as_bytes().to_vec()),
+                                        Value::BulkString(k.as_bytes().to_vec().into()),
+                                        Value::BulkString(v.as_bytes().to_vec().into()),
                                     ]
                                 })
                                 .collect();
@@ -479,8 +479,8 @@ mod tests {
                                 .iter()
                                 .map(|(k, v)| {
                                     (
-                                        Value::BulkString(k.as_bytes().to_vec()),
-                                        Value::BulkString(v.as_bytes().to_vec()),
+                                        Value::BulkString(k.as_bytes().to_vec().into()),
+                                        Value::BulkString(v.as_bytes().to_vec().into()),
                                     )
                                 })
                                 .collect();

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -427,8 +427,15 @@ impl From<Vec<u8>> for SegmentedBytes {
 
 impl RedisWrite for Cmd {
     fn write_arg(&mut self, arg: &[u8]) {
-        self.data.extend_from_slice(arg);
-        self.args.push(StoredArg::Inline(self.data.len()));
+        if arg.len() > SHARED_ARG_INLINE_MAX {
+            // One copy into an owned refcounted buffer, then zero-copy all
+            // the way to the socket (skips the packing and encode copies).
+            self.args
+                .push(StoredArg::Shared(bytes::Bytes::copy_from_slice(arg)));
+        } else {
+            self.data.extend_from_slice(arg);
+            self.args.push(StoredArg::Inline(self.data.len()));
+        }
     }
 
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
@@ -615,6 +622,20 @@ impl Cmd {
     /// share one contiguous segment.
     pub(crate) fn write_packed_segments(&self, out: &mut SegmentedBytes, scratch: &mut Vec<u8>) {
         let mut int_buf = ::itoa::Buffer::new();
+
+        // Reserve for everything that lands in scratch: all inline payloads
+        // (self.data) plus per-arg framing. Without this, large inline args
+        // pay repeated Vec-growth reallocs (the contiguous packer reserves
+        // exactly, see write_command_to_vec).
+        scratch.reserve(
+            self.data.len()
+                + 32 * (self.args.len() + 1)
+                + if self.is_fenced {
+                    FENCE_COMMAND.len()
+                } else {
+                    0
+                },
+        );
 
         scratch.push(b'*');
         scratch.extend_from_slice(int_buf.format(self.args.len()).as_bytes());

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -23,6 +23,20 @@ pub enum Arg<D> {
     Cursor,
 }
 
+/// Internal argument storage. Inline arguments live contiguously in
+/// `Cmd::data` (cheap for small args); large payloads are stored out-of-line
+/// as refcounted [`bytes::Bytes`] so they are never copied into the command
+/// buffer (send-side zero-copy).
+#[derive(Clone)]
+enum StoredArg {
+    /// End offset of an inline argument in `Cmd::data`.
+    Inline(usize),
+    /// Refcounted shared payload stored out-of-line.
+    Shared(bytes::Bytes),
+    /// A cursor placeholder created from `cursor_arg()`.
+    Cursor,
+}
+
 /// Atomic phase value: command is queued but not yet sent.
 pub const PHASE_QUEUED: u8 = 0;
 /// Atomic phase value: command has been sent to a node.
@@ -31,8 +45,7 @@ pub const PHASE_SENT: u8 = 1;
 /// Represents redis commands.
 pub struct Cmd {
     data: Vec<u8>,
-    // Arg::Simple contains the offset that marks the end of the argument
-    args: Vec<Arg<usize>>,
+    args: Vec<StoredArg>,
     cursor: Option<u64>,
     // If it's true command's response won't be read from socket. Useful for Pub/Sub.
     no_response: bool,
@@ -346,16 +359,82 @@ where
     Ok(())
 }
 
+/// Payloads at or below this size are inlined into the command buffer by
+/// [`Cmd::arg_shared`]; larger payloads are kept as refcounted segments and
+/// written to the socket via vectored I/O without ever being copied into a
+/// command or write buffer.
+pub const SHARED_ARG_INLINE_MAX: usize = 4 * 1024;
+
+/// A packed command (or pipeline of commands) represented as a sequence of
+/// byte segments for vectored socket writes.
+///
+/// Protocol framing and small inline arguments coalesce into contiguous
+/// segments; large shared payloads ([`Cmd::arg_shared`]) appear as their own
+/// refcounted segments pointing at the caller's allocation.
+#[derive(Debug, Default, Clone)]
+pub struct SegmentedBytes {
+    segments: Vec<bytes::Bytes>,
+    len: usize,
+}
+
+impl SegmentedBytes {
+    /// Append a segment. Empty segments are dropped.
+    pub fn push(&mut self, bytes: bytes::Bytes) {
+        if !bytes.is_empty() {
+            self.len += bytes.len();
+            self.segments.push(bytes);
+        }
+    }
+
+    /// Total byte length across all segments.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// True if there are no bytes.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Iterate over the segments.
+    pub fn segments(&self) -> impl ExactSizeIterator<Item = &bytes::Bytes> {
+        self.segments.iter()
+    }
+
+    /// Consume into the underlying segment list.
+    pub fn into_segments(self) -> Vec<bytes::Bytes> {
+        self.segments
+    }
+
+    /// Concatenate all segments into one contiguous buffer (used by tests and
+    /// non-vectored fallbacks).
+    pub fn to_contiguous(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.len);
+        for seg in &self.segments {
+            out.extend_from_slice(seg);
+        }
+        out
+    }
+}
+
+impl From<Vec<u8>> for SegmentedBytes {
+    fn from(buf: Vec<u8>) -> Self {
+        let mut out = SegmentedBytes::default();
+        out.push(bytes::Bytes::from(buf));
+        out
+    }
+}
+
 impl RedisWrite for Cmd {
     fn write_arg(&mut self, arg: &[u8]) {
         self.data.extend_from_slice(arg);
-        self.args.push(Arg::Simple(self.data.len()));
+        self.args.push(StoredArg::Inline(self.data.len()));
     }
 
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
         use std::io::Write;
         write!(self.data, "{arg}").unwrap();
-        self.args.push(Arg::Simple(self.data.len()));
+        self.args.push(StoredArg::Inline(self.data.len()));
     }
 }
 
@@ -455,6 +534,24 @@ impl Cmd {
         self
     }
 
+    /// Appends a binary argument without copying it into the command buffer.
+    ///
+    /// Payloads larger than [`SHARED_ARG_INLINE_MAX`] are stored as
+    /// refcounted [`bytes::Bytes`] and written to the socket directly from
+    /// the caller's allocation (vectored write) — the send-side zero-copy
+    /// path. Smaller payloads are inlined like a normal `arg()`, which is
+    /// cheaper than scatter-gather at small sizes.
+    #[inline]
+    pub fn arg_shared(&mut self, arg: bytes::Bytes) -> &mut Cmd {
+        if arg.len() <= SHARED_ARG_INLINE_MAX {
+            use crate::types::RedisWrite;
+            self.write_arg(&arg);
+        } else {
+            self.args.push(StoredArg::Shared(arg));
+        }
+        self
+    }
+
     /// Associate a trackable span to the command. This allow tracking the lifetime
     /// of the command.
     ///
@@ -484,7 +581,7 @@ impl Cmd {
     pub fn cursor_arg(&mut self, cursor: u64) -> &mut Cmd {
         assert!(!self.in_scan_mode());
         self.cursor = Some(cursor);
-        self.args.push(Arg::Cursor);
+        self.args.push(StoredArg::Cursor);
         self
     }
 
@@ -494,6 +591,73 @@ impl Cmd {
         let mut cmd = Vec::new();
         self.write_packed_command(&mut cmd);
         cmd
+    }
+
+    /// Returns the packed command as segments for vectored writes.
+    ///
+    /// Byte-identical on the wire to [`Cmd::get_packed_command`], but large
+    /// shared payloads ([`Cmd::arg_shared`]) are emitted as their own
+    /// refcounted segments instead of being copied into the packed buffer.
+    #[inline]
+    pub fn get_packed_segments(&self) -> SegmentedBytes {
+        let mut out = SegmentedBytes::default();
+        let mut scratch = Vec::new();
+        self.write_packed_segments(&mut out, &mut scratch);
+        out.push(bytes::Bytes::from(scratch));
+        out
+    }
+
+    /// Append this command's packed form to `out`, coalescing framing and
+    /// inline args into `scratch`. `scratch` is only flushed to `out` at
+    /// shared-payload boundaries — the caller MUST flush the remaining
+    /// `scratch` into `out` after the last command (as
+    /// [`Cmd::get_packed_segments`] does), so consecutive small commands
+    /// share one contiguous segment.
+    pub(crate) fn write_packed_segments(&self, out: &mut SegmentedBytes, scratch: &mut Vec<u8>) {
+        let mut int_buf = ::itoa::Buffer::new();
+
+        scratch.push(b'*');
+        scratch.extend_from_slice(int_buf.format(self.args.len()).as_bytes());
+        scratch.extend_from_slice(b"\r\n");
+
+        let mut prev = 0;
+        for arg in &self.args {
+            match arg {
+                StoredArg::Inline(i) => {
+                    let payload = &self.data[prev..*i];
+                    prev = *i;
+                    scratch.push(b'$');
+                    scratch.extend_from_slice(int_buf.format(payload.len()).as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                    scratch.extend_from_slice(payload);
+                    scratch.extend_from_slice(b"\r\n");
+                }
+                StoredArg::Cursor => {
+                    let cursor = int_buf.format(self.cursor.unwrap_or(0));
+                    let mut len_buf = ::itoa::Buffer::new();
+                    scratch.push(b'$');
+                    scratch.extend_from_slice(len_buf.format(cursor.len()).as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                    scratch.extend_from_slice(cursor.as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                }
+                StoredArg::Shared(payload) => {
+                    scratch.push(b'$');
+                    scratch.extend_from_slice(int_buf.format(payload.len()).as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                    // Flush framing accumulated so far, then emit the payload
+                    // as its own zero-copy segment.
+                    out.push(bytes::Bytes::from(std::mem::take(scratch)));
+                    out.push(payload.clone());
+                    scratch.extend_from_slice(b"\r\n");
+                }
+            }
+        }
+
+        // If this is a fenced command, append a PING command
+        if self.is_fenced {
+            scratch.extend_from_slice(FENCE_COMMAND);
+        }
     }
 
     pub(crate) fn write_packed_command(&self, cmd: &mut Vec<u8>) {
@@ -650,40 +814,24 @@ impl Cmd {
     /// Returns an iterator over the arguments in this command (including the command name itself)
     pub fn args_iter(&self) -> impl Clone + ExactSizeIterator<Item = Arg<&[u8]>> {
         let mut prev = 0;
-        self.args.iter().map(move |arg| match *arg {
-            Arg::Simple(i) => {
-                let arg = Arg::Simple(&self.data[prev..i]);
-                prev = i;
+        self.args.iter().map(move |arg| match arg {
+            StoredArg::Inline(i) => {
+                let arg = Arg::Simple(&self.data[prev..*i]);
+                prev = *i;
                 arg
             }
-
-            Arg::Cursor => Arg::Cursor,
+            StoredArg::Shared(bytes) => Arg::Simple(&bytes[..]),
+            StoredArg::Cursor => Arg::Cursor,
         })
     }
 
     /// Get a reference to the argument at `idx`.
     #[cfg(feature = "cluster")]
     pub fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
-        if idx >= self.args.len() {
-            return None;
-        }
-
-        let start = if idx == 0 {
-            0
-        } else {
-            match self.args[idx - 1] {
-                Arg::Simple(n) => n,
-                _ => 0,
-            }
-        };
-        let end = match self.args[idx] {
-            Arg::Simple(n) => n,
-            _ => 0,
-        };
-        if start == 0 && end == 0 {
-            return None;
-        }
-        Some(&self.data[start..end])
+        self.args_iter().nth(idx).and_then(|arg| match arg {
+            Arg::Simple(s) if !s.is_empty() => Some(s),
+            _ => None,
+        })
     }
 
     /// Client won't read and wait for results. Currently only used for Pub/Sub commands in RESP3.
@@ -903,5 +1051,92 @@ mod tests {
 
         let cloned = cmd.clone();
         assert!(cloned.is_blocking(), "clone must preserve is_blocking=true");
+    }
+
+    mod segmented_packing {
+        use super::super::*;
+
+        fn assert_segments_match_packed(cmd: &Cmd) {
+            assert_eq!(
+                cmd.get_packed_segments().to_contiguous(),
+                cmd.get_packed_command(),
+                "segmented packing must be byte-identical to contiguous packing"
+            );
+        }
+
+        #[test]
+        fn simple_command() {
+            assert_segments_match_packed(&crate::cmd("PING"));
+            assert_segments_match_packed(&crate::cmd("SET").arg("key").arg("value"));
+            assert_segments_match_packed(&crate::cmd("SET").arg("key").arg(42));
+        }
+
+        #[test]
+        fn shared_arg_small_is_inlined() {
+            let mut cmd = crate::cmd("SET");
+            cmd.arg("key")
+                .arg_shared(bytes::Bytes::from(vec![b'v'; 128]));
+            assert_segments_match_packed(&cmd);
+            // Small shared args coalesce: exactly one segment.
+            assert_eq!(cmd.get_packed_segments().segments().len(), 1);
+        }
+
+        #[test]
+        fn shared_arg_large_is_own_segment() {
+            let payload = bytes::Bytes::from(vec![b'v'; SHARED_ARG_INLINE_MAX + 1]);
+            let mut cmd = crate::cmd("SET");
+            cmd.arg("key").arg_shared(payload.clone());
+            assert_segments_match_packed(&cmd);
+            let packed = cmd.get_packed_segments();
+            // [framing][payload][trailing crlf]
+            assert_eq!(packed.segments().len(), 3);
+            // The payload segment shares the caller's allocation (zero-copy).
+            let seg = packed.segments().nth(1).unwrap();
+            assert_eq!(seg.as_ptr(), payload.as_ptr());
+        }
+
+        #[test]
+        fn shared_args_interleaved_with_args_iter_and_arg_idx() {
+            let payload = bytes::Bytes::from(vec![b'v'; SHARED_ARG_INLINE_MAX + 1]);
+            let mut cmd = crate::cmd("MSET");
+            cmd.arg("k1")
+                .arg_shared(payload.clone())
+                .arg("k2")
+                .arg("small");
+            assert_segments_match_packed(&cmd);
+            let args: Vec<_> = cmd
+                .args_iter()
+                .map(|a| match a {
+                    Arg::Simple(s) => s.to_vec(),
+                    Arg::Cursor => b"<cursor>".to_vec(),
+                })
+                .collect();
+            assert_eq!(args[0], b"MSET");
+            assert_eq!(args[1], b"k1");
+            assert_eq!(args[2], payload.to_vec());
+            assert_eq!(args[3], b"k2");
+            assert_eq!(args[4], b"small");
+            #[cfg(feature = "cluster")]
+            {
+                assert_eq!(cmd.arg_idx(1), Some(&b"k1"[..]));
+                assert_eq!(cmd.arg_idx(2), Some(&payload[..]));
+                assert_eq!(cmd.arg_idx(3), Some(&b"k2"[..]));
+            }
+        }
+
+        #[test]
+        fn cursor_command() {
+            let mut cmd = crate::cmd("SCAN");
+            cmd.cursor_arg(1234).arg("MATCH").arg("prefix:*");
+            assert_segments_match_packed(&cmd);
+        }
+
+        #[test]
+        fn fenced_command() {
+            let mut cmd = crate::cmd("GET");
+            cmd.arg("key");
+            cmd.set_fenced(true);
+            assert_segments_match_packed(&cmd);
+        }
     }
 }

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -833,6 +833,16 @@ impl Cmd {
     }
 
     /// Returns an iterator over the arguments in this command (including the command name itself)
+    /// Returns whether any argument is stored out-of-line as a shared
+    /// refcounted payload (via [`Cmd::arg_shared`] or a large [`RedisWrite`]
+    /// arg). When false, the command has no zero-copy send benefit and the
+    /// cheaper contiguous packing path is used.
+    #[inline]
+    pub fn has_out_of_line_args(&self) -> bool {
+        self.args.iter().any(|a| matches!(a, StoredArg::Shared(_)))
+    }
+
+    /// Iterate over the command arguments as byte slices (framing excluded).
     pub fn args_iter(&self) -> impl Clone + ExactSizeIterator<Item = Arg<&[u8]>> {
         let mut prev = 0;
         self.args.iter().map(move |arg| match arg {

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -689,18 +689,35 @@ impl ActualConnection {
             w: &mut W,
             segments: &crate::cmd::SegmentedBytes,
         ) -> io::Result<()> {
+            const MAX_SLICES: usize = 64;
             let segs = segments.segments().collect::<Vec<_>>();
-            let mut slices: Vec<io::IoSlice> = segs.iter().map(|s| io::IoSlice::new(s)).collect();
-            let mut remaining = &mut slices[..];
-            while !remaining.is_empty() {
-                let n = w.write_vectored(remaining)?;
+            let mut idx = 0;
+            let mut offset = 0;
+            while idx < segs.len() {
+                let end = std::cmp::min(idx + MAX_SLICES, segs.len());
+                let mut slices: Vec<io::IoSlice> = Vec::with_capacity(end - idx);
+                slices.push(io::IoSlice::new(&segs[idx][offset..]));
+                for seg in &segs[idx + 1..end] {
+                    slices.push(io::IoSlice::new(seg));
+                }
+                let mut n = w.write_vectored(&slices)?;
                 if n == 0 {
                     return Err(io::Error::new(
                         io::ErrorKind::WriteZero,
                         "failed to write whole command",
                     ));
                 }
-                io::IoSlice::advance_slices(&mut remaining, n);
+                while n > 0 {
+                    let remaining = segs[idx].len() - offset;
+                    if n >= remaining {
+                        n -= remaining;
+                        idx += 1;
+                        offset = 0;
+                    } else {
+                        offset += n;
+                        n = 0;
+                    }
+                }
             }
             w.flush()
         }

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -1328,7 +1328,14 @@ impl ConnectionLike for Connection {
             self.exit_pubsub()?;
         }
 
-        self.con.send_segments(&cmd.get_packed_segments())?;
+        // Only pay the segmented/vectored path when there's a large shared
+        // payload to keep off the copy path; otherwise the contiguous pack +
+        // single write is cheaper for small/normal commands.
+        if cmd.has_out_of_line_args() {
+            self.con.send_segments(&cmd.get_packed_segments())?;
+        } else {
+            self.send_bytes(&cmd.get_packed_command())?;
+        }
         if cmd.is_no_response() {
             return Ok(Value::Nil);
         }

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -681,6 +681,59 @@ impl ActualConnection {
         })
     }
 
+    /// Vectored send of a packed command's segments, avoiding a contiguous
+    /// copy of large shared payloads ([`crate::cmd::SegmentedBytes`]). On
+    /// partial writes the `IoSlice` cursor is advanced until fully drained.
+    pub fn send_segments(&mut self, segments: &crate::cmd::SegmentedBytes) -> RedisResult<Value> {
+        fn write_all_vectored<W: io::Write>(
+            w: &mut W,
+            segments: &crate::cmd::SegmentedBytes,
+        ) -> io::Result<()> {
+            let segs = segments.segments().collect::<Vec<_>>();
+            let mut slices: Vec<io::IoSlice> = segs.iter().map(|s| io::IoSlice::new(s)).collect();
+            let mut remaining = &mut slices[..];
+            while !remaining.is_empty() {
+                let n = w.write_vectored(remaining)?;
+                if n == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole command",
+                    ));
+                }
+                io::IoSlice::advance_slices(&mut remaining, n);
+            }
+            w.flush()
+        }
+
+        macro_rules! send_via {
+            ($conn:expr, $writer:expr) => {{
+                let res = write_all_vectored($writer, segments).map_err(RedisError::from);
+                match res {
+                    Err(e) => {
+                        if e.is_unrecoverable_error() {
+                            $conn.open = false;
+                        }
+                        Err(e)
+                    }
+                    Ok(_) => Ok(Value::Okay),
+                }
+            }};
+        }
+
+        match *self {
+            ActualConnection::Tcp(ref mut connection) => {
+                send_via!(connection, &mut connection.reader)
+            }
+            ActualConnection::TcpRustls(ref mut connection) => {
+                send_via!(connection, &mut connection.reader)
+            }
+            #[cfg(unix)]
+            ActualConnection::Unix(ref mut connection) => {
+                send_via!(connection, &mut connection.sock)
+            }
+        }
+    }
+
     pub fn send_bytes(&mut self, bytes: &[u8]) -> RedisResult<Value> {
         match *self {
             ActualConnection::Tcp(ref mut connection) => {
@@ -1271,12 +1324,11 @@ impl Connection {
 impl ConnectionLike for Connection {
     /// Sends a [Cmd] into the TCP socket and reads a single response from it.
     fn req_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
-        let pcmd = cmd.get_packed_command();
         if self.pubsub {
             self.exit_pubsub()?;
         }
 
-        self.send_bytes(&pcmd)?;
+        self.con.send_segments(&cmd.get_packed_segments())?;
         if cmd.is_no_response() {
             return Ok(Value::Nil);
         }

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -340,7 +340,8 @@ pub use crate::client::Client;
 pub use crate::client::GlideConnectionOptions;
 pub use crate::client::IAMTokenProvider;
 pub use crate::cmd::{
-    cmd, fenced_cmd, pack_command, pipe, Arg, Cmd, Iter, PHASE_QUEUED, PHASE_SENT,
+    cmd, fenced_cmd, pack_command, pipe, Arg, Cmd, Iter, SegmentedBytes, PHASE_QUEUED, PHASE_SENT,
+    SHARED_ARG_INLINE_MAX,
 };
 pub use crate::commands::{
     Commands, ControlFlow, Direction, LposOptions, PubSubCommands, SetOptions,

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -350,9 +350,9 @@ pub use crate::connection::{
     IntoConnectionInfo, Msg, PubSub, PubSubChannelOrPattern, PubSubSubscriptionInfo,
     PubSubSubscriptionKind, RedisConnectionInfo, TlsMode,
 };
-pub use crate::parser::{parse_redis_value, Parser};
 #[cfg(feature = "aio")]
 pub use crate::parser::ValueCodec;
+pub use crate::parser::{parse_redis_value, Parser};
 pub use crate::pipeline::{Pipeline, PipelineRetryStrategy};
 pub use crate::pubsub_synchronizer::PubSubSynchronizer;
 pub use push_manager::{PushInfo, PushManager};

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -351,6 +351,8 @@ pub use crate::connection::{
     PubSubSubscriptionKind, RedisConnectionInfo, TlsMode,
 };
 pub use crate::parser::{parse_redis_value, Parser};
+#[cfg(feature = "aio")]
+pub use crate::parser::ValueCodec;
 pub use crate::pipeline::{Pipeline, PipelineRetryStrategy};
 pub use crate::pubsub_synchronizer::PubSubSynchronizer;
 pub use push_manager::{PushInfo, PushManager};

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -138,7 +138,9 @@ where
                             combine::produce(|| Value::Nil).left()
                         } else {
                             take(*size as usize)
-                                .map(|bs: &[u8]| Value::BulkString(bs.to_vec()))
+                                .map(|bs: &[u8]| {
+                                    Value::BulkString(bytes::Bytes::copy_from_slice(bs))
+                                })
                                 .skip(crlf())
                                 .right()
                         }
@@ -231,7 +233,7 @@ where
                                     let mut it = result.into_iter();
                                     let first = it.next().unwrap_or(Value::Nil);
                                     if let Value::BulkString(kind) = first {
-                                        let push_kind = String::from_utf8(kind)
+                                        let push_kind = String::from_utf8(kind.to_vec())
                                             .map_err(StreamErrorFor::<I>::other)?;
                                         Ok(Value::Push {
                                             kind: get_push_kind(push_kind),
@@ -320,18 +322,289 @@ where
     ))
 }
 
+/// Zero-copy RESP parsing for the async codec path.
+///
+/// Strategy: instead of streaming partial frames through the `combine` parser
+/// (which must copy payloads into owned `Vec`s because a bulk string may
+/// straddle socket reads), we first *scan* the buffered bytes for one complete
+/// top-level frame without consuming anything. Once a full frame is buffered,
+/// we `split_to(len).freeze()` it into a refcounted [`Bytes`] (zero-copy) and
+/// build the [`Value`] tree by slicing bulk-string payloads directly out of
+/// that frame — no per-value allocation or memcpy.
+///
+/// The scan only walks type bytes and length headers (payloads are skipped by
+/// length), so its cost is proportional to the number of RESP elements, not
+/// the payload bytes.
+mod zero_copy {
+    use super::*;
+    use bytes::Bytes;
+
+    fn parse_error(detail: String) -> RedisError {
+        RedisError::from((ErrorKind::ParseError, "parse error", detail))
+    }
+
+    /// Find the `\r\n`-terminated line starting at `pos`.
+    /// Returns `(line_content_end, next_pos)` — content excludes the CRLF.
+    fn find_line(buf: &[u8], pos: usize) -> Option<(usize, usize)> {
+        let rel = buf[pos..].windows(2).position(|w| w == b"\r\n")?;
+        Some((pos + rel, pos + rel + 2))
+    }
+
+    fn line_str(buf: &[u8], start: usize, end: usize) -> RedisResult<&str> {
+        str::from_utf8(&buf[start..end])
+            .map_err(|e| parse_error(format!("invalid utf-8 in line: {e}")))
+    }
+
+    fn line_int(buf: &[u8], start: usize, end: usize) -> RedisResult<i64> {
+        line_str(buf, start, end)?
+            .trim()
+            .parse::<i64>()
+            .map_err(|_| parse_error("Expected integer, got garbage".to_string()))
+    }
+
+    /// How many child values follow an aggregate header byte with count `n`.
+    fn child_count(type_byte: u8, n: i64) -> usize {
+        match type_byte {
+            b'%' => n as usize * 2,
+            b'|' => n as usize * 2 + 1, // attribute: kv pairs + the data value
+            _ => n as usize,
+        }
+    }
+
+    /// Scan one RESP value starting at `pos`.
+    /// `Ok(Some(end))` — a complete value spans `pos..end`.
+    /// `Ok(None)` — need more data.
+    /// `Err` — malformed input.
+    pub(super) fn scan_value(buf: &[u8], pos: usize, depth: usize) -> RedisResult<Option<usize>> {
+        if pos >= buf.len() {
+            return Ok(None);
+        }
+        let b = buf[pos];
+        if matches!(b, b'*' | b'%' | b'|' | b'~' | b'>') && depth > MAX_RECURSE_DEPTH {
+            return Err(parse_error("Maximum recursion depth exceeded".to_string()));
+        }
+        match b {
+            // Line-delimited scalars.
+            b'+' | b'-' | b':' | b'_' | b',' | b'#' | b'(' => {
+                Ok(find_line(buf, pos + 1).map(|(_, next)| next))
+            }
+            // Length-prefixed blobs: bulk string, blob error, verbatim string.
+            b'$' | b'!' | b'=' => {
+                let Some((line_end, payload_start)) = find_line(buf, pos + 1) else {
+                    return Ok(None);
+                };
+                let size = line_int(buf, pos + 1, line_end)?;
+                if size < 0 {
+                    return Ok(Some(payload_start));
+                }
+                let end = payload_start + size as usize + 2;
+                if end > buf.len() {
+                    return Ok(None);
+                }
+                if &buf[end - 2..end] != b"\r\n" {
+                    return Err(parse_error("expected CRLF after blob payload".to_string()));
+                }
+                Ok(Some(end))
+            }
+            // Aggregates: array, map, attribute, set, push.
+            b'*' | b'%' | b'|' | b'~' | b'>' => {
+                let Some((line_end, mut cursor)) = find_line(buf, pos + 1) else {
+                    return Ok(None);
+                };
+                let n = line_int(buf, pos + 1, line_end)?;
+                if n < 0 {
+                    return Ok(Some(cursor));
+                }
+                for _ in 0..child_count(b, n) {
+                    match scan_value(buf, cursor, depth + 1)? {
+                        Some(end) => cursor = end,
+                        None => return Ok(None),
+                    }
+                }
+                Ok(Some(cursor))
+            }
+            other => Err(parse_error(format!(
+                "invalid RESP type byte {:?}",
+                other as char
+            ))),
+        }
+    }
+
+    /// Build a [`Value`] from a complete frame, slicing bulk-string payloads
+    /// out of `frame` with zero copies. `scan_value` must have validated the
+    /// frame is complete; bounds are still checked defensively.
+    pub(super) fn parse_value(frame: &Bytes, pos: &mut usize, depth: usize) -> RedisResult<Value> {
+        let buf = &frame[..];
+        if *pos >= buf.len() {
+            return Err(parse_error("unexpected end of frame".to_string()));
+        }
+        let b = buf[*pos];
+        if matches!(b, b'*' | b'%' | b'|' | b'~' | b'>') && depth > MAX_RECURSE_DEPTH {
+            return Err(parse_error("Maximum recursion depth exceeded".to_string()));
+        }
+        let type_pos = *pos;
+        match b {
+            b'+' | b'-' | b':' | b'_' | b',' | b'#' | b'(' => {
+                let (line_end, next) = find_line(buf, type_pos + 1)
+                    .ok_or_else(|| parse_error("unexpected end of frame".to_string()))?;
+                let line = line_str(buf, type_pos + 1, line_end)?;
+                *pos = next;
+                match b {
+                    b'+' => Ok(if line == "OK" {
+                        Value::Okay
+                    } else {
+                        Value::SimpleString(line.to_string())
+                    }),
+                    b'-' => Ok(Value::ServerError(err_parser(line))),
+                    b':' => Ok(Value::Int(line.trim().parse::<i64>().map_err(|_| {
+                        parse_error("Expected integer, got garbage".to_string())
+                    })?)),
+                    b'_' => Ok(Value::Nil),
+                    b',' => Ok(Value::Double(line.trim().parse::<f64>().map_err(|e| {
+                        parse_error(format!("Expected double, got garbage: {e}"))
+                    })?)),
+                    b'#' => match line {
+                        "t" => Ok(Value::Boolean(true)),
+                        "f" => Ok(Value::Boolean(false)),
+                        _ => Err(parse_error("Expected boolean, got garbage".to_string())),
+                    },
+                    b'(' => BigInt::parse_bytes(line.as_bytes(), 10)
+                        .map(Value::BigNumber)
+                        .ok_or_else(|| parse_error("Expected bigint, got garbage".to_string())),
+                    _ => unreachable!(),
+                }
+            }
+            b'$' | b'!' | b'=' => {
+                let (line_end, payload_start) = find_line(buf, type_pos + 1)
+                    .ok_or_else(|| parse_error("unexpected end of frame".to_string()))?;
+                let size = line_int(buf, type_pos + 1, line_end)?;
+                if size < 0 {
+                    *pos = payload_start;
+                    return Ok(Value::Nil);
+                }
+                let payload_end = payload_start + size as usize;
+                if payload_end + 2 > buf.len() {
+                    return Err(parse_error("unexpected end of frame".to_string()));
+                }
+                *pos = payload_end + 2;
+                match b {
+                    // The zero-copy slice: shares the frame's refcounted buffer.
+                    b'$' => Ok(Value::BulkString(frame.slice(payload_start..payload_end))),
+                    b'!' => {
+                        let text = String::from_utf8_lossy(&buf[payload_start..payload_end]);
+                        Ok(Value::ServerError(err_parser(&text)))
+                    }
+                    b'=' => {
+                        let text = String::from_utf8_lossy(&buf[payload_start..payload_end]);
+                        if let Some((format, text)) = text.split_once(':') {
+                            let format = match format {
+                                "txt" => VerbatimFormat::Text,
+                                "mkd" => VerbatimFormat::Markdown,
+                                x => VerbatimFormat::Unknown(x.to_string()),
+                            };
+                            Ok(Value::VerbatimString {
+                                format,
+                                text: text.to_string(),
+                            })
+                        } else {
+                            Err(parse_error(
+                                "parse error when decoding verbatim string".to_string(),
+                            ))
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            b'*' | b'%' | b'|' | b'~' | b'>' => {
+                let (line_end, next) = find_line(buf, type_pos + 1)
+                    .ok_or_else(|| parse_error("unexpected end of frame".to_string()))?;
+                let n = line_int(buf, type_pos + 1, line_end)?;
+                *pos = next;
+                if n < 0 {
+                    return Ok(Value::Nil);
+                }
+                match b {
+                    b'*' | b'~' => {
+                        let mut items = Vec::with_capacity(n as usize);
+                        for _ in 0..n {
+                            items.push(parse_value(frame, pos, depth + 1)?);
+                        }
+                        Ok(if b == b'*' {
+                            Value::Array(items)
+                        } else {
+                            Value::Set(items)
+                        })
+                    }
+                    b'%' => {
+                        let mut items = Vec::with_capacity(n as usize);
+                        for _ in 0..n {
+                            let k = parse_value(frame, pos, depth + 1)?;
+                            let v = parse_value(frame, pos, depth + 1)?;
+                            items.push((k, v));
+                        }
+                        Ok(Value::Map(items))
+                    }
+                    b'|' => {
+                        let mut attributes = Vec::with_capacity(n as usize);
+                        for _ in 0..n {
+                            let k = parse_value(frame, pos, depth + 1)?;
+                            let v = parse_value(frame, pos, depth + 1)?;
+                            attributes.push((k, v));
+                        }
+                        let data = Box::new(parse_value(frame, pos, depth + 1)?);
+                        Ok(Value::Attribute { data, attributes })
+                    }
+                    b'>' => {
+                        if n == 0 {
+                            return Ok(Value::Push {
+                                kind: PushKind::Other("".to_string()),
+                                data: vec![],
+                            });
+                        }
+                        let first = parse_value(frame, pos, depth + 1)?;
+                        let mut data = Vec::with_capacity(n as usize - 1);
+                        for _ in 1..n {
+                            data.push(parse_value(frame, pos, depth + 1)?);
+                        }
+                        let kind = match first {
+                            Value::BulkString(kind) => {
+                                String::from_utf8(kind.to_vec()).map_err(|e| {
+                                    parse_error(format!("invalid push kind: {e}"))
+                                })?
+                            }
+                            Value::SimpleString(kind) => kind,
+                            _ => {
+                                return Err(parse_error(
+                                    "parse error when decoding push".to_string(),
+                                ))
+                            }
+                        };
+                        Ok(Value::Push {
+                            kind: get_push_kind(kind),
+                            data,
+                        })
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            other => Err(parse_error(format!(
+                "invalid RESP type byte {:?}",
+                other as char
+            ))),
+        }
+    }
+}
+
 #[cfg(feature = "aio")]
 mod aio_support {
     use super::*;
 
-    use bytes::{Buf, BytesMut};
+    use bytes::BytesMut;
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
     #[derive(Default)]
-    pub struct ValueCodec {
-        state: AnySendSyncPartialState,
-    }
+    pub struct ValueCodec {}
 
     impl ValueCodec {
         fn decode_stream(
@@ -339,30 +612,30 @@ mod aio_support {
             bytes: &mut BytesMut,
             eof: bool,
         ) -> RedisResult<Option<RedisResult<Value>>> {
-            let (opt, removed_len) = {
-                let buffer = &bytes[..];
-                let mut stream =
-                    combine::easy::Stream(combine::stream::MaybePartialStream(buffer, !eof));
-                match combine::stream::decode_tokio(value(None), &mut stream, &mut self.state) {
-                    Ok(x) => x,
-                    Err(err) => {
-                        let err = err
-                            .map_position(|pos| pos.translate_position(buffer))
-                            .map_range(|range| format!("{range:?}"))
-                            .to_string();
-                        return Err(RedisError::from((
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            // Zero-copy path: wait until a complete top-level frame is
+            // buffered (scan consumes nothing), then freeze that frame into a
+            // refcounted `Bytes` and slice bulk-string payloads out of it.
+            match super::zero_copy::scan_value(&bytes[..], 0, 1)? {
+                None => {
+                    if eof {
+                        Err(RedisError::from((
                             ErrorKind::ParseError,
                             "parse error",
-                            err,
-                        )));
+                            "unexpected end of input".to_string(),
+                        )))
+                    } else {
+                        Ok(None)
                     }
                 }
-            };
-
-            bytes.advance(removed_len);
-            match opt {
-                Some(result) => Ok(Some(Ok(result))),
-                None => Ok(None),
+                Some(end) => {
+                    let frame = bytes.split_to(end).freeze();
+                    let mut pos = 0;
+                    let value = super::zero_copy::parse_value(&frame, &mut pos, 1)?;
+                    Ok(Some(Ok(value)))
+                }
             }
         }
     }

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -657,6 +657,8 @@ mod aio_support {
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
+    /// Tokio codec that decodes RESP frames zero-copy from the read
+    /// buffer. See the [`super::zero_copy`] module for the strategy.
     #[derive(Default)]
     pub struct ValueCodec {
         /// Resumable scan progress for the (single) incomplete frame at the

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -371,62 +371,119 @@ mod zero_copy {
         }
     }
 
-    /// Scan one RESP value starting at `pos`.
-    /// `Ok(Some(end))` — a complete value spans `pos..end`.
-    /// `Ok(None)` — need more data.
-    /// `Err` — malformed input.
-    pub(super) fn scan_value(buf: &[u8], pos: usize, depth: usize) -> RedisResult<Option<usize>> {
-        if pos >= buf.len() {
-            return Ok(None);
-        }
-        let b = buf[pos];
-        if matches!(b, b'*' | b'%' | b'|' | b'~' | b'>') && depth > MAX_RECURSE_DEPTH {
-            return Err(parse_error("Maximum recursion depth exceeded".to_string()));
-        }
-        match b {
-            // Line-delimited scalars.
-            b'+' | b'-' | b':' | b'_' | b',' | b'#' | b'(' => {
-                Ok(find_line(buf, pos + 1).map(|(_, next)| next))
+    /// Resumable scan state, persisted across `decode` calls so bytes of an
+    /// incomplete frame are only scanned once (previously the scan restarted
+    /// at offset 0 on every socket read — O(reads × elements) on large
+    /// multi-element frames, measured at ~25% of client CPU on MGET-heavy
+    /// load).
+    ///
+    /// Representation: `stack` holds the number of values still expected at
+    /// each open aggregate level, with an artificial root entry of 1 for the
+    /// top-level value. `pos` is the absolute offset (from the front of the
+    /// codec's read buffer) where scanning resumes; it stays valid across
+    /// calls because the codec only consumes buffer bytes once a frame
+    /// completes.
+    pub(super) struct ScanState {
+        pos: usize,
+        stack: Vec<usize>,
+    }
+
+    impl Default for ScanState {
+        fn default() -> Self {
+            ScanState {
+                pos: 0,
+                stack: vec![1],
             }
-            // Length-prefixed blobs: bulk string, blob error, verbatim string.
-            b'$' | b'!' | b'=' => {
-                let Some((line_end, payload_start)) = find_line(buf, pos + 1) else {
-                    return Ok(None);
-                };
-                let size = line_int(buf, pos + 1, line_end)?;
-                if size < 0 {
-                    return Ok(Some(payload_start));
+        }
+    }
+
+    impl ScanState {
+        pub(super) fn reset(&mut self) {
+            self.pos = 0;
+            self.stack.clear();
+            self.stack.push(1);
+        }
+    }
+
+    /// Continue scanning one top-level RESP value where the previous call
+    /// left off.
+    /// `Ok(Some(end))` — a complete value spans `0..end` of `buf`.
+    /// `Ok(None)` — need more data (state saved; call again with more bytes).
+    /// `Err` — malformed input (connection-fatal, state irrelevant).
+    pub(super) fn scan_resume(buf: &[u8], st: &mut ScanState) -> RedisResult<Option<usize>> {
+        loop {
+            // Close out completed aggregates.
+            while let Some(&top) = st.stack.last() {
+                if top == 0 {
+                    st.stack.pop();
+                } else {
+                    break;
                 }
-                let end = payload_start + size as usize + 2;
-                if end > buf.len() {
-                    return Ok(None);
-                }
-                if &buf[end - 2..end] != b"\r\n" {
-                    return Err(parse_error("expected CRLF after blob payload".to_string()));
-                }
-                Ok(Some(end))
             }
-            // Aggregates: array, map, attribute, set, push.
-            b'*' | b'%' | b'|' | b'~' | b'>' => {
-                let Some((line_end, mut cursor)) = find_line(buf, pos + 1) else {
-                    return Ok(None);
-                };
-                let n = line_int(buf, pos + 1, line_end)?;
-                if n < 0 {
-                    return Ok(Some(cursor));
+            let depth = st.stack.len();
+            let Some(remaining) = st.stack.last_mut() else {
+                return Ok(Some(st.pos));
+            };
+
+            let pos = st.pos;
+            if pos >= buf.len() {
+                return Ok(None);
+            }
+            let b = buf[pos];
+            // `depth` equals the recursion depth the old recursive
+            // scanner would have had (root entry counts as depth 1).
+            if matches!(b, b'*' | b'%' | b'|' | b'~' | b'>') && depth > MAX_RECURSE_DEPTH {
+                return Err(parse_error("Maximum recursion depth exceeded".to_string()));
+            }
+            match b {
+                // Line-delimited scalars.
+                b'+' | b'-' | b':' | b'_' | b',' | b'#' | b'(' => {
+                    let Some((_, next)) = find_line(buf, pos + 1) else {
+                        return Ok(None);
+                    };
+                    *remaining -= 1;
+                    st.pos = next;
                 }
-                for _ in 0..child_count(b, n) {
-                    match scan_value(buf, cursor, depth + 1)? {
-                        Some(end) => cursor = end,
-                        None => return Ok(None),
+                // Length-prefixed blobs: bulk string, blob error, verbatim string.
+                b'$' | b'!' | b'=' => {
+                    let Some((line_end, payload_start)) = find_line(buf, pos + 1) else {
+                        return Ok(None);
+                    };
+                    let size = line_int(buf, pos + 1, line_end)?;
+                    if size < 0 {
+                        *remaining -= 1;
+                        st.pos = payload_start;
+                        continue;
+                    }
+                    let end = payload_start + size as usize + 2;
+                    if end > buf.len() {
+                        return Ok(None);
+                    }
+                    if &buf[end - 2..end] != b"\r\n" {
+                        return Err(parse_error("expected CRLF after blob payload".to_string()));
+                    }
+                    *remaining -= 1;
+                    st.pos = end;
+                }
+                // Aggregates: array, map, attribute, set, push.
+                b'*' | b'%' | b'|' | b'~' | b'>' => {
+                    let Some((line_end, next)) = find_line(buf, pos + 1) else {
+                        return Ok(None);
+                    };
+                    let n = line_int(buf, pos + 1, line_end)?;
+                    *remaining -= 1;
+                    st.pos = next;
+                    if n >= 0 {
+                        st.stack.push(child_count(b, n));
                     }
                 }
-                Ok(Some(cursor))
+                other => {
+                    return Err(parse_error(format!(
+                        "invalid RESP type byte {:?}",
+                        other as char
+                    )))
+                }
             }
-            other => Err(parse_error(format!(
-                "invalid RESP type byte {:?}",
-                other as char
-            ))),
         }
     }
 
@@ -567,11 +624,8 @@ mod zero_copy {
                             data.push(parse_value(frame, pos, depth + 1)?);
                         }
                         let kind = match first {
-                            Value::BulkString(kind) => {
-                                String::from_utf8(kind.to_vec()).map_err(|e| {
-                                    parse_error(format!("invalid push kind: {e}"))
-                                })?
-                            }
+                            Value::BulkString(kind) => String::from_utf8(kind.to_vec())
+                                .map_err(|e| parse_error(format!("invalid push kind: {e}")))?,
                             Value::SimpleString(kind) => kind,
                             _ => {
                                 return Err(parse_error(
@@ -604,7 +658,12 @@ mod aio_support {
     use tokio_util::codec::{Decoder, Encoder};
 
     #[derive(Default)]
-    pub struct ValueCodec {}
+    pub struct ValueCodec {
+        /// Resumable scan progress for the (single) incomplete frame at the
+        /// front of the read buffer. Valid across calls because nothing is
+        /// consumed until the frame completes.
+        scan: super::zero_copy::ScanState,
+    }
 
     impl ValueCodec {
         fn decode_stream(
@@ -616,10 +675,15 @@ mod aio_support {
                 return Ok(None);
             }
             // Zero-copy path: wait until a complete top-level frame is
-            // buffered (scan consumes nothing), then freeze that frame into a
-            // refcounted `Bytes` and slice bulk-string payloads out of it.
-            match super::zero_copy::scan_value(&bytes[..], 0, 1)? {
-                None => {
+            // buffered (scan consumes nothing and resumes where the previous
+            // call stopped), then extract that frame and slice bulk-string
+            // payloads out of it.
+            match super::zero_copy::scan_resume(&bytes[..], &mut self.scan) {
+                Err(err) => {
+                    self.scan.reset();
+                    Err(err)
+                }
+                Ok(None) => {
                     if eof {
                         Err(RedisError::from((
                             ErrorKind::ParseError,
@@ -630,7 +694,8 @@ mod aio_support {
                         Ok(None)
                     }
                 }
-                Some(end) => {
+                Ok(Some(end)) => {
+                    self.scan.reset();
                     // Hybrid frame extraction, chosen from profiling:
                     // - Small frames: ONE bulk memcpy out of the read buffer.
                     //   Keeps the codec's BytesMut unshared so tokio reuses
@@ -1016,6 +1081,43 @@ mod tests {
             assert!(
                 parse_redis_value(&bytes).is_ok(),
                 "aggregate {:?} within depth limit failed to parse",
+                agg as char
+            );
+        }
+    }
+
+    /// The zero-copy codec's iterative scanner must enforce the same
+    /// recursion-depth guard as the recursive sync parser.
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_codec_max_recursion_depth_all_aggregate_types() {
+        use tokio_util::codec::Decoder;
+        for agg in [b'*', b'%', b'|', b'~', b'>'] {
+            let mut codec = ValueCodec::default();
+            let mut bytes =
+                bytes::BytesMut::from(&nested_aggregate_headers(agg, MAX_RECURSE_DEPTH + 5)[..]);
+            let result = codec.decode(&mut bytes);
+            let err = result.expect_err("expected recursion depth error");
+            assert!(
+                format!("{err:?}").contains("Maximum recursion depth exceeded"),
+                "aggregate {:?} did not hit the recursion guard: {err:?}",
+                agg as char
+            );
+        }
+    }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_codec_nesting_within_recursion_depth_parses() {
+        use tokio_util::codec::Decoder;
+        for agg in [b'*', b'~'] {
+            let mut codec = ValueCodec::default();
+            let mut bytes =
+                bytes::BytesMut::from(&nested_aggregate_headers(agg, MAX_RECURSE_DEPTH)[..]);
+            let result = codec.decode(&mut bytes);
+            assert!(
+                matches!(result, Ok(Some(Ok(_)))),
+                "aggregate {:?} within depth limit failed via codec: {result:?}",
                 agg as char
             );
         }

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -328,7 +328,7 @@ where
 /// (which must copy payloads into owned `Vec`s because a bulk string may
 /// straddle socket reads), we first *scan* the buffered bytes for one complete
 /// top-level frame without consuming anything. Once a full frame is buffered,
-/// we `split_to(len).freeze()` it into a refcounted [`Bytes`] (zero-copy) and
+/// we `split_to(len).freeze()` it into a refcounted [`bytes::Bytes`] (zero-copy) and
 /// build the [`Value`] tree by slicing bulk-string payloads directly out of
 /// that frame — no per-value allocation or memcpy.
 ///
@@ -658,7 +658,7 @@ mod aio_support {
     use tokio_util::codec::{Decoder, Encoder};
 
     /// Tokio codec that decodes RESP frames zero-copy from the read
-    /// buffer. See the [`super::zero_copy`] module for the strategy.
+    /// buffer. See the `zero_copy` module for the strategy.
     #[derive(Default)]
     pub struct ValueCodec {
         /// Resumable scan progress for the (single) incomplete frame at the

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -599,7 +599,7 @@ mod zero_copy {
 mod aio_support {
     use super::*;
 
-    use bytes::BytesMut;
+    use bytes::{Buf, Bytes, BytesMut};
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
@@ -631,7 +631,17 @@ mod aio_support {
                     }
                 }
                 Some(end) => {
-                    let frame = bytes.split_to(end).freeze();
+                    // Copy the complete frame out in ONE bulk memcpy and
+                    // advance the read buffer. Copying (rather than
+                    // `split_to(end).freeze()`) keeps the codec's BytesMut
+                    // unshared so tokio can keep reusing its allocation —
+                    // freezing was measured to cause realloc+copy churn in
+                    // `BytesMut::reserve` on every read. Individual bulk
+                    // strings are then zero-copy slices of this one frame
+                    // allocation: one alloc+memcpy per frame instead of one
+                    // per value.
+                    let frame = Bytes::copy_from_slice(&bytes[..end]);
+                    bytes.advance(end);
                     let mut pos = 0;
                     let value = super::zero_copy::parse_value(&frame, &mut pos, 1)?;
                     Ok(Some(Ok(value)))

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -631,17 +631,25 @@ mod aio_support {
                     }
                 }
                 Some(end) => {
-                    // Copy the complete frame out in ONE bulk memcpy and
-                    // advance the read buffer. Copying (rather than
-                    // `split_to(end).freeze()`) keeps the codec's BytesMut
-                    // unshared so tokio can keep reusing its allocation —
-                    // freezing was measured to cause realloc+copy churn in
-                    // `BytesMut::reserve` on every read. Individual bulk
-                    // strings are then zero-copy slices of this one frame
-                    // allocation: one alloc+memcpy per frame instead of one
-                    // per value.
-                    let frame = Bytes::copy_from_slice(&bytes[..end]);
-                    bytes.advance(end);
+                    // Hybrid frame extraction, chosen from profiling:
+                    // - Small frames: ONE bulk memcpy out of the read buffer.
+                    //   Keeps the codec's BytesMut unshared so tokio reuses
+                    //   its allocation (freezing every frame caused
+                    //   realloc+copy churn in BytesMut::reserve — 40% of
+                    //   client CPU under pipelined load).
+                    // - Large frames: take ownership zero-copy via
+                    //   split_to().freeze(). The buffer had to grow for them
+                    //   anyway, and copying hundreds of KB costs more than
+                    //   losing one allocation's reuse.
+                    // Bulk strings are then zero-copy slices of the frame.
+                    const FRAME_COPY_MAX: usize = 64 * 1024;
+                    let frame = if end > FRAME_COPY_MAX {
+                        bytes.split_to(end).freeze()
+                    } else {
+                        let frame = Bytes::copy_from_slice(&bytes[..end]);
+                        bytes.advance(end);
+                        frame
+                    };
                     let mut pos = 0;
                     let value = super::zero_copy::parse_value(&frame, &mut pos, 1)?;
                     Ok(Some(Ok(value)))

--- a/glide-core/redis-rs/redis/src/pipeline.rs
+++ b/glide-core/redis-rs/redis/src/pipeline.rs
@@ -97,6 +97,27 @@ impl Pipeline {
         encode_pipeline(&self.commands, self.transaction_mode)
     }
 
+    /// Returns the encoded pipeline as segments for vectored writes.
+    /// Byte-identical on the wire to [`Pipeline::get_packed_pipeline`], with
+    /// large shared payloads as their own zero-copy segments.
+    pub fn get_packed_pipeline_segments(&self) -> crate::cmd::SegmentedBytes {
+        let mut out = crate::cmd::SegmentedBytes::default();
+        let mut scratch = Vec::new();
+        if self.transaction_mode {
+            cmd("MULTI").write_packed_segments(&mut out, &mut scratch);
+            for command in &self.commands {
+                command.write_packed_segments(&mut out, &mut scratch);
+            }
+            cmd("EXEC").write_packed_segments(&mut out, &mut scratch);
+        } else {
+            for command in &self.commands {
+                command.write_packed_segments(&mut out, &mut scratch);
+            }
+        }
+        out.push(bytes::Bytes::from(scratch));
+        out
+    }
+
     #[cfg(feature = "aio")]
     pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
         write_pipeline(out, &self.commands, self.transaction_mode)

--- a/glide-core/redis-rs/redis/src/pipeline.rs
+++ b/glide-core/redis-rs/redis/src/pipeline.rs
@@ -97,6 +97,11 @@ impl Pipeline {
         encode_pipeline(&self.commands, self.transaction_mode)
     }
 
+    #[cfg(feature = "aio")]
+    pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
+        write_pipeline(out, &self.commands, self.transaction_mode)
+    }
+
     /// Returns the encoded pipeline as segments for vectored writes.
     /// Byte-identical on the wire to [`Pipeline::get_packed_pipeline`], with
     /// large shared payloads as their own zero-copy segments.

--- a/glide-core/redis-rs/redis/src/pipeline.rs
+++ b/glide-core/redis-rs/redis/src/pipeline.rs
@@ -118,11 +118,6 @@ impl Pipeline {
         out
     }
 
-    #[cfg(feature = "aio")]
-    pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
-        write_pipeline(out, &self.commands, self.transaction_mode)
-    }
-
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
         self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),

--- a/glide-core/redis-rs/redis/src/push_manager.rs
+++ b/glide-core/redis-rs/redis/src/push_manager.rs
@@ -92,7 +92,7 @@ impl PushManager {
 
         // Extract channel/pattern from push data
         let channel_or_pattern = match data.first() {
-            Some(Value::BulkString(bytes)) => bytes.clone(),
+            Some(Value::BulkString(bytes)) => bytes.to_vec(),
             _ => return,
         };
 
@@ -142,7 +142,7 @@ mod tests {
 
         let value = Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::BulkString("hello".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello".to_string().into_bytes().into())],
         });
 
         push_manager.try_send(&value);
@@ -151,7 +151,7 @@ mod tests {
         assert_eq!(push_info.kind, PushKind::Message);
         assert_eq!(
             push_info.data,
-            vec![Value::BulkString("hello".to_string().into_bytes())]
+            vec![Value::BulkString("hello".to_string().into_bytes().into())]
         );
     }
     #[test]
@@ -162,7 +162,7 @@ mod tests {
 
         let value = Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::BulkString("hello".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello".to_string().into_bytes().into())],
         });
 
         drop(rx);
@@ -177,19 +177,19 @@ mod tests {
 
         push_manager.try_send(&Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::BulkString("hello".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello".to_string().into_bytes().into())],
         })); // nothing happens!
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         push_manager.replace_sender(tx);
         push_manager.try_send(&Ok(Value::Push {
             kind: PushKind::Message,
-            data: vec![Value::BulkString("hello2".to_string().into_bytes())],
+            data: vec![Value::BulkString("hello2".to_string().into_bytes().into())],
         }));
 
         assert_eq!(
             rx.try_recv().unwrap().data,
-            vec![Value::BulkString("hello2".to_string().into_bytes())]
+            vec![Value::BulkString("hello2".to_string().into_bytes().into())]
         );
     }
     #[test]

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -362,7 +362,12 @@ pub enum Value {
     /// the same for all numeric responses.
     Int(i64),
     /// An arbitrary binary data, usually represents a binary-safe string.
-    BulkString(Vec<u8>),
+    ///
+    /// Held as a refcounted [`bytes::Bytes`] so the parser can hand out
+    /// zero-copy slices of the connection read buffer. Note: a long-lived
+    /// `BulkString` pins the read chunk it was sliced from; deep-copy
+    /// (`Bytes::copy_from_slice`) before retaining values indefinitely.
+    BulkString(bytes::Bytes),
     /// A response containing an array with more data. This is generally used by redis
     /// to express nested structures.
     Array(Vec<Value>),
@@ -556,6 +561,41 @@ impl Iterator for OwnedMapIter {
 /// separated at an early point so the value only holds the remaining
 /// types.
 impl Value {
+    /// Deep-copies any [`bytes::Bytes`] payloads so this value no longer
+    /// shares (and therefore pins) the connection read buffer it was parsed
+    /// from. Call this before retaining a value long-term (e.g. inserting
+    /// into a client-side cache); request/response flows that drop values
+    /// promptly do not need it.
+    pub fn detach_buffers(self) -> Value {
+        match self {
+            Value::BulkString(b) => Value::BulkString(bytes::Bytes::copy_from_slice(&b)),
+            Value::Array(items) => {
+                Value::Array(items.into_iter().map(Value::detach_buffers).collect())
+            }
+            Value::Set(items) => {
+                Value::Set(items.into_iter().map(Value::detach_buffers).collect())
+            }
+            Value::Map(items) => Value::Map(
+                items
+                    .into_iter()
+                    .map(|(k, v)| (k.detach_buffers(), v.detach_buffers()))
+                    .collect(),
+            ),
+            Value::Attribute { data, attributes } => Value::Attribute {
+                data: Box::new(data.detach_buffers()),
+                attributes: attributes
+                    .into_iter()
+                    .map(|(k, v)| (k.detach_buffers(), v.detach_buffers()))
+                    .collect(),
+            },
+            Value::Push { kind, data } => Value::Push {
+                kind,
+                data: data.into_iter().map(Value::detach_buffers).collect(),
+            },
+            other => other,
+        }
+    }
+
     /// Checks if the return value looks like it fulfils the cursor
     /// protocol.  That means the result is an array item of length
     /// two with the first one being a cursor and the second an
@@ -1770,14 +1810,14 @@ pub trait FromRedisValue: Sized {
 
     /// Convert bytes to a single element vector.
     fn from_byte_vec(_vec: &[u8]) -> Option<Vec<Self>> {
-        Self::from_owned_redis_value(Value::BulkString(_vec.into()))
+        Self::from_owned_redis_value(Value::BulkString(bytes::Bytes::copy_from_slice(_vec)))
             .map(|rv| vec![rv])
             .ok()
     }
 
     /// Convert bytes to a single element vector.
     fn from_owned_byte_vec(_vec: Vec<u8>) -> RedisResult<Vec<Self>> {
-        Self::from_owned_redis_value(Value::BulkString(_vec)).map(|rv| vec![rv])
+        Self::from_owned_redis_value(Value::BulkString(_vec.into())).map(|rv| vec![rv])
     }
 }
 
@@ -1886,9 +1926,9 @@ impl FromRedisValue for bool {
                 }
             }
             Value::BulkString(ref bytes) => {
-                if bytes == b"1" {
+                if bytes.as_ref() == b"1" {
                     Ok(true)
-                } else if bytes == b"0" {
+                } else if bytes.as_ref() == b"0" {
                     Ok(false)
                 } else {
                     invalid_type_error!(v, "Response type not bool compatible.");
@@ -1905,7 +1945,7 @@ impl FromRedisValue for CString {
     fn from_redis_value(v: &Value) -> RedisResult<CString> {
         let v = get_inner_value(v);
         match *v {
-            Value::BulkString(ref bytes) => Ok(CString::new(bytes.as_slice())?),
+            Value::BulkString(ref bytes) => Ok(CString::new(&bytes[..])?),
             Value::Okay => Ok(CString::new("OK")?),
             Value::SimpleString(ref val) => Ok(CString::new(val.as_bytes())?),
             _ => invalid_type_error!(v, "Response type not CString compatible."),
@@ -1942,7 +1982,7 @@ impl FromRedisValue for String {
     fn from_owned_redis_value(v: Value) -> RedisResult<String> {
         let v = get_owned_inner_value(v);
         match v {
-            Value::BulkString(bytes) => Ok(String::from_utf8(bytes)?),
+            Value::BulkString(bytes) => Ok(String::from_utf8(bytes.to_vec())?),
             Value::Okay => Ok("OK".to_string()),
             Value::SimpleString(val) => Ok(val),
             Value::VerbatimString { format: _, text } => Ok(text),
@@ -2000,7 +2040,7 @@ macro_rules! from_vec_from_redis_value {
                     // Binary data is parsed into a single-element vector, except
                     // for the element type `u8`, which directly consumes the entire
                     // array of bytes.
-                    Value::BulkString(bytes) => FromRedisValue::from_owned_byte_vec(bytes).map($convert),
+                    Value::BulkString(bytes) => FromRedisValue::from_owned_byte_vec(bytes.to_vec()).map($convert),
                     Value::Array(items) => FromRedisValue::from_owned_redis_values(items).map($convert),
                     Value::Set(items) => FromRedisValue::from_owned_redis_values(items).map($convert),
                     Value::Map(items) => {

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -2402,7 +2402,6 @@ impl<T: FromRedisValue> FromRedisValue for Option<T> {
     }
 }
 
-#[cfg(feature = "bytes")]
 impl FromRedisValue for bytes::Bytes {
     fn from_redis_value(v: &Value) -> RedisResult<Self> {
         let v = get_inner_value(v);

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -2413,7 +2413,7 @@ impl FromRedisValue for bytes::Bytes {
     fn from_owned_redis_value(v: Value) -> RedisResult<Self> {
         let v = get_owned_inner_value(v);
         match v {
-            Value::BulkString(bytes_vec) => Ok(bytes_vec.into()),
+            Value::BulkString(bytes_vec) => Ok(bytes_vec),
             _ => invalid_type_error!(v, "Not a bulk string"),
         }
     }

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -572,9 +572,7 @@ impl Value {
             Value::Array(items) => {
                 Value::Array(items.into_iter().map(Value::detach_buffers).collect())
             }
-            Value::Set(items) => {
-                Value::Set(items.into_iter().map(Value::detach_buffers).collect())
-            }
+            Value::Set(items) => Value::Set(items.into_iter().map(Value::detach_buffers).collect()),
             Value::Map(items) => Value::Map(
                 items
                     .into_iter()

--- a/glide-core/redis-rs/redis/tests/auth.rs
+++ b/glide-core/redis-rs/redis/tests/auth.rs
@@ -168,7 +168,7 @@ mod auth {
             .arg("foo")
             .query_async(&mut connection_should_succeed)
             .await;
-        assert_eq!(res.unwrap(), Value::BulkString(b"bar".to_vec()));
+        assert_eq!(res.unwrap(), Value::BulkString(b"bar".to_vec().into()));
 
         // Kill the connection to force reconnection
         kill_non_management_connections(&mut Connection::Cluster(management_connection.clone()))
@@ -198,7 +198,7 @@ mod auth {
         })
         .await
         .expect("Timeout waiting for reconnection");
-        assert_eq!(should_be_ok, Value::BulkString(b"bar".to_vec()));
+        assert_eq!(should_be_ok, Value::BulkString(b"bar".to_vec().into()));
 
         // Update the password in the connection
         connection_should_succeed
@@ -254,7 +254,7 @@ mod auth {
         })
         .await
         .expect("Timeout waiting for reconnection");
-        assert_eq!(result_should_succeed, Value::BulkString(b"bar".to_vec()));
+        assert_eq!(result_should_succeed, Value::BulkString(b"bar".to_vec().into()));
     }
 
     #[tokio::test]

--- a/glide-core/redis-rs/redis/tests/auth.rs
+++ b/glide-core/redis-rs/redis/tests/auth.rs
@@ -254,7 +254,10 @@ mod auth {
         })
         .await
         .expect("Timeout waiting for reconnection");
-        assert_eq!(result_should_succeed, Value::BulkString(b"bar".to_vec().into()));
+        assert_eq!(
+            result_should_succeed,
+            Value::BulkString(b"bar".to_vec().into())
+        );
     }
 
     #[tokio::test]

--- a/glide-core/redis-rs/redis/tests/parser.rs
+++ b/glide-core/redis-rs/redis/tests/parser.rs
@@ -27,9 +27,12 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
         match self.0 {
             Value::Nil | Value::Okay => Box::new(None.into_iter()),
             Value::Int(i) => Box::new(i.shrink().map(Value::Int).map(ArbitraryValue)),
-            Value::BulkString(ref xs) => {
-                Box::new(xs.shrink().map(Value::BulkString).map(ArbitraryValue))
-            }
+            Value::BulkString(ref xs) => Box::new(
+                xs.to_vec()
+                    .shrink()
+                    .map(|v| Value::BulkString(v.into()))
+                    .map(ArbitraryValue),
+            ),
             Value::Array(ref xs) | Value::Set(ref xs) => {
                 let ys = xs
                     .iter()
@@ -99,7 +102,7 @@ fn arbitrary_value(g: &mut Gen, recursive_size: usize) -> Value {
         match u8::arbitrary(g) % 6 {
             0 => Value::Nil,
             1 => Value::Int(Arbitrary::arbitrary(g)),
-            2 => Value::BulkString(Arbitrary::arbitrary(g)),
+            2 => Value::BulkString(Vec::<u8>::arbitrary(g).into()),
             3 => {
                 let size = {
                     let s = g.size();
@@ -194,5 +197,38 @@ quickcheck! {
             result.unwrap(),
             input.0,
         );
+    }
+
+    /// The zero-copy `ValueCodec` must decode identically no matter how the
+    /// frame bytes are chunked across socket reads (frames straddling reads
+    /// must simply wait for more data, consuming nothing).
+    fn codec_chunked_parse(input: ArbitraryValue, chunk_sizes: Vec<usize>) -> () {
+        use tokio_util::codec::Decoder as _;
+
+        let mut encoded_input = Vec::new();
+        encode_value(&input.0, &mut encoded_input).unwrap();
+
+        let mut codec = redis::ValueCodec::default();
+        let mut buf = bytes::BytesMut::new();
+        let mut decoded = None;
+        let mut fed = 0;
+        let mut chunks = chunk_sizes.into_iter();
+
+        while fed < encoded_input.len() {
+            let n = std::cmp::min(
+                chunks.next().unwrap_or(usize::MAX).clamp(1, 4096),
+                encoded_input.len() - fed,
+            );
+            buf.extend_from_slice(&encoded_input[fed..fed + n]);
+            fed += n;
+            if let Some(item) = codec.decode(&mut buf).unwrap() {
+                assert!(decoded.is_none(), "decoded more than one value");
+                assert!(fed == encoded_input.len(), "decoded before full frame was fed");
+                decoded = Some(item.unwrap());
+            }
+        }
+        assert_eq!(decoded.expect("no value decoded"), input.0);
+        assert!(buf.is_empty(), "codec left unconsumed bytes");
+        assert!(codec.decode_eof(&mut buf).unwrap().is_none());
     }
 }

--- a/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
@@ -242,7 +242,7 @@ pub fn respond_startup(name: &str, cmd: &[u8]) -> Result<(), RedisResult<Value>>
             Value::Int(0),
             Value::Int(16383),
             Value::Array(vec![
-                Value::BulkString(name.as_bytes().to_vec()),
+                Value::BulkString(name.as_bytes().to_vec().into()),
                 Value::Int(6379),
             ]),
         ])])))
@@ -276,13 +276,13 @@ pub fn create_topology_from_config(name: &str, slots_config: Vec<MockSlotRange>)
                 Value::Int(slot_config.slot_range.start as i64),
                 Value::Int(slot_config.slot_range.end as i64),
                 Value::Array(vec![
-                    Value::BulkString(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec().into()),
                     Value::Int(slot_config.primary_port as i64),
                 ]),
             ];
             config.extend(slot_config.replica_ports.into_iter().map(|replica_port| {
                 Value::Array(vec![
-                    Value::BulkString(name.as_bytes().to_vec()),
+                    Value::BulkString(name.as_bytes().to_vec().into()),
                     Value::Int(replica_port as i64),
                 ])
             }));

--- a/glide-core/redis-rs/redis/tests/test_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_async.rs
@@ -1033,7 +1033,7 @@ mod basic_async {
                 (
                     PushKind::Invalidate,
                     vec![Value::Array(vec![Value::BulkString(
-                        "key_1".as_bytes().to_vec()
+                        "key_1".as_bytes().to_vec().into()
                     )])]
                 ),
                 (kind, data)
@@ -1048,7 +1048,7 @@ mod basic_async {
                 (
                     PushKind::Invalidate,
                     vec![Value::Array(vec![Value::BulkString(
-                        "key_1".as_bytes().to_vec()
+                        "key_1".as_bytes().to_vec().into()
                     )])]
                 ),
                 (kind, data)

--- a/glide-core/redis-rs/redis/tests/test_basic.rs
+++ b/glide-core/redis-rs/redis/tests/test_basic.rs
@@ -1562,7 +1562,7 @@ mod basic {
                 (
                     PushKind::Invalidate,
                     vec![Value::Array(vec![Value::BulkString(
-                        "key_1".as_bytes().to_vec()
+                        "key_1".as_bytes().to_vec().into()
                     )])]
                 ),
                 (kind, data)
@@ -1578,7 +1578,7 @@ mod basic {
             (
                 PushKind::Invalidate,
                 vec![Value::Array(vec![Value::BulkString(
-                    "key_1".as_bytes().to_vec()
+                    "key_1".as_bytes().to_vec().into()
                 )])]
             ),
             (kind, data)

--- a/glide-core/redis-rs/redis/tests/test_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster.rs
@@ -153,12 +153,12 @@ mod cluster {
             result,
             Value::Map(vec![
                 (
-                    Value::BulkString("foo".as_bytes().to_vec()),
-                    Value::BulkString("baz".as_bytes().to_vec())
+                    Value::BulkString("foo".as_bytes().to_vec().into()),
+                    Value::BulkString("baz".as_bytes().to_vec().into())
                 ),
                 (
-                    Value::BulkString("bar".as_bytes().to_vec()),
-                    Value::BulkString("foobar".as_bytes().to_vec())
+                    Value::BulkString("bar".as_bytes().to_vec().into()),
+                    Value::BulkString("foobar".as_bytes().to_vec().into())
                 )
             ])
         );
@@ -276,7 +276,7 @@ mod cluster {
                     Value::Int(0),
                     Value::Int(16383),
                     Value::Array(vec![
-                        Value::BulkString("".as_bytes().to_vec()),
+                        Value::BulkString("".as_bytes().to_vec().into()),
                         Value::Int(6379),
                     ]),
                 ])])))
@@ -330,7 +330,7 @@ mod cluster {
                         Value::Int(0),
                         Value::Int(7000),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(6379),
                         ]),
                     ]),
@@ -338,7 +338,7 @@ mod cluster {
                         Value::Int(7001),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString("?".as_bytes().to_vec()),
+                            Value::BulkString("?".as_bytes().to_vec().into()),
                             Value::Int(6380),
                         ]),
                     ]),
@@ -431,7 +431,7 @@ mod cluster {
 
                 match requests.fetch_add(1, atomic::Ordering::SeqCst) {
                     0..=4 => Err(parse_redis_value(b"-TRYAGAIN mock\r\n")),
-                    _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                    _ => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                 }
             },
         );
@@ -509,7 +509,7 @@ mod cluster {
                         Value::Int(0),
                         Value::Int(1),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(6379),
                         ]),
                     ]),
@@ -517,7 +517,7 @@ mod cluster {
                         Value::Int(2),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(6380),
                         ]),
                     ]),
@@ -525,7 +525,7 @@ mod cluster {
                 _ => {
                     // Check that the correct node receives the request after rebuilding
                     assert_eq!(port, 6380);
-                    Err(Ok(Value::BulkString(b"123".to_vec())))
+                    Err(Ok(Value::BulkString(b"123".to_vec().into())))
                 }
             }
         });
@@ -565,7 +565,7 @@ mod cluster {
                             }
                             2 => {
                                 assert!(contains_slice(cmd, b"GET"));
-                                Err(Ok(Value::BulkString(b"123".to_vec())))
+                                Err(Ok(Value::BulkString(b"123".to_vec().into())))
                             }
                             _ => panic!("Node should not be called now"),
                         },
@@ -617,7 +617,7 @@ mod cluster {
                 2 => {
                     assert_eq!(port, 6380);
                     assert!(contains_slice(cmd, b"GET"));
-                    Err(Ok(Value::BulkString(b"123".to_vec())))
+                    Err(Ok(Value::BulkString(b"123".to_vec().into())))
                 }
                 _ => {
                     panic!("Unexpected request: {cmd:?}");
@@ -649,7 +649,7 @@ mod cluster {
                 respond_startup_with_replica(name, cmd)?;
 
                 match port {
-                    6380 => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                    6380 => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     _ => panic!("Wrong node"),
                 }
             },
@@ -721,7 +721,7 @@ mod cluster {
                         },
                         6380 => match count {
                             // Retry arrives at correct node and succeeds
-                            1 => Err(Ok(Value::BulkString(b"value".to_vec()))),
+                            1 => Err(Ok(Value::BulkString(b"value".to_vec().into()))),
                             _ => panic!("node:6380 should only be called once"),
                         },
                         _ => panic!("Unexpected port {port}"),
@@ -762,7 +762,7 @@ mod cluster {
                             std::io::ErrorKind::ConnectionReset,
                             "mock-io-error",
                         )))),
-                        _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                        _ => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     },
                 }
             },
@@ -821,7 +821,7 @@ mod cluster {
                         )
                             .into())),
                         // After slot refresh, retry succeeds
-                        _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                        _ => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     }
                 }
             },
@@ -995,7 +995,7 @@ mod cluster {
                     .filter_map(|expected_key| {
                         if cmd_str.contains(expected_key) {
                             Some(Value::BulkString(
-                                format!("{expected_key}-{port}").into_bytes(),
+                                format!("{expected_key}-{port}").into_bytes().into(),
                             ))
                         } else {
                             None
@@ -1031,12 +1031,12 @@ mod cluster {
                 respond_startup_with_replica_using_config(name, received_cmd, None)?;
                 if port == 6381 {
                     let results = vec![
-                        Value::BulkString("OK".as_bytes().to_vec()),
-                        Value::BulkString("QUEUED".as_bytes().to_vec()),
-                        Value::BulkString("QUEUED".as_bytes().to_vec()),
+                        Value::BulkString("OK".as_bytes().to_vec().into()),
+                        Value::BulkString("QUEUED".as_bytes().to_vec().into()),
+                        Value::BulkString("QUEUED".as_bytes().to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString("OK".as_bytes().to_vec()),
-                            Value::BulkString("bar".as_bytes().to_vec()),
+                            Value::BulkString("OK".as_bytes().to_vec().into()),
+                            Value::BulkString("bar".as_bytes().to_vec().into()),
                         ]),
                     ];
                     return Err(Ok(Value::Array(results)));
@@ -1054,8 +1054,8 @@ mod cluster {
         assert_eq!(
             result,
             vec![
-                Value::BulkString("OK".as_bytes().to_vec()),
-                Value::BulkString("bar".as_bytes().to_vec()),
+                Value::BulkString("OK".as_bytes().to_vec().into()),
+                Value::BulkString("bar".as_bytes().to_vec().into()),
             ]
         );
     }
@@ -1068,12 +1068,12 @@ mod cluster {
         pipeline.atomic().set("foo", "bar").get("foo");
         let packed_pipeline = pipeline.get_packed_pipeline();
         let results = vec![
-            Value::BulkString("OK".as_bytes().to_vec()),
-            Value::BulkString("QUEUED".as_bytes().to_vec()),
-            Value::BulkString("QUEUED".as_bytes().to_vec()),
+            Value::BulkString("OK".as_bytes().to_vec().into()),
+            Value::BulkString("QUEUED".as_bytes().to_vec().into()),
+            Value::BulkString("QUEUED".as_bytes().to_vec().into()),
             Value::Array(vec![
-                Value::BulkString("OK".as_bytes().to_vec()),
-                Value::BulkString("bar".as_bytes().to_vec()),
+                Value::BulkString("OK".as_bytes().to_vec().into()),
+                Value::BulkString("bar".as_bytes().to_vec().into()),
             ]),
         ];
         let expected_result = Value::Array(results);

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -366,7 +366,7 @@ mod cluster_async {
 
             let expected = vec![Value::Array(vec![
                 Value::Int(5),
-                Value::BulkString(b"5".to_vec()),
+                Value::BulkString(b"5".to_vec().into()),
             ])];
             let result = result.expect("Pipeline execution failed");
             assert_eq!(
@@ -453,7 +453,7 @@ mod cluster_async {
             let expected = vec![
                 Value::Int(5),
                 Value::Okay,
-                Value::BulkString(b"value".to_vec()),
+                Value::BulkString(b"value".to_vec().into()),
             ];
             assert_eq!(
                 result, expected,
@@ -1413,12 +1413,12 @@ mod cluster_async {
                 result,
                 Value::Map(vec![
                     (
-                        Value::BulkString("foo".as_bytes().to_vec()),
-                        Value::BulkString("baz".as_bytes().to_vec())
+                        Value::BulkString("foo".as_bytes().to_vec().into()),
+                        Value::BulkString("baz".as_bytes().to_vec().into())
                     ),
                     (
-                        Value::BulkString("bar".as_bytes().to_vec()),
-                        Value::BulkString("foobar".as_bytes().to_vec())
+                        Value::BulkString("bar".as_bytes().to_vec().into()),
+                        Value::BulkString("foobar".as_bytes().to_vec().into())
                     )
                 ])
             );
@@ -1704,7 +1704,7 @@ mod cluster_async {
                     Value::Int(0),
                     Value::Int(16383),
                     Value::Array(vec![
-                        Value::BulkString("".as_bytes().to_vec()),
+                        Value::BulkString("".as_bytes().to_vec().into()),
                         Value::Int(6379),
                     ]),
                 ])])))
@@ -1767,7 +1767,7 @@ mod cluster_async {
                     Value::Int(0),
                     Value::Int(16383),
                     Value::Array(vec![
-                        Value::BulkString("?".as_bytes().to_vec()),
+                        Value::BulkString("?".as_bytes().to_vec().into()),
                         Value::Int(6379),
                     ]),
                 ])])))
@@ -1805,7 +1805,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(7000),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(6379),
                         ]),
                     ]),
@@ -1813,7 +1813,7 @@ mod cluster_async {
                         Value::Int(7001),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString("?".as_bytes().to_vec()),
+                            Value::BulkString("?".as_bytes().to_vec().into()),
                             Value::Int(6380),
                         ]),
                     ]),
@@ -1851,7 +1851,7 @@ mod cluster_async {
 
                 match requests.fetch_add(1, atomic::Ordering::SeqCst) {
                     0..=4 => Err(parse_redis_value(b"-TRYAGAIN mock\r\n")),
-                    _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                    _ => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                 }
             },
         );
@@ -1953,7 +1953,7 @@ mod cluster_async {
             let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
 
             let is_get_cmd = contains_slice(cmd, b"GET");
-            let get_response = Err(Ok(Value::BulkString(b"123".to_vec())));
+            let get_response = Err(Ok(Value::BulkString(b"123".to_vec().into())));
             match i {
                 // Respond that the key exists on a node that does not yet have a connection:
                 0 => Err(parse_redis_value(
@@ -1972,7 +1972,7 @@ mod cluster_async {
                                 Value::Int(0),
                                 Value::Int(1),
                                 Value::Array(vec![
-                                    Value::BulkString(name.as_bytes().to_vec()),
+                                    Value::BulkString(name.as_bytes().to_vec().into()),
                                     Value::Int(6379),
                                 ]),
                             ]),
@@ -1980,7 +1980,7 @@ mod cluster_async {
                                 Value::Int(2),
                                 Value::Int(16383),
                                 Value::Array(vec![
-                                    Value::BulkString(name.as_bytes().to_vec()),
+                                    Value::BulkString(name.as_bytes().to_vec().into()),
                                     Value::Int(6380),
                                 ]),
                             ]),
@@ -2040,7 +2040,7 @@ mod cluster_async {
 
                 let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
                 let is_get_cmd = contains_slice(cmd, b"GET");
-                let get_response = Err(Ok(Value::BulkString(b"123".to_vec())));
+                let get_response = Err(Ok(Value::BulkString(b"123".to_vec().into())));
                 let moved_node = ports[0];
                 match i {
                     // Respond that the key exists on a node that does not yet have a connection:
@@ -2145,7 +2145,7 @@ mod cluster_async {
 
                 let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
                 let is_get_cmd = contains_slice(cmd, b"GET");
-                let get_response = Err(Ok(Value::BulkString(b"123".to_vec())));
+                let get_response = Err(Ok(Value::BulkString(b"123".to_vec().into())));
                 let moved_node = ports[0];
                 match i {
                     // The first request calls are the starting calls for each GET command where we want to respond with MOVED error
@@ -2243,7 +2243,7 @@ mod cluster_async {
                 }
 
                 let is_get_cmd = contains_slice(cmd, b"GET");
-                let get_response = Err(Ok(Value::BulkString(b"123".to_vec())));
+                let get_response = Err(Ok(Value::BulkString(b"123".to_vec().into())));
                 {
                     assert!(is_get_cmd, "{:?}", std::str::from_utf8(cmd));
                     get_response
@@ -2484,7 +2484,7 @@ mod cluster_async {
                     assert!(
                         res.iter().any(|(k, _)| k
                             == &Value::BulkString(
-                                format!("{}:{}", node_0_host, node_0_port).into_bytes()
+                                format!("{}:{}", node_0_host, node_0_port).into_bytes().into()
                             )),
                         "Expected to see node 0 only"
                     );
@@ -2858,7 +2858,7 @@ mod cluster_async {
                     if new_shard_replica_port == port {
                         // Simulate replica response for GET after slot migration
                         replica_requests.fetch_add(1, Ordering::Relaxed);
-                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                        Err(Ok(Value::BulkString(b"123".to_vec().into())))
                     } else {
                         panic!("unexpected port for GET command: {port:?}, Expected: {new_shard_replica_port:?}");
                     }
@@ -3075,7 +3075,7 @@ mod cluster_async {
                 } else if contains_slice(cmd, b"GET") {
                     if moved_to_port == port {
                         // Simulate primary response for GET
-                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                        Err(Ok(Value::BulkString(b"123".to_vec().into())))
                     } else {
                         panic!(
                             "unexpected port for GET command: {port:?}, Expected: {moved_to_port}"
@@ -3195,7 +3195,7 @@ mod cluster_async {
                 } else if contains_slice(cmd, b"GET") {
                     if port == primary_shard2 {
                         // Simulate second shard primary response for GET
-                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                        Err(Ok(Value::BulkString(b"123".to_vec().into())))
                     } else {
                         panic!("unexpected port for GET command: {port:?}, Expected: {primary_shard2:?}");
                     }
@@ -3363,7 +3363,7 @@ mod cluster_async {
                     if should_reconnect.swap(false, Ordering::SeqCst) {
                         Err(Err(broken_pipe_error()))
                     } else {
-                        Err(Ok(Value::BulkString(b"PONG".to_vec())))
+                        Err(Ok(Value::BulkString(b"PONG".to_vec().into())))
                     }
                 } else {
                     panic!("unexpected command {cmd:?}")
@@ -3406,7 +3406,7 @@ mod cluster_async {
             }),
         ));
 
-        assert_eq!(value, Ok(Value::BulkString(b"PONG".to_vec())));
+        assert_eq!(value, Ok(Value::BulkString(b"PONG".to_vec().into())));
         // `expected_init_calls` plus another PING for a new user connection created from refresh_connections
         assert_eq!(
             connection_count_clone.load(Ordering::Relaxed),
@@ -3467,7 +3467,7 @@ mod cluster_async {
                             }
                             2 => {
                                 assert!(contains_slice(cmd, b"GET"));
-                                Err(Ok(Value::BulkString(b"123".to_vec())))
+                                Err(Ok(Value::BulkString(b"123".to_vec().into())))
                             }
                             _ => panic!("Node should not be called now"),
                         },
@@ -3553,7 +3553,7 @@ mod cluster_async {
                 // accept the next request
                 (6379, 1) => {
                     assert!(contains_slice(cmd, b"GET"));
-                    Err(Ok(Value::BulkString(b"123".to_vec())))
+                    Err(Ok(Value::BulkString(b"123".to_vec().into())))
                 }
                 _ => panic!("Wrong node. port: {port}, received count: {count}"),
             }
@@ -3658,7 +3658,7 @@ mod cluster_async {
                 2 => {
                     assert_eq!(port, 6380);
                     assert!(contains_slice(cmd, b"GET"));
-                    Err(Ok(Value::BulkString(b"123".to_vec())))
+                    Err(Ok(Value::BulkString(b"123".to_vec().into())))
                 }
                 _ => {
                     panic!("Unexpected request: {cmd:?}");
@@ -3694,7 +3694,7 @@ mod cluster_async {
             move |cmd: &[u8], port| {
                 respond_startup_with_replica(name, cmd)?;
                 match port {
-                    6380 => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                    6380 => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     _ => panic!("Wrong node"),
                 }
             },
@@ -4142,7 +4142,7 @@ mod cluster_async {
                 let slots_config_vec = generate_topology_view(&ports, 1000, true);
                 respond_startup_with_config(name, received_cmd, Some(slots_config_vec), false)?;
                 if port == 6380 {
-                    return Err(Ok(Value::BulkString("foo".as_bytes().to_vec())));
+                    return Err(Ok(Value::BulkString("foo".as_bytes().to_vec().into())));
                 } else if port == 6381 {
                     return Err(Err(RedisError::from((
                         redis::ErrorKind::ResponseError,
@@ -4240,7 +4240,7 @@ mod cluster_async {
             move |received_cmd: &[u8], port| {
                 respond_startup_with_replica_using_config(name, received_cmd, None)?;
                 Err(Ok(Value::BulkString(
-                    format!("latency: {port}").into_bytes(),
+                    format!("latency: {port}").into_bytes().into(),
                 )))
             },
         );
@@ -4280,7 +4280,7 @@ mod cluster_async {
             move |received_cmd: &[u8], port| {
                 respond_startup_with_replica_using_config(name, received_cmd, None)?;
                 Err(Ok(Value::Array(vec![Value::BulkString(
-                    format!("key:{port}").into_bytes(),
+                    format!("key:{port}").into_bytes().into(),
                 )])))
             },
         );
@@ -4320,7 +4320,7 @@ mod cluster_async {
                     .filter_map(|expected_key| {
                         if cmd_str.contains(expected_key) {
                             Some(Value::BulkString(
-                                format!("{expected_key}-{port}").into_bytes(),
+                                format!("{expected_key}-{port}").into_bytes().into(),
                             ))
                         } else {
                             None
@@ -4369,7 +4369,7 @@ mod cluster_async {
                     .filter_map(|expected_key| {
                         if cmd_str.contains(expected_key) {
                             Some(Value::BulkString(
-                                format!("{expected_key}-{port}").into_bytes(),
+                                format!("{expected_key}-{port}").into_bytes().into(),
                             ))
                         } else {
                             None
@@ -4404,7 +4404,7 @@ mod cluster_async {
                 Err(Err((ErrorKind::IoError, "error").into()))
             } else {
                 Err(Ok(Value::Array(vec![Value::BulkString(
-                    format!("{port}").into_bytes(),
+                    format!("{port}").into_bytes().into(),
                 )])))
             }
         });
@@ -4436,7 +4436,7 @@ mod cluster_async {
                 }]),
             )?;
             Err(Ok(Value::Array(vec![Value::BulkString(
-                format!("{port}").into_bytes(),
+                format!("{port}").into_bytes().into(),
             )])))
         });
 
@@ -4506,7 +4506,7 @@ mod cluster_async {
                             ErrorKind::FatalSendError,
                             "mock-io-error",
                         )))),
-                        _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                        _ => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     },
                 }
             },
@@ -4583,7 +4583,7 @@ mod cluster_async {
                         )
                             .into())),
                         // After slot refresh, retry succeeds
-                        _ => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                        _ => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     }
                 }
             },
@@ -4984,7 +4984,7 @@ mod cluster_async {
                         // RESP2
                         Value::BulkString(client_info) => {
                             // ensure 4 connections - 2 for each client, its save to unwrap here
-                            String::from_utf8(client_info).unwrap()
+                            String::from_utf8(client_info.to_vec()).unwrap()
                         }
                         // RESP3
                         Value::VerbatimString { format: _, text } => text,
@@ -5367,7 +5367,7 @@ mod cluster_async {
                         load_errors_clone.lock().unwrap().push(port);
                         Err(parse_redis_value(b"-LOADING\r\n"))
                     }
-                    6379 => Err(Ok(Value::BulkString(b"123".to_vec()))),
+                    6379 => Err(Ok(Value::BulkString(b"123".to_vec().into()))),
                     _ => panic!("Wrong node"),
                 }
             },
@@ -5422,7 +5422,7 @@ mod cluster_async {
                     6379 => {
                         let attempts = load_errors_clone.fetch_add(1, Ordering::Relaxed) + 1;
                         if attempts % RETRIES == 0 {
-                            Err(Ok(Value::BulkString(b"123".to_vec())))
+                            Err(Ok(Value::BulkString(b"123".to_vec().into())))
                         } else {
                             Err(parse_redis_value(b"-LOADING\r\n"))
                         }
@@ -5687,7 +5687,7 @@ mod cluster_async {
                             "mock-io-error",
                         ))))
                     } else {
-                        Err(Ok(Value::BulkString(b"123".to_vec())))
+                        Err(Ok(Value::BulkString(b"123".to_vec().into())))
                     }
                 }
             },
@@ -6769,7 +6769,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(port as i64),
                         ]),
                     ])])));
@@ -6796,7 +6796,7 @@ mod cluster_async {
                             // Record ping count at retry GET
                             ping_at_get_1_clone.store(current_pings, atomic::Ordering::SeqCst);
                             // Return success
-                            Err(Ok(Value::BulkString(b"success".to_vec())))
+                            Err(Ok(Value::BulkString(b"success".to_vec().into())))
                         }
                     }
                 } else {
@@ -6901,7 +6901,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(port as i64),
                         ]),
                     ])])));
@@ -7012,7 +7012,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec()),
+                            Value::BulkString(name.as_bytes().to_vec().into()),
                             Value::Int(port as i64),
                         ]),
                     ])])));

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -2484,7 +2484,9 @@ mod cluster_async {
                     assert!(
                         res.iter().any(|(k, _)| k
                             == &Value::BulkString(
-                                format!("{}:{}", node_0_host, node_0_port).into_bytes().into()
+                                format!("{}:{}", node_0_host, node_0_port)
+                                    .into_bytes()
+                                    .into()
                             )),
                         "Expected to see node 0 only"
                     );

--- a/glide-core/redis-rs/redis/tests/test_cluster_pipeline.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_pipeline.rs
@@ -753,7 +753,10 @@ mod test_cluster_pipeline {
                     // When retry is enabled, TRYAGAIN errors should be retried, and `MGET` should return expected values.
                     assert_eq!(
                         result[2],
-                        Value::Array(vec![Value::BulkString(b"value".to_vec().into()), Value::Nil]),
+                        Value::Array(vec![
+                            Value::BulkString(b"value".to_vec().into()),
+                            Value::Nil
+                        ]),
                         "Pipeline result did not match expected output.\n\
                          Keys chosen: ('{migrated_key}', '{key}')\n\
                          key_slot: {key_slot}\n\

--- a/glide-core/redis-rs/redis/tests/test_cluster_pipeline.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_pipeline.rs
@@ -234,9 +234,9 @@ mod test_cluster_pipeline {
         // Assert that the pipeline with the good key succeeds.
         let expected = vec![
             Value::Okay,
-            Value::BulkString(b"value".to_vec()),
+            Value::BulkString(b"value".to_vec().into()),
             Value::Okay,
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value2".to_vec().into()),
         ];
         assert_eq!(
             &res[3..],
@@ -316,7 +316,7 @@ mod test_cluster_pipeline {
                 let expected = vec![
                     Value::Int(5),
                     Value::Okay,
-                    Value::BulkString(b"value".to_vec()),
+                    Value::BulkString(b"value".to_vec().into()),
                 ];
                 assert_eq!(
                     result, expected,
@@ -395,7 +395,7 @@ mod test_cluster_pipeline {
             if retries == 1 {
                 let expected = vec![Value::Array(vec![
                     Value::Okay,
-                    Value::BulkString(b"value".to_vec()),
+                    Value::BulkString(b"value".to_vec().into()),
                 ])];
                 assert!(result.is_ok());
                 let response = result.unwrap();
@@ -453,9 +453,9 @@ mod test_cluster_pipeline {
         // Verify the pipeline result.
         let expected = vec![
             Value::Okay,
-            Value::BulkString(b"pipeline_value".to_vec()),
+            Value::BulkString(b"pipeline_value".to_vec().into()),
             Value::Okay,
-            Value::BulkString(b"pipeline_value2".to_vec()),
+            Value::BulkString(b"pipeline_value2".to_vec().into()),
         ];
 
         assert_eq!(
@@ -524,9 +524,9 @@ mod test_cluster_pipeline {
 
             let inner = vec![
                 Value::Okay,
-                Value::BulkString(b"pipeline_value".to_vec()),
+                Value::BulkString(b"pipeline_value".to_vec().into()),
                 Value::Okay,
-                Value::BulkString(b"pipeline_value2".to_vec()),
+                Value::BulkString(b"pipeline_value2".to_vec().into()),
             ];
 
             let expected = if atomic {
@@ -626,8 +626,8 @@ mod test_cluster_pipeline {
                         Value::Int(1),
                         Value::Okay,
                         Value::Array(vec![
-                            Value::BulkString(b"value1".to_vec()),
-                            Value::BulkString(b"3".to_vec())
+                            Value::BulkString(b"value1".to_vec().into()),
+                            Value::BulkString(b"3".to_vec().into())
                         ])
                     ],
                     "Expected MSET to succeed and MGET to return the values, but got: {result:?} key: {moved_key} key2: {key2}"
@@ -753,7 +753,7 @@ mod test_cluster_pipeline {
                     // When retry is enabled, TRYAGAIN errors should be retried, and `MGET` should return expected values.
                     assert_eq!(
                         result[2],
-                        Value::Array(vec![Value::BulkString(b"value".to_vec()), Value::Nil]),
+                        Value::Array(vec![Value::BulkString(b"value".to_vec().into()), Value::Nil]),
                         "Pipeline result did not match expected output.\n\
                          Keys chosen: ('{migrated_key}', '{key}')\n\
                          key_slot: {key_slot}\n\

--- a/glide-core/redis-rs/redis/tests/test_types.rs
+++ b/glide-core/redis-rs/redis/tests/test_types.rs
@@ -111,14 +111,14 @@ mod types {
 
             let content: &[u8] = b"\x01\x02\x03\x04";
             let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone().into()));
             assert_eq!(v, Ok(content_vec));
 
             let content: &[u8] = b"1";
             let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone().into()));
             assert_eq!(v, Ok(vec![b'1']));
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.into()));
             assert_eq!(v, Ok(vec![1_u16]));
         }
     }
@@ -136,14 +136,14 @@ mod types {
 
             let content: &[u8] = b"\x01\x02\x03\x04";
             let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone().into()));
             assert_eq!(v, Ok(content_vec.into_boxed_slice()));
 
             let content: &[u8] = b"1";
             let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone().into()));
             assert_eq!(v, Ok(vec![b'1'].into_boxed_slice()));
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.into()));
             assert_eq!(v, Ok(vec![1_u16].into_boxed_slice()));
 
             assert_eq!(
@@ -170,14 +170,14 @@ mod types {
 
             let content: &[u8] = b"\x01\x02\x03\x04";
             let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone().into()));
             assert_eq!(v, Ok(Arc::from(content_vec)));
 
             let content: &[u8] = b"1";
             let content_vec: Vec<u8> = Vec::from(content);
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone()));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.clone().into()));
             assert_eq!(v, Ok(Arc::from(vec![b'1'])));
-            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec));
+            let v = parse_mode.parse_redis_value(Value::BulkString(content_vec.into()));
             assert_eq!(v, Ok(Arc::from(vec![1_u16])));
 
             assert_eq!(
@@ -377,7 +377,7 @@ mod types {
             let content_vec: Vec<u8> = Vec::from(content);
 
             let v: RedisResult<CString> =
-                parse_mode.parse_redis_value(Value::BulkString(content_vec));
+                parse_mode.parse_redis_value(Value::BulkString(content_vec.into()));
             assert_eq!(v, Ok(CString::new(content).unwrap()));
 
             let v: RedisResult<CString> =
@@ -461,7 +461,7 @@ mod types {
 
         let value = Value::Array(
             vec.iter()
-                .map(|val| Value::BulkString(val.clone()))
+                .map(|val| Value::BulkString(val.clone().into()))
                 .collect(),
         );
         let mut encoded_input = Vec::new();
@@ -508,7 +508,7 @@ mod types {
 
         let value = Value::Array(
             vec.iter()
-                .map(|val| Value::BulkString(val.clone()))
+                .map(|val| Value::BulkString(val.clone().into()))
                 .collect(),
         );
         let mut encoded_input = Vec::new();
@@ -530,7 +530,7 @@ mod types {
 
         let value = Value::Array(
             vec.iter()
-                .map(|val| Value::BulkString(val.clone()))
+                .map(|val| Value::BulkString(val.clone().into()))
                 .collect(),
         );
         let mut encoded_input = Vec::new();

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -295,7 +295,7 @@ pub(crate) fn convert_to_expected_type(
                 Value::BulkString(bytes) => {
                     let text = std::str::from_utf8(&bytes).unwrap();
                     let res = convert_lolwut_string(text);
-                    Ok(Value::BulkString(Vec::from(res)))
+                    Ok(Value::BulkString(Vec::from(res).into()))
                 }
                 // RESP 3 response
                 Value::VerbatimString {
@@ -303,7 +303,7 @@ pub(crate) fn convert_to_expected_type(
                     ref text,
                 } => {
                     let res = convert_lolwut_string(text);
-                    Ok(Value::BulkString(Vec::from(res)))
+                    Ok(Value::BulkString(Vec::from(res).into()))
                 }
                 _ => Err((
                     ErrorKind::TypeError,
@@ -1146,7 +1146,7 @@ pub(crate) fn convert_to_expected_type(
                     unreachable!()
                 };
                 if let Some(pair) = map.iter_mut().find(|(k, _)| {
-                    matches!(k, Value::BulkString(b) if b == b"flags")
+                    matches!(k, Value::BulkString(b) if b.as_ref() == b"flags")
                 }) {
                     let val = std::mem::replace(&mut pair.1, Value::Nil);
                     pair.1 = convert_to_expected_type(val, Some(ExpectedReturnType::Set))?;
@@ -1807,42 +1807,42 @@ mod tests {
     fn convert_xinfo_stream() {
         // Only a partial response is represented here for brevity - the rest of the response follows the same format.
         let groups_resp2_response = Value::Array(vec![
-            Value::BulkString("length".to_string().into_bytes()),
+            Value::BulkString("length".to_string().into_bytes().into()),
             Value::Int(2),
-            Value::BulkString("entries".to_string().into_bytes()),
+            Value::BulkString("entries".to_string().into_bytes().into()),
             Value::Array(vec![Value::Array(vec![
-                Value::BulkString("1-0".to_string().into_bytes()),
+                Value::BulkString("1-0".to_string().into_bytes().into()),
                 Value::Array(vec![
-                    Value::BulkString("a".to_string().into_bytes()),
-                    Value::BulkString("b".to_string().into_bytes()),
-                    Value::BulkString("c".to_string().into_bytes()),
-                    Value::BulkString("d".to_string().into_bytes()),
+                    Value::BulkString("a".to_string().into_bytes().into()),
+                    Value::BulkString("b".to_string().into_bytes().into()),
+                    Value::BulkString("c".to_string().into_bytes().into()),
+                    Value::BulkString("d".to_string().into_bytes().into()),
                 ]),
             ])]),
-            Value::BulkString("groups".to_string().into_bytes()),
+            Value::BulkString("groups".to_string().into_bytes().into()),
             Value::Array(vec![
                 Value::Array(vec![
-                    Value::BulkString("name".to_string().into_bytes()),
-                    Value::BulkString("group1".to_string().into_bytes()),
-                    Value::BulkString("consumers".to_string().into_bytes()),
+                    Value::BulkString("name".to_string().into_bytes().into()),
+                    Value::BulkString("group1".to_string().into_bytes().into()),
+                    Value::BulkString("consumers".to_string().into_bytes().into()),
                     Value::Array(vec![
                         Value::Array(vec![
-                            Value::BulkString("name".to_string().into_bytes()),
-                            Value::BulkString("consumer1".to_string().into_bytes()),
-                            Value::BulkString("pending".to_string().into_bytes()),
+                            Value::BulkString("name".to_string().into_bytes().into()),
+                            Value::BulkString("consumer1".to_string().into_bytes().into()),
+                            Value::BulkString("pending".to_string().into_bytes().into()),
                             Value::Array(vec![Value::Array(vec![
-                                Value::BulkString("1-0".to_string().into_bytes()),
+                                Value::BulkString("1-0".to_string().into_bytes().into()),
                                 Value::Int(1),
                             ])]),
                         ]),
                         Value::Array(vec![
-                            Value::BulkString("pending".to_string().into_bytes()),
+                            Value::BulkString("pending".to_string().into_bytes().into()),
                             Value::Array(vec![]),
                         ]),
                     ]),
                 ]),
                 Value::Array(vec![
-                    Value::BulkString("consumers".to_string().into_bytes()),
+                    Value::BulkString("consumers".to_string().into_bytes().into()),
                     Value::Array(vec![]),
                 ]),
             ]),
@@ -1850,54 +1850,54 @@ mod tests {
 
         let groups_resp3_response = Value::Map(vec![
             (
-                Value::BulkString("length".to_string().into_bytes()),
+                Value::BulkString("length".to_string().into_bytes().into()),
                 Value::Int(2),
             ),
             (
-                Value::BulkString("entries".to_string().into_bytes()),
+                Value::BulkString("entries".to_string().into_bytes().into()),
                 Value::Array(vec![Value::Array(vec![
-                    Value::BulkString("1-0".to_string().into_bytes()),
+                    Value::BulkString("1-0".to_string().into_bytes().into()),
                     Value::Array(vec![
-                        Value::BulkString("a".to_string().into_bytes()),
-                        Value::BulkString("b".to_string().into_bytes()),
-                        Value::BulkString("c".to_string().into_bytes()),
-                        Value::BulkString("d".to_string().into_bytes()),
+                        Value::BulkString("a".to_string().into_bytes().into()),
+                        Value::BulkString("b".to_string().into_bytes().into()),
+                        Value::BulkString("c".to_string().into_bytes().into()),
+                        Value::BulkString("d".to_string().into_bytes().into()),
                     ]),
                 ])]),
             ),
             (
-                Value::BulkString("groups".to_string().into_bytes()),
+                Value::BulkString("groups".to_string().into_bytes().into()),
                 Value::Array(vec![
                     Value::Map(vec![
                         (
-                            Value::BulkString("name".to_string().into_bytes()),
-                            Value::BulkString("group1".to_string().into_bytes()),
+                            Value::BulkString("name".to_string().into_bytes().into()),
+                            Value::BulkString("group1".to_string().into_bytes().into()),
                         ),
                         (
-                            Value::BulkString("consumers".to_string().into_bytes()),
+                            Value::BulkString("consumers".to_string().into_bytes().into()),
                             Value::Array(vec![
                                 Value::Map(vec![
                                     (
-                                        Value::BulkString("name".to_string().into_bytes()),
-                                        Value::BulkString("consumer1".to_string().into_bytes()),
+                                        Value::BulkString("name".to_string().into_bytes().into()),
+                                        Value::BulkString("consumer1".to_string().into_bytes().into()),
                                     ),
                                     (
-                                        Value::BulkString("pending".to_string().into_bytes()),
+                                        Value::BulkString("pending".to_string().into_bytes().into()),
                                         Value::Array(vec![Value::Array(vec![
-                                            Value::BulkString("1-0".to_string().into_bytes()),
+                                            Value::BulkString("1-0".to_string().into_bytes().into()),
                                             Value::Int(1),
                                         ])]),
                                     ),
                                 ]),
                                 Value::Map(vec![(
-                                    Value::BulkString("pending".to_string().into_bytes()),
+                                    Value::BulkString("pending".to_string().into_bytes().into()),
                                     Value::Array(vec![]),
                                 )]),
                             ]),
                         ),
                     ]),
                     Value::Map(vec![(
-                        Value::BulkString("consumers".to_string().into_bytes()),
+                        Value::BulkString("consumers".to_string().into_bytes().into()),
                         Value::Array(vec![]),
                     )]),
                 ]),
@@ -1925,12 +1925,12 @@ mod tests {
         );
 
         let resp2_empty_groups = Value::Array(vec![
-            Value::BulkString("groups".to_string().into_bytes()),
+            Value::BulkString("groups".to_string().into_bytes().into()),
             Value::Array(vec![]),
         ]);
 
         let resp3_empty_groups = Value::Map(vec![(
-            Value::BulkString("groups".to_string().into_bytes()),
+            Value::BulkString("groups".to_string().into_bytes().into()),
             Value::Array(vec![]),
         )]);
 
@@ -1975,15 +1975,15 @@ mod tests {
         // follows the same format.
         let groups_resp2_response = Value::Array(vec![
             Value::Array(vec![
-                Value::BulkString("name".to_string().into_bytes()),
-                Value::BulkString("mygroup".to_string().into_bytes()),
-                Value::BulkString("lag".to_string().into_bytes()),
+                Value::BulkString("name".to_string().into_bytes().into()),
+                Value::BulkString("mygroup".to_string().into_bytes().into()),
+                Value::BulkString("lag".to_string().into_bytes().into()),
                 Value::Int(0),
             ]),
             Value::Array(vec![
-                Value::BulkString("name".to_string().into_bytes()),
-                Value::BulkString("some-other-group".to_string().into_bytes()),
-                Value::BulkString("lag".to_string().into_bytes()),
+                Value::BulkString("name".to_string().into_bytes().into()),
+                Value::BulkString("some-other-group".to_string().into_bytes().into()),
+                Value::BulkString("lag".to_string().into_bytes().into()),
                 Value::Nil,
             ]),
         ]);
@@ -1991,21 +1991,21 @@ mod tests {
         let groups_resp3_response = Value::Array(vec![
             Value::Map(vec![
                 (
-                    Value::BulkString("name".to_string().into_bytes()),
-                    Value::BulkString("mygroup".to_string().into_bytes()),
+                    Value::BulkString("name".to_string().into_bytes().into()),
+                    Value::BulkString("mygroup".to_string().into_bytes().into()),
                 ),
                 (
-                    Value::BulkString("lag".to_string().into_bytes()),
+                    Value::BulkString("lag".to_string().into_bytes().into()),
                     Value::Int(0),
                 ),
             ]),
             Value::Map(vec![
                 (
-                    Value::BulkString("name".to_string().into_bytes()),
-                    Value::BulkString("some-other-group".to_string().into_bytes()),
+                    Value::BulkString("name".to_string().into_bytes().into()),
+                    Value::BulkString("some-other-group".to_string().into_bytes().into()),
                 ),
                 (
-                    Value::BulkString("lag".to_string().into_bytes()),
+                    Value::BulkString("lag".to_string().into_bytes().into()),
                     Value::Nil,
                 ),
             ]),
@@ -2045,86 +2045,86 @@ mod tests {
 
         let resp2_response = Value::Array(vec![
             Value::Array(vec![
-                Value::BulkString("library_name".to_string().into_bytes()),
-                Value::BulkString("mylib1".to_string().into_bytes()),
-                Value::BulkString("engine".to_string().into_bytes()),
-                Value::BulkString("LUA".to_string().into_bytes()),
-                Value::BulkString("functions".to_string().into_bytes()),
+                Value::BulkString("library_name".to_string().into_bytes().into()),
+                Value::BulkString("mylib1".to_string().into_bytes().into()),
+                Value::BulkString("engine".to_string().into_bytes().into()),
+                Value::BulkString("LUA".to_string().into_bytes().into()),
+                Value::BulkString("functions".to_string().into_bytes().into()),
                 Value::Array(vec![
                     Value::Array(vec![
-                        Value::BulkString("name".to_string().into_bytes()),
-                        Value::BulkString("myfunc1".to_string().into_bytes()),
-                        Value::BulkString("description".to_string().into_bytes()),
+                        Value::BulkString("name".to_string().into_bytes().into()),
+                        Value::BulkString("myfunc1".to_string().into_bytes().into()),
+                        Value::BulkString("description".to_string().into_bytes().into()),
                         Value::Nil,
-                        Value::BulkString("flags".to_string().into_bytes()),
+                        Value::BulkString("flags".to_string().into_bytes().into()),
                         Value::Array(vec![
-                            Value::BulkString("read".to_string().into_bytes()),
-                            Value::BulkString("write".to_string().into_bytes()),
+                            Value::BulkString("read".to_string().into_bytes().into()),
+                            Value::BulkString("write".to_string().into_bytes().into()),
                         ]),
                     ]),
                     Value::Array(vec![
-                        Value::BulkString("name".to_string().into_bytes()),
-                        Value::BulkString("myfunc2".to_string().into_bytes()),
-                        Value::BulkString("description".to_string().into_bytes()),
-                        Value::BulkString("blahblah".to_string().into_bytes()),
-                        Value::BulkString("flags".to_string().into_bytes()),
+                        Value::BulkString("name".to_string().into_bytes().into()),
+                        Value::BulkString("myfunc2".to_string().into_bytes().into()),
+                        Value::BulkString("description".to_string().into_bytes().into()),
+                        Value::BulkString("blahblah".to_string().into_bytes().into()),
+                        Value::BulkString("flags".to_string().into_bytes().into()),
                         Value::Array(vec![]),
                     ]),
                 ]),
             ]),
             Value::Array(vec![
-                Value::BulkString("library_name".to_string().into_bytes()),
-                Value::BulkString("mylib2".to_string().into_bytes()),
-                Value::BulkString("engine".to_string().into_bytes()),
-                Value::BulkString("LUA".to_string().into_bytes()),
-                Value::BulkString("functions".to_string().into_bytes()),
+                Value::BulkString("library_name".to_string().into_bytes().into()),
+                Value::BulkString("mylib2".to_string().into_bytes().into()),
+                Value::BulkString("engine".to_string().into_bytes().into()),
+                Value::BulkString("LUA".to_string().into_bytes().into()),
+                Value::BulkString("functions".to_string().into_bytes().into()),
                 Value::Array(vec![]),
-                Value::BulkString("library_code".to_string().into_bytes()),
-                Value::BulkString("<code>".to_string().into_bytes()),
+                Value::BulkString("library_code".to_string().into_bytes().into()),
+                Value::BulkString("<code>".to_string().into_bytes().into()),
             ]),
         ]);
 
         let resp3_response = Value::Array(vec![
             Value::Map(vec![
                 (
-                    Value::BulkString("library_name".to_string().into_bytes()),
-                    Value::BulkString("mylib1".to_string().into_bytes()),
+                    Value::BulkString("library_name".to_string().into_bytes().into()),
+                    Value::BulkString("mylib1".to_string().into_bytes().into()),
                 ),
                 (
-                    Value::BulkString("engine".to_string().into_bytes()),
-                    Value::BulkString("LUA".to_string().into_bytes()),
+                    Value::BulkString("engine".to_string().into_bytes().into()),
+                    Value::BulkString("LUA".to_string().into_bytes().into()),
                 ),
                 (
-                    Value::BulkString("functions".to_string().into_bytes()),
+                    Value::BulkString("functions".to_string().into_bytes().into()),
                     Value::Array(vec![
                         Value::Map(vec![
                             (
-                                Value::BulkString("name".to_string().into_bytes()),
-                                Value::BulkString("myfunc1".to_string().into_bytes()),
+                                Value::BulkString("name".to_string().into_bytes().into()),
+                                Value::BulkString("myfunc1".to_string().into_bytes().into()),
                             ),
                             (
-                                Value::BulkString("description".to_string().into_bytes()),
+                                Value::BulkString("description".to_string().into_bytes().into()),
                                 Value::Nil,
                             ),
                             (
-                                Value::BulkString("flags".to_string().into_bytes()),
+                                Value::BulkString("flags".to_string().into_bytes().into()),
                                 Value::Set(vec![
-                                    Value::BulkString("read".to_string().into_bytes()),
-                                    Value::BulkString("write".to_string().into_bytes()),
+                                    Value::BulkString("read".to_string().into_bytes().into()),
+                                    Value::BulkString("write".to_string().into_bytes().into()),
                                 ]),
                             ),
                         ]),
                         Value::Map(vec![
                             (
-                                Value::BulkString("name".to_string().into_bytes()),
-                                Value::BulkString("myfunc2".to_string().into_bytes()),
+                                Value::BulkString("name".to_string().into_bytes().into()),
+                                Value::BulkString("myfunc2".to_string().into_bytes().into()),
                             ),
                             (
-                                Value::BulkString("description".to_string().into_bytes()),
-                                Value::BulkString("blahblah".to_string().into_bytes()),
+                                Value::BulkString("description".to_string().into_bytes().into()),
+                                Value::BulkString("blahblah".to_string().into_bytes().into()),
                             ),
                             (
-                                Value::BulkString("flags".to_string().into_bytes()),
+                                Value::BulkString("flags".to_string().into_bytes().into()),
                                 Value::Set(vec![]),
                             ),
                         ]),
@@ -2133,20 +2133,20 @@ mod tests {
             ]),
             Value::Map(vec![
                 (
-                    Value::BulkString("library_name".to_string().into_bytes()),
-                    Value::BulkString("mylib2".to_string().into_bytes()),
+                    Value::BulkString("library_name".to_string().into_bytes().into()),
+                    Value::BulkString("mylib2".to_string().into_bytes().into()),
                 ),
                 (
-                    Value::BulkString("engine".to_string().into_bytes()),
-                    Value::BulkString("LUA".to_string().into_bytes()),
+                    Value::BulkString("engine".to_string().into_bytes().into()),
+                    Value::BulkString("LUA".to_string().into_bytes().into()),
                 ),
                 (
-                    Value::BulkString("functions".to_string().into_bytes()),
+                    Value::BulkString("functions".to_string().into_bytes().into()),
                     Value::Array(vec![]),
                 ),
                 (
-                    Value::BulkString("library_code".to_string().into_bytes()),
-                    Value::BulkString("<code>".to_string().into_bytes()),
+                    Value::BulkString("library_code".to_string().into_bytes().into()),
+                    Value::BulkString("<code>".to_string().into_bytes().into()),
                 ),
             ]),
         ]);
@@ -2196,11 +2196,11 @@ mod tests {
         let conversion_type = expected_type_for_cmd(cmd.arg("version").arg("42"));
 
         let converted_1 = convert_to_expected_type(
-            Value::BulkString(unconverted_string.clone().into_bytes()),
+            Value::BulkString(unconverted_string.clone().into_bytes().into()),
             conversion_type,
         );
         assert_eq!(
-            Value::BulkString(expected.clone().into_bytes()),
+            Value::BulkString(expected.clone().into_bytes().into()),
             converted_1.unwrap()
         );
 
@@ -2212,7 +2212,7 @@ mod tests {
             conversion_type,
         );
         assert_eq!(
-            Value::BulkString(expected.clone().into_bytes()),
+            Value::BulkString(expected.clone().into_bytes().into()),
             converted_2.unwrap()
         );
 
@@ -2220,11 +2220,11 @@ mod tests {
             Value::Map(vec![
                 (
                     Value::SimpleString("node 1".into()),
-                    Value::BulkString(unconverted_string.clone().into_bytes()),
+                    Value::BulkString(unconverted_string.clone().into_bytes().into()),
                 ),
                 (
                     Value::SimpleString("node 2".into()),
-                    Value::BulkString(unconverted_string.clone().into_bytes()),
+                    Value::BulkString(unconverted_string.clone().into_bytes().into()),
                 ),
             ]),
             conversion_type,
@@ -2233,11 +2233,11 @@ mod tests {
             Value::Map(vec![
                 (
                     Value::SimpleString("node 1".into()),
-                    Value::BulkString(expected.clone().into_bytes())
+                    Value::BulkString(expected.clone().into_bytes().into())
                 ),
                 (
                     Value::SimpleString("node 2".into()),
-                    Value::BulkString(expected.clone().into_bytes())
+                    Value::BulkString(expected.clone().into_bytes().into())
                 ),
             ]),
             converted_3.unwrap()
@@ -2363,49 +2363,49 @@ mod tests {
         ));
 
         let v6_response = Value::Array(vec![
-            Value::BulkString("0-0".to_string().into_bytes()),
+            Value::BulkString("0-0".to_string().into_bytes().into()),
             Value::Array(vec![
                 Value::Array(vec![
-                    Value::BulkString("1-0".to_string().into_bytes()),
+                    Value::BulkString("1-0".to_string().into_bytes().into()),
                     Value::Array(vec![
-                        Value::BulkString("field1".to_string().into_bytes()),
-                        Value::BulkString("value1".to_string().into_bytes()),
-                        Value::BulkString("field2".to_string().into_bytes()),
-                        Value::BulkString("value2".to_string().into_bytes()),
+                        Value::BulkString("field1".to_string().into_bytes().into()),
+                        Value::BulkString("value1".to_string().into_bytes().into()),
+                        Value::BulkString("field2".to_string().into_bytes().into()),
+                        Value::BulkString("value2".to_string().into_bytes().into()),
                     ]),
                 ]),
                 Value::Nil, // Entry IDs that were in the Pending Entry List but no longer in the stream get a nil value.
                 Value::Array(vec![
-                    Value::BulkString("1-1".to_string().into_bytes()),
+                    Value::BulkString("1-1".to_string().into_bytes().into()),
                     Value::Array(vec![
-                        Value::BulkString("field3".to_string().into_bytes()),
-                        Value::BulkString("value3".to_string().into_bytes()),
+                        Value::BulkString("field3".to_string().into_bytes().into()),
+                        Value::BulkString("value3".to_string().into_bytes().into()),
                     ]),
                 ]),
             ]),
         ]);
 
         let expected_v6_response = Value::Array(vec![
-            Value::BulkString("0-0".to_string().into_bytes()),
+            Value::BulkString("0-0".to_string().into_bytes().into()),
             Value::Map(vec![
                 (
-                    Value::BulkString("1-0".to_string().into_bytes()),
+                    Value::BulkString("1-0".to_string().into_bytes().into()),
                     Value::Array(vec![
                         Value::Array(vec![
-                            Value::BulkString("field1".to_string().into_bytes()),
-                            Value::BulkString("value1".to_string().into_bytes()),
+                            Value::BulkString("field1".to_string().into_bytes().into()),
+                            Value::BulkString("value1".to_string().into_bytes().into()),
                         ]),
                         Value::Array(vec![
-                            Value::BulkString("field2".to_string().into_bytes()),
-                            Value::BulkString("value2".to_string().into_bytes()),
+                            Value::BulkString("field2".to_string().into_bytes().into()),
+                            Value::BulkString("value2".to_string().into_bytes().into()),
                         ]),
                     ]),
                 ),
                 (
-                    Value::BulkString("1-1".to_string().into_bytes()),
+                    Value::BulkString("1-1".to_string().into_bytes().into()),
                     Value::Array(vec![Value::Array(vec![
-                        Value::BulkString("field3".to_string().into_bytes()),
-                        Value::BulkString("value3".to_string().into_bytes()),
+                        Value::BulkString("field3".to_string().into_bytes().into()),
+                        Value::BulkString("value3".to_string().into_bytes().into()),
                     ])]),
                 ),
             ]),
@@ -2421,53 +2421,53 @@ mod tests {
         );
 
         let v7_response = Value::Array(vec![
-            Value::BulkString("0-0".to_string().into_bytes()),
+            Value::BulkString("0-0".to_string().into_bytes().into()),
             Value::Array(vec![
                 Value::Array(vec![
-                    Value::BulkString("1-0".to_string().into_bytes()),
+                    Value::BulkString("1-0".to_string().into_bytes().into()),
                     Value::Array(vec![
-                        Value::BulkString("field1".to_string().into_bytes()),
-                        Value::BulkString("value1".to_string().into_bytes()),
-                        Value::BulkString("field2".to_string().into_bytes()),
-                        Value::BulkString("value2".to_string().into_bytes()),
+                        Value::BulkString("field1".to_string().into_bytes().into()),
+                        Value::BulkString("value1".to_string().into_bytes().into()),
+                        Value::BulkString("field2".to_string().into_bytes().into()),
+                        Value::BulkString("value2".to_string().into_bytes().into()),
                     ]),
                 ]),
                 Value::Array(vec![
-                    Value::BulkString("1-1".to_string().into_bytes()),
+                    Value::BulkString("1-1".to_string().into_bytes().into()),
                     Value::Array(vec![
-                        Value::BulkString("field3".to_string().into_bytes()),
-                        Value::BulkString("value3".to_string().into_bytes()),
+                        Value::BulkString("field3".to_string().into_bytes().into()),
+                        Value::BulkString("value3".to_string().into_bytes().into()),
                     ]),
                 ]),
             ]),
-            Value::Array(vec![Value::BulkString("1-2".to_string().into_bytes())]),
+            Value::Array(vec![Value::BulkString("1-2".to_string().into_bytes().into())]),
         ]);
 
         let expected_v7_response = Value::Array(vec![
-            Value::BulkString("0-0".to_string().into_bytes()),
+            Value::BulkString("0-0".to_string().into_bytes().into()),
             Value::Map(vec![
                 (
-                    Value::BulkString("1-0".to_string().into_bytes()),
+                    Value::BulkString("1-0".to_string().into_bytes().into()),
                     Value::Array(vec![
                         Value::Array(vec![
-                            Value::BulkString("field1".to_string().into_bytes()),
-                            Value::BulkString("value1".to_string().into_bytes()),
+                            Value::BulkString("field1".to_string().into_bytes().into()),
+                            Value::BulkString("value1".to_string().into_bytes().into()),
                         ]),
                         Value::Array(vec![
-                            Value::BulkString("field2".to_string().into_bytes()),
-                            Value::BulkString("value2".to_string().into_bytes()),
+                            Value::BulkString("field2".to_string().into_bytes().into()),
+                            Value::BulkString("value2".to_string().into_bytes().into()),
                         ]),
                     ]),
                 ),
                 (
-                    Value::BulkString("1-1".to_string().into_bytes()),
+                    Value::BulkString("1-1".to_string().into_bytes().into()),
                     Value::Array(vec![Value::Array(vec![
-                        Value::BulkString("field3".to_string().into_bytes()),
-                        Value::BulkString("value3".to_string().into_bytes()),
+                        Value::BulkString("field3".to_string().into_bytes().into()),
+                        Value::BulkString("value3".to_string().into_bytes().into()),
                     ])]),
                 ),
             ]),
-            Value::Array(vec![Value::BulkString("1-2".to_string().into_bytes())]),
+            Value::Array(vec![Value::BulkString("1-2".to_string().into_bytes().into())]),
         ]);
 
         assert_eq!(
@@ -2496,11 +2496,11 @@ mod tests {
     fn test_convert_array_to_map_with_none() {
         let unconverted_map = vec![
             (
-                Value::BulkString(b"key1".to_vec()),
-                Value::BulkString(b"10.5".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
+                Value::BulkString(b"10.5".to_vec().into()),
             ),
             (Value::Double(20.5), Value::Double(19.5)),
-            (Value::Double(18.5), Value::BulkString(b"30.2".to_vec())),
+            (Value::Double(18.5), Value::BulkString(b"30.2".to_vec().into())),
         ];
 
         let converted_type = ExpectedReturnType::Map {
@@ -2519,8 +2519,8 @@ mod tests {
         assert_eq!(converted_map.len(), 3);
 
         let (key, value) = &converted_map[0];
-        assert_eq!(*key, Value::BulkString(b"key1".to_vec()));
-        assert_eq!(*value, Value::BulkString(b"10.5".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key1".to_vec().into()));
+        assert_eq!(*value, Value::BulkString(b"10.5".to_vec().into()));
 
         let (key, value) = &converted_map[1];
         assert_eq!(*key, Value::Double(20.5));
@@ -2528,7 +2528,7 @@ mod tests {
 
         let (key, value) = &converted_map[2];
         assert_eq!(*key, Value::Double(18.5));
-        assert_eq!(*value, Value::BulkString(b"30.2".to_vec()));
+        assert_eq!(*value, Value::BulkString(b"30.2".to_vec().into()));
     }
 
     #[test]
@@ -2545,32 +2545,32 @@ mod tests {
         //
         let array_of_arrays = vec![
             Value::Array(vec![
-                Value::BulkString(b"key1".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
                 Value::Array(vec![Value::Array(vec![
-                    Value::BulkString(b"streamid-1".to_vec()),
+                    Value::BulkString(b"streamid-1".to_vec().into()),
                     Value::Array(vec![
-                        Value::BulkString(b"field1".to_vec()),
-                        Value::BulkString(b"value1".to_vec()),
+                        Value::BulkString(b"field1".to_vec().into()),
+                        Value::BulkString(b"value1".to_vec().into()),
                     ]),
                 ])]),
             ]),
             Value::Array(vec![
-                Value::BulkString(b"key2".to_vec()),
+                Value::BulkString(b"key2".to_vec().into()),
                 Value::Array(vec![
                     Value::Array(vec![
-                        Value::BulkString(b"streamid-2".to_vec()),
+                        Value::BulkString(b"streamid-2".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"field21".to_vec()),
-                            Value::BulkString(b"value21".to_vec()),
-                            Value::BulkString(b"field22".to_vec()),
-                            Value::BulkString(b"value22".to_vec()),
+                            Value::BulkString(b"field21".to_vec().into()),
+                            Value::BulkString(b"value21".to_vec().into()),
+                            Value::BulkString(b"field22".to_vec().into()),
+                            Value::BulkString(b"value22".to_vec().into()),
                         ]),
                     ]),
                     Value::Array(vec![
-                        Value::BulkString(b"streamid-3".to_vec()),
+                        Value::BulkString(b"streamid-3".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"field3".to_vec()),
-                            Value::BulkString(b"value3".to_vec()),
+                            Value::BulkString(b"field3".to_vec().into()),
+                            Value::BulkString(b"value3".to_vec().into()),
                         ]),
                     ]),
                 ]),
@@ -2602,40 +2602,40 @@ mod tests {
         assert_eq!(converted_map.len(), 2);
 
         let (key, value) = &converted_map[0];
-        assert_eq!(Value::BulkString(b"key1".to_vec()), *key);
+        assert_eq!(Value::BulkString(b"key1".to_vec().into()), *key);
         assert_eq!(
             Value::Map(vec![(
-                Value::BulkString(b"streamid-1".to_vec()),
+                Value::BulkString(b"streamid-1".to_vec().into()),
                 Value::Array(vec![Value::Array(vec![
-                    Value::BulkString(b"field1".to_vec()),
-                    Value::BulkString(b"value1".to_vec()),
+                    Value::BulkString(b"field1".to_vec().into()),
+                    Value::BulkString(b"value1".to_vec().into()),
                 ]),]),
             ),]),
             *value,
         );
 
         let (key, value) = &converted_map[1];
-        assert_eq!(*key, Value::BulkString(b"key2".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key2".to_vec().into()));
         assert_eq!(
             Value::Map(vec![
                 (
-                    Value::BulkString(b"streamid-2".to_vec()),
+                    Value::BulkString(b"streamid-2".to_vec().into()),
                     Value::Array(vec![
                         Value::Array(vec![
-                            Value::BulkString(b"field21".to_vec()),
-                            Value::BulkString(b"value21".to_vec()),
+                            Value::BulkString(b"field21".to_vec().into()),
+                            Value::BulkString(b"value21".to_vec().into()),
                         ]),
                         Value::Array(vec![
-                            Value::BulkString(b"field22".to_vec()),
-                            Value::BulkString(b"value22".to_vec()),
+                            Value::BulkString(b"field22".to_vec().into()),
+                            Value::BulkString(b"value22".to_vec().into()),
                         ]),
                     ]),
                 ),
                 (
-                    Value::BulkString(b"streamid-3".to_vec()),
+                    Value::BulkString(b"streamid-3".to_vec().into()),
                     Value::Array(vec![Value::Array(vec![
-                        Value::BulkString(b"field3".to_vec()),
-                        Value::BulkString(b"value3".to_vec()),
+                        Value::BulkString(b"field3".to_vec().into()),
+                        Value::BulkString(b"value3".to_vec().into()),
                     ]),]),
                 ),
             ]),
@@ -2659,10 +2659,10 @@ mod tests {
             (
                 Value::BulkString("key1".into()),
                 Value::Array(vec![Value::Array(vec![
-                    Value::BulkString(b"streamid-1".to_vec()),
+                    Value::BulkString(b"streamid-1".to_vec().into()),
                     Value::Array(vec![
-                        Value::BulkString(b"field1".to_vec()),
-                        Value::BulkString(b"value1".to_vec()),
+                        Value::BulkString(b"field1".to_vec().into()),
+                        Value::BulkString(b"value1".to_vec().into()),
                     ]),
                 ])]),
             ),
@@ -2670,19 +2670,19 @@ mod tests {
                 Value::BulkString("key2".into()),
                 Value::Array(vec![
                     Value::Array(vec![
-                        Value::BulkString(b"streamid-2".to_vec()),
+                        Value::BulkString(b"streamid-2".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"field21".to_vec()),
-                            Value::BulkString(b"value21".to_vec()),
-                            Value::BulkString(b"field22".to_vec()),
-                            Value::BulkString(b"value22".to_vec()),
+                            Value::BulkString(b"field21".to_vec().into()),
+                            Value::BulkString(b"value21".to_vec().into()),
+                            Value::BulkString(b"field22".to_vec().into()),
+                            Value::BulkString(b"value22".to_vec().into()),
                         ]),
                     ]),
                     Value::Array(vec![
-                        Value::BulkString(b"streamid-3".to_vec()),
+                        Value::BulkString(b"streamid-3".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"field3".to_vec()),
-                            Value::BulkString(b"value3".to_vec()),
+                            Value::BulkString(b"field3".to_vec().into()),
+                            Value::BulkString(b"value3".to_vec().into()),
                         ]),
                     ]),
                 ]),
@@ -2714,40 +2714,40 @@ mod tests {
         assert_eq!(converted_map.len(), 2);
 
         let (key, value) = &converted_map[0];
-        assert_eq!(Value::BulkString(b"key1".to_vec()), *key);
+        assert_eq!(Value::BulkString(b"key1".to_vec().into()), *key);
         assert_eq!(
             Value::Map(vec![(
-                Value::BulkString(b"streamid-1".to_vec()),
+                Value::BulkString(b"streamid-1".to_vec().into()),
                 Value::Array(vec![Value::Array(vec![
-                    Value::BulkString(b"field1".to_vec()),
-                    Value::BulkString(b"value1".to_vec()),
+                    Value::BulkString(b"field1".to_vec().into()),
+                    Value::BulkString(b"value1".to_vec().into()),
                 ]),]),
             ),]),
             *value,
         );
 
         let (key, value) = &converted_map[1];
-        assert_eq!(*key, Value::BulkString(b"key2".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key2".to_vec().into()));
         assert_eq!(
             Value::Map(vec![
                 (
-                    Value::BulkString(b"streamid-2".to_vec()),
+                    Value::BulkString(b"streamid-2".to_vec().into()),
                     Value::Array(vec![
                         Value::Array(vec![
-                            Value::BulkString(b"field21".to_vec()),
-                            Value::BulkString(b"value21".to_vec()),
+                            Value::BulkString(b"field21".to_vec().into()),
+                            Value::BulkString(b"value21".to_vec().into()),
                         ]),
                         Value::Array(vec![
-                            Value::BulkString(b"field22".to_vec()),
-                            Value::BulkString(b"value22".to_vec()),
+                            Value::BulkString(b"field22".to_vec().into()),
+                            Value::BulkString(b"value22".to_vec().into()),
                         ]),
                     ]),
                 ),
                 (
-                    Value::BulkString(b"streamid-3".to_vec()),
+                    Value::BulkString(b"streamid-3".to_vec().into()),
                     Value::Array(vec![Value::Array(vec![
-                        Value::BulkString(b"field3".to_vec()),
-                        Value::BulkString(b"value3".to_vec()),
+                        Value::BulkString(b"field3".to_vec().into()),
+                        Value::BulkString(b"value3".to_vec().into()),
                     ]),]),
                 ),
             ]),
@@ -2758,32 +2758,32 @@ mod tests {
     #[test]
     fn convert_function_stats() {
         let resp2_response_non_empty_first_part_data = vec![
-            Value::BulkString(b"running_script".into()),
+            Value::BulkString(bytes::Bytes::from_static(b"running_script")),
             Value::Array(vec![
-                Value::BulkString(b"name".into()),
-                Value::BulkString(b"<function name>".into()),
-                Value::BulkString(b"command".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"name")),
+                Value::BulkString(bytes::Bytes::from_static(b"<function name>")),
+                Value::BulkString(bytes::Bytes::from_static(b"command")),
                 Value::Array(vec![
-                    Value::BulkString(b"fcall".into()),
-                    Value::BulkString(b"<function name>".into()),
-                    Value::BulkString(b"... rest `fcall` args ...".into()),
+                    Value::BulkString(bytes::Bytes::from_static(b"fcall")),
+                    Value::BulkString(bytes::Bytes::from_static(b"<function name>")),
+                    Value::BulkString(bytes::Bytes::from_static(b"... rest `fcall` args ...")),
                 ]),
-                Value::BulkString(b"duration_ms".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"duration_ms")),
                 Value::Int(24529),
             ]),
         ];
 
         let resp2_response_empty_first_part_data =
-            vec![Value::BulkString(b"running_script".into()), Value::Nil];
+            vec![Value::BulkString(bytes::Bytes::from_static(b"running_script")), Value::Nil];
 
         let resp2_response_second_part_data = vec![
-            Value::BulkString(b"engines".into()),
+            Value::BulkString(bytes::Bytes::from_static(b"engines")),
             Value::Array(vec![
-                Value::BulkString(b"LUA".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"LUA")),
                 Value::Array(vec![
-                    Value::BulkString(b"libraries_count".into()),
+                    Value::BulkString(bytes::Bytes::from_static(b"libraries_count")),
                     Value::Int(3),
-                    Value::BulkString(b"functions_count".into()),
+                    Value::BulkString(bytes::Bytes::from_static(b"functions_count")),
                     Value::Int(5),
                 ]),
             ]),
@@ -2806,48 +2806,48 @@ mod tests {
 
         let resp2_cluster_response = Value::Map(vec![
             (
-                Value::BulkString(b"node1".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"node1")),
                 resp2_response_with_non_empty_first_part.clone(),
             ),
             (
-                Value::BulkString(b"node2".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"node2")),
                 resp2_response_with_empty_first_part.clone(),
             ),
             (
-                Value::BulkString(b"node3".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"node3")),
                 resp2_response_with_empty_first_part.clone(),
             ),
         ]);
 
         let resp3_response_non_empty_first_part_data = vec![(
-            Value::BulkString(b"running_script".into()),
+            Value::BulkString(bytes::Bytes::from_static(b"running_script")),
             Value::Map(vec![
                 (
-                    Value::BulkString(b"name".into()),
-                    Value::BulkString(b"<function name>".into()),
+                    Value::BulkString(bytes::Bytes::from_static(b"name")),
+                    Value::BulkString(bytes::Bytes::from_static(b"<function name>")),
                 ),
                 (
-                    Value::BulkString(b"command".into()),
+                    Value::BulkString(bytes::Bytes::from_static(b"command")),
                     Value::Array(vec![
-                        Value::BulkString(b"fcall".into()),
-                        Value::BulkString(b"<function name>".into()),
-                        Value::BulkString(b"... rest `fcall` args ...".into()),
+                        Value::BulkString(bytes::Bytes::from_static(b"fcall")),
+                        Value::BulkString(bytes::Bytes::from_static(b"<function name>")),
+                        Value::BulkString(bytes::Bytes::from_static(b"... rest `fcall` args ...")),
                     ]),
                 ),
-                (Value::BulkString(b"duration_ms".into()), Value::Int(24529)),
+                (Value::BulkString(bytes::Bytes::from_static(b"duration_ms")), Value::Int(24529)),
             ]),
         )];
 
         let resp3_response_empty_first_part_data =
-            vec![(Value::BulkString(b"running_script".into()), Value::Nil)];
+            vec![(Value::BulkString(bytes::Bytes::from_static(b"running_script")), Value::Nil)];
 
         let resp3_response_second_part_data = vec![(
-            Value::BulkString(b"engines".into()),
+            Value::BulkString(bytes::Bytes::from_static(b"engines")),
             Value::Map(vec![(
-                Value::BulkString(b"LUA".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"LUA")),
                 Value::Map(vec![
-                    (Value::BulkString(b"libraries_count".into()), Value::Int(3)),
-                    (Value::BulkString(b"functions_count".into()), Value::Int(5)),
+                    (Value::BulkString(bytes::Bytes::from_static(b"libraries_count")), Value::Int(3)),
+                    (Value::BulkString(bytes::Bytes::from_static(b"functions_count")), Value::Int(5)),
                 ]),
             )]),
         )];
@@ -2870,15 +2870,15 @@ mod tests {
 
         let resp3_cluster_response = Value::Map(vec![
             (
-                Value::BulkString(b"node1".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"node1")),
                 resp3_response_with_non_empty_first_part.clone(),
             ),
             (
-                Value::BulkString(b"node2".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"node2")),
                 resp3_response_with_empty_first_part.clone(),
             ),
             (
-                Value::BulkString(b"node3".into()),
+                Value::BulkString(bytes::Bytes::from_static(b"node3")),
                 resp3_response_with_empty_first_part.clone(),
             ),
         ]);
@@ -2959,19 +2959,19 @@ mod tests {
         assert!(expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key")).is_none());
 
         let flat_array = Value::Array(vec![
-            Value::BulkString(b"key1".to_vec()),
-            Value::BulkString(b"value1".to_vec()),
-            Value::BulkString(b"key2".to_vec()),
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"key1".to_vec().into()),
+            Value::BulkString(b"value1".to_vec().into()),
+            Value::BulkString(b"key2".to_vec().into()),
+            Value::BulkString(b"value2".to_vec().into()),
         ]);
         let two_dimensional_array = Value::Array(vec![
             Value::Array(vec![
-                Value::BulkString(b"key1".to_vec()),
-                Value::BulkString(b"value1".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
+                Value::BulkString(b"value1".to_vec().into()),
             ]),
             Value::Array(vec![
-                Value::BulkString(b"key2".to_vec()),
-                Value::BulkString(b"value2".to_vec()),
+                Value::BulkString(b"key2".to_vec().into()),
+                Value::BulkString(b"value2".to_vec().into()),
             ]),
         ]);
         let converted_flat_array =
@@ -2992,7 +2992,7 @@ mod tests {
         assert_eq!(empty_array, converted_empty_array);
 
         let flat_array_unexpected_length =
-            Value::Array(vec![Value::BulkString(b"somekey".to_vec())]);
+            Value::Array(vec![Value::BulkString(b"somekey".to_vec().into())]);
         assert!(
             convert_to_expected_type(
                 flat_array_unexpected_length,
@@ -3057,14 +3057,14 @@ mod tests {
         // and ArrayOfMemberScorePairs is mostly the same. Here we also test that the scores are converted to double
         // when the server response was a RESP2 flat array.
         let flat_array = Value::Array(vec![
-            Value::BulkString(b"one".to_vec()),
-            Value::BulkString(b"1.0".to_vec()),
-            Value::BulkString(b"two".to_vec()),
-            Value::BulkString(b"2.0".to_vec()),
+            Value::BulkString(b"one".to_vec().into()),
+            Value::BulkString(b"1.0".to_vec().into()),
+            Value::BulkString(b"two".to_vec().into()),
+            Value::BulkString(b"2.0".to_vec().into()),
         ]);
         let expected_response = Value::Array(vec![
-            Value::Array(vec![Value::BulkString(b"one".to_vec()), Value::Double(1.0)]),
-            Value::Array(vec![Value::BulkString(b"two".to_vec()), Value::Double(2.0)]),
+            Value::Array(vec![Value::BulkString(b"one".to_vec().into()), Value::Double(1.0)]),
+            Value::Array(vec![Value::BulkString(b"two".to_vec().into()), Value::Double(2.0)]),
         ]);
         let converted_flat_array = convert_to_expected_type(
             flat_array,
@@ -3083,12 +3083,12 @@ mod tests {
 
         // testing value conversion
         let flat_array = Value::Array(vec![
-            Value::BulkString(b"1".to_vec()),
-            Value::Array(vec![Value::BulkString(b"one".to_vec())]),
+            Value::BulkString(b"1".to_vec().into()),
+            Value::Array(vec![Value::BulkString(b"one".to_vec().into())]),
         ]);
         let expected_response = Value::Map(vec![(
             Value::BulkString("1".into()),
-            Value::Array(vec![Value::BulkString(b"one".to_vec())]),
+            Value::Array(vec![Value::BulkString(b"one".to_vec().into())]),
         )]);
         let converted_flat_array =
             convert_to_expected_type(flat_array, Some(ExpectedReturnType::ArrayOfStringAndArrays))
@@ -3274,8 +3274,8 @@ mod tests {
         ));
 
         let array_with_double_score = Value::Array(vec![
-            Value::BulkString(b"key1".to_vec()),
-            Value::BulkString(b"member1".to_vec()),
+            Value::BulkString(b"key1".to_vec().into()),
+            Value::BulkString(b"member1".to_vec().into()),
             Value::Double(2.0),
         ]);
         let result = convert_to_expected_type(
@@ -3286,9 +3286,9 @@ mod tests {
         assert_eq!(array_with_double_score, result);
 
         let array_with_string_score = Value::Array(vec![
-            Value::BulkString(b"key1".to_vec()),
-            Value::BulkString(b"member1".to_vec()),
-            Value::BulkString(b"2.0".to_vec()),
+            Value::BulkString(b"key1".to_vec().into()),
+            Value::BulkString(b"member1".to_vec().into()),
+            Value::BulkString(b"2.0".to_vec().into()),
         ]);
         let result = convert_to_expected_type(
             array_with_string_score.clone(),
@@ -3303,8 +3303,8 @@ mod tests {
         assert_eq!(Value::Nil, converted_nil_value);
 
         let array_with_unexpected_length = Value::Array(vec![
-            Value::BulkString(b"key1".to_vec()),
-            Value::BulkString(b"member1".to_vec()),
+            Value::BulkString(b"key1".to_vec().into()),
+            Value::BulkString(b"member1".to_vec().into()),
             Value::Double(2.0),
             Value::Double(2.0),
         ]);
@@ -3354,7 +3354,7 @@ mod tests {
         let array_response = Value::Array(vec![
             Value::Nil,
             Value::Double(1.5),
-            Value::BulkString(b"2.5".to_vec()),
+            Value::BulkString(b"2.5".to_vec().into()),
         ]);
         let converted_response = convert_to_expected_type(
             array_response,
@@ -3399,14 +3399,14 @@ mod tests {
         );
         let unconverted_map = vec![
             (
-                Value::BulkString(b"key1".to_vec()),
-                Value::BulkString(b"10.5".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
+                Value::BulkString(b"10.5".to_vec().into()),
             ),
             (
-                Value::BulkString(b"key2".to_vec()),
-                Value::BulkString(b"20.8".to_vec()),
+                Value::BulkString(b"key2".to_vec().into()),
+                Value::BulkString(b"20.8".to_vec().into()),
             ),
-            (Value::Double(20.5), Value::BulkString(b"30.2".to_vec())),
+            (Value::Double(20.5), Value::BulkString(b"30.2".to_vec().into())),
         ];
 
         let converted_map = convert_to_expected_type(
@@ -3424,24 +3424,24 @@ mod tests {
         assert_eq!(converted_map.len(), 3);
 
         let (key, value) = &converted_map[0];
-        assert_eq!(*key, Value::BulkString(b"key1".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key1".to_vec().into()));
         assert_eq!(*value, Value::Double(10.5));
 
         let (key, value) = &converted_map[1];
-        assert_eq!(*key, Value::BulkString(b"key2".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key2".to_vec().into()));
         assert_eq!(*value, Value::Double(20.8));
 
         let (key, value) = &converted_map[2];
-        assert_eq!(*key, Value::BulkString(b"20.5".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"20.5".to_vec().into()));
         assert_eq!(*value, Value::Double(30.2));
 
         let array_of_arrays = vec![
             Value::Array(vec![
-                Value::BulkString(b"key1".to_vec()),
-                Value::BulkString(b"10.5".to_vec()),
+                Value::BulkString(b"key1".to_vec().into()),
+                Value::BulkString(b"10.5".to_vec().into()),
             ]),
             Value::Array(vec![
-                Value::BulkString(b"key2".to_vec()),
+                Value::BulkString(b"key2".to_vec().into()),
                 Value::Double(20.5),
             ]),
         ];
@@ -3461,17 +3461,17 @@ mod tests {
         assert_eq!(converted_map.len(), 2);
 
         let (key, value) = &converted_map[0];
-        assert_eq!(*key, Value::BulkString(b"key1".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key1".to_vec().into()));
         assert_eq!(*value, Value::Double(10.5));
 
         let (key, value) = &converted_map[1];
-        assert_eq!(*key, Value::BulkString(b"key2".to_vec()));
+        assert_eq!(*key, Value::BulkString(b"key2".to_vec().into()));
         assert_eq!(*value, Value::Double(20.5));
 
         let array_of_arrays_err: Vec<Value> = vec![Value::Array(vec![
-            Value::BulkString(b"key".to_vec()),
-            Value::BulkString(b"value".to_vec()),
-            Value::BulkString(b"10.5".to_vec()),
+            Value::BulkString(b"key".to_vec().into()),
+            Value::BulkString(b"value".to_vec().into()),
+            Value::BulkString(b"10.5".to_vec().into()),
         ])];
 
         assert!(
@@ -3491,8 +3491,8 @@ mod tests {
         );
 
         let array = vec![
-            Value::BulkString(b"key".to_vec()),
-            Value::BulkString(b"20.5".to_vec()),
+            Value::BulkString(b"key".to_vec().into()),
+            Value::BulkString(b"20.5".to_vec().into()),
         ];
 
         let array_result = convert_to_expected_type(
@@ -3508,10 +3508,10 @@ mod tests {
         };
         assert_eq!(array_result.len(), 2);
 
-        assert_eq!(array_result[0], Value::BulkString(b"key".to_vec()));
+        assert_eq!(array_result[0], Value::BulkString(b"key".to_vec().into()));
         assert_eq!(array_result[1], Value::Double(20.5));
 
-        let array_err = vec![Value::BulkString(b"key".to_vec())];
+        let array_err = vec![Value::BulkString(b"key".to_vec().into())];
         assert!(
             convert_to_expected_type(
                 Value::Array(array_err),
@@ -3568,21 +3568,21 @@ mod tests {
     fn test_convert_to_geo_search_return_type() {
         let array = Value::Array(vec![
             Value::Array(vec![
-                Value::BulkString(b"name1".to_vec()),
-                Value::BulkString(b"1.23".to_vec()), // dist (float)
+                Value::BulkString(b"name1".to_vec().into()),
+                Value::BulkString(b"1.23".to_vec().into()), // dist (float)
                 Value::Int(123456),                  // hash (int)
                 Value::Array(vec![
-                    Value::BulkString(b"10.0".to_vec()), // lon (float)
-                    Value::BulkString(b"20.0".to_vec()), // lat (float)
+                    Value::BulkString(b"10.0".to_vec().into()), // lon (float)
+                    Value::BulkString(b"20.0".to_vec().into()), // lat (float)
                 ]),
             ]),
             Value::Array(vec![
-                Value::BulkString(b"name2".to_vec()),
-                Value::BulkString(b"2.34".to_vec()), // dist (float)
+                Value::BulkString(b"name2".to_vec().into()),
+                Value::BulkString(b"2.34".to_vec().into()), // dist (float)
                 Value::Int(654321),                  // hash (int)
                 Value::Array(vec![
-                    Value::BulkString(b"30.0".to_vec()), // lon (float)
-                    Value::BulkString(b"40.0".to_vec()), // lat (float)
+                    Value::BulkString(b"30.0".to_vec().into()), // lon (float)
+                    Value::BulkString(b"40.0".to_vec().into()), // lat (float)
                 ]),
             ]),
         ]);
@@ -3590,7 +3590,7 @@ mod tests {
         // Expected output value after conversion
         let expected_result = Value::Array(vec![
             Value::Array(vec![
-                Value::BulkString(b"name1".to_vec()),
+                Value::BulkString(b"name1".to_vec().into()),
                 Value::Array(vec![
                     Value::Double(1.23), // dist (float)
                     Value::Int(123456),  // hash (int)
@@ -3601,7 +3601,7 @@ mod tests {
                 ]),
             ]),
             Value::Array(vec![
-                Value::BulkString(b"name2".to_vec()),
+                Value::BulkString(b"name2".to_vec().into()),
                 Value::Array(vec![
                     Value::Double(2.34), // dist (float)
                     Value::Int(654321),  // hash (int)
@@ -3709,17 +3709,17 @@ mod tests {
         //   7) ["field2", "value2"]
         let response = Value::Array(vec![
             Value::Int(2),
-            Value::BulkString(b"key1".to_vec()),
-            Value::BulkString(b"sortval1".to_vec()),
+            Value::BulkString(b"key1".to_vec().into()),
+            Value::BulkString(b"sortval1".to_vec().into()),
             Value::Array(vec![
-                Value::BulkString(b"field1".to_vec()),
-                Value::BulkString(b"value1".to_vec()),
+                Value::BulkString(b"field1".to_vec().into()),
+                Value::BulkString(b"value1".to_vec().into()),
             ]),
-            Value::BulkString(b"key2".to_vec()),
-            Value::BulkString(b"sortval2".to_vec()),
+            Value::BulkString(b"key2".to_vec().into()),
+            Value::BulkString(b"sortval2".to_vec().into()),
             Value::Array(vec![
-                Value::BulkString(b"field2".to_vec()),
-                Value::BulkString(b"value2".to_vec()),
+                Value::BulkString(b"field2".to_vec().into()),
+                Value::BulkString(b"value2".to_vec().into()),
             ]),
         ]);
 
@@ -3735,22 +3735,22 @@ mod tests {
                 Value::Int(2),
                 Value::Map(vec![
                     (
-                        Value::BulkString(b"key1".to_vec()),
+                        Value::BulkString(b"key1".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"sortval1".to_vec()),
+                            Value::BulkString(b"sortval1".to_vec().into()),
                             Value::Map(vec![(
-                                Value::BulkString(b"field1".to_vec()),
-                                Value::BulkString(b"value1".to_vec()),
+                                Value::BulkString(b"field1".to_vec().into()),
+                                Value::BulkString(b"value1".to_vec().into()),
                             )]),
                         ]),
                     ),
                     (
-                        Value::BulkString(b"key2".to_vec()),
+                        Value::BulkString(b"key2".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"sortval2".to_vec()),
+                            Value::BulkString(b"sortval2".to_vec().into()),
                             Value::Map(vec![(
-                                Value::BulkString(b"field2".to_vec()),
-                                Value::BulkString(b"value2".to_vec()),
+                                Value::BulkString(b"field2".to_vec().into()),
+                                Value::BulkString(b"value2".to_vec().into()),
                             )]),
                         ]),
                     ),
@@ -3766,9 +3766,9 @@ mod tests {
         //   5) (nil)
         let nocontent_response = Value::Array(vec![
             Value::Int(2),
-            Value::BulkString(b"key1".to_vec()),
-            Value::BulkString(b"sortval1".to_vec()),
-            Value::BulkString(b"key2".to_vec()),
+            Value::BulkString(b"key1".to_vec().into()),
+            Value::BulkString(b"sortval1".to_vec().into()),
+            Value::BulkString(b"key2".to_vec().into()),
             Value::Nil,
         ]);
 
@@ -3784,14 +3784,14 @@ mod tests {
                 Value::Int(2),
                 Value::Map(vec![
                     (
-                        Value::BulkString(b"key1".to_vec()),
+                        Value::BulkString(b"key1".to_vec().into()),
                         Value::Array(vec![
-                            Value::BulkString(b"sortval1".to_vec()),
+                            Value::BulkString(b"sortval1".to_vec().into()),
                             Value::Map(vec![]),
                         ]),
                     ),
                     (
-                        Value::BulkString(b"key2".to_vec()),
+                        Value::BulkString(b"key2".to_vec().into()),
                         Value::Array(vec![Value::Nil, Value::Map(vec![])]),
                     ),
                 ]),
@@ -3827,11 +3827,11 @@ mod tests {
     /// CLIENT TRACKINGINFO response in RESP2 format (flat array, flags as Array).
     fn tracking_info_resp2() -> Value {
         Value::Array(vec![
-            Value::BulkString(b"flags".to_vec()),
-            Value::Array(vec![Value::BulkString(b"off".to_vec())]),
-            Value::BulkString(b"redirect".to_vec()),
+            Value::BulkString(b"flags".to_vec().into()),
+            Value::Array(vec![Value::BulkString(b"off".to_vec().into())]),
+            Value::BulkString(b"redirect".to_vec().into()),
             Value::Int(-1),
-            Value::BulkString(b"prefixes".to_vec()),
+            Value::BulkString(b"prefixes".to_vec().into()),
             Value::Array(vec![]),
         ])
     }
@@ -3840,12 +3840,12 @@ mod tests {
     fn tracking_info_resp3() -> Value {
         Value::Map(vec![
             (
-                Value::BulkString(b"flags".to_vec()),
-                Value::Set(vec![Value::BulkString(b"off".to_vec())]),
+                Value::BulkString(b"flags".to_vec().into()),
+                Value::Set(vec![Value::BulkString(b"off".to_vec().into())]),
             ),
-            (Value::BulkString(b"redirect".to_vec()), Value::Int(-1)),
+            (Value::BulkString(b"redirect".to_vec().into()), Value::Int(-1)),
             (
-                Value::BulkString(b"prefixes".to_vec()),
+                Value::BulkString(b"prefixes".to_vec().into()),
                 Value::Array(vec![]),
             ),
         ])
@@ -3878,22 +3878,22 @@ mod tests {
 
         let multi_node_input = Value::Map(vec![
             (
-                Value::BulkString(b"node1:6379".to_vec()),
+                Value::BulkString(b"node1:6379".to_vec().into()),
                 tracking_info_resp2(),
             ),
             (
-                Value::BulkString(b"node2:6370".to_vec()),
+                Value::BulkString(b"node2:6370".to_vec().into()),
                 tracking_info_resp2(),
             ),
         ]);
 
         let expected = Value::Map(vec![
             (
-                Value::BulkString(b"node1:6379".to_vec()),
+                Value::BulkString(b"node1:6379".to_vec().into()),
                 tracking_info_resp3(),
             ),
             (
-                Value::BulkString(b"node2:6370".to_vec()),
+                Value::BulkString(b"node2:6370".to_vec().into()),
                 tracking_info_resp3(),
             ),
         ]);
@@ -3909,22 +3909,22 @@ mod tests {
 
         let multi_node_input = Value::Map(vec![
             (
-                Value::BulkString(b"node1:6379".to_vec()),
+                Value::BulkString(b"node1:6379".to_vec().into()),
                 tracking_info_resp3(),
             ),
             (
-                Value::BulkString(b"node2:6370".to_vec()),
+                Value::BulkString(b"node2:6370".to_vec().into()),
                 tracking_info_resp3(),
             ),
         ]);
 
         let expected = Value::Map(vec![
             (
-                Value::BulkString(b"node1:6379".to_vec()),
+                Value::BulkString(b"node1:6379".to_vec().into()),
                 tracking_info_resp3(),
             ),
             (
-                Value::BulkString(b"node2:6370".to_vec()),
+                Value::BulkString(b"node2:6370".to_vec().into()),
                 tracking_info_resp3(),
             ),
         ]);

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1879,12 +1879,18 @@ mod tests {
                                 Value::Map(vec![
                                     (
                                         Value::BulkString("name".to_string().into_bytes().into()),
-                                        Value::BulkString("consumer1".to_string().into_bytes().into()),
+                                        Value::BulkString(
+                                            "consumer1".to_string().into_bytes().into(),
+                                        ),
                                     ),
                                     (
-                                        Value::BulkString("pending".to_string().into_bytes().into()),
+                                        Value::BulkString(
+                                            "pending".to_string().into_bytes().into(),
+                                        ),
                                         Value::Array(vec![Value::Array(vec![
-                                            Value::BulkString("1-0".to_string().into_bytes().into()),
+                                            Value::BulkString(
+                                                "1-0".to_string().into_bytes().into(),
+                                            ),
                                             Value::Int(1),
                                         ])]),
                                     ),
@@ -2440,7 +2446,9 @@ mod tests {
                     ]),
                 ]),
             ]),
-            Value::Array(vec![Value::BulkString("1-2".to_string().into_bytes().into())]),
+            Value::Array(vec![Value::BulkString(
+                "1-2".to_string().into_bytes().into(),
+            )]),
         ]);
 
         let expected_v7_response = Value::Array(vec![
@@ -2467,7 +2475,9 @@ mod tests {
                     ])]),
                 ),
             ]),
-            Value::Array(vec![Value::BulkString("1-2".to_string().into_bytes().into())]),
+            Value::Array(vec![Value::BulkString(
+                "1-2".to_string().into_bytes().into(),
+            )]),
         ]);
 
         assert_eq!(
@@ -2500,7 +2510,10 @@ mod tests {
                 Value::BulkString(b"10.5".to_vec().into()),
             ),
             (Value::Double(20.5), Value::Double(19.5)),
-            (Value::Double(18.5), Value::BulkString(b"30.2".to_vec().into())),
+            (
+                Value::Double(18.5),
+                Value::BulkString(b"30.2".to_vec().into()),
+            ),
         ];
 
         let converted_type = ExpectedReturnType::Map {
@@ -2773,8 +2786,10 @@ mod tests {
             ]),
         ];
 
-        let resp2_response_empty_first_part_data =
-            vec![Value::BulkString(bytes::Bytes::from_static(b"running_script")), Value::Nil];
+        let resp2_response_empty_first_part_data = vec![
+            Value::BulkString(bytes::Bytes::from_static(b"running_script")),
+            Value::Nil,
+        ];
 
         let resp2_response_second_part_data = vec![
             Value::BulkString(bytes::Bytes::from_static(b"engines")),
@@ -2834,20 +2849,31 @@ mod tests {
                         Value::BulkString(bytes::Bytes::from_static(b"... rest `fcall` args ...")),
                     ]),
                 ),
-                (Value::BulkString(bytes::Bytes::from_static(b"duration_ms")), Value::Int(24529)),
+                (
+                    Value::BulkString(bytes::Bytes::from_static(b"duration_ms")),
+                    Value::Int(24529),
+                ),
             ]),
         )];
 
-        let resp3_response_empty_first_part_data =
-            vec![(Value::BulkString(bytes::Bytes::from_static(b"running_script")), Value::Nil)];
+        let resp3_response_empty_first_part_data = vec![(
+            Value::BulkString(bytes::Bytes::from_static(b"running_script")),
+            Value::Nil,
+        )];
 
         let resp3_response_second_part_data = vec![(
             Value::BulkString(bytes::Bytes::from_static(b"engines")),
             Value::Map(vec![(
                 Value::BulkString(bytes::Bytes::from_static(b"LUA")),
                 Value::Map(vec![
-                    (Value::BulkString(bytes::Bytes::from_static(b"libraries_count")), Value::Int(3)),
-                    (Value::BulkString(bytes::Bytes::from_static(b"functions_count")), Value::Int(5)),
+                    (
+                        Value::BulkString(bytes::Bytes::from_static(b"libraries_count")),
+                        Value::Int(3),
+                    ),
+                    (
+                        Value::BulkString(bytes::Bytes::from_static(b"functions_count")),
+                        Value::Int(5),
+                    ),
                 ]),
             )]),
         )];
@@ -3063,8 +3089,14 @@ mod tests {
             Value::BulkString(b"2.0".to_vec().into()),
         ]);
         let expected_response = Value::Array(vec![
-            Value::Array(vec![Value::BulkString(b"one".to_vec().into()), Value::Double(1.0)]),
-            Value::Array(vec![Value::BulkString(b"two".to_vec().into()), Value::Double(2.0)]),
+            Value::Array(vec![
+                Value::BulkString(b"one".to_vec().into()),
+                Value::Double(1.0),
+            ]),
+            Value::Array(vec![
+                Value::BulkString(b"two".to_vec().into()),
+                Value::Double(2.0),
+            ]),
         ]);
         let converted_flat_array = convert_to_expected_type(
             flat_array,
@@ -3406,7 +3438,10 @@ mod tests {
                 Value::BulkString(b"key2".to_vec().into()),
                 Value::BulkString(b"20.8".to_vec().into()),
             ),
-            (Value::Double(20.5), Value::BulkString(b"30.2".to_vec().into())),
+            (
+                Value::Double(20.5),
+                Value::BulkString(b"30.2".to_vec().into()),
+            ),
         ];
 
         let converted_map = convert_to_expected_type(
@@ -3570,7 +3605,7 @@ mod tests {
             Value::Array(vec![
                 Value::BulkString(b"name1".to_vec().into()),
                 Value::BulkString(b"1.23".to_vec().into()), // dist (float)
-                Value::Int(123456),                  // hash (int)
+                Value::Int(123456),                         // hash (int)
                 Value::Array(vec![
                     Value::BulkString(b"10.0".to_vec().into()), // lon (float)
                     Value::BulkString(b"20.0".to_vec().into()), // lat (float)
@@ -3579,7 +3614,7 @@ mod tests {
             Value::Array(vec![
                 Value::BulkString(b"name2".to_vec().into()),
                 Value::BulkString(b"2.34".to_vec().into()), // dist (float)
-                Value::Int(654321),                  // hash (int)
+                Value::Int(654321),                         // hash (int)
                 Value::Array(vec![
                     Value::BulkString(b"30.0".to_vec().into()), // lon (float)
                     Value::BulkString(b"40.0".to_vec().into()), // lat (float)
@@ -3843,7 +3878,10 @@ mod tests {
                 Value::BulkString(b"flags".to_vec().into()),
                 Value::Set(vec![Value::BulkString(b"off".to_vec().into())]),
             ),
-            (Value::BulkString(b"redirect".to_vec().into()), Value::Int(-1)),
+            (
+                Value::BulkString(b"redirect".to_vec().into()),
+                Value::Int(-1),
+            ),
             (
                 Value::BulkString(b"prefixes".to_vec().into()),
                 Value::Array(vec![]),

--- a/glide-core/src/compression.rs
+++ b/glide-core/src/compression.rs
@@ -987,7 +987,7 @@ pub fn decompress_single_value_response(
             }
             // Data is compressed - decompress and propagate any errors (including size limit)
             let decompressed = manager.decompress_value(&bytes)?;
-            Ok(Value::BulkString(decompressed))
+            Ok(Value::BulkString(decompressed.into()))
         }
         Value::SimpleString(s) => {
             let bytes = s.as_bytes();
@@ -1000,7 +1000,7 @@ pub fn decompress_single_value_response(
             let decompressed = manager.decompress_value(bytes)?;
             match String::from_utf8(decompressed) {
                 Ok(decompressed_string) => Ok(Value::SimpleString(decompressed_string)),
-                Err(e) => Ok(Value::BulkString(e.into_bytes())),
+                Err(e) => Ok(Value::BulkString(e.into_bytes().into())),
             }
         }
         _ => Ok(value),

--- a/glide-core/src/pubsub/mock.rs
+++ b/glide-core/src/pubsub/mock.rs
@@ -676,7 +676,10 @@ impl MockPubSubBroker {
             }
         }
 
-        let result: Vec<Value> = channels.into_iter().map(|v| Value::BulkString(v.into())).collect();
+        let result: Vec<Value> = channels
+            .into_iter()
+            .map(|v| Value::BulkString(v.into()))
+            .collect();
         Ok(Value::Array(result))
     }
 
@@ -774,7 +777,10 @@ impl MockPubSubBroker {
             }
         }
 
-        let result: Vec<Value> = channels.into_iter().map(|v| Value::BulkString(v.into())).collect();
+        let result: Vec<Value> = channels
+            .into_iter()
+            .map(|v| Value::BulkString(v.into()))
+            .collect();
         Ok(Value::Array(result))
     }
 
@@ -870,7 +876,10 @@ impl MockPubSubBroker {
                 PubSubSubscriptionKind::Pattern => "Pattern",
                 PubSubSubscriptionKind::Sharded => "Sharded",
             };
-            let values_array: Vec<Value> = values.into_iter().map(|v| Value::BulkString(v.into())).collect();
+            let values_array: Vec<Value> = values
+                .into_iter()
+                .map(|v| Value::BulkString(v.into()))
+                .collect();
             redis_map.push((
                 Value::BulkString(key.as_bytes().to_vec().into()),
                 Value::Array(values_array),

--- a/glide-core/src/pubsub/mock.rs
+++ b/glide-core/src/pubsub/mock.rs
@@ -676,7 +676,7 @@ impl MockPubSubBroker {
             }
         }
 
-        let result: Vec<Value> = channels.into_iter().map(Value::BulkString).collect();
+        let result: Vec<Value> = channels.into_iter().map(|v| Value::BulkString(v.into())).collect();
         Ok(Value::Array(result))
     }
 
@@ -737,7 +737,7 @@ impl MockPubSubBroker {
                     count += 1;
                 }
             }
-            result.push((Value::BulkString(channel.clone()), Value::Int(count)));
+            result.push((Value::BulkString(channel.clone().into()), Value::Int(count)));
         }
 
         Ok(Value::Map(result))
@@ -774,7 +774,7 @@ impl MockPubSubBroker {
             }
         }
 
-        let result: Vec<Value> = channels.into_iter().map(Value::BulkString).collect();
+        let result: Vec<Value> = channels.into_iter().map(|v| Value::BulkString(v.into())).collect();
         Ok(Value::Array(result))
     }
 
@@ -815,7 +815,7 @@ impl MockPubSubBroker {
                     count += 1;
                 }
             }
-            result.push((Value::BulkString(channel.clone()), Value::Int(count)));
+            result.push((Value::BulkString(channel.clone().into()), Value::Int(count)));
         }
 
         Ok(Value::Map(result))
@@ -870,9 +870,9 @@ impl MockPubSubBroker {
                 PubSubSubscriptionKind::Pattern => "Pattern",
                 PubSubSubscriptionKind::Sharded => "Sharded",
             };
-            let values_array: Vec<Value> = values.into_iter().map(Value::BulkString).collect();
+            let values_array: Vec<Value> = values.into_iter().map(|v| Value::BulkString(v.into())).collect();
             redis_map.push((
-                Value::BulkString(key.as_bytes().to_vec()),
+                Value::BulkString(key.as_bytes().to_vec().into()),
                 Value::Array(values_array),
             ));
         }
@@ -1069,9 +1069,9 @@ impl MockPubSubBroker {
             let (desired, actual) = sync.get_subscription_state();
 
             let result = vec![
-                Value::BulkString(b"desired".to_vec()),
+                Value::BulkString(bytes::Bytes::from_static(b"desired")),
                 Self::convert_sub_map_to_value(desired),
-                Value::BulkString(b"actual".to_vec()),
+                Value::BulkString(bytes::Bytes::from_static(b"actual")),
                 Self::convert_sub_map_to_value(actual),
             ];
 
@@ -1079,9 +1079,9 @@ impl MockPubSubBroker {
         } else {
             let empty_map = HashMap::new();
             let result = vec![
-                Value::BulkString(b"desired".to_vec()),
+                Value::BulkString(bytes::Bytes::from_static(b"desired")),
                 Self::convert_sub_map_to_value(empty_map.clone()),
-                Value::BulkString(b"actual".to_vec()),
+                Value::BulkString(bytes::Bytes::from_static(b"actual")),
                 Self::convert_sub_map_to_value(empty_map),
             ];
             Value::Array(result)
@@ -1304,10 +1304,10 @@ fn create_push_info(
 
     let mut data = Vec::new();
     if let Some(pat) = pattern {
-        data.push(Value::BulkString(pat.as_bytes().to_vec()));
+        data.push(Value::BulkString(pat.as_bytes().to_vec().into()));
     }
-    data.push(Value::BulkString(channel.as_bytes().to_vec()));
-    data.push(Value::BulkString(message.to_vec()));
+    data.push(Value::BulkString(channel.as_bytes().to_vec().into()));
+    data.push(Value::BulkString(message.to_vec().into()));
 
     PushInfo { kind, data }
 }

--- a/glide-core/src/pubsub/synchronizer.rs
+++ b/glide-core/src/pubsub/synchronizer.rs
@@ -595,8 +595,10 @@ impl GlidePubSubSynchronizer {
                     PubSubSubscriptionKind::Pattern => "Pattern",
                     PubSubSubscriptionKind::Sharded => "Sharded",
                 };
-                let values_array: Vec<Value> =
-                    values.into_iter().map(|v| Value::BulkString(v.into())).collect();
+                let values_array: Vec<Value> = values
+                    .into_iter()
+                    .map(|v| Value::BulkString(v.into()))
+                    .collect();
                 (
                     Value::BulkString(key.as_bytes().to_vec().into()),
                     Value::Array(values_array),

--- a/glide-core/src/pubsub/synchronizer.rs
+++ b/glide-core/src/pubsub/synchronizer.rs
@@ -579,9 +579,9 @@ impl GlidePubSubSynchronizer {
         let (desired, actual) = self.get_subscription_state();
 
         Value::Array(vec![
-            Value::BulkString(b"desired".to_vec()),
+            Value::BulkString(b"desired".to_vec().into()),
             Self::convert_sub_map_to_value(desired),
-            Value::BulkString(b"actual".to_vec()),
+            Value::BulkString(b"actual".to_vec().into()),
             Self::convert_sub_map_to_value(actual),
         ])
     }
@@ -595,9 +595,10 @@ impl GlidePubSubSynchronizer {
                     PubSubSubscriptionKind::Pattern => "Pattern",
                     PubSubSubscriptionKind::Sharded => "Sharded",
                 };
-                let values_array: Vec<Value> = values.into_iter().map(Value::BulkString).collect();
+                let values_array: Vec<Value> =
+                    values.into_iter().map(|v| Value::BulkString(v.into())).collect();
                 (
-                    Value::BulkString(key.as_bytes().to_vec()),
+                    Value::BulkString(key.as_bytes().to_vec().into()),
                     Value::Array(values_array),
                 )
             })

--- a/glide-core/tests/test_cache.rs
+++ b/glide-core/tests/test_cache.rs
@@ -62,7 +62,7 @@ pub(crate) mod test_cache {
             assert!(get_result.is_ok());
             assert_eq!(
                 get_result.unwrap(),
-                Value::BulkString(b"cache_test_value".to_vec())
+                Value::BulkString(b"cache_test_value".to_vec().into())
             );
 
             // Entry count should be 1
@@ -76,7 +76,7 @@ pub(crate) mod test_cache {
             assert!(get_result.is_ok());
             assert_eq!(
                 get_result.unwrap(),
-                Value::BulkString(b"cache_test_value".to_vec())
+                Value::BulkString(b"cache_test_value".to_vec().into())
             );
 
             // Third GET - should also come from cache
@@ -86,7 +86,7 @@ pub(crate) mod test_cache {
             assert!(get_result.is_ok());
             assert_eq!(
                 get_result.unwrap(),
-                Value::BulkString(b"cache_test_value".to_vec())
+                Value::BulkString(b"cache_test_value".to_vec().into())
             );
 
             // Verify only 1 GET hit the server
@@ -340,7 +340,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(get_res, Value::BulkString(b"ttl_value".to_vec()));
+            assert_eq!(get_res, Value::BulkString(b"ttl_value".to_vec().into()));
 
             // Entry count should be 1
             let entry_count = test_basics.client.cache_entry_count().unwrap();
@@ -352,7 +352,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(get_res, Value::BulkString(b"ttl_value".to_vec()));
+            assert_eq!(get_res, Value::BulkString(b"ttl_value".to_vec().into()));
 
             // Should have 1 GET so far
             assert_command_count(&mut test_basics.client, "GET", 1, use_cluster).await;
@@ -368,7 +368,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(get_res, Value::BulkString(b"ttl_value".to_vec()));
+            assert_eq!(get_res, Value::BulkString(b"ttl_value".to_vec().into()));
 
             // Should now have 2 GETs
             assert_command_count(&mut test_basics.client, "GET", 2, use_cluster).await;
@@ -880,7 +880,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(result, Value::BulkString(b"shared_value".to_vec()));
+            assert_eq!(result, Value::BulkString(b"shared_value".to_vec().into()));
 
             // Entry count should be 1
             let entry_count = test_basics2.client.cache_entry_count().unwrap();
@@ -894,7 +894,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(result, Value::BulkString(b"shared_value".to_vec()));
+            assert_eq!(result, Value::BulkString(b"shared_value".to_vec().into()));
 
             // Only 1 GET should have hit the server (both clients used shared cache)
             assert_command_count(&mut test_basics1.client, "GET", 1, use_cluster).await;
@@ -965,7 +965,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(result, Value::BulkString(b"string_value".to_vec()));
+            assert_eq!(result, Value::BulkString(b"string_value".to_vec().into()));
 
             // Entry count should be 1
             let entry_count = test_basics.client.cache_entry_count().unwrap();
@@ -1046,7 +1046,7 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(result, Value::BulkString(b"cacheable_value".to_vec()));
+            assert_eq!(result, Value::BulkString(b"cacheable_value".to_vec().into()));
 
             // Entry count should be 1
             let entry_count = test_basics.client.cache_entry_count().unwrap();
@@ -1075,8 +1075,8 @@ pub(crate) mod test_cache {
             assert_eq!(
                 hgetall_result,
                 Value::Map(vec![(
-                    Value::BulkString(b"field1".to_vec()),
-                    Value::BulkString(b"value1".to_vec())
+                    Value::BulkString(b"field1".to_vec().into()),
+                    Value::BulkString(b"value1".to_vec().into())
                 )])
             );
 
@@ -1101,7 +1101,7 @@ pub(crate) mod test_cache {
                 .unwrap();
             assert_eq!(
                 smembers_result,
-                Value::Set(vec![Value::BulkString(b"member1".to_vec())])
+                Value::Set(vec![Value::BulkString(b"member1".to_vec().into())])
             );
 
             // Entry count should be 3
@@ -1238,7 +1238,7 @@ pub(crate) mod test_cache {
                 .unwrap();
             assert_eq!(
                 result1,
-                Value::BulkString(value1.as_bytes().to_vec()),
+                Value::BulkString(value1.as_bytes().to_vec().into()),
                 "first GET should return original value"
             );
 
@@ -1252,7 +1252,7 @@ pub(crate) mod test_cache {
                 .unwrap();
             assert_eq!(
                 result2,
-                Value::BulkString(value1.as_bytes().to_vec()),
+                Value::BulkString(value1.as_bytes().to_vec().into()),
                 "second GET should return cached value"
             );
 
@@ -1278,7 +1278,7 @@ pub(crate) mod test_cache {
                 .unwrap();
             assert_eq!(
                 result3,
-                Value::BulkString(value2.as_bytes().to_vec()),
+                Value::BulkString(value2.as_bytes().to_vec().into()),
                 "GET after invalidation should return updated value"
             );
         });

--- a/glide-core/tests/test_cache.rs
+++ b/glide-core/tests/test_cache.rs
@@ -1046,7 +1046,10 @@ pub(crate) mod test_cache {
                 .send_command(&mut get_cmd, None)
                 .await
                 .unwrap();
-            assert_eq!(result, Value::BulkString(b"cacheable_value".to_vec().into()));
+            assert_eq!(
+                result,
+                Value::BulkString(b"cacheable_value".to_vec().into())
+            );
 
             // Entry count should be 1
             let entry_count = test_basics.client.cache_entry_count().unwrap();

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -709,7 +709,7 @@ pub(crate) mod shared_client_tests {
                                 client.send_command(redis::cmd("GET").arg(&key), None).await;
                             assert_eq!(
                                 get_result.unwrap(),
-                                Value::BulkString("test_value".as_bytes().to_vec())
+                                Value::BulkString("test_value".as_bytes().to_vec().into())
                             );
                         }
                         Err(err) => {
@@ -805,7 +805,7 @@ pub(crate) mod shared_client_tests {
                                 client.send_command(redis::cmd("GET").arg(&key), None).await;
                             assert_eq!(
                                 get_result.unwrap(),
-                                Value::BulkString("test_value".as_bytes().to_vec())
+                                Value::BulkString("test_value".as_bytes().to_vec().into())
                             );
                         }
                         Err(err) => {
@@ -1019,7 +1019,7 @@ pub(crate) mod shared_client_tests {
                         .await;
                     assert_eq!(
                         get_result.unwrap(),
-                        Value::BulkString(test_value.as_bytes().to_vec()),
+                        Value::BulkString(test_value.as_bytes().to_vec().into()),
                         "GET should return the set value"
                     );
 
@@ -1041,7 +1041,7 @@ pub(crate) mod shared_client_tests {
                         .await;
                     assert_eq!(
                         get_after_reconnect.unwrap(),
-                        Value::BulkString(test_value.as_bytes().to_vec()),
+                        Value::BulkString(test_value.as_bytes().to_vec().into()),
                         "GET after reconnection should return the same value"
                     );
                 }
@@ -1380,7 +1380,7 @@ pub(crate) mod shared_client_tests {
                     );
                     assert_eq!(
                         get_result.unwrap(),
-                        Value::BulkString(test_value.as_bytes().to_vec()),
+                        Value::BulkString(test_value.as_bytes().to_vec().into()),
                         "GET should return the same value after reconnection"
                     );
 
@@ -1747,7 +1747,10 @@ pub(crate) mod shared_client_tests {
                     };
                     assert_eq!(
                         &res[..2],
-                        &[Value::Okay, Value::BulkString(value.as_bytes().to_vec().into()),],
+                        &[
+                            Value::Okay,
+                            Value::BulkString(value.as_bytes().to_vec().into()),
+                        ],
                         "Pipeline result: {res:?}"
                     );
 

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -305,12 +305,12 @@ pub(crate) mod shared_client_tests {
                 result,
                 Value::Map(vec![
                     (
-                        Value::BulkString("foo".as_bytes().to_vec()),
-                        Value::BulkString("baz".as_bytes().to_vec())
+                        Value::BulkString("foo".as_bytes().to_vec().into()),
+                        Value::BulkString("baz".as_bytes().to_vec().into())
                     ),
                     (
-                        Value::BulkString("bar".as_bytes().to_vec()),
-                        Value::BulkString("foobar".as_bytes().to_vec())
+                        Value::BulkString("bar".as_bytes().to_vec().into()),
+                        Value::BulkString("foobar".as_bytes().to_vec().into())
                     )
                 ])
             );
@@ -1682,12 +1682,12 @@ pub(crate) mod shared_client_tests {
                     Value::Int(1),
                     Value::Map(vec![
                         (
-                            Value::BulkString(field.as_bytes().to_vec()),
-                            Value::BulkString(value.as_bytes().to_vec())
+                            Value::BulkString(field.as_bytes().to_vec().into()),
+                            Value::BulkString(value.as_bytes().to_vec().into())
                         ),
                         (
-                            Value::BulkString(field2.as_bytes().to_vec()),
-                            Value::BulkString(value2.as_bytes().to_vec())
+                            Value::BulkString(field2.as_bytes().to_vec().into()),
+                            Value::BulkString(value2.as_bytes().to_vec().into())
                         )
                     ])
                 ]),
@@ -1747,7 +1747,7 @@ pub(crate) mod shared_client_tests {
                     };
                     assert_eq!(
                         &res[..2],
-                        &[Value::Okay, Value::BulkString(value.as_bytes().to_vec()),],
+                        &[Value::Okay, Value::BulkString(value.as_bytes().to_vec().into()),],
                         "Pipeline result: {res:?}"
                     );
 
@@ -1823,7 +1823,7 @@ pub(crate) mod shared_client_tests {
                 result,
                 Value::Array(vec![
                     Value::Okay,
-                    Value::BulkString(b"value1".to_vec()),
+                    Value::BulkString(b"value1".to_vec().into()),
                     Value::Nil,
                     Value::Nil,
                 ]),
@@ -1928,7 +1928,7 @@ pub(crate) mod shared_client_tests {
                 res,
                 Value::Array(vec![
                     Value::Okay,
-                    Value::BulkString(b"value1".to_vec()),
+                    Value::BulkString(b"value1".to_vec().into()),
                     Value::Nil,
                     Value::Nil,
                 ]),
@@ -2030,9 +2030,9 @@ pub(crate) mod shared_client_tests {
 
             let expected = Value::Array(vec![
                 Value::Okay,
-                Value::BulkString(value.as_bytes().to_vec()),
+                Value::BulkString(value.as_bytes().to_vec().into()),
                 Value::Okay,
-                Value::BulkString(value2.as_bytes().to_vec()),
+                Value::BulkString(value2.as_bytes().to_vec().into()),
             ]);
 
             assert_eq!(res, expected, "Pipeline result: {res:?}");
@@ -2187,9 +2187,9 @@ pub(crate) mod shared_client_tests {
 
             let expected = Value::Array(vec![
                 Value::Okay,
-                Value::BulkString("value1".as_bytes().to_vec()),
+                Value::BulkString("value1".as_bytes().to_vec().into()),
                 Value::Okay,
-                Value::BulkString("value2".as_bytes().to_vec()),
+                Value::BulkString("value2".as_bytes().to_vec().into()),
             ]);
 
             assert_eq!(res, expected, "Pipeline result: {res:?}");
@@ -2252,7 +2252,7 @@ pub(crate) mod shared_client_tests {
             let items = keys.iter().map(|key| (key, key)).collect::<Vec<_>>();
             let expected = keys
                 .iter()
-                .map(|key| Value::BulkString(key.as_bytes().to_vec()))
+                .map(|key| Value::BulkString(key.as_bytes().to_vec().into()))
                 .collect::<Vec<_>>();
             let mut pipeline = Pipeline::new();
             pipeline.mset(&items);
@@ -2322,8 +2322,8 @@ pub(crate) mod shared_client_tests {
                 Value::Array(vec![
                     Value::Okay,
                     Value::Map(vec![(
-                        Value::BulkString(b"appendonly".to_vec()),
-                        Value::BulkString(b"no".to_vec()),
+                        Value::BulkString(b"appendonly".to_vec().into()),
+                        Value::BulkString(b"no".to_vec().into()),
                     )])
                 ]),
                 "Pipeline result: {result:?}"
@@ -2565,8 +2565,8 @@ pub(crate) mod shared_client_tests {
                 Ok(Value::Array(vec![
                     Value::Int(1),
                     Value::Map(vec![(
-                        Value::BulkString(b"bar".to_vec()),
-                        Value::BulkString(b"vaz".to_vec()),
+                        Value::BulkString(b"bar".to_vec().into()),
+                        Value::BulkString(b"vaz".to_vec().into()),
                     )]),
                     Value::Boolean(true),
                     Value::Int(1),

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -1204,8 +1204,8 @@ mod compression_tests {
 
         // Test with array of uncompressed values (should return as-is)
         let array_response = Value::Array(vec![
-            Value::BulkString(b"value1".to_vec()),
-            Value::BulkString(b"value2".to_vec()),
+            Value::BulkString(b"value1".to_vec().into()),
+            Value::BulkString(b"value2".to_vec().into()),
             Value::Nil,
         ]);
         let result = decompress_batch_response(array_response.clone(), &manager);
@@ -1214,8 +1214,8 @@ mod compression_tests {
         match decompressed {
             Value::Array(values) => {
                 assert_eq!(values.len(), 3);
-                assert_eq!(values[0], Value::BulkString(b"value1".to_vec()));
-                assert_eq!(values[1], Value::BulkString(b"value2".to_vec()));
+                assert_eq!(values[0], Value::BulkString(b"value1".to_vec().into()));
+                assert_eq!(values[1], Value::BulkString(b"value2".to_vec().into()));
                 assert_eq!(values[2], Value::Nil);
             }
             _ => panic!("Expected array response"),
@@ -1225,8 +1225,8 @@ mod compression_tests {
         let test_data = b"test data for compression that is long enough to be compressed";
         let compressed = manager.compress_value(test_data).into_owned();
         let array_with_compressed = Value::Array(vec![
-            Value::BulkString(compressed.clone()),
-            Value::BulkString(b"uncompressed".to_vec()),
+            Value::BulkString(compressed.clone().into()),
+            Value::BulkString(b"uncompressed".to_vec().into()),
         ]);
         let result = decompress_batch_response(array_with_compressed, &manager);
         assert!(result.is_ok());
@@ -1235,19 +1235,19 @@ mod compression_tests {
             Value::Array(values) => {
                 assert_eq!(values.len(), 2);
                 // First value should be decompressed
-                assert_eq!(values[0], Value::BulkString(test_data.to_vec()));
+                assert_eq!(values[0], Value::BulkString(test_data.to_vec().into()));
                 // Second value should remain unchanged
-                assert_eq!(values[1], Value::BulkString(b"uncompressed".to_vec()));
+                assert_eq!(values[1], Value::BulkString(b"uncompressed".to_vec().into()));
             }
             _ => panic!("Expected array response"),
         }
 
         // Test with non-array response (single value)
-        let single_response = Value::BulkString(compressed.clone());
+        let single_response = Value::BulkString(compressed.clone().into());
         let result = decompress_batch_response(single_response, &manager);
         assert!(result.is_ok());
         let decompressed = result.unwrap();
-        assert_eq!(decompressed, Value::BulkString(test_data.to_vec()));
+        assert_eq!(decompressed, Value::BulkString(test_data.to_vec().into()));
 
         // Test with disabled compression manager
         let disabled_config = CompressionConfig {
@@ -1261,7 +1261,7 @@ mod compression_tests {
         let disabled_manager = CompressionManager::new(disabled_backend, disabled_config).unwrap();
 
         // With disabled manager, compressed data should NOT be decompressed
-        let array_with_compressed = Value::Array(vec![Value::BulkString(compressed.clone())]);
+        let array_with_compressed = Value::Array(vec![Value::BulkString(compressed.clone().into())]);
         let result = decompress_batch_response(array_with_compressed, &disabled_manager);
         assert!(result.is_ok());
         let not_decompressed = result.unwrap();
@@ -1269,7 +1269,7 @@ mod compression_tests {
             Value::Array(values) => {
                 assert_eq!(values.len(), 1);
                 // Value should remain compressed since manager is disabled
-                assert_eq!(values[0], Value::BulkString(compressed));
+                assert_eq!(values[0], Value::BulkString(compressed.into()));
             }
             _ => panic!("Expected array response"),
         }
@@ -1304,9 +1304,9 @@ mod compression_tests {
             Value::SimpleString("OK".to_string()),
             // MGET result - nested array with compressed values
             Value::Array(vec![
-                Value::BulkString(compressed1.clone()),
-                Value::BulkString(compressed2.clone()),
-                Value::BulkString(compressed3.clone()),
+                Value::BulkString(compressed1.clone().into()),
+                Value::BulkString(compressed2.clone().into()),
+                Value::BulkString(compressed3.clone().into()),
             ]),
         ]);
 
@@ -1325,9 +1325,9 @@ mod compression_tests {
                 match &values[1] {
                     Value::Array(mget_values) => {
                         assert_eq!(mget_values.len(), 3);
-                        assert_eq!(mget_values[0], Value::BulkString(test_data1.to_vec()));
-                        assert_eq!(mget_values[1], Value::BulkString(test_data2.to_vec()));
-                        assert_eq!(mget_values[2], Value::BulkString(test_data3.to_vec()));
+                        assert_eq!(mget_values[0], Value::BulkString(test_data1.to_vec().into()));
+                        assert_eq!(mget_values[1], Value::BulkString(test_data2.to_vec().into()));
+                        assert_eq!(mget_values[2], Value::BulkString(test_data3.to_vec().into()));
                     }
                     _ => panic!("Expected nested array for MGET result"),
                 }
@@ -1337,7 +1337,7 @@ mod compression_tests {
 
         // Test with deeply nested arrays (edge case)
         let deeply_nested = Value::Array(vec![Value::Array(vec![Value::Array(vec![
-            Value::BulkString(compressed1.clone()),
+            Value::BulkString(compressed1.clone().into()),
         ])])]);
 
         let result = decompress_batch_response(deeply_nested, &manager);
@@ -1349,7 +1349,7 @@ mod compression_tests {
             Value::Array(level1) => match &level1[0] {
                 Value::Array(level2) => match &level2[0] {
                     Value::Array(level3) => {
-                        assert_eq!(level3[0], Value::BulkString(test_data1.to_vec()));
+                        assert_eq!(level3[0], Value::BulkString(test_data1.to_vec().into()));
                     }
                     _ => panic!("Expected array at level 3"),
                 },
@@ -1360,10 +1360,10 @@ mod compression_tests {
 
         // Test with mixed nested and non-nested values
         let mixed_response = Value::Array(vec![
-            Value::BulkString(compressed1.clone()), // Direct compressed value
+            Value::BulkString(compressed1.clone().into()), // Direct compressed value
             Value::Array(vec![
                 // Nested array with compressed values
-                Value::BulkString(compressed2.clone()),
+                Value::BulkString(compressed2.clone().into()),
                 Value::Nil,
             ]),
             Value::SimpleString("OK".to_string()), // Simple string
@@ -1377,12 +1377,12 @@ mod compression_tests {
             Value::Array(values) => {
                 assert_eq!(values.len(), 3);
                 // First value should be decompressed
-                assert_eq!(values[0], Value::BulkString(test_data1.to_vec()));
+                assert_eq!(values[0], Value::BulkString(test_data1.to_vec().into()));
                 // Second value should be nested array with decompressed values
                 match &values[1] {
                     Value::Array(nested) => {
                         assert_eq!(nested.len(), 2);
-                        assert_eq!(nested[0], Value::BulkString(test_data2.to_vec()));
+                        assert_eq!(nested[0], Value::BulkString(test_data2.to_vec().into()));
                         assert_eq!(nested[1], Value::Nil);
                     }
                     _ => panic!("Expected nested array"),

--- a/glide-core/tests/test_compression.rs
+++ b/glide-core/tests/test_compression.rs
@@ -1237,7 +1237,10 @@ mod compression_tests {
                 // First value should be decompressed
                 assert_eq!(values[0], Value::BulkString(test_data.to_vec().into()));
                 // Second value should remain unchanged
-                assert_eq!(values[1], Value::BulkString(b"uncompressed".to_vec().into()));
+                assert_eq!(
+                    values[1],
+                    Value::BulkString(b"uncompressed".to_vec().into())
+                );
             }
             _ => panic!("Expected array response"),
         }
@@ -1261,7 +1264,8 @@ mod compression_tests {
         let disabled_manager = CompressionManager::new(disabled_backend, disabled_config).unwrap();
 
         // With disabled manager, compressed data should NOT be decompressed
-        let array_with_compressed = Value::Array(vec![Value::BulkString(compressed.clone().into())]);
+        let array_with_compressed =
+            Value::Array(vec![Value::BulkString(compressed.clone().into())]);
         let result = decompress_batch_response(array_with_compressed, &disabled_manager);
         assert!(result.is_ok());
         let not_decompressed = result.unwrap();
@@ -1325,9 +1329,18 @@ mod compression_tests {
                 match &values[1] {
                     Value::Array(mget_values) => {
                         assert_eq!(mget_values.len(), 3);
-                        assert_eq!(mget_values[0], Value::BulkString(test_data1.to_vec().into()));
-                        assert_eq!(mget_values[1], Value::BulkString(test_data2.to_vec().into()));
-                        assert_eq!(mget_values[2], Value::BulkString(test_data3.to_vec().into()));
+                        assert_eq!(
+                            mget_values[0],
+                            Value::BulkString(test_data1.to_vec().into())
+                        );
+                        assert_eq!(
+                            mget_values[1],
+                            Value::BulkString(test_data2.to_vec().into())
+                        );
+                        assert_eq!(
+                            mget_values[2],
+                            Value::BulkString(test_data3.to_vec().into())
+                        );
                     }
                     _ => panic!("Expected nested array for MGET result"),
                 }

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -729,7 +729,10 @@ mod socket_listener {
         };
         assert_eq!(values.len(), 3);
         for i in 0..3 {
-            assert_eq!(values.get(i).unwrap().1, Value::BulkString(b"foo".to_vec().into()));
+            assert_eq!(
+                values.get(i).unwrap().1,
+                Value::BulkString(b"foo".to_vec().into())
+            );
         }
     }
 
@@ -983,7 +986,9 @@ mod socket_listener {
                                     let values = values_for_read.lock().unwrap();
                                     assert_value(
                                         pointer,
-                                        Some(Value::BulkString(values[callback_index].clone().into())),
+                                        Some(Value::BulkString(
+                                            values[callback_index].clone().into(),
+                                        )),
                                     );
                                     results[callback_index] = State::ReceivedValue;
                                 }
@@ -1286,7 +1291,10 @@ mod socket_listener {
                 Value::Okay,
                 Value::Okay,
                 Value::BulkString(vec![b'b', b'a', b'r'].into()),
-                Value::Array(vec![Value::BulkString(vec![b'b', b'a', b'r'].into()), Value::Nil]),
+                Value::Array(vec![
+                    Value::BulkString(vec![b'b', b'a', b'r'].into()),
+                    Value::Nil,
+                ]),
                 Value::Int(1),
             ]),
         );

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -429,7 +429,7 @@ mod socket_listener {
         let mut responses = std::collections::HashMap::new();
         responses.insert(
             "*2\r\n$4\r\nINFO\r\n$11\r\nREPLICATION\r\n".to_string(),
-            Value::BulkString(b"role:master\r\nconnected_slaves:0\r\n".to_vec()),
+            Value::BulkString(b"role:master\r\nconnected_slaves:0\r\n".to_vec().into()),
         );
         let server_mock = ServerMock::new(responses);
         let addresses = server_mock.get_addresses();
@@ -644,7 +644,7 @@ mod socket_listener {
             &mut buffer,
             Some(&mut test_basics.socket),
             CALLBACK2_INDEX,
-            Value::BulkString(value.into_bytes()),
+            Value::BulkString(value.into_bytes().into()),
         );
     }
 
@@ -694,7 +694,7 @@ mod socket_listener {
             &mut buffer,
             Some(&mut test_basics.socket),
             CALLBACK2_INDEX,
-            Value::BulkString(value.into_bytes()),
+            Value::BulkString(value.into_bytes().into()),
         );
     }
 
@@ -729,7 +729,7 @@ mod socket_listener {
         };
         assert_eq!(values.len(), 3);
         for i in 0..3 {
-            assert_eq!(values.get(i).unwrap().1, Value::BulkString(b"foo".to_vec()));
+            assert_eq!(values.get(i).unwrap().1, Value::BulkString(b"foo".to_vec().into()));
         }
     }
 
@@ -918,7 +918,7 @@ mod socket_listener {
             &mut buffer,
             None,
             CALLBACK2_INDEX,
-            Value::BulkString(value.into_bytes()),
+            Value::BulkString(value.into_bytes().into()),
         );
     }
 
@@ -983,7 +983,7 @@ mod socket_listener {
                                     let values = values_for_read.lock().unwrap();
                                     assert_value(
                                         pointer,
-                                        Some(Value::BulkString(values[callback_index].clone())),
+                                        Some(Value::BulkString(values[callback_index].clone().into())),
                                     );
                                     results[callback_index] = State::ReceivedValue;
                                 }
@@ -1217,7 +1217,7 @@ mod socket_listener {
             CALLBACK_INDEX,
             Value::Array(vec![
                 Value::Okay,
-                Value::BulkString(vec![b'b', b'a', b'r']),
+                Value::BulkString(vec![b'b', b'a', b'r'].into()),
                 Value::Okay,
                 Value::Nil,
             ]),
@@ -1285,8 +1285,8 @@ mod socket_listener {
             Value::Array(vec![
                 Value::Okay,
                 Value::Okay,
-                Value::BulkString(vec![b'b', b'a', b'r']),
-                Value::Array(vec![Value::BulkString(vec![b'b', b'a', b'r']), Value::Nil]),
+                Value::BulkString(vec![b'b', b'a', b'r'].into()),
+                Value::Array(vec![Value::BulkString(vec![b'b', b'a', b'r'].into()), Value::Nil]),
                 Value::Int(1),
             ]),
         );
@@ -1390,7 +1390,7 @@ mod socket_listener {
             &mut buffer,
             Some(&mut test_basics.socket),
             CALLBACK_INDEX,
-            Value::BulkString(value.into_bytes()),
+            Value::BulkString(value.into_bytes().into()),
         );
     }
 

--- a/glide-core/tests/test_standalone_client.rs
+++ b/glide-core/tests/test_standalone_client.rs
@@ -133,19 +133,19 @@ mod standalone_client_tests {
         let mut primary_responses = std::collections::HashMap::new();
         primary_responses.insert(
             "*1\r\n$4\r\nPING\r\n".to_string(),
-            Value::BulkString(b"PONG".to_vec()),
+            Value::BulkString(b"PONG".to_vec().into()),
         );
         primary_responses.insert(
             "*2\r\n$4\r\nINFO\r\n$11\r\nREPLICATION\r\n".to_string(),
-            Value::BulkString(b"role:master\r\nconnected_slaves:3\r\n".to_vec()),
+            Value::BulkString(b"role:master\r\nconnected_slaves:3\r\n".to_vec().into()),
         );
         primary_responses.insert(
             "*2\r\n$5\r\nHELLO\r\n$1\r\n3\r\n".to_string(),
             Value::Map(vec![
-                (Value::BulkString(b"proto".to_vec()), Value::Int(3)),
+                (Value::BulkString(b"proto".to_vec().into()), Value::Int(3)),
                 (
-                    Value::BulkString(b"role".to_vec()),
-                    Value::BulkString(b"master".to_vec()),
+                    Value::BulkString(b"role".to_vec().into()),
+                    Value::BulkString(b"master".to_vec().into()),
                 ),
             ]),
         );
@@ -156,19 +156,19 @@ mod standalone_client_tests {
         let mut replica_responses = std::collections::HashMap::new();
         replica_responses.insert(
             "*1\r\n$4\r\nPING\r\n".to_string(),
-            Value::BulkString(b"PONG".to_vec()),
+            Value::BulkString(b"PONG".to_vec().into()),
         );
         replica_responses.insert(
             "*2\r\n$4\r\nINFO\r\n$11\r\nREPLICATION\r\n".to_string(),
-            Value::BulkString(b"role:slave\r\n".to_vec()),
+            Value::BulkString(b"role:slave\r\n".to_vec().into()),
         );
         replica_responses.insert(
             "*2\r\n$5\r\nHELLO\r\n$1\r\n3\r\n".to_string(),
             Value::Map(vec![
-                (Value::BulkString(b"proto".to_vec()), Value::Int(3)),
+                (Value::BulkString(b"proto".to_vec().into()), Value::Int(3)),
                 (
-                    Value::BulkString(b"role".to_vec()),
-                    Value::BulkString(b"replica".to_vec()),
+                    Value::BulkString(b"role".to_vec().into()),
+                    Value::BulkString(b"replica".to_vec().into()),
                 ),
             ]),
         );
@@ -190,7 +190,7 @@ mod standalone_client_tests {
         let mut responses = base;
         responses.insert(
             "*1\r\n$4\r\nINFO\r\n".to_string(),
-            Value::BulkString(format!("availability_zone:{az}\r\n").into_bytes()),
+            Value::BulkString(format!("availability_zone:{az}\r\n").into_bytes().into()),
         );
         responses
     }
@@ -1163,12 +1163,12 @@ mod standalone_client_tests {
         let mut responses = std::collections::HashMap::new();
         responses.insert(
             "*1\r\n$4\r\nPING\r\n".to_string(),
-            Value::BulkString(b"PONG".to_vec()),
+            Value::BulkString(b"PONG".to_vec().into()),
         );
         // GET command response
         responses.insert(
             "*2\r\n$3\r\nGET\r\n$3\r\nfoo\r\n".to_string(),
-            Value::BulkString(b"bar".to_vec()),
+            Value::BulkString(b"bar".to_vec().into()),
         );
         // SET command response (for testing write blocking)
         responses.insert(
@@ -1494,7 +1494,7 @@ mod standalone_client_tests {
             let value = read_result.unwrap();
             assert_eq!(
                 value,
-                Value::BulkString(b"test_value".to_vec()),
+                Value::BulkString(b"test_value".to_vec().into()),
                 "Read value should match written value"
             );
 

--- a/glide-core/tests/utilities/mocks.rs
+++ b/glide-core/tests/utilities/mocks.rs
@@ -100,10 +100,10 @@ fn receive_and_respond_to_next_message(
     if message.contains("HELLO") {
         let mut buffer = Vec::new();
         let response = Value::Map(vec![
-            (Value::BulkString(b"proto".to_vec()), Value::Int(3)),
+            (Value::BulkString(b"proto".to_vec().into()), Value::Int(3)),
             (
-                Value::BulkString(b"role".to_vec()),
-                Value::BulkString(b"master".to_vec()),
+                Value::BulkString(b"role".to_vec().into()),
+                Value::BulkString(b"master".to_vec().into()),
             ),
         ]);
         super::encode_value(&response, &mut buffer).unwrap();

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -628,7 +628,7 @@ pub async fn send_set_and_get(mut client: Client, key: String) {
     let get_result = client.send_command(&mut get_command, None).await.unwrap();
 
     assert_eq!(set_result, Value::Okay);
-    assert_eq!(get_result, Value::BulkString(value.into_bytes()));
+    assert_eq!(get_result, Value::BulkString(value.into_bytes().into()));
 }
 
 pub struct TestBasics {

--- a/java/src/jni_client.rs
+++ b/java/src/jni_client.rs
@@ -233,7 +233,7 @@ pub(crate) fn handle_push_notification(env: &mut JNIEnv, handle_id: jlong, push:
 
     let as_bytes = |v: &Value| -> Option<Vec<u8>> {
         match v {
-            Value::BulkString(b) => Some(b.clone()),
+            Value::BulkString(b) => Some(b.to_vec()),
             _ => None,
         }
     };
@@ -712,7 +712,7 @@ fn create_direct_byte_buffer<'local>(
 ) -> Result<JObject<'local>, crate::errors::FFIError> {
     match value {
         redis::Value::BulkString(data) => {
-            let (id, ptr, len) = register_native_buffer(data);
+            let (id, ptr, len) = register_native_buffer(data.to_vec());
             let bb = unsafe { env.new_direct_byte_buffer(ptr.cast(), len)? };
             // Register Java-side cleaner to free native buffer when GC'd
             let obj: JObject = bb.into();

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -265,7 +265,7 @@ fn resp_value_to_java<'local>(
         }
         Value::BulkString(data) => {
             if encoding_utf8 {
-                match String::from_utf8(data) {
+                match String::from_utf8(data.to_vec()) {
                     Ok(utf8_str) => Ok(JObject::from(env.new_string(utf8_str)?)),
                     Err(err) => {
                         let bytes = err.into_bytes();

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -513,12 +513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,9 +814,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "file-rotate"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
 dependencies = [
  "chrono",
  "flate2",
@@ -1101,20 +1095,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1479,27 +1467,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1616,11 +1609,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2252,8 +2245,8 @@ dependencies = [
  "rustls-platform-verifier",
  "ryu",
  "socket2",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "telemetrylib",
  "tokio",
  "tokio-retry2 0.5.8",
@@ -2436,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2641,6 +2634,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,9 +2685,9 @@ checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -2695,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3472,20 +3481,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3494,7 +3494,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3508,40 +3508,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3551,21 +3530,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3581,21 +3548,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3605,21 +3560,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/python/glide-async/src/lib.rs
+++ b/python/glide-async/src/lib.rs
@@ -473,7 +473,7 @@ fn glide(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
                 .into_any()
                 .unbind()),
             Value::BulkString(data) => {
-                let data_bytes = PyBytes::new(py, &data);
+                let data_bytes = PyBytes::new(py, &data[..]);
                 Ok(data_bytes
                     .into_pyobject(py)
                     .expect("BulkString: expected a proper conversion into Python bytes.")


### PR DESCRIPTION
### Summary

Reduces per-value memory copies on the client hot path. **Naming note:** the
receive side is *reduced-copy* — it removes the parser's per-bulk-string
allocation + `memcpy` and reaches the one-copy floor (kernel read buffer →
caller), **not** literally zero-copy. The send side via `Cmd::arg_shared` is
true zero-copy (owned `Bytes` → socket, vectored); plain `arg` send drops to
one copy. `Value::BulkString` becomes a refcounted `bytes::Bytes`, the async
decode path slices payloads directly out of the read buffer, and large command
args are written with vectored I/O straight from the caller's allocation.

Full design: `docs/zero-copy-initiative.md`. Detailed benchmark analysis
(methodology, raw numbers, caveats): `docs/zero-copy-benchmarks.md`.

> **This is a draft.** It is one interdependent branch but reviews naturally
> split into two stacked parts — **Phase 1 (receive)** and **Phase 2 (send)** —
> This is expected to be split into orthogonal PRs before merge — see the
> "Splitting" section below.

### Issue link

This Pull Request is linked to issue: _TODO: link tracking issue_

### Features / Behaviour Changes

- `Value::BulkString(Vec<u8>)` → `Value::BulkString(bytes::Bytes)`.
- New zero-copy RESP decoder for the async `ValueCodec` (scan-then-slice), with a
  resumable scanner so multi-read frames are scanned once.
- `Cmd::arg_shared(Bytes)` + automatic out-of-line storage of large args;
  `SegmentedBytes` packed form; vectored write sinks for the multiplexed, sync,
  and async single connections.
- No language-binding API change is required for the core win; the FFI response
  arena and arg handling were updated to carry the reduced-copy path through.

### Implementation

**Phase 1 — receive.** The `combine` streaming parser must own partial frames,
so the async hot path uses a purpose-built decoder: scan the read buffer for one
complete frame (consuming nothing), then extract it (bulk-copy ≤64 KB to keep
tokio's buffer reusable, `split_to().freeze()` above that) and build the `Value`
tree by slicing bulk-string payloads out of that one `Bytes`. Scanner state is
persisted across `decode` calls. The FFI arena stores `Bytes`, so non-buffered
GET/MGET is one-copy end to end. `Value::detach_buffers()` deep-copies at the
client-side cache insert so cached values never pin network buffers.

**Phase 2 — send.** `Cmd` args are `Inline | Shared(Bytes) | Cursor`; args > 4 KB
are held out-of-line and emitted as their own zero-copy segments in
`SegmentedBytes` (byte-identical on the wire to the contiguous packing,
unit-tested). The multiplexed connection splits read/write halves and writes
segments via `poll_write_vectored`; the sync and async single connections do the
same. Commands with no out-of-line payload keep the original contiguous path
(no small-command regression).

Reviewers: the interesting spots are `parser.rs` (`zero_copy` module — scanner +
slicing parser + hybrid frame extraction) and `aio/multiplexed_connection.rs`
(`VectoredSink`).

### Limitations

- **Phase 3 (true zero-copy receive)** — parsing straight into pre-registered
  caller buffers to remove the read-buffer staging copy — is not included; Phase 1
  already reaches the one-copy floor.
- Sync **pipeline** (`ConnectionLike::req_packed_commands`) takes an already-packed
  `&[u8]` at the trait boundary, so it stays contiguous (single commands are
  vectored).
- Socket-listener bindings (Node, python-async) still re-copy into protobuf; the
  parser win still applies in front of it. Compression forces an owned buffer.

### Testing

- `redis` lib: 299 unit tests incl. new segmented-packing + codec recursion-guard
  tests; `codec_chunked_parse` quickcheck (identical decode under arbitrary socket
  chunking).
- Connection integration (live server): `test_basic` 57 (sync send), `test_async`
  32 (async single-conn send).
- `glide-core` 150 lib tests; `ffi` 60 incl. live-server e2e.
- Lint: `cargo fmt --check`, `cargo clippy -- -D warnings` (redis lib),
  `cargo clippy --all-features --all-targets -- -D warnings` (glide-core, ffi) all
  clean. MSRV 1.71 preserved.

**Selected benchmark results** (valkey 8.1.3, loopback, vs branch point):

| Path | Result |
|------|--------|
| MGET 100×16 KB (e2e) | client CPU −60…−70% |
| MGET 100×1 KB (e2e) | throughput +1.9× |
| SET 256 KB via `arg_shared` (e2e) | throughput +3.2×, CPU −78% |
| SET 256 KB sync (instructions) | −39% (`arg`) / −84% (`arg_shared`) |
| decode micro-bench | −9% … −95% across shapes |

### Splitting this PR (planned)

This branch is one stack for review convenience but decomposes into orthogonal
PRs along the **receive vs send** axis (only shared file is `ffi/src/lib.rs`, in
disjoint functions):

1. **Foundation** — `Value::BulkString(Vec<u8>) → bytes::Bytes` + mechanical
   migration across redis/glide-core/ffi/bindings. Perf-neutral (combine parser
   still copies via `Bytes::copy_from_slice`). Merges first; unblocks receive.
2. **Receive** (on Foundation) — zero-copy frame codec + resumable scanner +
   FFI arena `Bytes` + cache `detach_buffers`. Delivers the receive win.
3. **Send** (independent of 1 & 2) — `arg_shared` + `SegmentedBytes` + vectored
   write sinks (multiplexed, sync, async-single) + FFI arg wiring.

Merge order: Foundation → Receive; Send in parallel.

### Checklist

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run and pass.
-   [x] Destination branch is correct - main or release.
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Update valkey-glide-docs if necessary.

Signed-off-by: Omer Rubinstein <omerrubi@amazon.com>
