### PR TITLE
CI: exempt Task and Feature labels from stale workflow auto-close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
                   days-before-pr-stale: 60
                   days-before-close: 14
                   days-before-pr-close: 10
-                  exempt-issue-labels: "bug 🐞,Users Pain,Epic ⚡,User issue 🚨,Untriaged user issue"
+                  exempt-issue-labels: "bug 🐞,Users Pain,Epic ⚡,User issue 🚨,Untriaged user issue,Task 🔧,Feature ✨"
                   exempt-all-milestones: true
                   operations-per-run: 50
                   labels-to-add-when-unstale: "Unstaled"


### PR DESCRIPTION
### Summary

Expands the `exempt-issue-labels` list in the daily stale workflow (`.github/workflows/stale.yml`) to include `Task 🔧` and `Feature ✨`, so issues tracking planned implementation work and feature requests are no longer auto-marked stale / auto-closed for inactivity.

### Issue link

N/A — trivial CI fix.

### Features / Behaviour Changes

Issues labeled `Task 🔧` or `Feature ✨` are now exempt from the stale bot (previously only `bug 🐞`, `Users Pain`, `Epic ⚡`, `User issue 🚨`, and `Untriaged user issue` were exempt). `Flaky-tests 🐦` is intentionally left out so those remain eligible for auto-close.

### Implementation

One-line change to the `exempt-issue-labels` input of the `actions/stale` step in `.github/workflows/stale.yml`. `actions/stale` matches full label names case-insensitively, so the emoji must be included; label names were verified against the repo's actual labels and the `Task`/`Feature` issue templates (`.github/ISSUE_TEMPLATE/task.yml`, `feature-request.yml`) to ensure exact matches.

### Limitations

Matching stays brittle — renaming a label's emoji would silently break the exemption.

### Testing

Config-only. Verified the label strings match the repository's actual labels exactly (emoji included). A data-driven review of the 177 currently open issues confirmed `Task 🔧` (56 issues) and `Feature ✨` (31 issues) are the highest-volume "keep" labels not already exempt, with no overlap into the intentionally-auto-closable `Flaky-tests 🐦` population.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
