### PR TITLE
Python: Fix flaky test_sync_pubsub_pattern_many_channels race condition

### DIFF
--- a/python/tests/sync_tests/test_sync_pubsub.py
+++ b/python/tests/sync_tests/test_sync_pubsub.py
@@ -775,8 +775,23 @@ class TestSyncPubSub:
                 if cluster_mode:
                     assert result == 1
 
-            # allow the message to propagate
-            time.sleep(1)
+            # The Callback and Sync read paths are non-blocking, so they
+            # must poll until every message has arrived; a fixed sleep races
+            # against slow CI (e.g. aarch64).  Only the Async path
+            # (get_pubsub_message) blocks per-message and needs no pre-wait.
+            if method == MethodTesting.Callback:
+                # Callback messages arrive asynchronously; poll the callback list.
+                wait_for_messages(
+                    NUM_CHANNELS, callback_messages, timeout=10.0
+                )
+            elif method == MethodTesting.Sync:
+                # try_get_pubsub_message is non-blocking; poll the client's
+                # internal pubsub queue until all arrive.
+                wait_for_messages(
+                    NUM_CHANNELS,
+                    listening_client._pubsub_queue,
+                    timeout=10.0,
+                )
 
             # Check if all messages are received correctly
             for index in range(len(channels)):


### PR DESCRIPTION
### Summary

Replace a fixed `time.sleep(1)` with proper polling via `wait_for_messages()` to eliminate the race condition where 256 PubSub messages haven't all arrived before the assertion runs, especially on slow aarch64 CI runners.

### Issue link

This Pull Request is linked to issue: [Python][Flaky Test] test_sync_pubsub_pattern_many_channels - callback message count assertion (https://github.com/valkey-io/valkey-glide/issues/6723)
Closes #6723

### Features / Behaviour Changes

No behavior changes. The test now deterministically waits for all messages to arrive (up to 10s timeout with 0.1s polling) instead of hoping 1 second is enough.

### Implementation

Replaced `time.sleep(1)` with method-specific polling using the existing `wait_for_messages()` helper:
- **Callback method**: Polls the `callback_messages` list until all 256 messages arrive
- **Sync method**: Polls `listening_client._pubsub_queue` until all 256 messages arrive
- **Async method**: No pre-wait needed since `get_pubsub_message()` blocks per-message

This is the exact same pattern already used in the sibling test `test_sync_pubsub_combined_exact_and_pattern_one_client` (lines 870-887 of the same file).

### Limitations

None.

### Testing

- Code review confirms the fix follows the identical pattern already proven in a sibling test
- The `wait_for_messages()` helper is well-tested and used across the test suite

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary