### PR TITLE
Java: Fix client rejecting commands from user shutdown hooks (#4809)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Java: Make the automatic JVM shutdown hook non-destructive so a command issued from a user's own shutdown hook is no longer rejected with `ClosingException: Client is shutting down`. The JVM runs all shutdown hooks concurrently, and GLIDE's hook previously tore the client down and blocked new requests, racing with (and aborting) legitimate work such as persisting state before exit. Deterministic teardown remains available via the client's `close()`. ([#4809](https://github.com/valkey-io/valkey-glide/issues/4809))
 * Core: Fix native panic for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))

--- a/java/client/src/main/java/glide/internal/AsyncRegistry.java
+++ b/java/client/src/main/java/glide/internal/AsyncRegistry.java
@@ -91,12 +91,32 @@ public final class AsyncRegistry {
                     });
 
     private static final Thread shutdownHook =
-            new Thread(AsyncRegistry::shutdown, "AsyncRegistry-Shutdown");
+            new Thread(AsyncRegistry::handleJvmShutdown, "AsyncRegistry-Shutdown");
 
     static {
         if (!"false".equalsIgnoreCase(System.getProperty("glide.autoShutdownHook", "true"))) {
             Runtime.getRuntime().addShutdownHook(shutdownHook);
         }
+    }
+
+    /**
+     * Handler invoked by the automatic JVM shutdown hook.
+     *
+     * <p>This is intentionally non-destructive. When the JVM is exiting, all shutdown hooks (this one
+     * and any registered by the user) run concurrently, and the client must remain usable so that a
+     * user's own shutdown hook can still issue commands (e.g. to persist state before exit). Setting
+     * the {@link #isShutdown} gate or cancelling in-flight futures here would abort those legitimate
+     * requests and previously surfaced as {@code ClosingException: Client is shutting down} (see <a
+     * href="https://github.com/valkey-io/valkey-glide/issues/4809">#4809</a>).
+     *
+     * <p>Eager cleanup is unnecessary at JVM exit: all internal GLIDE threads (callback workers,
+     * tokio runtime, timeout scheduler, cleaner) are daemon threads, and native resources are
+     * reclaimed by the OS once the process terminates. Deterministic teardown remains available
+     * through the explicit {@link #shutdown()} method and {@link
+     * glide.internal.GlideCoreClient#close()}.
+     */
+    static void handleJvmShutdown() {
+        // Intentionally a no-op: keep the client usable for concurrent user shutdown hooks.
     }
 
     /** Estimate initial capacity for the active futures map using inflight limit with margin. */
@@ -354,7 +374,14 @@ public final class AsyncRegistry {
         return activeFutures.size();
     }
 
