### PR TITLE
Java: Fix flaky Windows TLS tests with bounded retry for initial connection

### DIFF
--- a/java/integTest/src/test/java/glide/DnsTest.java
+++ b/java/integTest/src/test/java/glide/DnsTest.java
@@ -17,6 +17,7 @@ import glide.api.models.configuration.GlideClusterClientConfiguration;
 import glide.api.models.configuration.GlideClusterClientConfiguration.GlideClusterClientConfigurationBuilder;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.TlsAdvancedConfiguration;
+import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -28,7 +29,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  *
  * <p>See <a href="../../../../../../DEVELOPER.md#dns-tests">DNS Tests</a> for setup instructions.
  */
-@Timeout(10)
+@Timeout(25)
 @EnabledIfEnvironmentVariable(named = "VALKEY_GLIDE_DNS_TESTS_ENABLED", matches = ".*")
 public class DnsTest {
 
@@ -36,7 +37,8 @@ public class DnsTest {
     @ValueSource(booleans = {true, false})
     @SneakyThrows
     void testConnectWithValidHostnameNoTls(boolean clusterMode) {
-        try (BaseClient client = buildClient(clusterMode, false, HOSTNAME_NO_TLS)) {
+        try (BaseClient client =
+                createClientWithRetry(() -> buildClientFuture(clusterMode, false, HOSTNAME_NO_TLS))) {
             assertConnected(client);
         }
     }
@@ -44,14 +46,17 @@ public class DnsTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testConnectWithInvalidHostnameNoTls(boolean clusterMode) {
-        assertThrows(Exception.class, () -> buildClient(clusterMode, false, "nonexistent.invalid"));
+        assertThrows(
+                Exception.class,
+                () -> buildClientFuture(clusterMode, false, "nonexistent.invalid").get());
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @SneakyThrows
     void testTlsConnectWithHostnameInCert(boolean clusterMode) {
-        try (BaseClient client = buildClient(clusterMode, true, HOSTNAME_TLS)) {
+        try (BaseClient client =
+                createClientWithRetry(() -> buildClientFuture(clusterMode, true, HOSTNAME_TLS))) {
             assertConnected(client);
         }
     }
@@ -59,7 +64,9 @@ public class DnsTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testTlsConnectWithHostnameNotInCert(boolean clusterMode) {
-        assertThrows(Exception.class, () -> buildClient(clusterMode, true, HOSTNAME_NO_TLS));
+        assertThrows(
+                Exception.class,
+                () -> buildClientFuture(clusterMode, true, HOSTNAME_NO_TLS).get());
     }
 
     // -------------------
@@ -67,7 +74,8 @@ public class DnsTest {
     // -------------------
 
     @SneakyThrows
-    private static BaseClient buildClient(boolean clusterMode, boolean useTls, String hostname) {
+    private static CompletableFuture<BaseClient> buildClientFuture(
+            boolean clusterMode, boolean useTls, String hostname) {
 
         // Get port from test configuration.
         String[] hosts =
@@ -95,7 +103,7 @@ public class DnsTest {
                                 .tlsAdvancedConfiguration(tlsConfig)
                                 .build());
             }
-            return GlideClusterClient.createClient(builder.build()).get();
+            return GlideClusterClient.createClient(builder.build()).thenApply(c -> (BaseClient) c);
         } else {
             GlideClientConfigurationBuilder<?, ?> builder =
                     GlideClientConfiguration.builder().address(address).useTLS(useTls);
@@ -105,7 +113,7 @@ public class DnsTest {
                 builder.advancedConfiguration(
                         AdvancedGlideClientConfiguration.builder().tlsAdvancedConfiguration(tlsConfig).build());
             }
-            return GlideClient.createClient(builder.build()).get();
+            return GlideClient.createClient(builder.build()).thenApply(c -> (BaseClient) c);
         }
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/StandaloneTlsCertificateTest.java
+++ b/java/integTest/src/test/java/glide/standalone/StandaloneTlsCertificateTest.java
@@ -3,6 +3,7 @@ package glide.standalone;
 
 import static glide.Constants.IP_ADDRESS_V4;
 import static glide.Constants.IP_ADDRESS_V6;
+import static glide.TestUtilities.createClientWithRetry;
 import static glide.TestUtilities.getCaCertificate;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -62,7 +63,8 @@ public class StandaloneTlsCertificateTest {
         GlideClientConfiguration config =
                 TestUtilities.createStandaloneConfigWithRootCert(caCert, nodeAddr);
 
-        try (GlideClient client = GlideClient.createClient(config).get()) {
+        try (GlideClient client =
+                createClientWithRetry(() -> GlideClient.createClient(config))) {
             TestUtilities.assertConnected(client);
         }
     }
@@ -76,7 +78,8 @@ public class StandaloneTlsCertificateTest {
         GlideClientConfiguration config =
                 TestUtilities.createStandaloneConfigWithRootCert(certBundle, nodeAddr);
 
-        try (GlideClient client = GlideClient.createClient(config).get()) {
+        try (GlideClient client =
+                createClientWithRetry(() -> GlideClient.createClient(config))) {
             TestUtilities.assertConnected(client);
         }
     }
@@ -117,7 +120,8 @@ public class StandaloneTlsCertificateTest {
         GlideClientConfiguration config =
                 TestUtilities.createStandaloneConfigWithRootCert(caCert, address);
 
-        try (GlideClient client = GlideClient.createClient(config).get()) {
+        try (GlideClient client =
+                createClientWithRetry(() -> GlideClient.createClient(config))) {
             TestUtilities.assertConnected(client);
         }
     }
@@ -159,7 +163,8 @@ public class StandaloneTlsCertificateTest {
                             .build();
             ;
 
-            try (GlideClient client = GlideClient.createClient(config).get()) {
+            try (GlideClient client =
+                    createClientWithRetry(() -> GlideClient.createClient(config))) {
                 TestUtilities.assertConnected(client);
             }
         } finally {


### PR DESCRIPTION
### Summary

Fix flaky Windows TLS tests (DnsTest, StandaloneTlsCertificateTest) by using the existing `createClientWithRetry` helper for tests that expect successful connections.

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] Flaky StandaloneTlsCertificateTest](https://github.com/valkey-io/valkey-glide/issues/5688)
Closes #5688

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** On Windows CI, the Java test JVM runs natively while `valkey-server` runs inside WSL. After the server reports ready (checked via `valkey-cli PING` inside WSL), the WSL-to-Windows port-forwarding layer can have brief unavailability windows. Tests that make a single connection attempt with a ~2s timeout fail with "Connection refused" during this window.

Tests that *expect* failure (e.g., `testStandaloneTlsWithoutCertificateFails`) pass because any error is acceptable. Only tests expecting successful connections are affected.

**Fix:** Use the existing `createClientWithRetry` helper (introduced for issue #5343) which retries `createClient` up to 3 times with 1-second backoff:

1. **StandaloneTlsCertificateTest:** All success-expecting tests now use `createClientWithRetry(() -> GlideClient.createClient(config))` instead of `GlideClient.createClient(config).get()`.

2. **DnsTest:** Refactored `buildClient` → `buildClientFuture` returning `CompletableFuture<BaseClient>`. Success tests (`testConnectWithValidHostnameNoTls`, `testTlsConnectWithHostnameInCert`) use `createClientWithRetry`. Failure tests call `.get()` directly. Increased `@Timeout` from 10s to 25s to accommodate retry backoff.

### Limitations

100x validation skipped — this is a Windows-specific race condition that cannot be reproduced on Linux. The fix uses the exact same pattern that successfully resolved the same class of issue in #5343.

### Testing

- `./gradlew :integTest:compileTestJava` — BUILD SUCCESSFUL ✅
- Pattern matches established fix from #5343

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release