### PR TITLE
CD: Retry RC node test install to handle npm propagation race (backport #6343 to release-2.5)

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -538,7 +538,27 @@ jobs:
             - name: Run utils/node Tests
               working-directory: utils/release-candidate-testing/node
               run: |
-                  npm install @valkey/valkey-glide@${{ needs.get-build-parameters.outputs.npm_tag }} --save
+                  # The platform-specific optional dependency (e.g. @valkey/valkey-glide-linux-x64-gnu)
+                  # can lag behind the base package on the npm registry for a short window right after
+                  # publish. When that happens npm silently skips the optional dependency and the test
+                  # fails with "Cannot find module". Retry the install until the native module resolves.
+                  NPM_TAG="${{ needs.get-build-parameters.outputs.npm_tag }}"
+                  MAX_ATTEMPTS=5
+                  DELAY=15
+                  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+                      rm -rf node_modules package-lock.json
+                      npm install "@valkey/valkey-glide@${NPM_TAG}" --save
+                      if node -e "require('@valkey/valkey-glide')"; then
+                          echo "Native module resolved on attempt ${attempt}."
+                          break
+                      fi
+                      if [ "${attempt}" -eq "${MAX_ATTEMPTS}" ]; then
+                          echo "::error::@valkey/valkey-glide native module still unresolved after ${MAX_ATTEMPTS} attempts."
+                          exit 1
+                      fi
+                      echo "Attempt ${attempt}/${MAX_ATTEMPTS}: native module not resolvable yet (likely npm registry propagation). Retrying in ${DELAY}s..."
+                      sleep "${DELAY}"
+                  done
                   npm run build:utils
                   npm test
 


### PR DESCRIPTION
### Summary

Backport of #6343 to `release-2.5`. Clean cherry-pick of commit `841d6cfc5` from `main`.

The post-publish "Run utils/node Tests" step installs the freshly published base package and loads its native module. The platform-specific optional dependency (e.g. `@valkey/valkey-glide-linux-x64-gnu`) can lag behind the base package on the npm registry for a short window after publish; npm then silently skips the optional dependency and the test fails with `Cannot find module`. This retries the install (with a clean `node_modules`/lockfile) until the native module resolves.

### Issue link

References #6343
Closes N/A (backport of already-merged #6343)

### Features / Behaviour Changes

No runtime behaviour change. CI-only: the RC node test install in `.github/workflows/npm-cd.yml` now retries (up to 5 attempts, 15s apart) until `require('@valkey/valkey-glide')` resolves.

### Implementation

Clean cherry-pick of commit `841d6cfc5` from `main`. Only `.github/workflows/npm-cd.yml` is touched; applied with no conflicts.

### Limitations

None.

### Testing

CI-only change; validated on the next `release-2.5` npm CD run. YAML is syntactically unchanged from the merged main version.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated. (N/A — CI workflow change)
- [ ] CHANGELOG.md and documentation files are updated. (N/A — no user-facing change)