### PR TITLE
Fix socket listener connection error callback_idx assertion failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Fix socket listener connection error responses using `u32::MAX` as `callback_idx` instead of `0`. When client creation fails, the error response now uses the correct connection response callback index, matching the success path convention. Also add a connection retry strategy to socket listener tests to handle transient server startup delays in CI. ([#6434](https://github.com/valkey-io/valkey-glide/issues/6434))
 * Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 * Go: Remove `.gitignore` from the released module so consumers who commit `vendor/` keep the generated artifacts (`internal/protobuf/*.pb.go`, `rustbin/**`, `lib.h`) ([#6441](https://github.com/valkey-io/valkey-glide/pull/6441))

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -53,6 +53,10 @@ use uuid::Uuid;
 /// The socket file name
 const SOCKET_FILE_NAME: &str = "glide-socket";
 const UNIX_SOCKER_DIR: &str = "/tmp";
+/// Callback index used for responses to the initial connection request.
+/// The connection request does not carry a callback_idx field, so the
+/// convention is to always respond with index 0.
+const CONNECTION_RESPONSE_CALLBACK_IDX: u32 = 0;
 
 /// The maximum length of a request's arguments to be passed as a vector of
 /// strings instead of a pointer
@@ -925,7 +929,7 @@ async fn create_client(
         Ok(client) => client,
         Err(err) => return Err(ClientCreationError::ConnectionError(err)),
     };
-    write_result(Ok(Value::Okay), 0, writer, None).await?;
+    write_result(Ok(Value::Okay), CONNECTION_RESPONSE_CALLBACK_IDX, writer, None).await?;
     Ok(client)
 }
 
@@ -1028,7 +1032,7 @@ async fn listen_on_client_stream(socket: UnixStream) {
             let err_message = format!("Socket listener closed due to {reason:?}");
             let _res = write_closing_error(
                 ClosingError { err_message },
-                u32::MAX,
+                CONNECTION_RESPONSE_CALLBACK_IDX,
                 &writer,
                 "client creation",
             )
@@ -1042,7 +1046,7 @@ async fn listen_on_client_stream(socket: UnixStream) {
             log_error("client creation", &err_message);
             let _res = write_closing_error(
                 ClosingError { err_message },
-                u32::MAX,
+                CONNECTION_RESPONSE_CALLBACK_IDX,
                 &writer,
                 "client creation",
             )

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -385,6 +385,14 @@ mod socket_listener {
                 use_tls: use_tls.to_bool(),
                 cluster_mode,
                 request_timeout: Some(REQUEST_TIMEOUT_MS),
+                connection_retry_strategy: Some(
+                    glide_core::connection_request::ConnectionRetryStrategy {
+                        number_of_retries: 3,
+                        factor: 2,
+                        exponent_base: 2,
+                        ..Default::default()
+                    },
+                ),
                 ..Default::default()
             },
         );


### PR DESCRIPTION
## Summary

Fixes #6434

When client creation fails in `listen_on_client_stream`, the error response was sent with `callback_idx = u32::MAX` (4294967295) instead of the expected `callback_idx = 0`. This caused an assertion failure in 14 socket_listener standalone cluster tests when the connection to the standalone server failed transiently in CI:

```
assertion `left == right` failed
  left: 4294967295
 right: 0
```

## Root Cause

The connection request proto (`ConnectionRequest`) does not carry a `callback_idx` field. The protocol convention is that connection responses always use index 0. The success path in `create_client` correctly used `0`, but the error paths in `listen_on_client_stream` used `u32::MAX`.

## Changes

1. Introduces `CONNECTION_RESPONSE_CALLBACK_IDX` constant (= 0) in `socket_listener.rs` and uses it consistently in both the success and error paths for connection responses.
2. Adds a connection retry strategy (3 retries with exponential backoff) to the socket listener test `connect_to_redis` helper, so transient server startup delays in CI do not cause immediate connection failures.

## Testing

- `cargo check --features socket-layer` passes (library and tests compile)
- The fix ensures that even when a connection attempt fails, the error response carries the correct callback index (0), so the test assertion failure `4294967295 != 0` cannot recur.
- The retry strategy provides resilience against transient server startup delays.