### PR TITLE
fix(python): make async pipe transport fork-safe (cherry-pick #6679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))
 * Core/All: Buffer pending cluster requests during reconnect instead of failing immediately. A new `recovery_requests_queue_size` option (default: 1000) controls the queue depth. Set to 0 to disable. ([#6640](https://github.com/valkey-io/valkey-glide/pull/6640))
 * Python: Restore `BaseClient.__aenter__` return type to `Self` (from the widened `"BaseClient"` introduced in 2.5.0). Entering the async context manager (`async with await GlideClusterClient.create(...) as client`) now preserves the concrete subclass for static type checkers, matching `create()`. ([#6531](https://github.com/valkey-io/valkey-glide/issues/6531))
 * Core/FFI: fix(ffi): forward Disconnection push notifications past the malformed-frame guard. PR #6530 inadvertently chained `PushKind::Disconnection` (which carries an empty payload) through `extract_pubsub_data`, causing all disconnect notifications to be silently dropped on the async pipe path. ([#6543](https://github.com/valkey-io/valkey-glide/pull/6543))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -39,7 +39,7 @@ use std::slice::from_raw_parts;
 use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::{Condvar, OnceLock};
+use std::sync::Condvar;
 use std::{
     ffi::{CString, c_void},
     os::raw::{c_char, c_double, c_long, c_ulong},
@@ -562,7 +562,25 @@ struct SharedPipeWriter {
     #[allow(dead_code)]
     pipe_fd: i32,
 }
-static ASYNC_PIPE: OnceLock<SharedPipeWriter> = OnceLock::new();
+/// The process-wide async pipe state. Uses an atomic pointer so the read path
+/// is lock-free and cannot be inherited in a locked state after fork().
+/// Note: the `SharedPipeWriter` itself contains a `Mutex<Vec<u8>>` which is
+/// fork-unsafe; callers must swap in a fresh writer via `reinit_async_pipe`
+/// before any push touches the inherited instance.
+static ASYNC_PIPE: std::sync::atomic::AtomicPtr<SharedPipeWriter> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+/// Returns the current pipe writer, if one is installed. Lock-free read.
+#[inline]
+fn get_async_pipe() -> Option<&'static SharedPipeWriter> {
+    let p = ASYNC_PIPE.load(std::sync::atomic::Ordering::Acquire);
+    if p.is_null() {
+        None
+    } else {
+        // Safety: only leaked &'static SharedPipeWriter values are ever stored.
+        Some(unsafe { &*p })
+    }
+}
 impl SharedPipeWriter {
     fn push_success(&self, cid: u64, rid: usize, rp: usize, ap: usize) {
         let mut b = self.buffer.lock().unwrap();
@@ -691,77 +709,127 @@ pub unsafe extern "C" fn free_pipe_error_string(ptr: *mut c_char) {
 /// Initialize the process-wide shared pipe for async response delivery.
 /// Spawns a dedicated OS flush thread with adaptive batching.
 ///
+/// This function is idempotent within a single process — calling it multiple
+/// times with the same or different fd is safe (only the first call takes effect).
+/// After `fork()`, call [`reinit_async_pipe`] instead to create a fresh pipe
+/// and flush thread in the child process.
+///
 /// # Safety
-/// Must be called with a valid writable pipe file descriptor.
+///
+/// * `pipe_write_fd` must be a valid writable pipe file descriptor.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn init_async_pipe(pipe_write_fd: i32) {
-    ASYNC_PIPE.get_or_init(|| {
-        let w = SharedPipeWriter {
-            buffer: std::sync::Mutex::new(Vec::with_capacity(FRAME_SIZE * 64)),
-            condvar: Condvar::new(),
-            pipe_fd: pipe_write_fd,
-        };
-        let fd = pipe_write_fd;
-        std::thread::Builder::new()
-            .name("glide-async-pipe-flush".into())
-            .spawn(move || {
-                let flush_threshold: usize = std::env::var("GLIDE_PIPE_FLUSH_THRESHOLD")
-                    .ok()
-                    .and_then(|v| v.parse().ok())
-                    .unwrap_or(1);
-                while let Some(sw) = ASYNC_PIPE.get() {
-                    let data = {
-                        let mut buf = sw.buffer.lock().unwrap();
-                        while buf.is_empty() {
-                            buf = sw.condvar.wait(buf).unwrap();
-                        }
-                        // Flush threshold: if frames buffered <= threshold, flush immediately
-                        // to minimize latency. If more are queued, yield briefly to let more
-                        // accumulate for batch efficiency (amortizes syscall cost).
-                        // Configurable via GLIDE_PIPE_FLUSH_THRESHOLD (default: 1).
-                        let fc = buf.len() / FRAME_SIZE;
-                        if fc <= flush_threshold {
-                            let mut d = Vec::with_capacity(FRAME_SIZE * 4);
-                            std::mem::swap(&mut *buf, &mut d);
-                            d
-                        } else {
-                            drop(buf);
-                            std::thread::yield_now();
-                            let mut buf = sw.buffer.lock().unwrap();
-                            let mut d = Vec::with_capacity(FRAME_SIZE * 64);
-                            std::mem::swap(&mut *buf, &mut d);
-                            d
-                        }
-                    };
-                    if data.is_empty() {
-                        continue;
+    let w = create_pipe_writer(pipe_write_fd);
+    let ptr = w as *const SharedPipeWriter as *mut SharedPipeWriter;
+    // First-call-wins: only install if currently null.
+    if ASYNC_PIPE
+        .compare_exchange(
+            std::ptr::null_mut(),
+            ptr,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        )
+        .is_err()
+    {
+        // Another call already initialized — the leaked alloc is harmless.
+    }
+}
+
+/// Reinitialize the async pipe after `fork()`.
+///
+/// After `fork()`, the flush thread from the parent process is gone but the
+/// `ASYNC_PIPE` state is inherited. This function replaces the stale pipe
+/// writer with a fresh one backed by the new `pipe_write_fd`, and spawns a
+/// new flush thread.
+///
+/// The old `SharedPipeWriter` is intentionally leaked (not dropped) because
+/// the parent's Mutex/Condvar state is in an undefined state post-fork.
+///
+/// # Safety
+///
+/// * `pipe_write_fd` must be a valid writable pipe file descriptor.
+/// * Must only be called once per child process, before any commands are issued.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn reinit_async_pipe(pipe_write_fd: i32) {
+    let w = create_pipe_writer(pipe_write_fd);
+    let ptr = w as *const SharedPipeWriter as *mut SharedPipeWriter;
+    // Replace the stale writer. The old one is intentionally leaked —
+    // its mutex/condvar are in undefined state post-fork.
+    ASYNC_PIPE.store(ptr, std::sync::atomic::Ordering::Release);
+}
+
+/// Create a new `SharedPipeWriter` and spawn its flush thread.
+/// Returns a `&'static` reference by leaking the allocation (lives for
+/// the lifetime of the process).
+fn create_pipe_writer(pipe_write_fd: i32) -> &'static SharedPipeWriter {
+    let w = Box::new(SharedPipeWriter {
+        buffer: std::sync::Mutex::new(Vec::with_capacity(FRAME_SIZE * 64)),
+        condvar: Condvar::new(),
+        pipe_fd: pipe_write_fd,
+    });
+    // Leak to get 'static lifetime — the pipe writer lives for the process lifetime.
+    let w_ref: &'static SharedPipeWriter = Box::leak(w);
+    let fd = pipe_write_fd;
+    // Spawn flush thread. `w_ref` is &'static and SharedPipeWriter is Sync,
+    // so sharing across threads is safe.
+    let sw_ref = w_ref;
+    std::thread::Builder::new()
+        .name("glide-async-pipe-flush".into())
+        .spawn(move || {
+            let flush_threshold: usize = std::env::var("GLIDE_PIPE_FLUSH_THRESHOLD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1);
+            let sw = sw_ref;
+            loop {
+                let data = {
+                    let mut buf = sw.buffer.lock().unwrap();
+                    while buf.is_empty() {
+                        buf = sw.condvar.wait(buf).unwrap();
                     }
-                    let mut off = 0;
-                    while off < data.len() {
-                        let w = unsafe {
-                            libc::write(
-                                fd,
-                                data[off..].as_ptr() as *const libc::c_void,
-                                data.len() - off,
-                            )
-                        };
-                        if w > 0 {
-                            off += w as usize;
-                        } else if w == 0 {
-                            break;
-                        } else {
-                            let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
-                            if e == libc::EINTR || e == libc::EAGAIN {
-                                continue;
-                            }
-                            break; // EPIPE/EBADF — fd is gone
+                    let fc = buf.len() / FRAME_SIZE;
+                    if fc <= flush_threshold {
+                        let mut d = Vec::with_capacity(FRAME_SIZE * 4);
+                        std::mem::swap(&mut *buf, &mut d);
+                        d
+                    } else {
+                        drop(buf);
+                        std::thread::yield_now();
+                        let mut buf = sw.buffer.lock().unwrap();
+                        let mut d = Vec::with_capacity(FRAME_SIZE * 64);
+                        std::mem::swap(&mut *buf, &mut d);
+                        d
+                    }
+                };
+                if data.is_empty() {
+                    continue;
+                }
+                let mut off = 0;
+                while off < data.len() {
+                    let w = unsafe {
+                        libc::write(
+                            fd,
+                            data[off..].as_ptr() as *const libc::c_void,
+                            data.len() - off,
+                        )
+                    };
+                    if w > 0 {
+                        off += w as usize;
+                    } else if w == 0 {
+                        break;
+                    } else {
+                        let e = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+                        if e == libc::EINTR || e == libc::EAGAIN {
+                            continue;
                         }
+                        // EPIPE/EBADF — fd is gone, exit the flush thread.
+                        return;
                     }
                 }
-            })
-            .expect("flush thread");
-        w
-    });
+            }
+        })
+        .expect("flush thread");
+    w_ref
 }
 
 /// A `GlideClient` adapter.
@@ -813,14 +881,14 @@ impl ClientAdapter {
                 let cid = self
                     .pipe_client_id
                     .load(std::sync::atomic::Ordering::Relaxed);
-                if cid != 0 && ASYNC_PIPE.get().is_some() {
+                if cid != 0 && get_async_pipe().is_some() {
                     self.runtime.spawn(async move {
                         match request_future.await {
                             Ok(value) => {
                                 let buf = response_buf.map(|rb| (rb.0, rb.1));
                                 match valkey_value_to_arena_response(value, buf) {
                                     Ok((root_ptr, arena_ptr)) => {
-                                        if let Some(w) = ASYNC_PIPE.get() {
+                                        if let Some(w) = get_async_pipe() {
                                             w.push_success(
                                                 cid,
                                                 request_id,
@@ -830,7 +898,7 @@ impl ClientAdapter {
                                         }
                                     }
                                     Err(err) => {
-                                        if let Some(w) = ASYNC_PIPE.get() {
+                                        if let Some(w) = get_async_pipe() {
                                             w.push_error(
                                                 cid,
                                                 request_id,
@@ -842,7 +910,7 @@ impl ClientAdapter {
                                 }
                             }
                             Err(err) => {
-                                if let Some(w) = ASYNC_PIPE.get() {
+                                if let Some(w) = get_async_pipe() {
                                     w.push_error(
                                         cid,
                                         request_id,
@@ -1058,8 +1126,8 @@ impl ClientAdapter {
                 let cid = self
                     .pipe_client_id
                     .load(std::sync::atomic::Ordering::Relaxed);
-                if cid != 0 && ASYNC_PIPE.get().is_some() {
-                    if let Some(w) = ASYNC_PIPE.get() {
+                if cid != 0 && get_async_pipe().is_some() {
+                    if let Some(w) = get_async_pipe() {
                         w.push_error(cid, request_id, error_type, error_string);
                     }
                 } else {
@@ -1399,7 +1467,7 @@ fn create_client_internal(
                 if pipe_cid != 0 {
                     // Wait for ASYNC_PIPE if not yet initialized (brief spin during startup)
                     let w = loop {
-                        if let Some(w) = ASYNC_PIPE.get() {
+                        if let Some(w) = get_async_pipe() {
                             break w;
                         }
                         std::hint::spin_loop();
@@ -3549,7 +3617,7 @@ pub unsafe extern "C-unwind" fn get_cache_metrics(
     // Python pipe clients have cid != 0 AND ASYNC_PIPE initialized.
     // Go/other clients may have cid != 0 for address resolver but no pipe.
     let is_pipe_or_sync = matches!(client_adapter.core.client_type, ClientType::SyncClient)
-        || (cid != 0 && ASYNC_PIPE.get().is_some());
+        || (cid != 0 && get_async_pipe().is_some());
     if is_pipe_or_sync {
         match result {
             Ok(value) => match valkey_value_to_arena_response(value, None) {

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -125,6 +125,8 @@ def _get_new_future_instance() -> "TFuture":
 
 
 _async_pipe_read_fd: int = -1
+_async_pipe_write_fd: int = -1
+_async_pipe_init_pid: int = -1
 _next_client_id = itertools.count(1)
 
 
@@ -311,6 +313,41 @@ def _handle_pubsub_frame(client, response_ptr, arena_or_err, data, offset):
     return offset
 
 
+def _detect_fork_and_reset() -> None:
+    """Detect if we are in a forked child and reset pipe state.
+
+    After fork(), the flush thread is dead (threads don't survive fork) but
+    the pipe fd and Rust OnceLock state are inherited. Reset the Python-side
+    state so _setup_pipe will create a fresh pipe and call reinit_async_pipe.
+    Must be called while holding _async_pipe_lock.
+    """
+    global _async_pipe_read_fd, _async_pipe_write_fd
+    global _async_pipe_registered, _async_pipe_loop
+    global _pipe_remainder, _trio_pipe_active
+    current_pid = os.getpid()
+    if (
+        _async_pipe_read_fd >= 0
+        and _async_pipe_init_pid > 0
+        and current_pid != _async_pipe_init_pid
+    ):
+        try:
+            os.close(_async_pipe_read_fd)
+        except OSError:
+            pass
+        if _async_pipe_write_fd >= 0:
+            try:
+                os.close(_async_pipe_write_fd)
+            except OSError:
+                pass
+        _async_pipe_read_fd = -1
+        _async_pipe_write_fd = -1
+        _async_pipe_registered = False
+        _async_pipe_loop = None
+        _pipe_remainder = b""
+        _trio_pipe_active = False
+        _client_registry.clear()
+
+
 def _drain_stale_pipe_frames():
     """Drain stale frames from the pipe to prevent reading freed pointers."""
     while True:
@@ -401,6 +438,7 @@ class BaseClient(CoreCommands):
         self._pubsub_lock = threading.Lock()
         self._pending_push_notifications: List[PubSubMsg] = []
         self._pipe_client_id: int = 0
+        self._create_pid: int = 0
         self._is_asyncio: bool = True
 
     @classmethod
@@ -516,6 +554,7 @@ class BaseClient(CoreCommands):
         # Set pipe_client_id before create_client so Rust routes responses
         # through the pipe from the very first command — no race window.
         self._pipe_client_id = next(_next_client_id)
+        self._create_pid = os.getpid()
 
         client_response_ptr = self._lib.create_client(
             conn_req_bytes,
@@ -553,14 +592,23 @@ class BaseClient(CoreCommands):
 
     def _setup_pipe(self) -> None:
         """Initialize and register the shared response pipe."""
-        global _async_pipe_read_fd, _async_pipe_registered, _async_pipe_loop
-        global _pipe_remainder, _trio_pipe_active
+        global _async_pipe_read_fd, _async_pipe_write_fd
+        global _async_pipe_registered, _async_pipe_loop
+        global _pipe_remainder, _trio_pipe_active, _async_pipe_init_pid
         with _async_pipe_lock:
+            _detect_fork_and_reset()
+            current_pid = os.getpid()
+
             if _async_pipe_read_fd < 0:
                 try:
                     _async_pipe_read_fd, pw = os.pipe()
                     os.set_blocking(_async_pipe_read_fd, False)
-                    self._lib.init_async_pipe(pw)
+                    if _async_pipe_init_pid > 0 and current_pid != _async_pipe_init_pid:
+                        self._lib.reinit_async_pipe(pw)
+                    else:
+                        self._lib.init_async_pipe(pw)
+                    _async_pipe_write_fd = pw
+                    _async_pipe_init_pid = current_pid
                 except OSError:
                     _async_pipe_read_fd = -1
                     self._pipe_client_id = 0
@@ -674,6 +722,14 @@ class BaseClient(CoreCommands):
 
     # ==================== Command Execution ====================
 
+    def _check_same_process(self) -> None:
+        """Raise if this client is used from a forked child process."""
+        if self._create_pid and self._create_pid != os.getpid():
+            raise ClosingError(
+                "Cannot use a client created before fork(). "
+                "Create a new client in the child process."
+            )
+
     async def _execute_command(
         self,
         request_type: int,
@@ -684,6 +740,7 @@ class BaseClient(CoreCommands):
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
             )
+        self._check_same_process()
 
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
@@ -746,6 +803,7 @@ class BaseClient(CoreCommands):
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
             )
+        self._check_same_process()
 
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
@@ -794,6 +852,7 @@ class BaseClient(CoreCommands):
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
             )
+        self._check_same_process()
 
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
@@ -847,6 +906,7 @@ class BaseClient(CoreCommands):
         """
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
         if self._core_client == self._ffi.NULL:
             raise ValueError("Invalid client pointer.")
 
@@ -864,6 +924,7 @@ class BaseClient(CoreCommands):
     ) -> TResult:
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
 
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
@@ -893,6 +954,7 @@ class BaseClient(CoreCommands):
     async def _refresh_iam_token(self) -> TResult:
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
 
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()
@@ -1007,7 +1069,9 @@ class BaseClient(CoreCommands):
 
             _client_registry.pop(getattr(self, "_pipe_client_id", 0), None)
 
-            if self._core_client is not None:
+            # Skip FFI call if this client was created in a different process
+            # (the tokio Runtime doesn't survive fork; dropping it would hang).
+            if self._core_client is not None and self._create_pid == os.getpid():
                 self._lib.close_client(self._core_client)
                 self._core_client = None
 
@@ -1051,6 +1115,7 @@ class GlideClusterClient(BaseClient, ClusterCommands):
             raise ClosingError(
                 "Unable to execute requests; the client is closed. Please create a new client."
             )
+        self._check_same_process()
 
         callback_id = self._get_callback_id()
         fut = _get_new_future_instance()

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -672,6 +672,7 @@ class BaseClient(CoreCommands):
     async def get_pubsub_message(self) -> PubSubMsg:
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
         if self.config._get_pubsub_callback_and_context()[0] is not None:
             raise ConfigurationError(
                 "The operation will never complete since messages will be passed to the configured callback."
@@ -685,6 +686,7 @@ class BaseClient(CoreCommands):
     def try_get_pubsub_message(self) -> Optional[PubSubMsg]:
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
         if self.config._get_pubsub_callback_and_context()[0] is not None:
             raise ConfigurationError(
                 "The operation will never complete since messages will be passed to the configured callback."

--- a/python/glide-shared/glide_shared/_glide_ffi.py
+++ b/python/glide-shared/glide_shared/_glide_ffi.py
@@ -235,6 +235,7 @@ class _GlideFFI:
             );
             void close_client(const void* client_adapter_ptr);
             void init_async_pipe(int pipe_write_fd);
+            void reinit_async_pipe(int pipe_write_fd);
 
             void free_pipe_error_string(char* ptr);
             void free_pubsub_pointer_payload(uint8_t* ptr, size_t len);

--- a/python/tests/async_tests/test_fork_safety.py
+++ b/python/tests/async_tests/test_fork_safety.py
@@ -112,7 +112,7 @@ def _is_free_threaded() -> bool:
     _is_free_threaded(),
     reason="fork() is unsupported in free-threaded Python builds",
 )
-@pytest.mark.anyio
+@pytest.mark.asyncio
 class TestForkSafety:
     """Tests for fork() safety of the pipe transport (issue #6673)."""
 

--- a/python/tests/async_tests/test_fork_safety.py
+++ b/python/tests/async_tests/test_fork_safety.py
@@ -1,0 +1,275 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+"""
+Integration tests for fork() safety of the async pipe transport.
+
+The async pipe transport (PR #5637) uses a process-wide pipe and flush thread.
+After fork(), the flush thread is dead in the child but the pipe state is
+inherited. Without proper fork detection, commands in forked children hang
+indefinitely because responses are never flushed to the pipe.
+
+These tests verify that:
+1. Forked child processes can create and use glide clients
+2. Commands in forked children complete (don't hang)
+3. The parent process remains functional after children complete
+4. Reusing a parent's client in a child raises ClosingError
+"""
+
+import asyncio
+import multiprocessing
+import os
+import queue
+from typing import Any, List, Tuple
+
+import pytest
+from glide import GlideClusterClient
+from glide_shared.config import GlideClusterClientConfiguration, NodeAddress
+from glide_shared.exceptions import ClosingError
+
+from tests.async_tests.conftest import create_client
+from tests.utils.cluster import ValkeyCluster
+
+
+def _child_cluster_worker(
+    addresses_raw: List[Tuple[str, int]], result_queue: multiprocessing.Queue
+):
+    """Worker function for forked child processes (cluster mode).
+
+    Creates a fresh client in the child process and issues commands to verify
+    the pipe transport was properly reinitialized after fork.
+    """
+
+    async def run():
+        try:
+            config = GlideClusterClientConfiguration(
+                addresses=[NodeAddress(host=h, port=p) for h, p in addresses_raw],
+                request_timeout=5000,
+            )
+            client = await GlideClusterClient.create(config)
+
+            # Issue several commands to exercise the pipe transport
+            pid = os.getpid()
+            for i in range(10):
+                await client.set(f"fork_test:{pid}:{i}", f"value-{i}")
+
+            # Verify reads work too
+            result = await client.get(f"fork_test:{pid}:0")
+            assert result == b"value-0", f"Expected b'value-0', got {result!r}"
+
+            await client.close()
+            result_queue.put(("OK", pid))
+        except Exception as e:  # noqa: BLE001
+            result_queue.put(("ERROR", f"{type(e).__name__}: {e}"))
+
+    asyncio.run(run())
+
+
+def _child_stale_client_worker(
+    addresses_raw: List[Tuple[str, int]],
+    client_pid: int,
+    result_queue: multiprocessing.Queue,
+):
+    """Worker that tries to use a parent's client object — should raise."""
+
+    async def run():
+        # Simulate having a reference to a client created in the parent.
+        # We can't pass the actual client across fork (pickle), but we can
+        # check that _check_same_process fires by creating a client and
+        # then changing its _create_pid to simulate the parent's.
+        from glide_shared.config import GlideClusterClientConfiguration, NodeAddress
+
+        config = GlideClusterClientConfiguration(
+            addresses=[NodeAddress(host=h, port=p) for h, p in addresses_raw],
+            request_timeout=5000,
+        )
+        try:
+            client = await GlideClusterClient.create(config)
+            # Fake it as if it was created in the parent
+            client._create_pid = client_pid
+            await client.set("stale_test", "should_fail")
+            result_queue.put(("UNEXPECTED_SUCCESS", None))
+        except ClosingError as e:
+            if "fork" in str(e).lower():
+                result_queue.put(("OK_REJECTED", str(e)))
+            else:
+                result_queue.put(("WRONG_ERROR", str(e)))
+        except Exception as e:  # noqa: BLE001
+            result_queue.put(("ERROR", f"{type(e).__name__}: {e}"))
+
+    asyncio.run(run())
+
+
+def _is_free_threaded() -> bool:
+    """Detect free-threaded (no-GIL) Python builds."""
+    import sys
+
+    if hasattr(sys, "_is_gil_enabled"):
+        return not sys._is_gil_enabled()
+    return False
+
+
+@pytest.mark.skipif(
+    _is_free_threaded(),
+    reason="fork() is unsupported in free-threaded Python builds",
+)
+@pytest.mark.anyio
+class TestForkSafety:
+    """Tests for fork() safety of the pipe transport (issue #6673)."""
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    async def test_forked_children_can_use_clients(
+        self, request: Any, cluster_mode: bool
+    ):
+        """
+        After a parent creates a client (initializing the pipe + flush thread),
+        forked children must be able to create their own clients and issue
+        commands without hanging.
+
+        This is the core regression test for issue #6673.
+        """
+        # Create a client in the parent to initialize the pipe + flush thread
+        parent_client = await create_client(request, cluster_mode)
+        await parent_client.set("fork_parent_init", "initialized")
+
+        # Get addresses for children to connect to
+        valkey_cluster: ValkeyCluster = pytest.valkey_cluster  # type: ignore[attr-defined]
+        addresses_raw = [(addr.host, addr.port) for addr in valkey_cluster.nodes_addr]
+
+        await parent_client.close()
+
+        # Fork children and verify they can use clients
+        num_workers = 3
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue()
+
+        workers = []
+        for _ in range(num_workers):
+            p = ctx.Process(
+                target=_child_cluster_worker, args=(addresses_raw, result_queue)
+            )
+            p.start()
+            workers.append(p)
+
+        # Wait with timeout — if fork safety is broken, children will hang
+        for p in workers:
+            p.join(timeout=15.0)
+            if p.is_alive():
+                p.kill()
+                p.join()
+
+        # Collect results
+        results = []
+        for _ in range(num_workers):
+            try:
+                results.append(result_queue.get(timeout=5.0))
+            except queue.Empty:
+                break
+
+        ok_count = sum(1 for r in results if r[0] == "OK")
+        error_results = [r for r in results if r[0] == "ERROR"]
+        no_report = num_workers - len(results)
+
+        assert no_report == 0, (
+            f"{no_report} worker(s) were killed (hung). "
+            "Fork safety issue: pipe flush thread not reinitialized in child."
+        )
+        assert len(error_results) == 0, f"Worker errors: {error_results}"
+        assert ok_count == num_workers
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    async def test_parent_functional_after_fork(self, request: Any, cluster_mode: bool):
+        """
+        The parent process must remain functional after forking children.
+        Verifies that reinit in children doesn't corrupt the parent's pipe.
+        """
+        parent_client = await create_client(request, cluster_mode)
+        await parent_client.set("pre_fork_key", "pre_fork_value")
+
+        valkey_cluster: ValkeyCluster = pytest.valkey_cluster  # type: ignore[attr-defined]
+        addresses_raw = [(addr.host, addr.port) for addr in valkey_cluster.nodes_addr]
+
+        # Fork a child
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue()
+        p = ctx.Process(
+            target=_child_cluster_worker, args=(addresses_raw, result_queue)
+        )
+        p.start()
+        p.join(timeout=15.0)
+        if p.is_alive():
+            p.kill()
+            p.join()
+            pytest.fail("Child worker hung — fork safety broken")
+
+        # Parent should still work after child completes
+        await parent_client.set("post_fork_key", "post_fork_value")
+        result = await parent_client.get("post_fork_key")
+        assert result == b"post_fork_value"
+
+        await parent_client.close()
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    async def test_multiple_fork_cycles(self, request: Any, cluster_mode: bool):
+        """
+        Multiple fork/use/exit cycles should all work correctly.
+        Tests that the fork detection doesn't leave stale state.
+        """
+        # Initialize pipe in parent
+        parent_client = await create_client(request, cluster_mode)
+        await parent_client.set("cycle_test", "init")
+        await parent_client.close()
+
+        valkey_cluster: ValkeyCluster = pytest.valkey_cluster  # type: ignore[attr-defined]
+        addresses_raw = [(addr.host, addr.port) for addr in valkey_cluster.nodes_addr]
+
+        # Run 3 fork cycles
+        for cycle in range(3):
+            ctx = multiprocessing.get_context("fork")
+            result_queue = ctx.Queue()
+            p = ctx.Process(
+                target=_child_cluster_worker, args=(addresses_raw, result_queue)
+            )
+            p.start()
+            p.join(timeout=15.0)
+            if p.is_alive():
+                p.kill()
+                p.join()
+                pytest.fail(f"Worker hung in cycle {cycle}")
+
+            result = result_queue.get(timeout=5.0)
+            assert result[0] == "OK", f"Cycle {cycle} failed: {result}"
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    async def test_stale_client_raises_in_child(self, request: Any, cluster_mode: bool):
+        """
+        Using a parent's client object in a forked child must raise
+        ClosingError instead of silently hanging.
+        """
+        # Create client in parent
+        parent_client = await create_client(request, cluster_mode)
+        await parent_client.set("stale_test_init", "ok")
+        parent_pid = os.getpid()
+
+        valkey_cluster: ValkeyCluster = pytest.valkey_cluster  # type: ignore[attr-defined]
+        addresses_raw = [(addr.host, addr.port) for addr in valkey_cluster.nodes_addr]
+
+        await parent_client.close()
+
+        # Fork a child that simulates using a stale client
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue()
+        p = ctx.Process(
+            target=_child_stale_client_worker,
+            args=(addresses_raw, parent_pid, result_queue),
+        )
+        p.start()
+        p.join(timeout=15.0)
+        if p.is_alive():
+            p.kill()
+            p.join()
+            pytest.fail("Child hung — stale client check not working")
+
+        result = result_queue.get(timeout=5.0)
+        assert (
+            result[0] == "OK_REJECTED"
+        ), f"Expected ClosingError for stale client, got: {result}"

--- a/python/tests/test_api_consistency.py
+++ b/python/tests/test_api_consistency.py
@@ -88,6 +88,7 @@ EXCLUDED_TESTS_FILENAMES = {
     "async_only": [
         "test_deprecation_warnings.py",
         "test_client_side_cache.py",
+        "test_fork_safety.py",
     ],
     "sync_only": [
         "test_sync_client_side_cache.py",


### PR DESCRIPTION
### Summary

Cherry-pick of #6679 into release-2.5.

Makes the Python async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely.

### Issue link

Cherry-pick of [#6679](https://github.com/valkey-io/valkey-glide/pull/6679)

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct.