### PR TITLE
Rust: Fix flaky test_exact_subscriptions_survive_slot_migrations race condition

### DIFF
--- a/glide-core/tests/test_pubsub.rs
+++ b/glide-core/tests/test_pubsub.rs
@@ -16,7 +16,8 @@ use utilities::cluster::{
     ClusterTopology, LONG_CLUSTER_TEST_TIMEOUT, PubSubTestSetup, RedisCluster,
     generate_test_subscriptions_different_slots, migrate_channel_to_different_node,
     migrate_channels_to_different_nodes, subscribe_and_wait, trigger_failover,
-    verify_subscription_addresses_changed, wait_for_node_to_become_primary, wait_for_pubsub_state,
+    verify_subscription_addresses_changed, wait_for_node_to_become_primary,
+    wait_for_pubsub_state, wait_for_subscriptions_migrated,
 };
 
 const LOG_PREFIX: &str = "test_pubsub";
@@ -156,30 +157,17 @@ fn test_exact_subscriptions_survive_slot_migrations(#[case] num_channels: usize)
         )
         .await;
 
-        // small sleep to allow for the synchronizer handle_topology to start and unsubscribe
-        // Otherwise we will pass the wait_for_pubsub_state immediately on the same address
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let all_resubscribed = wait_for_pubsub_state(
-            &setup.synchronizer,
+        // Wait for subscriptions to migrate to new addresses using a deterministic
+        // polling loop instead of a fixed sleep. This avoids the race condition where
+        // the topology refresh hasn't fired yet or subscriptions are mid-reconciliation.
+        let (changed, unchanged, not_found) = wait_for_subscriptions_migrated(
+            &setup,
+            &subs_before,
+            &channels,
             PubSubSubscriptionKind::Exact,
-            &channels.iter().cloned().collect(),
-            true,
             RESUBSCRIPTION_TIMEOUT,
         )
         .await;
-        assert!(
-            all_resubscribed,
-            "All exact subscriptions should be re-established after migrations"
-        );
-
-        let subs_after = setup.get_subscriptions_by_address();
-        let (changed, unchanged, not_found) = verify_subscription_addresses_changed(
-            &subs_before,
-            &subs_after,
-            &channels,
-            PubSubSubscriptionKind::Exact,
-        );
 
         logger_core::log_info(
             LOG_PREFIX,
@@ -244,30 +232,17 @@ fn test_pattern_subscriptions_survive_slot_migrations(#[case] num_patterns: usiz
         )
         .await;
 
-        // small sleep to allow for the synchronizer handle_topology to start and unsubscribe
-        // Otherwise we will pass the wait_for_pubsub_state immediately on the same address
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let all_resubscribed = wait_for_pubsub_state(
-            &setup.synchronizer,
+        // Wait for subscriptions to migrate to new addresses using a deterministic
+        // polling loop instead of a fixed sleep. This avoids the race condition where
+        // the topology refresh hasn't fired yet or subscriptions are mid-reconciliation.
+        let (changed, unchanged, not_found) = wait_for_subscriptions_migrated(
+            &setup,
+            &subs_before,
+            &patterns,
             PubSubSubscriptionKind::Pattern,
-            &patterns.iter().cloned().collect(),
-            true,
             RESUBSCRIPTION_TIMEOUT,
         )
         .await;
-        assert!(
-            all_resubscribed,
-            "All pattern subscriptions should be re-established after migrations"
-        );
-
-        let subs_after = setup.get_subscriptions_by_address();
-        let (changed, unchanged, not_found) = verify_subscription_addresses_changed(
-            &subs_before,
-            &subs_after,
-            &patterns,
-            PubSubSubscriptionKind::Pattern,
-        );
 
         logger_core::log_info(
             LOG_PREFIX,

--- a/glide-core/tests/test_pubsub.rs
+++ b/glide-core/tests/test_pubsub.rs
@@ -16,8 +16,8 @@ use utilities::cluster::{
     ClusterTopology, LONG_CLUSTER_TEST_TIMEOUT, PubSubTestSetup, RedisCluster,
     generate_test_subscriptions_different_slots, migrate_channel_to_different_node,
     migrate_channels_to_different_nodes, subscribe_and_wait, trigger_failover,
-    verify_subscription_addresses_changed, wait_for_node_to_become_primary,
-    wait_for_pubsub_state, wait_for_subscriptions_migrated,
+    verify_subscription_addresses_changed, wait_for_node_to_become_primary, wait_for_pubsub_state,
+    wait_for_subscriptions_migrated,
 };
 
 const LOG_PREFIX: &str = "test_pubsub";
@@ -321,65 +321,33 @@ fn test_all_subscription_types_survive_same_slot_migration() {
             "Should have migrated to a different node"
         );
 
-        // small sleep to allow for the synchronizer handle_topology to start and unsubscribe
-        // Otherwise we will pass the wait_for_pubsub_state immediately on the same address
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        let exact_resub = wait_for_pubsub_state(
-            &setup.synchronizer,
-            PubSubSubscriptionKind::Exact,
-            &HashSet::from([exact_channel.clone()]),
-            true,
-            RESUBSCRIPTION_TIMEOUT,
-        )
-        .await;
-        let pattern_resub = wait_for_pubsub_state(
-            &setup.synchronizer,
-            PubSubSubscriptionKind::Pattern,
-            &HashSet::from([pattern.clone()]),
-            true,
-            RESUBSCRIPTION_TIMEOUT,
-        )
-        .await;
-        let sharded_resub = wait_for_pubsub_state(
-            &setup.synchronizer,
-            PubSubSubscriptionKind::Sharded,
-            &HashSet::from([sharded_channel.clone()]),
-            true,
-            RESUBSCRIPTION_TIMEOUT,
-        )
-        .await;
-
-        assert!(exact_resub, "Exact subscription should be re-established");
-        assert!(
-            pattern_resub,
-            "Pattern subscription should be re-established"
-        );
-        assert!(
-            sharded_resub,
-            "Sharded subscription should be re-established"
-        );
-
-        let subs_after = setup.get_subscriptions_by_address();
-
-        let (exact_changed, _, exact_not_found) = verify_subscription_addresses_changed(
+        // Poll until each subscription has moved to its new address. A fixed sleep
+        // can return before the topology refresh clears the old-address entries, so
+        // the assertions below would see a stale or empty snapshot.
+        let (exact_changed, _, exact_not_found) = wait_for_subscriptions_migrated(
+            &setup,
             &subs_before,
-            &subs_after,
             std::slice::from_ref(&exact_channel),
             PubSubSubscriptionKind::Exact,
-        );
-        let (pattern_changed, _, pattern_not_found) = verify_subscription_addresses_changed(
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        let (pattern_changed, _, pattern_not_found) = wait_for_subscriptions_migrated(
+            &setup,
             &subs_before,
-            &subs_after,
             std::slice::from_ref(&pattern),
             PubSubSubscriptionKind::Pattern,
-        );
-        let (sharded_changed, _, sharded_not_found) = verify_subscription_addresses_changed(
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        let (sharded_changed, _, sharded_not_found) = wait_for_subscriptions_migrated(
+            &setup,
             &subs_before,
-            &subs_after,
             std::slice::from_ref(&sharded_channel),
             PubSubSubscriptionKind::Sharded,
-        );
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
 
         assert_eq!(exact_not_found, 0, "Exact subscription should be found");
         assert_eq!(pattern_not_found, 0, "Pattern subscription should be found");
@@ -449,55 +417,33 @@ fn test_all_subscription_types_survive_different_slot_migrations() {
             tokio::time::sleep(MIGRATION_DELAY).await;
         }
 
-        // small sleep to allow for the synchronizer handle_topology to start and unsubscribe
-        // Otherwise we will pass the wait_for_pubsub_state immediately on the same address
-        tokio::time::sleep(Duration::from_millis(500)).await;
-
-        wait_for_pubsub_state(
-            &setup.synchronizer,
-            PubSubSubscriptionKind::Exact,
-            &HashSet::from([exact_channel.clone()]),
-            true,
-            RESUBSCRIPTION_TIMEOUT,
-        )
-        .await;
-        wait_for_pubsub_state(
-            &setup.synchronizer,
-            PubSubSubscriptionKind::Pattern,
-            &HashSet::from([pattern.clone()]),
-            true,
-            RESUBSCRIPTION_TIMEOUT,
-        )
-        .await;
-        wait_for_pubsub_state(
-            &setup.synchronizer,
-            PubSubSubscriptionKind::Sharded,
-            &HashSet::from([sharded_channel.clone()]),
-            true,
-            RESUBSCRIPTION_TIMEOUT,
-        )
-        .await;
-
-        let subs_after = setup.get_subscriptions_by_address();
-
-        let (exact_changed, _, _) = verify_subscription_addresses_changed(
+        // Poll until each subscription has moved to its new address. A fixed sleep
+        // can return before the topology refresh clears the old-address entries, so
+        // the assertions below would see a stale or empty snapshot.
+        let (exact_changed, _, _) = wait_for_subscriptions_migrated(
+            &setup,
             &subs_before,
-            &subs_after,
             std::slice::from_ref(&exact_channel),
             PubSubSubscriptionKind::Exact,
-        );
-        let (pattern_changed, _, _) = verify_subscription_addresses_changed(
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        let (pattern_changed, _, _) = wait_for_subscriptions_migrated(
+            &setup,
             &subs_before,
-            &subs_after,
             std::slice::from_ref(&pattern),
             PubSubSubscriptionKind::Pattern,
-        );
-        let (sharded_changed, _, _) = verify_subscription_addresses_changed(
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
+        let (sharded_changed, _, _) = wait_for_subscriptions_migrated(
+            &setup,
             &subs_before,
-            &subs_after,
             std::slice::from_ref(&sharded_channel),
             PubSubSubscriptionKind::Sharded,
-        );
+            RESUBSCRIPTION_TIMEOUT,
+        )
+        .await;
 
         assert_eq!(
             exact_changed, 1,

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -1024,3 +1024,43 @@ pub fn verify_subscription_addresses_changed(
 
     (changed, unchanged, not_found)
 }
+
+/// Wait for subscriptions to migrate to different addresses after slot migration.
+/// Polls until all channels are found at addresses different from their pre-migration locations.
+/// Returns (changed, unchanged, not_found) counts, or times out and returns the last observed state.
+///
+/// This replaces the fragile pattern of `sleep(500ms) + wait_for_pubsub_state + verify_addresses`
+/// with a single deterministic polling loop that checks the actual condition we care about:
+/// all subscriptions have moved to their new addresses.
+#[cfg(not(feature = "mock-pubsub"))]
+pub async fn wait_for_subscriptions_migrated(
+    setup: &PubSubTestSetup,
+    subs_before: &HashMap<String, PubSubSubscriptionInfo>,
+    channels: &[Vec<u8>],
+    kind: PubSubSubscriptionKind,
+    timeout: Duration,
+) -> (usize, usize, usize) {
+    let start = std::time::Instant::now();
+    loop {
+        let subs_after = setup.get_subscriptions_by_address();
+        let (changed, unchanged, not_found) =
+            verify_subscription_addresses_changed(subs_before, &subs_after, channels, kind);
+
+        if not_found == 0 && unchanged == 0 {
+            return (changed, unchanged, not_found);
+        }
+
+        if start.elapsed() >= timeout {
+            logger_core::log_warn(
+                "wait_for_subscriptions_migrated",
+                format!(
+                    "Timed out after {:?}: changed={}, unchanged={}, not_found={}",
+                    timeout, changed, unchanged, not_found
+                ),
+            );
+            return (changed, unchanged, not_found);
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -1027,7 +1027,7 @@ pub fn verify_subscription_addresses_changed(
 
 /// Wait for subscriptions to migrate to different addresses after slot migration.
 /// Polls until all channels are found at addresses different from their pre-migration locations.
-/// Returns (changed, unchanged, not_found) counts, or times out and returns the last observed state.
+/// Returns (changed, unchanged, not_found) counts, or the last observed state on timeout.
 ///
 /// This replaces the fragile pattern of `sleep(500ms) + wait_for_pubsub_state + verify_addresses`
 /// with a single deterministic polling loop that checks the actual condition we care about:


### PR DESCRIPTION
### Summary

Fix flaky pub/sub slot-migration tests that fail intermittently due to a race between a fixed sleep and the cluster topology-refresh interval.
Affected tests include `test_exact_subscriptions_survive_slot_migrations::case_2_many_channels` and `test_pattern_subscriptions_survive_slot_migrations::case_2_hundred_patterns`.

### Issue link

This Pull Request is linked to issue: [[Rust][Flaky Test] test_exact_subscriptions_survive_slot_migrations::case_2_many_channels](https://github.com/valkey-io/valkey-glide/issues/6560)

Closes #6560

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** After a slot migration, the tests waited with `tokio::time::sleep(Duration::from_millis(500))` for the topology refresh (which also runs every 500ms) to detect the migration.
When the sleep finishes before the topology refresh fires, `wait_for_pubsub_state` sees channels still at their old addresses and returns immediately.
The next topology refresh then clears those channels from `current_subscriptions_by_address`, so `get_subscriptions_by_address()` returns empty or partial results (for example 0 subscriptions found instead of the expected 10).

**Fix:** A `wait_for_subscriptions_migrated()` helper in `glide-core/tests/utilities/cluster.rs` replaces the `sleep(500ms) + wait_for_pubsub_state + verify_addresses` sequence with a single polling loop (100ms interval, configurable timeout).
It polls the exact post-condition the assertions check: every subscription is found at an address different from its pre-migration location (`not_found == 0 && unchanged == 0`).
Because it waits on that condition directly, the transient empty window is no longer observable, and on timeout it returns the last observed counts so the assertions still fail loudly.

All four slot-migration tests use the helper: `test_exact_subscriptions_survive_slot_migrations`, `test_pattern_subscriptions_survive_slot_migrations`, `test_all_subscription_types_survive_same_slot_migration`, and `test_all_subscription_types_survive_different_slot_migrations`.
The fixed 500ms sleep is removed from all of them, so the suite also runs faster.

### Limitations

None

### Testing

- All four slot-migration tests pass locally against a real cluster (`cargo test --test test_pubsub`, `test result: ok. 6 passed`).
- `cargo check --tests` compiles cleanly with no warnings.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release
