### PR TITLE
[Java] Fix flaky test SharedCommandTests.copy - ensure SET completes before COPY

### DIFF
--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -14393,7 +14393,7 @@ public class SharedCommandTests {
         assertFalse(client.copy(source, destination, 1).get());
 
         // source exists, destination does not
-        client.set(source, "one");
+        client.set(source, "one").get();
         assertTrue(client.copy(source, destination, 1, false).get());
         if (isCluster) {
             ((GlideClusterClient) client).select(1).get();
@@ -14409,7 +14409,7 @@ public class SharedCommandTests {
         }
 
         // setting new value for source
-        client.set(source, "two");
+        client.set(source, "two").get();
 
         // both exists, no REPLACE
         assertFalse(client.copy(source, destination, 1).get());
@@ -14468,7 +14468,7 @@ public class SharedCommandTests {
         }
 
         // source exists, destination does not
-        client.set(source, gs("one"));
+        client.set(source, gs("one")).get();
         assertTrue(client.copy(source, destination, 1, false).get());
         if (isCluster) {
             ((GlideClusterClient) client).select(1).get();
@@ -14483,7 +14483,7 @@ public class SharedCommandTests {
         }
 
         // setting new value for source
-        client.set(source, gs("two"));
+        client.set(source, gs("two")).get();
 
         // both exists, no REPLACE
         assertFalse(client.copy(source, destination, 1).get());
@@ -14525,12 +14525,12 @@ public class SharedCommandTests {
         assertFalse(client.copy(source, destination).get());
 
         // source exists, destination does not
-        client.set(source, "one");
+        client.set(source, "one").get();
         assertTrue(client.copy(source, destination, false).get());
         assertEquals("one", client.get(destination).get());
 
         // setting new value for source
-        client.set(source, "two");
+        client.set(source, "two").get();
 
         // both exists, no REPLACE
         assertFalse(client.copy(source, destination).get());
@@ -14557,12 +14557,12 @@ public class SharedCommandTests {
         assertFalse(client.copy(source, destination).get());
 
         // source exists, destination does not
-        client.set(source, gs("one"));
+        client.set(source, gs("one")).get();
         assertTrue(client.copy(source, destination, false).get());
         assertEquals(gs("one"), client.get(destination).get());
 
         // setting new value for source
-        client.set(source, gs("two"));
+        client.set(source, gs("two")).get();
 
         // both exists, no REPLACE
         assertFalse(client.copy(source, destination).get());


### PR DESCRIPTION
### Summary

Fix the flaky Java integration test `SharedCommandTests.copy` by awaiting `SET` completion before the `COPY` commands that depend on it.

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] SharedCommandTests.copy - standalone RESP3 assertion failure](https://github.com/valkey-io/valkey-glide/issues/6547)
Closes #6547

### Features / Behaviour Changes

None. This changes test code only.

### Implementation

`copy`, `copy_binary`, `copy_with_database_id`, and `copy_binary_with_database_id` in `java/integTest/src/test/java/glide/SharedCommandTests.java` called `client.set(source, value)` without awaiting the returned `CompletableFuture`, then asserted on the result of `COPY`. Commands are dispatched independently, so nothing ordered the `SET` ahead of the `COPY`. When the `COPY` reached the server first, the source key did not exist yet and `COPY` returned `false`. That is the `expected: <true> but was: <false>` failure in the issue.

All eight `set()` calls in those four methods now end in `.get()`. This makes the ordering explicit instead of narrowing the window, at a cost of one round trip per call. Assertions and coverage are unchanged, and the fix adds no sleeps or retries.

The destination-key collision theory in the issue does not hold: both `source` and `destination` are suffixed with a fresh `UUID.randomUUID()` per invocation.

### Limitations

None.

### Testing

The four affected test methods pass across all four parametrizations (standalone RESP2, standalone RESP3, cluster RESP2, cluster RESP3). `SharedCommandTests.copy` ran 100 consecutive times without failure. The full Java test matrix passes in CI on JDK 8 and 17 against engine versions 6.2 and 9.0.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
