### PR TITLE
FFI: Percent-decode userinfo in `create_client_from_uri`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core/FFI: Percent-decode userinfo in `create_client_from_uri` so credentials containing URI-reserved characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`, space, non-ASCII) authenticate correctly ([#6659](https://github.com/valkey-io/valkey-glide/issues/6659))
 * Core/All: Buffer pending cluster requests during reconnect instead of failing immediately. When a circular MOVED redirect triggers a reconnect, requests arriving during the recovery window are now queued and retried transparently once reconnection completes. A new `recovery_requests_queue_size` option (default: 1000) controls the queue depth. ([#6640](https://github.com/valkey-io/valkey-glide/pull/6640))
 * Java: Make the automatic JVM shutdown hook non-destructive so a command issued from a user's own shutdown hook is no longer rejected with `ClosingException: Client is shutting down`. The JVM runs all shutdown hooks concurrently, and GLIDE's hook previously tore the client down and blocked new requests, racing with (and aborting) legitimate work such as persisting state before exit. Deterministic teardown remains available via the client's `close()`. ([#4809](https://github.com/valkey-io/valkey-glide/issues/4809))
 * Core: Fix native panic for setex psetex and setnx commands ([#6551](https://github.com/valkey-io/valkey-glide/pull/6551))

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "logger_core",
+ "percent-encoding",
  "protobuf",
  "redis",
  "rstest",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -24,6 +24,7 @@ logger_core = { path = "../logger_core" }
 tracing = "0.1"
 serde_json = "1.0"
 url = "2"
+percent-encoding = "2"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -457,6 +457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +645,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,9 +695,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -942,6 +990,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
+ "dashmap 5.5.3",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -959,6 +1008,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
+ "sha2 0.11.0",
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "telemetrylib",
@@ -1034,7 +1084,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1106,6 +1156,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1554,6 +1613,7 @@ dependencies = [
  "mock-logger-core",
  "mock-redis",
  "mock-tokio",
+ "percent-encoding",
  "protobuf",
  "serde_json",
  "url",
@@ -2087,7 +2147,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap",
+ "dashmap 6.1.0",
  "dispose",
  "futures",
  "futures-util",
@@ -2437,7 +2497,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/ffi/miri-tests/Cargo.toml
+++ b/ffi/miri-tests/Cargo.toml
@@ -9,6 +9,7 @@ libc = "0.2"
 protobuf = { version = "3", features = [] }
 serde_json = "1.0"
 url = "2"
+percent-encoding = "2"
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 # Mock crates that can be used as drop-in replacements for the real crates
 redis = { path = "./mock-redis", package = "mock-redis" }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1925,6 +1925,21 @@ mod tests_create_client_from_uri_internal {
             "unexpected error: {err}"
         );
     }
+
+    #[test]
+    fn invalid_utf8_in_username_returns_error() {
+        // Symmetric to invalid_utf8_in_password_returns_error: the username
+        // decode branch must surface the same clear UTF-8 error rather than
+        // silently corrupt bytes. Password is valid so parsing reaches the
+        // username check.
+        let c_uri = CString::new("redis://%C3%28:pw@127.0.0.1:6379").unwrap();
+        let err = create_client_from_uri_internal(c_uri.as_ptr(), std::ptr::null())
+            .expect_err("expected UTF-8 error");
+        assert!(
+            err.contains("Username in URI is not valid UTF-8"),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 fn is_known_connection_options_json_key(key: &str) -> bool {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1790,14 +1790,27 @@ fn create_client_from_uri_internal(
     node_address.port = port;
     request.addresses.push(node_address);
 
-    // Extract authentication
+    // Extract authentication. `url::Url::password()` / `::username()` return the
+    // *percent-encoded* substring per RFC 3986 §3.2.1; the caller is expected
+    // to decode. Forwarding the encoded form as-is causes AUTH to fail whenever
+    // the password contains reserved characters (@, :, /, ?, #, %, +, space,
+    // non-ASCII) — see valkey-glide/issues/6659. This mirrors the decode step
+    // redis-rs itself performs at glide-core/redis-rs/redis/src/connection.rs:370,379.
     if let Some(password) = url.password() {
         let mut auth_info = connection_request::AuthenticationInfo::new();
-        auth_info.password = password.to_string().into();
+        auth_info.password = percent_encoding::percent_decode(password.as_bytes())
+            .decode_utf8()
+            .map_err(|_| "Password in URI is not valid UTF-8".to_string())?
+            .into_owned()
+            .into();
 
         // Handle username if present
         if !url.username().is_empty() {
-            auth_info.username = url.username().to_string().into();
+            auth_info.username = percent_encoding::percent_decode(url.username().as_bytes())
+                .decode_utf8()
+                .map_err(|_| "Username in URI is not valid UTF-8".to_string())?
+                .into_owned()
+                .into();
         }
 
         request.authentication_info = ::protobuf::MessageField::some(auth_info);
@@ -1836,6 +1849,82 @@ fn create_client_from_uri_internal(
     }
 
     Ok(request)
+}
+
+#[cfg(test)]
+mod tests_create_client_from_uri_internal {
+    //! Direct unit tests for `create_client_from_uri_internal`. The wider
+    //! integration suite in `ffi/tests/test_create_client_from_uri.rs` only
+    //! exercises the FFI entry point end-to-end (which requires a live server
+    //! and can't cheaply assert on the protobuf shape). These tests call the
+    //! internal function directly so we can assert that reserved characters
+    //! in userinfo round-trip into `AuthenticationInfo` as raw bytes — the
+    //! regression this file was written to prevent (issue #6659).
+    use super::*;
+    use std::ffi::CString;
+
+    fn parse_uri(uri: &str) -> connection_request::ConnectionRequest {
+        let c_uri = CString::new(uri).unwrap();
+        create_client_from_uri_internal(c_uri.as_ptr(), std::ptr::null())
+            .unwrap_or_else(|e| panic!("failed to parse {uri}: {e}"))
+    }
+
+    #[test]
+    fn reserved_char_password_is_percent_decoded() {
+        let req = parse_uri("redis://:p%40ss@127.0.0.1:6379");
+        let auth = req.authentication_info.as_ref().expect("auth info missing");
+        assert_eq!(&*auth.password, "p@ss");
+        assert_eq!(&*auth.username, "");
+    }
+
+    #[test]
+    fn reserved_char_username_is_percent_decoded() {
+        let req = parse_uri("redis://us%3Aer:p%40ss@127.0.0.1:6379");
+        let auth = req.authentication_info.as_ref().expect("auth info missing");
+        assert_eq!(&*auth.username, "us:er");
+        assert_eq!(&*auth.password, "p@ss");
+    }
+
+    #[test]
+    fn ascii_alphanumeric_credentials_are_unchanged() {
+        // Percent-decoding is a no-op on already-safe inputs — the pre-existing
+        // integration tests use these shapes; keep them working verbatim.
+        let req = parse_uri("redis://user:pass@127.0.0.1:6379");
+        let auth = req.authentication_info.as_ref().expect("auth info missing");
+        assert_eq!(&*auth.username, "user");
+        assert_eq!(&*auth.password, "pass");
+    }
+
+    #[test]
+    fn space_and_plus_in_password_are_percent_decoded() {
+        // '+' is NOT decoded to space in URI userinfo (that's application/x-www-form-urlencoded);
+        // "%20" decodes to space, "+" stays as "+".
+        let req = parse_uri("redis://:hello%20world+plus@127.0.0.1:6379");
+        let auth = req.authentication_info.as_ref().expect("auth info missing");
+        assert_eq!(&*auth.password, "hello world+plus");
+    }
+
+    #[test]
+    fn non_ascii_utf8_password_is_percent_decoded() {
+        // 'é' -> UTF-8 bytes 0xC3 0xA9 -> "%C3%A9"
+        let req = parse_uri("redis://:caf%C3%A9@127.0.0.1:6379");
+        let auth = req.authentication_info.as_ref().expect("auth info missing");
+        assert_eq!(&*auth.password, "café");
+    }
+
+    #[test]
+    fn invalid_utf8_in_password_returns_error() {
+        // "%C3%28" is an invalid UTF-8 sequence (0xC3 0x28 — 0xC3 expects a
+        // continuation byte in [0x80, 0xBF]). Decoding must surface a clear
+        // error rather than silently corrupt bytes.
+        let c_uri = CString::new("redis://:%C3%28@127.0.0.1:6379").unwrap();
+        let err = create_client_from_uri_internal(c_uri.as_ptr(), std::ptr::null())
+            .expect_err("expected UTF-8 error");
+        assert!(
+            err.contains("Password in URI is not valid UTF-8"),
+            "unexpected error: {err}"
+        );
+    }
 }
 
 fn is_known_connection_options_json_key(key: &str) -> bool {

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -14,8 +14,12 @@ struct Server {
 
 impl Server {
     fn new() -> Self {
+        Self::with_requirepass(None)
+    }
+
+    fn with_requirepass(password: Option<&str>) -> Self {
         let port = Self::get_available_port();
-        let process = Self::start_server(port);
+        let process = Self::start_server(port, password);
         Self { process, port }
     }
 
@@ -27,16 +31,19 @@ impl Server {
             .expect("Failed to find an available port")
     }
 
-    fn start_server(port: u16) -> Child {
+    fn start_server(port: u16, requirepass: Option<&str>) -> Child {
         let run_server = |engine_type: &str| {
-            Command::new(engine_type)
-                .arg("--port")
+            let mut cmd = Command::new(engine_type);
+            cmd.arg("--port")
                 .arg(port.to_string())
                 .arg("--save")
                 .arg("")
                 .arg("--appendonly")
-                .arg("no")
-                .spawn()
+                .arg("no");
+            if let Some(pw) = requirepass {
+                cmd.arg("--requirepass").arg(pw);
+            }
+            cmd.spawn()
         };
 
         let child = match run_server("valkey-server") {
@@ -1574,6 +1581,55 @@ fn test_create_client_from_uri_client_side_cache_zero_max_cache_kb() {
         "Expected max_cache_kb error, got: {error}"
     );
     unsafe {
+        free_connection_response(response as *mut ConnectionResponse);
+        drop(Box::from_raw(client_type));
+    }
+}
+
+// Live-server end-to-end regression test for issue #6659: a URI with a
+// percent-encoded reserved character in the password must decode before
+// AUTH is issued, otherwise the server rejects the connection.
+//
+// Prior to the fix, `redis://:p%40ss@host` sent `AUTH p%40ss` on the wire.
+// With `requirepass "p@ss"` set on the server side, connection failed.
+// The fix percent-decodes userinfo, so the server now receives `AUTH p@ss`
+// and the connection succeeds.
+#[test]
+fn test_create_client_from_uri_with_reserved_char_password_authenticates() {
+    let password = "p@ss";
+    let server = Server::with_requirepass(Some(password));
+    // "@" is percent-encoded as "%40" in the URI. Without decoding on the FFI
+    // side, the server would see "p%40ss" and reject the AUTH command.
+    let uri = CString::new(format!("redis://:p%40ss@127.0.0.1:{}", server.port)).unwrap();
+
+    let client_type = Box::into_raw(Box::new(ClientType::SyncClient));
+
+    let response = unsafe {
+        create_client_from_uri(
+            uri.as_ptr(),
+            ptr::null(),
+            client_type,
+            null_pubsub_callback(),
+        )
+    };
+
+    assert!(!response.is_null());
+    let conn_response = unsafe { &*response };
+
+    if !conn_response.connection_error_message.is_null() {
+        let error = parse_error_msg(conn_response.connection_error_message);
+        panic!(
+            "expected successful AUTH with percent-encoded password `p%40ss` \
+             (server requirepass = `{password}`), got: {error}"
+        );
+    }
+    assert!(
+        !conn_response.conn_ptr.is_null(),
+        "expected a live connection after successful AUTH"
+    );
+
+    unsafe {
+        close_client(conn_response.conn_ptr);
         free_connection_response(response as *mut ConnectionResponse);
         drop(Box::from_raw(client_type));
     }


### PR DESCRIPTION
### Summary

`create_client_from_uri` was forwarding percent-encoded userinfo verbatim into `AuthenticationInfo`, so passwords or usernames containing URI-reserved characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`, space, non-ASCII) reached the server as their `%XX` escapes and `AUTH` failed. This PR percent-decodes `url.password()` / `url.username()` before writing into the outbound `ConnectionRequest`, mirroring the pattern `redis-rs` itself already uses one layer down.

### Issue link

This Pull Request is linked to issue: [FFI: `create_client_from_uri` sends percent-encoded userinfo to server](https://github.com/valkey-io/valkey-glide/issues/6659)
Closes #6659

### Features / Behaviour Changes

- `redis://:p%40ss@host` now sends `AUTH p@ss` to the server (previously sent `AUTH p%40ss` and failed).
- Same fix applies to `username` for ACL users whose names contain reserved characters.
- Invalid UTF-8 in decoded userinfo now surfaces a clear error (`"Password in URI is not valid UTF-8"` / `"Username in URI is not valid UTF-8"`) instead of forwarding corrupt bytes.
- No breaking change: ASCII-alphanumeric credentials are unaffected (percent-decoding is a no-op on already-safe inputs).

### Implementation

Root cause: per RFC 3986 §3.2.1 and the `url` crate's contract, `Url::password()` and `Url::username()` return the *percent-encoded* substring — the caller is expected to decode. `create_client_from_uri_internal` was calling `.to_string()` on those values and forwarding them raw.

Fix: `ffi/src/lib.rs:1793–1817` — percent-decode both fields via `percent_encoding::percent_decode(...).decode_utf8()`, the exact pattern `redis-rs` uses at `glide-core/redis-rs/redis/src/connection.rs:370, 379`. `percent-encoding = "2"` added to `ffi/Cargo.toml` (transitive via `url = "2"`, but Rust requires a direct dep for `use`).

**Cross-binding audit** confirms the change is safe: `create_client_from_uri` has exactly one caller across the entire GLIDE ecosystem — `valkey-glide-ruby`. Every other binding (Go, Python-sync, Python-async, Java, Node, PHP, C#, C++) constructs a `ConnectionRequest` protobuf message with raw password bytes and calls the sibling entry point `create_client`, which never touches this code path. No other binding can regress.

The downstream Ruby fix ([valkey-io/valkey-glide-ruby#184](https://github.com/valkey-io/valkey-glide-ruby/issues/184)) depends on this PR merging first.

### Limitations

N/A — this is a targeted correctness fix.

### Testing

**New unit tests** (`ffi/src/lib.rs`, `mod tests_create_client_from_uri_internal`, 6 tests) — call `create_client_from_uri_internal` directly and assert on the outbound `ConnectionRequest.authentication_info`:

- Reserved-char password (`p%40ss` → `p@ss`) round-trips correctly.
- Reserved-char username (`us%3Aer` → `us:er`) round-trips correctly.
- ASCII-alphanumeric credentials pass through unchanged (regression guard).
- `%20` decodes to space; literal `+` stays as `+` (not form-encoding).
- Non-ASCII UTF-8 (`caf%C3%A9` → `café`) decodes correctly.
- Invalid UTF-8 (`%C3%28`) returns a clear error.

**New live-server integration test** (`ffi/tests/test_create_client_from_uri.rs`, `test_create_client_from_uri_with_reserved_char_password_authenticates`) — starts a Valkey/Redis server with `--requirepass p@ss`, connects via `redis://:p%40ss@host`, asserts the connection succeeds (i.e. `AUTH p@ss` reached the server on the wire). Extended the `Server` helper with `with_requirepass(Option<&str>)` to support this.

**Verified locally:**

```bash
cargo build --all-features                          # clean
cargo test --lib                                    # 20/20 pass (6 new)
cargo test --test test_create_client_from_uri       # 52/52 pass (1 new)
cargo fmt -- --check                                # clean
cargo clippy --all-features --all-targets -- -D warnings   # clean
```

Pre-existing `test_create_client_from_uri_with_password` and `test_create_client_from_uri_with_username_and_password` continue to pass unchanged — they use ASCII-alphanumeric credentials, on which percent-decoding is a no-op.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`cargo fmt`, `cargo clippy --all-features --all-targets -- -D warnings`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
