### PR TITLE
Fix native panic for setex psetex and setnx commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 ### Fixes
 
 * Core: Adding support for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
-* Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
+* Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))
 * Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
-* Core: Enforce the RESP3 parser recursion-depth limit for all aggregate types (map, set, push, attribute), not just arrays. A malicious or compromised server could previously send deeply nested `%`/`~`/`>`/`|` payloads that consumed one native stack frame per level and crashed the host application via stack exhaustion (DoS); such payloads now surface a graceful parse error. ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))
+* Core: fix(core): enforce RESP3 recursion-depth guard for all aggregate types ([#6477](https://github.com/valkey-io/valkey-glide/pull/6477))
 * Core: Update `anyhow` to 1.0.103 to fix RUSTSEC-2026-0190, an unsoundness advisory in `anyhow::Error::downcast_mut()` that can trigger undefined behavior ([#6364](https://github.com/valkey-io/valkey-glide/pull/6364))
 * Go: Remove `.gitignore` from the released module so consumers who commit `vendor/` keep the generated artifacts (`internal/protobuf/*.pb.go`, `rustbin/**`, `lib.h`) ([#6441](https://github.com/valkey-io/valkey-glide/pull/6441))
 
@@ -26,10 +26,10 @@
 
 ### Fixes
 
-* Python: Correct the `set` return type hint from `Optional[bytes]` to `Optional[Union[TOK, bytes]]`. The `SET` success reply is a RESP simple string (`+OK`), which GLIDE decodes to `str` (not `bytes`), so byte-only code that trusted the hint (e.g. `result.decode()`) type-checked but failed at runtime. Applies to the async client, sync client, and batch. ([#6347](https://github.com/valkey-io/valkey-glide/issues/6347))
-* Core/FFI: Fix heap corruption in `convert_vec_to_pointer` where `shrink_to_fit()` (a non-binding hint) was followed by `Vec::from_raw_parts` with `capacity = len`. When the allocator kept extra capacity, deallocation passed the wrong size, corrupting heap metadata and causing delayed SIGABRT crashes after many pubsub messages or response frees. ([#5637](https://github.com/valkey-io/valkey-glide/pull/5637))
-* Python: Fix `get(key, buffer=...)` under-reporting capacity for non-byte-format memoryviews. The sync client passed `len(response_buffer)` (element count) to the FFI instead of `response_buffer.nbytes`, so a memoryview with `itemsize > 1` (e.g. `array("I", ...)`) was treated as `itemsize`× smaller than its real capacity, spuriously failing valid GETs with "Value size exceeds buffer capacity". Byte-format (`"B"`) buffers were unaffected. ([#6310](https://github.com/valkey-io/valkey-glide/issues/6310))
-* Core: Honor `AWS_ENDPOINT_URL_STS` in the IAM credentials-provider loader so ElastiCache/MemoryDB IAM auth works in AWS partitions that do not publish a separate FIPS STS hostname (e.g. `us-gov-west-1`). Previously, setting `AWS_USE_FIPS_ENDPOINT=true` made the SDK construct a non-existent `sts-fips.<region>.amazonaws.com`, causing credential acquisition to hang. Matches `boto3` behavior. ([#5967](https://github.com/valkey-io/valkey-glide/issues/5967))
+* Python: fix(python): correct set return type hint to Optional[Union[TOK, bytes]] ([#6351](https://github.com/valkey-io/valkey-glide/pull/6351))
+* Core/FFI: Python: Change async client to use FFI for requests and unnamed pipe for responses instead of UDS for both ([#5637](https://github.com/valkey-io/valkey-glide/pull/5637))
+* Python: fix(python): use response_buffer.nbytes for buffer GET capacity ([#6311](https://github.com/valkey-io/valkey-glide/pull/6311))
+* Core: fix(core): honor AWS_ENDPOINT_URL_STS in IAM credentials-provider loader ([#5968](https://github.com/valkey-io/valkey-glide/pull/5968))
 * Core: Make the pipeline send-timeout liveness-aware so sustained backpressure on a live-but-slow connection waits for channel capacity instead of failing commands with `FatalSendError`, while a genuinely dead connection still fails fast ([#5446](https://github.com/valkey-io/valkey-glide/issues/5446))
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Core: Adding support for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
+* Core: Fix native panic for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Fix native panic (process crash) on `SETEX`/`PSETEX`/`SETNX` caused by missing `get_command()` match arms for those `RequestType` variants, and harden the surrounding catch-alls so any future unwired command produces a normal client error instead of crashing the process. Also fix commands with a registered `ExpectedReturnType` (e.g. `EXPIRE`, `PERSIST`, `SISMEMBER`, `PFADD`, and 12 others) raising a `TypeError` when queued inside a blockless `MULTI`/`EXEC`, by making `convert_to_expected_type()` pass the RESP `"QUEUED"` placeholder reply through unconverted instead of attempting type coercion on it. ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Core: Fix native panic (process crash) on `SETEX`/`PSETEX`/`SETNX` caused by missing `get_command()` match arms for those `RequestType` variants, and harden the surrounding catch-alls so any future unwired command produces a normal client error instead of crashing the process. Also fix commands with a registered `ExpectedReturnType` (e.g. `EXPIRE`, `PERSIST`, `SISMEMBER`, `PFADD`, and 12 others) raising a `TypeError` when queued inside a blockless `MULTI`/`EXEC`, by making `convert_to_expected_type()` pass the RESP `"QUEUED"` placeholder reply through unconverted instead of attempting type coercion on it. ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
+* Core: Adding support for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))
 * Core/FFI: fix(ffi): prevent pub/sub DoS from malformed server push frames ([#6530](https://github.com/valkey-io/valkey-glide/pull/6530))

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -62,6 +62,16 @@ pub(crate) fn convert_to_expected_type(
         return Ok(value);
     }
 
+    // If the value is the RESP "QUEUED" status reply (sent for any command issued
+    // while the connection is inside a MULTI transaction, before EXEC), return it
+    // as-is without attempting per-command type coercion - the real reply doesn't
+    // exist yet until EXEC runs, so e.g. coercing it to Boolean would incorrectly fail.
+    if let Value::SimpleString(ref s) = value {
+        if s == "QUEUED" {
+            return Ok(value);
+        }
+    }
+
     match expected {
         ExpectedReturnType::Map {
             key_type,
@@ -1663,6 +1673,7 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType<'_>>
         | b"MOVE"
         | b"COPY"
         | b"MSETNX"
+        | b"SETNX"
         | b"XGROUP DESTROY"
         | b"XGROUP CREATECONSUMER" => Some(ExpectedReturnType::Boolean),
         b"SMISMEMBER" | b"SCRIPT EXISTS" => Some(ExpectedReturnType::ArrayOfBools),

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -66,10 +66,10 @@ pub(crate) fn convert_to_expected_type(
     // while the connection is inside a MULTI transaction, before EXEC), return it
     // as-is without attempting per-command type coercion - the real reply doesn't
     // exist yet until EXEC runs, so e.g. coercing it to Boolean would incorrectly fail.
-    if let Value::SimpleString(ref s) = value {
-        if s == "QUEUED" {
-            return Ok(value);
-        }
+    if let Value::SimpleString(ref s) = value
+        && s == "QUEUED"
+    {
+        return Ok(value);
     }
 
     match expected {

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1673,7 +1673,6 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType<'_>>
         | b"MOVE"
         | b"COPY"
         | b"MSETNX"
-        | b"SETNX"
         | b"XGROUP DESTROY"
         | b"XGROUP CREATECONSUMER" => Some(ExpectedReturnType::Boolean),
         b"SMISMEMBER" | b"SCRIPT EXISTS" => Some(ExpectedReturnType::ArrayOfBools),

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -3602,6 +3602,39 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_to_expected_type_passes_through_queued_reply() {
+        // While a connection is mid-MULTI, the server replies with the "QUEUED"
+        // status for any command, regardless of that command's real reply type.
+        // convert_to_expected_type must return it as-is, not attempt coercion.
+        let queued = Value::SimpleString("QUEUED".to_string());
+
+        assert_eq!(
+            convert_to_expected_type(queued.clone(), Some(ExpectedReturnType::Boolean)).unwrap(),
+            queued
+        );
+        assert_eq!(
+            convert_to_expected_type(queued.clone(), Some(ExpectedReturnType::Double)).unwrap(),
+            queued
+        );
+        assert_eq!(
+            convert_to_expected_type(queued.clone(), Some(ExpectedReturnType::Set)).unwrap(),
+            queued
+        );
+        assert_eq!(
+            convert_to_expected_type(queued.clone(), None).unwrap(),
+            queued
+        );
+
+        // A real "QUEUED"-looking value should still coerce normally once it's
+        // not standing in for a queued reply - i.e. any other command's actual
+        // Boolean-coercible reply is unaffected by this guard.
+        assert_eq!(
+            convert_to_expected_type(Value::Int(1), Some(ExpectedReturnType::Boolean)).unwrap(),
+            Value::Boolean(true)
+        );
+    }
+
+    #[test]
     fn test_convert_spop_to_set_for_spop_count() {
         assert!(matches!(
             expected_type_for_cmd(redis::cmd("SPOP").arg("key1").arg("3")),

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -835,7 +835,10 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::SSubscribeBlocking => RequestType::SSubscribeBlocking,
             ProtobufRequestType::SUnsubscribeBlocking => RequestType::SUnsubscribeBlocking,
             ProtobufRequestType::GetSubscriptions => RequestType::GetSubscriptions,
-            _ => todo!(),
+            ProtobufRequestType::SetEx => RequestType::SetEx,
+            ProtobufRequestType::PSetEx => RequestType::PSetEx,
+            ProtobufRequestType::SetNX => RequestType::SetNX,
+            _ => RequestType::InvalidRequest,
         }
     }
 }
@@ -1418,7 +1421,10 @@ impl RequestType {
             RequestType::SSubscribeBlocking => Some(cmd("SSUBSCRIBE_BLOCKING")),
             RequestType::SUnsubscribeBlocking => Some(cmd("SUNSUBSCRIBE_BLOCKING")),
             RequestType::GetSubscriptions => Some(cmd("GET_SUBSCRIPTIONS")),
-            _ => todo!(),
+            RequestType::SetEx => Some(cmd("SETEX")),
+            RequestType::PSetEx => Some(cmd("PSETEX")),
+            RequestType::SetNX => Some(cmd("SETNX")),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
# Fix native panic on SETEX/PSETEX/SETNX, and a MULTI-queuing crash affecting 16 Boolean/ArrayOfBools-coerced commands

## Issue link
This Pull Request is linked to issue: Closes [issue](https://github.com/valkey-io/valkey-glide/issues/6557)

## Features / Behaviour Changes
SETEX, PSETEX, and SETNX no longer crash the client process. Previously, any call to these three commands hit an unimplemented match arm and triggered a native Rust panic (not yet implemented) that killed the whole process — not a catchable client-side error.
Commands with a registered ExpectedReturnType (Boolean, Double, Map, Set, ArrayOfBools) sent while a connection is mid-MULTI (queued, pre-EXEC) no longer error out. Previously, the server's +QUEUED placeholder reply was passed through type coercion as if it were the real reply, raising a TypeError on the client side. This affects 16 commands, including EXPIRE, PEXPIREAT, PERSIST, SISMEMBER, SMOVE, PFADD, RENAMENX, MOVE, COPY, MSETNX, HEXISTS, HSETNX, SMISMEMBER, SCRIPT EXISTS, XGROUP DESTROY/CREATECONSUMER.
No public API changes. SETNX's reply type is unchanged (raw 0/1 integer, matching the wire protocol and existing customCommand(["SETNX", ...]) contract).
## Root cause

## Implementation
**glide-core/src/request_type.rs**: Added the missing get_command() arms for RequestType::SetEx, PSetEx, SetNx (mapping to SETEX/PSETEX/SETNX), plus the parallel arms in the protobuf From<ProtobufRequestType> impl. Hardened both functions' catch-alls from _ => todo!() to _ => None (and _ => RequestType::InvalidRequest for the protobuf impl, since that function returns RequestType directly, not an Option). The None path already had a proper error-handling branch at the FFI call site (ffi/src/lib.rs), so this turns any future unwired RequestType variant into a normal client error instead of a process panic — not just a fix for these three commands.
**glide-core/src/client/value_conversion.rs**: Added an early-return guard in convert_to_expected_type() for Value::SimpleString("QUEUED"), mirroring the function's existing ServerError early-return. This is the single centralized coercion function called from execute_command_owned, so the fix covers all 16 affected commands (and any future command added to any coercion table) at one point, rather than patching per-command.

## Limitations
Fix is scoped to glide-core; no changes to client-language bindings (Python/Node/Java) since none of them expose the legacy SETEX/PSETEX/SETNX standalone commands.
The MULTI-queuing bug is only reachable via the older, blockless multi/exec application API pattern; the atomic-batch (is_atomic: true) mechanism was already unaffected.

## Testing
cargo check passes clean on glide-core.
Rebuilt the native FFI library and re-ran the original repros against a real server:
setex/psetex → "OK" (previously: process crash).
setnx on new/existing key → raw 1/0 (previously: process crash).
multi { incrby; pexpire } → [n, true] (previously: raised before EXEC).
multi { persist; pexpire; sismember } → [false, true, false] (previously: raised on first boolean-typed command).
Downstream Ruby client (valkey-glide-rb) full test suite: 552/552 passing, 0 regressions — including 6 previously-skipped tests for setex/psetex/setnx, and 2 new regression tests for the MULTI-queuing crash, with expected values cross-checked against redis-rb.
No test changes in this repo itself; repro/verification done downstream.

Checklist

- [x]  This Pull Request is related to one issue.
- [x]  Commit message has a detailed description of what changed and why.
- [x]  Tests are added or updated.
- [ ]  CHANGELOG.md and documentation files are updated.
- [ ]  Linters have been run (make *-lint targets) and Prettier has been run (make prettier-fix).
- [x]  Destination branch is correct - main or release
- [ ]  Create merge commit if merging release branch into main, squash otherwise.
- [ ]  Make sure to update the documentation in the valkey-glide-docs repository if necessary
