### PR TITLE
perf(core): vectored zero-copy send for large command args

### DIFF
--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
 name = "glide-ffi"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "glide-core",
  "lazy_static",
  "libc",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Valkey GLIDE Maintainers"]
 crate-type = ["staticlib", "rlib", "cdylib"]
 
 [dependencies]
+bytes = "1"
 libc = "0.2"
 protobuf = { version = "3", features = [] }
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -491,12 +491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,9 +730,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "file-rotate"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3ed82142801f5b1363f7d463963d114db80f467e860b1cd82228eaebc627a0"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
 dependencies = [
  "chrono",
  "flate2",
@@ -1013,20 +1007,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1370,27 +1358,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1498,11 +1491,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1555,6 +1548,7 @@ dependencies = [
 name = "miri-tests"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "libc",
  "mock-glide-core",
  "mock-logger-core",
@@ -1585,6 +1579,7 @@ version = "0.1.0"
 name = "mock-redis"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "mock-telemetry",
  "redis",
  "url",
@@ -2110,8 +2105,8 @@ dependencies = [
  "rustls-platform-verifier",
  "ryu",
  "socket2",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "telemetrylib",
  "tokio",
  "tokio-retry2 0.5.8",
@@ -2283,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2477,6 +2472,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,9 +2523,9 @@ checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -2531,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3288,20 +3299,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3310,7 +3312,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3324,40 +3326,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3367,21 +3348,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3397,21 +3366,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3421,21 +3378,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/ffi/miri-tests/Cargo.toml
+++ b/ffi/miri-tests/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bytes = "1"
 libc = "0.2"
 protobuf = { version = "3", features = [] }
 serde_json = "1.0"

--- a/ffi/miri-tests/mock-redis/Cargo.toml
+++ b/ffi/miri-tests/mock-redis/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+bytes = "1"
 redis = { path = "../../../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }
 telemetrylib = { path = "../mock-telemetry", package = "mock-telemetry" }
 url = "2"

--- a/ffi/miri-tests/mock-redis/src/lib.rs
+++ b/ffi/miri-tests/mock-redis/src/lib.rs
@@ -30,6 +30,7 @@ pub use cluster_routing::*;
 pub use cluster_topology::*;
 
 pub use redis::ToRedisArgs;
+pub use redis::SHARED_ARG_INLINE_MAX;
 
 pub struct Cmd {
     command_bytes: Vec<u8>,
@@ -47,6 +48,10 @@ impl Routable for Cmd {}
 
 impl Cmd {
     pub fn arg<T: ToRedisArgs>(&mut self, _arg: T) -> &mut Cmd {
+        self
+    }
+
+    pub fn arg_shared(&mut self, _arg: bytes::Bytes) -> &mut Cmd {
         self
     }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3037,6 +3037,31 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
 /// a scalar reply, one buffer per element for an array reply).
 ///
 /// # Safety
+/// Append a caller-provided argument to `cmd` with minimal copying.
+///
+/// Large payloads are copied ONCE at the FFI boundary into a refcounted
+/// `Bytes` (the caller's buffer is only guaranteed to live until this call
+/// returns) and then written to the socket zero-copy via vectored I/O —
+/// instead of being copied again at packing and encode time. Small args are
+/// inlined as before.
+fn append_cmd_arg(cmd: &mut Cmd, arg: &[u8]) {
+    if arg.len() > redis::SHARED_ARG_INLINE_MAX {
+        cmd.arg_shared(bytes::Bytes::copy_from_slice(arg));
+    } else {
+        cmd.arg(arg);
+    }
+}
+
+/// Like [`append_cmd_arg`] for owned buffers (compressed args): `Vec<u8>` to
+/// `Bytes` conversion is zero-copy, so large args are never copied at all.
+fn append_cmd_arg_owned(cmd: &mut Cmd, arg: Vec<u8>) {
+    if arg.len() > redis::SHARED_ARG_INLINE_MAX {
+        cmd.arg_shared(bytes::Bytes::from(arg));
+    } else {
+        cmd.arg(arg);
+    }
+}
+
 /// `client_adapter_ptr` and `args`/`args_len` follow the same contract as
 /// [`command_with_buffer`]. `route_input` follows the safety contract
 /// documented on [`RouteInput::resolve`]. Any buffers referenced by
@@ -3118,14 +3143,14 @@ unsafe fn execute_command(
             return unsafe { client_adapter.handle_redis_error(err, request_id) };
         }
 
-        // Use the compressed arguments
-        for command_arg in &owned_args {
-            cmd.arg(command_arg);
+        // Use the compressed arguments (owned: Vec->Bytes is zero-copy)
+        for command_arg in owned_args {
+            append_cmd_arg_owned(&mut cmd, command_arg);
         }
     } else {
         // Use the original arguments
         for command_arg in &arg_vec {
-            cmd.arg(command_arg);
+            append_cmd_arg(&mut cmd, command_arg);
         }
     }
 
@@ -4212,14 +4237,14 @@ pub(crate) unsafe fn create_cmd(
             return Err(format!("Compression failed: {}", err));
         }
 
-        // Use the compressed arguments
-        for command_arg in &owned_args {
-            cmd.arg(command_arg);
+        // Use the compressed arguments (owned: Vec->Bytes is zero-copy)
+        for command_arg in owned_args {
+            append_cmd_arg_owned(&mut cmd, command_arg);
         }
     } else {
         // Use the original arguments
         for command_arg in &arg_vec {
-            cmd.arg(command_arg);
+            append_cmd_arg(&mut cmd, command_arg);
         }
     }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3045,11 +3045,13 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
 /// instead of being copied again at packing and encode time. Small args are
 /// inlined as before.
 fn append_cmd_arg(cmd: &mut Cmd, arg: &[u8]) {
-    if arg.len() > redis::SHARED_ARG_INLINE_MAX {
-        cmd.arg_shared(bytes::Bytes::copy_from_slice(arg));
-    } else {
-        cmd.arg(arg);
-    }
+    // `write_arg` auto-shares large args (> SHARED_ARG_INLINE_MAX) through
+    // the recycled buffer pool: one pooled copy at the FFI boundary, then
+    // zero-copy vectored I/O to the socket. A direct
+    // `Bytes::copy_from_slice` here would allocate fresh per command and
+    // re-introduce page-fault churn under pipelined load (the buffer lives
+    // until the socket write completes).
+    cmd.arg(arg);
 }
 
 /// Like [`append_cmd_arg`] for owned buffers (compressed args): `Vec<u8>` to

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -44,7 +44,7 @@ url = "2"
 combine = { version = "4", default-features = false, features = ["std"] }
 
 # Only needed for AIO
-bytes = { version = "1", optional = true }
+bytes = { version = "1" }
 futures-util = { version = "0.3", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }
@@ -99,7 +99,6 @@ default = [
     "tls-rustls-insecure",
 ]
 aio = [
-    "bytes",
     "pin-project-lite",
     "futures-util",
     "futures-util/alloc",

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -44,7 +44,7 @@ url = "2"
 combine = { version = "4", default-features = false, features = ["std"] }
 
 # Only needed for AIO
-bytes = { version = "1" }
+bytes = { version = "1.9" }
 futures-util = { version = "0.3", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.7", optional = true }

--- a/glide-core/redis-rs/redis/examples/zc_sync_set.rs
+++ b/glide-core/redis-rs/redis/examples/zc_sync_set.rs
@@ -1,0 +1,49 @@
+//! Sync (blocking) connection SET throughput/CPU benchmark.
+//!
+//! Isolates the sync `Connection::req_command` send path: single blocking
+//! connection, SET of a fixed-size payload in a tight loop. No pipelining —
+//! each SET is one request/response round trip, so this measures the
+//! per-command send cost (where the vectored/zero-copy send lands).
+//!
+//! Usage: zc_sync_set <port> <mode:arg|shared> <value_size> <total_ops>
+use redis::ConnectionLike;
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let port: u16 = args[1].parse().unwrap();
+    let mode = args[2].clone();
+    let size: usize = args[3].parse().unwrap();
+    let total_ops: usize = args[4].parse().unwrap();
+
+    let client = redis::Client::open(format!("redis://127.0.0.1:{port}")).unwrap();
+    let mut con = client.get_connection(None).unwrap();
+
+    let payload = vec![b'x'; size];
+    let shared = bytes::Bytes::from(payload.clone());
+
+    let start = Instant::now();
+    for i in 0..total_ops {
+        let mut cmd = redis::cmd("SET");
+        cmd.arg(format!("zc:{}", i % 100));
+        match mode.as_str() {
+            // Plain arg() — large payloads auto-share inside write_arg.
+            "arg" => {
+                cmd.arg(&payload[..]);
+            }
+            // Explicit arg_shared — zero-copy from the caller's Bytes.
+            "shared" => {
+                cmd.arg_shared(shared.clone());
+            }
+            _ => panic!("bad mode"),
+        }
+        let v = con.req_command(&cmd).unwrap();
+        assert_eq!(v, redis::Value::Okay);
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "sync-set mode={mode} size={size} ops={total_ops} elapsed={:.3}s ops_per_sec={:.0}",
+        elapsed.as_secs_f64(),
+        total_ops as f64 / elapsed.as_secs_f64()
+    );
+}

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -23,6 +23,52 @@ use futures_util::{
 };
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
+
+/// Write all segments of a packed command to an async stream using vectored
+/// I/O, so large shared payloads ([`crate::cmd::SegmentedBytes`]) go straight
+/// to the socket without being copied into an intermediate buffer. Handles
+/// partial writes by advancing a `(segment, offset)` cursor (MSRV-compatible,
+/// avoids the 1.81 `IoSlice::advance_slices`).
+async fn write_all_segments_async<W>(
+    con: &mut W,
+    segments: &crate::cmd::SegmentedBytes,
+) -> RedisResult<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    use std::io::IoSlice;
+    const MAX_SLICES: usize = 64;
+    let segs = segments.segments().collect::<Vec<_>>();
+    let mut idx = 0;
+    let mut offset = 0;
+    while idx < segs.len() {
+        let end = std::cmp::min(idx + MAX_SLICES, segs.len());
+        let mut slices: Vec<IoSlice> = Vec::with_capacity(end - idx);
+        slices.push(IoSlice::new(&segs[idx][offset..]));
+        for seg in &segs[idx + 1..end] {
+            slices.push(IoSlice::new(seg));
+        }
+        let mut n = con.write_vectored(&slices).await?;
+        if n == 0 {
+            return Err(RedisError::from(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "failed to write whole command",
+            )));
+        }
+        while n > 0 {
+            let remaining = segs[idx].len() - offset;
+            if n >= remaining {
+                n -= remaining;
+                idx += 1;
+                offset = 0;
+            } else {
+                offset += n;
+                n = 0;
+            }
+        }
+    }
+    Ok(())
+}
 #[cfg(feature = "tokio-comp")]
 use tokio_util::codec::Decoder;
 
@@ -179,8 +225,12 @@ where
                 self.exit_pubsub().await?;
             }
             self.buf.clear();
-            cmd.write_packed_command(&mut self.buf);
-            self.con.write_all(&self.buf).await?;
+            if cmd.has_out_of_line_args() {
+                write_all_segments_async(&mut self.con, &cmd.get_packed_segments()).await?;
+            } else {
+                cmd.write_packed_command(&mut self.buf);
+                self.con.write_all(&self.buf).await?;
+            }
             if cmd.is_no_response() {
                 return Ok(Value::Nil);
             }
@@ -207,8 +257,13 @@ where
             }
 
             self.buf.clear();
-            cmd.write_packed_pipeline(&mut self.buf);
-            self.con.write_all(&self.buf).await?;
+            if cmd.commands().iter().any(|c| c.has_out_of_line_args()) {
+                write_all_segments_async(&mut self.con, &cmd.get_packed_pipeline_segments())
+                    .await?;
+            } else {
+                cmd.write_packed_pipeline(&mut self.buf);
+                self.con.write_all(&self.buf).await?;
+            }
 
             let mut first_err = None;
 

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -31,11 +31,176 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::task::{self, Poll};
 use std::time::Duration;
-#[cfg(feature = "tokio-comp")]
-use tokio_util::codec::Decoder;
 
 // Default connection timeout in ms
 const DEFAULT_CONNECTION_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(2000);
+
+/// Flush-directly threshold for the vectored sink's queued bytes. Above this,
+/// `poll_ready` applies backpressure by flushing before accepting more items.
+const VECTORED_SINK_HIGH_WATERMARK: usize = 512 * 1024;
+/// Max iovec entries per `write_vectored` call (typical kernel UIO_MAXIOV is
+/// 1024; 64 keeps the stack array small while amortizing syscalls well).
+const MAX_WRITE_SLICES: usize = 64;
+
+pin_project! {
+    /// Send-side zero-copy sink: queues the segments of packed commands and
+    /// writes them with vectored I/O. Large shared payloads
+    /// ([`crate::cmd::SegmentedBytes`]) go from the caller's allocation
+    /// straight to the socket without ever being copied into a write buffer.
+    struct VectoredSink<W> {
+        #[pin]
+        writer: W,
+        queue: VecDeque<bytes::Bytes>,
+        queued_bytes: usize,
+    }
+}
+
+impl<W> VectoredSink<W> {
+    fn new(writer: W) -> Self {
+        VectoredSink {
+            writer,
+            queue: VecDeque::new(),
+            queued_bytes: 0,
+        }
+    }
+}
+
+impl<W: AsyncWrite> VectoredSink<W> {
+    /// Drive queued segments into the writer. Completes when the queue is
+    /// empty and the writer is flushed.
+    fn poll_flush_queue(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context,
+    ) -> Poll<Result<(), RedisError>> {
+        let mut this = self.project();
+        loop {
+            if this.queue.is_empty() {
+                return this
+                    .writer
+                    .as_mut()
+                    .poll_flush(cx)
+                    .map_err(RedisError::from);
+            }
+            let mut slices = [std::io::IoSlice::new(&[]); MAX_WRITE_SLICES];
+            let mut n = 0;
+            for seg in this.queue.iter().take(MAX_WRITE_SLICES) {
+                slices[n] = std::io::IoSlice::new(seg);
+                n += 1;
+            }
+            match ready!(this.writer.as_mut().poll_write_vectored(cx, &slices[..n])) {
+                Ok(0) => {
+                    return Poll::Ready(Err(RedisError::from(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write queued segments to socket",
+                    ))));
+                }
+                Ok(mut written) => {
+                    *this.queued_bytes -= written;
+                    while written > 0 {
+                        let front = this.queue.front_mut().expect("queue can't be empty");
+                        if written >= front.len() {
+                            written -= front.len();
+                            this.queue.pop_front();
+                        } else {
+                            bytes::Buf::advance(front, written);
+                            written = 0;
+                        }
+                    }
+                }
+                Err(err) => return Poll::Ready(Err(err.into())),
+            }
+        }
+    }
+}
+
+impl<W: AsyncWrite> Sink<crate::cmd::SegmentedBytes> for VectoredSink<W> {
+    type Error = RedisError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        if self.queued_bytes <= VECTORED_SINK_HIGH_WATERMARK {
+            return Poll::Ready(Ok(()));
+        }
+        // Backpressure: drain before accepting more.
+        self.poll_flush_queue(cx)
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: crate::cmd::SegmentedBytes,
+    ) -> Result<(), Self::Error> {
+        let this = self.project();
+        for segment in item.into_segments() {
+            if !segment.is_empty() {
+                *this.queued_bytes += segment.len();
+                this.queue.push_back(segment);
+            }
+        }
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.poll_flush_queue(cx)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context,
+    ) -> Poll<Result<(), Self::Error>> {
+        ready!(self.as_mut().poll_flush_queue(cx))?;
+        self.project()
+            .writer
+            .poll_shutdown(cx)
+            .map_err(RedisError::from)
+    }
+}
+
+pin_project! {
+    /// Combines the decode stream (read half) and the vectored sink (write
+    /// half) back into one `Stream + Sink` object for [`Pipeline::new`].
+    struct SplitSinkStream<R, W> {
+        #[pin]
+        read: R,
+        #[pin]
+        write: W,
+    }
+}
+
+impl<R, W> Stream for SplitSinkStream<R, W>
+where
+    R: Stream<Item = RedisResult<Value>>,
+{
+    type Item = RedisResult<Value>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
+        self.project().read.poll_next(cx)
+    }
+}
+
+impl<R, W> Sink<crate::cmd::SegmentedBytes> for SplitSinkStream<R, W>
+where
+    W: Sink<crate::cmd::SegmentedBytes, Error = RedisError>,
+{
+    type Error = RedisError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.project().write.poll_ready(cx)
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: crate::cmd::SegmentedBytes,
+    ) -> Result<(), Self::Error> {
+        self.project().write.start_send(item)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.project().write.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
+        self.project().write.poll_close(cx)
+    }
+}
 
 // Senders which the result of a single request are sent through
 type PipelineOutput = oneshot::Sender<RedisResult<Value>>;
@@ -799,7 +964,7 @@ where
 /// on the same underlying connection (tcp/unix socket).
 #[derive(Clone)]
 pub struct MultiplexedConnection {
-    pipeline: Pipeline<Vec<u8>>,
+    pipeline: Pipeline<crate::cmd::SegmentedBytes>,
     db: i64,
     response_timeout: Duration,
     protocol: ProtocolVersion,
@@ -849,9 +1014,13 @@ impl MultiplexedConnection {
     where
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
-        let codec = ValueCodec::default()
-            .framed(stream)
+        let (read_half, write_half) = ::tokio::io::split(stream);
+        let read_stream = tokio_util::codec::FramedRead::new(read_half, ValueCodec::default())
             .and_then(|msg| async move { msg });
+        let codec = SplitSinkStream {
+            read: read_stream,
+            write: VectoredSink::new(write_half),
+        };
         let (mut pipeline, driver) = Pipeline::new(
             codec,
             glide_connection_options.disconnect_notifier,
@@ -921,7 +1090,7 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_single(
-                cmd.get_packed_command(),
+                cmd.get_packed_segments(),
                 timeout,
                 cmd.is_fenced(),
                 cmd.is_blocking(),
@@ -962,7 +1131,7 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_recv(
-                cmd.get_packed_pipeline(),
+                cmd.get_packed_pipeline_segments(),
                 Some(offset + count),
                 self.response_timeout,
                 cmd.is_atomic(),
@@ -1014,7 +1183,9 @@ impl MultiplexedConnection {
     }
 
     /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
-    pub(crate) fn builder(pipeline: Pipeline<Vec<u8>>) -> MultiplexedConnectionBuilder {
+    pub(crate) fn builder(
+        pipeline: Pipeline<crate::cmd::SegmentedBytes>,
+    ) -> MultiplexedConnectionBuilder {
         MultiplexedConnectionBuilder::new(pipeline)
     }
 
@@ -1029,7 +1200,7 @@ impl MultiplexedConnection {
 
 /// A builder for creating `MultiplexedConnection` instances.
 pub struct MultiplexedConnectionBuilder {
-    pipeline: Pipeline<Vec<u8>>,
+    pipeline: Pipeline<crate::cmd::SegmentedBytes>,
     db: Option<i64>,
     response_timeout: Option<Duration>,
     push_manager: Option<PushManager>,
@@ -1043,7 +1214,7 @@ pub struct MultiplexedConnectionBuilder {
 
 impl MultiplexedConnectionBuilder {
     /// Creates a new builder with the required pipeline
-    pub(crate) fn new(pipeline: Pipeline<Vec<u8>>) -> Self {
+    pub(crate) fn new(pipeline: Pipeline<crate::cmd::SegmentedBytes>) -> Self {
         Self {
             pipeline,
             db: None,
@@ -1627,7 +1798,7 @@ mod tests {
         // If poll_read is called during poll_ready (the fix), this response will be
         // delivered to cmd1_handle. If not (the bug), cmd1_handle will hang.
         resp_tx
-            .try_send(Ok(Value::BulkString(b"response1".to_vec())))
+            .try_send(Ok(Value::BulkString(b"response1".to_vec().into())))
             .expect("Failed to inject response");
 
         // Wait for command #1 to complete — with the bug, this times out
@@ -1640,7 +1811,7 @@ mod tests {
 
         match result {
             Ok(Ok(Ok(value))) => {
-                assert_eq!(value, Value::BulkString(b"response1".to_vec()));
+                assert_eq!(value, Value::BulkString(b"response1".to_vec().into()));
             }
             Ok(Ok(Err(e))) => {
                 panic!("Command 1 returned error: {:?}", e);

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -1798,7 +1798,7 @@ mod tests {
         // If poll_read is called during poll_ready (the fix), this response will be
         // delivered to cmd1_handle. If not (the bug), cmd1_handle will hang.
         resp_tx
-            .try_send(Ok(Value::BulkString(b"response1".to_vec().into())))
+            .try_send(Ok(Value::BulkString(b"response1".to_vec())))
             .expect("Failed to inject response");
 
         // Wait for command #1 to complete — with the bug, this times out
@@ -1811,7 +1811,7 @@ mod tests {
 
         match result {
             Ok(Ok(Ok(value))) => {
-                assert_eq!(value, Value::BulkString(b"response1".to_vec().into()));
+                assert_eq!(value, Value::BulkString(b"response1".to_vec()));
             }
             Ok(Ok(Err(e))) => {
                 panic!("Command 1 returned error: {:?}", e);

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -113,7 +113,7 @@ impl<W: AsyncWrite> VectoredSink<W> {
     }
 }
 
-impl<W: AsyncWrite> Sink<crate::cmd::SegmentedBytes> for VectoredSink<W> {
+impl<W: AsyncWrite> Sink<crate::cmd::SendBuf> for VectoredSink<W> {
     type Error = RedisError;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::Error>> {
@@ -124,15 +124,24 @@ impl<W: AsyncWrite> Sink<crate::cmd::SegmentedBytes> for VectoredSink<W> {
         self.poll_flush_queue(cx)
     }
 
-    fn start_send(
-        self: Pin<&mut Self>,
-        item: crate::cmd::SegmentedBytes,
-    ) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: crate::cmd::SendBuf) -> Result<(), Self::Error> {
         let this = self.project();
-        for segment in item.into_segments() {
-            if !segment.is_empty() {
-                *this.queued_bytes += segment.len();
-                this.queue.push_back(segment);
+        match item {
+            crate::cmd::SendBuf::Contiguous(buf) => {
+                if !buf.is_empty() {
+                    *this.queued_bytes += buf.len();
+                    // from_owner: avoids Bytes::from(Vec)'s shrink-realloc
+                    // on excess capacity.
+                    this.queue.push_back(bytes::Bytes::from_owner(buf));
+                }
+            }
+            crate::cmd::SendBuf::Segmented(segments) => {
+                for segment in segments.into_segments() {
+                    if !segment.is_empty() {
+                        *this.queued_bytes += segment.len();
+                        this.queue.push_back(segment);
+                    }
+                }
             }
         }
         Ok(())
@@ -176,9 +185,9 @@ where
     }
 }
 
-impl<R, W> Sink<crate::cmd::SegmentedBytes> for SplitSinkStream<R, W>
+impl<R, W> Sink<crate::cmd::SendBuf> for SplitSinkStream<R, W>
 where
-    W: Sink<crate::cmd::SegmentedBytes, Error = RedisError>,
+    W: Sink<crate::cmd::SendBuf, Error = RedisError>,
 {
     type Error = RedisError;
 
@@ -186,10 +195,7 @@ where
         self.project().write.poll_ready(cx)
     }
 
-    fn start_send(
-        self: Pin<&mut Self>,
-        item: crate::cmd::SegmentedBytes,
-    ) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: crate::cmd::SendBuf) -> Result<(), Self::Error> {
         self.project().write.start_send(item)
     }
 
@@ -964,7 +970,7 @@ where
 /// on the same underlying connection (tcp/unix socket).
 #[derive(Clone)]
 pub struct MultiplexedConnection {
-    pipeline: Pipeline<crate::cmd::SegmentedBytes>,
+    pipeline: Pipeline<crate::cmd::SendBuf>,
     db: i64,
     response_timeout: Duration,
     protocol: ProtocolVersion,
@@ -1090,7 +1096,13 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_single(
-                cmd.get_packed_segments(),
+                // Commands with no out-of-line payloads skip the segmented
+                // representation entirely (see SendBuf::Contiguous).
+                if cmd.has_out_of_line_args() {
+                    crate::cmd::SendBuf::Segmented(cmd.get_packed_segments())
+                } else {
+                    crate::cmd::SendBuf::Contiguous(cmd.get_packed_command())
+                },
                 timeout,
                 cmd.is_fenced(),
                 cmd.is_blocking(),
@@ -1131,7 +1143,7 @@ impl MultiplexedConnection {
         let result = self
             .pipeline
             .send_recv(
-                cmd.get_packed_pipeline_segments(),
+                crate::cmd::SendBuf::Segmented(cmd.get_packed_pipeline_segments()),
                 Some(offset + count),
                 self.response_timeout,
                 cmd.is_atomic(),
@@ -1183,9 +1195,7 @@ impl MultiplexedConnection {
     }
 
     /// Creates a new `MultiplexedConnectionBuilder` for constructing a `MultiplexedConnection`.
-    pub(crate) fn builder(
-        pipeline: Pipeline<crate::cmd::SegmentedBytes>,
-    ) -> MultiplexedConnectionBuilder {
+    pub(crate) fn builder(pipeline: Pipeline<crate::cmd::SendBuf>) -> MultiplexedConnectionBuilder {
         MultiplexedConnectionBuilder::new(pipeline)
     }
 
@@ -1200,7 +1210,7 @@ impl MultiplexedConnection {
 
 /// A builder for creating `MultiplexedConnection` instances.
 pub struct MultiplexedConnectionBuilder {
-    pipeline: Pipeline<crate::cmd::SegmentedBytes>,
+    pipeline: Pipeline<crate::cmd::SendBuf>,
     db: Option<i64>,
     response_timeout: Option<Duration>,
     push_manager: Option<PushManager>,
@@ -1214,7 +1224,7 @@ pub struct MultiplexedConnectionBuilder {
 
 impl MultiplexedConnectionBuilder {
     /// Creates a new builder with the required pipeline
-    pub(crate) fn new(pipeline: Pipeline<crate::cmd::SegmentedBytes>) -> Self {
+    pub(crate) fn new(pipeline: Pipeline<crate::cmd::SendBuf>) -> Self {
         Self {
             pipeline,
             db: None,

--- a/glide-core/redis-rs/redis/src/buf_pool.rs
+++ b/glide-core/redis-rs/redis/src/buf_pool.rs
@@ -1,0 +1,121 @@
+//! Recycled buffer pool for large transient payload copies.
+//!
+//! Two hot paths briefly need an owned buffer of tens-to-hundreds of KB whose
+//! lifetime is tied to a refcounted [`Bytes`]:
+//!
+//! - the RESP decoder copies each complete frame out of the read buffer
+//!   (`ValueCodec::decode_stream`), and
+//! - command building copies large borrowed args into shared payload segments
+//!   (`Cmd`'s `write_arg` auto-share).
+//!
+//! Allocating these buffers fresh per operation causes page-fault churn under
+//! pipelined load: with N requests in flight, N large buffers are alive
+//! concurrently, the allocator cannot recycle freed ones fast enough, and
+//! every new allocation's pages must be faulted in on first touch. Profiling
+//! against a real network peer showed this fault handling dominating client
+//! CPU at 64 KB payloads (30% of cycles, ~37 faults/op at pipeline depth 16).
+//!
+//! The pool recycles the underlying allocations so pages stay resident: a
+//! buffer returns here when the last `Bytes` referencing it drops, and the
+//! next operation reuses it (already-faulted pages) instead of allocating.
+
+use std::sync::Mutex;
+
+use bytes::Bytes;
+
+/// Copies at or below this size bypass the pool: the allocator's small size
+/// classes recycle them well and they touch few fresh pages.
+pub(crate) const POOL_MIN: usize = 4 * 1024;
+
+/// Buffers larger than this are not retained, so a burst of huge values
+/// cannot leave large allocations parked in the pool.
+const POOL_MAX_BUF_CAPACITY: usize = 1024 * 1024;
+
+/// Maximum number of retained idle buffers. In-flight buffers are not
+/// counted; this only bounds idle memory
+/// (`POOL_MAX_COUNT * POOL_MAX_BUF_CAPACITY` worst case).
+const POOL_MAX_COUNT: usize = 64;
+
+static POOL: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+
+/// Owner type handed to [`Bytes::from_owner`]; returns its allocation to the
+/// pool when the last referencing `Bytes` drops.
+struct PooledBuf(Vec<u8>);
+
+impl AsRef<[u8]> for PooledBuf {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Drop for PooledBuf {
+    fn drop(&mut self) {
+        let buf = std::mem::take(&mut self.0);
+        if buf.capacity() == 0 || buf.capacity() > POOL_MAX_BUF_CAPACITY {
+            return;
+        }
+        // A poisoned lock only means another thread panicked mid push/pop;
+        // the Vec is still structurally valid, so keep recycling.
+        let mut pool = POOL.lock().unwrap_or_else(|e| e.into_inner());
+        if pool.len() < POOL_MAX_COUNT {
+            pool.push(buf);
+        }
+    }
+}
+
+/// Copy `data` into a recycled buffer and return it as [`Bytes`].
+///
+/// The backing allocation returns to the pool when the returned `Bytes` (and
+/// every clone/slice of it) has dropped. Small copies (≤ [`POOL_MIN`]) use a
+/// plain [`Bytes::copy_from_slice`].
+pub(crate) fn pooled_bytes_from_slice(data: &[u8]) -> Bytes {
+    if data.len() <= POOL_MIN {
+        return Bytes::copy_from_slice(data);
+    }
+    let mut buf = {
+        let mut pool = POOL.lock().unwrap_or_else(|e| e.into_inner());
+        pool.pop().unwrap_or_default()
+    };
+    buf.clear();
+    buf.extend_from_slice(data);
+    Bytes::from_owner(PooledBuf(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_and_reuse() {
+        let payload = vec![7u8; POOL_MIN + 1];
+        let b = pooled_bytes_from_slice(&payload);
+        assert_eq!(&b[..], &payload[..]);
+        // Slices keep the buffer alive; dropping all of them recycles it.
+        let slice = b.slice(1..100);
+        drop(b);
+        assert_eq!(&slice[..], &payload[1..100]);
+        drop(slice);
+
+        // The next request should be able to reuse a pooled allocation and
+        // must return the right contents regardless.
+        let payload2 = vec![9u8; POOL_MIN + 512];
+        let b2 = pooled_bytes_from_slice(&payload2);
+        assert_eq!(&b2[..], &payload2[..]);
+    }
+
+    #[test]
+    fn small_copies_bypass_pool() {
+        let payload = vec![1u8; 16];
+        let b = pooled_bytes_from_slice(&payload);
+        assert_eq!(&b[..], &payload[..]);
+    }
+
+    #[test]
+    fn oversized_buffers_not_retained() {
+        let big = vec![3u8; POOL_MAX_BUF_CAPACITY + 1];
+        let b = pooled_bytes_from_slice(&big);
+        assert_eq!(b.len(), big.len());
+        // Exercises the oversized drop branch (buffer freed, not pooled).
+        drop(b);
+    }
+}

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -430,8 +430,16 @@ impl RedisWrite for Cmd {
         if arg.len() > SHARED_ARG_INLINE_MAX {
             // One copy into an owned refcounted buffer, then zero-copy all
             // the way to the socket (skips the packing and encode copies).
+            // The buffer comes from the recycled pool: it stays alive until
+            // the socket write completes, so at pipeline depth N there are N
+            // such buffers in flight — allocating them fresh per command
+            // caused page-fault churn that dominated client CPU (~37
+            // faults/op at 64 KB, depth 16). Pooling keeps the pages
+            // resident across commands.
             self.args
-                .push(StoredArg::Shared(bytes::Bytes::copy_from_slice(arg)));
+                .push(StoredArg::Shared(crate::buf_pool::pooled_bytes_from_slice(
+                    arg,
+                )));
         } else {
             self.data.extend_from_slice(arg);
             self.args.push(StoredArg::Inline(self.data.len()));

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -23,6 +23,20 @@ pub enum Arg<D> {
     Cursor,
 }
 
+/// Internal argument storage. Inline arguments live contiguously in
+/// `Cmd::data` (cheap for small args); large payloads are stored out-of-line
+/// as refcounted [`bytes::Bytes`] so they are never copied into the command
+/// buffer (send-side zero-copy).
+#[derive(Clone)]
+enum StoredArg {
+    /// End offset of an inline argument in `Cmd::data`.
+    Inline(usize),
+    /// Refcounted shared payload stored out-of-line.
+    Shared(bytes::Bytes),
+    /// A cursor placeholder created from `cursor_arg()`.
+    Cursor,
+}
+
 /// Atomic phase value: command is queued but not yet sent.
 pub const PHASE_QUEUED: u8 = 0;
 /// Atomic phase value: command has been sent to a node.
@@ -31,8 +45,7 @@ pub const PHASE_SENT: u8 = 1;
 /// Represents redis commands.
 pub struct Cmd {
     data: Vec<u8>,
-    // Arg::Simple contains the offset that marks the end of the argument
-    args: Vec<Arg<usize>>,
+    args: Vec<StoredArg>,
     cursor: Option<u64>,
     // If it's true command's response won't be read from socket. Useful for Pub/Sub.
     no_response: bool,
@@ -346,16 +359,89 @@ where
     Ok(())
 }
 
+/// Payloads at or below this size are inlined into the command buffer by
+/// [`Cmd::arg_shared`]; larger payloads are kept as refcounted segments and
+/// written to the socket via vectored I/O without ever being copied into a
+/// command or write buffer.
+pub const SHARED_ARG_INLINE_MAX: usize = 4 * 1024;
+
+/// A packed command (or pipeline of commands) represented as a sequence of
+/// byte segments for vectored socket writes.
+///
+/// Protocol framing and small inline arguments coalesce into contiguous
+/// segments; large shared payloads ([`Cmd::arg_shared`]) appear as their own
+/// refcounted segments pointing at the caller's allocation.
+#[derive(Debug, Default, Clone)]
+pub struct SegmentedBytes {
+    segments: Vec<bytes::Bytes>,
+    len: usize,
+}
+
+impl SegmentedBytes {
+    /// Append a segment. Empty segments are dropped.
+    pub fn push(&mut self, bytes: bytes::Bytes) {
+        if !bytes.is_empty() {
+            self.len += bytes.len();
+            self.segments.push(bytes);
+        }
+    }
+
+    /// Total byte length across all segments.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// True if there are no bytes.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Iterate over the segments.
+    pub fn segments(&self) -> impl ExactSizeIterator<Item = &bytes::Bytes> {
+        self.segments.iter()
+    }
+
+    /// Consume into the underlying segment list.
+    pub fn into_segments(self) -> Vec<bytes::Bytes> {
+        self.segments
+    }
+
+    /// Concatenate all segments into one contiguous buffer (used by tests and
+    /// non-vectored fallbacks).
+    pub fn to_contiguous(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.len);
+        for seg in &self.segments {
+            out.extend_from_slice(seg);
+        }
+        out
+    }
+}
+
+impl From<Vec<u8>> for SegmentedBytes {
+    fn from(buf: Vec<u8>) -> Self {
+        let mut out = SegmentedBytes::default();
+        out.push(bytes::Bytes::from(buf));
+        out
+    }
+}
+
 impl RedisWrite for Cmd {
     fn write_arg(&mut self, arg: &[u8]) {
-        self.data.extend_from_slice(arg);
-        self.args.push(Arg::Simple(self.data.len()));
+        if arg.len() > SHARED_ARG_INLINE_MAX {
+            // One copy into an owned refcounted buffer, then zero-copy all
+            // the way to the socket (skips the packing and encode copies).
+            self.args
+                .push(StoredArg::Shared(bytes::Bytes::copy_from_slice(arg)));
+        } else {
+            self.data.extend_from_slice(arg);
+            self.args.push(StoredArg::Inline(self.data.len()));
+        }
     }
 
     fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
         use std::io::Write;
         write!(self.data, "{arg}").unwrap();
-        self.args.push(Arg::Simple(self.data.len()));
+        self.args.push(StoredArg::Inline(self.data.len()));
     }
 }
 
@@ -455,6 +541,24 @@ impl Cmd {
         self
     }
 
+    /// Appends a binary argument without copying it into the command buffer.
+    ///
+    /// Payloads larger than [`SHARED_ARG_INLINE_MAX`] are stored as
+    /// refcounted [`bytes::Bytes`] and written to the socket directly from
+    /// the caller's allocation (vectored write) — the send-side zero-copy
+    /// path. Smaller payloads are inlined like a normal `arg()`, which is
+    /// cheaper than scatter-gather at small sizes.
+    #[inline]
+    pub fn arg_shared(&mut self, arg: bytes::Bytes) -> &mut Cmd {
+        if arg.len() <= SHARED_ARG_INLINE_MAX {
+            use crate::types::RedisWrite;
+            self.write_arg(&arg);
+        } else {
+            self.args.push(StoredArg::Shared(arg));
+        }
+        self
+    }
+
     /// Associate a trackable span to the command. This allow tracking the lifetime
     /// of the command.
     ///
@@ -484,7 +588,7 @@ impl Cmd {
     pub fn cursor_arg(&mut self, cursor: u64) -> &mut Cmd {
         assert!(!self.in_scan_mode());
         self.cursor = Some(cursor);
-        self.args.push(Arg::Cursor);
+        self.args.push(StoredArg::Cursor);
         self
     }
 
@@ -494,6 +598,87 @@ impl Cmd {
         let mut cmd = Vec::new();
         self.write_packed_command(&mut cmd);
         cmd
+    }
+
+    /// Returns the packed command as segments for vectored writes.
+    ///
+    /// Byte-identical on the wire to [`Cmd::get_packed_command`], but large
+    /// shared payloads ([`Cmd::arg_shared`]) are emitted as their own
+    /// refcounted segments instead of being copied into the packed buffer.
+    #[inline]
+    pub fn get_packed_segments(&self) -> SegmentedBytes {
+        let mut out = SegmentedBytes::default();
+        let mut scratch = Vec::new();
+        self.write_packed_segments(&mut out, &mut scratch);
+        out.push(bytes::Bytes::from(scratch));
+        out
+    }
+
+    /// Append this command's packed form to `out`, coalescing framing and
+    /// inline args into `scratch`. `scratch` is only flushed to `out` at
+    /// shared-payload boundaries — the caller MUST flush the remaining
+    /// `scratch` into `out` after the last command (as
+    /// [`Cmd::get_packed_segments`] does), so consecutive small commands
+    /// share one contiguous segment.
+    pub(crate) fn write_packed_segments(&self, out: &mut SegmentedBytes, scratch: &mut Vec<u8>) {
+        let mut int_buf = ::itoa::Buffer::new();
+
+        // Reserve for everything that lands in scratch: all inline payloads
+        // (self.data) plus per-arg framing. Without this, large inline args
+        // pay repeated Vec-growth reallocs (the contiguous packer reserves
+        // exactly, see write_command_to_vec).
+        scratch.reserve(
+            self.data.len()
+                + 32 * (self.args.len() + 1)
+                + if self.is_fenced {
+                    FENCE_COMMAND.len()
+                } else {
+                    0
+                },
+        );
+
+        scratch.push(b'*');
+        scratch.extend_from_slice(int_buf.format(self.args.len()).as_bytes());
+        scratch.extend_from_slice(b"\r\n");
+
+        let mut prev = 0;
+        for arg in &self.args {
+            match arg {
+                StoredArg::Inline(i) => {
+                    let payload = &self.data[prev..*i];
+                    prev = *i;
+                    scratch.push(b'$');
+                    scratch.extend_from_slice(int_buf.format(payload.len()).as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                    scratch.extend_from_slice(payload);
+                    scratch.extend_from_slice(b"\r\n");
+                }
+                StoredArg::Cursor => {
+                    let cursor = int_buf.format(self.cursor.unwrap_or(0));
+                    let mut len_buf = ::itoa::Buffer::new();
+                    scratch.push(b'$');
+                    scratch.extend_from_slice(len_buf.format(cursor.len()).as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                    scratch.extend_from_slice(cursor.as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                }
+                StoredArg::Shared(payload) => {
+                    scratch.push(b'$');
+                    scratch.extend_from_slice(int_buf.format(payload.len()).as_bytes());
+                    scratch.extend_from_slice(b"\r\n");
+                    // Flush framing accumulated so far, then emit the payload
+                    // as its own zero-copy segment.
+                    out.push(bytes::Bytes::from(std::mem::take(scratch)));
+                    out.push(payload.clone());
+                    scratch.extend_from_slice(b"\r\n");
+                }
+            }
+        }
+
+        // If this is a fenced command, append a PING command
+        if self.is_fenced {
+            scratch.extend_from_slice(FENCE_COMMAND);
+        }
     }
 
     pub(crate) fn write_packed_command(&self, cmd: &mut Vec<u8>) {
@@ -648,42 +833,36 @@ impl Cmd {
     }
 
     /// Returns an iterator over the arguments in this command (including the command name itself)
+    /// Returns whether any argument is stored out-of-line as a shared
+    /// refcounted payload (via [`Cmd::arg_shared`] or a large [`RedisWrite`]
+    /// arg). When false, the command has no zero-copy send benefit and the
+    /// cheaper contiguous packing path is used.
+    #[inline]
+    pub fn has_out_of_line_args(&self) -> bool {
+        self.args.iter().any(|a| matches!(a, StoredArg::Shared(_)))
+    }
+
+    /// Iterate over the command arguments as byte slices (framing excluded).
     pub fn args_iter(&self) -> impl Clone + ExactSizeIterator<Item = Arg<&[u8]>> {
         let mut prev = 0;
-        self.args.iter().map(move |arg| match *arg {
-            Arg::Simple(i) => {
-                let arg = Arg::Simple(&self.data[prev..i]);
-                prev = i;
+        self.args.iter().map(move |arg| match arg {
+            StoredArg::Inline(i) => {
+                let arg = Arg::Simple(&self.data[prev..*i]);
+                prev = *i;
                 arg
             }
-
-            Arg::Cursor => Arg::Cursor,
+            StoredArg::Shared(bytes) => Arg::Simple(&bytes[..]),
+            StoredArg::Cursor => Arg::Cursor,
         })
     }
 
     /// Get a reference to the argument at `idx`.
     #[cfg(feature = "cluster")]
     pub fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
-        if idx >= self.args.len() {
-            return None;
-        }
-
-        let start = if idx == 0 {
-            0
-        } else {
-            match self.args[idx - 1] {
-                Arg::Simple(n) => n,
-                _ => 0,
-            }
-        };
-        let end = match self.args[idx] {
-            Arg::Simple(n) => n,
-            _ => 0,
-        };
-        if start == 0 && end == 0 {
-            return None;
-        }
-        Some(&self.data[start..end])
+        self.args_iter().nth(idx).and_then(|arg| match arg {
+            Arg::Simple(s) if !s.is_empty() => Some(s),
+            _ => None,
+        })
     }
 
     /// Client won't read and wait for results. Currently only used for Pub/Sub commands in RESP3.
@@ -903,5 +1082,92 @@ mod tests {
 
         let cloned = cmd.clone();
         assert!(cloned.is_blocking(), "clone must preserve is_blocking=true");
+    }
+
+    mod segmented_packing {
+        use super::super::*;
+
+        fn assert_segments_match_packed(cmd: &Cmd) {
+            assert_eq!(
+                cmd.get_packed_segments().to_contiguous(),
+                cmd.get_packed_command(),
+                "segmented packing must be byte-identical to contiguous packing"
+            );
+        }
+
+        #[test]
+        fn simple_command() {
+            assert_segments_match_packed(&crate::cmd("PING"));
+            assert_segments_match_packed(&crate::cmd("SET").arg("key").arg("value"));
+            assert_segments_match_packed(&crate::cmd("SET").arg("key").arg(42));
+        }
+
+        #[test]
+        fn shared_arg_small_is_inlined() {
+            let mut cmd = crate::cmd("SET");
+            cmd.arg("key")
+                .arg_shared(bytes::Bytes::from(vec![b'v'; 128]));
+            assert_segments_match_packed(&cmd);
+            // Small shared args coalesce: exactly one segment.
+            assert_eq!(cmd.get_packed_segments().segments().len(), 1);
+        }
+
+        #[test]
+        fn shared_arg_large_is_own_segment() {
+            let payload = bytes::Bytes::from(vec![b'v'; SHARED_ARG_INLINE_MAX + 1]);
+            let mut cmd = crate::cmd("SET");
+            cmd.arg("key").arg_shared(payload.clone());
+            assert_segments_match_packed(&cmd);
+            let packed = cmd.get_packed_segments();
+            // [framing][payload][trailing crlf]
+            assert_eq!(packed.segments().len(), 3);
+            // The payload segment shares the caller's allocation (zero-copy).
+            let seg = packed.segments().nth(1).unwrap();
+            assert_eq!(seg.as_ptr(), payload.as_ptr());
+        }
+
+        #[test]
+        fn shared_args_interleaved_with_args_iter_and_arg_idx() {
+            let payload = bytes::Bytes::from(vec![b'v'; SHARED_ARG_INLINE_MAX + 1]);
+            let mut cmd = crate::cmd("MSET");
+            cmd.arg("k1")
+                .arg_shared(payload.clone())
+                .arg("k2")
+                .arg("small");
+            assert_segments_match_packed(&cmd);
+            let args: Vec<_> = cmd
+                .args_iter()
+                .map(|a| match a {
+                    Arg::Simple(s) => s.to_vec(),
+                    Arg::Cursor => b"<cursor>".to_vec(),
+                })
+                .collect();
+            assert_eq!(args[0], b"MSET");
+            assert_eq!(args[1], b"k1");
+            assert_eq!(args[2], payload.to_vec());
+            assert_eq!(args[3], b"k2");
+            assert_eq!(args[4], b"small");
+            #[cfg(feature = "cluster")]
+            {
+                assert_eq!(cmd.arg_idx(1), Some(&b"k1"[..]));
+                assert_eq!(cmd.arg_idx(2), Some(&payload[..]));
+                assert_eq!(cmd.arg_idx(3), Some(&b"k2"[..]));
+            }
+        }
+
+        #[test]
+        fn cursor_command() {
+            let mut cmd = crate::cmd("SCAN");
+            cmd.cursor_arg(1234).arg("MATCH").arg("prefix:*");
+            assert_segments_match_packed(&cmd);
+        }
+
+        #[test]
+        fn fenced_command() {
+            let mut cmd = crate::cmd("GET");
+            cmd.arg("key");
+            cmd.set_fenced(true);
+            assert_segments_match_packed(&cmd);
+        }
     }
 }

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -859,10 +859,14 @@ impl Cmd {
     /// Get a reference to the argument at `idx`.
     #[cfg(feature = "cluster")]
     pub fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
-        self.args_iter().nth(idx).and_then(|arg| match arg {
-            Arg::Simple(s) if !s.is_empty() => Some(s),
-            _ => None,
-        })
+        // Return the argument even when it is an empty slice: an empty bulk
+        // string (`b""`) is a present argument and must be distinguished from
+        // a missing one, so cluster routing of a `Cmd` matches routing of its
+        // packed RESP form (see `Routable for Value`).
+        match self.args_iter().nth(idx)? {
+            Arg::Simple(s) => Some(s),
+            Arg::Cursor => None,
+        }
     }
 
     /// Client won't read and wait for results. Currently only used for Pub/Sub commands in RESP3.
@@ -1032,6 +1036,13 @@ mod tests {
         assert_eq!(c.arg_idx(2), Some(&b"42"[..]));
         assert_eq!(c.arg_idx(3), None);
         assert_eq!(c.arg_idx(4), None);
+
+        // An empty bulk-string argument is present, not missing: it must
+        // return Some(b"") so cluster routing matches the packed RESP form.
+        let mut e = Cmd::new();
+        e.arg("GET").arg(b"");
+        assert_eq!(e.arg_idx(1), Some(&b""[..]));
+        assert_eq!(e.arg_idx(2), None);
     }
 
     #[test]

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -371,9 +371,16 @@ pub const SHARED_ARG_INLINE_MAX: usize = 4 * 1024;
 /// Protocol framing and small inline arguments coalesce into contiguous
 /// segments; large shared payloads ([`Cmd::arg_shared`]) appear as their own
 /// refcounted segments pointing at the caller's allocation.
+///
+/// The first segment is stored inline: the overwhelmingly common case (a
+/// command with no out-of-line payload packs into exactly one contiguous
+/// segment) performs **zero** heap allocations for the container. Profiling
+/// small pipelined commands showed a per-command `Vec<Bytes>` roughly
+/// doubling hot-path malloc/free traffic.
 #[derive(Debug, Default, Clone)]
 pub struct SegmentedBytes {
-    segments: Vec<bytes::Bytes>,
+    first: Option<bytes::Bytes>,
+    rest: Vec<bytes::Bytes>,
     len: usize,
 }
 
@@ -382,7 +389,11 @@ impl SegmentedBytes {
     pub fn push(&mut self, bytes: bytes::Bytes) {
         if !bytes.is_empty() {
             self.len += bytes.len();
-            self.segments.push(bytes);
+            if self.first.is_none() && self.rest.is_empty() {
+                self.first = Some(bytes);
+            } else {
+                self.rest.push(bytes);
+            }
         }
     }
 
@@ -396,21 +407,21 @@ impl SegmentedBytes {
         self.len == 0
     }
 
-    /// Iterate over the segments.
-    pub fn segments(&self) -> impl ExactSizeIterator<Item = &bytes::Bytes> {
-        self.segments.iter()
+    /// Iterate over the segments in order.
+    pub fn segments(&self) -> impl Iterator<Item = &bytes::Bytes> {
+        self.first.iter().chain(self.rest.iter())
     }
 
-    /// Consume into the underlying segment list.
-    pub fn into_segments(self) -> Vec<bytes::Bytes> {
-        self.segments
+    /// Consume into an iterator over the segments in order.
+    pub fn into_segments(self) -> impl Iterator<Item = bytes::Bytes> {
+        self.first.into_iter().chain(self.rest)
     }
 
     /// Concatenate all segments into one contiguous buffer (used by tests and
     /// non-vectored fallbacks).
     pub fn to_contiguous(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.len);
-        for seg in &self.segments {
+        for seg in self.segments() {
             out.extend_from_slice(seg);
         }
         out
@@ -422,6 +433,33 @@ impl From<Vec<u8>> for SegmentedBytes {
         let mut out = SegmentedBytes::default();
         out.push(bytes::Bytes::from(buf));
         out
+    }
+}
+
+/// A packed request travelling to a connection's write task.
+///
+/// Commands with no out-of-line payloads travel as the plain packed byte
+/// buffer (`Contiguous`) — the exact representation the framed writer used,
+/// with no segment container, `Bytes` conversion, or refcount bookkeeping on
+/// the hot path. Only commands carrying large shared payloads pay for the
+/// segmented representation.
+#[derive(Debug, Clone)]
+pub enum SendBuf {
+    /// Fully packed command bytes (no out-of-line payloads).
+    Contiguous(Vec<u8>),
+    /// Framing segments interleaved with zero-copy payload segments.
+    Segmented(SegmentedBytes),
+}
+
+impl From<Vec<u8>> for SendBuf {
+    fn from(buf: Vec<u8>) -> Self {
+        SendBuf::Contiguous(buf)
+    }
+}
+
+impl From<SegmentedBytes> for SendBuf {
+    fn from(segments: SegmentedBytes) -> Self {
+        SendBuf::Segmented(segments)
     }
 }
 
@@ -618,7 +656,10 @@ impl Cmd {
         let mut out = SegmentedBytes::default();
         let mut scratch = Vec::new();
         self.write_packed_segments(&mut out, &mut scratch);
-        out.push(bytes::Bytes::from(scratch));
+        // from_owner: Bytes::from(Vec) shrinks-to-fit when capacity > len
+        // (the framing reserve over-estimates), which reallocs + copies the
+        // whole packed command. from_owner keeps the Vec as-is.
+        out.push(bytes::Bytes::from_owner(scratch));
         out
     }
 
@@ -676,7 +717,7 @@ impl Cmd {
                     scratch.extend_from_slice(b"\r\n");
                     // Flush framing accumulated so far, then emit the payload
                     // as its own zero-copy segment.
-                    out.push(bytes::Bytes::from(std::mem::take(scratch)));
+                    out.push(bytes::Bytes::from_owner(std::mem::take(scratch)));
                     out.push(payload.clone());
                     scratch.extend_from_slice(b"\r\n");
                 }
@@ -1128,7 +1169,7 @@ mod tests {
                 .arg_shared(bytes::Bytes::from(vec![b'v'; 128]));
             assert_segments_match_packed(&cmd);
             // Small shared args coalesce: exactly one segment.
-            assert_eq!(cmd.get_packed_segments().segments().len(), 1);
+            assert_eq!(cmd.get_packed_segments().segments().count(), 1);
         }
 
         #[test]
@@ -1139,7 +1180,7 @@ mod tests {
             assert_segments_match_packed(&cmd);
             let packed = cmd.get_packed_segments();
             // [framing][payload][trailing crlf]
-            assert_eq!(packed.segments().len(), 3);
+            assert_eq!(packed.segments().count(), 3);
             // The payload segment shares the caller's allocation (zero-copy).
             let seg = packed.segments().nth(1).unwrap();
             assert_eq!(seg.as_ptr(), payload.as_ptr());

--- a/glide-core/redis-rs/redis/src/connection.rs
+++ b/glide-core/redis-rs/redis/src/connection.rs
@@ -681,6 +681,76 @@ impl ActualConnection {
         })
     }
 
+    /// Vectored send of a packed command's segments, avoiding a contiguous
+    /// copy of large shared payloads ([`crate::cmd::SegmentedBytes`]). On
+    /// partial writes the `IoSlice` cursor is advanced until fully drained.
+    pub fn send_segments(&mut self, segments: &crate::cmd::SegmentedBytes) -> RedisResult<Value> {
+        fn write_all_vectored<W: io::Write>(
+            w: &mut W,
+            segments: &crate::cmd::SegmentedBytes,
+        ) -> io::Result<()> {
+            const MAX_SLICES: usize = 64;
+            let segs = segments.segments().collect::<Vec<_>>();
+            let mut idx = 0;
+            let mut offset = 0;
+            while idx < segs.len() {
+                let end = std::cmp::min(idx + MAX_SLICES, segs.len());
+                let mut slices: Vec<io::IoSlice> = Vec::with_capacity(end - idx);
+                slices.push(io::IoSlice::new(&segs[idx][offset..]));
+                for seg in &segs[idx + 1..end] {
+                    slices.push(io::IoSlice::new(seg));
+                }
+                let mut n = w.write_vectored(&slices)?;
+                if n == 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write whole command",
+                    ));
+                }
+                while n > 0 {
+                    let remaining = segs[idx].len() - offset;
+                    if n >= remaining {
+                        n -= remaining;
+                        idx += 1;
+                        offset = 0;
+                    } else {
+                        offset += n;
+                        n = 0;
+                    }
+                }
+            }
+            w.flush()
+        }
+
+        macro_rules! send_via {
+            ($conn:expr, $writer:expr) => {{
+                let res = write_all_vectored($writer, segments).map_err(RedisError::from);
+                match res {
+                    Err(e) => {
+                        if e.is_unrecoverable_error() {
+                            $conn.open = false;
+                        }
+                        Err(e)
+                    }
+                    Ok(_) => Ok(Value::Okay),
+                }
+            }};
+        }
+
+        match *self {
+            ActualConnection::Tcp(ref mut connection) => {
+                send_via!(connection, &mut connection.reader)
+            }
+            ActualConnection::TcpRustls(ref mut connection) => {
+                send_via!(connection, &mut connection.reader)
+            }
+            #[cfg(unix)]
+            ActualConnection::Unix(ref mut connection) => {
+                send_via!(connection, &mut connection.sock)
+            }
+        }
+    }
+
     pub fn send_bytes(&mut self, bytes: &[u8]) -> RedisResult<Value> {
         match *self {
             ActualConnection::Tcp(ref mut connection) => {
@@ -1271,12 +1341,18 @@ impl Connection {
 impl ConnectionLike for Connection {
     /// Sends a [Cmd] into the TCP socket and reads a single response from it.
     fn req_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
-        let pcmd = cmd.get_packed_command();
         if self.pubsub {
             self.exit_pubsub()?;
         }
 
-        self.send_bytes(&pcmd)?;
+        // Only pay the segmented/vectored path when there's a large shared
+        // payload to keep off the copy path; otherwise the contiguous pack +
+        // single write is cheaper for small/normal commands.
+        if cmd.has_out_of_line_args() {
+            self.con.send_segments(&cmd.get_packed_segments())?;
+        } else {
+            self.send_bytes(&cmd.get_packed_command())?;
+        }
         if cmd.is_no_response() {
             return Ok(Value::Nil);
         }

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -340,7 +340,8 @@ pub use crate::client::Client;
 pub use crate::client::GlideConnectionOptions;
 pub use crate::client::IAMTokenProvider;
 pub use crate::cmd::{
-    cmd, fenced_cmd, pack_command, pipe, Arg, Cmd, Iter, PHASE_QUEUED, PHASE_SENT,
+    cmd, fenced_cmd, pack_command, pipe, Arg, Cmd, Iter, SegmentedBytes, PHASE_QUEUED, PHASE_SENT,
+    SHARED_ARG_INLINE_MAX,
 };
 pub use crate::commands::{
     Commands, ControlFlow, Direction, LposOptions, PubSubCommands, SetOptions,

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -400,6 +400,8 @@ pub use crate::{
 mod macros;
 mod pipeline;
 
+pub(crate) mod buf_pool;
+
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub mod aio;

--- a/glide-core/redis-rs/redis/src/pipeline.rs
+++ b/glide-core/redis-rs/redis/src/pipeline.rs
@@ -119,7 +119,7 @@ impl Pipeline {
                 command.write_packed_segments(&mut out, &mut scratch);
             }
         }
-        out.push(bytes::Bytes::from(scratch));
+        out.push(bytes::Bytes::from_owner(scratch));
         out
     }
 

--- a/glide-core/redis-rs/redis/src/pipeline.rs
+++ b/glide-core/redis-rs/redis/src/pipeline.rs
@@ -102,6 +102,27 @@ impl Pipeline {
         write_pipeline(out, &self.commands, self.transaction_mode)
     }
 
+    /// Returns the encoded pipeline as segments for vectored writes.
+    /// Byte-identical on the wire to [`Pipeline::get_packed_pipeline`], with
+    /// large shared payloads as their own zero-copy segments.
+    pub fn get_packed_pipeline_segments(&self) -> crate::cmd::SegmentedBytes {
+        let mut out = crate::cmd::SegmentedBytes::default();
+        let mut scratch = Vec::new();
+        if self.transaction_mode {
+            cmd("MULTI").write_packed_segments(&mut out, &mut scratch);
+            for command in &self.commands {
+                command.write_packed_segments(&mut out, &mut scratch);
+            }
+            cmd("EXEC").write_packed_segments(&mut out, &mut scratch);
+        } else {
+            for command in &self.commands {
+                command.write_packed_segments(&mut out, &mut scratch);
+            }
+        }
+        out.push(bytes::Bytes::from(scratch));
+        out
+    }
+
     fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
         self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -2364,7 +2364,6 @@ impl<T: FromRedisValue> FromRedisValue for Option<T> {
     }
 }
 
-#[cfg(feature = "bytes")]
 impl FromRedisValue for bytes::Bytes {
     fn from_redis_value(v: &Value) -> RedisResult<Self> {
         let v = get_inner_value(v);


### PR DESCRIPTION
### Summary

Send-side of the copy-reduction initiative (orthogonal to the receive changes —
touches only the send path, no `Value`/parser changes). Large command arguments
are written to the socket with vectored I/O straight from the caller's
allocation instead of being copied into the command buffer, the packed RESP
buffer, and the framed write buffer.

Part of the split of #6520. Independent of the receive PRs.

### Features / Behaviour Changes

- `Cmd::arg_shared(Bytes)` and automatic out-of-line storage in `write_arg` for
  args > `SHARED_ARG_INLINE_MAX` (4 KB), backed by a recycled buffer pool
  (`buf_pool.rs`) so in-flight payload buffers don't cause page-fault churn at
  pipeline depth.
- `SegmentedBytes` packed representation (byte-identical on the wire to
  `get_packed_command`, unit-tested; first segment stored inline — zero
  container allocations for single-segment commands).
- `SendBuf` request representation: commands with no out-of-line payloads
  travel to the write task as the plain packed `Vec<u8>` (the framed writer's
  exact representation) — small commands measured at parity with baseline.
- `VectoredSink` in the multiplexed connection; vectored send in the sync and
  async single connections, gated on `has_out_of_line_args`.
- Packing uses `Bytes::from_owner` (avoids `Bytes::from(Vec)`'s hidden
  shrink-realloc + copy when capacity > len).
- FFI sends large args through the pooled auto-share path.

### Implementation

`Cmd` args become `Inline | Shared(Bytes) | Cursor`. The multiplexed connection
splits its stream (`FramedRead` for reads unchanged; new `VectoredSink` for
writes). `bytes` becomes a required dependency of `redis`.

### Limitations

- Sync **pipeline** (`ConnectionLike::req_packed_commands`) takes an
  already-packed `&[u8]` at the trait boundary, so it stays contiguous; single
  commands are vectored.
- `arg` (borrowed) reduces the payload to one copy; `arg_shared` (owned `Bytes`)
  is true zero-copy on send. Compression forces an owned buffer.

### Testing

- `redis` segmented-packing unit tests; `test_basic` 57 (sync send path),
  `test_async` 32 (async single-conn send path); `ffi` live-server tests.
- Lint: `cargo clippy -- -D warnings` (redis lib) and `--all-features
  --all-targets` (ffi) clean; fmt clean; MSRV 1.71 preserved.

**Benchmarks** (valkey 8.1.3, loopback, vs main):

| Workload | Result |
|----------|--------|
| SET 256 KB via `arg_shared` (e2e) | throughput +3.2×, client CPU −78% |
| SET 256 KB sync (instructions) | −39% (`arg`) / −84% (`arg_shared`) |
| SET 16 KB | +3–7% throughput |

## PR stack

Part of the zero-copy initiative (3 orthogonal PRs): Foundation valkey-io/valkey-glide#6524 (type migration, perf-neutral) · Receive omerrubi-amzn/valkey-glide#2 (stacked on foundation) · **Send (this PR, independent — merges in either order)**.

## Benchmark results (send path)

Measured on loopback and over a real network hop: single-primary ElastiCache Valkey 8.1
(r7g.4xlarge), same-AZ EC2 clients on **x86 (c7i.8xlarge) and ARM/Graviton (c7gn.16xlarge)**,
TCP_NODELAY at glide's production default, network verified unsaturated, 3 alternating
reps/cell, `perf` instructions + page-faults, p50/p95/p99 latency. Client CPU per op is the
primary KPI (large cells sit at EC2's ~5 Gbps per-flow cap, so throughput can't move even
when the client gets cheaper). Full methodology: `docs/zero-copy-benchmarks.md` on #6524.

| workload | x86 CPU/op | ARM CPU/op |
|---|---|---|
| SET 256KB plain, depth 16 | **−22%** | **−32%** |
| SET 256KB `arg_shared`, depth 128 | **−40%** | **−45%** |
| SET 64KB, depth 16 | −13% | −16..18% |
| SET 512B–16KB | parity | parity |

- Page faults/op: 256KB plain SET 5 → 0.2 (x86), 13.5 → 0.1 (ARM). Profiling over the real
  hop exposed page-fault churn from fresh per-command payload buffers (alive until the
  socket write completes); the recycled buffer pool commit fixes it, and the FFI arg path
  routes through the same pool.
- Latency: send-path **p99 −50..170µs** at 256KB (both arches); p50 flat
  (transfer-dominated). Depth-1 (unpipelined) `arg_shared` 64KB: **+8–15% throughput,
  −10..20µs p50** — the one depth-1 win. SET 256KB depth-1: +37% throughput (x86).
- **Small-command parity (updated):** an earlier revision regressed sub-4KB commands
  10–22% at extreme pipeline depth (d128, ~300k+ ops/s single connection). Root-caused and
  fixed (see the "small-command parity" commit): per-command container allocation,
  `Bytes::from(Vec)` shrink-realloc, and segment bookkeeping — small commands now travel as
  the plain packed buffer (`SendBuf::Contiguous`). Re-verified with a 41-cell matrix on
  x86 AND ARM/Graviton: **every small/medium cell at parity with baseline**, all
  large-value wins unchanged.

### Checklist

-   [ ] Related to one issue.
-   [x] Commit messages describe what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md / docs updated.
-   [x] Linters run and pass.
-   [x] Destination branch correct - main.
-   [ ] Squash on merge.

Signed-off-by: Omer Rubinstein <omerrubi@amazon.com>



