### PR TITLE
Node: Fix flaky clientTrackingInfo test by reducing azCluster replica count

### DIFF
--- a/node/tests/GlideClusterClient.test.ts
+++ b/node/tests/GlideClusterClient.test.ts
@@ -119,7 +119,7 @@ describe("GlideClusterClient", () => {
             azCluster = await ValkeyCluster.createCluster(
                 true,
                 3,
-                4,
+                2,
                 getServerVersion,
             );
         }
@@ -2844,7 +2844,7 @@ describe("GlideClusterClient", () => {
                         ),
                     );
 
-                    const get_calls_per_replica = 25;
+                    const get_calls_per_replica = 50;
                     const get_calls = 100;
                     const get_cmdstat = `cmdstat_get:calls=${get_calls_per_replica}`;
 
@@ -2872,7 +2872,7 @@ describe("GlideClusterClient", () => {
                         return isReplicaNode && infoStr.includes(get_cmdstat);
                     }).length;
 
-                    expect(matching_entries_count).toBe(4);
+                    expect(matching_entries_count).toBe(2);
                 } finally {
                     // Cleanup
                     await client_for_config_set?.configSet(
@@ -2979,7 +2979,7 @@ describe("GlideClusterClient", () => {
                 // Skip test if version is below 8.0.0
                 if (cluster.checkIfServerVersionLessThan("8.0.0")) return;
 
-                const get_calls = 4;
+                const get_calls = 2;
                 const replica_calls = 1;
                 const get_cmdstat = `cmdstat_get:calls=${replica_calls}`;
                 let client_for_testing_az;
@@ -3022,7 +3022,7 @@ describe("GlideClusterClient", () => {
                     }).length;
 
                     // Validate that the get calls were distributed across replicas, each replica recieved 1 get call
-                    expect(matchingEntriesCount).toBe(4);
+                    expect(matchingEntriesCount).toBe(2);
                 } finally {
                     // Cleanup: Close the client after test execution
                     client_for_testing_az?.close();


### PR DESCRIPTION
### Summary
Reduce azCluster replica count from 4 to 2 to prevent topology convergence timeout in CI, fixing flakiness in clientTrackingInfo tests.

### Issue link
This Pull Request is linked to issue: [[Node][Flaky Test] GlideClusterClient clientTrackingInfo - cluster_manager.py topology timeout](https://github.com/valkey-io/valkey-glide/issues/6645)
Closes #6645

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The `azCluster` in `GlideClusterClient.test.ts` was configured with 4 replicas per shard (15 nodes total). The `cluster_manager.py` `wait_for_all_topology_views` function times out because 15 nodes take too long to converge in CI environments with limited resources. The timeout is 80 retries × 1s = 80s per server, which isn't always sufficient for all 15 nodes to see each other.

**Fix:** Reduce `azCluster` from 4 replicas to 2 replicas per shard (9 nodes total instead of 15). Update the AZ affinity tests accordingly:
- First AZ test: `get_calls_per_replica` changed from 25 to 50 (100 GETs / 2 replicas = 50 each), `matching_entries_count` assertion from 4 to 2
- Non-existing AZ test: `get_calls` changed from 4 to 2, `matchingEntriesCount` assertion from 4 to 2

The tests still validate the same multi-replica AZ routing logic with fewer nodes, making topology convergence much faster and more reliable.

### Limitations
None

### Testing
- Built the Node client from source (Rust native module + TypeScript)
- Ran the `clientTrackingInfo` tests **30 times consecutively** — all passed
- No topology timeout failures observed in any run
- Average test time: ~37 seconds (cluster creation is fast with 9 nodes)
- AZ affinity tests are skipped in local runs (require Valkey 8.0+) but the reduced cluster successfully starts

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md updated - N/A for flaky-test fixes; do NOT add a changelog entry (see Shared Rule 0).
- [x] Lint checked manually (matched surrounding style; lint tools not run locally per Shared Rule 3).
- [x] Destination branch is correct - main or release