### PR TITLE
ci(python): opt-in RUST_LOG tracing + script-test isolation investigation (stacked on #6605)

### DIFF
--- a/.github/workflows/fmt-python.yml
+++ b/.github/workflows/fmt-python.yml
@@ -19,6 +19,10 @@ on:
                 description: "Use self-hosted runners for Linux x64"
                 type: boolean
                 default: false
+            enable-core-tracing:
+                description: "Enable Rust core trace logging (RUST_LOG=debug,redis=trace) for diagnostic runs"
+                type: boolean
+                default: false
 
 concurrency:
     group: fmt-python-${{ github.ref }}
@@ -31,5 +35,6 @@ jobs:
         with:
             run-with-macos: use-self-hosted
             use-self-hosted-linux: ${{ inputs.use-self-hosted-linux || false }}
+            enable-core-tracing: ${{ inputs.enable-core-tracing || false }}
         name: FMT - Python
         secrets: inherit

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -77,6 +77,10 @@ on:
                 description: "Run only container tests (skip regular test-python job)"
                 type: boolean
                 default: false
+            enable-core-tracing:
+                description: "Enable Rust core trace logging (RUST_LOG=debug,redis=trace) for diagnostic runs"
+                type: boolean
+                default: false
 
     workflow_call:
         inputs:
@@ -90,6 +94,10 @@ on:
                 default: "false"
             use-self-hosted-linux:
                 description: "Use self-hosted runners for Linux x64"
+                type: boolean
+                default: false
+            enable-core-tracing:
+                description: "Enable Rust core trace logging (RUST_LOG=debug,redis=trace) for diagnostic runs"
                 type: boolean
                 default: false
 
@@ -202,6 +210,8 @@ jobs:
                   AWS_ACCESS_KEY_ID: test_access_key
                   AWS_SECRET_ACCESS_KEY: test_secret_key
                   AWS_SESSION_TOKEN: test_session_token
+                  RUST_LOG: ${{ inputs.enable-core-tracing && 'debug,redis=trace' || '' }}
+                  GLIDE_LOG_LEVEL: ${{ inputs.enable-core-tracing && 'trace' || '' }}
               run: |
                   python3 dev.py test --args --async-backend=asyncio --html=pytest_report.html --self-contained-html "$TEST_NAME_ARG"
 
@@ -212,6 +222,8 @@ jobs:
                   AWS_ACCESS_KEY_ID: test_access_key
                   AWS_SECRET_ACCESS_KEY: test_secret_key
                   AWS_SESSION_TOKEN: test_session_token
+                  RUST_LOG: ${{ inputs.enable-core-tracing && 'debug,redis=trace' || '' }}
+                  GLIDE_LOG_LEVEL: ${{ inputs.enable-core-tracing && 'trace' || '' }}
               run: |
                   python3 dev.py test --args --async-backend=asyncio --async-backend=trio --html=pytest_report.html --self-contained-html
 
@@ -222,6 +234,8 @@ jobs:
                   AWS_ACCESS_KEY_ID: test_access_key
                   AWS_SECRET_ACCESS_KEY: test_secret_key
                   AWS_SESSION_TOKEN: test_session_token
+                  RUST_LOG: ${{ inputs.enable-core-tracing && 'debug,redis=trace' || '' }}
+                  GLIDE_LOG_LEVEL: ${{ inputs.enable-core-tracing && 'trace' || '' }}
               run: |
                   python3 dev.py test --args tests/async_tests --async-backend=asyncio --async-backend=trio --html=pytest_report.html --self-contained-html
 
@@ -232,6 +246,8 @@ jobs:
                   AWS_ACCESS_KEY_ID: test_access_key
                   AWS_SECRET_ACCESS_KEY: test_secret_key
                   AWS_SESSION_TOKEN: test_session_token
+                  RUST_LOG: ${{ inputs.enable-core-tracing && 'debug,redis=trace' || '' }}
+                  GLIDE_LOG_LEVEL: ${{ inputs.enable-core-tracing && 'trace' || '' }}
               run: |
                   python3 dev.py test --args tests/sync_tests --html=pytest_report.html --self-contained-html
 

--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -163,9 +163,20 @@ pub fn init(minimal_level: Option<Level>, file_name: Option<&str>) -> Level {
     let level = minimal_level.unwrap_or(Level::Warn);
     let level_filter = level.to_filter();
     let reloads = INITIATE_ONCE.init_once.get_or_init(|| {
+        // Seed the stdout layer from RUST_LOG so operators can enable core trace output
+        // without threading a level through log_init(). RUST_LOG unset keeps stdout OFF
+        // (unchanged for existing consumers); when set, mirror the target-filter fallback
+        // below so directives like "debug,redis=trace" still route through as TRACE.
+        let stdout_initial_filter = match std::env::var("RUST_LOG") {
+            Ok(v) => {
+                LevelFilter::from(tracing::Level::from_str(&v).unwrap_or(tracing::Level::TRACE))
+            }
+            Err(_) => LevelFilter::OFF,
+        };
+
         let stdout_fmt = tracing_subscriber::fmt::layer()
             .with_ansi(true)
-            .with_filter(LevelFilter::OFF);
+            .with_filter(stdout_initial_filter);
 
         let (stdout_layer, stdout_reload) = reload::Layer::new(stdout_fmt);
 

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -11323,6 +11323,26 @@ async def script_kill_tests(
 
 @pytest.mark.anyio
 class TestScripts:
+    @pytest.fixture(autouse=True)
+    def _flush_pending_script_finalizers(self):
+        """Force gc.collect() before every TestScripts case so any pending
+        Script finalizers from prior parametrizations decrement the
+        process-global scripts_container ref count BEFORE the current
+        parametrization adds fresh entries.
+
+        Without this, on the trio backend the last parametrization can
+        observe the container entry it just created being wiped by a
+        delayed finalizer from an earlier iteration, causing
+        invoke_script's NoScript fallback to miss its get_script lookup
+        and surface NoScriptError to the caller (see failing job
+        30298869080 for reference).
+        """
+        import gc
+
+        gc.collect()
+        yield
+        gc.collect()
+
     @pytest.mark.smoke_test
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -11367,6 +11367,20 @@ def script_kill_tests(
 
 
 class TestSyncScripts:
+    @pytest.fixture(autouse=True)
+    def _flush_pending_script_finalizers(self):
+        """Sync twin: force gc.collect() before/after every TestSyncScripts
+        case so pending Script finalizers from prior parametrizations
+        drain BEFORE the current parametrization touches the
+        process-global scripts_container. See the async twin
+        (test_async_client.py::TestScripts._flush_pending_script_finalizers)
+        for rationale."""
+        import gc
+
+        gc.collect()
+        yield
+        gc.collect()
+
     @pytest.mark.smoke_test
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/tests/utils/utils.py
+++ b/python/tests/utils/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 import string
 from concurrent.futures import ThreadPoolExecutor
@@ -104,8 +105,15 @@ from tests.utils.cluster import ValkeyCluster
 TAnyGlideClient = Union[TGlideClient, TSyncGlideClient]
 
 T = TypeVar("T")
-DEFAULT_TEST_LOG_LEVEL = logLevel.OFF
-DEFAULT_SYNC_TEST_LOG_LEVEL = SyncLogLevel.OFF
+# RUST_LOG opt-in path (see .github/workflows/python.yml enable-core-tracing):
+# when the env var is present, run the async/sync test sessions at TRACE so
+# glide-core tracing_subscriber layers surface diagnostics. Unset keeps OFF,
+# the historical default that suppresses per-test log spam.
+_RUST_LOG_ENABLED = bool(os.environ.get("RUST_LOG"))
+DEFAULT_TEST_LOG_LEVEL = logLevel.TRACE if _RUST_LOG_ENABLED else logLevel.OFF
+DEFAULT_SYNC_TEST_LOG_LEVEL = (
+    SyncLogLevel.TRACE if _RUST_LOG_ENABLED else SyncLogLevel.OFF
+)
 USERNAME = "username"
 INITIAL_PASSWORD = "initial_password"
 NEW_PASSWORD = "new_secure_password"


### PR DESCRIPTION
### Summary

Add an opt-in `enable-core-tracing` workflow_dispatch input to `python.yml` and `fmt-python.yml`, wire it through `logger_core::init` so `RUST_LOG` seeds the stdout formatter layer at process start, and default the Python test session log level to `TRACE` when `RUST_LOG` is set. Stacked on #6605 so the tracing infrastructure is available while a script-test isolation investigation runs on top of the auth-cluster fixes landing there.

### Issue link

This Pull Request is linked to issue: N/A (diagnostic tracing opt-in plus staging ground for the follow-up script-test isolation investigation).

### Features / Behaviour Changes

- `.github/workflows/python.yml` and `.github/workflows/fmt-python.yml` gain a `workflow_dispatch` input `enable-core-tracing` (boolean, default `false`). When enabled the four `Test with pytest*` steps in the `test-python` job receive `RUST_LOG=debug,redis=trace` and `GLIDE_LOG_LEVEL=trace`. The default is unchanged so scheduled cron and PR CI runs are quiet.
- `logger_core::init` seeds the initial stdout formatter filter from the `RUST_LOG` env var. Unset keeps stdout `OFF` (unchanged for existing callers); a set value starts the layer at the parsed level, with the existing target-filter fallback so composite directives such as `debug,redis=trace` still route through as `TRACE`.
- `python/tests/utils/utils.py` reads `RUST_LOG` at import time and picks `Level.TRACE` for `DEFAULT_TEST_LOG_LEVEL` (and its sync twin) when the env var is set, `Level.OFF` otherwise. The two test conftests already call `Logger.set_logger_config(DEFAULT_TEST_LOG_LEVEL)` at module import, so this is the single knob that flips the whole test session on and off.

### Implementation

Two-line ternary on each pytest step so the env vars are only populated on manually triggered diagnostic runs; the FMT wrapper forwards the flag via `with:`. `logger_core::init` uses a `match std::env::var("RUST_LOG")` to pick the initial `LevelFilter`, keeping the file layer, reload wiring, and `log_init` external signature unchanged.

### Limitations

- The `enable-core-tracing` flag is not wired into the container-based `test-python-container` job. That job runs a narrower subset.
- The Python test-session default flip is scoped to `RUST_LOG` presence, not any glide-specific env; anyone setting `RUST_LOG` for their own reasons will now see glide-core trace output through the test session.

### Testing

- Workflow syntax: GitHub Actions parses `${{ inputs.enable-core-tracing && 'debug,redis=trace' || '' }}` as a valid ternary. With the flag unset both env vars evaluate to the empty string, which GitHub Actions treats as unset for the child process.
- `logger_core` tests pass with `cargo test -- --test-threads=1`.
- Diagnostic capture: a `workflow_dispatch` FMT Python run with `enable-core-tracing=true` surfaces `redis::cluster_async` retry logs, `redis::aio::multiplexed_connection` push-frame handling logs, and `script_lifetime` warn/info lines in the CI log.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated. (N/A: workflow-only opt-in plus internal logger init fix.)
-   [ ] CHANGELOG.md and documentation files are updated. (N/A: CI and internal init fix, no user-visible product behaviour changes.)
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary (N/A)
