### PR TITLE
Node: Fix flaky FLUSHALL timeout in commonjs-test.cjs

### DIFF
--- a/node/hybrid-node-tests/commonjs-test/commonjs-test.cjs
+++ b/node/hybrid-node-tests/commonjs-test/commonjs-test.cjs
@@ -13,6 +13,7 @@ const PORT_NUMBER = 4001;
 async function runTest(port) {
     const client = await GlideClient.createClient({
         addresses: [{ host: "localhost", port }],
+        requestTimeout: 5000,
     });
 
     try {


### PR DESCRIPTION
### Summary
Fix flaky FLUSHALL timeout in the commonjs-test.cjs hybrid node modules test by increasing the client's `requestTimeout` from the default 250ms to 5000ms.

### Issue link
This Pull Request is linked to issue: [[Node][Flaky Test] commonjs-test.cjs - FLUSHALL timeout in hybrid node modules test](https://github.com/valkey-io/valkey-glide/issues/6736)
Closes #6736

### Features / Behaviour Changes
No behaviour changes. This PR fixes test flakiness only.

### Implementation
**Root cause:** The GlideClient in commonjs-test.cjs was using the default `requestTimeout` of 250ms. In CI environments (GitHub Actions runners) under load, the system can be saturated even at command submission time, causing simple commands like FLUSHALL to exceed this timeout. The timeout_watchdog confirmed: "system was already saturated at submission time."

**Fix:** Set `requestTimeout: 5000` (5 seconds) in the `GlideClient.createClient` configuration. This is generous enough for CI environments under load while still catching actual connection issues. This aligns with the pattern used in the main test suite (TestUtilities.ts uses 1000ms, and specific tests use up to 10000ms).

### Limitations
None

### Testing
- Verified the fix is consistent with the `requestTimeout` configuration pattern used throughout the test suite (e.g., `node/tests/TestUtilities.ts` sets 1000ms by default, `GlideClient.test.ts` uses 10000ms for certain operations)
- The change is a single configuration value addition with no logic changes

### Checklist
- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md updated - N/A for flaky-test fixes; do NOT add a changelog entry.
- [x] Lint checked manually (matched surrounding style; lint tools not run locally).
- [x] Destination branch is correct - main or release