### PR TITLE
Python: Skip fork safety tests under trio backend

### DIFF
--- a/python/tests/async_tests/test_fork_safety.py
+++ b/python/tests/async_tests/test_fork_safety.py
@@ -116,6 +116,23 @@ def _is_free_threaded() -> bool:
 class TestForkSafety:
     """Tests for fork() safety of the pipe transport (issue #6673)."""
 
+    @pytest.fixture(autouse=True)
+    def _skip_on_trio(self, anyio_backend):
+        """Skip fork safety tests when running under the trio backend.
+
+        Trio does not support os.fork(); its internal WaitTaskRescheduled
+        primitive breaks in forked child processes, causing RuntimeError.
+        See: https://github.com/valkey-io/valkey-glide/issues/6722
+        """
+        backend_name = (
+            anyio_backend[0] if isinstance(anyio_backend, tuple) else anyio_backend
+        )
+        if backend_name == "trio":
+            pytest.skip(
+                "fork() is unsupported under trio "
+                "(WaitTaskRescheduled breaks in forked children)"
+            )
+
     @pytest.mark.parametrize("cluster_mode", [True])
     async def test_forked_children_can_use_clients(
         self, request: Any, cluster_mode: bool


### PR DESCRIPTION
### Summary

Skip `TestForkSafety` tests when running under the trio async backend. Trio fundamentally does not support `os.fork()` — its internal `WaitTaskRescheduled` primitive breaks in forked child processes, causing `RuntimeError: Task got bad yield`.

### Issue link

This Pull Request is linked to issue: [Python][Flaky Test] test_fork_safety tests fail with trio backend - WaitTaskRescheduled RuntimeError (https://github.com/valkey-io/valkey-glide/issues/6722)
Closes #6722

### Features / Behaviour Changes

No behavior changes to production code. Fork safety tests are now skipped when the trio backend is active, eliminating false failures in CI.

### Implementation

Added a class-level `autouse` pytest fixture `_skip_on_trio` to `TestForkSafety` that:
1. Receives the `anyio_backend` fixture (already available since tests use `@pytest.mark.anyio`)
2. Extracts the backend name from both string and tuple `("trio", {options})` formats
3. Calls `pytest.skip()` with an explanatory message when trio is detected

### Limitations

Fork safety tests will not run under trio. This is acceptable because trio explicitly does not support fork().

### Testing

- Ran the trio-backend fork tests 100 times (400 total test executions) — all correctly SKIPPED
- asyncio and uvloop backends continue to run fork tests normally

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary