### PR TITLE
fix(rust): Handles IPv6 in create_client_from_uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+* Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.
+
 * Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))
 * Core/FFI: Percent-decode userinfo in `create_client_from_uri` so credentials containing URI-reserved characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`, space, non-ASCII) authenticate correctly ([#6659](https://github.com/valkey-io/valkey-glide/issues/6659))
 * Core/All: Buffer pending cluster requests during reconnect instead of failing immediately. When a circular MOVED redirect triggers a reconnect, requests arriving during the recovery window are now queued and retried transparently once reconnection completes. A new `recovery_requests_queue_size` option (default: 1000) controls the queue depth. ([#6640](https://github.com/valkey-io/valkey-glide/pull/6640))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1846,11 +1846,13 @@ fn create_client_from_uri_internal(
     // Build base ConnectionRequest from URI
     let mut request = connection_request::ConnectionRequest::new();
 
-    // Extract host and port
-    let host = url
-        .host_str()
-        .ok_or_else(|| "URI missing host".to_string())?
-        .to_string();
+    // Extract host and port.
+    let host = match url.host() {
+        Some(url::Host::Domain(domain)) => domain.to_string(),
+        Some(url::Host::Ipv4(addr)) => addr.to_string(),
+        Some(url::Host::Ipv6(addr)) => addr.to_string(),
+        None => return Err("URI missing host".to_string()),
+    };
     let port = url.port().unwrap_or(6379) as u32;
 
     let mut node_address = connection_request::NodeAddress::new();
@@ -2007,6 +2009,66 @@ mod tests_create_client_from_uri_internal {
             err.contains("Username in URI is not valid UTF-8"),
             "unexpected error: {err}"
         );
+    }
+
+    fn host_and_port(uri: &str) -> (String, u32) {
+        let req = parse_uri(uri);
+        let addr = req.addresses.first().expect("no address parsed");
+        (addr.host.to_string(), addr.port)
+    }
+
+    #[test]
+    fn ipv6_literal_host_is_unbracketed() {
+        let (host, port) = host_and_port("redis://[::1]:6400");
+        assert_eq!(host, "::1");
+        assert_eq!(port, 6400);
+    }
+
+    #[test]
+    fn ipv6_uncompressed_literal_is_canonicalized_unbracketed() {
+        let (host, port) = host_and_port("redis://[0:0:0:0:0:0:0:1]:6400");
+        assert_eq!(host, "::1");
+        assert_eq!(port, 6400);
+    }
+
+    #[test]
+    fn ipv6_v4_mapped_literal_is_unbracketed() {
+        // v4-mapped address: assert on the canonical `Ipv6Addr::to_string()`
+        // output (no brackets). Kept in sync with the std canonical form.
+        let (host, port) = host_and_port("redis://[::ffff:127.0.0.1]:6400");
+        assert_eq!(
+            host,
+            std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x0001).to_string()
+        );
+        assert_eq!(port, 6400);
+    }
+
+    #[test]
+    fn ipv4_literal_host_is_unchanged() {
+        // Regression control: IPv4 literals must be byte-identical to before.
+        let (host, port) = host_and_port("redis://127.0.0.1:6400");
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 6400);
+    }
+
+    #[test]
+    fn domain_host_is_unchanged() {
+        // Regression control: domain hosts must be byte-identical to before.
+        let (host, port) = host_and_port("redis://localhost:6400");
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 6400);
+    }
+
+    #[test]
+    fn hostless_uri_returns_missing_host_error() {
+        // A URI that parses as a URL but carries no authority (e.g. only a
+        // path) has `url::Url::host()` == None. The `None` match arm must
+        // surface a clear "URI missing host" error rather than panicking or
+        // silently building an address with an empty host.
+        let c_uri = CString::new("redis:///0").unwrap();
+        let err = create_client_from_uri_internal(c_uri.as_ptr(), std::ptr::null())
+            .expect_err("expected missing-host error");
+        assert!(err.contains("URI missing host"), "unexpected error: {err}");
     }
 }
 


### PR DESCRIPTION
## Summary

Existing code did not handle IPv6 addresses correctly, leading to various hanging connection behavior. This PR correctly fixes this.

### What's changed

Match on the parsed `url::Host` instead of the raw host string, so the IPv6 case yields the unbracketed canonical form.

```rust
let host = match url.host() {
    Some(url::Host::Domain(domain)) => domain.to_string(),
    Some(url::Host::Ipv4(addr))    => addr.to_string(),
    Some(url::Host::Ipv6(addr))    => addr.to_string(), // unbracketed
    None => return Err("URI missing host".to_string()),
};
```

### Testing

- Unit tests assert `NodeAddress.host` is unbracketed for compressed (`[::1]`→`::1`), uncompressed (`[0:0:...:1]`→`::1`), and v4-mapped (`[::ffff:127.0.0.1]`) literals, with IPv4/domain regression controls. `build`, `test`, `clippy`, `fmt` all clean.