### PR TITLE
ci: fix cargo-deny CLI flag order for v0.20+ (backport #6490 to release-2.5)

### DIFF
--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -44,7 +44,7 @@ runs:
 
         - run: |
               cargo install --locked cargo-deny
-              cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
+              cargo deny --config ${GITHUB_WORKSPACE}/deny.toml check
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash
 

--- a/.github/workflows/redis-rs.yml
+++ b/.github/workflows/redis-rs.yml
@@ -85,7 +85,7 @@ jobs:
                   cargo fmt --all -- --check
                   cargo clippy -- -D warnings
                   cargo install --locked cargo-deny
-                  cargo deny check all --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev all
+                  cargo deny --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev check all
               working-directory: ./glide-core/redis-rs/redis
 
             - name: Test

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -549,7 +549,7 @@ where
                 {
                     // Last key reached; add the path argument index for each route and break
                     let path_idx = curr_arg_idx + 1;
-                    for (_, arg_indices) in routes.iter_mut() {
+                    for arg_indices in routes.values_mut() {
                         arg_indices.push(path_idx);
                     }
                     break;

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -160,12 +160,11 @@ impl<'a, T: FromRedisValue + 'a> AsyncIterInner<'a, T> {
             if let Some(v) = self.batch.next() {
                 return Some(v);
             };
-            if let Some(cursor) = self.cmd.cursor {
+            {
+                let cursor = self.cmd.cursor?;
                 if cursor == 0 {
                     return None;
                 }
-            } else {
-                return None;
             }
 
             let rv = self.con.req_packed_command(&self.cmd).await.ok()?;

--- a/glide-core/src/pubsub/mock.rs
+++ b/glide-core/src/pubsub/mock.rs
@@ -656,7 +656,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut channels: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -686,7 +686,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut patterns: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -725,7 +725,7 @@ impl MockPubSubBroker {
 
         for channel in &channels {
             let mut count = 0i64;
-            for (_, client_data) in clients.iter() {
+            for client_data in clients.values() {
                 let actual = client_data
                     .synchronizer
                     .actual_subscriptions
@@ -754,7 +754,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut channels: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -803,7 +803,7 @@ impl MockPubSubBroker {
 
         for channel in &channels {
             let mut count = 0i64;
-            for (_, client_data) in clients.iter() {
+            for client_data in clients.values() {
                 let actual = client_data
                     .synchronizer
                     .actual_subscriptions

--- a/glide-core/src/pubsub/synchronizer.rs
+++ b/glide-core/src/pubsub/synchronizer.rs
@@ -724,7 +724,7 @@ impl PubSubSynchronizer for GlidePubSubSynchronizer {
         } else {
             // For regular subscriptions (Exact/Pattern), remove from ALL addresses.
             // These are not slot-bound, and the server's unsubscribe is authoritative.
-            for (_, addr_subs) in current_by_addr.iter_mut() {
+            for addr_subs in current_by_addr.values_mut() {
                 if let Some(existing) = addr_subs.get_mut(&subscription_type) {
                     for channel in &channels {
                         existing.remove(channel);


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Cherry-pick of #6490 (merge commit 5c5f64d602450434146229fcce30e107b960b91a) onto `release-2.5`.

Fixes cargo-deny CLI flag order for compatibility with v0.20+ and resolves Clippy `for_kv_map` warnings introduced by Rust 1.97.

### Issue link

This Pull Request is linked to issue: [ci: fix cargo-deny CLI flag order for v0.20+](https://github.com/valkey-io/valkey-glide/pull/6490)

### Features / Behaviour Changes

No feature or behavior changes. This is a CI and lint-fix backport only:
- Reorders `cargo-deny` CLI arguments to match the v0.20+ required syntax (`cargo deny check <subcommand>` instead of `cargo deny <subcommand> check`).
- Fixes Clippy `for_kv_map` warnings in two Rust source files for Rust 1.97 compatibility.

### Implementation

Straight cherry-pick with `-x -s` of commit 5c5f64d from main. No manual conflict resolution was needed; the patch applied cleanly to `release-2.5`.

### Limitations

None.

### Testing

- `cargo check` passes for both `glide-core` and `glide-core/redis-rs/redis` crates on this branch.
- No new tests are needed since the changes are CI workflow fixes and trivial Clippy lint fixes.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary