### PR TITLE
fix: make TimeoutWatchdog singleton fork-safe

### DIFF
--- a/ffi/miri-tests/mock-glide-core/src/lib.rs
+++ b/ffi/miri-tests/mock-glide-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod errors;
 pub mod otel_db_semantics;
 pub mod request_type;
 pub mod scripts_container;
+pub mod timeout_watchdog;
 
 pub use client::*;
 pub use cluster_scan_container::*;

--- a/ffi/miri-tests/mock-glide-core/src/timeout_watchdog.rs
+++ b/ffi/miri-tests/mock-glide-core/src/timeout_watchdog.rs
@@ -1,0 +1,10 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+/// Mock TimeoutWatchdog for miri tests.
+pub struct TimeoutWatchdog;
+
+impl TimeoutWatchdog {
+    pub fn reinit_global() {
+        // No-op in miri mock.
+    }
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -781,6 +781,9 @@ pub unsafe extern "C" fn reinit_async_pipe(pipe_write_fd: i32) {
     // Replace the stale writer. The old one is intentionally leaked —
     // its mutex/condvar are in undefined state post-fork.
     ASYNC_PIPE.store(ptr, std::sync::atomic::Ordering::Release);
+
+    // Also reinitialize the timeout watchdog — its thread is dead post-fork.
+    glide_core::timeout_watchdog::TimeoutWatchdog::reinit_global();
 }
 
 /// Create a new `SharedPipeWriter` and spawn its flush thread.

--- a/glide-core/src/timeout_watchdog.rs
+++ b/glide-core/src/timeout_watchdog.rs
@@ -602,13 +602,55 @@ pub struct TimeoutWatchdog {
     tx: mpsc::Sender<DeadlineEntry>,
 }
 
-/// Global singleton watchdog instance.
-static GLOBAL_WATCHDOG: std::sync::OnceLock<TimeoutWatchdog> = std::sync::OnceLock::new();
+/// Global singleton watchdog instance. Uses an atomic pointer so the read path
+/// is lock-free and the state can be replaced after fork().
+static GLOBAL_WATCHDOG: std::sync::atomic::AtomicPtr<TimeoutWatchdog> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 impl TimeoutWatchdog {
     /// Get or initialize the global shared watchdog instance.
     pub fn global() -> &'static Self {
-        GLOBAL_WATCHDOG.get_or_init(Self::start_global)
+        let ptr = GLOBAL_WATCHDOG.load(std::sync::atomic::Ordering::Acquire);
+        if !ptr.is_null() {
+            // Safety: only leaked &'static TimeoutWatchdog values are stored.
+            return unsafe { &*ptr };
+        }
+        Self::init_global()
+    }
+
+    /// Initialize the global watchdog (first call or after reinit).
+    /// Uses compare_exchange so only one caller wins the race.
+    fn init_global() -> &'static Self {
+        let w = Box::new(Self::start_global());
+        let w_ref: &'static Self = Box::leak(w);
+        let ptr = w_ref as *const Self as *mut Self;
+        match GLOBAL_WATCHDOG.compare_exchange(
+            std::ptr::null_mut(),
+            ptr,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        ) {
+            Ok(_) => w_ref,
+            Err(existing) => {
+                // Another thread won the race — use theirs.
+                // The leaked alloc is harmless (only happens on contended first init).
+                unsafe { &*existing }
+            }
+        }
+    }
+
+    /// Reinitialize the global watchdog after fork().
+    ///
+    /// After fork(), the watchdog thread is dead but the AtomicPtr still points
+    /// to the old instance. This replaces it with a fresh one. The old instance
+    /// is intentionally leaked (its mpsc channel is in undefined state post-fork).
+    pub fn reinit_global() {
+        let w = Box::new(Self::start_global());
+        let w_ref: &'static Self = Box::leak(w);
+        let ptr = w_ref as *const Self as *mut Self;
+        GLOBAL_WATCHDOG.store(ptr, std::sync::atomic::Ordering::Release);
+        // Reset the published pending count — the old watchdog's entries are gone.
+        PUBLISHED_PENDING.store(0, Ordering::Relaxed);
     }
 
     /// Start the global watchdog instance (publishes pending count).
@@ -960,5 +1002,26 @@ mod tests {
         assert_eq!(cmd_name_from_bytes(b"PEXPIREAT"), "PEXPIREAT");
         assert_eq!(cmd_name_from_bytes(b"INCRBYFLOAT"), "INCRBYFLOAT");
         assert_eq!(cmd_name_from_bytes(b"unknowncmd"), "UNKNOWN");
+    }
+
+    // ── Fork Safety (reinit) ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn reinit_global_spawns_new_working_watchdog() {
+        // Ensure the global watchdog is initialized.
+        let _pre = TimeoutWatchdog::global();
+
+        // Simulate post-fork reinit: replace the global with a fresh instance.
+        TimeoutWatchdog::reinit_global();
+
+        // The new watchdog must be functional — register and await a timeout.
+        let watchdog = TimeoutWatchdog::global();
+        let rx = watchdog.register(Duration::from_millis(50), Instant::now());
+        let result = tokio::time::timeout(Duration::from_millis(500), rx).await;
+        assert!(
+            result.is_ok(),
+            "watchdog must fire after reinit_global (simulating post-fork)"
+        );
+        assert!(result.unwrap().is_ok());
     }
 }

--- a/glide-core/src/timeout_watchdog.rs
+++ b/glide-core/src/timeout_watchdog.rs
@@ -621,20 +621,21 @@ impl TimeoutWatchdog {
     /// Initialize the global watchdog (first call or after reinit).
     /// Uses compare_exchange so only one caller wins the race.
     fn init_global() -> &'static Self {
-        let w = Box::new(Self::start_global());
-        let w_ref: &'static Self = Box::leak(w);
-        let ptr = w_ref as *const Self as *mut Self;
+        let ptr = Box::into_raw(Box::new(Self::start_global()));
         match GLOBAL_WATCHDOG.compare_exchange(
             std::ptr::null_mut(),
             ptr,
             std::sync::atomic::Ordering::AcqRel,
             std::sync::atomic::Ordering::Acquire,
         ) {
-            Ok(_) => w_ref,
+            Ok(_) => unsafe { &*ptr },
             Err(existing) => {
-                // Another thread won the race — use theirs.
-                // The leaked alloc is harmless (only happens on contended first init).
-                unsafe { &*existing }
+                // Another thread won the race — drop ours (the Sender drop
+                // causes the spawned thread to exit via Disconnected).
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                    &*existing
+                }
             }
         }
     }

--- a/glide-core/src/timeout_watchdog.rs
+++ b/glide-core/src/timeout_watchdog.rs
@@ -612,7 +612,9 @@ impl TimeoutWatchdog {
     pub fn global() -> &'static Self {
         let ptr = GLOBAL_WATCHDOG.load(std::sync::atomic::Ordering::Acquire);
         if !ptr.is_null() {
-            // Safety: only leaked &'static TimeoutWatchdog values are stored.
+            // Safety: once installed as non-null, the pointer is never freed
+            // until process exit (reinit_global intentionally leaks the prior
+            // instance rather than dropping it).
             return unsafe { &*ptr };
         }
         Self::init_global()
@@ -644,7 +646,11 @@ impl TimeoutWatchdog {
     ///
     /// After fork(), the watchdog thread is dead but the AtomicPtr still points
     /// to the old instance. This replaces it with a fresh one. The old instance
-    /// is intentionally leaked (its mpsc channel is in undefined state post-fork).
+    /// is intentionally leaked — its internal Mutex/Condvar are in undefined
+    /// state post-fork and cannot be safely dropped.
+    ///
+    /// Must only be called in a forked child process where the previous
+    /// watchdog thread is no longer running.
     pub fn reinit_global() {
         let w = Box::new(Self::start_global());
         let w_ref: &'static Self = Box::leak(w);

--- a/python/glide-async/python/glide/glide_client.py
+++ b/python/glide-async/python/glide/glide_client.py
@@ -773,6 +773,7 @@ class BaseClient(CoreCommands):
     async def get_pubsub_message(self) -> PubSubMsg:
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
         if self.config._get_pubsub_callback_and_context()[0] is not None:
             raise ConfigurationError(
                 "The operation will never complete since messages will be passed to the configured callback."
@@ -786,6 +787,7 @@ class BaseClient(CoreCommands):
     def try_get_pubsub_message(self) -> Optional[PubSubMsg]:
         if self._is_closed:
             raise ClosingError("Client is closed.")
+        self._check_same_process()
         if self.config._get_pubsub_callback_and_context()[0] is not None:
             raise ConfigurationError(
                 "The operation will never complete since messages will be passed to the configured callback."

--- a/python/tests/async_tests/test_fork_safety.py
+++ b/python/tests/async_tests/test_fork_safety.py
@@ -112,7 +112,7 @@ def _is_free_threaded() -> bool:
     _is_free_threaded(),
     reason="fork() is unsupported in free-threaded Python builds",
 )
-@pytest.mark.anyio
+@pytest.mark.asyncio
 class TestForkSafety:
     """Tests for fork() safety of the pipe transport (issue #6673)."""
 

--- a/python/tests/async_tests/test_fork_safety.py
+++ b/python/tests/async_tests/test_fork_safety.py
@@ -99,6 +99,37 @@ def _child_stale_client_worker(
     asyncio.run(run())
 
 
+def _child_stale_pubsub_worker(
+    addresses_raw: List[Tuple[str, int]],
+    client_pid: int,
+    result_queue: multiprocessing.Queue,
+):
+    """Worker that tries pubsub on a stale client — should raise."""
+
+    async def run():
+        from glide_shared.config import GlideClusterClientConfiguration, NodeAddress
+
+        config = GlideClusterClientConfiguration(
+            addresses=[NodeAddress(host=h, port=p) for h, p in addresses_raw],
+            request_timeout=5000,
+        )
+        try:
+            client = await GlideClusterClient.create(config)
+            client._create_pid = client_pid
+            # Test get_pubsub_message path
+            await client.get_pubsub_message()
+            result_queue.put(("UNEXPECTED_SUCCESS", "get_pubsub_message"))
+        except ClosingError as e:
+            if "fork" in str(e).lower():
+                result_queue.put(("OK_REJECTED", str(e)))
+            else:
+                result_queue.put(("WRONG_ERROR", str(e)))
+        except Exception as e:  # noqa: BLE001
+            result_queue.put(("ERROR", f"{type(e).__name__}: {e}"))
+
+    asyncio.run(run())
+
+
 def _is_free_threaded() -> bool:
     """Detect free-threaded (no-GIL) Python builds."""
     import sys
@@ -273,3 +304,38 @@ class TestForkSafety:
         assert (
             result[0] == "OK_REJECTED"
         ), f"Expected ClosingError for stale client, got: {result}"
+
+    @pytest.mark.parametrize("cluster_mode", [True])
+    async def test_stale_pubsub_raises_in_child(
+        self, request: Any, cluster_mode: bool
+    ):
+        """
+        Using get_pubsub_message on a stale client in a forked child must
+        raise ClosingError (not hang waiting for a message that never comes).
+        """
+        parent_client = await create_client(request, cluster_mode)
+        await parent_client.set("pubsub_fork_init", "ok")
+        parent_pid = os.getpid()
+
+        valkey_cluster: ValkeyCluster = pytest.valkey_cluster  # type: ignore[attr-defined]
+        addresses_raw = [(addr.host, addr.port) for addr in valkey_cluster.nodes_addr]
+
+        await parent_client.close()
+
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue()
+        p = ctx.Process(
+            target=_child_stale_pubsub_worker,
+            args=(addresses_raw, parent_pid, result_queue),
+        )
+        p.start()
+        p.join(timeout=15.0)
+        if p.is_alive():
+            p.kill()
+            p.join()
+            pytest.fail("Child hung — pubsub stale client check not working")
+
+        result = result_queue.get(timeout=5.0)
+        assert (
+            result[0] == "OK_REJECTED"
+        ), f"Expected ClosingError for stale pubsub client, got: {result}"

--- a/python/tests/async_tests/test_fork_safety.py
+++ b/python/tests/async_tests/test_fork_safety.py
@@ -121,7 +121,15 @@ def _child_stale_pubsub_worker(
             result_queue.put(("UNEXPECTED_SUCCESS", "get_pubsub_message"))
         except ClosingError as e:
             if "fork" in str(e).lower():
-                result_queue.put(("OK_REJECTED", str(e)))
+                # Also verify try_get_pubsub_message raises
+                try:
+                    client.try_get_pubsub_message()
+                    result_queue.put(("UNEXPECTED_SUCCESS", "try_get_pubsub_message"))
+                except ClosingError as e2:
+                    if "fork" in str(e2).lower():
+                        result_queue.put(("OK_REJECTED", str(e)))
+                    else:
+                        result_queue.put(("WRONG_ERROR", str(e2)))
             else:
                 result_queue.put(("WRONG_ERROR", str(e)))
         except Exception as e:  # noqa: BLE001
@@ -306,9 +314,7 @@ class TestForkSafety:
         ), f"Expected ClosingError for stale client, got: {result}"
 
     @pytest.mark.parametrize("cluster_mode", [True])
-    async def test_stale_pubsub_raises_in_child(
-        self, request: Any, cluster_mode: bool
-    ):
+    async def test_stale_pubsub_raises_in_child(self, request: Any, cluster_mode: bool):
         """
         Using get_pubsub_message on a stale client in a forked child must
         raise ClosingError (not hang waiting for a message that never comes).


### PR DESCRIPTION
### Summary

Follow-up to #6679 (fork-safe async pipe). Makes the `TimeoutWatchdog` singleton fork-safe using the same `AtomicPtr` pattern, adds the missing `_check_same_process()` guard to pubsub entry points, and restricts fork tests to asyncio only (fork from trio is unsupported).

### Issue link

Closes #6708

### Implementation

- **Watchdog**: Replace `OnceLock<TimeoutWatchdog>` with `AtomicPtr<TimeoutWatchdog>` on lock-free read path, `compare_exchange` for first init, `store` for reinit. `reinit_async_pipe` now also calls `TimeoutWatchdog::reinit_global()` so the watchdog thread is respawned alongside the pipe writer in forked children.
- **Pubsub guard**: Add `_check_same_process()` to `get_pubsub_message` and `try_get_pubsub_message` so that the one remaining public entry point that could hang in a forked child.
- **Test marker**: `@pytest.mark.anyio` → `@pytest.mark.asyncio` on `TestForkSafety` since forking from a trio event loop is unsupported.

### Testing

- Unit test `reinit_global_spawns_new_working_watchdog` verifies the new watchdog fires after reinit.
- Existing `test_fork_safety.py` integration tests implicitly exercise the watchdog in forked children (commands use `request_timeout=5000`).
- All existing watchdog unit tests pass.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated. - internal change only
- [x] Linters have been run.
- [x] Destination branch is correct - main.