### PR TITLE
test(python): silence expected deprecation warnings and fix skip-marker misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixes
 
-* Python: silence expected deprecation warnings and fix skip-marker misuse
 * Core: Fix native panic for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Python: silence expected deprecation warnings and fix skip-marker misuse
 * Core: Fix native panic for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))

--- a/python/glide-async/python/glide/__init__.py
+++ b/python/glide-async/python/glide/__init__.py
@@ -227,6 +227,11 @@ class _LegacyModule(types.ModuleType):
         self._warned = False
 
     def __getattr__(self, name):
+        # Dunder lookups (e.g. inspect.getmodule -> hasattr(mod, "__file__"))
+        # traverse every module in sys.modules and would otherwise fire the
+        # deprecation warning even when no real symbol was imported.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         if not self._warned:
             warnings.warn(
                 f"Importing from '{self.__name__}' is deprecated. "

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -623,9 +623,11 @@ class TestBatch:
 
         transaction: Union[Transaction, ClusterTransaction]
         if isinstance(glide_client, GlideClient):
-            transaction = Transaction()
+            with pytest.warns(DeprecationWarning, match="Use Batch"):
+                transaction = Transaction()
         else:
-            transaction = ClusterTransaction()
+            with pytest.warns(DeprecationWarning, match="Use ClusterBatch"):
+                transaction = ClusterTransaction()
 
         assert transaction.is_atomic is True
 

--- a/python/tests/async_tests/test_deprecation_warnings.py
+++ b/python/tests/async_tests/test_deprecation_warnings.py
@@ -48,6 +48,9 @@ class TestDeprecationWarnings:
             # Import the module and access an attribute to trigger the warning
             exec(f"from {module_name} import {symbol_name}")
 
+    @pytest.mark.filterwarnings(
+        "ignore:Importing from .* is deprecated:DeprecationWarning"
+    )
     def test_deprecated_imports_still_work(self):
         """Test that deprecated imports still provide the correct classes."""
         for module_name, symbol_name in _legacy_modules_and_symbols.items():

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -615,9 +615,11 @@ class TestSyncBatch:
 
         transaction: Union[Transaction, ClusterTransaction]
         if isinstance(glide_sync_client, GlideClient):
-            transaction = Transaction()
+            with pytest.warns(DeprecationWarning, match="Use Batch"):
+                transaction = Transaction()
         else:
-            transaction = ClusterTransaction()
+            with pytest.warns(DeprecationWarning, match="Use ClusterBatch"):
+                transaction = ClusterTransaction()
 
         assert transaction.is_atomic is True
 

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -354,7 +354,7 @@ class TestGlideClients:
     def test_sync_select(self, glide_sync_client: GlideClient, cluster_mode):
         if cluster_mode:
             if sync_check_if_server_version_lt(glide_sync_client, "9.0.0"):
-                return pytest.mark.skip(
+                pytest.skip(
                     reason="Database ID selection in cluster mode requires Valkey >= 9.0.0"
                 )
 
@@ -528,6 +528,9 @@ class TestGlideClients:
         # Clean up the main client
         client.close()
 
+    @pytest.mark.filterwarnings(
+        "ignore:This process.*multi-threaded.*fork.*deadlocks:DeprecationWarning"
+    )
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     def test_sync_fork(self, glide_sync_client: TGlideClient):


### PR DESCRIPTION
### Summary

Silence expected Python test warnings at their source and fix one misused pytest skip marker so `PytestReturnNotNoneWarning`, `DeprecationWarning`, and related noise no longer pollutes the Python test logs.

### Issue link

Closes #6616. Fixes warning noise surfaced by FMT Python run [29978445673](https://github.com/valkey-io/valkey-glide/actions/runs/29978445673).

### Features / Behaviour Changes

None. Test-only changes plus one internal shim tweak with no user-visible effect.

### Implementation

* `python/glide-async/python/glide/__init__.py`: `_LegacyModule.__getattr__` raises `AttributeError` for dunder names (`__file__`, `__spec__`, etc.) before firing the legacy `DeprecationWarning`. Traceback introspection paths like `inspect.getmodule` call `hasattr(mod, "__file__")` on every module in `sys.modules`, which previously fired the shim's warning during unrelated tests.
* `python/tests/async_tests/test_batch.py`, `python/tests/sync_tests/test_sync_batch.py`: `test_deprecated_transaction_classes` wraps the intentional `Transaction()` and `ClusterTransaction()` constructor calls in `pytest.warns(DeprecationWarning, match=...)`.
* `python/tests/sync_tests/test_sync_client.py`: `test_sync_fork` is decorated with `@pytest.mark.filterwarnings("ignore:This process.*multi-threaded.*fork.*deadlocks:DeprecationWarning")` since the test exercises `os.fork()` on purpose. `test_sync_select` calls `pytest.skip(...)` instead of returning `pytest.mark.skip(...)` so pytest no longer flags a `PytestReturnNotNoneWarning`; the runtime skip semantics are preserved.
* `python/tests/async_tests/test_deprecation_warnings.py`: `test_deprecated_imports_still_work` is decorated with `@pytest.mark.filterwarnings("ignore:Importing from .* is deprecated:DeprecationWarning")` since it must access legacy modules outside `pytest.warns` to verify the deprecated import path still returns the correct symbol.

Suppressions are per-test and pattern-scoped. No global `filterwarnings=ignore::DeprecationWarning` is added to `pytest.ini` or `pyproject.toml`.

### Limitations

None.

### Testing

The async deprecation-warning suite passes (11 of 11). Each of the five warning fixes was verified against a baseline that reproduces the warning and a fixed version that clears it. Integration suites that require a live Valkey server and locally-built native extensions were not exercised in this environment.

<details>
<summary>Verification of the final implementation</summary>

```text
======================================================================
_LegacyModule.__getattr__ raises AttributeError for dunder names
======================================================================
BASELINE: __file__ access -> DeprecationWarnings emitted: 1 (BAD)
FIXED:    __file__ access -> DeprecationWarnings emitted: 0 (GOOD)
FIXED:    real-symbol access still warns: True

======================================================================
Transaction()/ClusterTransaction() constructors emit DeprecationWarning
======================================================================
Transaction() emits 'Use Batch' DeprecationWarning: True
  message: Use Batch(is_atomic=True) instead.
ClusterTransaction() emits 'Use ClusterBatch' DeprecationWarning: True
  message: Use ClusterBatch(is_atomic=True) instead.

======================================================================
os.fork() multi-thread DeprecationWarning matches the filterwarnings pattern
======================================================================
Warning text: 'This process (pid=1234) is multi-threaded, use of fork() may lead to deadlocks in the child.'
Pattern:      'This process.*multi-threaded.*fork.*deadlocks'
Match: True

======================================================================
`return pytest.mark.skip(...)` -> PytestReturnNotNoneWarning; `pytest.skip(...)` clean
======================================================================
  BASELINE (return pytest.mark.skip)      : FAILED (warning raised)
  FIXED    (pytest.skip)                  : SKIPPED (clean)

======================================================================
filterwarnings marker suppresses expected DeprecationWarning in test
======================================================================
  BASELINE (no marker)          : FAILED (warning raised)
  FIXED    (with marker)        : PASSED (clean)
```
</details>

<details>
<summary>test_deprecation_warnings.py results (11 passed)</summary>

```text
============================= test session starts ==============================
collecting ... collected 17 items / 6 deselected / 11 selected

tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.exceptions-RequestError] PASSED [  9%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.config-GlideClientConfiguration] PASSED [ 18%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.constants-OK] PASSED [ 27%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.routes-AllNodes] PASSED [ 36%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.async_commands.batch-Batch] PASSED [ 45%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.async_commands.batch_options-BatchOptions] PASSED [ 54%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.async_commands.bitmap-BitmapIndexType] PASSED [ 63%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.async_commands.command_args-Limit] PASSED [ 72%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.async_commands.sorted_set-ScoreBoundary] PASSED [ 81%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_legacy_module_deprecation_warning[glide.async_commands.stream-StreamAddOptions] PASSED [ 90%]
tests/async_tests/test_deprecation_warnings.py::TestDeprecationWarnings::test_deprecated_imports_still_work PASSED [100%]

======================= 11 passed, 6 deselected in 0.05s =======================
```
</details>

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
