### PR TITLE
Python: restore BaseClient.__aenter__ return type to Self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
 * Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 * Go: Remove `.gitignore` from the released module so consumers who commit `vendor/` keep the generated artifacts (`internal/protobuf/*.pb.go`, `rustbin/**`, `lib.h`) ([#6441](https://github.com/valkey-io/valkey-glide/pull/6441))

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -1030,7 +1030,7 @@ class BaseClient(CoreCommands):
         """
         await self.close(err_message)
 
-    async def __aenter__(self) -> "BaseClient":
+    async def __aenter__(self) -> Self:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -6,9 +6,15 @@ from __future__ import annotations
 import math
 import os
 import platform
+import sys
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Dict, List, Mapping, Optional, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Union, cast, get_type_hints
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 import anyio
 import pytest
@@ -161,6 +167,14 @@ class TestGlideClients:
             request, cluster_mode=cluster_mode, protocol=protocol, request_timeout=5000
         ) as client:
             assert not client._is_closed
+            # __aenter__ must be annotated `-> Self` so that subclasses keep
+            # their concrete type in `async with` (regression guard for
+            # https://github.com/valkey-io/valkey-glide/issues/6531). Annotating
+            # it as `"BaseClient"` widens the type for static type checkers.
+            aenter_return = get_type_hints(type(client).__aenter__)["return"]
+            assert aenter_return is Self, (
+                "BaseClient.__aenter__ must return `Self`, got " f"{aenter_return!r}"
+            )
 
         assert client._is_closed
 


### PR DESCRIPTION
### Summary

After upgrading from 2.4.2 to 2.5.0, `BaseClient.__aenter__` regressed from returning `Self` to the widened `"BaseClient"`. This made subclasses lose their concrete type when used as async context managers, so static type checkers (mypy) inferred `BaseClient` instead of `GlideClient`/`GlideClusterClient`. `create()` still correctly returns `Self`, so the two entry points became inconsistent.

The regression was introduced incidentally in #5637 (the async transport rewrite from UDS+protobuf to FFI+pipe), where `__aenter__`/`__aexit__` were moved and re-typed.

### Issue link

This Pull Request is linked to issue: [Python Type regressions in async BaseClient context manager](https://github.com/valkey-io/valkey-glide/issues/6531)
Closes #6531

### Features / Behaviour Changes

No runtime behaviour change. This is a type-annotation-only fix: `async with await GlideClusterClient.create(...) as client` once again types `client` as `GlideClusterClient` for static type checkers, matching the 2.4.2 behaviour.

### Implementation

- `python/glide-async/python/glide/glide_client.py`: change `BaseClient.__aenter__` return annotation from `"BaseClient"` back to `Self` (`Self` is already imported).
- `python/tests/async_tests/test_async_client.py`: add a regression guard inside the existing `test_context_manager`, asserting `get_type_hints(type(client).__aenter__)["return"] is Self`.

### Limitations

None. `MonitorClient.__aenter__` intentionally left as-is — it is not subclassed, so its `"MonitorClient"` annotation is correct.

### Testing

Built the async + sync clients locally (`python3 dev.py build`) and ran the affected test against a real Valkey server:

- With the fix: `test_context_manager[asyncio-*]` passes (all RESP2/RESP3 × cluster/standalone parametrizations).
- Reverting the source to the buggy `"BaseClient"` form and rebuilding: the same test fails with `AssertionError: BaseClient.__aenter__ must return Self, got <class 'glide.glide_client.BaseClient'>`, confirming the test guards the regression.
- `python3 dev.py lint` (isort/black/flake8/mypy) passes.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary