### PR TITLE
Python: Fix trio pub/sub BusyResourceError from duplicate shared-pipe reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Python: Fix trio backend pub/sub failures by keying the shared response-pipe reader task to the owning `trio.run()`, preventing a duplicate `_trio_pipe_reader` from waiting on the same pipe fd and raising `BusyResourceError` (which cancelled client teardown and left stale subscriptions polluting the shared test cluster) ([#6353](https://github.com/valkey-io/valkey-glide/issues/6353))
 * Java: Make the automatic JVM shutdown hook non-destructive so a command issued from a user's own shutdown hook is no longer rejected with `ClosingException: Client is shutting down`. The JVM runs all shutdown hooks concurrently, and GLIDE's hook previously tore the client down and blocked new requests, racing with (and aborting) legitimate work such as persisting state before exit. Deterministic teardown remains available via the client's `close()`. ([#4809](https://github.com/valkey-io/valkey-glide/issues/4809))
 * Core: Fix native panic for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -172,7 +172,13 @@ _async_pipe_registered: bool = False
 _async_pipe_loop: Optional[asyncio.AbstractEventLoop] = (
     None  # loop that owns the reader
 )
-_trio_pipe_active: bool = False  # True while trio system task is running
+# Identity of the trio.run() that owns the reader system task.  A given
+# reader lives for exactly one trio.run(); the token is set eagerly (under
+# _async_pipe_lock, before the spawned task starts) so registration is
+# idempotent within a run and re-registers cleanly across runs.  This is
+# what guarantees at most one _trio_pipe_reader ever waits on the shared fd:
+# trio raises BusyResourceError if two tasks wait on the same fd at once.
+_trio_pipe_token: Optional[object] = None
 _async_pipe_lock = threading.Lock()
 _client_registry: dict = {}
 _pipe_remainder: bytes = b""
@@ -433,12 +439,17 @@ def _on_async_pipe_readable() -> None:  # noqa: C901
         _pipe_remainder = data[offset:]
 
 
-async def _trio_pipe_reader(pipe_fd: int) -> None:
-    """Background trio task that reads from the shared pipe."""
+async def _trio_pipe_reader(pipe_fd: int, token: object) -> None:
+    """Background trio task that reads from the shared pipe.
+
+    ``token`` identifies the trio.run() this reader was spawned for.  On exit
+    it clears the shared registration only if it still owns that token, so a
+    reader that is cancelled while a newer trio.run() has already registered
+    its own reader cannot wipe the newer run's state.
+    """
     import trio
 
-    global _trio_pipe_active, _async_pipe_registered
-    _trio_pipe_active = True
+    global _trio_pipe_token, _async_pipe_registered
     try:
         while True:
             await trio.lowlevel.wait_readable(pipe_fd)
@@ -449,8 +460,10 @@ async def _trio_pipe_reader(pipe_fd: int) -> None:
             except Exception as e:
                 ClientLogger.log(LogLevel.ERROR, "trio_pipe", f"Pipe read error: {e}")
     finally:
-        _trio_pipe_active = False
-        _async_pipe_registered = False
+        with _async_pipe_lock:
+            if _trio_pipe_token is token:
+                _trio_pipe_token = None
+                _async_pipe_registered = False
 
 
 class BaseClient(CoreCommands):
@@ -575,7 +588,16 @@ class BaseClient(CoreCommands):
     def _setup_pipe(self) -> None:
         """Initialize and register the shared response pipe."""
         global _async_pipe_read_fd, _async_pipe_registered, _async_pipe_loop
-        global _pipe_remainder
+        global _pipe_remainder, _trio_pipe_token
+        # Identify the current trio.run() up front (outside the lock).  The
+        # token uniquely names this run, so it both makes registration
+        # idempotent within a run and tells a fresh run that a prior run's
+        # registration is stale.
+        trio_token = None
+        if not self._is_asyncio:
+            import trio
+
+            trio_token = trio.lowlevel.current_trio_token()
         with _async_pipe_lock:
             if _async_pipe_read_fd < 0:
                 try:
@@ -594,13 +616,21 @@ class BaseClient(CoreCommands):
                     _async_pipe_loop = None
                     _pipe_remainder = b""
                     _drain_stale_pipe_frames()
+            # Trio: registration belongs to exactly one trio.run().  If the
+            # recorded token differs from this run's, the previous run's reader
+            # is gone (trio.run() cancels its system tasks before returning), so
+            # re-register for this run.  Keying on the token instead of a
+            # lazily-set liveness flag prevents a second client in the same run
+            # from spawning a duplicate reader on the shared fd, which is what
+            # triggered BusyResourceError.
             if (
-                _async_pipe_registered
-                and not _trio_pipe_active
+                not self._is_asyncio
+                and _async_pipe_registered
                 and _async_pipe_loop is None
+                and _trio_pipe_token is not trio_token
             ):
-                # Trio task exited (back-to-back trio.run)
                 _async_pipe_registered = False
+                _trio_pipe_token = None
                 _pipe_remainder = b""
                 _drain_stale_pipe_frames()
             if _async_pipe_read_fd >= 0 and self._pipe_client_id:
@@ -613,11 +643,16 @@ class BaseClient(CoreCommands):
                         )
                         _async_pipe_loop = self._loop
                     else:
-                        # For trio: spawn a background task that polls the pipe
+                        # For trio: spawn a background task that polls the pipe.
+                        # Record the token before spawning (still under the
+                        # lock) so a concurrent _setup_pipe in this same run
+                        # sees us as registered and does not spawn a second
+                        # reader on the same fd.
                         import trio
 
+                        _trio_pipe_token = trio_token
                         trio.lowlevel.spawn_system_task(
-                            _trio_pipe_reader, _async_pipe_read_fd
+                            _trio_pipe_reader, _async_pipe_read_fd, trio_token
                         )
                     _async_pipe_registered = True
 


### PR DESCRIPTION
### Summary

The Python async client's trio backend fails ~293 `PubSubTests` in the full Python CI matrix with `BusyResourceError('attempt to register multiple listeners for same ident/filter pair')`, which then cascades into suite-wide message-count and `pubsub_numpat` assertion failures (including in the sync suite, which does not use trio).

Root cause is a real product bug in the async client, not a test bug.

Pub/sub responses are delivered over a single process-global response pipe fd. On the trio backend, that fd is serviced by one background system task, `_trio_pipe_reader`, spawned with `trio.lowlevel.spawn_system_task`. trio raises `BusyResourceError` if two tasks ever wait on the same fd at once.

Registration was guarded by a module global `_trio_pipe_active`, set to `True` lazily inside the spawned task's own first line. `spawn_system_task` only schedules the task, it does not run it synchronously, so the following race existed within a single `trio.run()`:

1. Client A calls `_setup_pipe`, spawns the reader, sets `_async_pipe_registered = True`. The reader has not started running yet, so `_trio_pipe_active` is still `False`.
2. Client B calls `_setup_pipe` before the reader's first line executes. It sees `_async_pipe_registered and not _trio_pipe_active and _async_pipe_loop is None`, misinterprets this as "the trio task exited (back-to-back trio.run)", resets `_async_pipe_registered = False`, and spawns a second `_trio_pipe_reader`.
3. Both readers call `trio.lowlevel.wait_readable(fd)` on the same fd, and trio raises `BusyResourceError`.

The error propagates out of the system-task nursery as `trio.Cancelled`, which cancels the client's teardown before it unsubscribes. The leftover subscription state pollutes the shared session cluster used by the whole parametrized suite. That pollution is the downstream cause of the "assert 7 == 1", "assert 3 == 0", non-zero `pubsub_numpat`, and leftover-shardchannel failures tracked in #6361, including in the sync pub/sub tests, which inherit the same polluted cluster.

Because each parametrized test runs its own `trio.run()` under `--async-backend=trio`, the collision recurred throughout the run.

### Issue link

This Pull Request is linked to issue: [\[Python\]\[Flaky Test\] PubSubTests with trio backend - BusyResourceError](https://github.com/valkey-io/valkey-glide/issues/6353)
Closes #6353
Closes #6361

### Features / Behaviour Changes

No public API or behaviour change. This is an internal concurrency fix in the async client's shared-pipe reader lifecycle. The asyncio path is unchanged; the wire protocol and FFI are untouched.

### Implementation

The fix keys the trio reader's registration to the identity of the owning `trio.run()` instead of a lazily-set liveness flag, and records that identity eagerly.

`python/glide-async/python/glide/glide_client.py`:

- Replaced the `_trio_pipe_active: bool` module global with `_trio_pipe_token: Optional[object]`, the token of the `trio.run()` that owns the reader.
- In `_setup_pipe`, capture the current run's token via `trio.lowlevel.current_trio_token()` and record it under `_async_pipe_lock` immediately before `spawn_system_task`. A concurrent second client in the same run therefore sees the run as already registered and does not spawn a duplicate reader on the shared fd. This closes the race window.
- Stale-registration detection for trio now compares the recorded token against the current run's token. `trio.run()` cancels its system tasks before returning, so a new run always has a different token and re-registers cleanly, while a second client within the same run matches the token and is a no-op.
- `_trio_pipe_reader` takes its owning `token` and, in its `finally`, clears the shared registration only if it still owns that token. A reader cancelled after a newer run has already registered its own reader can no longer wipe the newer run's state.
- All of these reads and writes now happen under `_async_pipe_lock`.

The net invariant: at most one `_trio_pipe_reader` is ever waiting on the shared fd, per `trio.run()` lifecycle, which eliminates the `BusyResourceError` condition and the cancelled teardown that polluted the shared cluster.

### Limitations

None. The change is scoped to the trio branch of the shared-pipe lifecycle. The asyncio `add_reader`/`is_closed` stale-detection path is byte-for-byte unchanged.

### Testing

The existing parametrized `PubSubTests` suite provides the coverage; no product behaviour changed, so no new tests were added. The suite is what regresses without the fix and passes with it. Reproduced first on the unmodified checkout, then validated after the fix, with self-hosted clusters (`valkey-server` on PATH). Commands run from `python/`.

Before (unmodified `main` @ `08c4a5e1`), trio only, async pub/sub file:

```
python3 dev.py test --args tests/async_tests/test_pubsub.py -k pubsub --async-backend=trio
==== 194 failed, 186 passed, 805 skipped, 17 warnings in 751.06s (0:12:31) =====
# 308 x BusyResourceError('attempt to register multiple listeners for same ident/filter pair')
# from glide.glide_client._trio_pipe_reader; 1232 x trio.Cancelled
```

After the fix, the full `-k pubsub` set under both backends (the FMT configuration), sync and async clients built:

```
python3 dev.py test --args -k pubsub --async-backend=asyncio --async-backend=trio
======= 1158 passed, 437 skipped, 8757 deselected in 3887.25s (1:04:47) ========
# 0 BusyResourceError, 0 trio.Cancelled
```

Re-running the exact scope that regressed (async pub/sub file, trio only) confirms the pass is stable, not intermittent:

```
python3 dev.py test --args tests/async_tests/test_pubsub.py -k pubsub --async-backend=trio
================ 380 passed, 805 skipped in 1397.76s (0:23:17) =================
# 0 BusyResourceError, 0 trio.Cancelled
```

The sync and asyncio pub/sub assertions that previously failed as pollution collateral now pass alongside the trio ones.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary