### PR TITLE
fix(Core): buffer pending requests for all recovery paths

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3726,22 +3726,26 @@ where
             RecoverFuture::ReconnectToInitialNodes(ref mut handle) => {
                 match Pin::new(handle).poll(cx) {
                     Poll::Pending => Poll::Pending,
-                    Poll::Ready(Ok(())) => {
-                        log_trace_lazy!("cluster", "Reconnected to initial nodes");
+                    Poll::Ready(Ok(())) | Poll::Ready(Err(_)) => {
+                        // Whether the task succeeded, failed, or panicked, mark recovery complete.
+                        // Then check if we actually have connections: if not, signal failure so
+                        // poll_flush can fail the recovery queue instead of draining it into
+                        // in-flight (which would cause an infinite reconnect loop).
                         self.state = ConnectionState::PollComplete;
-                        Poll::Ready(Ok(()))
-                    }
-                    Poll::Ready(Err(join_err)) => {
-                        if join_err.is_cancelled() {
-                            log_trace_lazy!(
+                        if self.inner.conn_lock.read().is_empty() {
+                            log_warn_rate_limited!(
                                 "cluster",
-                                "Reconnect to initial nodes task was aborted"
+                                5,
+                                "ReconnectToInitialNodes completed but no connections available"
                             );
+                            Poll::Ready(Err(RedisError::from((
+                                ErrorKind::AllConnectionsUnavailable,
+                                "No connections after reconnect to initial nodes",
+                            ))))
                         } else {
-                            log_warn_lazy!("cluster", format!("Reconnect to initial nodes task panicked: {:?} - marking recovery as complete", join_err));
+                            log_trace_lazy!("cluster", "Reconnected to initial nodes");
+                            Poll::Ready(Ok(()))
                         }
-                        self.state = ConnectionState::PollComplete;
-                        Poll::Ready(Ok(()))
                     }
                 }
             }
@@ -4035,24 +4039,27 @@ where
                 return Poll::Pending;
             }
             Poll::Ready(Err(err)) => {
-                // Buffer incoming requests for all recovery paths so they are retried
-                // once recovery completes, instead of being failed immediately.
+                // Special case: ReconnectToInitialNodes completed but no connections are
+                // available. Fail the recovery queue immediately to prevent an infinite
+                // buffer → drain → AllConnectionsUnavailable → reconnect loop.
+                if err.kind() == ErrorKind::AllConnectionsUnavailable {
+                    self.fail_recovery_queue();
+                    // Also buffer any NEW requests that just arrived before failing them
+                    // on the next poll cycle via the same path.
+                    self.buffer_pending_requests_to_recovery_queue();
+                    self.refresh_error = Some(err);
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+                // For all other errors (e.g. slot refresh errors), buffer requests
+                // so they are retried once recovery completes.
                 self.buffer_pending_requests_to_recovery_queue();
                 self.refresh_error = Some(err);
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
             Poll::Ready(Ok(())) => {
-                // Only drain the recovery queue if we actually have connections.
-                // If all connections are still unavailable after recovery (e.g. all nodes dead),
-                // fail the buffered requests immediately rather than dispatching them into
-                // in-flight where they would hit AllConnectionsUnavailable, re-trigger another
-                // ReconnectToInitialNodes, get re-buffered, and loop indefinitely.
-                if self.inner.conn_lock.read().is_empty() {
-                    self.fail_recovery_queue();
-                } else {
-                    self.drain_recovery_queue_to_inflight();
-                }
+                self.drain_recovery_queue_to_inflight();
             }
         }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3616,38 +3616,6 @@ where
         }
     }
 
-    /// Fail all pending requests immediately with ClientError.
-    /// Called when entering recovery to prevent requests from waiting for slow
-    /// reconnection cycles (e.g., ReconnectToInitialNodes, RefreshingSlots).
-    fn fail_pending_requests(inner: &Core<C>) {
-        let mut rx_guard = inner
-            .pending_requests_rx
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let mut requests = Vec::new();
-        while let Ok(request) = rx_guard.try_recv() {
-            requests.push(request);
-        }
-        drop(rx_guard);
-        let count = requests.len();
-        if count > 0 {
-            log_warn_rate_limited!(
-                "cluster",
-                5,
-                format!(
-                    "fail_pending_requests: failing {} pending requests (Connection in recovery)",
-                    count
-                )
-            );
-        }
-        for request in requests {
-            let _ = request.sender.send(Err(RedisError::from((
-                ErrorKind::ClientError,
-                "Connection in recovery",
-            ))));
-        }
-    }
-
     fn poll_recover(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), RedisError>> {
         log_trace_lazy!("cluster", "entered poll_recover");
 
@@ -4037,28 +4005,15 @@ where
 
         match self.as_mut().poll_recover(cx) {
             Poll::Pending => {
-                // Only buffer during fast reconnects (circular MOVED path).
-                // For ReconnectToInitialNodes and RefreshingSlots, fail fast to preserve throughput.
-                if matches!(
-                    &self.state,
-                    ConnectionState::Recover(RecoverFuture::Reconnect(_))
-                ) {
-                    self.buffer_pending_requests_to_recovery_queue();
-                } else {
-                    ClusterConnInner::fail_pending_requests(&self.inner);
-                }
+                // Buffer incoming requests for all recovery paths so they are retried
+                // once recovery completes, instead of being failed immediately.
+                self.buffer_pending_requests_to_recovery_queue();
                 return Poll::Pending;
             }
             Poll::Ready(Err(err)) => {
-                // Same: only buffer during fast Reconnect path.
-                if matches!(
-                    &self.state,
-                    ConnectionState::Recover(RecoverFuture::Reconnect(_))
-                ) {
-                    self.buffer_pending_requests_to_recovery_queue();
-                } else {
-                    ClusterConnInner::fail_pending_requests(&self.inner);
-                }
+                // Buffer incoming requests for all recovery paths so they are retried
+                // once recovery completes, instead of being failed immediately.
+                self.buffer_pending_requests_to_recovery_queue();
                 self.refresh_error = Some(err);
                 cx.waker().wake_by_ref();
                 return Poll::Pending;

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3616,6 +3616,30 @@ where
         }
     }
 
+    /// Fail all requests in the recovery queue with an `AllConnectionsUnavailable` error.
+    /// Called when recovery completes but no connections are available,
+    /// to prevent buffered requests from looping through reconnect indefinitely.
+    fn fail_recovery_queue(&mut self) {
+        if self.recovery_queue.is_empty() {
+            return;
+        }
+        let count = self.recovery_queue.len();
+        log_warn_rate_limited!(
+            "cluster",
+            5,
+            format!(
+                "fail_recovery_queue: failing {} queued requests - no connections after recovery",
+                count
+            )
+        );
+        while let Some(request) = self.recovery_queue.pop_front() {
+            let _ = request.sender.send(Err(RedisError::from((
+                ErrorKind::AllConnectionsUnavailable,
+                "No connections available after recovery",
+            ))));
+        }
+    }
+
     fn poll_recover(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), RedisError>> {
         log_trace_lazy!("cluster", "entered poll_recover");
 
@@ -4019,7 +4043,16 @@ where
                 return Poll::Pending;
             }
             Poll::Ready(Ok(())) => {
-                self.drain_recovery_queue_to_inflight();
+                // Only drain the recovery queue if we actually have connections.
+                // If all connections are still unavailable after recovery (e.g. all nodes dead),
+                // fail the buffered requests immediately rather than dispatching them into
+                // in-flight where they would hit AllConnectionsUnavailable, re-trigger another
+                // ReconnectToInitialNodes, get re-buffered, and loop indefinitely.
+                if self.inner.conn_lock.read().is_empty() {
+                    self.fail_recovery_queue();
+                } else {
+                    self.drain_recovery_queue_to_inflight();
+                }
             }
         }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3532,7 +3532,6 @@ where
         Ok((address, conn))
     }
 
-    /// Fail all pending requests immediately with ClientError.
     /// Buffer incoming requests into the recovery queue while reconnect is in progress.
     /// Requests beyond the queue cap are immediately failed to provide bounded memory usage.
     /// The cap is configured via `recovery_requests_queue_size` in `ClusterParams` (default 1000).
@@ -3616,26 +3615,34 @@ where
         }
     }
 
-    /// Fail all requests in the recovery queue with an `AllConnectionsUnavailable` error.
-    /// Called when recovery completes but no connections are available,
-    /// to prevent buffered requests from looping through reconnect indefinitely.
-    fn fail_recovery_queue(&mut self) {
-        if self.recovery_queue.is_empty() {
-            return;
+    /// Fail all pending requests immediately with ClientError.
+    /// Called when entering recovery to prevent requests from waiting for slow
+    /// reconnection cycles (e.g., ReconnectToInitialNodes, RefreshingSlots).
+    fn fail_pending_requests(inner: &Core<C>) {
+        let mut rx_guard = inner
+            .pending_requests_rx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let mut requests = Vec::new();
+        while let Ok(request) = rx_guard.try_recv() {
+            requests.push(request);
         }
-        let count = self.recovery_queue.len();
-        log_warn_rate_limited!(
-            "cluster",
-            5,
-            format!(
-                "fail_recovery_queue: failing {} queued requests - no connections after recovery",
-                count
-            )
-        );
-        while let Some(request) = self.recovery_queue.pop_front() {
+        drop(rx_guard);
+        let count = requests.len();
+        if count > 0 {
+            log_warn_rate_limited!(
+                "cluster",
+                5,
+                format!(
+                    "fail_pending_requests: failing {} pending requests (Connection in recovery)",
+                    count
+                )
+            );
+        }
+        for request in requests {
             let _ = request.sender.send(Err(RedisError::from((
-                ErrorKind::AllConnectionsUnavailable,
-                "No connections available after recovery",
+                ErrorKind::ClientError,
+                "Connection in recovery",
             ))));
         }
     }
@@ -3726,26 +3733,22 @@ where
             RecoverFuture::ReconnectToInitialNodes(ref mut handle) => {
                 match Pin::new(handle).poll(cx) {
                     Poll::Pending => Poll::Pending,
-                    Poll::Ready(Ok(())) | Poll::Ready(Err(_)) => {
-                        // Whether the task succeeded, failed, or panicked, mark recovery complete.
-                        // Then check if we actually have connections: if not, signal failure so
-                        // poll_flush can fail the recovery queue instead of draining it into
-                        // in-flight (which would cause an infinite reconnect loop).
+                    Poll::Ready(Ok(())) => {
+                        log_trace_lazy!("cluster", "Reconnected to initial nodes");
                         self.state = ConnectionState::PollComplete;
-                        if self.inner.conn_lock.read().is_empty() {
-                            log_warn_rate_limited!(
+                        Poll::Ready(Ok(()))
+                    }
+                    Poll::Ready(Err(join_err)) => {
+                        if join_err.is_cancelled() {
+                            log_trace_lazy!(
                                 "cluster",
-                                5,
-                                "ReconnectToInitialNodes completed but no connections available"
+                                "Reconnect to initial nodes task was aborted"
                             );
-                            Poll::Ready(Err(RedisError::from((
-                                ErrorKind::AllConnectionsUnavailable,
-                                "No connections after reconnect to initial nodes",
-                            ))))
                         } else {
-                            log_trace_lazy!("cluster", "Reconnected to initial nodes");
-                            Poll::Ready(Ok(()))
+                            log_warn_lazy!("cluster", format!("Reconnect to initial nodes task panicked: {:?} - marking recovery as complete", join_err));
                         }
+                        self.state = ConnectionState::PollComplete;
+                        Poll::Ready(Ok(()))
                     }
                 }
             }
@@ -4033,27 +4036,30 @@ where
 
         match self.as_mut().poll_recover(cx) {
             Poll::Pending => {
-                // Buffer incoming requests for all recovery paths so they are retried
-                // once recovery completes, instead of being failed immediately.
-                self.buffer_pending_requests_to_recovery_queue();
+                // Buffer during fast reconnects (circular MOVED) and slot refresh paths.
+                // For ReconnectToInitialNodes, fail fast to preserve throughput.
+                if matches!(
+                    &self.state,
+                    ConnectionState::Recover(RecoverFuture::Reconnect(_))
+                        | ConnectionState::Recover(RecoverFuture::RefreshingSlots(_))
+                ) {
+                    self.buffer_pending_requests_to_recovery_queue();
+                } else {
+                    ClusterConnInner::fail_pending_requests(&self.inner);
+                }
                 return Poll::Pending;
             }
             Poll::Ready(Err(err)) => {
-                // Special case: ReconnectToInitialNodes completed but no connections are
-                // available. Fail the recovery queue immediately to prevent an infinite
-                // buffer → drain → AllConnectionsUnavailable → reconnect loop.
-                if err.kind() == ErrorKind::AllConnectionsUnavailable {
-                    self.fail_recovery_queue();
-                    // Also buffer any NEW requests that just arrived before failing them
-                    // on the next poll cycle via the same path.
+                // Same: only buffer during fast Reconnect or RefreshingSlots paths.
+                if matches!(
+                    &self.state,
+                    ConnectionState::Recover(RecoverFuture::Reconnect(_))
+                        | ConnectionState::Recover(RecoverFuture::RefreshingSlots(_))
+                ) {
                     self.buffer_pending_requests_to_recovery_queue();
-                    self.refresh_error = Some(err);
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
+                } else {
+                    ClusterConnInner::fail_pending_requests(&self.inner);
                 }
-                // For all other errors (e.g. slot refresh errors), buffer requests
-                // so they are retried once recovery completes.
-                self.buffer_pending_requests_to_recovery_queue();
                 self.refresh_error = Some(err);
                 cx.waker().wake_by_ref();
                 return Poll::Pending;

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7392,7 +7392,7 @@ mod cluster_async {
     /// (commands before recovery starts and after recovery completes succeed).
     #[test]
     #[serial_test::serial]
-    fn test_async_cluster_concurrent_requests_buffered_during_reconnect_to_initial_nodes() {
+    fn test_async_cluster_concurrent_requests_fail_fast_during_reconnect_to_initial_nodes() {
         let name = "test_concurrent_reconnect_initial_nodes";
         // How many SET commands before AllConnectionsUnavailable fires
         const FAIL_ON_SET_N: usize = 30;

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7367,6 +7367,321 @@ mod cluster_async {
         );
     }
 
+    /// Tests that concurrent commands arriving while the cluster is in
+    /// `RecoverFuture::ReconnectToInitialNodes` recovery are **buffered** and complete
+    /// after recovery, not immediately failed or silently dropped.
+    ///
+    /// ## How ReconnectToInitialNodes is triggered
+    ///
+    /// When a command receives `AllConnectionsUnavailable`, `Request::poll` returns
+    /// `Next::ReconnectToInitialNodes`, which maps to `PollFlushAction::ReconnectFromInitialConnections`,
+    /// which transitions `ConnectionState` to `Recover(RecoverFuture::ReconnectToInitialNodes(handle))`.
+    ///
+    /// ## Recovery window
+    ///
+    /// PING is delayed to widen the recovery window so that concurrent tasks accumulate
+    /// in `pending_requests_tx` while the `ReconnectToInitialNodes` JoinHandle is `Pending`.
+    ///
+    /// ## Assertion
+    ///
+    /// Zero command errors: all commands must succeed after recovery completes.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_concurrent_requests_buffered_during_reconnect_to_initial_nodes() {
+        let name = "test_concurrent_reconnect_initial_nodes";
+        // How many SET commands before AllConnectionsUnavailable fires
+        const FAIL_ON_SET_N: usize = 30;
+        const CONCURRENCY: usize = 20;
+        const PIPELINE_ITERATIONS: usize = 5;
+        const PIPELINE_SIZE: usize = 10;
+        const DELAY_AFTER_FAIL_MS: u64 = 5;
+        // Delay PING (used in reconnect handshake) to widen the recovery window so that
+        // concurrent tasks accumulate in pending_requests_tx while the JoinHandle is Pending.
+        const PING_DELAY_MS: u64 = 20;
+
+        let set_count = Arc::new(atomic::AtomicUsize::new(0));
+        let set_count_clone = set_count.clone();
+        let fail_fired = Arc::new(atomic::AtomicBool::new(false));
+        let fail_fired_clone = fail_fired.clone();
+        let fail_fired_handler = fail_fired.clone();
+        let name_handler = name.to_string();
+
+        let _handler = MockConnectionBehavior::register_new(
+            name,
+            Arc::new(move |cmd: &[u8], port| {
+                let name = name_handler.as_str();
+                if contains_slice(cmd, b"PING") {
+                    if fail_fired_handler.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(PING_DELAY_MS));
+                    }
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::Int(port as i64),
+                        ]),
+                    ])])));
+                }
+                if contains_slice(cmd, b"SET") {
+                    let i = set_count_clone.fetch_add(1, atomic::Ordering::SeqCst);
+                    if i == FAIL_ON_SET_N {
+                        fail_fired_clone.store(true, atomic::Ordering::SeqCst);
+                        // AllConnectionsUnavailable triggers Next::ReconnectToInitialNodes
+                        // → PollFlushAction::ReconnectFromInitialConnections
+                        // → RecoverFuture::ReconnectToInitialNodes
+                        return Err(Err(RedisError::from((
+                            ErrorKind::AllConnectionsUnavailable,
+                            "all connections unavailable (test-injected)",
+                        ))));
+                    }
+                    if fail_fired_clone.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(DELAY_AFTER_FAIL_MS));
+                    }
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"GET") {
+                    return Err(Ok(Value::BulkString(b"value".to_vec().into())));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(4)
+            .build()
+            .expect("failed to build multi-thread runtime");
+
+        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .retries(5)
+            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
+            .build()
+            .expect("failed to build ClusterClient");
+
+        let connection: ClusterConnection<MockConnection> = runtime
+            .block_on(client.get_async_generic_connection())
+            .expect("failed to get async connection");
+
+        let results = runtime.block_on(async move {
+            let barrier = Arc::new(tokio::sync::Barrier::new(CONCURRENCY));
+            let tasks: Vec<_> = (0..CONCURRENCY)
+                .map(|task_id| {
+                    let mut conn = connection.clone();
+                    let barrier = barrier.clone();
+                    tokio::spawn(async move {
+                        barrier.wait().await;
+                        let mut cmd_errors = 0usize;
+                        let mut cmd_successes = 0usize;
+                        for iter in 0..PIPELINE_ITERATIONS {
+                            for k in 0..PIPELINE_SIZE {
+                                let cmd = redis::Cmd::new()
+                                    .arg("SET")
+                                    .arg(format!("t{task_id}_key{k}"))
+                                    .arg("value")
+                                    .clone();
+                                match conn.req_packed_command(&cmd).await {
+                                    Ok(_) => cmd_successes += 1,
+                                    Err(e) => {
+                                        println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
+                                        cmd_errors += 1;
+                                    }
+                                }
+                            }
+                        }
+                        (task_id, cmd_successes, cmd_errors)
+                    })
+                })
+                .collect();
+            futures::future::join_all(tasks).await
+        });
+
+        let total_errors: usize = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|(_, _, e)| e)
+            .sum();
+        let total_sets = set_count.load(atomic::Ordering::SeqCst);
+
+        assert_eq!(
+            total_errors,
+            0,
+            "Expected zero command errors: commands buffered during ReconnectToInitialNodes \
+             recovery must succeed after recovery. Got {} errors (total SETs to mock: {}).",
+            total_errors,
+            total_sets,
+        );
+    }
+
+    /// Tests that concurrent commands arriving while the cluster is in
+    /// `RecoverFuture::RefreshingSlots` recovery are **buffered** and complete after
+    /// recovery, not immediately failed or silently dropped.
+    ///
+    /// ## How RefreshingSlots is triggered
+    ///
+    /// A MOVED to a **different host** (non-circular) causes `Next::RefreshSlots`, which maps
+    /// to `PollFlushAction::RebuildSlots`, which transitions `ConnectionState` to
+    /// `Recover(RecoverFuture::RefreshingSlots(handle))`.
+    ///
+    /// A circular MOVED (same host:port) would take the `Reconnect` fast-path instead,
+    /// so we must use a different hostname in the MOVED response.
+    ///
+    /// ## Recovery window
+    ///
+    /// CLUSTER SLOTS response is delayed after the MOVED fires to keep the
+    /// `RefreshingSlots` JoinHandle in `Poll::Pending` long enough for concurrent tasks
+    /// to accumulate in `pending_requests_tx`.
+    ///
+    /// ## Assertion
+    ///
+    /// Zero command errors: all commands must succeed after the slot refresh completes.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_concurrent_requests_buffered_during_refreshing_slots() {
+        let name = "test_concurrent_refreshing_slots";
+        const MOVED_ON_SET_N: usize = 30;
+        const CONCURRENCY: usize = 20;
+        const PIPELINE_ITERATIONS: usize = 5;
+        const PIPELINE_SIZE: usize = 10;
+        const DELAY_AFTER_MOVED_MS: u64 = 5;
+        // Delay CLUSTER SLOTS to widen the RefreshingSlots recovery window.
+        const CLUSTER_SLOTS_DELAY_MS: u64 = 30;
+
+        let set_count = Arc::new(atomic::AtomicUsize::new(0));
+        let set_count_clone = set_count.clone();
+        let moved_fired = Arc::new(atomic::AtomicBool::new(false));
+        let moved_fired_clone = moved_fired.clone();
+        let moved_fired_cluster = moved_fired.clone();
+        let name_handler = name.to_string();
+
+        let _handler = MockConnectionBehavior::register_new(
+            name,
+            Arc::new(move |cmd: &[u8], port| {
+                let name = name_handler.as_str();
+                if contains_slice(cmd, b"PING") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    // Delay CLUSTER SLOTS after MOVED fires to keep RefreshingSlots Pending
+                    if moved_fired_cluster.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            CLUSTER_SLOTS_DELAY_MS,
+                        ));
+                    }
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::Int(port as i64),
+                        ]),
+                    ])])));
+                }
+                if contains_slice(cmd, b"SET") {
+                    let i = set_count_clone.fetch_add(1, atomic::Ordering::SeqCst);
+                    if i == MOVED_ON_SET_N {
+                        moved_fired_clone.store(true, atomic::Ordering::SeqCst);
+                        // Non-circular MOVED: different hostname triggers RebuildSlots → RefreshingSlots.
+                        // The client will re-fetch CLUSTER SLOTS and re-route to the real node.
+                        // We deliberately use a different hostname so the client does NOT take the
+                        // circular-MOVED Reconnect fast-path; it must go through RefreshingSlots.
+                        return Err(parse_redis_value(
+                            format!("-MOVED 0 other_host:6380\r\n").as_bytes(),
+                        ));
+                    }
+                    if moved_fired_clone.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(DELAY_AFTER_MOVED_MS));
+                    }
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"GET") {
+                    return Err(Ok(Value::BulkString(b"value".to_vec().into())));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(4)
+            .build()
+            .expect("failed to build multi-thread runtime");
+
+        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .retries(5)
+            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
+            .build()
+            .expect("failed to build ClusterClient");
+
+        let connection: ClusterConnection<MockConnection> = runtime
+            .block_on(client.get_async_generic_connection())
+            .expect("failed to get async connection");
+
+        let results = runtime.block_on(async move {
+            let barrier = Arc::new(tokio::sync::Barrier::new(CONCURRENCY));
+            let tasks: Vec<_> = (0..CONCURRENCY)
+                .map(|task_id| {
+                    let mut conn = connection.clone();
+                    let barrier = barrier.clone();
+                    tokio::spawn(async move {
+                        barrier.wait().await;
+                        let mut cmd_errors = 0usize;
+                        let mut cmd_successes = 0usize;
+                        for iter in 0..PIPELINE_ITERATIONS {
+                            for k in 0..PIPELINE_SIZE {
+                                let cmd = redis::Cmd::new()
+                                    .arg("SET")
+                                    .arg(format!("t{task_id}_key{k}"))
+                                    .arg("value")
+                                    .clone();
+                                match conn.req_packed_command(&cmd).await {
+                                    Ok(_) => cmd_successes += 1,
+                                    Err(e) => {
+                                        println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
+                                        cmd_errors += 1;
+                                    }
+                                }
+                            }
+                        }
+                        (task_id, cmd_successes, cmd_errors)
+                    })
+                })
+                .collect();
+            futures::future::join_all(tasks).await
+        });
+
+        let total_errors: usize = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|(_, _, e)| e)
+            .sum();
+        let total_sets = set_count.load(atomic::Ordering::SeqCst);
+
+        assert_eq!(
+            total_errors,
+            0,
+            "Expected zero command errors: commands buffered during RefreshingSlots recovery \
+             must succeed after recovery. Got {} errors (total SETs to mock: {}).",
+            total_errors,
+            total_sets,
+        );
+    }
+
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;
         use redis::ConnectionInfo;

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7368,8 +7368,12 @@ mod cluster_async {
     }
 
     /// Tests that concurrent commands arriving while the cluster is in
-    /// `RecoverFuture::ReconnectToInitialNodes` recovery are **buffered** and complete
-    /// after recovery, not immediately failed or silently dropped.
+    /// `RecoverFuture::ReconnectToInitialNodes` recovery are **failed fast** with
+    /// `ClientError("Connection in recovery")`, not silently dropped or hung indefinitely.
+    ///
+    /// `ReconnectToInitialNodes` is a slow recovery path (may block for connection_timeout
+    /// per attempt). Requests are intentionally failed immediately to preserve throughput,
+    /// rather than buffered (which would cause requests to wait for the full reconnect cycle).
     ///
     /// ## How ReconnectToInitialNodes is triggered
     ///
@@ -7384,7 +7388,8 @@ mod cluster_async {
     ///
     /// ## Assertion
     ///
-    /// Zero command errors: all commands must succeed after recovery completes.
+    /// Some command errors are expected (fail-fast), but most commands should succeed
+    /// (commands before recovery starts and after recovery completes succeed).
     #[test]
     #[serial_test::serial]
     fn test_async_cluster_concurrent_requests_buffered_during_reconnect_to_initial_nodes() {
@@ -7510,13 +7515,32 @@ mod cluster_async {
             .filter_map(|r| r.as_ref().ok())
             .map(|(_, _, e)| e)
             .sum();
+        let total_successes: usize = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok())
+            .map(|(_, s, _)| s)
+            .sum();
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
 
+        // With fail-fast behavior, requests that arrive during ReconnectToInitialNodes recovery
+        // get an immediate ClientError. Only the commands that arrive AFTER recovery completes
+        // (or before it starts) should succeed. Some errors are expected and correct.
+        assert!(
+            total_errors > 0,
+            "Expected some command errors during ReconnectToInitialNodes recovery (fail-fast path), \
+             but got zero. Got {} total SET commands to mock.",
+            total_sets,
+        );
+        // Assert no commands are silently dropped: every command must either succeed or error.
+        let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
         assert_eq!(
-            total_errors, 0,
-            "Expected zero command errors: commands buffered during ReconnectToInitialNodes \
-             recovery must succeed after recovery. Got {} errors (total SETs to mock: {}).",
-            total_errors, total_sets,
+            total_successes + total_errors,
+            expected_cmds,
+            "Commands were silently dropped: {} succeeded + {} errors = {} != {} expected",
+            total_successes,
+            total_errors,
+            total_successes + total_errors,
+            expected_cmds,
         );
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7247,7 +7247,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::BulkString(name.as_bytes().to_vec()),
                             Value::Int(port as i64),
                         ]),
                     ])])));
