### PR TITLE
Backport #6435 and #6490 to release-2.5 (crossbeam-epoch RUSTSEC-2026-0204 + cargo-deny v0.20 CI fix)

### DIFF
--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -44,7 +44,7 @@ runs:
 
         - run: |
               cargo install --locked cargo-deny
-              cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
+              cargo deny --config ${GITHUB_WORKSPACE}/deny.toml check
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash
 

--- a/.github/workflows/redis-rs.yml
+++ b/.github/workflows/redis-rs.yml
@@ -85,7 +85,7 @@ jobs:
                   cargo fmt --all -- --check
                   cargo clippy -- -D warnings
                   cargo install --locked cargo-deny
-                  cargo deny check all --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev all
+                  cargo deny --config ${GITHUB_WORKSPACE}/deny.toml --exclude-dev check all
               working-directory: ./glide-core/redis-rs/redis
 
             - name: Test

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/glide-core/redis-rs/Cargo.lock
+++ b/glide-core/redis-rs/Cargo.lock
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/glide-core/redis-rs/redis/src/cluster_routing.rs
+++ b/glide-core/redis-rs/redis/src/cluster_routing.rs
@@ -549,7 +549,7 @@ where
                 {
                     // Last key reached; add the path argument index for each route and break
                     let path_idx = curr_arg_idx + 1;
-                    for (_, arg_indices) in routes.iter_mut() {
+                    for arg_indices in routes.values_mut() {
                         arg_indices.push(path_idx);
                     }
                     break;

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -160,12 +160,11 @@ impl<'a, T: FromRedisValue + 'a> AsyncIterInner<'a, T> {
             if let Some(v) = self.batch.next() {
                 return Some(v);
             };
-            if let Some(cursor) = self.cmd.cursor {
+            {
+                let cursor = self.cmd.cursor?;
                 if cursor == 0 {
                     return None;
                 }
-            } else {
-                return None;
             }
 
             let rv = self.con.req_packed_command(&self.cmd).await.ok()?;

--- a/glide-core/src/pubsub/mock.rs
+++ b/glide-core/src/pubsub/mock.rs
@@ -656,7 +656,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut channels: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -686,7 +686,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut patterns: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -725,7 +725,7 @@ impl MockPubSubBroker {
 
         for channel in &channels {
             let mut count = 0i64;
-            for (_, client_data) in clients.iter() {
+            for client_data in clients.values() {
                 let actual = client_data
                     .synchronizer
                     .actual_subscriptions
@@ -754,7 +754,7 @@ impl MockPubSubBroker {
         let clients = self.clients.read().await;
         let mut channels: HashSet<Vec<u8>> = HashSet::new();
 
-        for (_, client_data) in clients.iter() {
+        for client_data in clients.values() {
             let actual = client_data
                 .synchronizer
                 .actual_subscriptions
@@ -803,7 +803,7 @@ impl MockPubSubBroker {
 
         for channel in &channels {
             let mut count = 0i64;
-            for (_, client_data) in clients.iter() {
+            for client_data in clients.values() {
                 let actual = client_data
                     .synchronizer
                     .actual_subscriptions

--- a/glide-core/src/pubsub/synchronizer.rs
+++ b/glide-core/src/pubsub/synchronizer.rs
@@ -724,7 +724,7 @@ impl PubSubSynchronizer for GlidePubSubSynchronizer {
         } else {
             // For regular subscriptions (Exact/Pattern), remove from ALL addresses.
             // These are not slot-bound, and the server's unsubscribe is authoritative.
-            for (_, addr_subs) in current_by_addr.iter_mut() {
+            for addr_subs in current_by_addr.values_mut() {
                 if let Some(existing) = addr_subs.get_mut(&subscription_type) {
                     for channel in &channels {
                         existing.remove(channel);


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Backport of two merged PRs into `release-2.5`:

1. **#6435** (commit d67764cda): Updates crossbeam-epoch from 0.9.18 to 0.9.20 to resolve RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared`).
2. **#6490** (commit 5c5f64d60): Fixes cargo-deny CLI flag order for v0.20+ and resolves Rust 1.97 clippy warnings (`for_kv_map`, `question_mark`).

These two backports have a chicken-and-egg dependency: #6435 alone fails lint because of pre-existing clippy errors on release-2.5 (fixed by #6490), while #6490 alone fails lint because cargo-deny flags the crossbeam-epoch advisory (fixed by #6435). Together they make the lint job green.

### Issue link

This Pull Request is linked to issue: [Update crossbeam-epoch to fix RUSTSEC-2026-0204 vulnerability](https://github.com/valkey-io/valkey-glide/issues/6433)
Closes https://github.com/valkey-io/valkey-glide/issues/6433

### Features / Behaviour Changes

No behavior changes. The first commit is a lockfile-only update to a transitive dev-dependency. The second commit fixes CI configuration (cargo-deny flag order) and suppresses new clippy lints introduced in Rust 1.97.

### Implementation

Cherry-picked both merge commits onto `release-2.5` in sequence:
1. d67764cda (crossbeam-epoch lockfile bump in `glide-core/Cargo.lock` and `glide-core/redis-rs/Cargo.lock`)
2. 5c5f64d60 (cargo-deny CLI fix in `.github/workflows/lint-rust/action.yml` and `.github/workflows/redis-rs.yml`, plus clippy fixes in `glide-core/redis-rs/redis/src/cluster_routing.rs`, `glide-core/redis-rs/redis/src/cmd.rs`, `glide-core/src/pubsub/mock.rs`, `glide-core/src/pubsub/synchronizer.rs`)

Both applied cleanly with no conflicts.

### Limitations

None.

### Testing

- `cargo check` passes in both `glide-core` and `glide-core/redis-rs/redis`.
- Verified crossbeam-epoch 0.9.20 in both lockfiles.
- Both commits are GPG-signed and show "Verified" on GitHub.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
