### PR TITLE
ci(node): install exact release_version in RC test, not dist-tag

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -553,14 +553,21 @@ jobs:
                   DELAY=15
                   for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
                       rm -rf node_modules package-lock.json
-                      npm install "@valkey/valkey-glide@${RELEASE_VERSION}" --save
-                      # Read the version from the installed package.json on disk. The package's
-                      # "exports" map only exposes ".", so require("@valkey/valkey-glide/package.json")
-                      # would throw ERR_PACKAGE_PATH_NOT_EXPORTED; read the file directly instead.
-                      INSTALLED_VERSION=$(jq -r .version node_modules/@valkey/valkey-glide/package.json 2>/dev/null || true)
-                      if [ "${INSTALLED_VERSION}" = "${RELEASE_VERSION}" ] && node -e "require('@valkey/valkey-glide')"; then
-                          echo "Version ${RELEASE_VERSION} installed and native module resolved on attempt ${attempt}."
-                          break
+                      # The install itself is what waits on registry propagation: when the exact
+                      # version is not visible on an npm edge yet, `npm install` exits non-zero
+                      # (ETARGET/404). Guard it with `if` so that (under the default `set -e` shell)
+                      # a transient miss is retried instead of aborting the step on the first attempt.
+                      if npm install "@valkey/valkey-glide@${RELEASE_VERSION}" --save; then
+                          # Read the version from the installed package.json on disk. The package's
+                          # "exports" map only exposes ".", so require("@valkey/valkey-glide/package.json")
+                          # would throw ERR_PACKAGE_PATH_NOT_EXPORTED; read the file directly instead.
+                          INSTALLED_VERSION=$(jq -r .version node_modules/@valkey/valkey-glide/package.json 2>/dev/null || true)
+                          if [ "${INSTALLED_VERSION}" = "${RELEASE_VERSION}" ] && node -e "require('@valkey/valkey-glide')"; then
+                              echo "Version ${RELEASE_VERSION} installed and native module resolved on attempt ${attempt}."
+                              break
+                          fi
+                      else
+                          INSTALLED_VERSION=""
                       fi
                       if [ "${attempt}" -eq "${MAX_ATTEMPTS}" ]; then
                           echo "::error::@valkey/valkey-glide@${RELEASE_VERSION} not fully installable after ${MAX_ATTEMPTS} attempts (installed version: '${INSTALLED_VERSION:-none}')."

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -538,25 +538,35 @@ jobs:
             - name: Run utils/node Tests
               working-directory: utils/release-candidate-testing/node
               run: |
+                  # Install the exact version this workflow just published, NOT the dist-tag
+                  # (latest/next). The dist-tag pointer itself propagates across npm edges with lag,
+                  # so installing by tag can resolve the previous release and pass without ever
+                  # exercising the newly published package.
+                  #
                   # The platform-specific optional dependency (e.g. @valkey/valkey-glide-linux-x64-gnu)
-                  # can lag behind the base package on the npm registry for a short window right after
-                  # publish. When that happens npm silently skips the optional dependency and the test
-                  # fails with "Cannot find module". Retry the install until the native module resolves.
-                  NPM_TAG="${{ needs.get-build-parameters.outputs.npm_tag }}"
+                  # can also lag behind the base package on the npm registry for a short window right
+                  # after publish. When that happens npm silently skips the optional dependency and the
+                  # test fails with "Cannot find module". Retry the install until the native module
+                  # resolves, and assert the installed version matches the published version.
+                  RELEASE_VERSION="${{ needs.get-build-parameters.outputs.release_version }}"
                   MAX_ATTEMPTS=5
                   DELAY=15
                   for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
                       rm -rf node_modules package-lock.json
-                      npm install "@valkey/valkey-glide@${NPM_TAG}" --save
-                      if node -e "require('@valkey/valkey-glide')"; then
-                          echo "Native module resolved on attempt ${attempt}."
+                      npm install "@valkey/valkey-glide@${RELEASE_VERSION}" --save
+                      # Read the version from the installed package.json on disk. The package's
+                      # "exports" map only exposes ".", so require("@valkey/valkey-glide/package.json")
+                      # would throw ERR_PACKAGE_PATH_NOT_EXPORTED; read the file directly instead.
+                      INSTALLED_VERSION=$(jq -r .version node_modules/@valkey/valkey-glide/package.json 2>/dev/null || true)
+                      if [ "${INSTALLED_VERSION}" = "${RELEASE_VERSION}" ] && node -e "require('@valkey/valkey-glide')"; then
+                          echo "Version ${RELEASE_VERSION} installed and native module resolved on attempt ${attempt}."
                           break
                       fi
                       if [ "${attempt}" -eq "${MAX_ATTEMPTS}" ]; then
-                          echo "::error::@valkey/valkey-glide native module still unresolved after ${MAX_ATTEMPTS} attempts."
+                          echo "::error::@valkey/valkey-glide@${RELEASE_VERSION} not fully installable after ${MAX_ATTEMPTS} attempts (installed version: '${INSTALLED_VERSION:-none}')."
                           exit 1
                       fi
-                      echo "Attempt ${attempt}/${MAX_ATTEMPTS}: native module not resolvable yet (likely npm registry propagation). Retrying in ${DELAY}s..."
+                      echo "Attempt ${attempt}/${MAX_ATTEMPTS}: version '${INSTALLED_VERSION:-none}' / native module not resolvable yet (likely npm registry propagation). Retrying in ${DELAY}s..."
                       sleep "${DELAY}"
                   done
                   npm run build:utils


### PR DESCRIPTION
### Summary

Fixes #6593. The npm CD "Run utils/node Tests" step installed the freshly published package by **dist-tag** (`@valkey/valkey-glide@${npm_tag}`, where `npm_tag` is only ever `latest`/`next`) rather than by the exact `release_version` that was just published.

The retry loop added in #6343 was meant to wait out npm registry propagation lag for the new version's platform-specific optional dependency (native module). But because the install targets a dist-tag, it can be satisfied by the **previous** release: the `latest`/`next` pointer itself propagates across npm edges with lag, so an edge still serving the old target lets `require()` succeed on the first attempt and the job passes **without ever exercising the version this run just published**.

### Issue link

Closes #6593

### Features / Behaviour Changes

No runtime behaviour change. CI-only: the RC node test now installs the exact `release_version` and asserts the installed version matches before the retry loop breaks, so a green result guarantees the just-published artifact (base package + native optional dependency) is installable and loadable.

### Implementation

- Install `@valkey/valkey-glide@${{ needs.get-build-parameters.outputs.release_version }}` (exact version) instead of `@${npm_tag}`. `release_version` is already an existing `get-build-parameters` output and is the same value stamped into the published `package.json`.
- Assert the installed `package.json` version equals `release_version` before breaking out of the retry loop (defense-in-depth against dist-tag / metadata lag).
- Read the installed version from disk with `jq` rather than `require('@valkey/valkey-glide/package.json')`: the package's `exports` map only exposes `.`, so the subpath require would throw `ERR_PACKAGE_PATH_NOT_EXPORTED`.

### Limitations

None. Self-contained CI workflow change. Will be backported to `release-2.5` and `release-2.4` (which carry the same #6343/#6340 defect) after merge.

### Testing

CI-only change; validated on the next `main` npm CD publish run. YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`).

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated. (N/A — CI workflow change, no unit-testable surface)
- [ ] CHANGELOG.md and documentation files are updated. (N/A — no user-facing change)