### PR TITLE
fix(ffi): forward Disconnection push notifications past the malformed-frame guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6538](https://github.com/valkey-io/valkey-glide/pull/6538))
+* Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))
 * Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
 * Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6538](https://github.com/valkey-io/valkey-glide/pull/6538))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))
 * Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
 * Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1240,9 +1240,15 @@ unsafe fn process_push_notification(
     pubsub_callback: PubSubCallback,
     client_adapter_ptr: usize,
 ) {
-    let Some((message, channel, pattern)) = extract_pubsub_data(&push_msg) else {
-        return;
-    };
+    let (message, channel, pattern) =
+        if push_msg.kind == redis::PushKind::Disconnection {
+            (vec![], vec![], None)
+        } else {
+            let Some(data) = extract_pubsub_data(&push_msg) else {
+                return;
+            };
+            data
+        };
 
     let (message_ptr, message_len) = convert_vec_to_pointer(message);
     let (channel_ptr, channel_len) = convert_vec_to_pointer(channel);
@@ -1417,10 +1423,12 @@ fn create_client_internal(
                         }
                         std::hint::spin_loop();
                     };
-                    if (push_msg.kind == redis::PushKind::Message
+                    if push_msg.kind == redis::PushKind::Disconnection {
+                        let kind: i32 = PushKind::from(push_msg.kind) as i32;
+                        w.push_pubsub_inline(pipe_cid, kind, &[], &[], &[]);
+                    } else if (push_msg.kind == redis::PushKind::Message
                         || push_msg.kind == redis::PushKind::PMessage
-                        || push_msg.kind == redis::PushKind::SMessage
-                        || push_msg.kind == redis::PushKind::Disconnection)
+                        || push_msg.kind == redis::PushKind::SMessage)
                         && let Some((message, channel, pattern)) = extract_pubsub_data(&push_msg)
                     {
                         let kind: i32 = PushKind::from(push_msg.kind) as i32;
@@ -5861,5 +5869,38 @@ mod tests_push_notification_safety {
             data: vec![Value::Int(1), Value::Int(2), Value::Int(3)],
         };
         assert!(extract_pubsub_data(&all_ints).is_none());
+    }
+
+    #[test]
+    fn test_disconnection_with_empty_data_reaches_callback() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_callback_count();
+        let push_msg = redis::PushInfo {
+            kind: redis::PushKind::Disconnection,
+            data: vec![],
+        };
+        unsafe {
+            process_push_notification(push_msg, counting_callback, 0);
+        }
+        assert_eq!(CALLBACK_INVOCATIONS.load(Ordering::SeqCst), 1);
+        let data = LAST_CALLBACK_DATA.lock().unwrap();
+        let capture = data.as_ref().unwrap();
+        assert!(capture.message.is_empty());
+        assert!(capture.channel.is_empty());
+        assert!(capture.pattern.is_none());
+    }
+
+    #[test]
+    fn test_malformed_message_frame_still_dropped() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset_callback_count();
+        let push_msg = redis::PushInfo {
+            kind: redis::PushKind::Message,
+            data: vec![Value::Int(99)],
+        };
+        unsafe {
+            process_push_notification(push_msg, counting_callback, 0);
+        }
+        assert_eq!(CALLBACK_INVOCATIONS.load(Ordering::SeqCst), 0);
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1240,15 +1240,14 @@ unsafe fn process_push_notification(
     pubsub_callback: PubSubCallback,
     client_adapter_ptr: usize,
 ) {
-    let (message, channel, pattern) =
-        if push_msg.kind == redis::PushKind::Disconnection {
-            (vec![], vec![], None)
-        } else {
-            let Some(data) = extract_pubsub_data(&push_msg) else {
-                return;
-            };
-            data
+    let (message, channel, pattern) = if push_msg.kind == redis::PushKind::Disconnection {
+        (vec![], vec![], None)
+    } else {
+        let Some(data) = extract_pubsub_data(&push_msg) else {
+            return;
         };
+        data
+    };
 
     let (message_ptr, message_len) = convert_vec_to_pointer(message);
     let (channel_ptr, channel_len) = convert_vec_to_pointer(channel);


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

PR #6530 introduced `extract_pubsub_data` which correctly rejects push frames with fewer than 2 bulk strings (preventing DoS from malformed pub/sub frames). However, redis-rs emits `PushKind::Disconnection` notifications with an intentionally empty payload (`data: vec![]`). The async pipe path chained the Disconnection kind check with `extract_pubsub_data`, silently dropping every legitimate disconnect notification.

This fix special-cases `PushKind::Disconnection` before the `extract_pubsub_data` guard so disconnect notifications are forwarded with empty message/channel/pattern (the pre-#6530 encoding), while malformed Message/PMessage/SMessage frames continue to be dropped.

### Issue link

This Pull Request is linked to issue: [Disconnection push notifications silently dropped after #6530](https://github.com/valkey-io/valkey-glide/pull/6530)
Closes regression introduced by #6530

### Features / Behaviour Changes

- `PushKind::Disconnection` notifications now reach the async pipe (and downstream Python `_handle_inline_pubsub`) again, restoring the transport-disconnected warning path.
- No API or wire-format changes; the empty-payload encoding for Disconnection is the same as before #6530.

### Implementation

Two locations in `ffi/src/lib.rs`:

1. **Async pipe path** (~line 1420): added an early `if push_msg.kind == Disconnection` branch that writes the frame with empty slices via `push_pubsub_inline`, before the `extract_pubsub_data` call that handles Message/PMessage/SMessage.
2. **`process_push_notification`** (~line 1238): same special-case so the function is safe to call with a Disconnection push (produces empty message/channel/pattern for the callback).

The sync path and fallback callback path already exclude Disconnection from their kind filters, so they are unaffected.

### Limitations

None. This restores the pre-#6530 behavior for Disconnection frames while preserving the malformed-frame DoS protection for pub/sub frames.

### Testing

- Added `test_disconnection_with_empty_data_reaches_callback`: confirms a Disconnection push with empty data invokes the callback with empty message/channel/pattern.
- Added `test_malformed_message_frame_still_dropped`: confirms a Message push with only non-BulkString elements is still silently dropped.
- All 11 tests in `tests_push_notification_safety` pass: `cargo test -p glide-ffi tests_push_notification_safety`
- `cargo check` on the `ffi` crate passes cleanly.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary