### PR TITLE
Update TLS test Cluster creation setup in cluster_manager.py to fix timeouts.

### DIFF
--- a/glide-core/redis-rs/redis/tests/support/mod.rs
+++ b/glide-core/redis-rs/redis/tests/support/mod.rs
@@ -637,7 +637,9 @@ pub fn build_keys_and_certs_for_tls(tempdir: &TempDir) -> TlsFilePaths {
     }
 
     // Build CA Key
-    make_key(&ca_key, 4096);
+    // 2048 bits is enough for a test CA and generates much faster than 4096 on
+    // entropy-constrained runners. Matches the Python cluster manager.
+    make_key(&ca_key, 2048);
 
     // Build redis key
     make_key(&redis_key, 2048);

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -434,7 +434,9 @@ pub fn build_tls_file_paths(tempdir: &tempfile::TempDir) -> TlsFilePaths {
     }
 
     // Build CA Key
-    make_key(&ca_key, 4096);
+    // 2048 bits is enough for a test CA and generates much faster than 4096 on
+    // entropy-constrained runners. Matches the Python cluster manager.
+    make_key(&ca_key, 2048);
 
     // Build redis key
     make_key(&redis_key, 2048);

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -160,10 +160,11 @@ def generate_tls_certs():
             text=True,
         )
         # genrsa can stall on low-entropy ARM64 runners. Cap the wait at 30s so a
-        # real stall fails here with this function's message (the signature that
-        # identified #6699) rather than tripping the caller's 80s budget in
-        # cluster.py first. Kill the child on timeout so a stalled openssl stops
-        # writing to the shared ca.key, which the next run would otherwise race.
+        # real stall raises subprocess.TimeoutExpired here, naming the full openssl
+        # argv that identified #6699, rather than tripping the caller's 80s budget
+        # in cluster.py first, where the failure is attributed to the whole cluster
+        # start. Kill the child on timeout so a stalled openssl stops writing to
+        # the shared ca.key, which the next run would otherwise race.
         try:
             output, err = p.communicate(timeout=30)
         except subprocess.TimeoutExpired:

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -159,9 +159,17 @@ def generate_tls_certs():
             stderr=subprocess.PIPE,
             text=True,
         )
-        # ARM64 runners may have limited entropy, causing genrsa to block.
-        # Use a generous timeout to avoid flaky failures on slow CI runners.
-        output, err = p.communicate(timeout=60)
+        # genrsa can stall on low-entropy ARM64 runners. Cap the wait at 30s so a
+        # real stall fails here with this function's message (the signature that
+        # identified #6699) rather than tripping the caller's 80s budget in
+        # cluster.py first. Kill the child on timeout so a stalled openssl stops
+        # writing to the shared ca.key, which the next run would otherwise race.
+        try:
+            output, err = p.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            p.communicate()
+            raise
         if p.returncode != 0:
             raise Exception(
                 f"Failed to make key for {name}. Executed: {str(p.args)}:\n{err}"

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -159,12 +159,9 @@ def generate_tls_certs():
             stderr=subprocess.PIPE,
             text=True,
         )
-        # genrsa can stall on low-entropy ARM64 runners. Cap the wait at 30s so a
-        # real stall raises subprocess.TimeoutExpired here, naming the full openssl
-        # argv that identified #6699, rather than tripping the caller's 80s budget
-        # in cluster.py first, where the failure is attributed to the whole cluster
-        # start. Kill the child on timeout so a stalled openssl stops writing to
-        # the shared ca.key, which the next run would otherwise race.
+        # openssl genrsa can stall on low-entropy aarch64 runners. Time out here
+        # (inside cluster.py's 80s budget) and kill the child so it stops
+        # writing to the shared ca.key.
         try:
             output, err = p.communicate(timeout=30)
         except subprocess.TimeoutExpired:
@@ -177,9 +174,7 @@ def generate_tls_certs():
             )
 
     # Build CA key
-    # Use 2048-bit key for test certificates: adequate for CI/testing purposes
-    # and significantly faster to generate on entropy-constrained environments
-    # (e.g., aarch64 runners).
+    # 2048-bit is enough for test certs and faster on low-entropy runners.
     make_key(ca_key, 2048)
 
     # Build server key

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -159,15 +159,19 @@ def generate_tls_certs():
             stderr=subprocess.PIPE,
             text=True,
         )
-        # ARM64 runners take longer to generate TLS certificates, and sometimes fail if the timeout shorter (10 seconds).
-        output, err = p.communicate(timeout=20)
+        # ARM64 runners may have limited entropy, causing genrsa to block.
+        # Use a generous timeout to avoid flaky failures on slow CI runners.
+        output, err = p.communicate(timeout=60)
         if p.returncode != 0:
             raise Exception(
                 f"Failed to make key for {name}. Executed: {str(p.args)}:\n{err}"
             )
 
     # Build CA key
-    make_key(ca_key, 4096)
+    # Use 2048-bit key for test certificates: adequate for CI/testing purposes
+    # and significantly faster to generate on entropy-constrained environments
+    # (e.g., aarch64 runners).
+    make_key(ca_key, 2048)
 
     # Build server key
     make_key(SERVER_KEY, 2048)


### PR DESCRIPTION
### Summary

Fixes a flaky TLS cluster setup in CI where `openssl genrsa` for the test CA exceeded the harness timeout on entropy-starved aarch64 GitHub Actions runners, failing every TLS-dependent test in the run. Test harness only, no shipped client behavior changes.

### Issue link

This Pull Request is linked to issue: [[Python][Flaky Test] Cluster TLS setup - openssl genrsa timeout on aarch64
 #6699](https://github.com/valkey-io/valkey-glide/issues/6699)
Closes #6699

### Features / Behaviour Changes

None. This is a test-harness-only change; no user-visible client behavior is affected.

### Implementation

- Reduced the test CA key from 4096 to 2048 bits in all three TLS harnesses (`utils/cluster_manager.py`, `glide-core/tests/utilities/mod.rs`, `glide-core/redis-rs/redis/tests/support/mod.rs`), matching the 2048-bit server keys already generated alongside them.
- Raised the `openssl genrsa` wait in `make_key` (Python) from 20s to 30s and made the timeout path call `p.kill()` and reap the child before re-raising, so a stalled openssl can no longer keep writing to the shared `ca.key` in the persistent TLS folder and race the next run.
- The 30s ceiling stays inside the caller's 80s `communicate` budget in `python/tests/utils/cluster.py`, so a real stall surfaces as a `subprocess.TimeoutExpired` naming the openssl argv rather than as a generic cluster-start timeout.
- Added comments at each call site recording why 2048 bits is sufficient for a single-CI-job CA and why the timeout is capped where it is.

### Limitations

Only `make_key` (the two `openssl genrsa` calls) has the kill-on-timeout guard. The three follow-on openssl steps in `generate_tls_certs()` (CA cert, CSR, server cert) still use `communicate(timeout=10)` without a kill; they were left out of scope for this fix since the observed CI failure is on `genrsa` and widening the change would exceed the intent of a targeted flake fix.

### Testing

- Reproduced #6699 on the base commit at 10-way parallelism (4/10 runs failed with `openssl genrsa ... 4096` timeout at 20s) and confirmed the fix (10/10 pass, worst case 11.24s under the 30s ceiling).
- Drove the Python end-user path via `ValkeyCluster(tls=True, cluster_mode=True, shard_count=3, replica_count=1)`: TLS cluster up in 25.4s of the 80s budget, `TLS PING -> PONG`, `cluster_state:ok` with the chain verifying to the 2048-bit CA.
- Verified both `make_key` timeout promises against a stalling openssl shim: HEAD raises `TimeoutExpired` naming the real argv and kills the child; base leaks it and keeps writing the shared `ca.key`.
- Ran the Rust TLS paths through both modified harnesses: 10 `glide-core` standalone TLS tests pass, and `test_connection_manager_reconnect_after_delay` in `redis-rs` passes.
- Replayed both Rust harnesses' openssl sequence at 2048 and 4096 bits; chain verifies and a real `valkey-server` boots with the material at both sizes.

Measurements were taken on a 14-core Apple Silicon host, not a GitHub aarch64 runner, so the mechanism and direction reproduce faithfully but the absolute CI-runner margin will differ.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated. (Not applicable: test-harness-only, no user-visible change.)
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary (Not applicable: no user-visible behavior change.)
