### PR TITLE
Python: Fix flaky test_migrate timeout in standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Python: Fix flaky test_migrate timeout in standalone mode ([#6739](https://github.com/valkey-io/valkey-glide/pull/6739))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.
 
 * Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))

--- a/python/tests/async_tests/test_async_client.py
+++ b/python/tests/async_tests/test_async_client.py
@@ -9718,11 +9718,11 @@ class TestCommands:
         await glide_client.set(key, value)
 
         with pytest.raises(RequestError):
-            await glide_client.migrate("invalid-host", 6379, key, 0, 5000)
+            await glide_client.migrate("invalid-host", 6379, key, 0, 500)
 
         with pytest.raises(RequestError):
             await glide_client.migrate(
-                "invalid-host", 6379, key, 0, 5000, MigrateOptions(copy=True)
+                "invalid-host", 6379, key, 0, 500, MigrateOptions(copy=True)
             )
 
         with pytest.raises(ValueError):
@@ -9736,11 +9736,11 @@ class TestCommands:
             await glide_client.set(key2, "value2")
             await glide_client.set(key3, "value3")
             with pytest.raises(RequestError):
-                await glide_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
+                await glide_client.migrate("invalid-host", 6379, [key2, key3], 0, 500)
 
             # Multi-key: empty keys list raises ValueError
             with pytest.raises(ValueError):
-                await glide_client.migrate("invalid-host", 6379, [], 0, 5000)
+                await glide_client.migrate("invalid-host", 6379, [], 0, 500)
 
             # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
             non_existent1 = get_random_string(5)
@@ -9750,7 +9750,7 @@ class TestCommands:
                 6379,
                 [non_existent1, non_existent2],
                 0,
-                5000,
+                500,
             )
             assert result == b"NOKEY"
 

--- a/python/tests/async_tests/test_batch.py
+++ b/python/tests/async_tests/test_batch.py
@@ -1719,8 +1719,8 @@ class TestBatch:
         )
         key = get_random_string(10)
         await glide_client.set(key, "value")
-        batch.migrate("invalid-host", 6379, key, 0, 5000)
-        batch.migrate("invalid-host", 6379, key, 0, 5000, MigrateOptions(copy=True))
+        batch.migrate("invalid-host", 6379, key, 0, 500)
+        batch.migrate("invalid-host", 6379, key, 0, 500, MigrateOptions(copy=True))
         result = await exec_batch(glide_client, batch, raise_on_error=False)
         assert result is not None
         assert isinstance(result[0], RequestError)
@@ -1730,7 +1730,7 @@ class TestBatch:
         if not cluster_mode:
             batch2 = Batch(is_atomic=False)
             with pytest.raises(ValueError):
-                batch2.migrate("invalid-host", 6379, [], 0, 5000)
+                batch2.migrate("invalid-host", 6379, [], 0, 500)
 
     @pytest.fixture(scope="class")
     def second_server(self, request):

--- a/python/tests/sync_tests/test_sync_batch.py
+++ b/python/tests/sync_tests/test_sync_batch.py
@@ -1340,8 +1340,8 @@ class TestSyncBatch:
         )
         key = get_random_string(10)
         glide_sync_client.set(key, "value")
-        batch.migrate("invalid-host", 6379, key, 0, 5000)
-        batch.migrate("invalid-host", 6379, key, 0, 5000, MigrateOptions(copy=True))
+        batch.migrate("invalid-host", 6379, key, 0, 500)
+        batch.migrate("invalid-host", 6379, key, 0, 500, MigrateOptions(copy=True))
         result = exec_batch(glide_sync_client, batch, raise_on_error=False)
         assert result is not None
         assert isinstance(result[0], RequestError)
@@ -1351,7 +1351,7 @@ class TestSyncBatch:
         if not cluster_mode:
             batch2 = Batch(is_atomic=False)
             with pytest.raises(ValueError):
-                batch2.migrate("invalid-host", 6379, [], 0, 5000)
+                batch2.migrate("invalid-host", 6379, [], 0, 500)
 
     @pytest.fixture(scope="class")
     def second_server(self, request):

