### PR TITLE
feat(go): expose inflightRequestsLimit configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changes
 
+* Go: Expose `inflightRequestsLimit` configuration via `WithInflightRequestsLimit`, bringing the Go client to parity with Java, Python, and Node ([#6385](https://github.com/valkey-io/valkey-glide/issues/6385))
 * Core/FFI: Add `command_with_route_info` FFI entrypoint, accepting routing as a `RouteInfo` C-struct pointer instead of protobuf-encoded bytes — the same mechanism `batch()` already uses. Existing `command`, `command_with_buffer`, `command_with_buffers`, and `invoke_script` are unchanged. ([#6494](https://github.com/valkey-io/valkey-glide/pull/6494))
 * CI: Publish the Python `valkey-glide` and `valkey-glide-sync` packages to PyPI via Trusted Publishing (OIDC) with PEP 740 attestations, replacing API-token uploads ([#6478](https://github.com/valkey-io/valkey-glide/pull/6478))
 * Node: Replace socket IPC with direct NAPI layer ([#5325](https://github.com/valkey-io/valkey-glide/pull/5325))

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -222,20 +222,21 @@ const (
 type AddressResolver func(host string, port int) (string, int)
 
 type baseClientConfiguration struct {
-	addresses            []NodeAddress
-	useTLS               bool
-	credentials          *ServerCredentials
-	readFrom             ReadFrom
-	requestTimeout       time.Duration
-	clientName           string
-	clientAZ             string
-	reconnectStrategy    *BackoffStrategy
-	lazyConnect          bool
-	DatabaseId           *int `json:"database_id,omitempty"`
-	compressionConfig    *CompressionConfiguration
-	clientSideCache      *ClientSideCache
-	addressResolver      AddressResolver
-	clientCircuitBreaker *ClientCircuitBreakerConfiguration
+	addresses             []NodeAddress
+	useTLS                bool
+	credentials           *ServerCredentials
+	readFrom              ReadFrom
+	requestTimeout        time.Duration
+	clientName            string
+	clientAZ              string
+	reconnectStrategy     *BackoffStrategy
+	lazyConnect           bool
+	DatabaseId            *int `json:"database_id,omitempty"`
+	compressionConfig     *CompressionConfiguration
+	clientSideCache       *ClientSideCache
+	addressResolver       AddressResolver
+	inflightRequestsLimit uint32
+	clientCircuitBreaker  *ClientCircuitBreakerConfiguration
 }
 
 func (config *baseClientConfiguration) toProtobuf() (*protobuf.ConnectionRequest, error) {
@@ -308,6 +309,10 @@ func (config *baseClientConfiguration) toProtobuf() (*protobuf.ConnectionRequest
 			return nil, fmt.Errorf("invalid circuit breaker configuration: %w", err)
 		}
 		request.ClientCircuitBreaker = cbPb
+	}
+
+	if config.inflightRequestsLimit != 0 {
+		request.InflightRequestsLimit = config.inflightRequestsLimit
 	}
 
 	return &request, nil
@@ -611,6 +616,14 @@ func (config *ClientConfiguration) WithClientCircuitBreaker(
 	return config
 }
 
+// WithInflightRequestsLimit sets the maximum number of concurrent requests allowed to be in-flight (sent but not yet
+// completed). This limit is used to control memory usage and prevent the client from overwhelming the server or getting
+// stuck in case of a queue backlog. If not set, a default value of 1000 will be used.
+func (config *ClientConfiguration) WithInflightRequestsLimit(limit uint32) *ClientConfiguration {
+	config.inflightRequestsLimit = limit
+	return config
+}
+
 func (config *ClientConfiguration) GetAddressResolver() AddressResolver {
 	return config.addressResolver
 }
@@ -854,6 +867,14 @@ func (config *ClusterClientConfiguration) WithClientCircuitBreaker(
 	cb *ClientCircuitBreakerConfiguration,
 ) *ClusterClientConfiguration {
 	config.clientCircuitBreaker = cb
+	return config
+}
+
+// WithInflightRequestsLimit sets the maximum number of concurrent requests allowed to be in-flight (sent but not yet
+// completed). This limit is used to control memory usage and prevent the client from overwhelming the server or getting
+// stuck in case of a queue backlog. If not set, a default value of 1000 will be used.
+func (config *ClusterClientConfiguration) WithInflightRequestsLimit(limit uint32) *ClusterClientConfiguration {
+	config.inflightRequestsLimit = limit
 	return config
 }
 

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -1482,3 +1482,32 @@ func TestNewClientSideCache_ServerAssistedExplicitlyDisabled(t *testing.T) {
 	cache.WithServerAssisted(false)
 	assert.False(t, cache.ServerAssisted)
 }
+
+func TestClientConfiguration_WithInflightRequestsLimit(t *testing.T) {
+	config := NewClientConfiguration().
+		WithAddress(&NodeAddress{Host: "localhost", Port: 6379}).
+		WithInflightRequestsLimit(5000)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(5000), result.InflightRequestsLimit)
+}
+
+func TestClientConfiguration_WithInflightRequestsLimit_notSet(t *testing.T) {
+	config := NewClientConfiguration().
+		WithAddress(&NodeAddress{Host: "localhost", Port: 6379})
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(0), result.InflightRequestsLimit)
+}
+
+func TestClusterClientConfiguration_WithInflightRequestsLimit(t *testing.T) {
+	config := NewClusterClientConfiguration().
+		WithAddress(&NodeAddress{Host: "localhost", Port: 6379}).
+		WithInflightRequestsLimit(2000)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(2000), result.InflightRequestsLimit)
+}

--- a/go/integTest/connection_test.go
+++ b/go/integTest/connection_test.go
@@ -487,3 +487,87 @@ func (suite *GlideTestSuite) TestConnectWithIPv6AddressSucceeds_Cluster() {
 
 	assertConnected(suite.T(), client)
 }
+
+func (suite *GlideTestSuite) TestInflightRequestsLimit_Standalone() {
+	inflightLimit := uint32(5)
+	clientConfig := defaultClientConfig().
+		WithAddress(&suite.standaloneHosts[0]).
+		WithInflightRequestsLimit(inflightLimit)
+
+	client, err := glide.NewClient(clientConfig)
+	require.NoError(suite.T(), err)
+	defer client.Close()
+
+	keyName := "nonexistkeylist-standalone-" + suite.T().Name()
+
+	// Send inflightLimit + 1 blocking requests
+	errCh := make(chan error, inflightLimit+1)
+	for i := uint32(0); i <= inflightLimit; i++ {
+		go func() {
+			_, e := client.BLPop(context.Background(), []string{keyName}, 0)
+			if e != nil {
+				errCh <- e
+			}
+		}()
+	}
+
+	// At least one request should fail with an error about maximum inflight requests
+	select {
+	case e := <-errCh:
+		assert.Contains(suite.T(), e.Error(), "maximum inflight requests")
+	case <-time.After(5 * time.Second):
+		suite.T().Fatal("Timed out waiting for inflight limit rejection")
+	}
+
+	// Cleanup: push values to unblock pending requests
+	cleanupConfig := defaultClientConfig().WithAddress(&suite.standaloneHosts[0])
+	cleanupClient, err := glide.NewClient(cleanupConfig)
+	require.NoError(suite.T(), err)
+	defer cleanupClient.Close()
+	for i := uint32(0); i < inflightLimit; i++ {
+		_, err := cleanupClient.LPush(context.Background(), keyName, []string{"val"})
+		require.NoError(suite.T(), err)
+	}
+}
+
+func (suite *GlideTestSuite) TestInflightRequestsLimit_Cluster() {
+	inflightLimit := uint32(5)
+	clientConfig := defaultClusterClientConfig().
+		WithAddress(&suite.clusterHosts[0]).
+		WithInflightRequestsLimit(inflightLimit)
+
+	client, err := glide.NewClusterClient(clientConfig)
+	require.NoError(suite.T(), err)
+	defer client.Close()
+
+	keyName := "nonexistkeylist-cluster-" + suite.T().Name()
+
+	// Send inflightLimit + 1 blocking requests
+	errCh := make(chan error, inflightLimit+1)
+	for i := uint32(0); i <= inflightLimit; i++ {
+		go func() {
+			_, e := client.BLPop(context.Background(), []string{keyName}, 0)
+			if e != nil {
+				errCh <- e
+			}
+		}()
+	}
+
+	// At least one request should fail with an error about maximum inflight requests
+	select {
+	case e := <-errCh:
+		assert.Contains(suite.T(), e.Error(), "maximum inflight requests")
+	case <-time.After(5 * time.Second):
+		suite.T().Fatal("Timed out waiting for inflight limit rejection")
+	}
+
+	// Cleanup: push values to unblock pending requests
+	cleanupConfig := defaultClusterClientConfig().WithAddress(&suite.clusterHosts[0])
+	cleanupClient, err := glide.NewClusterClient(cleanupConfig)
+	require.NoError(suite.T(), err)
+	defer cleanupClient.Close()
+	for i := uint32(0); i < inflightLimit; i++ {
+		_, err := cleanupClient.LPush(context.Background(), keyName, []string{"val"})
+		require.NoError(suite.T(), err)
+	}
+}


### PR DESCRIPTION
### Summary

Expose the `inflightRequestsLimit` configuration option in the Go client, bringing it to parity with Java, Python, and Node. This allows Go users to control the maximum number of concurrent in-flight requests per connection (default 1000, applied by the Rust core).

### Issue link

Closes #6385

### Features / Behaviour Changes

- Add `WithInflightRequestsLimit(limit uint32)` to both `ClientConfiguration` and `ClusterClientConfiguration`
- When set to a non-zero value, the limit is forwarded to the Rust core via the existing protobuf field
- When not set (zero value), the core applies its default of 1000

### Implementation

- Added `inflightRequestsLimit uint32` field to `baseClientConfiguration`
- Wired it into `toProtobuf()` (only set when non-zero, matching the zero-means-default convention)
- Added `WithInflightRequestsLimit` builder methods on both client configuration types with doc comments matching the Java/Node/Python descriptions

### Testing

- **Unit tests** (`go/config/config_test.go`): 3 tests covering standalone set, standalone not-set (defaults to 0), and cluster set — verifying correct protobuf serialization
- **Integration tests** (`go/integTest/connection_test.go`): 2 tests (standalone + cluster) that flood `BLPop` requests beyond the limit and assert the overflow request is rejected with "maximum inflight requests" — mirrors the Java `SharedClientTests.inflight_requests_limit` test
- All config unit tests pass locally, `gofumpt` and `golangci-lint` clean

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary