### PR TITLE
ci(python): run test-release when only one package is published manually

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -646,7 +646,7 @@ jobs:
                       python/glide-sync/dist/*.tar.gz
 
     test-release:
-        if: ${{ github.event_name == 'push' || inputs.publish_async== true || inputs.publish_sync == true }}
+        if: ${{ !failure() && !cancelled() && (github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true) }}
         name: Test the release
         runs-on: ${{ matrix.build.RUNNER }}
         needs:
@@ -745,7 +745,7 @@ jobs:
                   echo "PYPI_VERSION=${PYPI_VERSION}" >> $GITHUB_ENV
 
             - name: Run the Async Client tests
-              if: ${{ inputs.publish_async == true }}
+              if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
@@ -760,7 +760,7 @@ jobs:
                   python async_rc_test.py
 
             - name: Run the Async Clients tests with PyPy
-              if: ${{ inputs.publish_async == true }}
+              if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
@@ -775,7 +775,7 @@ jobs:
                   pypy3 async_rc_test.py
 
             - name: Run the Sync Client tests
-              if: ${{ inputs.publish_sync == true }}
+              if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |
@@ -790,7 +790,7 @@ jobs:
                   python sync_rc_test.py
 
             - name: Run the Sync Client tests with PyPy
-              if: ${{ inputs.publish_sync == true }}
+              if: ${{ github.event_name == 'push' || inputs.publish_sync == true }}
               shell: bash
               working-directory: ./utils/release-candidate-testing/python
               run: |

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -646,7 +646,7 @@ jobs:
                       python/glide-sync/dist/*.tar.gz
 
     test-release:
-        if: ${{ !failure() && !cancelled() && (github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true) }}
+        if: ${{ github.repository_owner == 'valkey-io' && !failure() && !cancelled() && (github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true) }}
         name: Test the release
         runs-on: ${{ matrix.build.RUNNER }}
         needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))
 * Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
 * Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Fix a latent workflow bug where the `test-release` job in `pypi-cd.yml` is silently skipped on manual `workflow_dispatch` runs that only publish one package (e.g. async-only or sync-only).
GitHub skips any downstream job whose `needs` dependency was skipped when the job lacks an `always()`-family condition, so a single-package manual release published to PyPI but never ran post-publish validation.

### Issue link

Found by review bot on the release-2.5 backport of #6478.

### Features / Behaviour Changes

- `test-release` now runs whenever the release path is active and no dependency actually failed: it tolerates a skipped sibling publish job but still blocks on a failed or cancelled run.
- The per-package test steps now also run on `push` events (tag-triggered releases), ensuring both async and sync validation suites execute during full releases.

### Implementation

1. Changed the `test-release` job's condition to the standard GitHub Actions idiom for "run even if a dependency was skipped, but never over a failure":
   `if: ${{ !failure() && !cancelled() && (github.event_name == 'push' || inputs.publish_async == true || inputs.publish_sync == true) }}`
   At job level, `failure()` is true when any job in the `needs` chain failed and `cancelled()` covers aborted runs, so this is equivalent to enumerating each `needs.*.result` explicitly while staying robust if the dependency list changes later.
2. Added `github.event_name == 'push'` to each test step's `if:` so tag-triggered releases (which publish both packages) run both validation suites. Previously these steps only gated on `inputs.publish_async` / `inputs.publish_sync`, which are undefined on push events.

### Limitations

None. The fix is minimal and uses the GitHub-documented status-check idiom.

### Testing

- YAML validated via `python3 -c "import yaml; yaml.safe_load(open(...))"`.
- Manual review of GitHub Actions `if:` / `needs` semantics confirms `!failure() && !cancelled()` matches the documented behavior for tolerating skipped dependencies while blocking on failures and cancellations.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
