### PR TITLE
feat(utils): support cluster-announce-hostname in cluster_manager.py

### DIFF
--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -434,6 +434,15 @@ def start_server(
     # Bind server to both IPv4 and IPv6 loopback addresses.
     cmd_args.extend(["--bind", DEFAULT_HOST_IPV4, DEFAULT_HOST_IPV6])
 
+    # If host is a DNS hostname, set cluster-announce-hostname so
+    # the cluster topology reports DNS names instead of IP addresses.
+    if cluster_mode:
+        try:
+            import ipaddress
+            ipaddress.ip_address(host)
+        except ValueError:
+            cmd_args.extend(["--cluster-announce-hostname", host])
+
     if server_version >= (7, 0, 0):
         cmd_args.extend(["--enable-debug-command", "yes"])
     # Enable multi-database support in cluster mode for Valkey 9.0+


### PR DESCRIPTION
### Summary

Add `cluster-announce-hostname` support to `cluster_manager.py` when the `--host` argument is a DNS hostname rather than an IP address. This enables testing DNS-based cluster topology scenarios (e.g., AWS ElastiCache endpoints) using local test infrastructure.

### Issue link

Need for GLIDE C# client issue: [GetServers uses IPEndPoint instead of EndPoint, causing exceptions with ElastiCache](https://github.com/valkey-io/valkey-glide-csharp/issues/419)

### Features / Behaviour Changes

When `--host` is a DNS hostname (not an IP address) and `--cluster-mode` is enabled, `cluster_manager.py` now passes `--cluster-announce-hostname <host>` to the Valkey server process. This causes the cluster topology (CLUSTER SLOTS/CLUSTER NODES) to report DNS hostnames instead of IP addresses.

No behaviour change when `--host` is an IP address (the default `127.0.0.1`).

### Implementation

In `start_server()`, after setting `--bind`, check whether `host` is a valid IP address using Python's `ipaddress.ip_address()`. If it's not (i.e., it's a DNS hostname) and cluster mode is enabled, append `--cluster-announce-hostname <host>` to the server command arguments.

### Limitations

- Only applies to cluster mode (standalone doesn't support `cluster-announce-hostname`).
- The hostname must comply with Valkey's hostname validation (alphanumeric, hyphens, dots only — no underscores).

### Testing

Tested manually with the Valkey GLIDE C# client:
- Started a 3-node cluster with `--host valkey.glide.test.tls.com`
- Verified `CLUSTER NODES` reports DNS hostnames in the topology
- Verified the C# client's `GetServers()` / `GetEndPoints(false)` correctly return `DnsEndPoint` instances

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated.~~
- [x] ~~CHANGELOG.md and documentation files are updated.~~
- [x] ~~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~~
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] ~~Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary~~