-    /** Shutdown cleanup - cancel all pending operations during client shutdown. */
+    /**
+     * Explicit, destructive shutdown cleanup - cancel all pending operations and stop the timeout
+     * scheduler. Sets the {@link #isShutdown} gate so no new requests are accepted afterward.
+     *
+     * <p>This is <em>not</em> wired to the automatic JVM shutdown hook (that path is intentionally
+     * non-destructive; see {@link #handleJvmShutdown()}). Call this only when you want deterministic
+     * teardown of the registry.
+     */
     public static void shutdown() {
         // Set shutdown flag first to prevent new registrations
         // This must happen before any clearing to avoid race conditions

--- a/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
+++ b/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
@@ -182,6 +182,54 @@ public class AsyncRegistryTest {
         assertFalse(AsyncRegistry.isShutdown());
     }
 
+    // ==================== JVM Shutdown Hook Behavior (issue #4809) ====================
+
+    @Test
+    void handleJvmShutdown_doesNotSetShutdownFlag() {
+        assertFalse(AsyncRegistry.isShutdown());
+
+        AsyncRegistry.handleJvmShutdown();
+
+        // The automatic JVM-exit hook must be non-destructive so concurrent user shutdown
+        // hooks can keep using the client.
+        assertFalse(AsyncRegistry.isShutdown());
+    }
+
+    @Test
+    void handleJvmShutdown_allowsSubsequentRegistration() {
+        // Simulate the JVM exit hook firing.
+        AsyncRegistry.handleJvmShutdown();
+
+        // A command issued from a user's own shutdown hook (running concurrently) must still
+        // register successfully rather than being rejected with a ClosingException. This is the
+        // regression guard for issue #4809.
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        long id = AsyncRegistry.register(f, 0, 1L, 0);
+
+        assertTrue(id > 0, "register() must succeed after the JVM shutdown hook runs");
+        assertFalse(f.isDone(), "future must not be pre-failed");
+        assertEquals(1, AsyncRegistry.getActiveFutureCount());
+    }
+
+    @Test
+    void handleJvmShutdown_doesNotCancelPendingFutures() {
+        CompletableFuture<Object> f = new CompletableFuture<>();
+        // Register with a Java-side timeout so we also cover the scheduled timeout-task path.
+        AsyncRegistry.register(f, 0, 1L, 60_000);
+
+        assertEquals(1, AsyncRegistry.getActiveFutureCount());
+        assertEquals(1, AsyncRegistry.getPendingTimeoutCount());
+
+        AsyncRegistry.handleJvmShutdown();
+
+        // In-flight requests must not be aborted by the JVM-exit hook; they are left to complete
+        // (or be reclaimed at process exit). Both futures and their scheduled timeout tasks must
+        // survive.
+        assertFalse(f.isDone());
+        assertEquals(1, AsyncRegistry.getActiveFutureCount());
+        assertEquals(1, AsyncRegistry.getPendingTimeoutCount());
+    }
+
     private static void assertClosingException(CompletableFuture<?> future, String expectedMessage) {
         try {
             future.get();

--- a/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
+++ b/java/client/src/test/java/glide/internal/AsyncRegistryTest.java
@@ -228,6 +228,10 @@ public class AsyncRegistryTest {
         assertFalse(f.isDone());
         assertEquals(1, AsyncRegistry.getActiveFutureCount());
         assertEquals(1, AsyncRegistry.getPendingTimeoutCount());
+
+        // Clean up: cancel the abandoned future so its 60s timeout task is cancelled and doesn't
+        // outlive this test and invoke GlideNativeBridge.markTimedOut in the test JVM.
+        f.cancel(true);
     }
 
     private static void assertClosingException(CompletableFuture<?> future, String expectedMessage) {

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -296,6 +296,10 @@ tasks.withType(Test) {
         systemProperty 'test.server.cluster.tls', clusterTlsHosts
         systemProperty 'test.server.azcluster', azClusterHosts
         systemProperty 'test.server.tls', System.getProperty("tls")
+        // Opt-in flag for the (disabled-by-default) shutdown-hook IT; see ShutdownHookIT.
+        if (System.getProperty("RUN_SHUTDOWN_HOOK_IT") != null) {
+            systemProperty 'RUN_SHUTDOWN_HOOK_IT', System.getProperty("RUN_SHUTDOWN_HOOK_IT")
+        }
     }
 
     testLogging {

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -296,7 +296,7 @@ tasks.withType(Test) {
         systemProperty 'test.server.cluster.tls', clusterTlsHosts
         systemProperty 'test.server.azcluster', azClusterHosts
         systemProperty 'test.server.tls', System.getProperty("tls")
-        // Opt-in flag for the (disabled-by-default) shutdown-hook IT; see ShutdownHookIT.
+        // Opt-in flag for the (disabled-by-default) shutdown-hook IT; see ShutdownHookIntegrationTest.
         if (System.getProperty("RUN_SHUTDOWN_HOOK_IT") != null) {
             systemProperty 'RUN_SHUTDOWN_HOOK_IT', System.getProperty("RUN_SHUTDOWN_HOOK_IT")
         }

--- a/java/integTest/src/test/java/glide/shutdown/ShutdownHookIT.java
+++ b/java/integTest/src/test/java/glide/shutdown/ShutdownHookIT.java
@@ -1,0 +1,145 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.shutdown;
+
+import static glide.TestConfiguration.STANDALONE_HOSTS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * End-to-end regression test for <a
+ * href="https://github.com/valkey-io/valkey-glide/issues/4809">issue #4809</a>: a command issued
+ * from the application's own JVM shutdown hook must still succeed rather than being rejected with
+ * {@code ClosingException: Client is shutting down}.
+ *
+ * <p>This forks {@link ShutdownHookReproducer} in a child JVM (a real shutdown hook can only be
+ * observed from a dying JVM), sends it SIGTERM, and asserts on the emitted markers. It reuses the
+ * suite's shared standalone server — the reproducer only issues {@code PING}, which is read-only
+ * and leaves no state behind, so it cannot affect other tests.
+ *
+ * <p>Disabled by default because forking a JVM and relying on signal timing is heavier and more
+ * timing-sensitive than a typical unit/integration test. Enable explicitly with {@code
+ * -DRUN_SHUTDOWN_HOOK_IT=true}. Two example invocations:
+ *
+ * <pre>{@code
+ * # Run this test only:
+ * ./gradlew :integTest:test --tests 'glide.shutdown.ShutdownHookIT' -DRUN_SHUTDOWN_HOOK_IT=true
+ *
+ * # Run the full integTest suite with this test included:
+ * ./gradlew :integTest:test -DRUN_SHUTDOWN_HOOK_IT=true
+ * }</pre>
+ *
+ * <p>If a mechanism to differentiate PR runs from the nightly full-matrix runs lands in the future,
+ * this test would be a good candidate to move onto that mechanism (nightly-only) instead of the
+ * manual opt-in flag.
+ */
+public class ShutdownHookIT {
+
+    @Test
+    @Timeout(60)
+    void commandFromUserShutdownHookSucceeds() throws Exception {
+        Assumptions.assumeTrue(
+                Boolean.getBoolean("RUN_SHUTDOWN_HOOK_IT"),
+                "Shutdown-hook IT disabled; run with -DRUN_SHUTDOWN_HOOK_IT=true");
+        // Process.destroy() maps to SIGTERM on POSIX (JVM shutdown hooks fire) but to
+        // TerminateProcess on Windows (hooks are skipped), so the reproducer would fail spuriously
+        // on Windows even after the fix.
+        Assumptions.assumeFalse(
+                System.getProperty("os.name", "").toLowerCase().startsWith("windows"),
+                "Shutdown-hook IT is POSIX-only (Process.destroy is not SIGTERM on Windows)");
+
+        String hostPort = STANDALONE_HOSTS[0];
+        Assumptions.assumeFalse(
+                hostPort == null || hostPort.isEmpty(), "No standalone server address available");
+        int lastColon = hostPort.lastIndexOf(':');
+        Assumptions.assumeTrue(
+                lastColon > 0 && lastColon < hostPort.length() - 1,
+                "Malformed standalone endpoint (expected host:port): " + hostPort);
+        String host = hostPort.substring(0, lastColon);
+        String port = hostPort.substring(lastColon + 1);
+
+        String javaBin =
+                System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        List<String> command = new ArrayList<>();
+        command.add(javaBin);
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+        // Native lib is loaded from the GLIDE jar; mirror the integTest library path just in case.
+        command.add("-Djava.library.path=" + System.getProperty("java.library.path", ""));
+        command.add(ShutdownHookReproducer.class.getName());
+        command.add(host);
+        command.add(port);
+
+        // Redirect child output to a file rather than reading the live pipe: the pipe is closed when
+        // the child is reaped after SIGTERM, which would race with reading the hook's final output.
+        File outFile = File.createTempFile("glide-shutdown-hook-it", ".log");
+        outFile.deleteOnExit();
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(ProcessBuilder.Redirect.to(outFile));
+        Process process = pb.start();
+
+        try {
+            // Wait until the child has connected and registered its shutdown hook.
+            waitFor(() -> readFile(outFile).contains(ShutdownHookReproducer.READY_MARKER), 30_000);
+
+            // Trigger a graceful SIGTERM so both the child's and GLIDE's shutdown hooks run.
+            process.destroy();
+
+            // Wait for the child to exit and flush its hook output.
+            assertTrue(
+                    process.waitFor(20, TimeUnit.SECONDS),
+                    () -> "reproducer did not exit after SIGTERM. Output:\n" + readFile(outFile));
+        } finally {
+            if (process.isAlive()) {
+                process.destroyForcibly();
+            }
+        }
+
+        String out = readFile(outFile);
+        assertTrue(
+                out.contains(ShutdownHookReproducer.INITIAL_PING_OK_MARKER),
+                () -> "reproducer never connected/pinged. Output:\n" + out);
+        assertTrue(
+                out.contains(ShutdownHookReproducer.HOOK_PING_OK_MARKER)
+                        || out.contains(ShutdownHookReproducer.HOOK_PING_FAIL_MARKER),
+                () -> "reproducer's shutdown hook never ran. Output:\n" + out);
+        assertTrue(
+                out.contains(ShutdownHookReproducer.HOOK_PING_OK_MARKER),
+                () ->
+                        "command issued from the user shutdown hook was rejected (issue #4809 regression)."
+                                + " Output:\n"
+                                + out);
+    }
+
+    private static String readFile(File file) {
+        try {
+            return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private interface Condition {
+        boolean met();
+    }
+
+    private static void waitFor(Condition condition, long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.met()) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+    }
+}

--- a/java/integTest/src/test/java/glide/shutdown/ShutdownHookIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/shutdown/ShutdownHookIntegrationTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Timeout;
  *
  * <pre>{@code
  * # Run this test only:
- * ./gradlew :integTest:test --tests 'glide.shutdown.ShutdownHookIT' -DRUN_SHUTDOWN_HOOK_IT=true
+ * ./gradlew :integTest:test --tests 'glide.shutdown.ShutdownHookIntegrationTest' -DRUN_SHUTDOWN_HOOK_IT=true
  *
  * # Run the full integTest suite with this test included:
  * ./gradlew :integTest:test -DRUN_SHUTDOWN_HOOK_IT=true
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Timeout;
  * this test would be a good candidate to move onto that mechanism (nightly-only) instead of the
  * manual opt-in flag.
  */
-public class ShutdownHookIT {
+public class ShutdownHookIntegrationTest {
 
     @Test
     @Timeout(60)

--- a/java/integTest/src/test/java/glide/shutdown/ShutdownHookReproducer.java
+++ b/java/integTest/src/test/java/glide/shutdown/ShutdownHookReproducer.java
@@ -1,0 +1,68 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.shutdown;
+
+import glide.api.GlideClient;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+
+/**
+ * Standalone helper process for {@link ShutdownHookIT}. It reproduces the scenario from <a
+ * href="https://github.com/valkey-io/valkey-glide/issues/4809">issue #4809</a>: a client that is
+ * still used from the application's own JVM shutdown hook.
+ *
+ * <p>This must run in its own JVM because a real {@link Runtime#addShutdownHook} only fires as the
+ * JVM exits, at which point the in-process test framework can no longer make assertions. The parent
+ * test forks this class, sends it SIGTERM, and inspects the emitted markers on stdout.
+ *
+ * <p>Args: {@code <host> <port>}. Emitted markers: {@code INITIAL_PING_OK} on the initial ping,
+ * {@code HOOK_PING_OK} if the ping issued from the shutdown hook succeeds (the fix), or {@code
+ * HOOK_PING_FAIL:<exception>} if it is rejected (the bug). Markers are chosen so that none is a
+ * substring of another, allowing simple {@code contains} checks in the parent test.
+ */
+public final class ShutdownHookReproducer {
+
+    public static final String READY_MARKER = "READY";
+    public static final String INITIAL_PING_OK_MARKER = "INITIAL_PING_OK";
+    public static final String HOOK_PING_OK_MARKER = "HOOK_PING_OK";
+    public static final String HOOK_PING_FAIL_MARKER = "HOOK_PING_FAIL:";
+
+    private ShutdownHookReproducer() {}
+
+    public static void main(String[] args) throws Exception {
+        String host = args[0];
+        int port = Integer.parseInt(args[1]);
+
+        GlideClient client =
+                GlideClient.createClient(
+                                GlideClientConfiguration.builder()
+                                        .address(NodeAddress.builder().host(host).port(port).build())
+                                        .build())
+                        .get();
+
+        System.out.println(INITIAL_PING_OK_MARKER + ": " + client.ping().get());
+
+        Runtime.getRuntime()
+                .addShutdownHook(
+                        new Thread(
+                                () -> {
+                                    try {
+                                        // Give the JVM's other shutdown hooks (including GLIDE's own) a chance
+                                        // to run concurrently, mirroring the original report.
+                                        Thread.sleep(500);
+                                        System.out.println(HOOK_PING_OK_MARKER + ": " + client.ping().get());
+                                    } catch (Throwable t) {
+                                        System.out.println(HOOK_PING_FAIL_MARKER + t);
+                                    } finally {
+                                        System.out.flush();
+                                    }
+                                }));
+
+        // Signal readiness, then idle until the parent sends SIGTERM.
+        System.out.println(READY_MARKER);
+        System.out.flush();
+
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/java/integTest/src/test/java/glide/shutdown/ShutdownHookReproducer.java
+++ b/java/integTest/src/test/java/glide/shutdown/ShutdownHookReproducer.java
@@ -6,9 +6,9 @@ import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
 
 /**
- * Standalone helper process for {@link ShutdownHookIT}. It reproduces the scenario from <a
- * href="https://github.com/valkey-io/valkey-glide/issues/4809">issue #4809</a>: a client that is
- * still used from the application's own JVM shutdown hook.
+ * Standalone helper process for {@link ShutdownHookIntegrationTest}. It reproduces the scenario
+ * from <a href="https://github.com/valkey-io/valkey-glide/issues/4809">issue #4809</a>: a client
+ * that is still used from the application's own JVM shutdown hook.
  *
  * <p>This must run in its own JVM because a real {@link Runtime#addShutdownHook} only fires as the
  * JVM exits, at which point the in-process test framework can no longer make assertions. The parent


### PR DESCRIPTION
### Summary

Make GLIDE's automatic JVM shutdown hook non-destructive so a command issued from an application's own `Runtime.addShutdownHook` no longer fails with `ClosingException: Client is shutting down, cannot register new requests`.

### Issue link

This Pull Request is linked to issue: [Java: Client shuts down on SIGTERM before user's shutdown hook can persist state](https://github.com/valkey-io/valkey-glide/issues/4809)
Closes #4809

### Features / Behaviour Changes

- Commands issued from a user JVM shutdown hook now succeed instead of racing against GLIDE's own hook and being rejected.
- No public API changes. Deterministic teardown remains available via the client's `close()`; the `-Dglide.autoShutdownHook=false` / `AsyncRegistry.removeShutdownHook()` opt-outs still work (they're now redundant for the reported scenario, but preserved for compatibility).

### Implementation

Root cause: the JVM runs all shutdown hooks concurrently. GLIDE's auto hook was wired to the destructive `AsyncRegistry.shutdown()`, which set an `isShutdown` gate and cancelled all pending futures. Any command a user's own concurrent shutdown hook issued afterwards was rejected in `AsyncRegistry.register()` (`AsyncRegistry.java:147`).

Fix: repoint the auto hook at a new, intentionally non-destructive `handleJvmShutdown()` (a documented no-op). It does not set `isShutdown`, does not cancel futures, and does not stop the timeout scheduler — the client stays usable during the shutdown-hook window. Eager cleanup is unnecessary at JVM exit: every internal GLIDE thread (callback workers, tokio runtime, timeout scheduler, cleaner) is a daemon, and native resources are reclaimed by the OS on process termination. Explicit destructive teardown is unchanged — `AsyncRegistry.shutdown()` still works if called directly, and the native `failAllWithError` safety net (fired when callback workers die) is untouched.

Files changed:
- `java/client/src/main/java/glide/internal/AsyncRegistry.java` — new `handleJvmShutdown()`, hook rewired to it, Javadoc clarifies `shutdown()` is now for explicit teardown only.
- `java/client/src/test/java/glide/internal/AsyncRegistryTest.java` — 3 new unit tests: hook doesn't set `isShutdown`, allows subsequent registration, doesn't cancel pending futures (or their scheduled timeout tasks).
- `java/integTest/src/test/java/glide/shutdown/ShutdownHookIT.java` + `ShutdownHookReproducer.java` — opt-in end-to-end regression test. Forks a child JVM (the reporter's exact reproducer), sends SIGTERM, asserts the ping issued from its shutdown hook returns PONG.
- `java/integTest/build.gradle` — forwards `-DRUN_SHUTDOWN_HOOK_IT` to the forked test JVM.
- `CHANGELOG.md`.

### Limitations

- The end-to-end integration test is opt-in (`-DRUN_SHUTDOWN_HOOK_IT=true`) because forking a JVM and relying on signal timing is heavier and more timing-sensitive than a typical test. Unit tests provide the always-on regression guard.
- The IT is POSIX-only (`Process.destroy()` maps to `TerminateProcess` on Windows, which bypasses shutdown hooks); it self-skips on Windows.

### Testing

- `./gradlew :client:test --tests 'glide.internal.AsyncRegistryTest'` — all pass, including 3 new tests.
- `./gradlew :integTest:test --tests 'glide.shutdown.ShutdownHookIT' -DRUN_SHUTDOWN_HOOK_IT=true` — passes.
- **Regression-guard verification:** temporarily reverted the fix (repointed the hook back at destructive `shutdown()`), re-ran the IT — it fails with the exact `ClosingException: Client is shutting down, cannot register new requests` reported in the issue, then passes again once the fix is restored.
- `./gradlew spotlessCheck` — clean.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary