### PR TITLE
fix(core): buffer pending requests during cluster reconnect (cherry-pick #6640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core/All: Buffer pending cluster requests during reconnect instead of failing immediately. A new `recovery_requests_queue_size` option (default: 1000) controls the queue depth. Set to 0 to disable. ([#6640](https://github.com/valkey-io/valkey-glide/pull/6640))
 * Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))
 * CI: Run `test-release` in `pypi-cd.yml` when only one package is published manually, so a skipped sibling publish job no longer causes post-publish validation to be skipped entirely ([#6542](https://github.com/valkey-io/valkey-glide/pull/6542))

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -185,6 +185,9 @@ where
     false
 }
 
+/// Default maximum number of requests to buffer during a cluster reconnect window.
+pub const DEFAULT_RECOVERY_REQUESTS_QUEUE_SIZE: u32 = 1000;
+
 /// This represents an async Cluster connection. It stores the
 /// underlying connections maintained for each node in the cluster, as well
 /// as common parameters for connecting to nodes and executing commands.
@@ -631,10 +634,14 @@ pub(crate) struct ClusterConnInner<C> {
     periodic_checks_handler: Option<JoinHandle<()>>,
     // Handler of fast connection validation task
     connections_validation_handler: Option<JoinHandle<()>>,
+    /// Requests buffered during a reconnect/recovery window.
+    /// Drained to `in_flight_requests` once recovery completes.
+    /// Bounded by `recovery_requests_queue_size` cluster param (default 1000).
+    recovery_queue: std::collections::VecDeque<PendingRequest<C>>,
 }
 
 impl<C> Dispose for ClusterConnInner<C> {
-    fn dispose(self) {
+    fn dispose(mut self) {
         if let Some(conn_lock) = self.inner.conn_lock.try_read() {
             // Each node may contain user and *maybe* a management connection
             let mut count = 0usize;
@@ -652,6 +659,14 @@ impl<C> Dispose for ClusterConnInner<C> {
         if let Some(handle) = self.connections_validation_handler {
             #[cfg(feature = "tokio-comp")]
             handle.abort()
+        }
+
+        // Fail any requests buffered in the recovery queue
+        for request in self.recovery_queue.drain(..) {
+            let _ = request.sender.send(Err(RedisError::from((
+                ErrorKind::ClientError,
+                "Connection dropped",
+            ))));
         }
 
         // Reduce the number of clients
@@ -1569,6 +1584,7 @@ where
             state: ConnectionState::PollComplete,
             periodic_checks_handler: None,
             connections_validation_handler: None,
+            recovery_queue: std::collections::VecDeque::new(),
         };
         // Initial slots and subscriptions refresh
         Self::refresh_slots_and_subscriptions_with_retries(
@@ -3517,8 +3533,92 @@ where
     }
 
     /// Fail all pending requests immediately with ClientError.
+    /// Buffer incoming requests into the recovery queue while reconnect is in progress.
+    /// Requests beyond the queue cap are immediately failed to provide bounded memory usage.
+    /// The cap is configured via `recovery_requests_queue_size` in `ClusterParams` (default 1000).
+    fn buffer_pending_requests_to_recovery_queue(&mut self) {
+        let cap = self
+            .inner
+            .get_cluster_param(|p| p.recovery_requests_queue_size)
+            .unwrap_or(DEFAULT_RECOVERY_REQUESTS_QUEUE_SIZE) as usize;
+
+        let mut rx_guard = self
+            .inner
+            .pending_requests_rx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // Pre-emptively reclaim slots held by requests whose callers have already
+        // given up (e.g. timed out), freeing space before we try to enqueue new ones.
+        if self.recovery_queue.len() >= cap {
+            self.recovery_queue
+                .retain(|queued| !queued.sender.is_closed());
+        }
+
+        let mut overflow_count = 0usize;
+        while let Ok(request) = rx_guard.try_recv() {
+            if request.sender.is_closed() {
+                continue; // caller already gave up (e.g. client-side timeout)
+            }
+            if self.recovery_queue.len() < cap {
+                self.recovery_queue.push_back(request);
+            } else {
+                // Fail inline to avoid accumulating an unbounded overflow Vec.
+                let _ = request.sender.send(Err(RedisError::from((
+                    ErrorKind::ClientError,
+                    "Connection in recovery",
+                ))));
+                overflow_count += 1;
+            }
+        }
+        drop(rx_guard);
+
+        if overflow_count > 0 {
+            log_warn_rate_limited!(
+                "cluster",
+                5,
+                format!(
+                    "buffer_pending_requests_to_recovery_queue: recovery queue full (cap={}), \
+                     failed {} overflow requests",
+                    cap, overflow_count
+                )
+            );
+        }
+    }
+
+    /// Drain the recovery queue into `in_flight_requests` now that recovery is complete.
+    /// Requests are dispatched in FIFO order (the order they arrived while recovering).
+    fn drain_recovery_queue_to_inflight(&mut self) {
+        if self.recovery_queue.is_empty() {
+            return;
+        }
+        let retry_params = self.inner.cluster_params.read().retry_params.clone();
+        let count = self.recovery_queue.len();
+        log_info_rate_limited!(
+            "cluster",
+            10,
+            format!(
+                "drain_recovery_queue_to_inflight: dispatching {} queued requests after recovery",
+                count
+            )
+        );
+        while let Some(request) = self.recovery_queue.pop_front() {
+            if request.sender.is_closed() {
+                continue; // caller gave up
+            }
+            let future = Self::try_request(request.info.clone(), self.inner.clone()).boxed();
+            self.in_flight_requests.push(Box::pin(Request {
+                retry_params: retry_params.clone(),
+                request: Some(request),
+                core: self.inner.clone(),
+                future: RequestState::Future { future },
+            }));
+        }
+    }
+
+    /// Fail all pending requests immediately with ClientError.
     /// Called when entering recovery to prevent requests from waiting for slow
-    /// reconnection cycles.
+    /// reconnection cycles (e.g., ReconnectToInitialNodes, RefreshingSlots).
     fn fail_pending_requests(inner: &Core<C>) {
         let mut rx_guard = inner
             .pending_requests_rx
@@ -3595,7 +3695,8 @@ where
                             self.state = ConnectionState::Recover(RecoverFuture::RefreshingSlots(
                                 new_handle,
                             ));
-                            Poll::Ready(Ok(()))
+                            cx.waker().wake_by_ref(); // ensure we are polled again to check the new handle
+                            Poll::Pending // stay in recovery, do NOT drain the queue yet
                         }
                     }
                     Poll::Ready(Err(join_err)) => {
@@ -3936,16 +4037,35 @@ where
 
         match self.as_mut().poll_recover(cx) {
             Poll::Pending => {
-                // Fail any requests queued while in recovery
-                ClusterConnInner::fail_pending_requests(&self.inner);
+                // Only buffer during fast reconnects (circular MOVED path).
+                // For ReconnectToInitialNodes and RefreshingSlots, fail fast to preserve throughput.
+                if matches!(
+                    &self.state,
+                    ConnectionState::Recover(RecoverFuture::Reconnect(_))
+                ) {
+                    self.buffer_pending_requests_to_recovery_queue();
+                } else {
+                    ClusterConnInner::fail_pending_requests(&self.inner);
+                }
                 return Poll::Pending;
             }
             Poll::Ready(Err(err)) => {
+                // Same: only buffer during fast Reconnect path.
+                if matches!(
+                    &self.state,
+                    ConnectionState::Recover(RecoverFuture::Reconnect(_))
+                ) {
+                    self.buffer_pending_requests_to_recovery_queue();
+                } else {
+                    ClusterConnInner::fail_pending_requests(&self.inner);
+                }
                 self.refresh_error = Some(err);
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
-            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Ok(())) => {
+                self.drain_recovery_queue_to_inflight();
+            }
         }
 
         match ready!(self.poll_complete(cx)) {
@@ -4052,6 +4172,13 @@ where
         // If we no longer have any requests in flight we are done (skips any reconnection
         // attempts)
         if self.in_flight_requests.is_empty() {
+            // Fail any requests buffered during recovery — we are closing, they won't be retried.
+            for request in self.recovery_queue.drain(..) {
+                let _ = request.sender.send(Err(RedisError::from((
+                    ErrorKind::ClientError,
+                    "Connection closed",
+                ))));
+            }
             return Poll::Ready(Ok(()));
         }
 

--- a/glide-core/redis-rs/redis/src/cluster_client.rs
+++ b/glide-core/redis-rs/redis/src/cluster_client.rs
@@ -52,6 +52,7 @@ struct BuilderParams {
     cache: Option<Arc<dyn GlideCache>>,
     server_assisted_cache: bool,
     address_resolver: Option<Arc<dyn AddressResolver>>,
+    recovery_requests_queue_size: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -159,6 +160,7 @@ pub struct ClusterParams {
     pub(crate) server_assisted_cache: bool,
     /// Optional callback for resolving addresses before connection.
     pub(crate) address_resolver: Option<Arc<dyn AddressResolver>>,
+    pub(crate) recovery_requests_queue_size: Option<u32>,
 }
 
 impl ClusterParams {
@@ -194,6 +196,7 @@ impl ClusterParams {
             cache: value.cache,
             server_assisted_cache: value.server_assisted_cache,
             address_resolver: value.address_resolver,
+            recovery_requests_queue_size: value.recovery_requests_queue_size,
         })
     }
 }
@@ -227,6 +230,7 @@ impl ClusterParams {
             cache: None,
             server_assisted_cache: false,
             address_resolver: None,
+            recovery_requests_queue_size: None, // will use default of 1000 in buffer_pending_requests
         }
     }
 }
@@ -600,6 +604,15 @@ impl ClusterClientBuilder {
     /// Sets whether server-assisted client-side caching (CLIENT TRACKING) is enabled.
     pub fn server_assisted_cache(mut self, enabled: bool) -> ClusterClientBuilder {
         self.builder_params.server_assisted_cache = enabled;
+        self
+    }
+
+    /// Sets the maximum number of requests to buffer in the recovery queue when a cluster
+    /// reconnect is in progress. Buffered requests are retried transparently after
+    /// reconnection. Requests beyond this limit are failed immediately to provide bounded
+    /// memory usage. Defaults to 1000 if not set.
+    pub fn recovery_requests_queue_size(mut self, size: u32) -> ClusterClientBuilder {
+        self.builder_params.recovery_requests_queue_size = Some(size);
         self
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7136,6 +7136,237 @@ mod cluster_async {
         );
     }
 
+    /// Mirrors the Python stress-test script that exposed the "Connection in recovery" bug.
+    ///
+    /// ## Scenario
+    ///
+    /// 20 concurrent tasks each send PIPELINE_ITERATIONS × PIPELINE_SIZE individual SET
+    /// commands. The mock triggers a circular MOVED on the **30th SET command globally**,
+    /// so several commands complete successfully before the disruption. After the MOVED
+    /// triggers, all subsequent SETs are delayed by 5ms and return OK.
+    ///
+    /// The circular MOVED on an individual command causes the cluster client to enter a
+    /// reconnect/recovery cycle (via `Next::Reconnect` → `PollFlushAction::Reconnect` →
+    /// `RecoverFuture::Reconnect`). Any commands that arrive at `pending_requests_tx`
+    /// while the connection is in recovery must be **buffered** (not failed) and succeed
+    /// once recovery completes.
+    ///
+    /// ## Why individual commands (not pipelines)
+    ///
+    /// Pipeline MOVED errors are handled inline within `handle_non_atomic_pipeline_request`
+    /// via `handle_reconnect_logic`, which bypasses the Sink's state machine entirely.
+    /// Only individual commands go through `Next::Reconnect` → `PollFlushAction::Reconnect`
+    /// → Sink's `Recover` state, which is the path where `buffer_pending_requests_to_recovery_queue`
+    /// is exercised.
+    ///
+    /// ## Why this requires a multi-threaded runtime
+    ///
+    /// On a single-threaded (current_thread) runtime, the reconnect's outer JoinHandle
+    /// always completes before the background connection task's next `poll_flush`, so
+    /// `poll_recover` always returns `Poll::Ready` and no requests see the recovery window.
+    ///
+    /// On a multi-threaded runtime the background task and the reconnect task can run on
+    /// different OS threads simultaneously; `poll_recover` may return `Poll::Pending` with
+    /// requests already queued, exercising the buffering path.
+    ///
+    /// ## SET delay after MOVED
+    ///
+    /// Once the circular MOVED fires, the mock handler inserts a 5 ms
+    /// `std::thread::sleep` before returning OK for every subsequent SET command.
+    /// This simulates realistic server latency and keeps tasks slow to complete,
+    /// ensuring they are in-flight (queued in `pending_requests_tx`) during the recovery
+    /// window.
+    ///
+    /// ## PING delay
+    ///
+    /// The PING handler (part of the reconnect handshake) sleeps 10 ms to widen the
+    /// recovery window. This keeps the reconnect JoinHandle in `Poll::Pending` long enough
+    /// for concurrent tasks to queue commands in `pending_requests_tx`.
+    ///
+    /// ## Test flow
+    ///
+    /// 1. Use a multi-threaded Tokio runtime with 4 worker threads.
+    /// 2. Register mock behaviour for a synthetic cluster name.
+    /// 3. 20 tasks start together behind a barrier; each sends PIPELINE_ITERATIONS × PIPELINE_SIZE
+    ///    individual SET commands.
+    /// 4. On the 30th SET globally the mock returns a circular MOVED → Sink enters Recover state.
+    /// 5. After MOVED fires, every SET response is delayed 5ms to keep tasks in-flight.
+    /// 6. PING is delayed 10ms to keep the reconnect JoinHandle pending.
+    /// 7. Commands arriving during recovery must be buffered and succeed after recovery.
+    /// 8. Assert zero command errors across all tasks.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_concurrent_requests_during_circular_moved_reconnect() {
+        let name = "test_concurrent_circular_moved";
+        // Trigger circular MOVED on the Nth SET to let several pipelines succeed before disruption
+        const MOVED_ON_SET_N: usize = 30;
+        const CONCURRENCY: usize = 20;
+        const PIPELINE_ITERATIONS: usize = 5;
+        const PIPELINE_SIZE: usize = 10; // SET commands per pipeline
+                                         // After MOVED fires, delay each SET response by this many ms to widen recovery window
+        const DELAY_AFTER_MOVED_MS: u64 = 5;
+        // Delay CLUSTER SLOTS response to keep the recovery JoinHandle in Poll::Pending longer.
+        // This is the primary mechanism for widening the recovery window: by slowing the
+        // slots-refresh task, concurrent pipeline tasks accumulate in pending_requests_tx.
+        const CLUSTER_SLOTS_DELAY_MS: u64 = 30;
+
+        let set_count = Arc::new(atomic::AtomicUsize::new(0));
+        let set_count_clone = set_count.clone();
+        let moved_fired = Arc::new(atomic::AtomicBool::new(false));
+        let moved_fired_clone = moved_fired.clone();
+        let moved_fired_cluster = moved_fired.clone();
+        let name_handler = name.to_string();
+
+        // Register the mock handler globally so it is available to the multi-threaded
+        // runtime's background connection task.
+        let _handler = MockConnectionBehavior::register_new(
+            name,
+            Arc::new(move |cmd: &[u8], port| {
+                let name = name_handler.as_str();
+                if contains_slice(cmd, b"PING") {
+                    // Delay PING to keep the reconnect JoinHandle in Poll::Pending while
+                    // concurrent tasks queue commands in pending_requests_tx.
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    // After MOVED fires, delay the CLUSTER SLOTS response to keep the
+                    // recovery JoinHandle in Poll::Pending while pipeline tasks queue up.
+                    if moved_fired_cluster.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            CLUSTER_SLOTS_DELAY_MS,
+                        ));
+                    }
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::Int(port as i64),
+                        ]),
+                    ])])));
+                }
+                if contains_slice(cmd, b"SET") {
+                    let i = set_count_clone.fetch_add(1, atomic::Ordering::SeqCst);
+                    if i == MOVED_ON_SET_N {
+                        // Trigger circular MOVED mid-run to exercise the recovery window
+                        moved_fired_clone.store(true, atomic::Ordering::SeqCst);
+                        return Err(parse_redis_value(
+                            format!("-MOVED 5000 {name}:{port}\r\n").as_bytes(),
+                        ));
+                    }
+                    // After MOVED has fired, delay to keep pipelines in-flight during recovery
+                    if moved_fired_clone.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(DELAY_AFTER_MOVED_MS));
+                    }
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"GET") {
+                    return Err(Ok(Value::BulkString(b"value".to_vec().into())));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        // Use a multi-threaded runtime so that the background connection task and the
+        // reconnect task can run on different OS threads simultaneously.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(4)
+            .build()
+            .expect("failed to build multi-thread runtime");
+
+        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .retries(5)
+            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
+            .build()
+            .expect("failed to build ClusterClient");
+
+        let connection: ClusterConnection<MockConnection> = runtime
+            .block_on(client.get_async_generic_connection())
+            .expect("failed to get async connection");
+
+        // Each task sends PIPELINE_ITERATIONS × PIPELINE_SIZE individual SET commands.
+        // All tasks start simultaneously via a barrier.
+        // The circular MOVED fires mid-run (on SET #{MOVED_ON_SET_N} globally); commands
+        // arriving while the Sink is in recovery must be buffered and succeed, not fail.
+        let results = runtime.block_on(async move {
+            let barrier = Arc::new(tokio::sync::Barrier::new(CONCURRENCY));
+            let tasks: Vec<_> = (0..CONCURRENCY)
+                .map(|task_id| {
+                    let mut conn = connection.clone();
+                    let barrier = barrier.clone();
+                    tokio::spawn(async move {
+                        barrier.wait().await;
+                        let mut cmd_errors = 0usize;
+                        let mut cmd_successes = 0usize;
+                        for iter in 0..PIPELINE_ITERATIONS {
+                            for k in 0..PIPELINE_SIZE {
+                                let cmd = redis::Cmd::new()
+                                    .arg("SET")
+                                    .arg(format!("t{task_id}_key{k}"))
+                                    .arg("value")
+                                    .clone();
+                                match conn.req_packed_command(&cmd).await {
+                                    Ok(_) => cmd_successes += 1,
+                                    Err(e) => {
+                                        println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
+                                        cmd_errors += 1;
+                                    }
+                                }
+                            }
+                        }
+                        (task_id, cmd_successes, cmd_errors)
+                    })
+                })
+                .collect();
+            futures::future::join_all(tasks).await
+        });
+
+        let total_cmd_successes: usize = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|(_, s, _)| s)
+            .sum();
+        let total_cmd_errors: usize = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|(_, _, e)| e)
+            .sum();
+        let total_sets = set_count.load(atomic::Ordering::SeqCst);
+        let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
+
+        println!(
+            "Results: {} tasks, {}/{} SET commands succeeded, {} cmd errors, \
+             {} SET commands reached mock (MOVED triggered on SET #{})",
+            CONCURRENCY,
+            total_cmd_successes,
+            expected_cmds,
+            total_cmd_errors,
+            total_sets,
+            MOVED_ON_SET_N,
+        );
+
+        assert_eq!(
+            total_cmd_errors, 0,
+            "Expected zero command errors after recovery queue fix. \
+             {} commands failed (total SETs to mock: {})",
+            total_cmd_errors, total_sets,
+        );
+
+        println!(
+            "PASS: all {}/{} SET commands succeeded with zero errors during/after circular MOVED reconnect",
+            total_cmd_successes,
+            expected_cmds,
+        );
+    }
+
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;
         use redis::ConnectionInfo;

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -67,6 +67,12 @@ pub const FINISHED_SCAN_CURSOR: &str = "finished";
 /// The value of 1000 provides a buffer for bursts while still allowing full utilization of the maximum request rate.
 pub const DEFAULT_MAX_INFLIGHT_REQUESTS: u32 = 1000;
 
+/// Default recovery queue size: maximum requests buffered during cluster reconnect.
+/// Buffered requests are retried transparently after reconnection. Requests beyond
+/// this limit are failed immediately to provide bounded memory usage.
+/// See `recovery_requests_queue_size` in `ConnectionRequest`.
+pub const DEFAULT_RECOVERY_REQUESTS_QUEUE_SIZE: u32 = 1000;
+
 /// The connection check interval is currently not exposed to the user via ConnectionRequest,
 /// as improper configuration could negatively impact performance or pub/sub resiliency.
 /// A 3-second interval provides a reasonable balance between connection validation
@@ -2106,6 +2112,11 @@ async fn create_cluster_client(
     // Always use with Glide
     builder = builder.periodic_connections_checks(Some(CONNECTION_CHECKS_INTERVAL));
 
+    let recovery_requests_queue_size = request
+        .recovery_requests_queue_size
+        .unwrap_or(DEFAULT_RECOVERY_REQUESTS_QUEUE_SIZE);
+    builder = builder.recovery_requests_queue_size(recovery_requests_queue_size);
+
     let client = builder.build()?;
     let iam_token_provider: Option<Arc<dyn redis::IAMTokenProvider>> = iam_token_manager
         .map(|manager| Arc::new(manager.get_token_handle()) as Arc<dyn redis::IAMTokenProvider>);
@@ -2298,6 +2309,11 @@ fn sanitized_request_string(request: &ConnectionRequest) -> String {
         request.inflight_requests_limit,
     );
 
+    let recovery_requests_queue_size = format_optional_value(
+        "\nRecovery requests queue size: {}",
+        request.recovery_requests_queue_size,
+    );
+
     let node_discovery_mode = match request.node_discovery_mode {
         NodeDiscoveryMode::Standard => "\nNode discovery mode: Standard",
         NodeDiscoveryMode::Static => "\nNode discovery mode: Static",
@@ -2305,7 +2321,7 @@ fn sanitized_request_string(request: &ConnectionRequest) -> String {
     };
 
     format!(
-        "\nAddresses: {addresses}{tls_mode}{cluster_mode}{request_timeout}{connection_timeout}{rfr_strategy}{connection_retry_strategy}{database_id}{protocol}{client_name}{periodic_checks}{pubsub_subscriptions}{inflight_requests_limit}{node_discovery_mode}",
+        "\nAddresses: {addresses}{tls_mode}{cluster_mode}{request_timeout}{connection_timeout}{rfr_strategy}{connection_retry_strategy}{database_id}{protocol}{client_name}{periodic_checks}{pubsub_subscriptions}{inflight_requests_limit}{recovery_requests_queue_size}{node_discovery_mode}",
     )
 }
 

--- a/glide-core/src/client/types.rs
+++ b/glide-core/src/client/types.rs
@@ -36,6 +36,7 @@ pub struct ConnectionRequest {
     pub periodic_checks: Option<PeriodicCheck>,
     pub pubsub_subscriptions: Option<redis::PubSubSubscriptionInfo>,
     pub inflight_requests_limit: Option<u32>,
+    pub recovery_requests_queue_size: Option<u32>,
     pub lazy_connect: bool,
     pub refresh_topology_from_initial_nodes: bool,
     pub root_certs: Vec<Vec<u8>>,
@@ -353,6 +354,7 @@ impl From<protobuf::ConnectionRequest> for ConnectionRequest {
         }
 
         let inflight_requests_limit = none_if_zero(value.inflight_requests_limit);
+        let recovery_requests_queue_size = value.recovery_requests_queue_size;
         let lazy_connect = value.lazy_connect;
         let refresh_topology_from_initial_nodes = value.refresh_topology_from_initial_nodes;
         let root_certs = value
@@ -447,6 +449,7 @@ impl From<protobuf::ConnectionRequest> for ConnectionRequest {
             periodic_checks,
             pubsub_subscriptions,
             inflight_requests_limit,
+            recovery_requests_queue_size,
             lazy_connect,
             refresh_topology_from_initial_nodes,
             root_certs,

--- a/glide-core/src/protobuf/connection_request.proto
+++ b/glide-core/src/protobuf/connection_request.proto
@@ -139,6 +139,7 @@ message ConnectionRequest {
     NodeDiscoveryMode node_discovery_mode = 28;
     optional string address_resolver_key = 29;
     optional ClientCircuitBreakerConfig client_circuit_breaker = 30;
+    optional uint32 recovery_requests_queue_size = 34;
 }
 
 message ClientCircuitBreakerConfig {

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -631,7 +631,8 @@ func (config *ClientConfiguration) GetSubscription() *StandaloneSubscriptionConf
 // used.
 type ClusterClientConfiguration struct {
 	baseClientConfiguration
-	subscriptionConfig *ClusterSubscriptionConfig
+	subscriptionConfig        *ClusterSubscriptionConfig
+	recoveryRequestsQueueSize *uint32
 	AdvancedClusterClientConfiguration
 }
 
@@ -712,6 +713,10 @@ func (config *ClusterClientConfiguration) ToProtobuf() (*protobuf.ConnectionRequ
 			}
 			request.RootCerts = [][]byte{tlsConfig.RootCertificates}
 		}
+	}
+
+	if config.recoveryRequestsQueueSize != nil {
+		request.RecoveryRequestsQueueSize = config.recoveryRequestsQueueSize
 	}
 
 	return request, nil
@@ -854,6 +859,16 @@ func (config *ClusterClientConfiguration) WithClientCircuitBreaker(
 	cb *ClientCircuitBreakerConfiguration,
 ) *ClusterClientConfiguration {
 	config.clientCircuitBreaker = cb
+	return config
+}
+
+// WithRecoveryRequestsQueueSize sets the maximum number of requests to buffer in the
+// recovery queue when a cluster reconnect is in progress. Buffered requests are retried
+// transparently after reconnection. Requests beyond this limit are failed immediately.
+// Set to 0 to disable the recovery queue and use fail-fast behavior.
+// If not set, a default value of 1000 will be used.
+func (config *ClusterClientConfiguration) WithRecoveryRequestsQueueSize(size uint32) *ClusterClientConfiguration {
+	config.recoveryRequestsQueueSize = &size
 	return config
 }
 

--- a/go/config/config_test.go
+++ b/go/config/config_test.go
@@ -1482,3 +1482,33 @@ func TestNewClientSideCache_ServerAssistedExplicitlyDisabled(t *testing.T) {
 	cache.WithServerAssisted(false)
 	assert.False(t, cache.ServerAssisted)
 }
+
+func TestClusterClientConfiguration_WithRecoveryRequestsQueueSize(t *testing.T) {
+	config := NewClusterClientConfiguration().
+		WithAddress(&NodeAddress{Host: "localhost", Port: 6379}).
+		WithRecoveryRequestsQueueSize(2000)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(2000), result.GetRecoveryRequestsQueueSize())
+}
+
+func TestClusterClientConfiguration_WithRecoveryRequestsQueueSize_notSet(t *testing.T) {
+	config := NewClusterClientConfiguration().
+		WithAddress(&NodeAddress{Host: "localhost", Port: 6379})
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.Nil(t, result.RecoveryRequestsQueueSize) // nil when not set
+}
+
+func TestClusterClientConfiguration_WithRecoveryRequestsQueueSize_zero_disables_queue(t *testing.T) {
+	config := NewClusterClientConfiguration().
+		WithAddress(&NodeAddress{Host: "localhost", Port: 6379}).
+		WithRecoveryRequestsQueueSize(0)
+
+	result, err := config.ToProtobuf()
+	assert.NoError(t, err)
+	assert.NotNil(t, result.RecoveryRequestsQueueSize)
+	assert.Equal(t, uint32(0), *result.RecoveryRequestsQueueSize) // 0 = disabled
+}

--- a/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/GlideClusterClientConfiguration.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
  *         .subscriptionConfiguration(subscriptionConfiguration)
  *         .reconnectStrategy(reconnectionConfiguration)
  *         .inflightRequestsLimit(1000)
+ *         .recoveryRequestsQueueSize(1000)
  *         .clientSideCache(ClientSideCache.create(1024, 60000))
  *         .advancedConfiguration(AdvancedGlideClusterClientConfiguration.builder().connectionTimeout(500).build())
  *         .build();
@@ -42,4 +43,12 @@ public class GlideClusterClientConfiguration extends BaseClientConfiguration {
     @Builder.Default
     private final AdvancedGlideClusterClientConfiguration advancedConfiguration =
             AdvancedGlideClusterClientConfiguration.builder().build();
+
+    /**
+     * The maximum number of requests to buffer in the recovery queue when a cluster reconnect is in
+     * progress. Buffered requests are retried transparently after reconnection. Requests beyond this
+     * limit are failed immediately to provide bounded memory usage. If not set, a default value of
+     * 1000 will be used. Set to 0 to disable the recovery queue and restore fail-fast behaviour.
+     */
+    private final Integer recoveryRequestsQueueSize;
 }

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -268,6 +268,13 @@ public class ConnectionManager {
                                                     .build());
                                 }
                             }
+
+                            // Set recovery requests queue size only when explicitly
+                            // configured; the core applies its own default otherwise.
+                            if (clusterConfig.getRecoveryRequestsQueueSize() != null) {
+                                requestBuilder.setRecoveryRequestsQueueSize(
+                                        clusterConfig.getRecoveryRequestsQueueSize());
+                            }
                         }
 
                         // Set timeouts

--- a/java/client/src/test/java/glide/api/models/configuration/BaseClientConfigurationTest.java
+++ b/java/client/src/test/java/glide/api/models/configuration/BaseClientConfigurationTest.java
@@ -161,4 +161,26 @@ public class BaseClientConfigurationTest {
         ClientSideCache cacheDefault = ClientSideCache.builder().maxCacheKb(1024).build();
         assertFalse(cacheDefault.isServerAssisted());
     }
+
+    @Test
+    public void testRecoveryRequestsQueueSizeDefault() {
+        // recoveryRequestsQueueSize should default to null when not specified
+        GlideClusterClientConfiguration config =
+                GlideClusterClientConfiguration.builder()
+                        .address(NodeAddress.builder().host("localhost").port(7000).build())
+                        .build();
+        assertNull(config.getRecoveryRequestsQueueSize());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 100, 500, 1000, 5000})
+    public void testRecoveryRequestsQueueSizeSetValue(int queueSize) {
+        // recoveryRequestsQueueSize should be stored on the cluster config
+        GlideClusterClientConfiguration config =
+                GlideClusterClientConfiguration.builder()
+                        .address(NodeAddress.builder().host("localhost").port(7000).build())
+                        .recoveryRequestsQueueSize(queueSize)
+                        .build();
+        assertEquals(queueSize, config.getRecoveryRequestsQueueSize());
+    }
 }

--- a/node/src/GlideClusterClient.ts
+++ b/node/src/GlideClusterClient.ts
@@ -282,6 +282,15 @@ export type GlideClusterClientConfiguration = BaseClientConfiguration & {
     periodicChecks?: PeriodicChecks;
 
     /**
+     * The maximum number of requests to buffer in the recovery queue when a cluster
+     * reconnect is in progress. Buffered requests are retried transparently after
+     * reconnection. Requests beyond this limit are failed immediately to provide
+     * bounded memory usage. If not set, a default value of 1000 will be used.
+     * Set to 0 to disable the recovery queue and use fail-fast behavior.
+     */
+    recoveryRequestsQueueSize?: number;
+
+    /**
      * PubSub subscriptions to be used for the client.
      * Will be applied via SUBSCRIBE/PSUBSCRIBE/SSUBSCRIBE commands during connection establishment.
      */
@@ -679,6 +688,11 @@ export class GlideClusterClient extends BaseClient {
         }
 
         this.configurePubsub(options, configuration);
+
+        if (options.recoveryRequestsQueueSize !== undefined) {
+            configuration.recoveryRequestsQueueSize =
+                options.recoveryRequestsQueueSize;
+        }
 
         if (options.advancedConfiguration) {
             this.configureAdvancedConfigurationBase(

--- a/node/tests/GlideClientInternals.test.ts
+++ b/node/tests/GlideClientInternals.test.ts
@@ -1095,6 +1095,23 @@ describe("GlideClusterClientConfiguration", () => {
             config.advancedConfiguration?.refreshTopologyFromInitialNodes,
         ).toBeUndefined();
     });
+
+    it("should set recoveryRequestsQueueSize", () => {
+        const config: GlideClusterClientConfiguration = {
+            addresses: [{ host: "localhost", port: 6379 }],
+            recoveryRequestsQueueSize: 500,
+        };
+
+        expect(config.recoveryRequestsQueueSize).toBe(500);
+    });
+
+    it("should default recoveryRequestsQueueSize to undefined when not specified", () => {
+        const config: GlideClusterClientConfiguration = {
+            addresses: [{ host: "localhost", port: 6379 }],
+        };
+
+        expect(config.recoveryRequestsQueueSize).toBeUndefined();
+    });
 });
 
 describe("Circular Dependency Fix", () => {

--- a/python/.flake8
+++ b/python/.flake8
@@ -9,5 +9,6 @@ exclude =
     .denv
     .env_main
     glide-shared/glide_shared/protobuf
+    glide-async/python/glide_shared/protobuf
     build
 extend-ignore = E203

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
+ "sha2",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "telemetrylib",

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -1052,7 +1052,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
- "sha2",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "telemetrylib",

--- a/python/glide-shared/glide_shared/config.py
+++ b/python/glide-shared/glide_shared/config.py
@@ -1304,6 +1304,12 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
             This limit is used to control the memory usage and prevent the client from overwhelming the server or getting
             stuck in case of a queue backlog.
             If not set, a default value will be used.
+        recovery_requests_queue_size (Optional[int]): The maximum number of requests to buffer in the
+            recovery queue when a cluster reconnect is in progress. Buffered requests are retried
+            transparently after reconnection. Requests beyond this limit are failed immediately to
+            provide bounded memory usage.
+            Set to 0 to disable the recovery queue and use fail-fast behavior.
+            If not set, a default value of 1000 will be used.
         client_az (Optional[str]): Availability Zone of the client.
             If ReadFrom strategy is AZAffinity, this setting ensures that readonly commands are directed to replicas within
             the specified AZ if exits.
@@ -1388,6 +1394,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         ] = PeriodicChecksStatus.ENABLED_DEFAULT_CONFIGS,
         pubsub_subscriptions: Optional[PubSubSubscriptions] = None,
         inflight_requests_limit: Optional[int] = None,
+        recovery_requests_queue_size: Optional[int] = None,
         client_az: Optional[str] = None,
         advanced_config: Optional[AdvancedGlideClusterClientConfiguration] = None,
         lazy_connect: Optional[bool] = None,
@@ -1417,6 +1424,7 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
         )
         self.periodic_checks = periodic_checks
         self.pubsub_subscriptions = pubsub_subscriptions
+        self.recovery_requests_queue_size = recovery_requests_queue_size
 
     def _create_a_protobuf_conn_request(
         self, cluster_mode: bool = False
@@ -1454,6 +1462,8 @@ class GlideClusterClientConfiguration(BaseClientConfiguration):
 
         if self.lazy_connect is not None:
             request.lazy_connect = self.lazy_connect
+        if self.recovery_requests_queue_size is not None:
+            request.recovery_requests_queue_size = self.recovery_requests_queue_size
         return request
 
     def _get_pubsub_callback_and_context(

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -714,3 +714,19 @@ def test_tcp_nodelay_in_protobuf_request():
     )
     request_default = config_default._create_a_protobuf_conn_request()
     assert not request_default.HasField("tcp_nodelay")
+
+
+def test_recovery_requests_queue_size_in_proto():
+    """Verify recovery_requests_queue_size is accepted and mapped to the proto request."""
+    # Default: not set — field should be absent (HasField returns False)
+    config = GlideClusterClientConfiguration([NodeAddress("localhost", 6379)])
+    request = config._create_a_protobuf_conn_request(cluster_mode=True)
+    assert not request.HasField("recovery_requests_queue_size")
+
+    # Custom value
+    config_custom = GlideClusterClientConfiguration(
+        [NodeAddress("localhost", 6379)],
+        recovery_requests_queue_size=500,
+    )
+    request_custom = config_custom._create_a_protobuf_conn_request(cluster_mode=True)
+    assert request_custom.recovery_requests_queue_size == 500


### PR DESCRIPTION
### Summary

Cherry-pick of #6640 into release-2.5.

Buffers pending cluster requests during a circular MOVED reconnect window instead of immediately failing them with `"Connection in recovery"`. Requests are queued (bounded by `recovery_requests_queue_size`, default 1000) and retried transparently once reconnection completes.

### Issue link

Cherry-pick of [#6640](https://github.com/valkey-io/valkey-glide/pull/6640)

### Features / Behaviour Changes

See #6640 for full details.

### Implementation

Adapted for release-2.5: the only structural difference from main is that `in_flight_requests` on release-2.5 uses `FuturesUnordered<Pin<Box<Request<C>>>>` (pinned + boxed) rather than `FuturesUnordered<Request<C>>`, so `drain_recovery_queue_to_inflight` wraps the push with `Box::pin(...)`.

### Testing

All circular MOVED tests pass. See #6640 for full test details.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] Linters pass clean.
- [x] Destination branch is correct - release-2.5