--- a/python/tests/sync_tests/test_sync_client.py
+++ b/python/tests/sync_tests/test_sync_client.py
@@ -9847,11 +9847,11 @@ class TestCommands:
         glide_sync_client.set(key, value)
 
         with pytest.raises(RequestError):
-            glide_sync_client.migrate("invalid-host", 6379, key, 0, 5000)
+            glide_sync_client.migrate("invalid-host", 6379, key, 0, 500)
 
         with pytest.raises(RequestError):
             glide_sync_client.migrate(
-                "invalid-host", 6379, key, 0, 5000, MigrateOptions(copy=True)
+                "invalid-host", 6379, key, 0, 500, MigrateOptions(copy=True)
             )
 
         with pytest.raises(ValueError):
@@ -9865,11 +9865,11 @@ class TestCommands:
             glide_sync_client.set(key2, "value2")
             glide_sync_client.set(key3, "value3")
             with pytest.raises(RequestError):
-                glide_sync_client.migrate("invalid-host", 6379, [key2, key3], 0, 5000)
+                glide_sync_client.migrate("invalid-host", 6379, [key2, key3], 0, 500)
 
             # Multi-key: empty keys list raises ValueError
             with pytest.raises(ValueError):
-                glide_sync_client.migrate("invalid-host", 6379, [], 0, 5000)
+                glide_sync_client.migrate("invalid-host", 6379, [], 0, 500)
 
             # Multi-key NOKEY: non-existent keys return NOKEY immediately (no connection made).
             non_existent1 = get_random_string(5)
@@ -9879,7 +9879,7 @@ class TestCommands:
                 6379,
                 [non_existent1, non_existent2],
                 0,
-                5000,
+                500,
             )
             assert result == b"NOKEY"
 


### PR DESCRIPTION
### Summary

Reduce MIGRATE timeout from 5000ms to 500ms for error-case tests using `"invalid-host"` to prevent client-side TimeoutError in CI environments.

### Issue link

This Pull Request is linked to issue: [[Python][Flaky Test] test_migrate / test_pipeline_migrate - TimeoutError on standalone mode](https://github.com/valkey-io/valkey-glide/issues/6738)
Closes #6738

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The MIGRATE command to `"invalid-host"` with a 5000ms timeout blocks the Valkey server connection during DNS resolution/TCP connection attempts to the unreachable host. Under CI load with parallel tests, DNS resolution for non-existent hostnames can take variable amounts of time. After multiple MIGRATE calls (each potentially blocking up to 5 seconds), subsequent commands on the same connection time out because the client's request timeout is exceeded.

**Fix:** Reduce the timeout parameter from `5000` to `500` in all error-case MIGRATE calls that use `"invalid-host"`. 500ms is sufficient to trigger the expected error (IOERR/timeout from the server) without blocking the connection long enough to cause client-side timeouts. The `test_migrate_success` / `test_pipeline_migrate_success` functions that test actual migration with real servers retain their 5000ms timeout.

Files changed (16 lines across 4 files):
- `python/tests/async_tests/test_async_client.py` — 5 occurrences
- `python/tests/async_tests/test_batch.py` — 3 occurrences
- `python/tests/sync_tests/test_sync_batch.py` — 3 occurrences
- `python/tests/sync_tests/test_sync_client.py` — 5 occurrences

### Limitations

None

### Testing

Ran all affected tests 100 times each with zero failures:
```
pytest tests/async_tests/test_async_client.py::TestCommands::test_migrate --count=100 -x
# 200 passed, 1000 skipped in 15.19s

pytest tests/async_tests/test_batch.py -k "migrate and asyncio" --count=100 -x
# 400 passed, 200 skipped in 5.47s

pytest tests/sync_tests/test_sync_client.py -k "test_sync_migrate" --count=100 -x
# 400 passed, 200 skipped in 17.82s

pytest tests/sync_tests/test_sync_batch.py -k "migrate" --count=100 -x
# 400 passed, 200 skipped in 2.87s
```

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run.
- [x] Destination branch is correct - main or release