### PR TITLE
perf(core): zero-copy receive path for GET/MGET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Changes
 
-* Core: perf(core): zero-copy receive path for GET/MGET. The async RESP decoder now scans the read buffer for one complete frame, extracts it into a recycled pooled buffer, and slices bulk-string payloads out of it as refcounted `Bytes` — eliminating the per-value allocation + copy. The FFI response arena stores those slices directly, so non-buffered GET/MGET responses are one-copy end to end (kernel read buffer → caller). Benchmarked on ElastiCache: −44…−77% client CPU per op on pipelined MGET workloads, GET ≤16KB at parity. ([#6559](https://github.com/valkey-io/valkey-glide/pull/6559))
+* Core: Zero-copy receive path for GET/MGET ([#6559](https://github.com/valkey-io/valkey-glide/pull/6559))
 * Go: Expose `inflightRequestsLimit` configuration via `WithInflightRequestsLimit`, bringing the Go client to parity with Java, Python, and Node ([#6385](https://github.com/valkey-io/valkey-glide/issues/6385))
 * Core/FFI: Add `command_with_route_info` FFI entrypoint, accepting routing as a `RouteInfo` C-struct pointer instead of protobuf-encoded bytes — the same mechanism `batch()` already uses. Existing `command`, `command_with_buffer`, `command_with_buffers`, and `invoke_script` are unchanged. ([#6494](https://github.com/valkey-io/valkey-glide/pull/6494))
 * CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6478](https://github.com/valkey-io/valkey-glide/pull/6478))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changes
 
+* Core: perf(core): zero-copy receive path for GET/MGET. The async RESP decoder now scans the read buffer for one complete frame, extracts it into a recycled pooled buffer, and slices bulk-string payloads out of it as refcounted `Bytes` — eliminating the per-value allocation + copy. The FFI response arena stores those slices directly, so non-buffered GET/MGET responses are one-copy end to end (kernel read buffer → caller). Benchmarked on ElastiCache: −44…−77% client CPU per op on pipelined MGET workloads, GET ≤16KB at parity. ([#6559](https://github.com/valkey-io/valkey-glide/pull/6559))
 * Core/FFI: Add `command_with_route_info` FFI entrypoint, accepting routing as a `RouteInfo` C-struct pointer instead of protobuf-encoded bytes — the same mechanism `batch()` already uses. Existing `command`, `command_with_buffer`, `command_with_buffers`, and `invoke_script` are unchanged. ([#6494](https://github.com/valkey-io/valkey-glide/pull/6494))
 * CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6478](https://github.com/valkey-io/valkey-glide/pull/6478))
 * Node: Replace socket IPC with direct NAPI layer ([#5325](https://github.com/valkey-io/valkey-glide/pull/5325))

--- a/docs/zero-copy-benchmarks.md
+++ b/docs/zero-copy-benchmarks.md
@@ -162,3 +162,53 @@ larger on Graviton).
   (bimodal run-to-run variance present in baseline too) and is retracted.
 - Throughput only improves where CPU was the binding constraint (e.g. SET 256KB depth 1:
   +37% x86, +15..22% ARM); flow-capped cells are unchanged by design.
+
+## Multi-connection pool contention (ElastiCache + microbench, 2026-07-19)
+
+**Question:** the recycled buffer pool originally used one process-global
+`Mutex<Vec<Vec<u8>>>`, taken by every payload >4 KB (send args and receive
+frames) across all connections. Does it contend under multi-connection load,
+and does the 8-shard thread-affine pool fix it?
+
+**Method:** two builds byte-identical except `buf_pool.rs` (`sharded` vs
+`global`); same infra as the real-network validation (c7i.8xlarge client +
+same-AZ `cache.r7g.4xlarge`, us-west-2a). Harnesses: `zc_multiconn`
+(C independent `MultiplexedConnection`s × depth-16 persistent workers) and
+`zc_poolstress` (pure pool build/drop, no I/O). 3 alternating reps/cell,
+`perf stat` (task-clock, instructions, context-switches).
+
+### Live ElastiCache (GET/SET × 8 KB/64 KB × 1–32 connections, depth 16)
+
+- **Throughput identical in every cell** (Δ < 0.1%): all ≥8-connection cells
+  sit on the ~12.4 Gbps instance network plateau, so the wire — not the pool
+  lock — is the ceiling.
+- **Client CPU/op: sharded −3..5% at 16–32 connections** (8 KB GET @32 conns:
+  20.0 µs vs 21.2 µs), with instructions/op flat → the recovered time is
+  lock-wait, not executed work. Single-connection cells: parity.
+
+### Pure pool microbenchmark (no I/O — worst case, 8 KB payload)
+
+| threads | sharded M ops/s | global M ops/s | global CPU ns/op | sharded ns/op |
+|---:|---:|---:|---:|---:|
+| 1 | 3.78 | 3.81 | 262 | 265 |
+| 4 | 6.48 | 2.01 | 1 959 | 515 |
+| 8 | 12.10 | **1.41** | 4 673 | 527 |
+| 16 | 6.57 | 1.50 | 8 956 | 1 904 |
+| 32 | 5.34 | 1.62 | 18 672 | 3 731 |
+
+The global mutex collapses beyond ~4 threads: throughput drops *below* its
+single-thread rate, CPU/op inflates ~70×, and context switches explode to
+~165 K per M-ops (futex convoy). The sharded pool scales to ~12 M ops/s and
+degrades gracefully.
+
+### Honest framing
+
+The global-lock collapse point (~2–4 M pool-ops/s) is roughly 10× beyond what
+any real network workload drives on this hardware (max observed live rate:
+~190 K ops/s over the wire, ~380 K/s loopback — where the variants are
+indistinguishable in throughput). Sharding is justified as removing a hard
+scalability cliff (faster NICs / bigger instances / more runtime threads move
+workloads toward it) plus the measured −3..5% CPU/op at high connection
+counts, with no regression in any cell (worst: +0.9% CPU single-threaded,
+within noise). No new threads are created by the sharding — see the design
+doc.

--- a/docs/zero-copy-initiative.md
+++ b/docs/zero-copy-initiative.md
@@ -132,9 +132,12 @@ the pages stay resident. Design points:
   collapse ~8.6× under parallel load (see the multi-connection contention
   section in `zero-copy-benchmarks.md`).
 - **Bounds:** copies ≤4 KB bypass the pool (allocator small-size classes
-  handle them well); buffers >1 MB are never retained; idle retention is
-  capped at 8 buffers/shard → 64 MiB worst-case process-wide. In-flight
-  buffers are unbounded by design (bounded by pipeline depth).
+  handle them well); copies >1 MB also bypass it entirely — no pooled buffer
+  could satisfy them without an immediate realloc, so popping one would only
+  drain a warm buffer from mid-size traffic, and their allocations are never
+  retained (a burst of huge values can't park large idle memory). Idle
+  retention is capped at 8 buffers/shard → 64 MiB worst-case process-wide.
+  In-flight buffers are unbounded by design (bounded by pipeline depth).
 - **Poison recovery:** a poisoned shard lock only means another thread
   panicked mid push/pop; the `Vec` is structurally valid, so recycling
   continues (`unwrap_or_else(into_inner)`). Thread-teardown TLS access falls

--- a/docs/zero-copy-initiative.md
+++ b/docs/zero-copy-initiative.md
@@ -108,6 +108,38 @@ pack-and-write path — the segmented/vectored machinery is only paid when a
 large shared payload can actually skip a copy (avoids a measured +10%
 small-command regression).
 
+### Recycled buffer pool (`buf_pool`) — shared by both phases
+
+Two hot paths briefly need an owned buffer of tens-to-hundreds of KB whose
+lifetime is tied to a refcounted `Bytes`: the decoder's per-frame copy
+(receive) and `write_arg`'s auto-share copy of large borrowed args (send).
+Allocating these fresh per operation caused page-fault churn under pipelined
+load (~37 faults/op at 64 KB, depth 16); the pool recycles the allocations so
+the pages stay resident. Design points:
+
+- **Recycling via drop hook:** buffers are handed out as
+  `Bytes::from_owner(PooledBuf)`; the allocation returns to the pool only when
+  the *last* `Bytes` clone/slice drops, so a buffer can never be reused while
+  still referenced. No `unsafe`.
+- **Sharded, not global:** the pool is **8 independent `Mutex<Vec<Vec<u8>>>`
+  shards**. Threads are assigned a shard round-robin via a cached
+  `thread_local` index — **no threads are created**; existing runtime/binding
+  threads simply stop sharing one lock. A `Bytes` may be dropped on a
+  different thread than allocated it; the buffer then parks in the dropping
+  thread's shard, which is harmless (the pool is a best-effort cache, not an
+  ownership structure). Rationale: a single process-global mutex on every
+  >4 KB payload across *all* connections is a scalability cliff — measured to
+  collapse ~8.6× under parallel load (see the multi-connection contention
+  section in `zero-copy-benchmarks.md`).
+- **Bounds:** copies ≤4 KB bypass the pool (allocator small-size classes
+  handle them well); buffers >1 MB are never retained; idle retention is
+  capped at 8 buffers/shard → 64 MiB worst-case process-wide. In-flight
+  buffers are unbounded by design (bounded by pipeline depth).
+- **Poison recovery:** a poisoned shard lock only means another thread
+  panicked mid push/pop; the `Vec` is structurally valid, so recycling
+  continues (`unwrap_or_else(into_inner)`). Thread-teardown TLS access falls
+  back to shard 0 instead of panicking.
+
 ---
 
 ## 3. Safety

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2555,7 +2555,13 @@ pub struct ResponseArena {
     /// All CommandResponse nodes. Index 0 is the root.
     nodes: Vec<CommandResponse>,
     /// Owned string buffers (kept alive until arena is freed).
-    strings: Vec<Vec<u8>>,
+    ///
+    /// Held as [`bytes::Bytes`] so `BulkString` payloads — zero-copy slices
+    /// of the connection read buffer — can be stored without a `to_vec()`
+    /// copy. NOTE: while the arena is alive it pins the read-buffer chunks
+    /// its slices came from; bindings free the arena promptly after
+    /// materializing values, keeping that window short.
+    strings: Vec<bytes::Bytes>,
 }
 
 const MAX_ARENA_POOL_SIZE: usize = 16;
@@ -2617,7 +2623,9 @@ impl ResponseArena {
     }
 
     /// Store a string buffer, returning (ptr, len) for the CommandResponse fields.
-    fn store_string(&mut self, data: Vec<u8>) -> (*mut c_char, c_long) {
+    /// Accepts anything convertible to `Bytes`; `Vec<u8>` converts zero-copy.
+    fn store_string(&mut self, data: impl Into<bytes::Bytes>) -> (*mut c_char, c_long) {
+        let data = data.into();
         let ptr = data.as_ptr() as *mut c_char;
         let len = data.len() as c_long;
         self.strings.push(data);
@@ -2686,9 +2694,11 @@ impl ResponseArena {
                         unsafe {
                             std::ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
                         }
-                        data.len().to_string().into_bytes()
+                        bytes::Bytes::from(data.len().to_string().into_bytes())
                     } else {
-                        data.into()
+                        // Zero-copy: the arena keeps the refcounted slice of
+                        // the read buffer alive; no payload copy.
+                        data
                     };
                 let (ptr, len) = self.store_string(data);
                 self.nodes[idx].response_type = ResponseType::String;
@@ -2770,7 +2780,7 @@ impl ResponseArena {
 
                 // kind key
                 let ki = self.alloc_node();
-                let (ptr, len) = self.store_string(b"kind".to_vec());
+                let (ptr, len) = self.store_string(bytes::Bytes::from_static(b"kind"));
                 self.nodes[ki].response_type = ResponseType::String;
                 self.nodes[ki].string_value = ptr;
                 self.nodes[ki].string_value_len = len;
@@ -2785,7 +2795,7 @@ impl ResponseArena {
 
                 // values key
                 let vk = self.alloc_node();
-                let (ptr, len) = self.store_string(b"values".to_vec());
+                let (ptr, len) = self.store_string(bytes::Bytes::from_static(b"values"));
                 self.nodes[vk].response_type = ResponseType::String;
                 self.nodes[vk].string_value = ptr;
                 self.nodes[vk].string_value_len = len;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -175,6 +175,15 @@ pub struct CommandResponse {
     /// Below two values are related to each other.
     /// `string_value` represents the string.
     /// `string_value_len` represents the length of the string.
+    ///
+    /// Despite the `*mut` type (kept for C ABI compatibility), callers MUST
+    /// treat this memory as **read-only**: for arena-allocated responses it
+    /// points into a refcounted buffer shared with every other string in the
+    /// same response (a zero-copy slice of the decoded network frame), so
+    /// writing through it corrupts sibling values. It is valid only until
+    /// `free_command_response` / `free_response_arena`; the backing buffer is
+    /// recycled afterwards, so a stale pointer reads (or corrupts) unrelated
+    /// future response data rather than faulting.
     pub string_value: *mut c_char,
     pub string_value_len: c_long,
 
@@ -2584,7 +2593,16 @@ impl ResponseArena {
             }
         })
     }
-    fn return_to_pool(self) {
+    fn return_to_pool(mut self) {
+        // Drop the string buffers NOW, not when this pool slot is next
+        // reused: `strings` holds refcounted `Bytes` that pin the decoded
+        // response frames (and their recycled `buf_pool` allocations). A
+        // parked arena that kept them alive would pin up to
+        // MAX_ARENA_POOL_SIZE frames per thread indefinitely on an idle
+        // thread and starve the frame-buffer pool. Only the node Vec's
+        // capacity is worth recycling.
+        self.strings.clear();
+        self.nodes.clear();
         ARENA_POOL.with(|p| {
             let mut p = p.borrow_mut();
             if p.len() < MAX_ARENA_POOL_SIZE {
@@ -2624,6 +2642,13 @@ impl ResponseArena {
 
     /// Store a string buffer, returning (ptr, len) for the CommandResponse fields.
     /// Accepts anything convertible to `Bytes`; `Vec<u8>` converts zero-copy.
+    ///
+    /// The returned pointer aliases the (possibly shared) `Bytes` buffer —
+    /// for zero-copy `BulkString`s that is the decoded network frame, shared
+    /// by every other slice of the same response and recycled through
+    /// `buf_pool` after release. It is therefore read-only and valid only
+    /// until the arena releases its strings (`return_to_pool`); see the
+    /// `CommandResponse::string_value` contract.
     fn store_string(&mut self, data: impl Into<bytes::Bytes>) -> (*mut c_char, c_long) {
         let data = data.into();
         let ptr = data.as_ptr() as *mut c_char;
@@ -2873,6 +2898,158 @@ pub unsafe extern "C" fn free_response_arena(arena_ptr: *mut ResponseArena) {
     }
 }
 
+#[cfg(test)]
+mod tests_response_arena {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Owner for `Bytes::from_owner` that records when the allocation is
+    /// released, so tests can observe whether a `Bytes` slice is still
+    /// pinning its backing buffer (as zero-copy `BulkString`s pin the
+    /// decoded response frame).
+    struct DropTracked(Vec<u8>, Arc<AtomicBool>);
+
+    impl AsRef<[u8]> for DropTracked {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
+
+    impl Drop for DropTracked {
+        fn drop(&mut self) {
+            self.1.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Regression test: freeing a response arena must release the `Bytes`
+    /// frame slices it holds, even though the arena itself is parked in
+    /// `ARENA_POOL` for reuse. If `return_to_pool` kept `strings` populated,
+    /// a freed GET/MGET response would pin its read-buffer frame (and its
+    /// recycled `buf_pool` allocation) indefinitely on an idle thread.
+    #[test]
+    fn free_response_arena_releases_frame_buffers() {
+        let released = Arc::new(AtomicBool::new(false));
+        let frame = bytes::Bytes::from_owner(DropTracked(vec![7u8; 64], released.clone()));
+
+        // Two BulkStrings slicing the same frame, as the zero-copy decoder
+        // produces for an MGET response.
+        let value = Value::Array(vec![
+            Value::BulkString(frame.slice(0..16)),
+            Value::BulkString(frame.slice(16..32)),
+        ]);
+        drop(frame);
+
+        let (root, arena_ptr) =
+            valkey_value_to_arena_response(value, &[]).expect("arena build failed");
+
+        // While the response is alive, its string pointers alias the pinned
+        // frame; read them back the way a binding would (this also gives
+        // MIRI a provenance check on the handed-out pointers).
+        unsafe {
+            let root_ref = &*root;
+            assert!(matches!(root_ref.response_type, ResponseType::Array));
+            assert_eq!(root_ref.array_value_len, 2);
+            for i in 0..root_ref.array_value_len {
+                let child = &*root_ref.array_value.add(i as usize);
+                assert!(matches!(child.response_type, ResponseType::String));
+                assert_eq!(child.string_value_len, 16);
+                let payload = std::slice::from_raw_parts(
+                    child.string_value as *const u8,
+                    child.string_value_len as usize,
+                );
+                assert_eq!(payload, &[7u8; 16]);
+            }
+        }
+        assert!(
+            !released.load(Ordering::SeqCst),
+            "frame must stay pinned while the response is alive"
+        );
+
+        // Freeing the response must drop the frame slices immediately —
+        // NOT hold them until the pooled arena slot is next reused.
+        unsafe { free_response_arena(arena_ptr) };
+        assert!(
+            released.load(Ordering::SeqCst),
+            "freed arena parked in ARENA_POOL must not keep pinning response frame buffers"
+        );
+    }
+
+    /// The caller-buffer path (`response_buffers=` / MGET-into-buffers):
+    /// exercises the bounds-checked `copy_nonoverlapping` into caller memory
+    /// under MIRI, plus the undersized-buffer error before the copy.
+    #[test]
+    fn response_buffer_copy_path_is_bounds_checked() {
+        let payload = bytes::Bytes::from_static(b"0123456789abcdef");
+
+        // Large enough buffer: value copied, node reports the byte count.
+        let mut buf = vec![0u8; 32];
+        let value = Value::BulkString(payload.clone());
+        let (root, arena_ptr) =
+            valkey_value_to_arena_response(value, &[(buf.as_mut_ptr(), buf.len())])
+                .expect("arena build failed");
+        unsafe {
+            let root_ref = &*root;
+            assert!(matches!(root_ref.response_type, ResponseType::String));
+            // string_value holds the written-length as a decimal string.
+            let len_str = std::slice::from_raw_parts(
+                root_ref.string_value as *const u8,
+                root_ref.string_value_len as usize,
+            );
+            assert_eq!(len_str, b"16");
+            assert_eq!(&buf[..16], &payload[..]);
+            free_response_arena(arena_ptr);
+        }
+
+        // Undersized buffer: must error before any copy happens.
+        let mut small = vec![0u8; 4];
+        let value = Value::BulkString(payload);
+        let res = valkey_value_to_arena_response(value, &[(small.as_mut_ptr(), small.len())]);
+        assert!(res.is_err(), "oversized value must not be copied");
+        assert_eq!(&small[..], &[0u8; 4], "no partial write on error");
+    }
+
+    /// Map-shaped tree: exercises `finalize`'s index->pointer fixups for
+    /// `map_key`/`map_value` and nested string reads under MIRI.
+    #[test]
+    fn map_tree_finalize_fixups() {
+        let frame = bytes::Bytes::from_static(b"key1val1key2val2");
+        let value = Value::Map(vec![
+            (
+                Value::BulkString(frame.slice(0..4)),
+                Value::BulkString(frame.slice(4..8)),
+            ),
+            (
+                Value::BulkString(frame.slice(8..12)),
+                Value::BulkString(frame.slice(12..16)),
+            ),
+        ]);
+        let (root, arena_ptr) = valkey_value_to_arena_response(value, &[]).expect("build failed");
+        unsafe {
+            let root_ref = &*root;
+            assert!(matches!(root_ref.response_type, ResponseType::Map));
+            assert_eq!(root_ref.array_value_len, 2);
+            let expected: [(&[u8], &[u8]); 2] = [(b"key1", b"val1"), (b"key2", b"val2")];
+            for (i, (ek, ev)) in expected.iter().enumerate() {
+                let wrapper = &*root_ref.array_value.add(i);
+                let k = &*wrapper.map_key;
+                let v = &*wrapper.map_value;
+                let kb = std::slice::from_raw_parts(
+                    k.string_value as *const u8,
+                    k.string_value_len as usize,
+                );
+                let vb = std::slice::from_raw_parts(
+                    v.string_value as *const u8,
+                    v.string_value_len as usize,
+                );
+                assert_eq!(kb, *ek);
+                assert_eq!(vb, *ev);
+            }
+            free_response_arena(arena_ptr);
+        }
+    }
+}
+
 /// Executes a command.
 ///
 /// # Safety
@@ -3037,13 +3214,6 @@ pub unsafe extern "C-unwind" fn command_with_buffer(
     }
 }
 
-/// The underlying command execution implementation. Used by various command
-/// execution API like: [`command_with_buffer`], [`command_with_buffers`],
-/// and [`command_with_route_info`]. It builds and dispatches the command,
-/// writing the reply into `response_buffer` when present (a single buffer for
-/// a scalar reply, one buffer per element for an array reply).
-///
-/// # Safety
 /// Append a caller-provided argument to `cmd` with minimal copying.
 ///
 /// Large payloads are copied ONCE at the FFI boundary into a refcounted
@@ -3061,16 +3231,25 @@ fn append_cmd_arg(cmd: &mut Cmd, arg: &[u8]) {
     cmd.arg(arg);
 }
 
-/// Like [`append_cmd_arg`] for owned buffers (compressed args): `Vec<u8>` to
-/// `Bytes` conversion is zero-copy, so large args are never copied at all.
+/// Like [`append_cmd_arg`] for owned buffers (compressed args): the `Vec` is
+/// adopted as-is via `Bytes::from_owner`, so large args are never copied at
+/// all. (`Bytes::from(Vec)` would shrink-to-fit — a realloc + full copy —
+/// whenever the compressor left excess capacity.)
 fn append_cmd_arg_owned(cmd: &mut Cmd, arg: Vec<u8>) {
     if arg.len() > redis::SHARED_ARG_INLINE_MAX {
-        cmd.arg_shared(bytes::Bytes::from(arg));
+        cmd.arg_shared(bytes::Bytes::from_owner(arg));
     } else {
         cmd.arg(arg);
     }
 }
 
+/// The underlying command execution implementation. Used by various command
+/// execution API like: [`command_with_buffer`], [`command_with_buffers`],
+/// and [`command_with_route_info`]. It builds and dispatches the command,
+/// writing the reply into `response_buffer` when present (a single buffer for
+/// a scalar reply, one buffer per element for an array reply).
+///
+/// # Safety
 /// `client_adapter_ptr` and `args`/`args_len` follow the same contract as
 /// [`command_with_buffer`]. `route_input` follows the safety contract
 /// documented on [`RouteInput::resolve`]. Any buffers referenced by

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -120,6 +120,8 @@ keep-alive = ["socket2"]
 sentinel = ["rand"]
 
 [dev-dependencies]
+bytes = "1"
+tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.9"
 socket2 = "0.6"
 fnv = "1"
@@ -162,6 +164,11 @@ required-features = ["cluster-async"]
 
 [[bench]]
 name = "bench_basic"
+harness = false
+required-features = ["tokio-comp"]
+
+[[bench]]
+name = "bench_zerocopy"
 harness = false
 required-features = ["tokio-comp"]
 

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -120,7 +120,7 @@ keep-alive = ["socket2"]
 sentinel = ["rand"]
 
 [dev-dependencies]
-bytes = "1"
+bytes = "1.9"
 tokio-util = { version = "0.7", features = ["codec"] }
 rand = "0.9"
 socket2 = "0.6"

--- a/glide-core/redis-rs/redis/benches/bench_zerocopy.rs
+++ b/glide-core/redis-rs/redis/benches/bench_zerocopy.rs
@@ -1,0 +1,163 @@
+//! Focused parser decode benchmark for the zero-copy (Phase 1) work.
+//!
+//! Measures `parse_redis_value` on bulk-string-heavy RESP payloads across a
+//! range of value sizes and array cardinalities. This isolates the cost that
+//! Phase 1 targets: the per-bulk-string `to_vec()` allocation + memcpy in the
+//! parser. Self-contained (manual RESP encoding), needs no server.
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use redis::parse_redis_value;
+
+use bytes::BytesMut;
+use redis::ValueCodec;
+use tokio_util::codec::Decoder;
+
+/// Encode a single RESP bulk string: `$<len>\r\n<payload>\r\n`.
+fn encode_bulk(payload: &[u8], out: &mut Vec<u8>) {
+    out.push(b'$');
+    out.extend_from_slice(payload.len().to_string().as_bytes());
+    out.extend_from_slice(b"\r\n");
+    out.extend_from_slice(payload);
+    out.extend_from_slice(b"\r\n");
+}
+
+/// Encode a RESP array header: `*<count>\r\n`.
+fn encode_array_header(count: usize, out: &mut Vec<u8>) {
+    out.push(b'*');
+    out.extend_from_slice(count.to_string().as_bytes());
+    out.extend_from_slice(b"\r\n");
+}
+
+/// A single bulk string of `size` bytes (the single-GET shape).
+fn single_bulk(size: usize) -> Vec<u8> {
+    let payload = vec![b'x'; size];
+    let mut out = Vec::new();
+    encode_bulk(&payload, &mut out);
+    out
+}
+
+/// An array of `count` bulk strings each `size` bytes (the MGET/HGETALL shape).
+fn array_of_bulks(count: usize, size: usize) -> Vec<u8> {
+    let payload = vec![b'x'; size];
+    let mut out = Vec::new();
+    encode_array_header(count, &mut out);
+    for _ in 0..count {
+        encode_bulk(&payload, &mut out);
+    }
+    out
+}
+
+fn bench_single_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_single_get");
+    for size in [64usize, 1024, 16 * 1024, 256 * 1024] {
+        let input = single_bulk(size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| parse_redis_value(input).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn bench_mget_array(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode_mget_array");
+    // (count, value_size): small values dominated by alloc count; large by memcpy.
+    for (count, size) in [(1000usize, 64usize), (1000, 1024), (100, 16 * 1024)] {
+        let input = array_of_bulks(count, size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{count}x{size}")),
+            &input,
+            |b, input| {
+                b.iter(|| parse_redis_value(input).unwrap());
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Decode via the async `ValueCodec` path — this is the path the multiplexed
+/// connection uses in production, and where the zero-copy change lands.
+/// `iter_batched` keeps the buffer refill out of the timed region.
+fn codec_decode_all(mut buf: BytesMut) -> usize {
+    let mut codec = ValueCodec::default();
+    let mut n = 0;
+    while let Some(item) = codec.decode(&mut buf).unwrap() {
+        item.unwrap();
+        n += 1;
+    }
+    n
+}
+
+fn bench_codec_single_get(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_single_get");
+    for size in [64usize, 1024, 16 * 1024, 256 * 1024] {
+        let input = single_bulk(size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter_batched(
+                || BytesMut::from(&input[..]),
+                |buf| assert_eq!(codec_decode_all(buf), 1),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_codec_mget_array(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_mget_array");
+    for (count, size) in [(1000usize, 64usize), (1000, 1024), (100, 16 * 1024)] {
+        let input = array_of_bulks(count, size);
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{count}x{size}")),
+            &input,
+            |b, input| {
+                b.iter_batched(
+                    || BytesMut::from(&input[..]),
+                    |buf| assert_eq!(codec_decode_all(buf), 1),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Pipelined shape: many independent single-GET replies in one read buffer,
+/// decoded frame by frame (how a pipelined burst actually hits the codec).
+fn bench_codec_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("codec_pipeline");
+    for (count, size) in [(100usize, 1024usize), (100, 16 * 1024)] {
+        let one = single_bulk(size);
+        let input: Vec<u8> = one
+            .iter()
+            .cycle()
+            .take(one.len() * count)
+            .copied()
+            .collect();
+        group.throughput(Throughput::Bytes(input.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{count}x{size}")),
+            &input,
+            |b, input| {
+                b.iter_batched(
+                    || BytesMut::from(&input[..]),
+                    |buf| assert_eq!(codec_decode_all(buf), count),
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_single_get,
+    bench_mget_array,
+    bench_codec_single_get,
+    bench_codec_mget_array,
+    bench_codec_pipeline
+);
+criterion_main!(benches);

--- a/glide-core/redis-rs/redis/examples/zc_e2e.rs
+++ b/glide-core/redis-rs/redis/examples/zc_e2e.rs
@@ -1,0 +1,90 @@
+//! Clean e2e receive-path benchmark: pipelined GET / MGET against a live
+//! server through MultiplexedConnection. No workload generation in the hot
+//! loop — isolates client receive-path CPU.
+//!
+//! Usage: zc_e2e <port> <mode:get|mget> <value_size> <total_ops> <pipeline_depth>
+use futures::future::join_all;
+use redis::{aio::MultiplexedConnection, AsyncCommands, Client};
+use std::time::Instant;
+
+async fn get_conn(port: u16) -> MultiplexedConnection {
+    let client = Client::open(format!("redis://127.0.0.1:{port}")).unwrap();
+    client
+        .get_multiplexed_tokio_connection(redis::GlideConnectionOptions::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let port: u16 = args[1].parse().unwrap();
+    let mode = args[2].clone();
+    let size: usize = args[3].parse().unwrap();
+    let total_ops: usize = args[4].parse().unwrap();
+    let depth: usize = args[5].parse().unwrap();
+
+    let mut conn = get_conn(port).await;
+    let payload = vec![b'x'; size];
+
+    // Preload keys.
+    let nkeys = 100usize;
+    for i in 0..nkeys {
+        let _: () = conn.set(format!("zc:{i}"), &payload).await.unwrap();
+    }
+    let mget_keys: Vec<String> = (0..nkeys).map(|i| format!("zc:{i}")).collect();
+
+    let start = Instant::now();
+    let mut done = 0usize;
+    while done < total_ops {
+        let batch = depth.min(total_ops - done);
+        let futs = (0..batch).map(|j| {
+            let mut c = conn.clone();
+            let mode = &mode;
+            let keys = &mget_keys;
+            async move {
+                match mode.as_str() {
+                    "get" => {
+                        let v: Vec<u8> = c.get(format!("zc:{}", j % 100)).await.unwrap();
+                        assert_eq!(v.len(), size);
+                    }
+                    // Consume the raw Value (glide-core's actual pattern: it
+                    // reads BulkString bytes in place, no Vec conversion).
+                    "getv" => {
+                        let mut cmd = redis::cmd("GET");
+                        cmd.arg(format!("zc:{}", j % 100));
+                        let v = c.send_packed_command(&cmd).await.unwrap();
+                        match v {
+                            redis::Value::BulkString(b) => assert_eq!(b.len(), size),
+                            other => panic!("unexpected {other:?}"),
+                        }
+                    }
+                    "mgetv" => {
+                        let mut cmd = redis::cmd("MGET");
+                        for k in keys {
+                            cmd.arg(k);
+                        }
+                        let v = c.send_packed_command(&cmd).await.unwrap();
+                        match v {
+                            redis::Value::Array(items) => assert_eq!(items.len(), keys.len()),
+                            other => panic!("unexpected {other:?}"),
+                        }
+                    }
+                    "mget" => {
+                        let vs: Vec<Vec<u8>> = c.mget(keys).await.unwrap();
+                        assert_eq!(vs.len(), keys.len());
+                    }
+                    _ => panic!("bad mode"),
+                }
+            }
+        });
+        join_all(futs).await;
+        done += batch;
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "mode={mode} size={size} ops={total_ops} depth={depth} elapsed={:.3}s ops_per_sec={:.0}",
+        elapsed.as_secs_f64(),
+        total_ops as f64 / elapsed.as_secs_f64()
+    );
+}

--- a/glide-core/redis-rs/redis/examples/zc_multiconn.rs
+++ b/glide-core/redis-rs/redis/examples/zc_multiconn.rs
@@ -1,0 +1,145 @@
+//! Multi-connection pool-contention benchmark (harness v3).
+//!
+//! Measures the recycled buffer pool (`buf_pool`) under multi-connection
+//! load: C independent MultiplexedConnections on a multi-threaded runtime,
+//! each with `depth` persistent pipelined workers. Every >4KiB payload
+//! (GET receive frames, SET send args) takes the pool lock on alloc and
+//! on drop, so lock contention scales with connections × runtime threads.
+//!
+//! Usage: zc_multiconn <host:port> <mode:get|set> <value_size> <duration_secs> <depth> <conns> <threads>
+//! Output: one CSV line: mode,size,depth,conns,threads,ops,secs,ops_per_sec,p50us,p95us,p99us
+use redis::{aio::MultiplexedConnection, Client};
+use std::time::Instant;
+
+async fn get_conn(hostport: &str) -> MultiplexedConnection {
+    let client = Client::open(format!("redis://{hostport}")).unwrap();
+    let opts = redis::GlideConnectionOptions {
+        tcp_nodelay: true,
+        ..Default::default()
+    };
+    client.get_multiplexed_tokio_connection(opts).await.unwrap()
+}
+
+async fn one(mode: &str, c: &mut MultiplexedConnection, j: usize, size: usize, payload: &[u8]) {
+    match mode {
+        "get" => {
+            let mut cmd = redis::cmd("GET");
+            cmd.arg(format!("zc:{}", j % 100));
+            match c.send_packed_command(&cmd).await.unwrap() {
+                redis::Value::BulkString(b) => assert_eq!(b.len(), size),
+                o => panic!("{o:?}"),
+            }
+        }
+        "set" => {
+            let mut cmd = redis::cmd("SET");
+            cmd.arg(format!("zc:{}", j % 100)).arg(payload);
+            assert_eq!(
+                c.send_packed_command(&cmd).await.unwrap(),
+                redis::Value::Okay
+            );
+        }
+        _ => panic!("bad mode"),
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let hostport = args[1].clone();
+    let mode = args[2].clone();
+    let size: usize = args[3].parse().unwrap();
+    let dur: f64 = args[4].parse().unwrap();
+    let depth: usize = args[5].parse().unwrap();
+    let conns: usize = args[6].parse().unwrap();
+    let threads: usize = args[7].parse().unwrap();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(threads)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let payload = std::sync::Arc::new(vec![b'x'; size]);
+
+        // Preload keys once.
+        let mut c0 = get_conn(&hostport).await;
+        for i in 0..100usize {
+            let mut cmd = redis::cmd("SET");
+            cmd.arg(format!("zc:{i}")).arg(&payload[..]);
+            assert_eq!(
+                c0.send_packed_command(&cmd).await.unwrap(),
+                redis::Value::Okay
+            );
+        }
+
+        let mut connections = Vec::with_capacity(conns);
+        for _ in 0..conns {
+            connections.push(get_conn(&hostport).await);
+        }
+
+        // Persistent pipelined workers per connection until deadline
+        // (same worker model as harness v2 — no per-batch futures Vec).
+        let run_window = |secs: f64| {
+            let connections = connections.clone();
+            let mode = mode.clone();
+            let payload = payload.clone();
+            async move {
+                let start = Instant::now();
+                let mut tasks = Vec::with_capacity(conns * depth);
+                for (ci, conn) in connections.into_iter().enumerate() {
+                    for w in 0..depth {
+                        let mut c = conn.clone();
+                        let mode = mode.clone();
+                        let payload = payload.clone();
+                        tasks.push(tokio::spawn(async move {
+                            let mut n = 0usize;
+                            let mut j = ci * depth + w;
+                            let mut lats: Vec<u64> = Vec::with_capacity(8192);
+                            while start.elapsed().as_secs_f64() < secs {
+                                let t0 = Instant::now();
+                                one(&mode, &mut c, j, payload.len(), &payload).await;
+                                lats.push(t0.elapsed().as_micros() as u64);
+                                n += 1;
+                                j += depth;
+                            }
+                            (n, lats)
+                        }));
+                    }
+                }
+                let mut done = 0usize;
+                let mut all: Vec<u64> = Vec::new();
+                for t in tasks {
+                    let (n, mut l) = t.await.unwrap();
+                    done += n;
+                    all.append(&mut l);
+                }
+                all.sort_unstable();
+                let pct = |p: f64| -> u64 {
+                    if all.is_empty() {
+                        0
+                    } else {
+                        all[((all.len() - 1) as f64 * p) as usize]
+                    }
+                };
+                (
+                    done,
+                    start.elapsed().as_secs_f64(),
+                    pct(0.50),
+                    pct(0.95),
+                    pct(0.99),
+                )
+            }
+        };
+
+        // Warmup (uncounted).
+        let warm = (dur * 0.2).min(1.0);
+        if warm > 0.0 {
+            let _ = run_window(warm).await;
+        }
+        let (ops, secs, p50, p95, p99) = run_window(dur).await;
+        println!(
+            "{mode},{size},{depth},{conns},{threads},{ops},{secs:.3},{:.0},{p50},{p95},{p99}",
+            ops as f64 / secs
+        );
+    });
+}

--- a/glide-core/redis-rs/redis/examples/zc_poolstress.rs
+++ b/glide-core/redis-rs/redis/examples/zc_poolstress.rs
@@ -1,0 +1,47 @@
+//! Pure pool-contention microbenchmark — no I/O, no server.
+//!
+//! Each thread builds and drops a `Cmd` with one payload argument. When the
+//! payload exceeds SHARED_ARG_INLINE_MAX (4 KiB), `write_arg` routes it
+//! through the recycled buffer pool: one pool pop + memcpy on build, one
+//! pool push on drop. This isolates exactly the pool lock under thread
+//! parallelism.
+//!
+//! Usage: zc_poolstress <threads> <payload_size> <iters_per_thread>
+//! Output: threads,size,iters,total_ops,secs,ops_per_sec
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let threads: usize = args[1].parse().unwrap();
+    let size: usize = args[2].parse().unwrap();
+    let iters: usize = args[3].parse().unwrap();
+
+    let payload = std::sync::Arc::new(vec![b'x'; size]);
+    let start = Instant::now();
+    let handles: Vec<_> = (0..threads)
+        .map(|t| {
+            let payload = payload.clone();
+            std::thread::spawn(move || {
+                let mut sink = 0usize;
+                for i in 0..iters {
+                    let mut cmd = redis::cmd("SET");
+                    cmd.arg("k").arg(&payload[..]);
+                    // Touch the packed form so the build can't be elided.
+                    sink = sink.wrapping_add(cmd.get_packed_segments().len() + t + i);
+                    // Cmd drops here -> pooled Bytes drops -> pool push.
+                }
+                sink
+            })
+        })
+        .collect();
+    let mut sink = 0usize;
+    for h in handles {
+        sink = sink.wrapping_add(h.join().unwrap());
+    }
+    let secs = start.elapsed().as_secs_f64();
+    let total = threads * iters;
+    println!(
+        "{threads},{size},{iters},{total},{secs:.3},{:.0},sink={sink}",
+        total as f64 / secs
+    );
+}

--- a/glide-core/redis-rs/redis/src/buf_pool.rs
+++ b/glide-core/redis-rs/redis/src/buf_pool.rs
@@ -125,6 +125,13 @@ mod tests {
     /// Pool tests assert on shared shard state; serialize them so one test's
     /// pops/pushes can't race another's assertions (test threads round-robin
     /// onto the same 8 shards).
+    ///
+    /// NOTE: this guard only covers tests in this module. Any other lib test
+    /// that routes a >[`POOL_MIN`] payload through
+    /// [`pooled_bytes_from_slice`] (e.g. decoding a large frame through the
+    /// codec) touches the same shards without taking `SERIAL` and would race
+    /// the shard-state assertions below. Keep such tests out of the lib test
+    /// binary or extend this guard if that ever happens.
     static SERIAL: Mutex<()> = Mutex::new(());
 
     #[test]
@@ -170,8 +177,11 @@ mod tests {
     #[test]
     fn oversized_requests_do_not_drain_the_pool() {
         let _g = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
-        // Dedicated thread => dedicated shard; SERIAL keeps other pool tests
-        // from touching the shards concurrently.
+        // A fresh thread gets a round-robin shard index — possibly one
+        // shared with a previous thread, so the assertions below are
+        // self-contained (fill to cap, then compare against the cap) rather
+        // than assuming an empty shard. SERIAL keeps other pool tests from
+        // touching the shards concurrently.
         std::thread::spawn(|| {
             // Fill this thread's shard to its retention cap: hold
             // SHARD_MAX_COUNT pooled buffers alive at once, then drop them

--- a/glide-core/redis-rs/redis/src/buf_pool.rs
+++ b/glide-core/redis-rs/redis/src/buf_pool.rs
@@ -31,12 +31,42 @@ pub(crate) const POOL_MIN: usize = 4 * 1024;
 /// cannot leave large allocations parked in the pool.
 const POOL_MAX_BUF_CAPACITY: usize = 1024 * 1024;
 
-/// Maximum number of retained idle buffers. In-flight buffers are not
-/// counted; this only bounds idle memory
-/// (`POOL_MAX_COUNT * POOL_MAX_BUF_CAPACITY` worst case).
-const POOL_MAX_COUNT: usize = 64;
+/// Number of independent pool shards. Threads are assigned a shard
+/// round-robin, so concurrent connections on different runtime threads don't
+/// serialize on a single process-wide lock for every large payload.
+const SHARD_COUNT: usize = 8;
 
-static POOL: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+/// Maximum number of retained idle buffers **per shard**. In-flight buffers
+/// are not counted; this only bounds idle memory
+/// (`SHARD_COUNT * SHARD_MAX_COUNT * POOL_MAX_BUF_CAPACITY` = 64 MiB worst
+/// case process-wide, unchanged from the previous single-pool bound).
+const SHARD_MAX_COUNT: usize = 8;
+
+static POOL: [Mutex<Vec<Vec<u8>>>; SHARD_COUNT] = [
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+    Mutex::new(Vec::new()),
+];
+
+/// The shard this thread checks first. Buffers may be popped from one shard
+/// and returned to another (a `Bytes` can be dropped on any thread); the
+/// pool is a best-effort cache, so that only shifts where buffers idle.
+fn shard() -> &'static Mutex<Vec<Vec<u8>>> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    thread_local! {
+        static SHARD_IDX: usize = NEXT.fetch_add(1, Ordering::Relaxed) % SHARD_COUNT;
+    }
+    // TLS can be unavailable while a thread is being torn down (a `Bytes`
+    // drop can run that late); fall back to shard 0 rather than panicking.
+    let idx = SHARD_IDX.try_with(|i| *i).unwrap_or(0);
+    &POOL[idx]
+}
 
 /// Owner type handed to [`Bytes::from_owner`]; returns its allocation to the
 /// pool when the last referencing `Bytes` drops.
@@ -56,8 +86,8 @@ impl Drop for PooledBuf {
         }
         // A poisoned lock only means another thread panicked mid push/pop;
         // the Vec is still structurally valid, so keep recycling.
-        let mut pool = POOL.lock().unwrap_or_else(|e| e.into_inner());
-        if pool.len() < POOL_MAX_COUNT {
+        let mut pool = shard().lock().unwrap_or_else(|e| e.into_inner());
+        if pool.len() < SHARD_MAX_COUNT {
             pool.push(buf);
         }
     }
@@ -73,7 +103,7 @@ pub(crate) fn pooled_bytes_from_slice(data: &[u8]) -> Bytes {
         return Bytes::copy_from_slice(data);
     }
     let mut buf = {
-        let mut pool = POOL.lock().unwrap_or_else(|e| e.into_inner());
+        let mut pool = shard().lock().unwrap_or_else(|e| e.into_inner());
         pool.pop().unwrap_or_default()
     };
     buf.clear();
@@ -117,5 +147,31 @@ mod tests {
         assert_eq!(b.len(), big.len());
         // Exercises the oversized drop branch (buffer freed, not pooled).
         drop(b);
+    }
+
+    /// Concurrent pop/recycle across threads: every returned `Bytes` must
+    /// contain exactly the caller's data (no cross-thread buffer mixups),
+    /// including slices that outlive the parent handle.
+    #[test]
+    fn concurrent_reuse_is_correct() {
+        let threads: Vec<_> = (0..8)
+            .map(|t| {
+                std::thread::spawn(move || {
+                    for i in 0..200usize {
+                        let fill = (t * 31 + i) as u8;
+                        let len = POOL_MIN + 1 + (i % 3) * 1024;
+                        let payload = vec![fill; len];
+                        let b = pooled_bytes_from_slice(&payload);
+                        let slice = b.slice(len / 2..len);
+                        drop(b);
+                        assert!(slice.iter().all(|&x| x == fill), "corrupted slice");
+                        drop(slice); // recycles the buffer for other threads
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
     }
 }

--- a/glide-core/redis-rs/redis/src/buf_pool.rs
+++ b/glide-core/redis-rs/redis/src/buf_pool.rs
@@ -97,9 +97,16 @@ impl Drop for PooledBuf {
 ///
 /// The backing allocation returns to the pool when the returned `Bytes` (and
 /// every clone/slice of it) has dropped. Small copies (≤ [`POOL_MIN`]) use a
-/// plain [`Bytes::copy_from_slice`].
+/// plain [`Bytes::copy_from_slice`]. Oversized copies
+/// (> [`POOL_MAX_BUF_CAPACITY`]) bypass the pool entirely: no pooled buffer
+/// can satisfy them without an immediate realloc, so popping one would only
+/// drain a warm buffer from mid-size traffic and then discard it (the drop
+/// hook never retains capacities above the cap).
 pub(crate) fn pooled_bytes_from_slice(data: &[u8]) -> Bytes {
     if data.len() <= POOL_MIN {
+        return Bytes::copy_from_slice(data);
+    }
+    if data.len() > POOL_MAX_BUF_CAPACITY {
         return Bytes::copy_from_slice(data);
     }
     let mut buf = {
@@ -115,8 +122,14 @@ pub(crate) fn pooled_bytes_from_slice(data: &[u8]) -> Bytes {
 mod tests {
     use super::*;
 
+    /// Pool tests assert on shared shard state; serialize them so one test's
+    /// pops/pushes can't race another's assertions (test threads round-robin
+    /// onto the same 8 shards).
+    static SERIAL: Mutex<()> = Mutex::new(());
+
     #[test]
     fn roundtrip_and_reuse() {
+        let _g = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         let payload = vec![7u8; POOL_MIN + 1];
         let b = pooled_bytes_from_slice(&payload);
         assert_eq!(&b[..], &payload[..]);
@@ -135,6 +148,7 @@ mod tests {
 
     #[test]
     fn small_copies_bypass_pool() {
+        let _g = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         let payload = vec![1u8; 16];
         let b = pooled_bytes_from_slice(&payload);
         assert_eq!(&b[..], &payload[..]);
@@ -142,11 +156,46 @@ mod tests {
 
     #[test]
     fn oversized_buffers_not_retained() {
+        let _g = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         let big = vec![3u8; POOL_MAX_BUF_CAPACITY + 1];
         let b = pooled_bytes_from_slice(&big);
         assert_eq!(b.len(), big.len());
-        // Exercises the oversized drop branch (buffer freed, not pooled).
+        assert_eq!(&b[..4], &[3u8; 4]);
+        // Oversized requests take the bypass (plain copy, nothing pooled).
         drop(b);
+    }
+
+    /// Regression: an oversized request must not pop (and then destroy) a
+    /// warm pooled buffer that mid-size traffic could have reused.
+    #[test]
+    fn oversized_requests_do_not_drain_the_pool() {
+        let _g = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
+        // Dedicated thread => dedicated shard; SERIAL keeps other pool tests
+        // from touching the shards concurrently.
+        std::thread::spawn(|| {
+            // Fill this thread's shard to its retention cap: hold
+            // SHARD_MAX_COUNT pooled buffers alive at once, then drop them
+            // all so each parks.
+            let held: Vec<_> = (0..SHARD_MAX_COUNT)
+                .map(|_| pooled_bytes_from_slice(&vec![1u8; POOL_MIN + 1]))
+                .collect();
+            drop(held);
+            let parked = shard().lock().unwrap_or_else(|e| e.into_inner()).len();
+            assert_eq!(parked, SHARD_MAX_COUNT, "shard should be full");
+
+            // Oversized request: must bypass the pool entirely.
+            let big = pooled_bytes_from_slice(&vec![2u8; POOL_MAX_BUF_CAPACITY + 1]);
+            assert_eq!(big.len(), POOL_MAX_BUF_CAPACITY + 1);
+            drop(big);
+
+            let after = shard().lock().unwrap_or_else(|e| e.into_inner()).len();
+            assert_eq!(
+                after, SHARD_MAX_COUNT,
+                "oversized request consumed a pooled buffer"
+            );
+        })
+        .join()
+        .unwrap();
     }
 
     /// Concurrent pop/recycle across threads: every returned `Bytes` must
@@ -154,6 +203,7 @@ mod tests {
     /// including slices that outlive the parent handle.
     #[test]
     fn concurrent_reuse_is_correct() {
+        let _g = SERIAL.lock().unwrap_or_else(|e| e.into_inner());
         let threads: Vec<_> = (0..8)
             .map(|t| {
                 std::thread::spawn(move || {

--- a/glide-core/redis-rs/redis/src/cache/glide_cache.rs
+++ b/glide-core/redis-rs/redis/src/cache/glide_cache.rs
@@ -579,6 +579,9 @@ impl<S: EvictionStrategy + 'static> GlideCache for GlideCacheImpl<S> {
     }
 
     fn insert(&self, key: Vec<u8>, key_type: CachedKeyType, value: Value) {
+        // Cached values outlive the request; deep-copy so they don't pin the
+        // connection read buffers their BulkStrings were zero-copy sliced from.
+        let value = value.detach_buffers();
         let entry_size = calculate_entry_size(&key, &value);
 
         if self.core.entry_too_big(entry_size) {

--- a/glide-core/redis-rs/redis/src/cmd.rs
+++ b/glide-core/redis-rs/redis/src/cmd.rs
@@ -1229,5 +1229,31 @@ mod tests {
             cmd.set_fenced(true);
             assert_segments_match_packed(&cmd);
         }
+
+        /// Pipeline-level parity: MULTI/EXEC interleaving and the scratch
+        /// buffer carried across commands must still be byte-identical to
+        /// the contiguous pipeline packer, with and without shared payloads.
+        #[test]
+        fn pipeline_segments_match_packed() {
+            let payload = bytes::Bytes::from(vec![b'v'; SHARED_ARG_INLINE_MAX + 1]);
+            for transaction in [false, true] {
+                let mut pl = crate::pipe();
+                if transaction {
+                    pl.atomic();
+                }
+                let mut c1 = crate::cmd("SET");
+                c1.arg("k1").arg_shared(payload.clone());
+                let mut c2 = crate::cmd("GET");
+                c2.arg("k2");
+                let mut c3 = crate::cmd("SET");
+                c3.arg("k3").arg_shared(payload.clone());
+                pl.add_command(c1).add_command(c2).add_command(c3);
+                assert_eq!(
+                    pl.get_packed_pipeline_segments().to_contiguous(),
+                    pl.get_packed_pipeline(),
+                    "segmented pipeline packing must be byte-identical (transaction={transaction})"
+                );
+            }
+        }
     }
 }

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -351,6 +351,8 @@ pub use crate::connection::{
     IntoConnectionInfo, Msg, PubSub, PubSubChannelOrPattern, PubSubSubscriptionInfo,
     PubSubSubscriptionKind, RedisConnectionInfo, TlsMode,
 };
+#[cfg(feature = "aio")]
+pub use crate::parser::ValueCodec;
 pub use crate::parser::{parse_redis_value, Parser};
 pub use crate::pipeline::{Pipeline, PipelineRetryStrategy};
 pub use crate::pubsub_synchronizer::PubSubSynchronizer;

--- a/glide-core/redis-rs/redis/src/lib.rs
+++ b/glide-core/redis-rs/redis/src/lib.rs
@@ -351,7 +351,10 @@ pub use crate::connection::{
     IntoConnectionInfo, Msg, PubSub, PubSubChannelOrPattern, PubSubSubscriptionInfo,
     PubSubSubscriptionKind, RedisConnectionInfo, TlsMode,
 };
+// Exposed for the codec integration tests (tests/parser.rs); not a supported
+// public API surface.
 #[cfg(feature = "aio")]
+#[doc(hidden)]
 pub use crate::parser::ValueCodec;
 pub use crate::parser::{parse_redis_value, Parser};
 pub use crate::pipeline::{Pipeline, PipelineRetryStrategy};

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -345,6 +345,14 @@ mod zero_copy {
 
     /// Find the `\r\n`-terminated line starting at `pos`.
     /// Returns `(line_content_end, next_pos)` — content excludes the CRLF.
+    ///
+    /// Known worst case: while a line is *incomplete*, each `decode` call
+    /// rescans it from `pos` (`ScanState.pos` only advances on complete
+    /// elements), so a line-delimited element straddling many reads costs
+    /// O(reads × line length). Bulk payloads are skipped by length and
+    /// unaffected; RESP lines (headers, simple strings/errors) are short in
+    /// practice, so we keep the scanner simple rather than tracking
+    /// intra-line progress.
     fn find_line(buf: &[u8], pos: usize) -> Option<(usize, usize)> {
         let rel = buf[pos..].windows(2).position(|w| w == b"\r\n")?;
         Some((pos + rel, pos + rel + 2))

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -362,13 +362,26 @@ mod zero_copy {
             .map_err(|_| parse_error("Expected integer, got garbage".to_string()))
     }
 
-    /// How many child values follow an aggregate header byte with count `n`.
-    fn child_count(type_byte: u8, n: i64) -> usize {
+    /// How many child values follow an aggregate header byte with count `n`
+    /// (`n >= 0`). Errors instead of wrapping if the count overflows `usize`
+    /// (only reachable on 32-bit targets — a hostile length header must not
+    /// silently truncate into a misparse).
+    fn child_count(type_byte: u8, n: i64) -> RedisResult<usize> {
+        let n = usize::try_from(n)
+            .map_err(|_| parse_error("aggregate length exceeds platform limits".to_string()))?;
         match type_byte {
-            b'%' => n as usize * 2,
-            b'|' => n as usize * 2 + 1, // attribute: kv pairs + the data value
-            _ => n as usize,
+            b'%' => n.checked_mul(2),
+            b'|' => n.checked_mul(2).and_then(|c| c.checked_add(1)), // kv pairs + the data value
+            _ => Some(n),
         }
+        .ok_or_else(|| parse_error("aggregate length exceeds platform limits".to_string()))
+    }
+
+    /// Convert a non-negative blob size to `usize`, erroring instead of
+    /// truncating on 32-bit targets.
+    fn blob_size(size: i64) -> RedisResult<usize> {
+        usize::try_from(size)
+            .map_err(|_| parse_error("blob length exceeds platform limits".to_string()))
     }
 
     /// Resumable scan state, persisted across `decode` calls so bytes of an
@@ -455,7 +468,12 @@ mod zero_copy {
                         st.pos = payload_start;
                         continue;
                     }
-                    let end = payload_start + size as usize + 2;
+                    let end = blob_size(size)?
+                        .checked_add(payload_start)
+                        .and_then(|e| e.checked_add(2))
+                        .ok_or_else(|| {
+                            parse_error("blob length exceeds platform limits".to_string())
+                        })?;
                     if end > buf.len() {
                         return Ok(None);
                     }
@@ -474,7 +492,7 @@ mod zero_copy {
                     *remaining -= 1;
                     st.pos = next;
                     if n >= 0 {
-                        st.stack.push(child_count(b, n));
+                        st.stack.push(child_count(b, n)?);
                     }
                 }
                 other => {
@@ -539,7 +557,12 @@ mod zero_copy {
                     *pos = payload_start;
                     return Ok(Value::Nil);
                 }
-                let payload_end = payload_start + size as usize;
+                let payload_end = blob_size(size)?
+                    .checked_add(payload_start)
+                    .filter(|e| e.checked_add(2).is_some())
+                    .ok_or_else(|| {
+                        parse_error("blob length exceeds platform limits".to_string())
+                    })?;
                 if payload_end + 2 > buf.len() {
                     return Err(parse_error("unexpected end of frame".to_string()));
                 }
@@ -578,7 +601,19 @@ mod zero_copy {
                 let n = line_int(buf, type_pos + 1, line_end)?;
                 *pos = next;
                 if n < 0 {
-                    return Ok(Value::Nil);
+                    // Negative aggregate counts: `*-1`/`~-1` are RESP2 nil
+                    // arrays. The old parser mapped a negative push count to
+                    // an empty Push (same as `>0`), so preserve that; other
+                    // negative counts are treated as Nil (the old parser had
+                    // no sane behavior for them).
+                    return Ok(if b == b'>' {
+                        Value::Push {
+                            kind: PushKind::Other("".to_string()),
+                            data: vec![],
+                        }
+                    } else {
+                        Value::Nil
+                    });
                 }
                 match b {
                     b'*' | b'~' => {
@@ -1121,6 +1156,42 @@ mod tests {
                 "aggregate {:?} within depth limit failed via codec: {result:?}",
                 agg as char
             );
+        }
+    }
+
+    /// Negative aggregate counts: `>-1` must decode like the old recursive
+    /// parser (an empty Push), while `*-1`/`~-1` remain RESP2 nil.
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_codec_negative_aggregate_counts() {
+        use tokio_util::codec::Decoder;
+        let cases: &[(&[u8], Value)] = &[
+            (
+                b">-1\r\n",
+                Value::Push {
+                    kind: PushKind::Other("".to_string()),
+                    data: vec![],
+                },
+            ),
+            (b"*-1\r\n", Value::Nil),
+            (b"~-1\r\n", Value::Nil),
+            (b"$-1\r\n", Value::Nil),
+        ];
+        for (input, expected) in cases {
+            let mut codec = ValueCodec::default();
+            let mut bytes = bytes::BytesMut::from(*input);
+            let decoded = codec
+                .decode(&mut bytes)
+                .expect("decode failed")
+                .expect("expected a value")
+                .expect("expected Ok value");
+            assert_eq!(
+                &decoded,
+                expected,
+                "input {:?}",
+                String::from_utf8_lossy(input)
+            );
+            assert!(bytes.is_empty(), "codec must consume the whole frame");
         }
     }
 }

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -653,7 +653,7 @@ mod zero_copy {
 mod aio_support {
     use super::*;
 
-    use bytes::{Buf, Bytes, BytesMut};
+    use bytes::{Buf, BytesMut};
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
@@ -698,25 +698,24 @@ mod aio_support {
                 }
                 Ok(Some(end)) => {
                     self.scan.reset();
-                    // Hybrid frame extraction, chosen from profiling:
-                    // - Small frames: ONE bulk memcpy out of the read buffer.
-                    //   Keeps the codec's BytesMut unshared so tokio reuses
-                    //   its allocation (freezing every frame caused
-                    //   realloc+copy churn in BytesMut::reserve — 40% of
-                    //   client CPU under pipelined load).
-                    // - Large frames: take ownership zero-copy via
-                    //   split_to().freeze(). The buffer had to grow for them
-                    //   anyway, and copying hundreds of KB costs more than
-                    //   losing one allocation's reuse.
-                    // Bulk strings are then zero-copy slices of the frame.
-                    const FRAME_COPY_MAX: usize = 64 * 1024;
-                    let frame = if end > FRAME_COPY_MAX {
-                        bytes.split_to(end).freeze()
-                    } else {
-                        let frame = Bytes::copy_from_slice(&bytes[..end]);
-                        bytes.advance(end);
-                        frame
-                    };
+                    // Copy the complete frame out of the read buffer into a
+                    // recycled pooled buffer (see `buf_pool`), then slice
+                    // bulk-string payloads out of it zero-copy.
+                    //
+                    // Copy-always was chosen from profiling against a real
+                    // network peer:
+                    // - Freezing frames out of the read buffer (even only
+                    //   large ones) defeats the BytesMut allocation reuse and
+                    //   causes realloc/page-fault churn in `reserve`; a
+                    //   256 KB GET measured 2x the client CPU of the copy
+                    //   path under pipelined load.
+                    // - A fresh allocation per frame is the other churn
+                    //   source (~16 concurrent frames alive at depth 16
+                    //   defeat allocator reuse; fault handling reached 30% of
+                    //   client CPU at 64 KB). The pool recycles the frame
+                    //   buffers so their pages stay resident.
+                    let frame = crate::buf_pool::pooled_bytes_from_slice(&bytes[..end]);
+                    bytes.advance(end);
                     let mut pos = 0;
                     let value = super::zero_copy::parse_value(&frame, &mut pos, 1)?;
                     Ok(Some(Ok(value)))

--- a/glide-core/redis-rs/redis/src/parser.rs
+++ b/glide-core/redis-rs/redis/src/parser.rs
@@ -322,17 +322,349 @@ where
     ))
 }
 
+/// Zero-copy RESP parsing for the async codec path.
+///
+/// Strategy: instead of streaming partial frames through the `combine` parser
+/// (which must copy payloads into owned `Vec`s because a bulk string may
+/// straddle socket reads), we first *scan* the buffered bytes for one complete
+/// top-level frame without consuming anything. Once a full frame is buffered,
+/// we `split_to(len).freeze()` it into a refcounted [`bytes::Bytes`] (zero-copy) and
+/// build the [`Value`] tree by slicing bulk-string payloads directly out of
+/// that frame — no per-value allocation or memcpy.
+///
+/// The scan only walks type bytes and length headers (payloads are skipped by
+/// length), so its cost is proportional to the number of RESP elements, not
+/// the payload bytes.
+mod zero_copy {
+    use super::*;
+    use bytes::Bytes;
+
+    fn parse_error(detail: String) -> RedisError {
+        RedisError::from((ErrorKind::ParseError, "parse error", detail))
+    }
+
+    /// Find the `\r\n`-terminated line starting at `pos`.
+    /// Returns `(line_content_end, next_pos)` — content excludes the CRLF.
+    fn find_line(buf: &[u8], pos: usize) -> Option<(usize, usize)> {
+        let rel = buf[pos..].windows(2).position(|w| w == b"\r\n")?;
+        Some((pos + rel, pos + rel + 2))
+    }
+
+    fn line_str(buf: &[u8], start: usize, end: usize) -> RedisResult<&str> {
+        str::from_utf8(&buf[start..end])
+            .map_err(|e| parse_error(format!("invalid utf-8 in line: {e}")))
+    }
+
+    fn line_int(buf: &[u8], start: usize, end: usize) -> RedisResult<i64> {
+        line_str(buf, start, end)?
+            .trim()
+            .parse::<i64>()
+            .map_err(|_| parse_error("Expected integer, got garbage".to_string()))
+    }
+
+    /// How many child values follow an aggregate header byte with count `n`.
+    fn child_count(type_byte: u8, n: i64) -> usize {
+        match type_byte {
+            b'%' => n as usize * 2,
+            b'|' => n as usize * 2 + 1, // attribute: kv pairs + the data value
+            _ => n as usize,
+        }
+    }
+
+    /// Resumable scan state, persisted across `decode` calls so bytes of an
+    /// incomplete frame are only scanned once (previously the scan restarted
+    /// at offset 0 on every socket read — O(reads × elements) on large
+    /// multi-element frames, measured at ~25% of client CPU on MGET-heavy
+    /// load).
+    ///
+    /// Representation: `stack` holds the number of values still expected at
+    /// each open aggregate level, with an artificial root entry of 1 for the
+    /// top-level value. `pos` is the absolute offset (from the front of the
+    /// codec's read buffer) where scanning resumes; it stays valid across
+    /// calls because the codec only consumes buffer bytes once a frame
+    /// completes.
+    pub(super) struct ScanState {
+        pos: usize,
+        stack: Vec<usize>,
+    }
+
+    impl Default for ScanState {
+        fn default() -> Self {
+            ScanState {
+                pos: 0,
+                stack: vec![1],
+            }
+        }
+    }
+
+    impl ScanState {
+        pub(super) fn reset(&mut self) {
+            self.pos = 0;
+            self.stack.clear();
+            self.stack.push(1);
+        }
+    }
+
+    /// Continue scanning one top-level RESP value where the previous call
+    /// left off.
+    /// `Ok(Some(end))` — a complete value spans `0..end` of `buf`.
+    /// `Ok(None)` — need more data (state saved; call again with more bytes).
+    /// `Err` — malformed input (connection-fatal, state irrelevant).
+    pub(super) fn scan_resume(buf: &[u8], st: &mut ScanState) -> RedisResult<Option<usize>> {
+        loop {
+            // Close out completed aggregates.
+            while let Some(&top) = st.stack.last() {
+                if top == 0 {
+                    st.stack.pop();
+                } else {
+                    break;
+                }
+            }
+            let depth = st.stack.len();
+            let Some(remaining) = st.stack.last_mut() else {
+                return Ok(Some(st.pos));
+            };
+
+            let pos = st.pos;
+            if pos >= buf.len() {
+                return Ok(None);
+            }
+            let b = buf[pos];
+            // `depth` equals the recursion depth the old recursive
+            // scanner would have had (root entry counts as depth 1).
+            if matches!(b, b'*' | b'%' | b'|' | b'~' | b'>') && depth > MAX_RECURSE_DEPTH {
+                return Err(parse_error("Maximum recursion depth exceeded".to_string()));
+            }
+            match b {
+                // Line-delimited scalars.
+                b'+' | b'-' | b':' | b'_' | b',' | b'#' | b'(' => {
+                    let Some((_, next)) = find_line(buf, pos + 1) else {
+                        return Ok(None);
+                    };
+                    *remaining -= 1;
+                    st.pos = next;
+                }
+                // Length-prefixed blobs: bulk string, blob error, verbatim string.
+                b'$' | b'!' | b'=' => {
+                    let Some((line_end, payload_start)) = find_line(buf, pos + 1) else {
+                        return Ok(None);
+                    };
+                    let size = line_int(buf, pos + 1, line_end)?;
+                    if size < 0 {
+                        *remaining -= 1;
+                        st.pos = payload_start;
+                        continue;
+                    }
+                    let end = payload_start + size as usize + 2;
+                    if end > buf.len() {
+                        return Ok(None);
+                    }
+                    if &buf[end - 2..end] != b"\r\n" {
+                        return Err(parse_error("expected CRLF after blob payload".to_string()));
+                    }
+                    *remaining -= 1;
+                    st.pos = end;
+                }
+                // Aggregates: array, map, attribute, set, push.
+                b'*' | b'%' | b'|' | b'~' | b'>' => {
+                    let Some((line_end, next)) = find_line(buf, pos + 1) else {
+                        return Ok(None);
+                    };
+                    let n = line_int(buf, pos + 1, line_end)?;
+                    *remaining -= 1;
+                    st.pos = next;
+                    if n >= 0 {
+                        st.stack.push(child_count(b, n));
+                    }
+                }
+                other => {
+                    return Err(parse_error(format!(
+                        "invalid RESP type byte {:?}",
+                        other as char
+                    )))
+                }
+            }
+        }
+    }
+
+    /// Build a [`Value`] from a complete frame, slicing bulk-string payloads
+    /// out of `frame` with zero copies. `scan_value` must have validated the
+    /// frame is complete; bounds are still checked defensively.
+    pub(super) fn parse_value(frame: &Bytes, pos: &mut usize, depth: usize) -> RedisResult<Value> {
+        let buf = &frame[..];
+        if *pos >= buf.len() {
+            return Err(parse_error("unexpected end of frame".to_string()));
+        }
+        let b = buf[*pos];
+        if matches!(b, b'*' | b'%' | b'|' | b'~' | b'>') && depth > MAX_RECURSE_DEPTH {
+            return Err(parse_error("Maximum recursion depth exceeded".to_string()));
+        }
+        let type_pos = *pos;
+        match b {
+            b'+' | b'-' | b':' | b'_' | b',' | b'#' | b'(' => {
+                let (line_end, next) = find_line(buf, type_pos + 1)
+                    .ok_or_else(|| parse_error("unexpected end of frame".to_string()))?;
+                let line = line_str(buf, type_pos + 1, line_end)?;
+                *pos = next;
+                match b {
+                    b'+' => Ok(if line == "OK" {
+                        Value::Okay
+                    } else {
+                        Value::SimpleString(line.to_string())
+                    }),
+                    b'-' => Ok(Value::ServerError(err_parser(line))),
+                    b':' => Ok(Value::Int(line.trim().parse::<i64>().map_err(|_| {
+                        parse_error("Expected integer, got garbage".to_string())
+                    })?)),
+                    b'_' => Ok(Value::Nil),
+                    b',' => Ok(Value::Double(line.trim().parse::<f64>().map_err(|e| {
+                        parse_error(format!("Expected double, got garbage: {e}"))
+                    })?)),
+                    b'#' => match line {
+                        "t" => Ok(Value::Boolean(true)),
+                        "f" => Ok(Value::Boolean(false)),
+                        _ => Err(parse_error("Expected boolean, got garbage".to_string())),
+                    },
+                    b'(' => BigInt::parse_bytes(line.as_bytes(), 10)
+                        .map(Value::BigNumber)
+                        .ok_or_else(|| parse_error("Expected bigint, got garbage".to_string())),
+                    _ => unreachable!(),
+                }
+            }
+            b'$' | b'!' | b'=' => {
+                let (line_end, payload_start) = find_line(buf, type_pos + 1)
+                    .ok_or_else(|| parse_error("unexpected end of frame".to_string()))?;
+                let size = line_int(buf, type_pos + 1, line_end)?;
+                if size < 0 {
+                    *pos = payload_start;
+                    return Ok(Value::Nil);
+                }
+                let payload_end = payload_start + size as usize;
+                if payload_end + 2 > buf.len() {
+                    return Err(parse_error("unexpected end of frame".to_string()));
+                }
+                *pos = payload_end + 2;
+                match b {
+                    // The zero-copy slice: shares the frame's refcounted buffer.
+                    b'$' => Ok(Value::BulkString(frame.slice(payload_start..payload_end))),
+                    b'!' => {
+                        let text = String::from_utf8_lossy(&buf[payload_start..payload_end]);
+                        Ok(Value::ServerError(err_parser(&text)))
+                    }
+                    b'=' => {
+                        let text = String::from_utf8_lossy(&buf[payload_start..payload_end]);
+                        if let Some((format, text)) = text.split_once(':') {
+                            let format = match format {
+                                "txt" => VerbatimFormat::Text,
+                                "mkd" => VerbatimFormat::Markdown,
+                                x => VerbatimFormat::Unknown(x.to_string()),
+                            };
+                            Ok(Value::VerbatimString {
+                                format,
+                                text: text.to_string(),
+                            })
+                        } else {
+                            Err(parse_error(
+                                "parse error when decoding verbatim string".to_string(),
+                            ))
+                        }
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            b'*' | b'%' | b'|' | b'~' | b'>' => {
+                let (line_end, next) = find_line(buf, type_pos + 1)
+                    .ok_or_else(|| parse_error("unexpected end of frame".to_string()))?;
+                let n = line_int(buf, type_pos + 1, line_end)?;
+                *pos = next;
+                if n < 0 {
+                    return Ok(Value::Nil);
+                }
+                match b {
+                    b'*' | b'~' => {
+                        let mut items = Vec::with_capacity(n as usize);
+                        for _ in 0..n {
+                            items.push(parse_value(frame, pos, depth + 1)?);
+                        }
+                        Ok(if b == b'*' {
+                            Value::Array(items)
+                        } else {
+                            Value::Set(items)
+                        })
+                    }
+                    b'%' => {
+                        let mut items = Vec::with_capacity(n as usize);
+                        for _ in 0..n {
+                            let k = parse_value(frame, pos, depth + 1)?;
+                            let v = parse_value(frame, pos, depth + 1)?;
+                            items.push((k, v));
+                        }
+                        Ok(Value::Map(items))
+                    }
+                    b'|' => {
+                        let mut attributes = Vec::with_capacity(n as usize);
+                        for _ in 0..n {
+                            let k = parse_value(frame, pos, depth + 1)?;
+                            let v = parse_value(frame, pos, depth + 1)?;
+                            attributes.push((k, v));
+                        }
+                        let data = Box::new(parse_value(frame, pos, depth + 1)?);
+                        Ok(Value::Attribute { data, attributes })
+                    }
+                    b'>' => {
+                        if n == 0 {
+                            return Ok(Value::Push {
+                                kind: PushKind::Other("".to_string()),
+                                data: vec![],
+                            });
+                        }
+                        let first = parse_value(frame, pos, depth + 1)?;
+                        let mut data = Vec::with_capacity(n as usize - 1);
+                        for _ in 1..n {
+                            data.push(parse_value(frame, pos, depth + 1)?);
+                        }
+                        let kind = match first {
+                            Value::BulkString(kind) => String::from_utf8(kind.to_vec())
+                                .map_err(|e| parse_error(format!("invalid push kind: {e}")))?,
+                            Value::SimpleString(kind) => kind,
+                            _ => {
+                                return Err(parse_error(
+                                    "parse error when decoding push".to_string(),
+                                ))
+                            }
+                        };
+                        Ok(Value::Push {
+                            kind: get_push_kind(kind),
+                            data,
+                        })
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            other => Err(parse_error(format!(
+                "invalid RESP type byte {:?}",
+                other as char
+            ))),
+        }
+    }
+}
+
 #[cfg(feature = "aio")]
 mod aio_support {
     use super::*;
 
-    use bytes::{Buf, BytesMut};
+    use bytes::{Buf, Bytes, BytesMut};
     use tokio::io::AsyncRead;
     use tokio_util::codec::{Decoder, Encoder};
 
+    /// Tokio codec that decodes RESP frames zero-copy from the read
+    /// buffer. See the `zero_copy` module for the strategy.
     #[derive(Default)]
     pub struct ValueCodec {
-        state: AnySendSyncPartialState,
+        /// Resumable scan progress for the (single) incomplete frame at the
+        /// front of the read buffer. Valid across calls because nothing is
+        /// consumed until the frame completes.
+        scan: super::zero_copy::ScanState,
     }
 
     impl ValueCodec {
@@ -341,30 +673,54 @@ mod aio_support {
             bytes: &mut BytesMut,
             eof: bool,
         ) -> RedisResult<Option<RedisResult<Value>>> {
-            let (opt, removed_len) = {
-                let buffer = &bytes[..];
-                let mut stream =
-                    combine::easy::Stream(combine::stream::MaybePartialStream(buffer, !eof));
-                match combine::stream::decode_tokio(value(None), &mut stream, &mut self.state) {
-                    Ok(x) => x,
-                    Err(err) => {
-                        let err = err
-                            .map_position(|pos| pos.translate_position(buffer))
-                            .map_range(|range| format!("{range:?}"))
-                            .to_string();
-                        return Err(RedisError::from((
+            if bytes.is_empty() {
+                return Ok(None);
+            }
+            // Zero-copy path: wait until a complete top-level frame is
+            // buffered (scan consumes nothing and resumes where the previous
+            // call stopped), then extract that frame and slice bulk-string
+            // payloads out of it.
+            match super::zero_copy::scan_resume(&bytes[..], &mut self.scan) {
+                Err(err) => {
+                    self.scan.reset();
+                    Err(err)
+                }
+                Ok(None) => {
+                    if eof {
+                        Err(RedisError::from((
                             ErrorKind::ParseError,
                             "parse error",
-                            err,
-                        )));
+                            "unexpected end of input".to_string(),
+                        )))
+                    } else {
+                        Ok(None)
                     }
                 }
-            };
-
-            bytes.advance(removed_len);
-            match opt {
-                Some(result) => Ok(Some(Ok(result))),
-                None => Ok(None),
+                Ok(Some(end)) => {
+                    self.scan.reset();
+                    // Hybrid frame extraction, chosen from profiling:
+                    // - Small frames: ONE bulk memcpy out of the read buffer.
+                    //   Keeps the codec's BytesMut unshared so tokio reuses
+                    //   its allocation (freezing every frame caused
+                    //   realloc+copy churn in BytesMut::reserve — 40% of
+                    //   client CPU under pipelined load).
+                    // - Large frames: take ownership zero-copy via
+                    //   split_to().freeze(). The buffer had to grow for them
+                    //   anyway, and copying hundreds of KB costs more than
+                    //   losing one allocation's reuse.
+                    // Bulk strings are then zero-copy slices of the frame.
+                    const FRAME_COPY_MAX: usize = 64 * 1024;
+                    let frame = if end > FRAME_COPY_MAX {
+                        bytes.split_to(end).freeze()
+                    } else {
+                        let frame = Bytes::copy_from_slice(&bytes[..end]);
+                        bytes.advance(end);
+                        frame
+                    };
+                    let mut pos = 0;
+                    let value = super::zero_copy::parse_value(&frame, &mut pos, 1)?;
+                    Ok(Some(Ok(value)))
+                }
             }
         }
     }
@@ -727,6 +1083,43 @@ mod tests {
             assert!(
                 parse_redis_value(&bytes).is_ok(),
                 "aggregate {:?} within depth limit failed to parse",
+                agg as char
+            );
+        }
+    }
+
+    /// The zero-copy codec's iterative scanner must enforce the same
+    /// recursion-depth guard as the recursive sync parser.
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_codec_max_recursion_depth_all_aggregate_types() {
+        use tokio_util::codec::Decoder;
+        for agg in [b'*', b'%', b'|', b'~', b'>'] {
+            let mut codec = ValueCodec::default();
+            let mut bytes =
+                bytes::BytesMut::from(&nested_aggregate_headers(agg, MAX_RECURSE_DEPTH + 5)[..]);
+            let result = codec.decode(&mut bytes);
+            let err = result.expect_err("expected recursion depth error");
+            assert!(
+                format!("{err:?}").contains("Maximum recursion depth exceeded"),
+                "aggregate {:?} did not hit the recursion guard: {err:?}",
+                agg as char
+            );
+        }
+    }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_codec_nesting_within_recursion_depth_parses() {
+        use tokio_util::codec::Decoder;
+        for agg in [b'*', b'~'] {
+            let mut codec = ValueCodec::default();
+            let mut bytes =
+                bytes::BytesMut::from(&nested_aggregate_headers(agg, MAX_RECURSE_DEPTH)[..]);
+            let result = codec.decode(&mut bytes);
+            assert!(
+                matches!(result, Ok(Some(Ok(_)))),
+                "aggregate {:?} within depth limit failed via codec: {result:?}",
                 agg as char
             );
         }

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -566,6 +566,13 @@ impl Value {
     /// from. Call this before retaining a value long-term (e.g. inserting
     /// into a client-side cache); request/response flows that drop values
     /// promptly do not need it.
+    ///
+    /// Note the amplification: every `BulkString` produced by the zero-copy
+    /// decoder is a slice of its response's single frame buffer, so
+    /// retaining even one small slice pins the *entire* frame (e.g. keeping
+    /// one 16-byte element of a 6 MB MGET response holds all 6 MB — plus its
+    /// recycled `buf_pool` allocation — alive). If you extract and keep a
+    /// subset of a response, detach it first.
     pub fn detach_buffers(self) -> Value {
         match self {
             Value::BulkString(b) => Value::BulkString(bytes::Bytes::copy_from_slice(&b)),

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -561,6 +561,39 @@ impl Iterator for OwnedMapIter {
 /// separated at an early point so the value only holds the remaining
 /// types.
 impl Value {
+    /// Deep-copies any [`bytes::Bytes`] payloads so this value no longer
+    /// shares (and therefore pins) the connection read buffer it was parsed
+    /// from. Call this before retaining a value long-term (e.g. inserting
+    /// into a client-side cache); request/response flows that drop values
+    /// promptly do not need it.
+    pub fn detach_buffers(self) -> Value {
+        match self {
+            Value::BulkString(b) => Value::BulkString(bytes::Bytes::copy_from_slice(&b)),
+            Value::Array(items) => {
+                Value::Array(items.into_iter().map(Value::detach_buffers).collect())
+            }
+            Value::Set(items) => Value::Set(items.into_iter().map(Value::detach_buffers).collect()),
+            Value::Map(items) => Value::Map(
+                items
+                    .into_iter()
+                    .map(|(k, v)| (k.detach_buffers(), v.detach_buffers()))
+                    .collect(),
+            ),
+            Value::Attribute { data, attributes } => Value::Attribute {
+                data: Box::new(data.detach_buffers()),
+                attributes: attributes
+                    .into_iter()
+                    .map(|(k, v)| (k.detach_buffers(), v.detach_buffers()))
+                    .collect(),
+            },
+            Value::Push { kind, data } => Value::Push {
+                kind,
+                data: data.into_iter().map(Value::detach_buffers).collect(),
+            },
+            other => other,
+        }
+    }
+
     /// Checks if the return value looks like it fulfils the cursor
     /// protocol.  That means the result is an array item of length
     /// two with the first one being a cursor and the second an

--- a/glide-core/redis-rs/redis/tests/parser.rs
+++ b/glide-core/redis-rs/redis/tests/parser.rs
@@ -199,4 +199,36 @@ quickcheck! {
         );
     }
 
+    /// The zero-copy `ValueCodec` must decode identically no matter how the
+    /// frame bytes are chunked across socket reads (frames straddling reads
+    /// must simply wait for more data, consuming nothing).
+    fn codec_chunked_parse(input: ArbitraryValue, chunk_sizes: Vec<usize>) -> () {
+        use tokio_util::codec::Decoder as _;
+
+        let mut encoded_input = Vec::new();
+        encode_value(&input.0, &mut encoded_input).unwrap();
+
+        let mut codec = redis::ValueCodec::default();
+        let mut buf = bytes::BytesMut::new();
+        let mut decoded = None;
+        let mut fed = 0;
+        let mut chunks = chunk_sizes.into_iter();
+
+        while fed < encoded_input.len() {
+            let n = std::cmp::min(
+                chunks.next().unwrap_or(usize::MAX).clamp(1, 4096),
+                encoded_input.len() - fed,
+            );
+            buf.extend_from_slice(&encoded_input[fed..fed + n]);
+            fed += n;
+            if let Some(item) = codec.decode(&mut buf).unwrap() {
+                assert!(decoded.is_none(), "decoded more than one value");
+                assert!(fed == encoded_input.len(), "decoded before full frame was fed");
+                decoded = Some(item.unwrap());
+            }
+        }
+        assert_eq!(decoded.expect("no value decoded"), input.0);
+        assert!(buf.is_empty(), "codec left unconsumed bytes");
+        assert!(codec.decode_eof(&mut buf).unwrap().is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Receive-side zero-copy for GET/MGET (split out of #6520). Realizes the read-path win on top of the `Value::BulkString(Bytes)` foundation: bulk-string payloads are sliced directly out of the decoded response frame instead of being allocated + copied per value.

> **Naming:** this reaches the one-copy floor (kernel read buffer → caller), i.e. *reduced-copy*, not literally zero-copy.

Final PR of the zero-copy initiative; targets `main` directly. The other two have **merged**:
* Foundation #6524 (`Value::BulkString(Bytes)`)
* Send #6523 (vectored zero-copy send)

## Features / Behaviour Changes

* New zero-copy decoder for the async `ValueCodec`: scan the read buffer for one complete frame (consuming nothing), copy it out into a **recycled pooled buffer** (`buf_pool`), then slice bulk-string payloads out of that one frame `Bytes` — no per-value alloc or memcpy.
* Resumable scanner (`ScanState`) — multi-read frames are scanned once.
* Recycled frame-buffer pool: **8 thread-affine shards** (no new threads, 64 MiB idle bound); requests >1 MB bypass the pool. A pure microbenchmark shows a single global mutex collapsing 8.6× beyond 4 threads while the sharded pool scales.
* FFI `ResponseArena` stores `Bytes` → non-buffered GET/MGET is one-copy end to end. Freed arenas release their frame slices immediately (`return_to_pool` clears `strings`/`nodes`).
* `Value::detach_buffers()` deep-copy applied at client-side cache insert so cached values don't pin frame buffers. Documented tradeoff: retaining one slice pins its response's entire frame.
* Decoder parity + hardening: `>-1` decodes to an empty Push (matching the recursive parser it replaced); blob/aggregate length headers use checked math so 32-bit targets error instead of truncate-and-misparse.

## Implementation

The `combine` streaming parser must own partial frames, so the async hot path uses a purpose-built scan-then-slice decoder (`parser.rs::zero_copy`). The sync `parse_redis_value` path keeps `combine`. Copy-always frame extraction was chosen from profiling against a real network peer: freezing frames out of the read buffer defeats `BytesMut` allocation reuse (2× the CPU of copying at 256 KB), and a fresh allocation per frame defeats allocator reuse under pipelining (fault handling reached 30% of client CPU at 64 KB).

## Limitations

* One-copy floor remains (the kernel `recv` copy); parsing straight into pre-registered buffers is a possible follow-up.
* Socket-listener bindings (Node, python-async) re-copy into protobuf; the parser win still applies in front of that layer.
* Known worst case (documented in code): a line-delimited element straddling many reads is rescanned per read — bulk payloads are unaffected; RESP lines are short in practice.

## Benchmarks

Loopback and a real network hop: single-primary ElastiCache Valkey 8.1 (r7g.4xlarge), same-AZ EC2 clients on x86 (c7i.8xlarge) and ARM/Graviton (c7gn.16xlarge), 41-cell × 3-rep matrix. Client CPU per op is the primary KPI (large cells sit at EC2's ~5 Gbps per-flow cap). Full methodology: `docs/zero-copy-benchmarks.md`.

| workload | x86 CPU/op | ARM CPU/op |
|---|---|---|
| MGET 100×4KB, depth 16 | **−65%** | **−77%** |
| MGET 100×64KB, depth 16 | **−62%** | **−44%** |
| GET 64KB, depth 128 | −2% | **−19%** |
| GET 256KB, depth 16 | **−6%** | **−8%** |
| GET 512B, depth 128 | −3% (tput **+11%**) | −2% (tput **+13%**) |
| GET ≤16KB (all depths) | parity | parity |

* Page faults/op on MGET 64KB: **1938 → 18.7** (x86); the win is larger on Graviton.
* Multi-connection: live cells are network-plateaued with the sharded pool saving 3–5% client CPU/op at 16–32 connections.
* Latency p50/p99 flat — the CPU saving is headroom, not per-op latency.

## Testing

* `parser` codec tests + `codec_chunked_parse` quickcheck (identical decode under arbitrary socket chunking) + recursion-guard + negative-aggregate-count tests.
* First MIRI coverage of the FFI response arena (frame-release regression, caller-buffer bounds path, map finalize fixups).
* Pool drain-regression + cross-thread stress tests; pipeline-level segmented-packing byte-identity test.
* Bindings audited for the `CommandResponse.string_value` read-only contract: Go (`C.GoBytes`) and python-sync (`ffi.buffer[:]`) copy at the boundary; neither writes through the pointer.
* Lint: `cargo clippy -- -D warnings` (redis lib), `--all-features --all-targets` (glide-core, ffi) clean; fmt clean; MSRV 1.71.

## Review-round updates

**2026-07-19 (round 1)** — two human passes + review bot: FFI arena frame-pinning leak fixed (bot finding); decoder parity + 32-bit hardening; sharded buffer pool + oversized bypass; MIRI arena tests; bench harnesses (`zc_multiconn`, `zc_poolstress`); docs.

**2026-07-19 (round 2)** — independent review, approve-with-nits; all addressed in `31cdc508e` (docs-only): CHANGELOG entry added, pool-test isolation comments corrected, incomplete-line rescan corner documented, `detach_buffers` amplification documented, `ValueCodec` export marked `#[doc(hidden)]`, bindings audited for the read-only contract.

### Checklist

- [x] Commit message describes what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md / docs updated.
- [x] Linters run and pass.
- [x] Destination branch correct — targets `main`.
- [x] Squash on merge.

Signed-off-by: Omer Rubinstein <omerrubi@amazon.com>
