### PR TITLE
ci(python): publish to PyPI via Trusted Publishing with PEP 740 attestations (#6478) (backport to release-2.5)

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -37,6 +37,7 @@ concurrency:
 
 permissions:
     id-token: write
+    attestations: write
 
 jobs:
     load-platform-matrix:
@@ -492,9 +493,9 @@ jobs:
                   path: python/glide-sync/wheels
                   if-no-files-found: error
 
-    build-source-dist-and-publish-to-pypi:
-        if: ${{ github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true }}
-        name: Publish the base PyPi package
+    publish-async-to-pypi:
+        if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
+        name: Publish the async PyPi package
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
         needs: publish-binaries
@@ -543,15 +544,20 @@ jobs:
                   path: python/glide-async/wheels
                   merge-multiple: true
 
+            - name: Async client - Collect wheels and sdist for publishing
+              run: |
+                  mkdir -p python/glide-async/dist
+                  cp python/glide-async/wheels/*.whl python/glide-async/dist/
+                  cp python/glide-async/sdist/*.tar.gz python/glide-async/dist/
+
             - name: Async client - Publish binaries and source to PyPI
-              if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
-              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-              env:
-                  MATURIN_PYPI_TOKEN: ${{ secrets.LIVEPYPI_API_TOKEN }}
-                  MATURIN_REPOSITORY: pypi
+              # Trusted Publishing (OIDC) with PEP 740 attestations; requires the
+              # top-level `id-token: write` permission and a GitHub-hosted runner.
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
               with:
-                  command: upload
-                  args: --skip-existing python/glide-async/wheels/* python/glide-async/sdist/*
+                  packages-dir: python/glide-async/dist
+                  skip-existing: true
+                  attestations: true
 
             - name: Async client - Upload built wheels and sdist as GitHub artifacts
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -561,12 +567,47 @@ jobs:
                       python/glide-async/wheels/*.whl
                       python/glide-async/dist/*.tar.gz
 
+    publish-sync-to-pypi:
+        if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
+        name: Publish the sync PyPi package
+        runs-on: ubuntu-latest
+        environment: AWS_ACTIONS
+        needs: publish-binaries
+        steps:
+            - name: Checkout
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+            - name: Set the release version
+              shell: bash
+              run: |
+                  echo "RELEASE_VERSION=${{needs.publish-binaries.outputs.release_version}}" >> $GITHUB_ENV
+
+            - name: Set the package version for Python
+              working-directory: ./python
+              run: |
+                  SED_FOR_MACOS=`if [[ "${{ matrix.build.OS }}" =~ .*"macos".*  ]]; then echo "''"; fi`
+                  # Set the version for the Async, Sync and Shared packages
+                  # List of packages to update
+                  for package in glide-async glide-sync glide-shared; do
+                    echo "Patching version in $package/pyproject.toml"
+                    sed -i $SED_FOR_MACOS "s/^dynamic = \[\s*\"version\"\s*\]/version = \"${{ env.RELEASE_VERSION }}\"/" "./$package/pyproject.toml"
+
+                    # Log the updated file
+                    cat "./$package/pyproject.toml"
+                  done
+
+            - name: Copy README file into package directories
+              working-directory: ./python
+              run: |
+                  cp README.md glide-sync/README.md
+                  cp README.md glide-async/README.md
+
             ### SYNC CLIENT ###
 
             - name: Install build and release tools
               run: |
                   python3 -m pip install --upgrade pip
-                  python3 -m pip install build twine
+                  python3 -m pip install build
                   python3 -m pip install -U packaging
 
             - name: Sync client - Build source distributions
@@ -581,13 +622,20 @@ jobs:
                   path: python/glide-sync/wheels
                   merge-multiple: true
 
-            - name: Sync client - Publish binaries and source to PyPI
-              if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
-              env:
-                  TWINE_USERNAME: __token__
-                  TWINE_PASSWORD: ${{ secrets.LIVEPYPI_API_TOKEN }}
+            - name: Sync client - Collect wheels and sdist for publishing
               run: |
-                  twine upload python/glide-sync/wheels/* python/glide-sync/dist/*
+                  # The sdist is already in python/glide-sync/dist (from `build --sdist`);
+                  # add the wheels alongside it so a single directory is published.
+                  cp python/glide-sync/wheels/*.whl python/glide-sync/dist/
+
+            - name: Sync client - Publish binaries and source to PyPI
+              # Trusted Publishing (OIDC) with PEP 740 attestations; requires the
+              # top-level `id-token: write` permission and a GitHub-hosted runner.
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+              with:
+                  packages-dir: python/glide-sync/dist
+                  skip-existing: true
+                  attestations: true
 
             - name: Sync client - Upload built wheels and sdist as GitHub artifacts
               uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -603,7 +651,8 @@ jobs:
         runs-on: ${{ matrix.build.RUNNER }}
         needs:
             [
-                build-source-dist-and-publish-to-pypi,
+                publish-async-to-pypi,
+                publish-sync-to-pypi,
                 publish-binaries,
                 load-platform-matrix,
             ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changes
 
-
+* CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6478](https://github.com/valkey-io/valkey-glide/pull/6478))
 * Go: Add multi-key `MIGRATE` support ([#6293](https://github.com/valkey-io/valkey-glide/pull/6293))
 * Core, Java, Go, Node, Python: Support server-assisted invalidation and add `CLIENT TRACKINGINFO` command ([#5961](https://github.com/valkey-io/valkey-glide/issues/5961))
 * Core, Java, Python, Node, Go: Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands ([#6286](https://github.com/valkey-io/valkey-glide/issues/6286))

--- a/python/DEVELOPER.md
+++ b/python/DEVELOPER.md
@@ -375,7 +375,8 @@ This section explains how the `valkey-glide` (async client) and `valkey-glide-sy
     We use `maturin build` from the `glide-async` directory to create a Python wheel that includes the compiled Rust extension and all Python code.
 
 4. **Multiplatform packaging for PyPI**
-    To publish wheels to PyPI, we use the `PyO3/maturin-action` GitHub Action, which builds manylinux and macOS wheels for different Python versions (both CPython and PyPy). This action runs in CI and uses prebuilt Docker containers for compatibility.
+    To build wheels for PyPI, we use the `PyO3/maturin-action` GitHub Action, which builds manylinux and macOS wheels for different Python versions (both CPython and PyPy). This action runs in CI and uses prebuilt Docker containers for compatibility.
+    The built wheels and sdist are then uploaded to PyPI with the `pypa/gh-action-pypi-publish` action via Trusted Publishing (OIDC) with PEP 740 attestations, rather than an API token.
 
 5. **Local testing**
     You can test building a wheel and installing it locally using:


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Backport of #6478 to the `release-2.5` branch. Switches both PyPI upload paths in `pypi-cd.yml` from token-based uploads to `pypa/gh-action-pypi-publish` under Trusted Publishing (OIDC), enabling PEP 740 attestations. Each package (async and sync) now publishes in its own job, matching the constraint that the action be invoked only once per job.

### Issue link

This Pull Request is linked to issue: [ci(python): publish to PyPI via Trusted Publishing with PEP 740 attestations](https://github.com/valkey-io/valkey-glide/pull/6478)

### Features / Behaviour Changes

No public API changes. This is a CI-only change affecting the PyPI release workflow:
- Async client: replaces maturin-action upload with a collect + publish step using Trusted Publishing.
- Sync client: replaces twine upload with a collect + publish step using Trusted Publishing.
- Removes all `LIVEPYPI_API_TOKEN` / `MATURIN_PYPI_TOKEN` / `TWINE_*` usage from these paths.
- Pins `pypa/gh-action-pypi-publish` by commit SHA (`release/v1`).
- Adds `attestations: write` permission for the publish jobs.

### Implementation

Cherry-pick of commit `cdacd2aa618c5917e2ec3e79835f78b324452230` from `main`. The `CHANGELOG.md` conflict was resolved by keeping only the #6478 entry in the Pending 2.5 section (other main-only entries were excluded). The workflow YAML (`pypi-cd.yml`) merged cleanly.

### Limitations

None. The workflow change is self-contained.

### Testing

This is a CI workflow change. Validation will occur when:
1. CI runs on this PR (workflow syntax check).
2. The next release tag on `release-2.5` triggers the publish workflow.

The original PR (#6478) was validated on `main` before merge.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary