### PR TITLE
Python: Fix flaky test_sync_standalone_scan_with_count infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Python: Fix flaky test_sync_standalone_scan_with_count infinite loop ([#6682](https://github.com/valkey-io/valkey-glide/pull/6682))
 * Core/FFI: Percent-decode userinfo in `create_client_from_uri` so credentials containing URI-reserved characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`, space, non-ASCII) authenticate correctly ([#6659](https://github.com/valkey-io/valkey-glide/issues/6659))
 * Core/All: Buffer pending cluster requests during reconnect instead of failing immediately. When a circular MOVED redirect triggers a reconnect, requests arriving during the recovery window are now queued and retried transparently once reconnection completes. A new `recovery_requests_queue_size` option (default: 1000) controls the queue depth. ([#6640](https://github.com/valkey-io/valkey-glide/pull/6640))
 * Python: Fix trio pub/sub BusyResourceError from duplicate shared-pipe reader ([#6605](https://github.com/valkey-io/valkey-glide/pull/6605))

--- a/python/tests/async_tests/test_scan.py
+++ b/python/tests/async_tests/test_scan.py
@@ -466,6 +466,8 @@ class TestScan:
             cursor = cursor_bytes.decode()
             keys_of_1 = cast(List[str], result_of_1[1])
             keys.extend(keys_of_1)
+            if cursor == "0":
+                break
             result_of_100 = await glide_client.scan(cursor, count=100)
             cursor_bytes = cast(bytes, result_of_100[0])
             cursor = cursor_bytes.decode()

--- a/python/tests/sync_tests/test_sync_scan.py
+++ b/python/tests/sync_tests/test_sync_scan.py
@@ -462,6 +462,8 @@ class TestSyncScan:
             cursor = cursor_bytes.decode()
             keys_of_1 = cast(List[str], result_of_1[1])
             keys.extend(keys_of_1)
+            if cursor == "0":
+                break
             result_of_100 = glide_sync_client.scan(cursor, count=100)
             cursor_bytes = cast(bytes, result_of_100[0])
             cursor = cursor_bytes.decode()


### PR DESCRIPTION
### Summary

Fix flaky `test_sync_standalone_scan_with_count` that times out after 300 seconds with `FatalReceiveError: channel closed` errors. The root cause is a missing cursor completion check between two consecutive scan calls in the test loop.

### Issue link

This Pull Request is linked to issue: [[Python][Flaky Test] test_sync_standalone_scan_with_count - Timeout (>300.0s)](https://github.com/valkey-io/valkey-glide/issues/6681)
Closes #6681

### Features / Behaviour Changes

No behaviour changes. This is a test-only fix.

### Implementation

The standalone scan-with-count tests (both sync and async) perform two scan calls per loop iteration: one with `count=1` and one with `count=100`, to compare result sizes. However, after the first scan returns cursor `"0"` (indicating scan completion), the code did not break out of the loop. Instead, it passed cursor `"0"` to the second scan, which starts a brand-new scan cycle from the beginning. Under connection instability (as indicated by the `FatalReceiveError` in the issue logs), this unnecessary re-scan could cause the test to loop indefinitely, exceeding the 300s timeout.

The fix adds a `if cursor == "0": break` check between the two scan calls — matching the pattern already used in the cluster variant (`test_sync_cluster_scan_with_count`) which correctly checks `cursor.is_finished()` between its two scans.

### Limitations

None.

### Testing

- Ran `test_sync_standalone_scan_with_count[ProtocolVersion.RESP2-False]` 100 times (`--count=100 -x`): all 100 passed with 0 failures (total runtime <1s).
- Also ran both RESP2 and RESP3 variants 100 times each (200 total): all passed.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release