@@ -7268,7 +7268,7 @@ mod cluster_async {
                     return Err(Ok(Value::SimpleString("OK".into())));
                 }
                 if contains_slice(cmd, b"GET") {
-                    return Err(Ok(Value::BulkString(b"value".to_vec().into())));
+                    return Err(Ok(Value::BulkString(b"value".to_vec())));
                 }
                 Err(Ok(Value::SimpleString("OK".into())))
             }),
@@ -7432,7 +7432,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::BulkString(name.as_bytes().to_vec()),
                             Value::Int(port as i64),
                         ]),
                     ])])));
@@ -7455,7 +7455,7 @@ mod cluster_async {
                     return Err(Ok(Value::SimpleString("OK".into())));
                 }
                 if contains_slice(cmd, b"GET") {
-                    return Err(Ok(Value::BulkString(b"value".to_vec().into())));
+                    return Err(Ok(Value::BulkString(b"value".to_vec())));
                 }
                 Err(Ok(Value::SimpleString("OK".into())))
             }),
@@ -7510,26 +7510,27 @@ mod cluster_async {
             futures::future::join_all(tasks).await
         });
 
+        // Unwrap join results — if any worker panicked the test should fail loudly, not silently
+        // drop the worker's counts and produce a misleading assertion failure.
         let total_errors: usize = results
             .iter()
