### PR TITLE
Node: Fix flaky IAM auth test cluster creation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Pending 2.4
 
 #### Fixes
+* Node: Fix flaky IAM authentication test cluster creation ([#6633](https://github.com/valkey-io/valkey-glide/pull/6633))
 * CORE: Fall back to existing cluster connections when initial nodes are unavailable during topology refresh. When `refreshTopologyFromInitialNodes=true` and the initial/seed node is unreachable (e.g., dead primary during failover), the topology refresh now queries healthy existing connections instead of failing silently. This complements #5812 to enable failover recovery when the seed node itself is the failed node. ([#5814](https://github.com/valkey-io/valkey-glide/pull/5814))
 * Node: Fix SIGSEGV in pubsub under pnpm strict hoisting — replace `value_from_split_pointer(high_u32, low_u32)` with `value_from_pointer(i64)` in the Node.js Rust client to accept response pointers as a single integer, eliminating the high/low split that caused upper 32-bit truncation when `protobufjs.util.Long` was null ([#5851](https://github.com/valkey-io/valkey-glide/issues/5851))
 

--- a/node/tests/AuthTest.test.ts
+++ b/node/tests/AuthTest.test.ts
@@ -637,18 +637,33 @@ describe("IAM Auth: Mock Credentials", () => {
         let lastError: Error | undefined;
 
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            let partialCluster: ValkeyCluster | undefined;
+
             try {
-                return await ValkeyCluster.createCluster(
+                partialCluster = await ValkeyCluster.createCluster(
                     clusterMode,
                     shardCount,
                     replicaCount,
                     getServerVersion,
                 );
+                return partialCluster;
             } catch (error) {
                 lastError = error as Error;
                 console.warn(
                     `Cluster creation attempt ${attempt}/${maxRetries} failed: ${lastError.message}`,
                 );
+
+                // Clean up any partial cluster state (e.g., servers started
+                // but CLUSTER MEET failed) to free ports before retrying.
+                if (partialCluster) {
+                    try {
+                        await partialCluster.close();
+                    } catch (closeError) {
+                        console.warn(
+                            `Failed to close partial cluster: ${(closeError as Error).message}`,
+                        );
+                    }
+                }
 
                 if (attempt < maxRetries) {
                     // Wait before retrying with exponential backoff
@@ -692,8 +707,10 @@ describe("IAM Auth: Mock Credentials", () => {
     }, 120000);
 
     afterAll(async () => {
-        await iamCluster?.close();
-        await iamStandalone?.close();
+        await Promise.allSettled([
+            iamCluster?.close(),
+            iamStandalone?.close(),
+        ]);
     });
 
     it(
@@ -716,16 +733,18 @@ describe("IAM Auth: Mock Credentials", () => {
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            const client = await GlideClusterClient.createClient({
-                addresses: addresses,
-                credentials: {
-                    username: username,
-                    iamConfig: iamConfig,
-                },
-                useTLS: global.TLS, // Use TLS setting from test configuration
-            });
+            let client: GlideClusterClient | undefined;
 
             try {
+                client = await GlideClusterClient.createClient({
+                    addresses: addresses,
+                    credentials: {
+                        username: username,
+                        iamConfig: iamConfig,
+                    },
+                    useTLS: global.TLS, // Use TLS setting from test configuration
+                });
+
                 // Basic ping test to verify connection
                 await assertConnected(client);
 
@@ -742,7 +761,7 @@ describe("IAM Auth: Mock Credentials", () => {
                 const value2 = await client.get("iam_test_key2");
                 expect(value2).toBe("iam_test_value2");
             } finally {
-                client.close();
+                client?.close();
             }
         },
         TIMEOUT,
@@ -768,16 +787,18 @@ describe("IAM Auth: Mock Credentials", () => {
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            const client = await GlideClusterClient.createClient({
-                addresses: addresses,
-                credentials: {
-                    username: username,
-                    iamConfig: iamConfig,
-                },
-                useTLS: global.TLS, // Use TLS setting from test configuration
-            });
+            let client: GlideClusterClient | undefined;
 
             try {
+                client = await GlideClusterClient.createClient({
+                    addresses: addresses,
+                    credentials: {
+                        username: username,
+                        iamConfig: iamConfig,
+                    },
+                    useTLS: global.TLS, // Use TLS setting from test configuration
+                });
+
                 // Verify initial connection
                 await assertConnected(client);
 
@@ -792,7 +813,7 @@ describe("IAM Auth: Mock Credentials", () => {
                 const value = await client.get("iam_auto_refresh_key");
                 expect(value).toBe("iam_auto_refresh_value");
             } finally {
-                client.close();
+                client?.close();
             }
         },
         TIMEOUT,
@@ -818,16 +839,18 @@ describe("IAM Auth: Mock Credentials", () => {
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            const client = await GlideClient.createClient({
-                addresses: addresses,
-                credentials: {
-                    username: username,
-                    iamConfig: iamConfig,
-                },
-                useTLS: global.TLS, // Use TLS setting from test configuration
-            });
+            let client: GlideClient | undefined;
 
             try {
+                client = await GlideClient.createClient({
+                    addresses: addresses,
+                    credentials: {
+                        username: username,
+                        iamConfig: iamConfig,
+                    },
+                    useTLS: global.TLS, // Use TLS setting from test configuration
+                });
+
                 // Basic ping test to verify connection
                 await assertConnected(client);
 
@@ -844,7 +867,7 @@ describe("IAM Auth: Mock Credentials", () => {
                 const value2 = await client.get("iam_test_key2");
                 expect(value2).toBe("iam_test_value2");
             } finally {
-                client.close();
+                client?.close();
             }
         },
         TIMEOUT,
@@ -870,16 +893,18 @@ describe("IAM Auth: Mock Credentials", () => {
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            const client = await GlideClient.createClient({
-                addresses: addresses,
-                credentials: {
-                    username: username,
-                    iamConfig: iamConfig,
-                },
-                useTLS: global.TLS, // Use TLS setting from test configuration
-            });
+            let client: GlideClient | undefined;
 
             try {
+                client = await GlideClient.createClient({
+                    addresses: addresses,
+                    credentials: {
+                        username: username,
+                        iamConfig: iamConfig,
+                    },
+                    useTLS: global.TLS, // Use TLS setting from test configuration
+                });
+
                 // Verify initial connection
                 await assertConnected(client);
 
@@ -894,7 +919,7 @@ describe("IAM Auth: Mock Credentials", () => {
                 const value = await client.get("iam_auto_refresh_key");
                 expect(value).toBe("iam_auto_refresh_value");
             } finally {
-                client.close();
+                client?.close();
             }
         },
         TIMEOUT,

--- a/node/tests/AuthTest.test.ts
+++ b/node/tests/AuthTest.test.ts
@@ -621,6 +621,81 @@ describe("Auth tests", () => {
 
 // IAM Auth tests with mock credentials
 describe("IAM Auth: Mock Credentials", () => {
+    let iamCluster: ValkeyCluster;
+    let iamStandalone: ValkeyCluster;
+
+    /**
+     * Creates a ValkeyCluster with retry logic to handle transient failures
+     * such as port conflicts or slow server startup in CI environments.
+     */
+    async function createClusterWithRetry(
+        clusterMode: boolean,
+        shardCount: number,
+        replicaCount: number,
+        maxRetries: number = 3,
+    ): Promise<ValkeyCluster> {
+        let lastError: Error | undefined;
+
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                return await ValkeyCluster.createCluster(
+                    clusterMode,
+                    shardCount,
+                    replicaCount,
+                    getServerVersion,
+                );
+            } catch (error) {
+                lastError = error as Error;
+                console.warn(
+                    `Cluster creation attempt ${attempt}/${maxRetries} failed: ${lastError.message}`,
+                );
+
+                if (attempt < maxRetries) {
+                    // Wait before retrying with exponential backoff
+                    const delay = 2000 * attempt;
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, delay),
+                    );
+                }
+            }
+        }
+
+        throw new Error(
+            `Failed to create cluster after ${maxRetries} attempts. Last error: ${lastError?.message}`,
+        );
+    }
+
+    beforeAll(async () => {
+        // Skip setup if AWS credentials are not set
+        if (!process.env.AWS_ACCESS_KEY_ID) {
+            return;
+        }
+
+        const clusterAddresses = global.CLUSTER_ENDPOINTS;
+        const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
+
+        iamCluster = clusterAddresses
+            ? await ValkeyCluster.initFromExistingCluster(
+                  true,
+                  parseEndpoints(clusterAddresses),
+                  getServerVersion,
+              )
+            : await createClusterWithRetry(true, 3, 1);
+
+        iamStandalone = standaloneAddresses
+            ? await ValkeyCluster.initFromExistingCluster(
+                  false,
+                  parseEndpoints(standaloneAddresses),
+                  getServerVersion,
+              )
+            : await createClusterWithRetry(false, 1, 0);
+    }, 120000);
+
+    afterAll(async () => {
+        await iamCluster?.close();
+        await iamStandalone?.close();
+    });
+
     it(
         "test_iam_authentication_with_mock_credentials",
         async () => {
@@ -637,35 +712,20 @@ describe("IAM Auth: Mock Credentials", () => {
             const username = IAM_USERNAME; // Use default user
             const iamConfig = createTestIamConfig(5);
 
-            // Use existing cluster from global setup
-            const clusterAddresses = global.CLUSTER_ENDPOINTS;
-            const cluster = clusterAddresses
-                ? await ValkeyCluster.initFromExistingCluster(
-                      true,
-                      parseEndpoints(clusterAddresses),
-                      getServerVersion,
-                  )
-                : await ValkeyCluster.createCluster(
-                      true,
-                      3,
-                      1,
-                      getServerVersion,
-                  );
-
-            const addresses = cluster
+            const addresses = iamCluster
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            try {
-                const client = await GlideClusterClient.createClient({
-                    addresses: addresses,
-                    credentials: {
-                        username: username,
-                        iamConfig: iamConfig,
-                    },
-                    useTLS: global.TLS, // Use TLS setting from test configuration
-                });
+            const client = await GlideClusterClient.createClient({
+                addresses: addresses,
+                credentials: {
+                    username: username,
+                    iamConfig: iamConfig,
+                },
+                useTLS: global.TLS, // Use TLS setting from test configuration
+            });
 
+            try {
                 // Basic ping test to verify connection
                 await assertConnected(client);
 
@@ -681,10 +741,8 @@ describe("IAM Auth: Mock Credentials", () => {
                 await client.set("iam_test_key2", "iam_test_value2");
                 const value2 = await client.get("iam_test_key2");
                 expect(value2).toBe("iam_test_value2");
-
-                client.close();
             } finally {
-                await cluster.close();
+                client.close();
             }
         },
         TIMEOUT,
@@ -706,35 +764,20 @@ describe("IAM Auth: Mock Credentials", () => {
             const username = IAM_USERNAME;
             const iamConfig = createTestIamConfig(2); // Short interval for automatic refresh
 
-            // Use existing cluster from global setup
-            const clusterAddresses = global.CLUSTER_ENDPOINTS;
-            const cluster = clusterAddresses
-                ? await ValkeyCluster.initFromExistingCluster(
-                      true,
-                      parseEndpoints(clusterAddresses),
-                      getServerVersion,
-                  )
-                : await ValkeyCluster.createCluster(
-                      true,
-                      3,
-                      1,
-                      getServerVersion,
-                  );
-
-            const addresses = cluster
+            const addresses = iamCluster
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            try {
-                const client = await GlideClusterClient.createClient({
-                    addresses: addresses,
-                    credentials: {
-                        username: username,
-                        iamConfig: iamConfig,
-                    },
-                    useTLS: global.TLS, // Use TLS setting from test configuration
-                });
+            const client = await GlideClusterClient.createClient({
+                addresses: addresses,
+                credentials: {
+                    username: username,
+                    iamConfig: iamConfig,
+                },
+                useTLS: global.TLS, // Use TLS setting from test configuration
+            });
 
+            try {
                 // Verify initial connection
                 await assertConnected(client);
 
@@ -748,10 +791,8 @@ describe("IAM Auth: Mock Credentials", () => {
                 );
                 const value = await client.get("iam_auto_refresh_key");
                 expect(value).toBe("iam_auto_refresh_value");
-
-                client.close();
             } finally {
-                await cluster.close();
+                client.close();
             }
         },
         TIMEOUT,
@@ -773,35 +814,20 @@ describe("IAM Auth: Mock Credentials", () => {
             const username = IAM_USERNAME;
             const iamConfig = createTestIamConfig(5);
 
-            // Use existing standalone server from global setup
-            const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
-            const server = standaloneAddresses
-                ? await ValkeyCluster.initFromExistingCluster(
-                      false,
-                      parseEndpoints(standaloneAddresses),
-                      getServerVersion,
-                  )
-                : await ValkeyCluster.createCluster(
-                      false,
-                      1,
-                      0,
-                      getServerVersion,
-                  );
-
-            const addresses = server
+            const addresses = iamStandalone
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            try {
-                const client = await GlideClient.createClient({
-                    addresses: addresses,
-                    credentials: {
-                        username: username,
-                        iamConfig: iamConfig,
-                    },
-                    useTLS: global.TLS, // Use TLS setting from test configuration
-                });
+            const client = await GlideClient.createClient({
+                addresses: addresses,
+                credentials: {
+                    username: username,
+                    iamConfig: iamConfig,
+                },
+                useTLS: global.TLS, // Use TLS setting from test configuration
+            });
 
+            try {
                 // Basic ping test to verify connection
                 await assertConnected(client);
 
@@ -817,10 +843,8 @@ describe("IAM Auth: Mock Credentials", () => {
                 await client.set("iam_test_key2", "iam_test_value2");
                 const value2 = await client.get("iam_test_key2");
                 expect(value2).toBe("iam_test_value2");
-
-                client.close();
             } finally {
-                await server.close();
+                client.close();
             }
         },
         TIMEOUT,
@@ -842,35 +866,20 @@ describe("IAM Auth: Mock Credentials", () => {
             const username = IAM_USERNAME;
             const iamConfig = createTestIamConfig(2);
 
-            // Use existing standalone server from global setup
-            const standaloneAddresses = global.STAND_ALONE_ENDPOINT;
-            const server = standaloneAddresses
-                ? await ValkeyCluster.initFromExistingCluster(
-                      false,
-                      parseEndpoints(standaloneAddresses),
-                      getServerVersion,
-                  )
-                : await ValkeyCluster.createCluster(
-                      false,
-                      1,
-                      0,
-                      getServerVersion,
-                  );
-
-            const addresses = server
+            const addresses = iamStandalone
                 .getAddresses()
                 .map(([host, port]) => ({ host, port }));
 
-            try {
-                const client = await GlideClient.createClient({
-                    addresses: addresses,
-                    credentials: {
-                        username: username,
-                        iamConfig: iamConfig,
-                    },
-                    useTLS: global.TLS, // Use TLS setting from test configuration
-                });
+            const client = await GlideClient.createClient({
+                addresses: addresses,
+                credentials: {
+                    username: username,
+                    iamConfig: iamConfig,
+                },
+                useTLS: global.TLS, // Use TLS setting from test configuration
+            });
 
+            try {
                 // Verify initial connection
                 await assertConnected(client);
 
@@ -884,10 +893,8 @@ describe("IAM Auth: Mock Credentials", () => {
                 );
                 const value = await client.get("iam_auto_refresh_key");
                 expect(value).toBe("iam_auto_refresh_value");
-
-                client.close();
             } finally {
-                await server.close();
+                client.close();
             }
         },
         TIMEOUT,


### PR DESCRIPTION
### Summary

Fix flaky `test_iam_authentication_with_mock_credentials` test that fails intermittently with "Failed to send CLUSTER MEET command" due to transient cluster creation failures in CI.

### Issue link

This Pull Request is linked to issue: [The Node test test_iam_authentication_with_mock_credentials in node/tests/AuthTest.test.ts fails](https://github.com/valkey-io/valkey-glide/issues/6631)
Closes #6631

### Features / Behaviour Changes

No feature changes. This PR only improves test reliability.

### Implementation

The IAM authentication tests previously created a new cluster independently within each test case without any retry logic. In slow CI environments, or when previous test cleanup hasn't fully completed, `cluster_manager.py` can time out waiting for servers to start, then fail the CLUSTER MEET command.

Changes:
- **Shared cluster setup**: Move cluster and standalone server creation from individual tests into `beforeAll`/`afterAll` hooks, reducing cluster creations from 4 to 2
- **Retry with backoff**: Add `createClusterWithRetry` helper that retries cluster creation up to 3 times with exponential backoff (2s, 4s delays)
- **Proper cleanup**: Add `afterAll` to ensure clusters are always stopped, preventing port conflicts for subsequent tests
- **Extended timeout**: Set `beforeAll` timeout to 120s to accommodate potential retries

### Limitations

None.

### Testing

- TypeScript type-checking passes (no new errors introduced)
- Verified cluster creation works locally with `cluster_manager.py`
- The fix is designed to handle the transient CI failure described in #6631

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run.
- [x] Destination branch is correct - main or release