### PR TITLE
Node: Fix flaky TLS cluster test by reducing cluster size and adding retry

### DIFF
--- a/node/tests/TlsTest.test.ts
+++ b/node/tests/TlsTest.test.ts
@@ -24,31 +24,72 @@ const TLS_OPTIONS = {
     useTLS: true,
 };
 
+/**
+ * Retry wrapper for cluster creation. TLS cluster startup can fail transiently
+ * in CI due to port contention, resource pressure, or slow topology convergence.
+ * Retries up to maxAttempts times before giving up.
+ */
+async function createClusterWithRetry(
+    clusterMode: boolean,
+    shardCount: number,
+    replicaCount: number,
+    maxAttempts: number = 3,
+): Promise<ValkeyCluster> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            return await ValkeyCluster.createCluster(
+                clusterMode,
+                shardCount,
+                replicaCount,
+                getServerVersion,
+                true,
+                TLS_OPTIONS,
+            );
+        } catch (error) {
+            lastError = error;
+            Logger.log(
+                "warn",
+                "TlsTest",
+                `Cluster creation attempt ${attempt}/${maxAttempts} failed: ${error}`,
+            );
+
+            if (attempt < maxAttempts) {
+                // Wait briefly before retrying to allow ports to be released
+                await new Promise((resolve) =>
+                    setTimeout(resolve, 2000 * attempt),
+                );
+            }
+        }
+    }
+
+    throw lastError;
+}
+
 // tls cluster tests
 describe("tls GlideClusterClient", () => {
     let cluster: ValkeyCluster;
     let client: GlideClusterClient | undefined;
 
     beforeAll(async () => {
-        cluster = await ValkeyCluster.createCluster(
-            true,
-            3,
-            2,
-            getServerVersion,
-            true,
-            TLS_OPTIONS,
-        );
-        // Small delay to ensure cluster is fully ready after TLS setup
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        // Use 3 shards with 0 replicas (3 nodes total) instead of 3 shards
+        // with 2 replicas (9 nodes). This test only validates TLS connectivity
+        // via ping, so minimal cluster size reduces startup time and resource
+        // contention that cause transient CI failures.
+        cluster = await createClusterWithRetry(true, 3, 0);
     }, CLUSTER_CREATION_TIMEOUT);
 
     afterEach(async () => {
-        await flushAndCloseClient(
-            true,
-            cluster?.getAddresses(),
-            client,
-            TLS_OPTIONS,
-        );
+        if (cluster) {
+            await flushAndCloseClient(
+                true,
+                cluster.getAddresses(),
+                client,
+                TLS_OPTIONS,
+            );
+        }
+
         client = undefined;
     });
 
@@ -66,9 +107,6 @@ describe("tls GlideClusterClient", () => {
                 error as Error,
             );
         }
-
-        // Additional delay to ensure proper TLS cleanup
-        await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -91,31 +129,25 @@ describe("tls GlideClusterClient", () => {
     );
 });
 
-// tls cluster tests
+// tls standalone tests
 describe("tls GlideClient", () => {
     let cluster: ValkeyCluster;
     let client: GlideClient | undefined;
 
     beforeAll(async () => {
-        cluster = await ValkeyCluster.createCluster(
-            false,
-            1,
-            1,
-            getServerVersion,
-            true,
-            TLS_OPTIONS,
-        );
-        // Small delay to ensure cluster is fully ready after TLS setup
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        cluster = await createClusterWithRetry(false, 1, 1);
     }, CLUSTER_CREATION_TIMEOUT);
 
     afterEach(async () => {
-        await flushAndCloseClient(
-            false,
-            cluster?.getAddresses(),
-            client,
-            TLS_OPTIONS,
-        );
+        if (cluster) {
+            await flushAndCloseClient(
+                false,
+                cluster.getAddresses(),
+                client,
+                TLS_OPTIONS,
+            );
+        }
+
         client = undefined;
     });
 
@@ -133,9 +165,6 @@ describe("tls GlideClient", () => {
                 error as Error,
             );
         }
-
-        // Additional delay to ensure proper TLS cleanup
-        await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(


### PR DESCRIPTION
### Summary
Fix the flaky `clusterClient connect with insecure TLS` test that has been intermittently failing in CI across all Node.js versions and engine versions.

### Issue link
This Pull Request is linked to issue: [[Node][Flaky Test] GlideClusterClient › clusterClient connect with insecure TLS (protocol: 1)](https://github.com/valkey-io/valkey-glide/issues/4366)
Closes #4366

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The TLS cluster test was creating 9 nodes (3 shards × (1 primary + 2 replicas)) which is excessive for a simple TLS connectivity test that only calls `ping()`. This caused:
1. **Resource contention** - CI runners (4 vCPUs) struggle to start 9 TLS-enabled Valkey instances concurrently alongside other parallel test files
2. **Topology convergence timeouts** - More nodes means longer time for all nodes to discover each other via `CLUSTER SLOTS`, often exceeding the cluster_manager.py timeout
3. **Port exhaustion** - 9 random ports needed per test run increases the chance of "Address already in use" collisions
4. **No recovery from transient failures** - Any single failure in cluster_manager.py (port conflict, slow server start) failed the entire test with no retry

**Fix:**
- Reduce cluster from 9 nodes to 3 nodes (3 shards, 0 replicas) - the minimum for proper hash slot coverage in cluster mode, and all this test needs
- Add `createClusterWithRetry()` that retries cluster creation up to 3 times with increasing backoff (2s, 4s) between attempts to handle transient infrastructure failures
- Guard `afterEach` with cluster existence check to prevent cascading errors when `beforeAll` fails
- Remove fixed `setTimeout` delays (1000ms post-creation, 100ms post-close) that were unreliable timing hacks rather than proper synchronization

### Limitations
None

### Testing
The fix addresses the documented CI failure modes:
- Reduced node count directly reduces startup time and resource pressure
- Retry logic handles the "port already in use" and "server start timeout" failures shown in CI logs
- The test validates the same TLS connectivity behavior (insecure TLS + ping) with fewer infrastructure requirements

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md updated - N/A for flaky-test fixes; do NOT add a changelog entry.
- [x] Lint checked manually (matched surrounding style; lint tools not run locally per Shared Rule 3).
- [x] Destination branch is correct - main