### PR TITLE
Java: Fix Dockerfile for AL2023 compatibility

### DIFF
--- a/java/e2e/circuit-breaker-test/Dockerfile
+++ b/java/e2e/circuit-breaker-test/Dockerfile
@@ -2,8 +2,10 @@ FROM amazoncorretto:21
 
 WORKDIR /app
 
-# Install Docker CLI for container manipulation (exec DEBUG SLEEP)
-RUN yum install -y tar gzip curl && \
+# Install Docker CLI for container manipulation (exec DEBUG SLEEP).
+# curl is already provided by the base image's curl-minimal package; installing the
+# full curl package conflicts with it, so we only add tar/gzip here.
+RUN yum install -y tar gzip && \
     curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.5.1.tgz | \
     tar xz --strip-components=1 -C /usr/local/bin docker/docker && \
     yum clean all

--- a/java/e2e/dns-failover-test/Dockerfile
+++ b/java/e2e/dns-failover-test/Dockerfile
@@ -3,7 +3,7 @@ FROM public.ecr.aws/amazoncorretto/amazoncorretto:21
 WORKDIR /app
 
 # Install Docker CLI
-RUN amazon-linux-extras install docker -y && yum clean all
+RUN dnf install docker -y && dnf clean all
 
 # Copy the application JAR
 COPY build/libs/dns-failover-test-1.0-SNAPSHOT.jar /app/app.jar

--- a/java/e2e/dns-failover-test/Dockerfile
+++ b/java/e2e/dns-failover-test/Dockerfile
@@ -1,9 +1,14 @@
-FROM public.ecr.aws/amazoncorretto/amazoncorretto:21
+FROM amazoncorretto:21
 
 WORKDIR /app
 
-# Install Docker CLI
-RUN dnf install docker -y && dnf clean all
+# Install Docker CLI for container manipulation (stop cluster nodes, restart DNS server).
+# curl is already provided by the base image's curl-minimal package; installing the
+# full curl package conflicts with it, so we only add tar/gzip here.
+RUN yum install -y tar gzip && \
+    curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.5.1.tgz | \
+    tar xz --strip-components=1 -C /usr/local/bin docker/docker && \
+    yum clean all
 
 # Copy the application JAR
 COPY build/libs/dns-failover-test-1.0-SNAPSHOT.jar /app/app.jar


### PR DESCRIPTION
### Summary

Align both Java e2e test images (`dns-failover-test` and `circuit-breaker-test`) on a single, conflict-free way of installing the Docker CLI.

The DNS failover test image previously failed to build because it used `amazon-linux-extras install docker`, an AL2-only tool that does not exist on the Amazon Linux 2023 base image (#6632). Rather than swap in another distro-repo install, both images now extract only the pinned static Docker **client** binary from download.docker.com, exactly as the circuit-breaker test already intended. The test containers only drive the host Docker daemon over the bind-mounted `/var/run/docker.sock`, so only the client is needed, and pinning it decouples the install from whatever distro the base image happens to track (the coupling that caused #6632 in the first place).

While aligning the two images, the shared install line surfaced a second latent bug (#6639): `yum install -y tar gzip curl` aborts on the current `amazoncorretto:21` image because it ships `curl-minimal` (from `@System`), which provides the `curl` binary and conflicts with the full `curl` package. `curl-minimal` is sufficient to download the static client, so both images now install only `tar` and `gzip`.

### Issue link

This Pull Request is linked to issues:
- DNS Failover Test Docker build failure: Closes #6632
- circuit-breaker-test curl/curl-minimal conflict: Closes #6639

### Features / Behaviour Changes

No behaviour changes. Both e2e images install the Docker CLI the same conflict-free way and remain functionally identical for the tests, which only shell out to the host `docker` client.

### Implementation

`java/e2e/dns-failover-test/Dockerfile`:
- Base image aligned to `amazoncorretto:21` (matching circuit-breaker-test).
- Install the pinned static Docker client (`docker-27.5.1`) from download.docker.com instead of `amazon-linux-extras`/`dnf install docker`, dropping the unused daemon/containerd/runc and pinning the client version.
- Install only `tar gzip` (not `curl`), since `curl-minimal` already provides the binary needed for the download.

`java/e2e/circuit-breaker-test/Dockerfile`:
- Drop `curl` from the `yum install` list so it reads `yum install -y tar gzip`, resolving the `curl`/`curl-minimal` conflict. Base image, Docker client version pin, and JAR copy are unchanged.

Both files now use an identical install line and comment style so the sibling images stay consistent.

### Limitations

The static client architecture is pinned to `x86_64`, matching the existing circuit-breaker-test image and the `ubuntu-latest` (x86_64) CI runners. Local arm64 runs of `run-test.sh` would need a parametrized architecture; if that becomes desirable it should be applied to both files together in a follow-up so they stay in sync.

### Testing

- DNS Failover Test CI job builds the image with the pinned static client and runs the e2e failover scenario end to end.
- Verified the `curl`/`curl-minimal` conflict reproduces on the current `amazoncorretto:21` image and that installing only `tar gzip` builds cleanly.
- circuit-breaker-test is not currently exercised by a dedicated CI job; the change is the minimal, mechanical fix mirroring the validated dns-failover install.

### Checklist

- [x] This Pull Request is related to one or more issues.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated. (N/A - this is test-infrastructure; the DNS Failover Test CI job exercises the change.)
- [ ] CHANGELOG.md and documentation files are updated. (N/A - test-infra fix, no CHANGELOG entry needed.)
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary