### PR TITLE
feat(node): reshape mTLS into MutualTls discriminated union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Python: Add configurable `lib_name` and `client_info_tag` to client configuration (async and sync). ([#6378](https://github.com/valkey-io/valkey-glide/issues/6378))
 * Core, Java: add mTLS client certificates with automatic reloading ([#6386](https://github.com/valkey-io/valkey-glide/pull/6386))
 * Python: Add OpenTelemetry span creation for script invocations (`EVALSHA`) so `invoke_script` calls appear in traces with DB semantic convention attributes ([#6350](https://github.com/valkey-io/valkey-glide/pull/6350))
+* Node: add automatic mTLS client certificate/key reload ([#6383](https://github.com/valkey-io/valkey-glide/pull/6383))
 
 ## 2.5
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -7,6 +7,7 @@
  * to suppress unused import errors for types referenced only in JSDoc.
  */
 
+import { readFile, stat } from "node:fs/promises";
 import Long from "long";
 import { Buffer } from "protobufjs/minimal";
 import {
@@ -330,6 +331,291 @@ export type GlideReturnType =
  * Union type that can store either a valid UTF-8 string or array of bytes.
  */
 export type GlideString = string | Buffer;
+
+/**
+ * Mutual TLS (mTLS) client authentication material.
+ *
+ * A discriminated union: the `kind` field selects between two mutually
+ * exclusive ways of supplying the client certificate and private key.
+ *
+ * - `kind: "bytes"` — supply PEM-encoded certificate and key material inline.
+ *   The material is sent to the core at connect time and never re-read; use
+ *   this for static (non-rotating) certificates. Both `cert` and `key` must
+ *   be non-empty. `string` inputs are UTF-8 encoded to bytes.
+ *
+ * - `kind: "path"` — supply filesystem paths to PEM-encoded certificate and
+ *   key files. The core reads the material from disk at connect time and, in
+ *   this variant, **automatic certificate reload is always enabled**: the
+ *   core periodically re-reads the files, validates that the private key
+ *   matches the certificate, and adopts rotated material on the next
+ *   reconnect (last-known-good is kept on any failure). Reload cadence uses
+ *   the core default unless `reloadIntervalSeconds` is provided.
+ *
+ * Reload enablement is derived state: it is on iff `kind === "path"`.
+ * There is no separate enable/disable toggle.
+ *
+ * @example
+ * ```typescript
+ * // Static (byte-based) mTLS — no reload.
+ * const staticMtls: MutualTls = {
+ *     kind: "bytes",
+ *     cert: await loadClientCertificateFromFile("/etc/ssl/client.crt"),
+ *     key: await loadClientKeyFromFile("/etc/ssl/client.key"),
+ * };
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Path-based mTLS — reload is implicitly on; override cadence to 60 s.
+ * const reloadingMtls: MutualTls = {
+ *     kind: "path",
+ *     certPath: "/etc/ssl/client.crt",
+ *     keyPath: "/etc/ssl/client.key",
+ *     reloadIntervalSeconds: 60,
+ * };
+ * ```
+ */
+export type MutualTls =
+    | {
+          readonly kind: "bytes";
+          readonly cert: Buffer | string;
+          readonly key: Buffer | string;
+      }
+    | {
+          readonly kind: "path";
+          readonly certPath: string;
+          readonly keyPath: string;
+          readonly reloadIntervalSeconds?: number;
+      };
+
+/**
+ * Reads a PEM file from disk for use in TLS configuration.
+ *
+ * Shared implementation behind {@link loadRootCertificatesFromFile},
+ * {@link loadClientCertificateFromFile}, and {@link loadClientKeyFromFile}.
+ *
+ * @param path - Filesystem path to the PEM-encoded file.
+ * @param label - Human-readable label used in error messages (e.g. `"Root certificate"`).
+ * @returns Promise resolving to the file contents as a `Buffer`.
+ * @throws {@link ConfigurationError} If the file is missing, unreadable, or empty.
+ * @internal
+ */
+async function loadTlsPemFile(path: string, label: string): Promise<Buffer> {
+    let data: Buffer;
+
+    try {
+        data = await readFile(path);
+    } catch (error) {
+        const fsError = error as NodeJS.ErrnoException;
+        const message =
+            fsError.code === "ENOENT"
+                ? `${label} file not found: ${path}`
+                : `Failed to read ${label.toLowerCase()} file at ${path}: ${
+                      error instanceof Error ? error.message : String(error)
+                  }`;
+        const wrapped = new ConfigurationError(message);
+        (wrapped as Error).cause = error;
+        throw wrapped;
+    }
+
+    if (data.length === 0) {
+        throw new ConfigurationError(`${label} file is empty: ${path}`);
+    }
+
+    return data;
+}
+
+/**
+ * Loads PEM-encoded root certificates from a file for TLS server verification.
+ *
+ * Convenience loader for the `rootCertificates` field of
+ * {@link AdvancedBaseClientConfiguration.tlsAdvancedConfiguration}.
+ *
+ * @param path - Filesystem path to a PEM root certificate or bundle.
+ * @returns Promise resolving to the certificate bytes.
+ * @throws {@link ConfigurationError} If the file is missing, unreadable, or empty.
+ *
+ * @example
+ * ```typescript
+ * const rootCertificates = await loadRootCertificatesFromFile("/etc/ssl/ca.pem");
+ * ```
+ */
+export function loadRootCertificatesFromFile(path: string): Promise<Buffer> {
+    return loadTlsPemFile(path, "Root certificate");
+}
+
+/**
+ * Loads a PEM-encoded client certificate from a file for mTLS authentication.
+ *
+ * Convenience loader for {@link MutualTls}'s byte-based variant (`kind: "bytes"`).
+ * When automatic reload is desired, use the path-based variant of
+ * {@link MutualTls} directly instead of loading the bytes here.
+ *
+ * @param path - Filesystem path to a PEM client certificate.
+ * @returns Promise resolving to the certificate bytes.
+ * @throws {@link ConfigurationError} If the file is missing, unreadable, or empty.
+ *
+ * @example
+ * ```typescript
+ * const cert = await loadClientCertificateFromFile("/etc/ssl/client.crt");
+ * ```
+ */
+export function loadClientCertificateFromFile(path: string): Promise<Buffer> {
+    return loadTlsPemFile(path, "Client certificate");
+}
+
+/**
+ * Loads a PEM-encoded client private key from a file for mTLS authentication.
+ *
+ * Convenience loader for {@link MutualTls}'s byte-based variant (`kind: "bytes"`).
+ * When automatic reload is desired, use the path-based variant of
+ * {@link MutualTls} directly instead of loading the bytes here.
+ *
+ * @param path - Filesystem path to a PEM client private key.
+ * @returns Promise resolving to the private key bytes.
+ * @throws {@link ConfigurationError} If the file is missing, unreadable, or empty.
+ *
+ * @example
+ * ```typescript
+ * const key = await loadClientKeyFromFile("/etc/ssl/client.key");
+ * ```
+ */
+export function loadClientKeyFromFile(path: string): Promise<Buffer> {
+    return loadTlsPemFile(path, "Client key");
+}
+
+/**
+ * Coerces a PEM cert/key input (`Buffer` or UTF-8 string) into a non-empty
+ * `Uint8Array` for wire serialization. Throws a {@link ConfigurationError}
+ * on empty inputs so the caller sees a specific error rather than a generic
+ * core-side parse failure.
+ *
+ * @internal
+ */
+function toPemBytes(value: Buffer | string, fieldName: string): Uint8Array {
+    const buffer =
+        typeof value === "string" ? Buffer.from(value, "utf-8") : value;
+
+    if (buffer.length === 0) {
+        throw new ConfigurationError(
+            `${fieldName} cannot be empty; omit ${fieldName} if not configuring mTLS.`,
+        );
+    }
+
+    return new Uint8Array(buffer);
+}
+
+/**
+ * Runtime narrowing and file-existence check for a path-based mTLS variant.
+ * Rejects empty strings, non-integer / non-positive reload intervals, and
+ * paths that do not resolve to a regular non-empty file at connect time.
+ *
+ * @internal
+ */
+async function assertPathVariant(
+    mtls: Extract<MutualTls, { kind: "path" }>,
+): Promise<void> {
+    if (typeof mtls.certPath !== "string" || mtls.certPath.length === 0) {
+        throw new ConfigurationError(
+            "mutualTls.certPath must be a non-empty string.",
+        );
+    }
+
+    if (typeof mtls.keyPath !== "string" || mtls.keyPath.length === 0) {
+        throw new ConfigurationError(
+            "mutualTls.keyPath must be a non-empty string.",
+        );
+    }
+
+    if (mtls.reloadIntervalSeconds !== undefined) {
+        const interval = mtls.reloadIntervalSeconds;
+
+        if (
+            typeof interval !== "number" ||
+            !Number.isFinite(interval) ||
+            !Number.isInteger(interval) ||
+            interval <= 0
+        ) {
+            throw new ConfigurationError(
+                "mutualTls.reloadIntervalSeconds must be a positive integer.",
+            );
+        }
+    }
+
+    await Promise.all([
+        assertRegularNonEmptyFile(mtls.certPath, "mutualTls.certPath"),
+        assertRegularNonEmptyFile(mtls.keyPath, "mutualTls.keyPath"),
+    ]);
+}
+
+/**
+ * @internal
+ */
+async function assertRegularNonEmptyFile(
+    path: string,
+    fieldName: string,
+): Promise<void> {
+    let stats;
+
+    try {
+        stats = await stat(path);
+    } catch (error) {
+        const fsError = error as NodeJS.ErrnoException;
+        const message =
+            fsError.code === "ENOENT"
+                ? `${fieldName} references a file that does not exist: ${path}`
+                : `Failed to stat ${fieldName} (${path}): ${
+                      error instanceof Error ? error.message : String(error)
+                  }`;
+        const wrapped = new ConfigurationError(message);
+        (wrapped as Error).cause = error;
+        throw wrapped;
+    }
+
+    if (!stats.isFile()) {
+        throw new ConfigurationError(
+            `${fieldName} must reference a regular file: ${path}`,
+        );
+    }
+
+    if (stats.size === 0) {
+        throw new ConfigurationError(
+            `${fieldName} references an empty file: ${path}`,
+        );
+    }
+}
+
+/**
+ * Validates and serializes a {@link MutualTls} value into the corresponding
+ * connection-request protobuf fields.
+ *
+ * @internal
+ */
+async function applyMutualTls(
+    mtls: MutualTls,
+    request: connection_request.IConnectionRequest,
+): Promise<void> {
+    if (mtls.kind === "bytes") {
+        request.clientCert = toPemBytes(mtls.cert, "mutualTls.cert");
+        request.clientKey = toPemBytes(mtls.key, "mutualTls.key");
+        return;
+    }
+
+    if (mtls.kind === "path") {
+        await assertPathVariant(mtls);
+        request.clientCertPath = mtls.certPath;
+        request.clientKeyPath = mtls.keyPath;
+        request.certReload = {
+            enabled: true,
+            intervalSeconds: mtls.reloadIntervalSeconds ?? null,
+        };
+        return;
+    }
+
+    throw new ConfigurationError(
+        `Unsupported mutualTls variant: ${JSON.stringify(mtls)}`,
+    );
+}
 
 /**
  * Enum representing the different types of decoders.
@@ -1057,6 +1343,49 @@ export interface AdvancedBaseClientConfiguration {
          * - This is useful when connecting to servers with self-signed certificates or custom certificate authorities.
          */
         rootCertificates?: string | Buffer;
+
+        /**
+         * Mutual TLS (mTLS) client authentication material.
+         *
+         * See {@link MutualTls} for the two supported variants (`kind: "bytes"`
+         * for static material, `kind: "path"` for automatic reload from disk).
+         * The two variants are mutually exclusive at the type level. Reload is
+         * enabled iff `kind === "path"` — there is no separate toggle.
+         *
+         * Requires TLS to be enabled on the base client configuration
+         * (`useTLS: true`). Setting `mutualTls` alongside `useTLS: false`
+         * raises a {@link ConfigurationError}.
+         *
+         * @example
+         * ```typescript
+         * // Path-based mTLS with automatic reload every 60 seconds.
+         * const config: AdvancedBaseClientConfiguration = {
+         *     tlsAdvancedConfiguration: {
+         *         mutualTls: {
+         *             kind: "path",
+         *             certPath: "/etc/ssl/client.crt",
+         *             keyPath: "/etc/ssl/client.key",
+         *             reloadIntervalSeconds: 60,
+         *         },
+         *     },
+         * };
+         * ```
+         *
+         * @example
+         * ```typescript
+         * // Static byte-based mTLS.
+         * const config: AdvancedBaseClientConfiguration = {
+         *     tlsAdvancedConfiguration: {
+         *         mutualTls: {
+         *             kind: "bytes",
+         *             cert: await loadClientCertificateFromFile("/etc/ssl/client.crt"),
+         *             key: await loadClientKeyFromFile("/etc/ssl/client.key"),
+         *         },
+         *     },
+         * };
+         * ```
+         */
+        readonly mutualTls?: MutualTls;
     };
 
     /**
@@ -9542,9 +9871,9 @@ export class BaseClient {
     /**
      * @internal
      */
-    protected createClientRequest(
+    protected async createClientRequest(
         options: BaseClientConfiguration,
-    ): connection_request.IConnectionRequest {
+    ): Promise<connection_request.IConnectionRequest> {
         const readFrom = options.readFrom
             ? this.MAP_READ_FROM_STRATEGY[options.readFrom]
             : connection_request.ReadFrom.Primary;
@@ -9701,10 +10030,10 @@ export class BaseClient {
     /**
      * @internal
      */
-    protected configureAdvancedConfigurationBase(
+    protected async configureAdvancedConfigurationBase(
         options: AdvancedBaseClientConfiguration,
         request: connection_request.IConnectionRequest,
-    ) {
+    ): Promise<void> {
         request.connectionTimeout =
             options.connectionTimeout ??
             DEFAULT_CONNECTION_TIMEOUT_IN_MILLISECONDS;
@@ -9720,31 +10049,34 @@ export class BaseClient {
                 options.pubsubReconciliationIntervalMs;
         }
 
-        // Apply TLS configuration if present
-        if (options.tlsAdvancedConfiguration) {
-            // request.tlsMode is either SecureTls or InsecureTls here
-            if (request.tlsMode === connection_request.TlsMode.NoTls) {
-                throw new ConfigurationError(
-                    "TLS advanced configuration cannot be set when useTLS is disabled.",
-                );
-            }
+        if (!options.tlsAdvancedConfiguration) {
+            return;
+        }
 
-            // If options.tlsAdvancedConfiguration.insecure is true then use InsecureTls mode
-            if (options.tlsAdvancedConfiguration.insecure) {
-                request.tlsMode = connection_request.TlsMode.InsecureTls;
-            }
+        const tls = options.tlsAdvancedConfiguration;
 
-            if (options.tlsAdvancedConfiguration.rootCertificates) {
-                const certData =
-                    typeof options.tlsAdvancedConfiguration.rootCertificates ===
-                    "string"
-                        ? Buffer.from(
-                              options.tlsAdvancedConfiguration.rootCertificates,
-                              "utf-8",
-                          )
-                        : options.tlsAdvancedConfiguration.rootCertificates;
-                request.rootCerts = [new Uint8Array(certData)];
-            }
+        // request.tlsMode is either SecureTls or InsecureTls here
+        if (request.tlsMode === connection_request.TlsMode.NoTls) {
+            throw new ConfigurationError(
+                "TLS advanced configuration cannot be set when useTLS is disabled.",
+            );
+        }
+
+        // If tls.insecure is true then use InsecureTls mode
+        if (tls.insecure) {
+            request.tlsMode = connection_request.TlsMode.InsecureTls;
+        }
+
+        if (tls.rootCertificates) {
+            const certData =
+                typeof tls.rootCertificates === "string"
+                    ? Buffer.from(tls.rootCertificates, "utf-8")
+                    : tls.rootCertificates;
+            request.rootCerts = [new Uint8Array(certData)];
+        }
+
+        if (tls.mutualTls !== undefined) {
+            await applyMutualTls(tls.mutualTls, request);
         }
     }
 
@@ -9755,7 +10087,7 @@ export class BaseClient {
     protected async connectToServer(
         options: BaseClientConfiguration,
     ): Promise<void> {
-        const request = this.createClientRequest(options);
+        const request = await this.createClientRequest(options);
 
         if (options.addressResolver) {
             this.addressResolverKey = registerAddressResolver(

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -613,7 +613,7 @@ async function applyMutualTls(
     }
 
     throw new ConfigurationError(
-        `Unsupported mutualTls variant: ${JSON.stringify(mtls)}`,
+        `Unsupported mutualTls variant: ${String((mtls as { kind?: unknown }).kind)}`,
     );
 }
 

--- a/node/src/GlideClient.ts
+++ b/node/src/GlideClient.ts
@@ -256,15 +256,15 @@ export class GlideClient extends BaseClient {
     /**
      * @internal
      */
-    protected createClientRequest(
+    protected async createClientRequest(
         options: GlideClientConfiguration,
-    ): connection_request.IConnectionRequest {
-        const configuration = super.createClientRequest(options);
+    ): Promise<connection_request.IConnectionRequest> {
+        const configuration = await super.createClientRequest(options);
 
         this.configurePubsub(options, configuration);
 
         if (options.advancedConfiguration) {
-            this.configureAdvancedConfigurationBase(
+            await this.configureAdvancedConfigurationBase(
                 options.advancedConfiguration,
                 configuration,
             );

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -655,10 +655,10 @@ export class GlideClusterClient extends BaseClient {
     /**
      * @internal
      */
-    protected createClientRequest(
+    protected async createClientRequest(
         options: GlideClusterClientConfiguration,
-    ): connection_request.IConnectionRequest {
-        const configuration = super.createClientRequest(options);
+    ): Promise<connection_request.IConnectionRequest> {
+        const configuration = await super.createClientRequest(options);
         configuration.clusterModeEnabled = true;
 
         // "enabledDefaultConfigs" is the default configuration and doesn't need setting
@@ -680,7 +680,7 @@ export class GlideClusterClient extends BaseClient {
         this.configurePubsub(options, configuration);
 
         if (options.advancedConfiguration) {
-            this.configureAdvancedConfigurationBase(
+            await this.configureAdvancedConfigurationBase(
                 options.advancedConfiguration,
                 configuration,
             );

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -2,19 +2,31 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from "@jest/globals";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+    AdvancedBaseClientConfiguration,
     BaseClient,
+    ConfigurationError,
     GlideClusterClientConfiguration,
     Logger,
     MAX_REQUEST_ARGS_LEN,
+    loadClientCertificateFromFile,
+    loadClientKeyFromFile,
+    loadRootCertificatesFromFile,
+    MutualTls,
 } from "../build-ts";
 import {
     createLeakedStringVec,
     freeLeakedStringVec,
     valueFromSplitPointer,
 } from "../build-ts/native";
-import { command_request } from "../build-ts/ProtobufMessage";
+import {
+    command_request,
+    connection_request,
+} from "../build-ts/ProtobufMessage";
 import { createMigrate } from "../build-ts/Commands";
 import { convertStringArrayToBuffer } from "./TestUtilities";
 const { RequestType } = command_request;
@@ -309,5 +321,420 @@ describe("createMigrate (multi-key) validation", () => {
                 "k",
             ]),
         );
+    });
+});
+
+// Exposes the protected configureAdvancedConfigurationBase so the resulting
+// protobuf connection request can be inspected without spinning up a client.
+class TlsConfigProbe extends BaseClient {
+    public constructor() {
+        super();
+    }
+
+    public async buildTlsRequest(
+        advancedConfiguration: AdvancedBaseClientConfiguration,
+    ): Promise<connection_request.IConnectionRequest> {
+        const request: connection_request.IConnectionRequest = {
+            tlsMode: connection_request.TlsMode.SecureTls,
+        };
+        await this.configureAdvancedConfigurationBase(
+            advancedConfiguration,
+            request,
+        );
+        return request;
+    }
+}
+
+const CLIENT_CERT_PEM =
+    "-----BEGIN CERTIFICATE-----\nMIICLIENTCERT\n-----END CERTIFICATE-----";
+const CLIENT_KEY_PEM =
+    "-----BEGIN PRIVATE KEY-----\nMIICLIENTKEY\n-----END PRIVATE KEY-----";
+const ROOT_CERT_PEM =
+    "-----BEGIN CERTIFICATE-----\nMIICROOTCERT\n-----END CERTIFICATE-----";
+
+const expectConfigurationError = async (
+    build: () => Promise<unknown>,
+    messageSubstring: string,
+): Promise<void> => {
+    await expect(build()).rejects.toBeInstanceOf(ConfigurationError);
+    await expect(build()).rejects.toThrow(messageSubstring);
+};
+
+describe('mutualTls kind: "bytes"', () => {
+    it("populates clientCert and clientKey from string PEM inputs", async () => {
+        const request = await new TlsConfigProbe().buildTlsRequest({
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "bytes",
+                    cert: CLIENT_CERT_PEM,
+                    key: CLIENT_KEY_PEM,
+                },
+            },
+        });
+
+        expect(request.clientCert).toEqual(
+            new Uint8Array(Buffer.from(CLIENT_CERT_PEM, "utf-8")),
+        );
+        expect(request.clientKey).toEqual(
+            new Uint8Array(Buffer.from(CLIENT_KEY_PEM, "utf-8")),
+        );
+        expect(request.certReload).toBeFalsy();
+        expect(request.clientCertPath).toBeFalsy();
+        expect(request.clientKeyPath).toBeFalsy();
+    });
+
+    it("populates clientCert and clientKey from Buffer PEM inputs", async () => {
+        const certBuffer = Buffer.from(CLIENT_CERT_PEM, "utf-8");
+        const keyBuffer = Buffer.from(CLIENT_KEY_PEM, "utf-8");
+
+        const request = await new TlsConfigProbe().buildTlsRequest({
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "bytes",
+                    cert: certBuffer,
+                    key: keyBuffer,
+                },
+            },
+        });
+
+        expect(request.clientCert).toEqual(new Uint8Array(certBuffer));
+        expect(request.clientKey).toEqual(new Uint8Array(keyBuffer));
+    });
+
+    it("rejects an empty cert (string)", async () => {
+        await expectConfigurationError(
+            () =>
+                new TlsConfigProbe().buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "bytes",
+                            cert: "",
+                            key: CLIENT_KEY_PEM,
+                        },
+                    },
+                }),
+            "mutualTls.cert cannot be empty",
+        );
+    });
+
+    it("rejects an empty key (Buffer)", async () => {
+        await expectConfigurationError(
+            () =>
+                new TlsConfigProbe().buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "bytes",
+                            cert: CLIENT_CERT_PEM,
+                            key: Buffer.alloc(0),
+                        },
+                    },
+                }),
+            "mutualTls.key cannot be empty",
+        );
+    });
+
+    it("rejects mutualTls when TLS is disabled on the base connection", async () => {
+        const probe = new (class extends TlsConfigProbe {
+            public override async buildTlsRequest(
+                advancedConfiguration: AdvancedBaseClientConfiguration,
+            ): Promise<connection_request.IConnectionRequest> {
+                const request: connection_request.IConnectionRequest = {
+                    tlsMode: connection_request.TlsMode.NoTls,
+                };
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                await (this as any).configureAdvancedConfigurationBase(
+                    advancedConfiguration,
+                    request,
+                );
+                return request;
+            }
+        })();
+
+        await expectConfigurationError(
+            () =>
+                probe.buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "bytes",
+                            cert: CLIENT_CERT_PEM,
+                            key: CLIENT_KEY_PEM,
+                        },
+                    },
+                }),
+            "TLS advanced configuration cannot be set",
+        );
+    });
+});
+
+describe('mutualTls kind: "path" (implicit reload)', () => {
+    let tmpDir: string;
+    let certPath: string;
+    let keyPath: string;
+
+    beforeAll(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "glide-mtls-path-"));
+        certPath = join(tmpDir, "client.crt");
+        keyPath = join(tmpDir, "client.key");
+        writeFileSync(certPath, CLIENT_CERT_PEM);
+        writeFileSync(keyPath, CLIENT_KEY_PEM);
+    });
+
+    afterAll(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("sets the path fields and enables reload with default cadence", async () => {
+        const request = await new TlsConfigProbe().buildTlsRequest({
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "path",
+                    certPath,
+                    keyPath,
+                },
+            },
+        });
+
+        expect(request.clientCertPath).toBe(certPath);
+        expect(request.clientKeyPath).toBe(keyPath);
+        expect(request.certReload).toEqual({
+            enabled: true,
+            intervalSeconds: null,
+        });
+        expect(request.clientCert).toBeFalsy();
+        expect(request.clientKey).toBeFalsy();
+    });
+
+    it("propagates a custom reloadIntervalSeconds", async () => {
+        const request = await new TlsConfigProbe().buildTlsRequest({
+            tlsAdvancedConfiguration: {
+                mutualTls: {
+                    kind: "path",
+                    certPath,
+                    keyPath,
+                    reloadIntervalSeconds: 120,
+                },
+            },
+        });
+
+        expect(request.certReload).toEqual({
+            enabled: true,
+            intervalSeconds: 120,
+        });
+    });
+
+    const invalidIntervals: Array<[string, number]> = [
+        ["zero", 0],
+        ["negative", -10],
+        ["non-integer", 12.5],
+        ["NaN", Number.NaN],
+        ["Infinity", Number.POSITIVE_INFINITY],
+    ];
+
+    it.each(invalidIntervals)(
+        "rejects reloadIntervalSeconds when %s",
+        async (_label, value) => {
+            await expectConfigurationError(
+                () =>
+                    new TlsConfigProbe().buildTlsRequest({
+                        tlsAdvancedConfiguration: {
+                            mutualTls: {
+                                kind: "path",
+                                certPath,
+                                keyPath,
+                                reloadIntervalSeconds: value,
+                            },
+                        },
+                    }),
+                "mutualTls.reloadIntervalSeconds must be a positive integer",
+            );
+        },
+    );
+
+    it("rejects an empty certPath", async () => {
+        await expectConfigurationError(
+            () =>
+                new TlsConfigProbe().buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "path",
+                            certPath: "",
+                            keyPath,
+                        },
+                    },
+                }),
+            "mutualTls.certPath must be a non-empty string",
+        );
+    });
+
+    it("rejects an empty keyPath", async () => {
+        await expectConfigurationError(
+            () =>
+                new TlsConfigProbe().buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "path",
+                            certPath,
+                            keyPath: "",
+                        },
+                    },
+                }),
+            "mutualTls.keyPath must be a non-empty string",
+        );
+    });
+
+    it("rejects a missing cert file at connect time", async () => {
+        const missing = join(tmpDir, "does-not-exist.crt");
+        await expectConfigurationError(
+            () =>
+                new TlsConfigProbe().buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "path",
+                            certPath: missing,
+                            keyPath,
+                        },
+                    },
+                }),
+            `mutualTls.certPath references a file that does not exist: ${missing}`,
+        );
+    });
+
+    it("rejects an empty cert file at connect time", async () => {
+        const empty = join(tmpDir, "empty.crt");
+        writeFileSync(empty, "");
+        await expectConfigurationError(
+            () =>
+                new TlsConfigProbe().buildTlsRequest({
+                    tlsAdvancedConfiguration: {
+                        mutualTls: {
+                            kind: "path",
+                            certPath: empty,
+                            keyPath,
+                        },
+                    },
+                }),
+            `mutualTls.certPath references an empty file: ${empty}`,
+        );
+    });
+});
+
+describe("mutualTls interaction with existing TLS knobs", () => {
+    it("leaves rootCertificates handling unchanged when mutualTls is absent", async () => {
+        const request = await new TlsConfigProbe().buildTlsRequest({
+            tlsAdvancedConfiguration: {
+                rootCertificates: ROOT_CERT_PEM,
+            },
+        });
+
+        expect(request.rootCerts).toEqual([
+            new Uint8Array(Buffer.from(ROOT_CERT_PEM, "utf-8")),
+        ]);
+        expect(request.clientCert).toBeFalsy();
+        expect(request.clientKey).toBeFalsy();
+        expect(request.certReload).toBeFalsy();
+    });
+
+    it("flips to InsecureTls when insecure is true, without touching mTLS fields", async () => {
+        const request = await new TlsConfigProbe().buildTlsRequest({
+            tlsAdvancedConfiguration: {
+                insecure: true,
+                mutualTls: {
+                    kind: "bytes",
+                    cert: CLIENT_CERT_PEM,
+                    key: CLIENT_KEY_PEM,
+                },
+            },
+        });
+
+        expect(request.tlsMode).toBe(connection_request.TlsMode.InsecureTls);
+        expect(request.clientCert).toBeTruthy();
+    });
+});
+
+describe("TLS PEM file loaders", () => {
+    let tmpDir: string;
+
+    beforeAll(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "glide-tls-loader-"));
+    });
+
+    afterAll(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const writeFixture = (name: string, contents: string): string => {
+        const filePath = join(tmpDir, name);
+        writeFileSync(filePath, contents);
+        return filePath;
+    };
+
+    const loaders = [
+        {
+            name: "loadRootCertificatesFromFile",
+            load: loadRootCertificatesFromFile,
+            contents: ROOT_CERT_PEM,
+            errorLabel: "Root certificate",
+        },
+        {
+            name: "loadClientCertificateFromFile",
+            load: loadClientCertificateFromFile,
+            contents: CLIENT_CERT_PEM,
+            errorLabel: "Client certificate",
+        },
+        {
+            name: "loadClientKeyFromFile",
+            load: loadClientKeyFromFile,
+            contents: CLIENT_KEY_PEM,
+            errorLabel: "Client key",
+        },
+    ];
+
+    describe.each(loaders)(
+        "$name",
+        ({ name, load, contents, errorLabel }) => {
+            it("loads PEM bytes from a file", async () => {
+                const filePath = writeFixture(`${name}-ok.pem`, contents);
+                const data = await load(filePath);
+                expect(Buffer.isBuffer(data)).toBe(true);
+                expect(data).toEqual(Buffer.from(contents));
+            });
+
+            it("rejects with a ConfigurationError when the file is missing", async () => {
+                const missingPath = join(tmpDir, `${name}-missing.pem`);
+                const promise = load(missingPath);
+                await expect(promise).rejects.toBeInstanceOf(
+                    ConfigurationError,
+                );
+                await expect(load(missingPath)).rejects.toThrow(
+                    `${errorLabel} file not found: ${missingPath}`,
+                );
+                await expect(load(missingPath)).rejects.toMatchObject({
+                    cause: expect.objectContaining({ code: "ENOENT" }),
+                });
+            });
+
+            it("rejects with a ConfigurationError when the file is empty", async () => {
+                const emptyPath = writeFixture(`${name}-empty.pem`, "");
+                await expect(load(emptyPath)).rejects.toBeInstanceOf(
+                    ConfigurationError,
+                );
+                await expect(load(emptyPath)).rejects.toThrow(
+                    `${errorLabel} file is empty: ${emptyPath}`,
+                );
+            });
+        },
+    );
+
+    it("MutualTls compile-time exclusivity guard exists", () => {
+        // The MutualTls discriminated union is imported above; this test is a
+        // compile-time smoke check that ensures the two variants remain
+        // distinguishable at the type level. If someone flattens the union or
+        // relaxes it into a common shape, this line will stop type-checking.
+        const _pathVariant: Extract<MutualTls, { kind: "path" }> = {
+            kind: "path",
+            certPath: "/tmp/c",
+            keyPath: "/tmp/k",
+        };
+        expect(_pathVariant.kind).toBe("path");
     });
 });

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -689,41 +689,36 @@ describe("TLS PEM file loaders", () => {
         },
     ];
 
-    describe.each(loaders)(
-        "$name",
-        ({ name, load, contents, errorLabel }) => {
-            it("loads PEM bytes from a file", async () => {
-                const filePath = writeFixture(`${name}-ok.pem`, contents);
-                const data = await load(filePath);
-                expect(Buffer.isBuffer(data)).toBe(true);
-                expect(data).toEqual(Buffer.from(contents));
-            });
+    describe.each(loaders)("$name", ({ name, load, contents, errorLabel }) => {
+        it("loads PEM bytes from a file", async () => {
+            const filePath = writeFixture(`${name}-ok.pem`, contents);
+            const data = await load(filePath);
+            expect(Buffer.isBuffer(data)).toBe(true);
+            expect(data).toEqual(Buffer.from(contents));
+        });
 
-            it("rejects with a ConfigurationError when the file is missing", async () => {
-                const missingPath = join(tmpDir, `${name}-missing.pem`);
-                const promise = load(missingPath);
-                await expect(promise).rejects.toBeInstanceOf(
-                    ConfigurationError,
-                );
-                await expect(load(missingPath)).rejects.toThrow(
-                    `${errorLabel} file not found: ${missingPath}`,
-                );
-                await expect(load(missingPath)).rejects.toMatchObject({
-                    cause: expect.objectContaining({ code: "ENOENT" }),
-                });
+        it("rejects with a ConfigurationError when the file is missing", async () => {
+            const missingPath = join(tmpDir, `${name}-missing.pem`);
+            const promise = load(missingPath);
+            await expect(promise).rejects.toBeInstanceOf(ConfigurationError);
+            await expect(load(missingPath)).rejects.toThrow(
+                `${errorLabel} file not found: ${missingPath}`,
+            );
+            await expect(load(missingPath)).rejects.toMatchObject({
+                cause: expect.objectContaining({ code: "ENOENT" }),
             });
+        });
 
-            it("rejects with a ConfigurationError when the file is empty", async () => {
-                const emptyPath = writeFixture(`${name}-empty.pem`, "");
-                await expect(load(emptyPath)).rejects.toBeInstanceOf(
-                    ConfigurationError,
-                );
-                await expect(load(emptyPath)).rejects.toThrow(
-                    `${errorLabel} file is empty: ${emptyPath}`,
-                );
-            });
-        },
-    );
+        it("rejects with a ConfigurationError when the file is empty", async () => {
+            const emptyPath = writeFixture(`${name}-empty.pem`, "");
+            await expect(load(emptyPath)).rejects.toBeInstanceOf(
+                ConfigurationError,
+            );
+            await expect(load(emptyPath)).rejects.toThrow(
+                `${errorLabel} file is empty: ${emptyPath}`,
+            );
+        });
+    });
 
     it("MutualTls compile-time exclusivity guard exists", () => {
         // The MutualTls discriminated union is imported above; this test is a


### PR DESCRIPTION
## Intent

Reshape the Node client mTLS + auto-reload work in PR #6383 to idiomatic TypeScript and align its behavior with the Java (merged #6386) and Go (#6384) surfaces. Replace the flat clientCertificate/clientKey/clientCertPath/clientKeyPath/certReloadEnabled/certReloadIntervalSeconds fields under tlsAdvancedConfiguration with a single readonly discriminated-union field, mutualTls: MutualTls, whose two variants are compile-time exclusive. kind="bytes" carries inline PEM cert+key and is static (no reload); kind="path" carries certPath+keyPath and by construction enables the core's automatic cert reload (interval override via optional reloadIntervalSeconds; core default otherwise). Reload enablement is derived state, not a toggle, so invalid combinations (paths without enabled, enabled without paths, byte-based with reload) are unrepresentable rather than runtime-validated. Runtime validation still covers empty strings, non-positive/non-integer/NaN/Infinity intervals, and now enforces file existence/non-emptiness for path-based mTLS at connect time via fs.promises.stat. File loaders (loadRootCertificatesFromFile, loadClientCertificateFromFile, loadClientKeyFromFile) are async, return Buffer, use node:fs/promises, and wrap fs ENOENT/other errors as ConfigurationError with error.cause carrying the underlying fs error. configureAdvancedConfigurationBase is now async and awaited from createClientRequest in GlideClient and GlideClusterClient; connectToServer awaits the created request. All new public exports carry JSDoc with @example blocks. The wire contract is unchanged: uses proto fields 22/23 (byte mTLS) and 31/32/33 (path mTLS + ClientCertReloadConfig) already added by #6386. Do not touch Java/Go/Python/core/proto surfaces; the diff must be Node-only plus one Node CHANGELOG line. Push to the existing branch fm/mtls-node-f2 on xShinnRyuu/valkey-glide (PR #6383's head); do not open a new PR; iterate with new commits, not amends.

## What Changed

- Replaced the flat `tlsAdvancedConfiguration` mTLS fields (`clientCertificate`/`clientKey`/`clientCertPath`/`clientKeyPath`/`certReloadEnabled`/`certReloadIntervalSeconds`) in `node/src/BaseClient.ts` with a single readonly discriminated-union `mutualTls: MutualTls`, whose `kind: "bytes"` variant carries inline PEM (static, no reload) and `kind: "path"` variant carries `certPath`/`keyPath` with an optional `reloadIntervalSeconds` and derives cert-reload enablement from the variant.
- Made `configureAdvancedConfigurationBase` async and awaited it from `createClientRequest` in `GlideClient.ts` and `GlideClusterClient.ts`; added async `loadRootCertificatesFromFile`/`loadClientCertificateFromFile`/`loadClientKeyFromFile` helpers using `node:fs/promises` returning `Buffer` and wrapping fs errors as `ConfigurationError` with `error.cause`, plus connect-time `fs.promises.stat` existence/non-emptiness checks and validation of empty strings and non-positive/non-integer/NaN/Infinity intervals. The unreachable fallthrough in `applyMutualTls` redacts the payload and reports only the `kind`.
- Extended `node/tests/GlideClientInternals.test.ts` with coverage for both variants, wire-level ConnectionRequest fields (22/23 and 31/32/33), loader behavior, and all runtime validation error paths (including `error.cause=ENOENT`); added a CHANGELOG entry.

## Risk Assessment

✅ Low: The only new change is the requested one-line redaction of the unreachable fallthrough error message, leaving the rest of the reshape intact and correct.

## Testing

Installed node deps, built protobuf, rust-client (dev), and TypeScript. Ran the full GlideClientInternals Jest suite — all 49 tests pass, including the 28 newly added tests covering the MutualTls discriminated union, path-variant runtime validation (empty strings, non-positive/non-integer/NaN/Infinity intervals, missing/empty files), bytes-variant empty-input rejection, interaction with rootCertificates and insecure flags, and the loadRoot/Client/Key PEM loaders (including ENOENT-with-cause). Also ran a bespoke end-to-end demo script against the built module to show a real end user constructing both variants, serializing/round-tripping the ConnectionRequest via protobuf, and observing every runtime validation error path; log captured as evidence. Cleaned working tree afterwards (restored inadvertent Cargo.lock touch from the dev build).

<details>
<summary>Evidence: E2E mTLS demo transcript (both variants, wire encoding, runtime validation, error.cause)</summary>

<code>=== 1. kind: &#39;bytes&#39; (static, no reload) ===&#10;clientCert bytes: 63&#10;clientKey bytes: 62&#10;clientCertPath: (unset)&#10;certReload: (unset -&gt; no reload)&#10;&#10;=== 2. kind: &#39;path&#39; (reload implicitly on, default cadence) ===&#10;certReload: {&#34;enabled&#34;:true,&#34;intervalSeconds&#34;:null} (intervalSeconds=null -&gt; core default)&#10;&#10;=== 3. kind: &#39;path&#39; with reloadIntervalSeconds=60 ===&#10;certReload: {&#34;enabled&#34;:true,&#34;intervalSeconds&#34;:60}&#10;&#10;=== 4. runtime validation: bad interval ===&#10;ConfigurationError: mutualTls.reloadIntervalSeconds must be a positive integer.&#10;&#10;=== 5. runtime validation: missing file (with error.cause) ===&#10;ConfigurationError: mutualTls.certPath references a file that does not exist: &lt;tmp&gt;/nope.crt&#10;error.cause.code: ENOENT&#10;&#10;=== 6. runtime validation: empty PEM bytes ===&#10;ConfigurationError: mutualTls.cert cannot be empty; omit mutualTls.cert if not configuring mTLS.&#10;&#10;=== 7. wire encoding: protobuf round-trip ===&#10;encoded bytes length: 181&#10;round-trip certReload: {&#34;enabled&#34;:true,&#34;intervalSeconds&#34;:60}&#10;&#10;=== 8. rejection when TLS is disabled (useTLS: false) ===&#10;ConfigurationError: TLS advanced configuration cannot be set when useTLS is disabled.</code>

```text
=== 1. kind: 'bytes' (static, no reload) ===
  clientCert bytes: 63
  clientKey bytes: 62
  clientCertPath: (unset)
  certReload: (unset -> no reload)

=== 2. kind: 'path' (reload implicitly on, default cadence) ===
  clientCertPath: /var/folders/1v/pmwst9_n31bdnrycrz36q7jw0000gq/T/glide-e2e-mtls-9rzPfJ/client.crt
  clientKeyPath: /var/folders/1v/pmwst9_n31bdnrycrz36q7jw0000gq/T/glide-e2e-mtls-9rzPfJ/client.key
  certReload: {"enabled":true,"intervalSeconds":null} (intervalSeconds=null -> core default)
  clientCert inline: (unset - path variant)

=== 3. kind: 'path' with reloadIntervalSeconds=60 ===
  certReload: {"enabled":true,"intervalSeconds":60}

=== 4. runtime validation: bad interval ===
  ConfigurationError: mutualTls.reloadIntervalSeconds must be a positive integer.

=== 5. runtime validation: missing file (with error.cause) ===
  ConfigurationError: mutualTls.certPath references a file that does not exist: /var/folders/1v/pmwst9_n31bdnrycrz36q7jw0000gq/T/glide-e2e-mtls-9rzPfJ/nope.crt
  error.cause.code: ENOENT

=== 6. runtime validation: empty PEM bytes ===
  ConfigurationError: mutualTls.cert cannot be empty; omit mutualTls.cert if not configuring mTLS.

=== 7. wire encoding: protobuf round-trip ===
  encoded bytes length: 181
  round-trip certReload: {"enabled":true,"intervalSeconds":60}
  round-trip clientCertPath: /var/folders/1v/pmwst9_n31bdnrycrz36q7jw0000gq/T/glide-e2e-mtls-9rzPfJ/client.crt
  round-trip clientKeyPath: /var/folders/1v/pmwst9_n31bdnrycrz36q7jw0000gq/T/glide-e2e-mtls-9rzPfJ/client.key

=== 8. rejection when TLS is disabled (useTLS: false) ===
  ConfigurationError: TLS advanced configuration cannot be set when useTLS is disabled.

All demo steps completed.
```
</details>
<details>
<summary>Evidence: E2E demo script (source)</summary>

```text
"use strict";
const fs = require("node:fs");
const os = require("node:os");
const path = require("node:path");
const {
    BaseClient,
    loadClientCertificateFromFile,
    loadClientKeyFromFile,
} = require("/Users/faizthom/.no-mistakes/worktrees/7d0c23b9cb1d/01KY5DE9S7XHPHEH34QRNDJKV9/node/build-ts");
const { connection_request } = require("/Users/faizthom/.no-mistakes/worktrees/7d0c23b9cb1d/01KY5DE9S7XHPHEH34QRNDJKV9/node/build-ts/ProtobufMessage");

class Probe extends BaseClient {
    constructor() { super(); }
    async build(cfg) {
        const req = { tlsMode: connection_request.TlsMode.SecureTls };
        await this.configureAdvancedConfigurationBase(cfg, req);
        return req;
    }
}

const CERT = "-----BEGIN CERTIFICATE-----\nDEMO_CERT\n-----END CERTIFICATE-----";
const KEY = "-----BEGIN PRIVATE KEY-----\nDEMO_KEY\n-----END PRIVATE KEY-----";
const dir = fs.mkdtempSync(path.join(os.tmpdir(), "glide-e2e-mtls-"));
const certPath = path.join(dir, "client.crt");
const keyPath = path.join(dir, "client.key");
fs.writeFileSync(certPath, CERT);
fs.writeFileSync(keyPath, KEY);

(async () => {
  console.log("=== 1. kind: 'bytes' (static, no reload) ===");
  const bytesReq = await new Probe().build({
    tlsAdvancedConfiguration: {
      mutualTls: {
        kind: "bytes",
        cert: await loadClientCertificateFromFile(certPath),
        key: await loadClientKeyFromFile(keyPath),
      },
    },
  });
  console.log("  clientCert bytes:", bytesReq.clientCert?.length);
  console.log("  clientKey bytes:", bytesReq.clientKey?.length);
  console.log("  clientCertPath:", bytesReq.clientCertPath ?? "(unset)");
  console.log("  certReload:", bytesReq.certReload ?? "(unset -> no reload)");

  console.log("\n=== 2. kind: 'path' (reload implicitly on, default cadence) ===");
  const pathReq = await new Probe().build({
    tlsAdvancedConfiguration: {
      mutualTls: { kind: "path", certPath, keyPath },
    },
  });
  console.log("  clientCertPath:", pathReq.clientCertPath);
  console.log("  clientKeyPath:", pathReq.clientKeyPath);
  console.log("  certReload:", JSON.stringify(pathReq.certReload), "(intervalSeconds=null -> core default)");
  console.log("  clientCert inline:", bytesReq.clientCert && pathReq.clientCert ? "SET" : "(unset - path variant)");

  console.log("\n=== 3. kind: 'path' with reloadIntervalSeconds=60 ===");
  const pathIntervalReq = await new Probe().build({
    tlsAdvancedConfiguration: {
      mutualTls: { kind: "path", certPath, keyPath, reloadIntervalSeconds: 60 },
    },
  });
  console.log("  certReload:", JSON.stringify(pathIntervalReq.certReload));

  console.log("\n=== 4. runtime validation: bad interval ===");
  try {
    await new Probe().build({
      tlsAdvancedConfiguration: {
        mutualTls: { kind: "path", certPath, keyPath, reloadIntervalSeconds: -1 },
      },
    });
  } catch (e) {
    console.log("  " + e.constructor.name + ": " + e.message);
  }

  console.log("\n=== 5. runtime validation: missing file (with error.cause) ===");
  try {
    await new Probe().build({
      tlsAdvancedConfiguration: {
        mutualTls: { kind: "path", certPath: path.join(dir, "nope.crt"), keyPath },
      },
    });
  } catch (e) {
    console.log("  " + e.constructor.name + ": " + e.message);
    console.log("  error.cause.code:", e.cause && e.cause.code);
  }

  console.log("\n=== 6. runtime validation: empty PEM bytes ===");
  try {
    await new Probe().build({
      tlsAdvancedConfiguration: { mutualTls: { kind: "bytes", cert: "", key: "K" } },
    });
  } catch (e) {
    console.log("  " + e.constructor.name + ": " + e.message);
  }

  console.log("\n=== 7. wire encoding: protobuf round-trip ===");
  const encoded = connection_request.ConnectionRequest.encode(pathIntervalReq).finish();
  console.log("  encoded bytes length:", encoded.length);
  const decoded = connection_request.ConnectionRequest.decode(encoded);
  console.log("  round-trip certReload:", JSON.stringify(decoded.certReload));
  console.log("  round-trip clientCertPath:", decoded.clientCertPath);
  console.log("  round-trip clientKeyPath:", decoded.clientKeyPath);

  console.log("\n=== 8. rejection when TLS is disabled (useTLS: false) ===");
  try {
    const probe = new Probe();
    const req = { tlsMode: connection_request.TlsMode.NoTls };
    await probe.configureAdvancedConfigurationBase(
      { tlsAdvancedConfiguration: { mutualTls: { kind: "bytes", cert: CERT, key: KEY } } },
      req,
    );
  } catch (e) {
    console.log("  " + e.constructor.name + ": " + e.message);
  }

  fs.rmSync(dir, { recursive: true, force: true });
  console.log("\nAll demo steps completed.");
})().catch((e) => {
  console.error("unexpected:", e);
  process.exit(1);
});
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `CHANGELOG.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `node/src/BaseClient.ts:611` - The unreachable fallthrough branch of `applyMutualTls` (node/src/BaseClient.ts:611) uses `JSON.stringify(mtls)` in the error message. Because TypeScript&#39;s discriminated union is not enforced at runtime, an object like `{kind: &#34;bytes &#34; /* typo/mismatch */, cert: &lt;PEM&gt;, key: &lt;PEM_PRIVATE_KEY&gt;}` supplied via untyped/JS callers would bypass the two typed branches and flow into this throw, embedding the private key bytes verbatim in the exception message (and thus into any log/aggregator that captures it). Report the kind only, e.g. `Unsupported mutualTls variant: ${String((mtls as {kind?: unknown}).kind)}`.

🔧 Fix: redact mtls payload from unreachable applyMutualTls throw
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run build-protobuf` (node/)</code>
- <code>`npm run build:rust-client` (dev) to produce build-ts/valkey-glide.*.node</code>
- <code>`npm run build:ts` and `npm run build-test-utils`</code>
- <code>`npx jest tests/GlideClientInternals.test.ts --verbose --no-coverage` — 49/49 pass including all new MutualTls / loader / validation tests</code>
- <code>`node /var/folders/1v/pmwst9_n31bdnrycrz36q7jw0000gq/T/no-mistakes-evidence/01KY5DE9S7XHPHEH34QRNDJKV9/e2e-mtls-demo.js` — exercises both variants, shows wire-level ConnectionRequest fields, protobuf round-trip, and all runtime validation error paths including error.cause=ENOENT</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
