### PR TITLE
Go: Relax memory stats assertions for transiently negative values

### DIFF
--- a/go/integTest/memory_commands_test.go
+++ b/go/integTest/memory_commands_test.go
@@ -306,13 +306,17 @@ func (suite *GlideTestSuite) assertMemoryStatsFields(result models.MemoryStats) 
 
 	assert.Greater(t, result.AllocatorActive, int64(0))
 	assert.Greater(t, result.AllocatorAllocated, int64(0))
-	assert.GreaterOrEqual(t, result.AllocatorFragmentationBytes, int64(0))
+	// AllocatorFragmentationBytes (active - allocated) can be transiently negative on Redis 6.2
+	// due to memory accounting race conditions.
+	assert.IsType(t, int64(0), result.AllocatorFragmentationBytes)
 	assert.Greater(t, result.AllocatorResident, int64(0))
 	assert.IsType(t, int64(0), result.AllocatorRssBytes)
 	assert.GreaterOrEqual(t, result.AofBuffer, int64(0))
 	assert.GreaterOrEqual(t, result.ClientsNormal, int64(0))
 	assert.GreaterOrEqual(t, result.ClientsSlaves, int64(0))
-	assert.GreaterOrEqual(t, result.DatasetBytes, int64(0))
+	// DatasetBytes is a derived metric (total - overhead components) that can be transiently
+	// negative on Redis 6.2 due to memory accounting race conditions.
+	assert.IsType(t, int64(0), result.DatasetBytes)
 	assert.IsType(t, int64(0), result.FragmentationBytes)
 	assert.GreaterOrEqual(t, result.KeysBytesPerKey, int64(0))
 	assert.GreaterOrEqual(t, result.KeysCount, int64(0))


### PR DESCRIPTION
### Summary

Stabilizes `TestMemoryStats_Standalone` and `TestMemoryCommands_StandaloneSequentialExecution` by relaxing assertions for derived memory metrics that can be transiently negative on Redis 6.2.

### Issue link

This Pull Request is linked to issue: [[Go][Flaky Test] TestMemoryStats_Standalone / TestMemoryCommands_StandaloneSequentialExecution](https://github.com/valkey-io/valkey-glide/issues/6622)
Closes #6622

### Features / Behaviour Changes

None. This PR only changes test assertions — no library code, no public API, no protocol behavior is affected.

### Implementation

`DatasetBytes` is calculated by Redis as `total_allocated - startup_allocated - replication_backlog - clients_normal - clients_slaves - aof_buffer - lua_caches - overhead`. On Redis 6.2, transient memory accounting race conditions can cause this value to be negative (observed: -16328, -16288).

Similarly, `AllocatorFragmentationBytes` is `allocator_active - allocator_allocated`, which can also go negative transiently.

Changed both assertions from `assert.GreaterOrEqual(t, value, int64(0))` to `assert.IsType(t, int64(0), value)`. This follows the **existing pattern** already used in the same function for three other fields that can be negative:
- `AllocatorRssBytes`
- `FragmentationBytes`
- `RssOverheadBytes`

The `IsType` assertion still verifies the field is properly parsed as an `int64`, but does not enforce a non-negative constraint on values that Redis can legitimately report as negative.

### Limitations

This fix is specific to the test assertions. It does not change how the library parses or exposes memory stats values.

### Testing

- Fix compiles cleanly (`go build ./integTest/` passes)
- Assertion pattern already proven stable by 3 existing uses in the same function
- The fix cannot introduce new flakiness since `IsType` always passes for a correctly typed field

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated. (Not applicable: flaky-test fix, no product behavior change.)
-   [ ] Linters have been run. (CI is authoritative.)
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary (Not applicable: no user-facing behavior change.)