-            .filter_map(|r| r.as_ref().ok())
+            .map(|r| r.as_ref().expect("worker task panicked"))
             .map(|(_, _, e)| e)
             .sum();
         let total_successes: usize = results
             .iter()
-            .filter_map(|r| r.as_ref().ok())
+            .map(|r| r.as_ref().expect("worker task panicked"))
             .map(|(_, s, _)| s)
             .sum();
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
 
         // With fail-fast behavior, requests that arrive during ReconnectToInitialNodes recovery
-        // get an immediate ClientError. Only the commands that arrive AFTER recovery completes
-        // (or before it starts) should succeed. Some errors are expected and correct.
-        assert!(
-            total_errors > 0,
-            "Expected some command errors during ReconnectToInitialNodes recovery (fail-fast path), \
-             but got zero. Got {} total SET commands to mock.",
-            total_sets,
+        // get an immediate ClientError. We observe but do not assert on total_errors > 0 because
+        // on a loaded CI runner recovery may complete before any concurrent worker reaches
+        // pending_requests_tx, yielding zero errors without indicating a bug.
+        println!(
+            "ReconnectToInitialNodes fail-fast: {} errors, {} successes (total SETs to mock: {})",
+            total_errors, total_successes, total_sets,
         );
         // Assert no commands are silently dropped: every command must either succeed or error.
         let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
@@ -7609,7 +7610,7 @@ mod cluster_async {
                         Value::Int(0),
                         Value::Int(16383),
                         Value::Array(vec![
-                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::BulkString(name.as_bytes().to_vec()),
                             Value::Int(port as i64),
                         ]),
                     ])])));
@@ -7622,9 +7623,7 @@ mod cluster_async {
                         // The client will re-fetch CLUSTER SLOTS and re-route to the real node.
                         // We deliberately use a different hostname so the client does NOT take the
                         // circular-MOVED Reconnect fast-path; it must go through RefreshingSlots.
-                        return Err(parse_redis_value(
-                            format!("-MOVED 0 other_host:6380\r\n").as_bytes(),
-                        ));
+                        return Err(parse_redis_value(b"-MOVED 0 other_host:6380\r\n"));
                     }
                     if moved_fired_clone.load(atomic::Ordering::SeqCst) {
                         std::thread::sleep(std::time::Duration::from_millis(DELAY_AFTER_MOVED_MS));
@@ -7632,7 +7631,7 @@ mod cluster_async {
                     return Err(Ok(Value::SimpleString("OK".into())));
                 }
                 if contains_slice(cmd, b"GET") {
-                    return Err(Ok(Value::BulkString(b"value".to_vec().into())));
+                    return Err(Ok(Value::BulkString(b"value".to_vec())));
                 }
                 Err(Ok(Value::SimpleString("OK".into())))
             }),
@@ -7689,16 +7688,15 @@ mod cluster_async {
 
         let total_errors: usize = results
             .iter()
-            .filter_map(|r| r.as_ref().ok())
+            .map(|r| r.as_ref().expect("worker task panicked"))
             .map(|(_, _, e)| e)
             .sum();
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
 
         assert_eq!(
             total_errors, 0,
-            "Expected zero command errors: commands buffered during RefreshingSlots recovery \
-             must succeed after recovery. Got {} errors (total SETs to mock: {}).",
-            total_errors, total_sets,
+            "commands buffered during RefreshingSlots recovery must succeed; total SETs to mock: {}",
+            total_sets,
         );
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7513,12 +7513,10 @@ mod cluster_async {
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
 
         assert_eq!(
-            total_errors,
-            0,
+            total_errors, 0,
             "Expected zero command errors: commands buffered during ReconnectToInitialNodes \
              recovery must succeed after recovery. Got {} errors (total SETs to mock: {}).",
-            total_errors,
-            total_sets,
+            total_errors, total_sets,
         );
     }
 
@@ -7673,12 +7671,10 @@ mod cluster_async {
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
 
         assert_eq!(
-            total_errors,
-            0,
+            total_errors, 0,
             "Expected zero command errors: commands buffered during RefreshingSlots recovery \
              must succeed after recovery. Got {} errors (total SETs to mock: {}).",
-            total_errors,
-            total_sets,
+            total_errors, total_sets,
         );
     }
 

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -837,19 +837,15 @@ mod cluster_client_tests {
         // Test for #4990: Failover causes near-zero throughput
         // See: https://github.com/valkey-io/valkey-glide/issues/4990
         //
-        // Kills all cluster nodes (with a TCP blackhole as one seed node) to force
-        // ReconnectToInitialNodes recovery. Fires CONCURRENT_CMDS commands all at once and
-        // asserts that all of them complete (either with a result or an error) within a
-        // generous deadline once recovery finishes.
-        //
-        // Before the PR fix, requests were immediately failed during ReconnectToInitialNodes.
-        // After the fix, requests are buffered in the recovery queue and retried once recovery
-        // completes. Either way, requests must NOT be silently lost or hung indefinitely.
+        // Kills all cluster nodes with a TCP blackhole as seed node, then measures how many
+        // commands complete in a time window during reconnection. Without the fix, poll_flush
+        // blocks behind the reconnect task (2000ms per attempt) and commands are not processed.
+        // With the fix, ReconnectToInitialNodes path calls fail_pending_requests immediately,
+        // so commands get ClientError quickly and the loop can advance.
         block_on_all(async {
             const CONNECTION_TIMEOUT_MS: u64 = 2000;
-            // Per-command deadline: one full reconnect cycle + generous retry margin
-            const CMD_DEADLINE_MS: u64 = CONNECTION_TIMEOUT_MS * 3 + 2000;
-            const CONCURRENT_CMDS: usize = 10;
+            const WINDOW_MS: u64 = 3000;
+            const MIN_COMMANDS_WITH_FIX: u32 = 10;
 
             // TCP blackhole: accepts connections but never responds.
             // Simulates a seed node whose DNS hasn't updated after failover.
@@ -889,13 +885,12 @@ mod cluster_client_tests {
                 .build()
                 .expect("build cluster client");
 
-            let conn: redis::cluster_async::ClusterConnection = cluster_client
+            let mut conn: redis::cluster_async::ClusterConnection = cluster_client
                 .get_async_connection(None, None, None)
                 .await
                 .expect("connect to cluster");
 
             let ping: redis::RedisResult<redis::Value> = conn
-                .clone()
                 .route_command(
                     &redis::cmd("PING"),
                     redis::cluster_routing::RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random),
@@ -903,7 +898,7 @@ mod cluster_client_tests {
                 .await;
             assert!(ping.is_ok(), "PING before kill failed: {:?}", ping);
 
-            // Kill all cluster nodes to trigger ReconnectToInitialNodes
+            // Kill all cluster nodes to trigger reconnect
             for pid in &pids {
                 std::process::Command::new("kill")
                     .args(["-9", &pid.to_string()])
@@ -914,53 +909,37 @@ mod cluster_client_tests {
             // Wait for connection health checks to detect failures
             tokio::time::sleep(Duration::from_millis(500)).await;
 
-            // Fire CONCURRENT_CMDS commands all at once.
-            // They should be buffered during recovery and all complete within the deadline —
-            // none should be silently dropped or hung indefinitely.
-            let cmd = {
-                let mut c = redis::cmd("GET");
-                c.arg("{test}key");
-                c
-            };
+            // Measure how many commands complete (success or error) in the window.
+            // With fail-fast, each command gets ClientError immediately so the loop
+            // advances quickly. Without the fix, each command would block for
+            // CONNECTION_TIMEOUT_MS waiting for the reconnect task to finish.
+            let mut completed: u32 = 0;
+            let mut cmd = redis::cmd("GET");
+            cmd.arg("{test}key");
+            let window_start = std::time::Instant::now();
 
-            let mut handles = Vec::with_capacity(CONCURRENT_CMDS);
-            for _ in 0..CONCURRENT_CMDS {
-                let mut c = conn.clone();
-                let cmd = cmd.clone();
-                let handle = tokio::spawn(async move {
-                    tokio::time::timeout(
-                        Duration::from_millis(CMD_DEADLINE_MS),
-                        c.route_command(
-                            &cmd,
-                            redis::cluster_routing::RoutingInfo::SingleNode(
-                                SingleNodeRoutingInfo::SpecificNode(Route::new(
-                                    0,
-                                    SlotAddr::Master,
-                                )),
-                            ),
+            while window_start.elapsed() < Duration::from_millis(WINDOW_MS) {
+                let _ = tokio::time::timeout(
+                    Duration::from_millis(CONNECTION_TIMEOUT_MS + 500),
+                    conn.route_command(
+                        &cmd,
+                        redis::cluster_routing::RoutingInfo::SingleNode(
+                            SingleNodeRoutingInfo::SpecificNode(Route::new(0, SlotAddr::Master)),
                         ),
-                    )
-                    .await
-                });
-                handles.push(handle);
+                    ),
+                )
+                .await;
+                completed += 1;
             }
 
-            let mut completed = 0usize;
-            for handle in handles {
-                // Ok(Ok(_)) or Ok(Err(_)) = command completed within the deadline (redis ok or err)
-                // Ok(Err(timeout)) would be a tokio::time::error::Elapsed — not Ok(Ok/Err)
-                // Err(_) = task panicked
-                if let Ok(Ok(_)) = handle.await {
-                    completed += 1;
-                }
-            }
-
-            assert_eq!(
-                completed, CONCURRENT_CMDS,
-                "Concurrent requests were lost or hung: only {}/{} completed within {}ms during \
-                 ReconnectToInitialNodes recovery. Requests must be buffered and returned (ok or err), \
-                 not silently dropped.",
-                completed, CONCURRENT_CMDS, CMD_DEADLINE_MS,
+            assert!(
+                completed >= MIN_COMMANDS_WITH_FIX,
+                "Send loop blocked: only {}/{} commands completed in {}ms. \
+                 Each command serialized behind reconnect_to_initial_nodes blocking for {}ms.",
+                completed,
+                MIN_COMMANDS_WITH_FIX,
+                WINDOW_MS,
+                CONNECTION_TIMEOUT_MS,
             );
         });
     }

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -933,7 +933,10 @@ mod cluster_client_tests {
                         c.route_command(
                             &cmd,
                             redis::cluster_routing::RoutingInfo::SingleNode(
-                                SingleNodeRoutingInfo::SpecificNode(Route::new(0, SlotAddr::Master)),
+                                SingleNodeRoutingInfo::SpecificNode(Route::new(
+                                    0,
+                                    SlotAddr::Master,
+                                )),
                             ),
                         ),
                     )

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -837,14 +837,19 @@ mod cluster_client_tests {
         // Test for #4990: Failover causes near-zero throughput
         // See: https://github.com/valkey-io/valkey-glide/issues/4990
         //
-        // Kills all cluster nodes with a TCP blackhole as seed node, then measures how many
-        // commands complete in a time window during reconnection. Without fixes, poll_flush blocks
-        // and causes commands to not be processed, leading to near-zero throughput (~1 completes
-        // every few seconds instead of immediately).
+        // Kills all cluster nodes (with a TCP blackhole as one seed node) to force
+        // ReconnectToInitialNodes recovery. Fires CONCURRENT_CMDS commands all at once and
+        // asserts that all of them complete (either with a result or an error) within a
+        // generous deadline once recovery finishes.
+        //
+        // Before the PR fix, requests were immediately failed during ReconnectToInitialNodes.
+        // After the fix, requests are buffered in the recovery queue and retried once recovery
+        // completes. Either way, requests must NOT be silently lost or hung indefinitely.
         block_on_all(async {
             const CONNECTION_TIMEOUT_MS: u64 = 2000;
-            const WINDOW_MS: u64 = 3000;
-            const MIN_COMMANDS_WITH_FIX: u32 = 10;
+            // Per-command deadline: one full reconnect cycle + generous retry margin
+            const CMD_DEADLINE_MS: u64 = CONNECTION_TIMEOUT_MS * 3 + 2000;
+            const CONCURRENT_CMDS: usize = 10;
 
             // TCP blackhole: accepts connections but never responds.
             // Simulates a seed node whose DNS hasn't updated after failover.
@@ -884,12 +889,13 @@ mod cluster_client_tests {
                 .build()
                 .expect("build cluster client");
 
-            let mut conn: redis::cluster_async::ClusterConnection = cluster_client
+            let conn: redis::cluster_async::ClusterConnection = cluster_client
                 .get_async_connection(None, None, None)
                 .await
                 .expect("connect to cluster");
 
             let ping: redis::RedisResult<redis::Value> = conn
+                .clone()
                 .route_command(
                     &redis::cmd("PING"),
                     redis::cluster_routing::RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random),
@@ -897,7 +903,7 @@ mod cluster_client_tests {
                 .await;
             assert!(ping.is_ok(), "PING before kill failed: {:?}", ping);
 
-            // Kill all cluster nodes to trigger reconnect
+            // Kill all cluster nodes to trigger ReconnectToInitialNodes
             for pid in &pids {
                 std::process::Command::new("kill")
                     .args(["-9", &pid.to_string()])
@@ -908,34 +914,50 @@ mod cluster_client_tests {
             // Wait for connection health checks to detect failures
             tokio::time::sleep(Duration::from_millis(500)).await;
 
-            // Measure how many commands complete (success or error) in the window
-            let mut completed: u32 = 0;
-            let mut cmd = redis::cmd("GET");
-            cmd.arg("{test}key");
-            let window_start = std::time::Instant::now();
+            // Fire CONCURRENT_CMDS commands all at once.
+            // They should be buffered during recovery and all complete within the deadline —
+            // none should be silently dropped or hung indefinitely.
+            let cmd = {
+                let mut c = redis::cmd("GET");
+                c.arg("{test}key");
+                c
+            };
 
-            while window_start.elapsed() < Duration::from_millis(WINDOW_MS) {
-                let _ = tokio::time::timeout(
-                    Duration::from_millis(CONNECTION_TIMEOUT_MS + 500),
-                    conn.route_command(
-                        &cmd,
-                        redis::cluster_routing::RoutingInfo::SingleNode(
-                            SingleNodeRoutingInfo::SpecificNode(Route::new(0, SlotAddr::Master)),
+            let mut handles = Vec::with_capacity(CONCURRENT_CMDS);
+            for _ in 0..CONCURRENT_CMDS {
+                let mut c = conn.clone();
+                let cmd = cmd.clone();
+                let handle = tokio::spawn(async move {
+                    tokio::time::timeout(
+                        Duration::from_millis(CMD_DEADLINE_MS),
+                        c.route_command(
+                            &cmd,
+                            redis::cluster_routing::RoutingInfo::SingleNode(
+                                SingleNodeRoutingInfo::SpecificNode(Route::new(0, SlotAddr::Master)),
+                            ),
                         ),
-                    ),
-                )
-                .await;
-                completed += 1;
+                    )
+                    .await
+                });
+                handles.push(handle);
             }
 
-            assert!(
-                completed >= MIN_COMMANDS_WITH_FIX,
-                "Send loop blocked: only {}/{} commands completed in {}ms. \
-                 Each command serialized behind ready!(reconnect_to_initial_nodes) blocking for {}ms.",
-                completed,
-                MIN_COMMANDS_WITH_FIX,
-                WINDOW_MS,
-                CONNECTION_TIMEOUT_MS,
+            let mut completed = 0usize;
+            for handle in handles {
+                // Ok(Ok(_)) or Ok(Err(_)) = command completed within the deadline (redis ok or err)
+                // Ok(Err(timeout)) would be a tokio::time::error::Elapsed — not Ok(Ok/Err)
+                // Err(_) = task panicked
+                if let Ok(Ok(_)) = handle.await {
+                    completed += 1;
+                }
+            }
+
+            assert_eq!(
+                completed, CONCURRENT_CMDS,
+                "Concurrent requests were lost or hung: only {}/{} completed within {}ms during \
+                 ReconnectToInitialNodes recovery. Requests must be buffered and returned (ok or err), \
+                 not silently dropped.",
+                completed, CONCURRENT_CMDS, CMD_DEADLINE_MS,
             );
         });
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Extend request buffering during cluster recovery to also cover the `RefreshingSlots` path, in addition to the `Reconnect` path already fixed by #6640. Requests arriving while a slot refresh is in progress are now buffered and retried transparently once the refresh completes, instead of being failed immediately with `ClientError("Connection in recovery")`.

`ReconnectToInitialNodes` intentionally keeps the existing fail-fast behavior to preserve throughput during slow reconnect cycles.

### Issue link

N/A

### Features / Behaviour Changes

**Before this PR (post-#6640 state):**
- `Reconnect` (circular MOVED): requests buffered ✅
- `RefreshingSlots` (MOVED / topology change): requests failed immediately with `ClientError` ❌
- `ReconnectToInitialNodes` (all nodes dead): requests failed immediately ✅ (intentional)

**After this PR:**
- `Reconnect`: requests buffered ✅ (unchanged)
- `RefreshingSlots`: requests **now buffered** → retried after slot refresh completes ✅
- `ReconnectToInitialNodes`: requests failed immediately ✅ (unchanged, intentional)

Slot refreshes typically complete in <100ms, so buffering here eliminates transient `"Connection in recovery"` errors that callers previously had to handle with retry logic.

### Implementation

**`glide-core/redis-rs/redis/src/cluster_async/mod.rs`**

In `poll_flush`, the `matches!` guard in both the `Poll::Pending` and `Poll::Ready(Err)` arms is extended to include `RefreshingSlots`:

```rust
// Before:
ConnectionState::Recover(RecoverFuture::Reconnect(_))

// After:
ConnectionState::Recover(RecoverFuture::Reconnect(_))
    | ConnectionState::Recover(RecoverFuture::RefreshingSlots(_))
```

All other logic (`fail_pending_requests`, `buffer_pending_requests_to_recovery_queue`, `drain_recovery_queue_to_inflight`, the recovery queue cap) is unchanged from #6640.

### Limitations

- `ReconnectToInitialNodes` is intentionally kept fail-fast. Buffering during a slow reconnect (may block for `connection_timeout` per attempt) would cause requests to wait seconds, degrading throughput during full cluster outages.
- Overflow requests beyond `recovery_requests_queue_size` (default 1000) are still failed immediately.

### Testing

**Existing test (passes, regression coverage):**
- `test_async_cluster_concurrent_requests_during_circular_moved_reconnect`: verifies `Reconnect` path still buffers and all 1000 commands succeed.

**New tests:**
- `test_async_cluster_concurrent_requests_fail_fast_during_reconnect_to_initial_nodes`: verifies `ReconnectToInitialNodes` path still fails fast — some errors expected, no commands silently dropped.
- `test_async_cluster_concurrent_requests_buffered_during_refreshing_slots`: verifies `RefreshingSlots` path now buffers — asserts zero command errors after slot refresh completes.
- `test_reconnect_to_initial_nodes_doesnt_block_throughput` (integration test, glide-core): verifies fail-fast throughput during `ReconnectToInitialNodes` — ≥10 commands complete in a 3-second window even with a 2-second blackhole connection timeout.

### Checklist

Before submitting the PR make sure the following are checked:

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [ ] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
