### PR TITLE
test(core): reproduce silent half-open cluster connection detection

### DIFF
--- a/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
+++ b/glide-core/redis-rs/redis/tests/support/mock_cluster.rs
@@ -96,6 +96,61 @@ fn get_behaviors() -> std::sync::RwLockWriteGuard<'static, HashMap<String, MockC
     MOCK_CONN_BEHAVIORS.write().unwrap()
 }
 
+/// Ports whose async PING requests must never resolve. Reproduces a silent
+/// half-open TCP flow: the transport looks alive but any read on it stays
+/// pending forever. The set is process-global so any test that flips a port
+/// on must clear it before returning, otherwise sibling tests reusing the
+/// same port hang. Callers should acquire an [`AsyncPingBlackholeGuard`]
+/// rather than toggling the raw setter, so that a panic or early return also
+/// clears the port on unwind.
+static ASYNC_PING_BLACKHOLE_PORTS: Lazy<RwLock<std::collections::HashSet<u16>>> =
+    Lazy::new(Default::default);
+
+fn set_async_ping_blackhole_raw(port: u16, blackhole: bool) {
+    let mut guard = ASYNC_PING_BLACKHOLE_PORTS.write().unwrap();
+    if blackhole {
+        guard.insert(port);
+    } else {
+        guard.remove(&port);
+    }
+}
+
+/// RAII guard that installs a PING blackhole on construction and clears it
+/// on drop, including during a panic-driven unwind. Hold the guard for the
+/// entire region that needs the blackhole; do not toggle the state manually.
+#[must_use = "the blackhole is only active while the guard is held; bind it to a name"]
+pub struct AsyncPingBlackholeGuard {
+    port: u16,
+}
+
+impl AsyncPingBlackholeGuard {
+    pub fn new(port: u16) -> Self {
+        set_async_ping_blackhole_raw(port, true);
+        AsyncPingBlackholeGuard { port }
+    }
+}
+
+impl Drop for AsyncPingBlackholeGuard {
+    fn drop(&mut self) {
+        set_async_ping_blackhole_raw(self.port, false);
+    }
+}
+
+fn async_ping_blackholed(port: u16) -> bool {
+    ASYNC_PING_BLACKHOLE_PORTS.read().unwrap().contains(&port)
+}
+
+/// Number of async connections opened against a given mock cluster since it
+/// was registered. Tests use this to detect that the reconnect path fired.
+pub fn mock_connection_count(name: &str) -> usize {
+    MOCK_CONN_BEHAVIORS
+        .read()
+        .unwrap()
+        .get(name)
+        .map(|b| b.connection_id_provider.load(Ordering::SeqCst))
+        .unwrap_or(0)
+}
+
 #[derive(Default)]
 pub enum ConnectionIPReturnType {
     /// New connections' IP will be returned as None
@@ -349,8 +404,12 @@ pub fn respond_startup_with_config(
 #[cfg(feature = "cluster-async")]
 impl aio::ConnectionLike for MockConnection {
     fn req_packed_command<'a>(&'a mut self, cmd: &'a redis::Cmd) -> RedisFuture<'a, Value> {
+        let packed = cmd.get_packed_command();
+        if async_ping_blackholed(self.port) && contains_slice(&packed, b"PING") {
+            return Box::pin(future::pending());
+        }
         Box::pin(future::ready(
-            (self.handler)(&cmd.get_packed_command(), self.port)
+            (self.handler)(&packed, self.port)
                 .map_err(|err| err.and_then(|v| v.extract_error()))
                 .expect_err("Handler did not specify a response"),
         ))

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7372,6 +7372,120 @@ mod cluster_async {
         );
     }
 
+    /// Regression test for silent half-open cluster connections.
+    ///
+    /// A middlebox on the network path (a stateful NAT or load balancer) can
+    /// silently evict an idle TCP flow between the client and one cluster
+    /// shard. No FIN or RST reaches the client, so the transport looks open,
+    /// `is_closed()` stays false, and the periodic connection validation
+    /// misses the dead socket. Every subsequent request to that shard then
+    /// times out for the remainder of the runtime lifetime.
+    ///
+    /// This test uses the mock cluster harness to put port 6379 into a PING
+    /// "blackhole": any PING routed to that port returns a future that never
+    /// resolves, mimicking a half-open transport where the read half stays
+    /// pending forever. It then waits a few multiples of the periodic
+    /// validation interval and asserts that the client opened at least one
+    /// new connection (proving the validation task detected the dead socket
+    /// and drove a reconnect) and can drive a fresh command afterwards.
+    ///
+    /// On pre-fix code the mock connection reports `is_closed() == false`
+    /// forever, the validation task never triggers a refresh, and the
+    /// connection-count assertion below fails.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_periodic_check_detects_silent_half_open_connection() {
+        let name = "test_periodic_check_detects_half_open";
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(0)
+                .periodic_connections_checks(Some(Duration::from_millis(500))),
+            name,
+            move |cmd: &[u8], _port| {
+                if let Err(err) = respond_startup(name, cmd) {
+                    return Err(err);
+                }
+                Err(Ok(Value::BulkString(b"PONG".to_vec().into())))
+            },
+        );
+
+        // Drive one command to prove the connection is healthy end-to-end.
+        let value = runtime.block_on(
+            cmd("ECHO")
+                .arg("hello")
+                .query_async::<_, Value>(&mut connection),
+        );
+        assert_eq!(value, Ok(Value::BulkString(b"PONG".to_vec().into())));
+
+        let conns_before = mock_connection_count(name);
+
+        // Simulate a silent half-open flow on port 6379: any PING routed to
+        // that port hangs forever, mimicking a middlebox eviction with no FIN
+        // or RST. The RAII guard clears the port on drop, so a panic anywhere
+        // below still restores global state and does not leak into sibling
+        // tests that reuse port 6379.
+        let blackhole_guard = AsyncPingBlackholeGuard::new(6379);
+
+        // Wait a few multiples of the heartbeat interval so the validation
+        // task can fire, time out on PING, and drive a reconnect.
+        runtime.block_on(async {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        });
+
+        // Take the blackhole off so the reconnect attempt itself does not
+        // hang: the mock's connect() path is unaffected, but a PING during a
+        // fresh handshake would otherwise stall.
+        drop(blackhole_guard);
+
+        // Give the reconnect path enough time to complete the fresh handshake
+        // and install the replacement connection into routing before we
+        // sample the counter and probe a follow-up command.
+        runtime.block_on(async {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        });
+
+        let conns_after = mock_connection_count(name);
+
+        assert!(
+            conns_after > conns_before,
+            "expected periodic validation to detect the half-open transport and \
+             open at least one new connection; before={conns_before}, after={conns_after}"
+        );
+
+        // The reconnect path swapped in a fresh transport; a follow-up command
+        // must now succeed. This catches regressions where the validation task
+        // detects the dead socket but the refresh fails to install a working
+        // replacement. The reconnect can still be settling into routing, so
+        // poll for a bounded window rather than assuming the first attempt
+        // sees the fresh transport.
+        let post_reconnect = runtime.block_on(async {
+            let mut last: Result<Value, RedisError> = Ok(Value::Nil);
+            for _ in 0..20 {
+                let attempt = cmd("ECHO")
+                    .arg("world")
+                    .query_async::<_, Value>(&mut connection)
+                    .await;
+                if matches!(&attempt, Ok(Value::BulkString(_))) {
+                    return attempt;
+                }
+                last = attempt;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            last
+        });
+        assert_eq!(
+            post_reconnect,
+            Ok(Value::BulkString(b"PONG".to_vec().into())),
+            "expected a fresh command to succeed after reconnect"
+        );
+    }
+
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;
         use redis::ConnectionInfo;


### PR DESCRIPTION
### Summary

Red regression test that reproduces the silent half-open cluster connection pathology in a deterministic, network-free harness. This PR ships only the test; the fix is in the stacked PR that follows.

### Issue link

This Pull Request is linked to issue: 

### Features / Behaviour Changes

None. Test-only.

### Implementation

- Adds a mock-cluster helper (`set_async_ping_blackhole`, `mock_connection_count`) that lets a test declare specific ports whose async `PING` requests return a future that never resolves. This mimics a stateful middlebox eviction: the transport looks alive, no FIN or RST is delivered, and any read on that flow stays pending forever.
- Adds `test_async_cluster_periodic_check_detects_silent_half_open_connection`, which:
  1. Boots a `MockEnv` cluster with `periodic_connections_checks(500ms)`.
  2. Drives one healthy command to prove the connection works end-to-end.
  3. Puts port 6379 into the PING blackhole.
  4. Waits a few multiples of the heartbeat interval.
  5. Asserts the mock's `connection_id_provider` counter has advanced, proving the periodic validation task detected the dead transport and drove a reconnect.

On current `main` the test fails: the periodic task only checks `is_closed()`, which stays false for a silent half-open flow, so no reconnect is triggered and the counter never advances. The follow-up fix PR flips it green.

### Limitations

- Tokio-only (matches the rest of the cluster-async test suite).
- Uses `serial_test` because the mock cluster registry is global state.

### Testing

- `cargo test --features cluster-async,tokio-comp --test test_cluster_async test_async_cluster_periodic_check_detects_silent_half_open_connection`
  - On current `main`: FAILS with `expected periodic validation to detect the half-open transport and open at least one new connection; before=3, after=3`.
  - With the stacked fix applied: PASSES.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated. (Not applicable: test-only PR, no user-visible change; CHANGELOG entry lives on the stacked fix PR.)
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). (Formatting reviewed manually; CI enforces.)
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
