### PR TITLE
Rust: Fix flaky test_pipeline_can_reconnect by filtering partial pipeline failures

### DIFF
--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -2026,6 +2026,13 @@ pub(crate) mod shared_client_tests {
                         )
                         .await
                         .ok()
+                        .filter(|value| {
+                            // Retry if any response contains a server error (e.g. BrokenPipe
+                            // during reconnection). The pipeline may partially succeed when
+                            // some commands route to a healthy node while others hit a
+                            // still-recovering connection.
+                            !matches!(value, Value::Array(arr) if arr.iter().any(|v| matches!(v, Value::ServerError(_))))
+                        })
                 },
                 std::time::Duration::from_millis(10_000),
             )
@@ -2183,6 +2190,11 @@ pub(crate) mod shared_client_tests {
                         )
                         .await
                         .ok()
+                        .filter(|value| {
+                            // Retry if any response contains a server error (e.g. BrokenPipe
+                            // during reconnection).
+                            !matches!(value, Value::Array(arr) if arr.iter().any(|v| matches!(v, Value::ServerError(_))))
+                        })
                 },
                 std::time::Duration::from_millis(10_000),
             )


### PR DESCRIPTION
### Summary

Fix flaky `test_pipeline_can_reconnect::use_cluster_2_true` test that fails intermittently with `BrokenPipe` errors when the pipeline receives partial failures during reconnection.

### Issue link

This Pull Request is linked to issue: [[Rust][Flaky Test] test_pipeline_can_reconnect](https://github.com/valkey-io/valkey-glide/issues/6711)
Closes #6711

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The test kills a connection for one specific route (key2's slot), then retries the pipeline in a loop using `.ok()` to convert `Result<Value, Error>` to `Option<Value>`. When the cluster is partially reconnecting, `send_pipeline` returns `Ok(Value::Array([ok, value, ServerError(BrokenPipe), ServerError(BrokenPipe)]))` — commands to healthy nodes succeed, but commands to the recovering node return embedded `ServerError` values. Since `.ok()` converts any `Ok(...)` to `Some(...)`, the retry loop accepts this partial failure as success, and the subsequent `assert_eq!` fails.

**Fix:** Add `.filter()` after `.ok()` to reject pipeline results containing any `Value::ServerError` variant. This ensures the retry loop continues until all pipeline commands succeed. Applied to both `test_pipeline_can_reconnect` and `test_pipeline_reconnect_after_kill_all_connections` (same pattern).

### Limitations

None

### Testing

- Fix compiles cleanly (`cargo check --tests`)
- Ran `test_pipeline_can_reconnect` 100 consecutive times — all 100 passes, 0 failures
- `test_pipeline_reconnect_after_kill_all_connections` also passes consistently

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Lint checked manually (matched surrounding style; lint tools not run per shared rule 3).
- [x] Destination branch is correct - main