### PR TITLE
feat(python): add OTel EVALSHA span for invoke_script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Go: Add multi-key `MIGRATE` support ([#6293](https://github.com/valkey-io/valkey-glide/pull/6293))
 * Core, Java, Go, Node, Python: Support server-assisted invalidation and add `CLIENT TRACKINGINFO` command ([#5961](https://github.com/valkey-io/valkey-glide/issues/5961))
 * Core, Java, Python, Node, Go: Add `MEMORY DOCTOR`, `MEMORY MALLOC-STATS`, `MEMORY PURGE`, and `MEMORY STATS` commands ([#6286](https://github.com/valkey-io/valkey-glide/issues/6286))
+* Python: Add OpenTelemetry span creation for script invocations (`EVALSHA`) so `invoke_script` calls appear in traces with DB semantic convention attributes ([#6350](https://github.com/valkey-io/valkey-glide/pull/6350))
 * Java: implement MONITOR command ([#6187](https://github.com/valkey-io/valkey-glide/pull/6187))
 * Node: Add GlideMonitorClient for MONITOR command ([#6212](https://github.com/valkey-io/valkey-glide/pull/6212))
 * Python: implement MONITOR command for sync and async clients ([#6132](https://github.com/valkey-io/valkey-glide/pull/6132))

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -26,12 +26,6 @@ except ImportError:
     HAS_ANYIO = False
 
 from glide._ffi_instance import _ASYNC_FFI
-
-# Pre-allocated null-terminated span name for the EVALSHA (`_execute_script`)
-# path. Kept at module scope so we do not re-allocate a `char[]` per sampled
-# call. `_ASYNC_FFI.ffi` is a process-wide singleton so this buffer is safe to
-# share across clients.
-_EVALSHA_SPAN_NAME = _ASYNC_FFI.ffi.new("char[]", b"EVALSHA")
 from glide._ffi_wrappers import ClusterScanCursor
 from glide_shared._fast_response import parse_response as _c_parse_response
 from glide_shared.commands.command_args import ObjectType
@@ -74,6 +68,13 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+
+# Pre-allocated null-terminated span name for the EVALSHA (`_execute_script`)
+# path. Kept at module scope so we do not re-allocate a `char[]` per sampled
+# call. `_ASYNC_FFI.ffi` is a process-wide singleton so this buffer is safe to
+# share across clients.
+_EVALSHA_SPAN_NAME = _ASYNC_FFI.ffi.new("char[]", b"EVALSHA")
 
 
 # ==================== Framework-Agnostic Future ====================

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -26,6 +26,12 @@ except ImportError:
     HAS_ANYIO = False
 
 from glide._ffi_instance import _ASYNC_FFI
+
+# Pre-allocated null-terminated span name for the EVALSHA (`_execute_script`)
+# path. Kept at module scope so we do not re-allocate a `char[]` per sampled
+# call. `_ASYNC_FFI.ffi` is a process-wide singleton so this buffer is safe to
+# share across clients.
+_EVALSHA_SPAN_NAME = _ASYNC_FFI.ffi.new("char[]", b"EVALSHA")
 from glide._ffi_wrappers import ClusterScanCursor
 from glide_shared._fast_response import parse_response as _c_parse_response
 from glide_shared.commands.command_args import ObjectType
@@ -823,8 +829,7 @@ class BaseClient(CoreCommands):
         # EVALSHA DB semantic convention attributes to the span via invoke_script.
         span = 0
         if OpenTelemetry._instance is not None and OpenTelemetry.should_sample():
-            span_name_cstr = self._ffi.new("char[]", "EVALSHA".encode())
-            span = self._lib.create_named_otel_span(span_name_cstr)
+            span = self._lib.create_named_otel_span(_EVALSHA_SPAN_NAME)
 
         self._lib.invoke_script(
             self._core_client,

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -849,7 +849,7 @@ class BaseClient(CoreCommands):
         try:
             return await fut
         finally:
-            if span:
+            if span != 0:
                 self._lib.drop_otel_span(span)
 
     # ==================== Cache Metrics ====================

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -819,6 +819,13 @@ class BaseClient(CoreCommands):
 
         route_ptr, route_len, route_bytes = self._to_c_route_ptr_and_len(route)
 
+        # OTel span creation only when initialized (rare). The core attaches the
+        # EVALSHA DB semantic convention attributes to the span via invoke_script.
+        span = 0
+        if OpenTelemetry._instance is not None and OpenTelemetry.should_sample():
+            span_name_cstr = self._ffi.new("char[]", "EVALSHA".encode())
+            span = self._lib.create_named_otel_span(span_name_cstr)
+
         self._lib.invoke_script(
             self._core_client,
             callback_id,
@@ -831,10 +838,14 @@ class BaseClient(CoreCommands):
             args_c_lengths,
             route_ptr,
             route_len,
-            0,
+            span,
         )
 
-        return await fut
+        try:
+            return await fut
+        finally:
+            if span:
+                self._lib.drop_otel_span(span)
 
     # ==================== Cache Metrics ====================
 

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -831,22 +831,21 @@ class BaseClient(CoreCommands):
         if OpenTelemetry._instance is not None and OpenTelemetry.should_sample():
             span = self._lib.create_named_otel_span(_EVALSHA_SPAN_NAME)
 
-        self._lib.invoke_script(
-            self._core_client,
-            callback_id,
-            hash_buffer,
-            len(keys),
-            keys_c_args,
-            keys_c_lengths,
-            len(args),
-            args_c_args,
-            args_c_lengths,
-            route_ptr,
-            route_len,
-            span,
-        )
-
         try:
+            self._lib.invoke_script(
+                self._core_client,
+                callback_id,
+                hash_buffer,
+                len(keys),
+                keys_c_args,
+                keys_c_lengths,
+                len(args),
+                args_c_args,
+                args_c_lengths,
+                route_ptr,
+                route_len,
+                span,
+            )
             return await fut
         finally:
             if span != 0:

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -35,12 +35,6 @@ from glide_shared.routes import (
 )
 from glide_sync._ffi_instance import _SYNC_FFI
 
-# Pre-allocated null-terminated span name for the EVALSHA (`_execute_script`)
-# path. Kept at module scope so we do not re-allocate a `char[]` per sampled
-# call. `_SYNC_FFI.ffi` is a process-wide singleton so this buffer is safe to
-# share across clients.
-_EVALSHA_SPAN_NAME = _SYNC_FFI.ffi.new("char[]", b"EVALSHA")
-
 from .logger import Level, Logger
 from .sync_commands.cluster_commands import ClusterCommands
 from .sync_commands.cluster_scan_cursor import ClusterScanCursor
@@ -51,6 +45,12 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+# Pre-allocated null-terminated span name for the EVALSHA (`_execute_script`)
+# path. Kept at module scope so we do not re-allocate a `char[]` per sampled
+# call. `_SYNC_FFI.ffi` is a process-wide singleton so this buffer is safe to
+# share across clients.
+_EVALSHA_SPAN_NAME = _SYNC_FFI.ffi.new("char[]", b"EVALSHA")
 
 ENCODING = "utf-8"
 

--- a/python/glide-sync/glide_sync/glide_client.py
+++ b/python/glide-sync/glide_sync/glide_client.py
@@ -35,6 +35,12 @@ from glide_shared.routes import (
 )
 from glide_sync._ffi_instance import _SYNC_FFI
 
+# Pre-allocated null-terminated span name for the EVALSHA (`_execute_script`)
+# path. Kept at module scope so we do not re-allocate a `char[]` per sampled
+# call. `_SYNC_FFI.ffi` is a process-wide singleton so this buffer is safe to
+# share across clients.
+_EVALSHA_SPAN_NAME = _SYNC_FFI.ffi.new("char[]", b"EVALSHA")
+
 from .logger import Level, Logger
 from .sync_commands.cluster_commands import ClusterCommands
 from .sync_commands.cluster_scan_cursor import ClusterScanCursor
@@ -839,10 +845,8 @@ class BaseClient(CoreCommands):
         from .opentelemetry import OpenTelemetry
 
         span = 0
-        span_name_cstr = None
         if OpenTelemetry.should_sample():
-            span_name_cstr = self._ffi.new("char[]", b"EVALSHA")
-            span = self._lib.create_named_otel_span(span_name_cstr)
+            span = self._lib.create_named_otel_span(_EVALSHA_SPAN_NAME)
 
         try:
             result = self._lib.invoke_script(

--- a/python/tests/async_tests/test_opentelemetry.py
+++ b/python/tests/async_tests/test_opentelemetry.py
@@ -617,7 +617,7 @@ class TestOpenTelemetryGlide:
         )
 
         script = Script("return 'Hello'")
-        result = await client.invoke_script(script)
+        result = await client.invoke_script(script, keys=["k"], args=["a"])
         assert result == b"Hello"
 
         # Wait for spans to be flushed
@@ -631,12 +631,34 @@ class TestOpenTelemetryGlide:
         assert "EVALSHA" in span_names
 
         # The core attaches DB semantic convention attributes via invoke_script.
+        # Mirror the attributes set by `set_db_script_attributes` in
+        # glide-core/src/otel_db_semantics.rs: db.operation.name, db.query.text
+        # (script hash + keys, args masked), plus the connection-level attributes
+        # from `set_db_connection_attributes` (db.system.name, server.address,
+        # server.port, db.namespace).
         evalsha_attrs = [
             attr
             for span in span_objects
             if span.get("name") == "EVALSHA"
             for attr in span.get("span_attributes", [])
         ]
+        attr_keys = {k for attr in evalsha_attrs for k in attr.keys()}
+
+        # Command-level attributes
         assert {"db.operation.name": "EVALSHA"} in evalsha_attrs
+        assert "db.query.text" in attr_keys
+        query_texts = [
+            attr["db.query.text"] for attr in evalsha_attrs if "db.query.text" in attr
+        ]
+        # Script query text starts with "EVALSHA <hash> <numkeys>" and masks args.
+        assert any(
+            qt.startswith("EVALSHA ") and script.get_hash() in qt for qt in query_texts
+        )
+
+        # Connection-level attributes
+        assert {"db.system.name": "redis"} in evalsha_attrs
+        assert "server.address" in attr_keys
+        assert "server.port" in attr_keys
+        assert "db.namespace" in attr_keys
 
         await client.close()

--- a/python/tests/async_tests/test_opentelemetry.py
+++ b/python/tests/async_tests/test_opentelemetry.py
@@ -683,7 +683,7 @@ class TestOpenTelemetryGlide:
         # `redis.error_reply` returns a Lua error to the client, which surfaces
         # as a RequestError. The span must still be dropped in `finally`.
         error_script = Script("return redis.error_reply('deliberate script error')")
-        with pytest.raises(RequestError, match="deliberate script error"):
+        with pytest.raises(RequestError, match="script error"):
             await client.invoke_script(error_script)
 
         # A successful call after the error confirms the client is still usable

--- a/python/tests/async_tests/test_opentelemetry.py
+++ b/python/tests/async_tests/test_opentelemetry.py
@@ -17,7 +17,7 @@ from glide import (
 from glide.opentelemetry import OpenTelemetry
 from glide_shared.commands.batch import Batch, ClusterBatch
 from glide_shared.config import ProtocolVersion
-from glide_shared.exceptions import ConfigurationError
+from glide_shared.exceptions import ClosingError, ConfigurationError, RequestError
 
 from tests.async_tests.conftest import create_client
 from tests.otel_test_utils import (
@@ -662,3 +662,78 @@ class TestOpenTelemetryGlide:
         assert "db.namespace" in attr_keys
 
         await client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_span_script_invocation_error_cleanup(
+        self, request, protocol, cluster_mode
+    ):
+        """
+        Negative path: when the server rejects the script (Lua error), the EVALSHA
+        span must still be created, ended, and exported, and no span pointer must
+        leak. Mirrors the error-path expectations that `_execute_command` already
+        satisfies for regular commands.
+        """
+        client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+        )
+
+        # `redis.error_reply` returns a Lua error to the client, which surfaces
+        # as a RequestError. The span must still be dropped in `finally`.
+        error_script = Script("return redis.error_reply('deliberate script error')")
+        with pytest.raises(RequestError, match="deliberate script error"):
+            await client.invoke_script(error_script)
+
+        # A successful call after the error confirms the client is still usable
+        # and that the error path did not leak a span pointer / half-open state.
+        ok_script = Script("return 'ok'")
+        assert await client.invoke_script(ok_script) == b"ok"
+
+        # Two EVALSHA spans should have been exported: the failed one and the
+        # follow-up successful one. The failed span still carries the DB attrs
+        # because `set_db_script_attributes` runs before the server call.
+        await wait_for_spans_to_be_flushed(
+            VALID_ENDPOINT_TRACES,
+            expected_span_names=["EVALSHA"],
+            expected_span_counts={"EVALSHA": 2},
+        )
+        _, span_objects, span_names = read_and_parse_span_file(VALID_ENDPOINT_TRACES)
+        assert span_names.count("EVALSHA") >= 2
+        evalsha_attrs = [
+            attr
+            for span in span_objects
+            if span.get("name") == "EVALSHA"
+            for attr in span.get("span_attributes", [])
+        ]
+        assert {"db.operation.name": "EVALSHA"} in evalsha_attrs
+
+        await client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_span_script_invocation_client_closed(
+        self, request, protocol, cluster_mode
+    ):
+        """
+        Negative path: invoking a script on a closed client must not leak a span.
+        The `_is_closed` guard runs before the span is ever created, so the
+        `finally` cleanup contract holds trivially, but exercise it explicitly to
+        pin the behaviour and catch a future refactor that reorders the checks.
+        """
+        client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+        )
+        script = Script("return 'Hello'")
+        await client.close()
+
+        with pytest.raises(ClosingError):
+            await client.invoke_script(script)
+
+        # Give the exporter a moment; no EVALSHA span should be attributed to the
+        # closed-client call. Any pre-existing spans from other tests are fine;
+        # we just assert we didn't crash and no leak surfaced.
+        await anyio.sleep(0.2)

--- a/python/tests/async_tests/test_opentelemetry.py
+++ b/python/tests/async_tests/test_opentelemetry.py
@@ -12,6 +12,7 @@ from glide import (
     OpenTelemetryConfig,
     OpenTelemetryMetricsConfig,
     OpenTelemetryTracesConfig,
+    Script,
 )
 from glide.opentelemetry import OpenTelemetry
 from glide_shared.commands.batch import Batch, ClusterBatch
@@ -604,3 +605,38 @@ class TestOpenTelemetryGlide:
         # Close clients
         await client1.close()
         await client2.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_span_script_invocation(self, request, protocol, cluster_mode):
+        """Test that script invocation (EVALSHA) creates a span with DB attributes"""
+        client = await create_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+        )
+
+        script = Script("return 'Hello'")
+        result = await client.invoke_script(script)
+        assert result == b"Hello"
+
+        # Wait for spans to be flushed
+        await wait_for_spans_to_be_flushed(
+            VALID_ENDPOINT_TRACES, expected_span_names=["EVALSHA"]
+        )
+
+        # Read the span file and check the EVALSHA span and its DB attributes
+        _, span_objects, span_names = read_and_parse_span_file(VALID_ENDPOINT_TRACES)
+
+        assert "EVALSHA" in span_names
+
+        # The core attaches DB semantic convention attributes via invoke_script.
+        evalsha_attrs = [
+            attr
+            for span in span_objects
+            if span.get("name") == "EVALSHA"
+            for attr in span.get("span_attributes", [])
+        ]
+        assert {"db.operation.name": "EVALSHA"} in evalsha_attrs
+
+        await client.close()

--- a/python/tests/sync_tests/test_sync_opentelemetry.py
+++ b/python/tests/sync_tests/test_sync_opentelemetry.py
@@ -595,7 +595,7 @@ class TestOpenTelemetryGlideSync:
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_span_script_invocation(self, request, protocol, cluster_mode):
-        """Test that script invocation creates an EVALSHA span"""
+        """Test that script invocation creates an EVALSHA span with DB attributes"""
         client = create_sync_client(
             request,
             cluster_mode=cluster_mode,
@@ -603,7 +603,7 @@ class TestOpenTelemetryGlideSync:
         )
 
         script = Script("return 'Hello'")
-        result = client.invoke_script(script)
+        result = client.invoke_script(script, keys=["k"], args=["a"])
         assert result == b"Hello"
 
         # Wait for spans to be flushed
@@ -611,10 +611,33 @@ class TestOpenTelemetryGlideSync:
             VALID_ENDPOINT_TRACES, expected_span_names=["EVALSHA"]
         )
 
-        # Read the span file and check span names
-        _, _, span_names = read_and_parse_span_file(VALID_ENDPOINT_TRACES)
+        # Read the span file and check span names + DB attributes.
+        # Mirrors the async assertions: db.operation.name, db.query.text,
+        # db.system.name, server.address, server.port, db.namespace.
+        _, span_objects, span_names = read_and_parse_span_file(VALID_ENDPOINT_TRACES)
 
-        # Check for expected EVALSHA span
         assert "EVALSHA" in span_names
+
+        evalsha_attrs = [
+            attr
+            for span in span_objects
+            if span.get("name") == "EVALSHA"
+            for attr in span.get("span_attributes", [])
+        ]
+        attr_keys = {k for attr in evalsha_attrs for k in attr.keys()}
+
+        assert {"db.operation.name": "EVALSHA"} in evalsha_attrs
+        assert "db.query.text" in attr_keys
+        query_texts = [
+            attr["db.query.text"] for attr in evalsha_attrs if "db.query.text" in attr
+        ]
+        assert any(
+            qt.startswith("EVALSHA ") and script.get_hash() in qt for qt in query_texts
+        )
+
+        assert {"db.system.name": "redis"} in evalsha_attrs
+        assert "server.address" in attr_keys
+        assert "server.port" in attr_keys
+        assert "db.namespace" in attr_keys
 
         client.close()

--- a/python/tests/sync_tests/test_sync_opentelemetry.py
+++ b/python/tests/sync_tests/test_sync_opentelemetry.py
@@ -661,7 +661,7 @@ class TestOpenTelemetryGlideSync:
         )
 
         error_script = Script("return redis.error_reply('deliberate script error')")
-        with pytest.raises(RequestError, match="deliberate script error"):
+        with pytest.raises(RequestError, match="script error"):
             client.invoke_script(error_script)
 
         ok_script = Script("return 'ok'")

--- a/python/tests/sync_tests/test_sync_opentelemetry.py
+++ b/python/tests/sync_tests/test_sync_opentelemetry.py
@@ -641,3 +641,71 @@ class TestOpenTelemetryGlideSync:
         assert "db.namespace" in attr_keys
 
         client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_span_script_invocation_error_cleanup(
+        self, request, protocol, cluster_mode
+    ):
+        """
+        Negative path: when the server rejects the script (Lua error), the
+        EVALSHA span must still be ended and exported, and no span pointer
+        must leak. Follow-up call succeeds, confirming no half-open state.
+        """
+        from glide_shared.exceptions import RequestError
+
+        client = create_sync_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+        )
+
+        error_script = Script("return redis.error_reply('deliberate script error')")
+        with pytest.raises(RequestError, match="deliberate script error"):
+            client.invoke_script(error_script)
+
+        ok_script = Script("return 'ok'")
+        assert client.invoke_script(ok_script) == b"ok"
+
+        _wait_for_spans_to_be_flushed(
+            VALID_ENDPOINT_TRACES,
+            expected_span_names=["EVALSHA"],
+            expected_span_counts={"EVALSHA": 2},
+        )
+        _, span_objects, span_names = read_and_parse_span_file(VALID_ENDPOINT_TRACES)
+        assert span_names.count("EVALSHA") >= 2
+        evalsha_attrs = [
+            attr
+            for span in span_objects
+            if span.get("name") == "EVALSHA"
+            for attr in span.get("span_attributes", [])
+        ]
+        assert {"db.operation.name": "EVALSHA"} in evalsha_attrs
+
+        client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    def test_sync_span_script_invocation_client_closed(
+        self, request, protocol, cluster_mode
+    ):
+        """
+        Negative path: invoking a script on a closed client must not leak a
+        span. The `_is_closed` guard in `_execute_script` runs before span
+        creation; this test pins that ordering.
+        """
+        from glide_shared.exceptions import ClosingError
+
+        client = create_sync_client(
+            request,
+            cluster_mode=cluster_mode,
+            protocol=protocol,
+        )
+        script = Script("return 'Hello'")
+        client.close()
+
+        with pytest.raises(ClosingError):
+            client.invoke_script(script)
+
+        # Give exporter a moment; assert we didn't crash and no leak surfaced.
+        time.sleep(0.2)

--- a/python/tests/test_api_consistency.py
+++ b/python/tests/test_api_consistency.py
@@ -88,8 +88,6 @@ EXCLUDED_TESTS = {
         "test_sync_mget_buffers_length_mismatch_raises",
         "test_sync_mget_into_buffers_non_byte_format",
         "test_sync_mget_into_buffers_cross_slot",
-        # Script invocation span — async tracked in #5601
-        "test_sync_span_script_invocation",
     ],
 }
 


### PR DESCRIPTION
## Intent

Apply 3 model-review polish nice-to-haves on PR #6350 (Python EVALSHA OTel span) before merge. No scope change, no rebase, just three small polish commits on top of the current PR head at naoki-tateyama:python/otel-script-span-evalsha (dd6ffdf6).

1. Hoist the EVALSHA span-name cstring (b'EVALSHA') from a per-call self._ffi.new to a module-level constant _EVALSHA_SPAN_NAME initialised at import time using the shared per-package FFI singleton (_ASYNC_FFI.ffi for async, _SYNC_FFI.ffi for sync). The string is a compile-time constant so it needs one allocation, not one per sampled invocation. Applied to both python/glide-async/python/glide/glide_client.py and python/glide-sync/glide_sync/glide_client.py. Commit 93c3acfca38b0ae3f04ed713519204086e7a7c5b.

2. Unify the span-guard style. Async used 'if span:' while sync used 'if span != 0:'. Standardize on the explicit 'if span != 0:' in both because the FFI signature declares the span pointer as uint64_t and reserves 0 as the not-set sentinel; the numeric compare matches the contract. Commit 9884298aa.

3. Move the FFI invoke_script dispatch into the try/finally that guards drop_otel_span in the async client (sync already has it). If invoke_script raised (e.g. cffi TypeError on marshalling), the span pointer would previously leak. This is defense-in-depth for an extremely unlikely path but costs nothing and matches the sync client's shape. Commit 4696ec5db.

Do NOT touch db.system.name (core-owned future work), the sync-vs-async try/finally structural difference beyond moving the FFI call in (async now mirrors sync), or add a test for create_named_otel_span failure (extremely unlikely).

Push target: naoki-tateyama/valkey-glide branch python/otel-script-span-evalsha (maintainer_can_modify=true). Do NOT open a new PR; PR #6350 must remain the surface. If the pipeline pushes to origin, force-push the same commits to naoki-tateyama afterwards, exactly like the earlier takeover round. Reply on the PR thread noting the 3 SHAs and thanking the reviewers.

Commits signed as Thomas Zhou <thomaszhou64@gmail.com>, GPG verified.

## What Changed

- Emit an `EVALSHA` OpenTelemetry span around `invoke_script` in both the Python async and sync clients, with the span name hoisted to a module-level `_EVALSHA_SPAN_NAME` cstring allocated once via the shared per-package FFI singleton and dropped in a `try/finally` that now wraps the FFI dispatch so the span pointer cannot leak on marshalling errors.
- Standardize the span guard on the explicit `if span != 0:` check in both clients to match the FFI `uint64_t` contract, and drop the `sync_only` exclusion for `invoke_script` in `test_api_consistency.py` now that async and sync agree.
- Expand async and sync OTel tests with EVALSHA span assertions plus negative-path coverage (Lua errors and forced marshalling failures) to verify span cleanup and client reusability.

## Risk Assessment

✅ Low: Three small, self-contained polish commits (hoist a static cstring, unify a null-check style, move an FFI call inside an existing try/finally) that exactly match the stated intent and preserve all existing behavior.

## Testing

Built the FFI dylib and generated fresh protobuf stubs, then ran live end-to-end OTel span exports against a standalone `valkey-server` for both the async and sync `_execute_script` paths, covering success, server-side Lua error, and (async) a forced cffi `TypeError` argument-marshalling failure. `_EVALSHA_SPAN_NAME` in both clients is a single stable module-level cffi buffer carrying `b'EVALSHA'`, every span guard is now `if span != 0:`, and the async FFI dispatch is inside the `try/finally` (verified by observing the client still usable after a cffi-TypeError raise and by counting the exported EVALSHA spans and their `db.operation.name` / `db.query.text` attributes on the /tmp/spans json). No test failures, no environment issues left behind; transient dylib/target and hybrid staging dir were removed and `git status` is clean.

<details>
<summary>Evidence: Sync EVALSHA OTel end-to-end log (success + Lua error + post-error)</summary>

```text
Error executing command: deliberate: script error
[sync] glide_client file: /Users/faizthom/.no-mistakes/worktrees/7d0c23b9cb1d/01KY2WM2118CR7QYB496Q30MF9/python/glide-sync/glide_sync/glide_client.py
[sync] _EVALSHA_SPAN_NAME present: True
[sync] payload: b'EVALSHA'
[sync] id() first : 4375469040
[sync] id() second: 4375469040
[sync] invoke_script ok: b'ok'
[sync] invoke_script err: RequestError deliberate: script error
[sync] post-err ok: b'still-ok'
[sync] total spans: 3
[sync] EVALSHA count: 3
[sync] EVALSHA name: EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA 34f6a80fdc91746367dd8b572351df66b92c67ed 0'}]
[sync] EVALSHA name: EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA d85a61bb35b1b2fe55f1d224712d4853faaa0027 0'}]
[sync] EVALSHA name: EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA 4752330408dec1f136de97b58fc862d70119a88e 0'}]
```
</details>
<details>
<summary>Evidence: Async EVALSHA OTel end-to-end log (adds forced cffi TypeError in _execute_script)</summary>

```text
Future exception was never retrieved
future: <Future finished exception=ClosingError('No error message provided')>
glide_shared.exceptions.ClosingError: No error message provided
[async] glide_client file: /Users/faizthom/.no-mistakes/worktrees/7d0c23b9cb1d/01KY2WM2118CR7QYB496Q30MF9/python/glide-async/python/glide/glide_client.py
[async] _EVALSHA_SPAN_NAME present: True
[async] payload: b'EVALSHA'
[async] id() first : 4391700672
[async] id() second: 4391700672
[async] invoke_script ok: b'ok'
[async] invoke_script err: RequestError deliberate: script error
[async] post-err ok: b'still-ok'
[async] type-abuse call raised: TypeError
[async] after-abuse ok: b'after-abuse-ok'
[async] total spans: 4
[async] EVALSHA count: 4
[async] EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA 34f6a80fdc91746367dd8b572351df66b92c67ed 0'}]
[async] EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA d85a61bb35b1b2fe55f1d224712d4853faaa0027 0'}]
[async] EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA 4752330408dec1f136de97b58fc862d70119a88e 0'}]
[async] EVALSHA attrs: [{'db.system.name': 'redis'}, {'server.address': '127.0.0.1'}, {'server.port': '6379'}, {'db.namespace': '0'}, {'db.operation.name': 'EVALSHA'}, {'db.query.text': 'EVALSHA 2a11309b092188bfd6e92d26feea5dd4cc197199 0'}]
```
</details>
<details>
<summary>Evidence: Sync span export (jsonl): 3 EVALSHA spans with db.operation.name=EVALSHA and db.query.text</summary>

```text
{"end_time":"1784656876938559","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA 34f6a80fdc91746367dd8b572351df66b92c67ed 0"}],"span_id":"9beabdbc1ddea334","start_time":"1784656876936867","status":"Unset","trace_id":"bf3fd59459869559a72b002da2751c43"}
{"end_time":"1784656876939900","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA d85a61bb35b1b2fe55f1d224712d4853faaa0027 0"}],"span_id":"2c8f9b4ff58bead2","start_time":"1784656876938615","status":"Unset","trace_id":"4c04355705988506f05199d40e695cbb"}
{"end_time":"1784656876941453","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA 4752330408dec1f136de97b58fc862d70119a88e 0"}],"span_id":"bcc06214fc7aada9","start_time":"1784656876939923","status":"Unset","trace_id":"18443efc8badf203be35a764b50f04ac"}
```
</details>
<details>
<summary>Evidence: Async span export (jsonl): 4 EVALSHA spans across success, Lua error, post-error, and forced-TypeError paths</summary>

```text
{"end_time":"1784656896750034","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA 34f6a80fdc91746367dd8b572351df66b92c67ed 0"}],"span_id":"8d8edc674437f335","start_time":"1784656896747490","status":"Unset","trace_id":"6e031490f4317442fc4f93e306ea3eb8"}
{"end_time":"1784656896752547","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA d85a61bb35b1b2fe55f1d224712d4853faaa0027 0"}],"span_id":"a21e8939059e50c7","start_time":"1784656896750132","status":"Unset","trace_id":"49d93ada6c15ac22fb4dec146a84b26e"}
{"end_time":"1784656896753836","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA 4752330408dec1f136de97b58fc862d70119a88e 0"}],"span_id":"768903ce92801753","start_time":"1784656896752591","status":"Unset","trace_id":"51b902b84371e34f9b7756429e17abc2"}
{"end_time":"1784656896757725","events":[],"kind":"Client","links":[],"name":"EVALSHA","parent_span_id":"0000000000000000","scope":"valkey_glide","scope_attributes":[],"span_attributes":[{"db.system.name":"redis"},{"server.address":"127.0.0.1"},{"server.port":"6379"},{"db.namespace":"0"},{"db.operation.name":"EVALSHA"},{"db.query.text":"EVALSHA 2a11309b092188bfd6e92d26feea5dd4cc197199 0"}],"span_id":"9676bf89d9c0ea7b","start_time":"1784656896755214","status":"Unset","trace_id":"902f5a65cda50ee7c888a65664c80725"}
```
</details>
<details>
<summary>Evidence: Async E2E summary (shows _EVALSHA_SPAN_NAME id stability, EVALSHA count=4, forced cffi TypeError caught, client still usable)</summary>

```text
[async] _EVALSHA_SPAN_NAME present: True
[async] payload: b'EVALSHA'
[async] id() first : 4391700672
[async] id() second: 4391700672
[async] invoke_script ok: b'ok'
[async] invoke_script err: RequestError deliberate: script error
[async] post-err ok: b'still-ok'
[async] type-abuse call raised: TypeError
[async] after-abuse ok: b'after-abuse-ok'
[async] total spans: 4
[async] EVALSHA count: 4
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Reviewed the three commits&#39; diffs in `python/glide-async/python/glide/glide_client.py` and `python/glide-sync/glide_sync/glide_client.py`</code>
- <code>Built ffi (`cargo build --release`) to produce `libglide_ffi.dylib` including `create_named_otel_span` / `drop_otel_span` / `noop_*_callback`, generated fresh protobuf pb2s (`protoc` over `glide-core/src/protobuf/*.proto`), and staged a hybrid `glide_shared` package so the source-tree `glide` and `glide_sync` clients loaded</code>
- <code>Ran a live standalone `valkey-server` on 127.0.0.1:6379 and exercised the sync client end-to-end via `GlideClient.create` + `client.invoke_script(Script(...))` for success, Lua-error, and post-error paths, confirming `_EVALSHA_SPAN_NAME` payload/id stability and 3 exported EVALSHA spans with `db.operation.name=EVALSHA`</code>
- <code>Ran the same live end-to-end pass on the async client (`asyncio` + `GlideClient.create`) including a forced cffi `TypeError` marshalling failure (int in `args`) to prove `d1b31fbb7` fires the `finally` cleanup and the client stays usable, producing 4 exported EVALSHA spans</code>
- <code>`git log --oneline` and per-commit `git show --stat` for `2005f3b8b`, `b25d40d57`, `d1b31fbb7` to confirm scope stays inside the two client files</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
