### PR TITLE
[Backport release-2.5] Java: Fix Dockerfile for AL2023 compatibility (#6634)

### DIFF
--- a/java/e2e/circuit-breaker-test/Dockerfile
+++ b/java/e2e/circuit-breaker-test/Dockerfile
@@ -2,8 +2,10 @@ FROM amazoncorretto:21
 
 WORKDIR /app
 
-# Install Docker CLI for container manipulation (exec DEBUG SLEEP)
-RUN yum install -y tar gzip curl && \
+# Install Docker CLI for container manipulation (exec DEBUG SLEEP).
+# curl is already provided by the base image's curl-minimal package; installing the
+# full curl package conflicts with it, so we only add tar/gzip here.
+RUN yum install -y tar gzip && \
     curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.5.1.tgz | \
     tar xz --strip-components=1 -C /usr/local/bin docker/docker && \
     yum clean all

--- a/java/e2e/dns-failover-test/Dockerfile
+++ b/java/e2e/dns-failover-test/Dockerfile
@@ -1,9 +1,14 @@
-FROM public.ecr.aws/amazoncorretto/amazoncorretto:21
+FROM amazoncorretto:21
 
 WORKDIR /app
 
-# Install Docker CLI
-RUN amazon-linux-extras install docker -y && yum clean all
+# Install Docker CLI for container manipulation (stop cluster nodes, restart DNS server).
+# curl is already provided by the base image's curl-minimal package; installing the
+# full curl package conflicts with it, so we only add tar/gzip here.
+RUN yum install -y tar gzip && \
+    curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.5.1.tgz | \
+    tar xz --strip-components=1 -C /usr/local/bin docker/docker && \
+    yum clean all
 
 # Copy the application JAR
 COPY build/libs/dns-failover-test-1.0-SNAPSHOT.jar /app/app.jar


### PR DESCRIPTION
### Summary

Backport of #6634 to `release-2.5`. Fix the Java e2e DNS failover and circuit-breaker-test Dockerfiles for AL2023 compatibility (package name changes) and pin the static Docker client used by the DNS failover test.

### Issue link

N/A (backport of #6634).

### Features / Behaviour Changes

None (identical Dockerfile fix already in `main`).

### Implementation

Cherry-picked a0770b0fc5be5cb249a655e6d1cfaa6480512c09 from `main`. Applied cleanly with no conflicts because both Dockerfiles on `release-2.5` were byte-identical to their pre-fix state on `main`.

### Limitations

N/A.

### Testing

Same test surface as #6634 (the e2e Docker images now build on AL2023 runners). CI on this PR will exercise the affected paths.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary