### PR TITLE
Remove the repository-level SECURITY.md in favor of the organization-level SECURITY.md (#6439) (backport to release-2.5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,7 +278,7 @@ valkey-glide/
 
 - **Getting Started:** [README.md](./README.md)
 - **Contributing:** [CONTRIBUTING.md](./CONTRIBUTING.md)
-- **Security:** [SECURITY.md](./SECURITY.md)
+- **Security:** [SECURITY.md](https://github.com/valkey-io/.github/blob/main/SECURITY.md)
 - **Documentation:** [docs/README.md](./docs/README.md)
 - **Examples:** [examples/](./examples/)
 - **Language-Specific Guides:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
 ## Security issue notifications
-See [SECURITY.md](./SECURITY.md)
+See [SECURITY.md](https://github.com/valkey-io/.github/blob/main/SECURITY.md)
 
 
 ## Licensing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,0 @@
-# Reporting a Vulnerability
-
-If you believe you've discovered a security vulnerability, please contact the Valkey team at security@lists.valkey.io.
-Please *DO NOT* create an issue.
-We follow a responsible disclosure procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
-If you would like to be added to our list of vendors, please reach out to the Valkey team at valkey-glide@lists.valkey.io.


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Backport of #6439 to `release-2.5`. Removes the repository-level `SECURITY.md` in favor of the organization-level `SECURITY.md`.

### Issue link

This Pull Request is linked to issue: [Remove the repository-level SECURITY.md in favor of the organization-level SECURITY.md](https://github.com/valkey-io/valkey-glide/pull/6439)
References #6439

### Features / Behaviour Changes

No feature or behaviour changes. This removes a redundant `SECURITY.md` file that is now maintained at the organization level, and updates `CONTRIBUTING.md` to point to the organization-level security policy.

### Implementation

Clean cherry-pick of commit d12ab462c99a68987c9a1d0cba049a064fc0228e from `main`.

### Limitations

None.

### Testing

N/A. This is a documentation-only change (file removal and link update).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary