### PR TITLE
feat(node): replace Proxy-based abandon detection with Rust-level pool tracking

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -478,7 +478,6 @@ fn get_timeout_from_cmd_arg(
 /// Returns true for commands with user-specified blocking timeouts that
 /// should be excluded from latency tracking (they distort p99).
 /// Also used by the pool abandon monitor to skip clients executing blocking commands.
-/// Keep in sync with BLOCKING_COMMANDS in node/src/ClientPool.ts.
 pub fn is_blocking_command(cmd: &Cmd) -> bool {
     let command = cmd.command().unwrap_or_default();
     match command.as_slice() {

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -3212,6 +3212,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "bytes",
+ "dashmap 5.5.3",
  "glide-core",
  "logger_core",
  "napi",

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -21,6 +21,7 @@ logger_core = { path = "../../logger_core" }
 telemetrylib = { path = "../../glide-core/telemetry" }
 byteorder = "1"
 bytes = "1"
+dashmap = "5"
 num-traits = "0.2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1276,7 +1276,9 @@ impl GlideClientHandle {
         let command_span_for_error = cmd.span();
 
         // Pool abandon detection: refresh activity and mark blocking commands
-        let pool_blocking_ids = if pool::get_client_pool_map().contains_key(&self.client_id) {
+        let pool_blocking_ids = if pool::any_pool_clients()
+            && pool::get_client_pool_map().contains_key(&self.client_id)
+        {
             pool::refresh_activity(self.client_id);
             if glide_core::client::is_blocking_command(&cmd)
                 && pool::mark_blocking(self.client_id, true)
@@ -1490,7 +1492,9 @@ impl GlideClientHandle {
         let command_span_for_error = command_span.clone();
 
         // Pool abandon detection: refresh activity for batch duration
-        let pool_ids = if pool::get_client_pool_map().contains_key(&self.client_id) {
+        let pool_ids = if pool::any_pool_clients()
+            && pool::get_client_pool_map().contains_key(&self.client_id)
+        {
             pool::refresh_activity(self.client_id);
             Some(self.client_id)
         } else {
@@ -1588,7 +1592,9 @@ impl GlideClientHandle {
         };
 
         // Pool abandon detection: refresh activity for script execution
-        let pool_ids = if pool::get_client_pool_map().contains_key(&self.client_id) {
+        let pool_ids = if pool::any_pool_clients()
+            && pool::get_client_pool_map().contains_key(&self.client_id)
+        {
             pool::refresh_activity(self.client_id);
             Some(self.client_id)
         } else {
@@ -1657,7 +1663,7 @@ impl GlideClientHandle {
         });
 
         // Pool abandon detection: refresh activity for scan
-        if pool::get_client_pool_map().contains_key(&self.client_id) {
+        if pool::any_pool_clients() && pool::get_client_pool_map().contains_key(&self.client_id) {
             pool::refresh_activity(self.client_id);
         }
 

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -313,6 +313,9 @@ struct SingleCommandMessage {
     callback_idx: u32,
     cmd: redis::Cmd,
     routing: Option<RoutingInfo>,
+    /// If this command was marked as blocking for pool abandon detection,
+    /// contains the client_id to unmark after completion.
+    pool_blocking_ids: Option<u64>,
 }
 
 /// Batch command message for pipeline or transaction execution.
@@ -326,6 +329,8 @@ struct BatchCommandMessage {
     retry_connection_error: bool,
     routing: Option<RoutingInfo>,
     command_span: Option<GlideSpan>,
+    /// Pool client_id for blocking protection during batch execution.
+    pool_ids: Option<u64>,
 }
 
 /// Script invocation message (EVALSHA with auto-LOAD fallback)
@@ -335,6 +340,8 @@ struct ScriptInvocationMessage {
     keys: Vec<Bytes>,
     args: Vec<Bytes>,
     routing: Option<RoutingInfo>,
+    /// Pool client_id for blocking protection during script execution.
+    pool_ids: Option<u64>,
 }
 
 /// Cluster scan message
@@ -939,6 +946,7 @@ pub fn create_direct_client<'a>(
                     let mut cmd = cmd_msg.cmd;
                     let callback_idx = cmd_msg.callback_idx;
                     let routing = cmd_msg.routing;
+                    let pool_blocking_ids = cmd_msg.pool_blocking_ids;
                     let inflight = Arc::clone(&worker_inflight);
                     let buffer = Arc::clone(&response_buffer_worker);
                     let wake = wake_tsfn_worker.clone();
@@ -956,6 +964,10 @@ pub fn create_direct_client<'a>(
                             Ok(()) => client_clone.send_command(&mut cmd, routing).await,
                             Err(err) => Err(err),
                         };
+                        // Unmark blocking after command completes
+                        if let Some(client_id) = pool_blocking_ids {
+                            pool::mark_blocking(client_id, false);
+                        }
                         let response = build_response(callback_idx, result, cmd.span());
                         inflight.fetch_add(1, Ordering::Release);
                         if buffer.push(response)
@@ -968,12 +980,19 @@ pub fn create_direct_client<'a>(
                 WorkerMessage::Batch(batch_msg) => {
                     let mut client_clone = client.clone();
                     let callback_idx = batch_msg.callback_idx;
+                    let pool_ids = batch_msg.pool_ids;
                     let inflight = Arc::clone(&worker_inflight);
                     let buffer = Arc::clone(&response_buffer_worker);
                     let wake = wake_tsfn_worker.clone();
 
                     // Spawn local task for batch execution
                     task::spawn_local(async move {
+                        // Mark as blocking for duration of batch execution.
+                        // Conservative: prevents abandon monitor from discarding a client
+                        // mid-batch even if abandon_timeout < batch execution time.
+                        if let Some(client_id) = pool_ids {
+                            pool::mark_blocking(client_id, true);
+                        }
                         let command_span = batch_msg.command_span.clone();
                         let result = execute_batch(
                             &mut client_clone,
@@ -987,6 +1006,10 @@ pub fn create_direct_client<'a>(
                             batch_msg.command_span,
                         )
                         .await;
+                        // Unmark blocking after batch completes
+                        if let Some(client_id) = pool_ids {
+                            pool::mark_blocking(client_id, false);
+                        }
                         let response = build_response(callback_idx, result, command_span);
                         inflight.fetch_add(1, Ordering::Release);
                         if buffer.push(response)
@@ -999,16 +1022,27 @@ pub fn create_direct_client<'a>(
                 WorkerMessage::ScriptInvocation(script_msg) => {
                     let mut client_clone = client.clone();
                     let callback_idx = script_msg.callback_idx;
+                    let pool_ids = script_msg.pool_ids;
                     let inflight = Arc::clone(&worker_inflight);
                     let buffer = Arc::clone(&response_buffer_worker);
                     let wake = wake_tsfn_worker.clone();
 
                     task::spawn_local(async move {
+                        // Mark as blocking for duration of script execution.
+                        // Conservative: prevents abandon monitor from discarding a client
+                        // mid-script even if abandon_timeout < script execution time.
+                        if let Some(client_id) = pool_ids {
+                            pool::mark_blocking(client_id, true);
+                        }
                         let keys: Vec<&[u8]> = script_msg.keys.iter().map(|k| k.as_ref()).collect();
                         let args: Vec<&[u8]> = script_msg.args.iter().map(|a| a.as_ref()).collect();
                         let result = client_clone
                             .invoke_script(&script_msg.hash, &keys, &args, script_msg.routing)
                             .await;
+                        // Unmark blocking after script completes
+                        if let Some(client_id) = pool_ids {
+                            pool::mark_blocking(client_id, false);
+                        }
                         let response = build_response(callback_idx, result, None);
                         inflight.fetch_add(1, Ordering::Release);
                         if buffer.push(response)
@@ -1241,11 +1275,26 @@ impl GlideClientHandle {
         };
         let command_span_for_error = cmd.span();
 
+        // Pool abandon detection: refresh activity and mark blocking commands
+        let pool_blocking_ids = if pool::get_client_pool_map().contains_key(&self.client_id) {
+            pool::refresh_activity(self.client_id);
+            if glide_core::client::is_blocking_command(&cmd)
+                && pool::mark_blocking(self.client_id, true)
+            {
+                Some(self.client_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         // Send command to the pinned worker thread via channel
         let msg = WorkerMessage::Command(SingleCommandMessage {
             callback_idx,
             cmd,
             routing,
+            pool_blocking_ids,
         });
 
         // Send via channel (non-blocking)
@@ -1436,6 +1485,14 @@ impl GlideClientHandle {
         };
         let command_span_for_error = command_span.clone();
 
+        // Pool abandon detection: refresh activity for batch duration
+        let pool_ids = if pool::get_client_pool_map().contains_key(&self.client_id) {
+            pool::refresh_activity(self.client_id);
+            Some(self.client_id)
+        } else {
+            None
+        };
+
         // Send batch message to worker
         let msg = WorkerMessage::Batch(BatchCommandMessage {
             callback_idx,
@@ -1447,6 +1504,7 @@ impl GlideClientHandle {
             retry_connection_error: retry_connection_error.unwrap_or(false),
             routing,
             command_span,
+            pool_ids,
         });
 
         let send_failed = match &self.command_tx {
@@ -1525,12 +1583,21 @@ impl GlideClientHandle {
             None => None,
         };
 
+        // Pool abandon detection: refresh activity for script execution
+        let pool_ids = if pool::get_client_pool_map().contains_key(&self.client_id) {
+            pool::refresh_activity(self.client_id);
+            Some(self.client_id)
+        } else {
+            None
+        };
+
         let msg = WorkerMessage::ScriptInvocation(ScriptInvocationMessage {
             callback_idx,
             hash,
             keys,
             args,
             routing,
+            pool_ids,
         });
 
         let send_failed = match &self.command_tx {

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1305,6 +1305,10 @@ impl GlideClientHandle {
         if send_failed {
             // Channel closed - client was shut down
             self.inflight_requests.fetch_add(1, Ordering::Relaxed);
+            // Release blocking mark — the worker will never run
+            if let Some(client_id) = pool_blocking_ids {
+                pool::mark_blocking(client_id, false);
+            }
             mark_span_error(&command_span_for_error, "Client connection closed");
             let response = CommandResponse {
                 callback_idx,
@@ -1651,6 +1655,11 @@ impl GlideClientHandle {
             object_type,
             allow_non_covered_slots: allow_non_covered_slots.unwrap_or(false),
         });
+
+        // Pool abandon detection: refresh activity for scan
+        if pool::get_client_pool_map().contains_key(&self.client_id) {
+            pool::refresh_activity(self.client_id);
+        }
 
         let send_failed = match &self.command_tx {
             Some(tx) => tx.send(msg).is_err(),

--- a/node/rust-client/src/pool.rs
+++ b/node/rust-client/src/pool.rs
@@ -4,9 +4,13 @@
 //!
 //! Uses the same deferred Promise pattern as GlideClientHandle for async work:
 //! synchronous N-API call spawns work on a runtime, resolves/rejects via Deferred.
+//!
+//! Note: #[napi] exports are invisible to the Rust compiler's usage analysis,
+//! so dead_code warnings are suppressed at module level.
 
 #![allow(dead_code)]
 
+use dashmap::DashMap;
 use glide_core::client::{Client, ConnectionRequest};
 use glide_core::connection_request::ConnectionRequest as ProtobufConnectionRequest;
 use glide_core::pool::{self, ClientPool, POOL_RUNNING, PoolConfig};
@@ -15,9 +19,9 @@ use napi::bindgen_prelude::*;
 use napi::{Env, Error, Result, Status};
 use napi_derive::napi;
 use protobuf::Message;
-use std::sync::OnceLock;
-use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, OnceLock};
+use std::time::{Duration, Instant};
 
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -32,6 +36,192 @@ fn get_pool_runtime() -> &'static tokio::runtime::Runtime {
             .build()
             .expect("Failed to create pool runtime")
     })
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CLIENT-TO-POOL TRACKING (for abandon detection hooks in command dispatch)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Maps client_id → pool_id for all pool-borrowed clients.
+/// Consulted by GlideClientHandle::send_command to refresh activity.
+static CLIENT_POOL_MAP: LazyLock<DashMap<u64, u64>> = LazyLock::new(DashMap::new);
+
+/// Tracks activity timestamps for pool-borrowed clients.
+/// Updated on every command dispatch for registered clients.
+static CLIENT_ACTIVITY: LazyLock<DashMap<u64, Instant>> = LazyLock::new(DashMap::new);
+
+/// Tracks blocking state for pool-borrowed clients.
+/// Set to true while a blocking command is in flight.
+static CLIENT_BLOCKING: LazyLock<DashMap<u64, Arc<AtomicBool>>> = LazyLock::new(DashMap::new);
+
+/// Get the client-to-pool map (for use by command dispatch hooks).
+pub fn get_client_pool_map() -> &'static DashMap<u64, u64> {
+    &CLIENT_POOL_MAP
+}
+
+/// Refresh the activity timestamp for a pool-borrowed client.
+/// Called from send_command/send_batch/invoke_script hooks.
+pub fn refresh_activity(client_id: u64) {
+    if let Some(mut entry) = CLIENT_ACTIVITY.get_mut(&client_id) {
+        *entry.value_mut() = Instant::now();
+    }
+}
+
+/// Mark/unmark a pool-borrowed client as executing a blocking command.
+/// Returns true if the mark was applied (client is registered).
+pub fn mark_blocking(client_id: u64, blocking: bool) -> bool {
+    if let Some(entry) = CLIENT_BLOCKING.get(&client_id) {
+        entry.value().store(blocking, Ordering::Release);
+        // Refresh activity on unmark (so client isn't immediately reclaimable after a long block)
+        if !blocking {
+            refresh_activity(client_id);
+        }
+        true
+    } else {
+        false
+    }
+}
+
+/// Register a client as pool-borrowed. Called by TS on acquire.
+#[napi]
+pub fn pool_register_client(pool_id: i64, client_id: i64) {
+    let cid = client_id as u64;
+    CLIENT_POOL_MAP.insert(cid, pool_id as u64);
+    CLIENT_ACTIVITY.insert(cid, Instant::now());
+    CLIENT_BLOCKING.insert(cid, Arc::new(AtomicBool::new(false)));
+}
+
+/// Unregister a client from pool tracking. Called by TS on release/close.
+#[napi]
+pub fn pool_unregister_client(client_id: i64) {
+    let cid = client_id as u64;
+    CLIENT_POOL_MAP.remove(&cid);
+    CLIENT_ACTIVITY.remove(&cid);
+    CLIENT_BLOCKING.remove(&cid);
+}
+
+/// Drain discarded client IDs from the abandon monitor.
+/// Returns client IDs that were abandoned and should be closed by TS.
+#[napi]
+pub fn pool_drain_discarded(pool_id: i64) -> Vec<i64> {
+    // The Node abandon monitor stores discarded IDs in DISCARDED_CLIENTS
+    let mut result = vec![];
+    DISCARDED_CLIENTS.retain(|key, &mut pid| {
+        if pid == pool_id as u64 {
+            result.push(*key as i64);
+            false // remove from map
+        } else {
+            true // keep
+        }
+    });
+    result
+}
+
+/// Stores client IDs discarded by the abandon monitor, keyed by client_id → pool_id.
+static DISCARDED_CLIENTS: LazyLock<DashMap<u64, u64>> = LazyLock::new(DashMap::new);
+
+/// Stores monitor abort handles per pool_id.
+static MONITOR_HANDLES: LazyLock<DashMap<u64, tokio::task::JoinHandle<()>>> =
+    LazyLock::new(DashMap::new);
+
+/// Start the abandon monitor for a pool. Called by TS during pool creation.
+/// pool_id is an arbitrary identifier used to group clients.
+/// abandon_timeout_ms of 0 disables the monitor.
+#[napi]
+pub fn pool_start_monitor(pool_id: i64, abandon_timeout_ms: i64) {
+    start_node_abandon_monitor(
+        pool_id as u64,
+        Duration::from_millis(abandon_timeout_ms as u64),
+    );
+}
+
+/// Stop and abort the abandon monitor for a pool. Called by TS on close().
+#[napi]
+pub fn pool_stop_monitor(pool_id: i64) {
+    if let Some((_, handle)) = MONITOR_HANDLES.remove(&(pool_id as u64)) {
+        handle.abort();
+    }
+}
+
+/// Start the Node-specific abandon monitor for a pool.
+/// Scans CLIENT_ACTIVITY for clients that exceeded abandon_timeout.
+fn start_node_abandon_monitor(pool_id: u64, abandon_timeout: Duration) {
+    if abandon_timeout.is_zero() {
+        return;
+    }
+
+    let scan_interval = std::cmp::max(abandon_timeout / 2, Duration::from_secs(1));
+
+    let handle = get_pool_runtime().spawn(async move {
+        loop {
+            tokio::time::sleep(scan_interval).await;
+
+            // Collect abandoned client IDs
+            let now = Instant::now();
+            let mut abandoned = vec![];
+
+            for entry in CLIENT_POOL_MAP.iter() {
+                let client_id = *entry.key();
+                let pid = *entry.value();
+
+                if pid != pool_id {
+                    continue;
+                }
+
+                // Skip blocking clients
+                if let Some(blocking) = CLIENT_BLOCKING.get(&client_id)
+                    && blocking.value().load(Ordering::Acquire)
+                {
+                    continue;
+                }
+
+                // Check activity
+                if let Some(activity) = CLIENT_ACTIVITY.get(&client_id)
+                    && now.duration_since(*activity.value()) > abandon_timeout
+                {
+                    abandoned.push(client_id);
+                }
+            }
+
+            // Discard abandoned clients
+            for client_id in abandoned {
+                // Revalidate before discarding (TOCTOU protection, fresh timestamp)
+                let recheck_now = Instant::now();
+                let should_discard = CLIENT_ACTIVITY
+                    .get(&client_id)
+                    .map(|a| recheck_now.duration_since(*a.value()) > abandon_timeout)
+                    .unwrap_or(false)
+                    && CLIENT_BLOCKING
+                        .get(&client_id)
+                        .map(|b| !b.value().load(Ordering::Acquire))
+                        .unwrap_or(true);
+
+                if should_discard {
+                    // Remove from tracking and mark as discarded
+                    CLIENT_POOL_MAP.remove(&client_id);
+                    CLIENT_ACTIVITY.remove(&client_id);
+                    CLIENT_BLOCKING.remove(&client_id);
+                    DISCARDED_CLIENTS.insert(client_id, pool_id);
+                    logger_core::log_warn(
+                        "pool",
+                        format!(
+                            "Abandon detection: client {client_id} exceeded inactivity timeout — discarding"
+                        ),
+                    );
+                }
+            }
+
+            // Stop if no more clients for this pool
+            if !CLIENT_POOL_MAP.iter().any(|e| *e.value() == pool_id) {
+                break;
+            }
+        }
+
+        // Clean up handle on self-termination
+        MONITOR_HANDLES.remove(&pool_id);
+    });
+
+    MONITOR_HANDLES.insert(pool_id, handle);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/node/rust-client/src/pool.rs
+++ b/node/rust-client/src/pool.rs
@@ -216,7 +216,8 @@ fn start_node_abandon_monitor(pool_id: u64, abandon_timeout: Duration) {
 
             // Discard abandoned clients
             for client_id in abandoned {
-                // Revalidate before discarding (TOCTOU protection, fresh timestamp)
+                // Revalidate before discarding (TOCTOU mitigation — reduces but does not
+                // eliminate the race window, same pattern as glide-core's monitor)
                 let recheck_now = Instant::now();
                 let should_discard = CLIENT_ACTIVITY
                     .get(&client_id)
@@ -255,6 +256,7 @@ fn start_node_abandon_monitor(pool_id: u64, abandon_timeout: Duration) {
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // POOL CONFIG / METRICS
+// TODO: Wire TS pool to these Rust-managed functions, replacing TS-level state duplication.
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[napi(object)]

--- a/node/rust-client/src/pool.rs
+++ b/node/rust-client/src/pool.rs
@@ -5,7 +5,7 @@
 //! Uses the same deferred Promise pattern as GlideClientHandle for async work:
 //! synchronous N-API call spawns work on a runtime, resolves/rejects via Deferred.
 //!
-//! Note: #[napi] exports are invisible to the Rust compiler's usage analysis,
+//! Note: `#[napi]` exports are invisible to the Rust compiler's usage analysis,
 //! so dead_code warnings are suppressed at module level.
 
 #![allow(dead_code)]
@@ -129,6 +129,9 @@ static MONITOR_HANDLES: LazyLock<DashMap<u64, tokio::task::JoinHandle<()>>> =
 /// abandon_timeout_ms of 0 disables the monitor.
 #[napi]
 pub fn pool_start_monitor(pool_id: i64, abandon_timeout_ms: i64) {
+    if abandon_timeout_ms <= 0 {
+        return; // 0 = disabled, negative = invalid
+    }
     start_node_abandon_monitor(
         pool_id as u64,
         Duration::from_millis(abandon_timeout_ms as u64),
@@ -138,9 +141,12 @@ pub fn pool_start_monitor(pool_id: i64, abandon_timeout_ms: i64) {
 /// Stop and abort the abandon monitor for a pool. Called by TS on close().
 #[napi]
 pub fn pool_stop_monitor(pool_id: i64) {
-    if let Some((_, handle)) = MONITOR_HANDLES.remove(&(pool_id as u64)) {
+    let pid = pool_id as u64;
+    if let Some((_, handle)) = MONITOR_HANDLES.remove(&pid) {
         handle.abort();
     }
+    // Drop any undrained discard records for this pool
+    DISCARDED_CLIENTS.retain(|_, owner| *owner != pid);
 }
 
 /// Start the Node-specific abandon monitor for a pool.
@@ -211,14 +217,10 @@ fn start_node_abandon_monitor(pool_id: u64, abandon_timeout: Duration) {
                 }
             }
 
-            // Stop if no more clients for this pool
-            if !CLIENT_POOL_MAP.iter().any(|e| *e.value() == pool_id) {
-                break;
-            }
+            // Do not self-terminate: clients are registered lazily on acquire,
+            // so an empty pool is a normal transient state. The monitor is
+            // aborted by pool_stop_monitor() when the pool closes.
         }
-
-        // Clean up handle on self-termination
-        MONITOR_HANDLES.remove(&pool_id);
     });
 
     MONITOR_HANDLES.insert(pool_id, handle);

--- a/node/rust-client/src/pool.rs
+++ b/node/rust-client/src/pool.rs
@@ -229,7 +229,9 @@ fn start_node_abandon_monitor(pool_id: u64, abandon_timeout: Duration) {
 
                 if should_discard {
                     // Remove from tracking and mark as discarded
-                    CLIENT_POOL_MAP.remove(&client_id);
+                    if CLIENT_POOL_MAP.remove(&client_id).is_some() {
+                        POOL_CLIENT_COUNT.fetch_sub(1, Ordering::Relaxed);
+                    }
                     CLIENT_ACTIVITY.remove(&client_id);
                     CLIENT_BLOCKING.remove(&client_id);
                     DISCARDED_CLIENTS.insert(client_id, pool_id);

--- a/node/rust-client/src/pool.rs
+++ b/node/rust-client/src/pool.rs
@@ -42,6 +42,26 @@ fn get_pool_runtime() -> &'static tokio::runtime::Runtime {
 // CLIENT-TO-POOL TRACKING (for abandon detection hooks in command dispatch)
 // ═══════════════════════════════════════════════════════════════════════════════
 
+use std::sync::atomic::AtomicU64;
+
+/// Process-global pool ID allocator. Guarantees uniqueness across worker_threads.
+static NEXT_POOL_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Allocate a unique pool ID. Called by TS in the constructor.
+#[napi]
+pub fn pool_allocate_id() -> i64 {
+    NEXT_POOL_ID.fetch_add(1, Ordering::Relaxed) as i64
+}
+
+/// Counter of registered pool clients (for fast-path gate in command dispatch).
+static POOL_CLIENT_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Returns true if any pool clients are currently registered.
+/// Used to skip DashMap lookup on the hot path for non-pool clients.
+pub fn any_pool_clients() -> bool {
+    POOL_CLIENT_COUNT.load(Ordering::Relaxed) > 0
+}
+
 /// Maps client_id → pool_id for all pool-borrowed clients.
 /// Consulted by GlideClientHandle::send_command to refresh activity.
 static CLIENT_POOL_MAP: LazyLock<DashMap<u64, u64>> = LazyLock::new(DashMap::new);
@@ -89,15 +109,20 @@ pub fn pool_register_client(pool_id: i64, client_id: i64) {
     CLIENT_POOL_MAP.insert(cid, pool_id as u64);
     CLIENT_ACTIVITY.insert(cid, Instant::now());
     CLIENT_BLOCKING.insert(cid, Arc::new(AtomicBool::new(false)));
+    POOL_CLIENT_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Unregister a client from pool tracking. Called by TS on release/close.
 #[napi]
 pub fn pool_unregister_client(client_id: i64) {
     let cid = client_id as u64;
-    CLIENT_POOL_MAP.remove(&cid);
+    if CLIENT_POOL_MAP.remove(&cid).is_some() {
+        POOL_CLIENT_COUNT.fetch_sub(1, Ordering::Relaxed);
+    }
     CLIENT_ACTIVITY.remove(&cid);
     CLIENT_BLOCKING.remove(&cid);
+    // Drop any pending discard record so it can't be applied to a later borrow
+    DISCARDED_CLIENTS.remove(&cid);
 }
 
 /// Drain discarded client IDs from the abandon monitor.

--- a/node/src/ClientPool.ts
+++ b/node/src/ClientPool.ts
@@ -92,6 +92,7 @@ export class ClientPool {
     private active = new Map<number, PoolEntry>();
     private closed = false;
     private nextId = 1;
+    private resetting = 0;
     private readonly maxSize: number;
     private readonly minIdle: number;
     private readonly acquireTimeoutMs: number;
@@ -210,7 +211,10 @@ export class ClientPool {
         }
 
         // If below max size, create a new client
-        if (this.idle.length + this.active.size < this.maxSize) {
+        if (
+            this.idle.length + this.active.size + this.resetting <
+            this.maxSize
+        ) {
             const newEntry = await this.createEntry();
             this.active.set(newEntry.id, newEntry);
             poolRegisterClient(this.poolId, newEntry.client.getClientId());
@@ -268,8 +272,14 @@ export class ClientPool {
         // Unregister from Rust-level pool tracking
         poolUnregisterClient(entry.client.getClientId());
 
-        // State reset on the actual connection
-        await this.resetClientState(entry.client);
+        // State reset on the actual connection (track as resetting for capacity)
+        this.resetting++;
+
+        try {
+            await this.resetClientState(entry.client);
+        } finally {
+            this.resetting--;
+        }
 
         // If waiters are queued, hand directly to next waiter (FIFO fairness)
         if (this.waiters.length > 0 && !this.closed) {

--- a/node/src/ClientPool.ts
+++ b/node/src/ClientPool.ts
@@ -29,6 +29,7 @@ import type { GlideClientConfiguration } from "./GlideClient";
 import { GlideClusterClient } from "./GlideClusterClient";
 import type { GlideClusterClientConfiguration } from "./GlideClusterClient";
 import {
+    poolAllocateId,
     poolDrainDiscarded,
     poolRegisterClient,
     poolStartMonitor,
@@ -100,8 +101,6 @@ export class ClientPool {
     private readonly clientConfig: BaseClientConfiguration;
     private waiters: Waiter[] = [];
 
-    private static nextPoolId = 1;
-
     private constructor(
         maxSize: number,
         minIdle: number,
@@ -117,8 +116,8 @@ export class ClientPool {
         this.isCluster = isCluster;
         this.clientConfig = clientConfig;
 
-        // Use static counter as unique pool identifier for Rust-level tracking
-        this.poolId = ClientPool.nextPoolId++;
+        // Allocate pool ID from Rust (process-global, safe across worker_threads)
+        this.poolId = poolAllocateId();
 
         // Start Rust-level abandon monitor (handles blocking detection, activity
         // tracking, and discard — no JS Proxy or setInterval needed)

--- a/node/src/ClientPool.ts
+++ b/node/src/ClientPool.ts
@@ -166,7 +166,12 @@ export class ClientPool {
         // This validates connectivity — if the config is wrong (bad address,
         // wrong cluster mode), the error propagates to the caller immediately
         // instead of being discovered at acquire() time.
-        await pool.createAndAddClient();
+        try {
+            await pool.createAndAddClient();
+        } catch (e) {
+            pool.close(); // Stop monitor and clean up
+            throw e;
+        }
 
         // Remaining warmup is best-effort background
         for (let i = 1; i < minIdle; i++) {
@@ -281,17 +286,20 @@ export class ClientPool {
             this.resetting--;
         }
 
+        if (this.closed) {
+            entry.client.close();
+            return;
+        }
+
         // If waiters are queued, hand directly to next waiter (FIFO fairness)
-        if (this.waiters.length > 0 && !this.closed) {
+        if (this.waiters.length > 0) {
             const waiter = this.waiters.shift()!;
             waiter.resolve(entry);
             return;
         }
 
         // Return to idle stack (LIFO for connection reuse locality)
-        if (!this.closed) {
-            this.idle.push(entry);
-        }
+        this.idle.push(entry);
     }
 
     /**

--- a/node/src/ClientPool.ts
+++ b/node/src/ClientPool.ts
@@ -28,6 +28,13 @@ import { GlideClient } from "./GlideClient";
 import type { GlideClientConfiguration } from "./GlideClient";
 import { GlideClusterClient } from "./GlideClusterClient";
 import type { GlideClusterClientConfiguration } from "./GlideClusterClient";
+import {
+    poolDrainDiscarded,
+    poolRegisterClient,
+    poolStartMonitor,
+    poolStopMonitor,
+    poolUnregisterClient,
+} from "../build-ts/native";
 
 /** Re-export the pool client type (full command set). */
 export type PoolClient = BaseClient;
@@ -88,17 +95,12 @@ export class ClientPool {
     private readonly minIdle: number;
     private readonly acquireTimeoutMs: number;
     private readonly abandonTimeoutMs: number;
+    private readonly poolId: number;
     private readonly isCluster: boolean;
     private readonly clientConfig: BaseClientConfiguration;
     private waiters: Waiter[] = [];
-    /** Tracks last command activity per active entry id. */
-    private lastActivity = new Map<number, number>();
-    /** Tracks entries currently executing a blocking command. */
-    private blockingEntries = new Set<number>();
-    /** Maps proxy client → entry id for release lookup. */
-    private proxyToEntryId = new WeakMap<object, number>();
-    /** Abandon monitor interval handle. */
-    private abandonMonitor: ReturnType<typeof setInterval> | null = null;
+
+    private static nextPoolId = 1;
 
     private constructor(
         maxSize: number,
@@ -115,18 +117,12 @@ export class ClientPool {
         this.isCluster = isCluster;
         this.clientConfig = clientConfig;
 
-        // Start abandon monitor if enabled
-        if (abandonTimeoutMs > 0) {
-            this.abandonMonitor = setInterval(
-                () => this.scanForAbandoned(),
-                abandonTimeoutMs / 2,
-            );
+        // Use static counter as unique pool identifier for Rust-level tracking
+        this.poolId = ClientPool.nextPoolId++;
 
-            // Unref so it doesn't prevent Node.js from exiting
-            if (this.abandonMonitor.unref) {
-                this.abandonMonitor.unref();
-            }
-        }
+        // Start Rust-level abandon monitor (handles blocking detection, activity
+        // tracking, and discard — no JS Proxy or setInterval needed)
+        poolStartMonitor(this.poolId, abandonTimeoutMs);
     }
 
     /**
@@ -192,21 +188,34 @@ export class ClientPool {
             throw new Error("Pool is closed");
         }
 
+        // Drain any clients discarded by the Rust abandon monitor
+        const discarded = poolDrainDiscarded(this.poolId);
+
+        for (const clientId of discarded) {
+            for (const [id, entry] of this.active) {
+                if (entry.client.getClientId() === clientId) {
+                    this.active.delete(id);
+                    entry.client.close();
+                    break;
+                }
+            }
+        }
+
         // Fast path: LIFO pop from idle stack
         const entry = this.idle.pop();
 
         if (entry) {
             this.active.set(entry.id, entry);
-            this.lastActivity.set(entry.id, Date.now());
-            return this.wrapClient(entry);
+            poolRegisterClient(this.poolId, entry.client.getClientId());
+            return entry.client;
         }
 
         // If below max size, create a new client
         if (this.idle.length + this.active.size < this.maxSize) {
             const newEntry = await this.createEntry();
             this.active.set(newEntry.id, newEntry);
-            this.lastActivity.set(newEntry.id, Date.now());
-            return this.wrapClient(newEntry);
+            poolRegisterClient(this.poolId, newEntry.client.getClientId());
+            return newEntry.client;
         }
 
         // At max size — wait for a release
@@ -228,8 +237,8 @@ export class ClientPool {
                 resolve: (entry: PoolEntry) => {
                     clearTimeout(timer);
                     this.active.set(entry.id, entry);
-                    this.lastActivity.set(entry.id, Date.now());
-                    resolve(this.wrapClient(entry));
+                    poolRegisterClient(this.poolId, entry.client.getClientId());
+                    resolve(entry.client);
                 },
                 reject,
                 timer,
@@ -244,31 +253,21 @@ export class ClientPool {
      * GlideClient connection before making it idle again.
      */
     async release(client: BaseClient): Promise<void> {
-        // Find entry by client reference or proxy mapping
+        // Find entry by client reference
         let entry: PoolEntry | undefined;
-        const entryId = this.proxyToEntryId.get(client);
 
-        if (entryId !== undefined) {
-            entry = this.active.get(entryId);
-
-            if (entry) {
-                this.active.delete(entryId);
-                this.proxyToEntryId.delete(client);
-            }
-        } else {
-            for (const [id, e] of this.active) {
-                if (e.client === client) {
-                    entry = e;
-                    this.active.delete(id);
-                    break;
-                }
+        for (const [id, e] of this.active) {
+            if (e.client === client) {
+                entry = e;
+                this.active.delete(id);
+                break;
             }
         }
 
         if (!entry) return;
 
-        this.lastActivity.delete(entry.id);
-        this.blockingEntries.delete(entry.id);
+        // Unregister from Rust-level pool tracking
+        poolUnregisterClient(entry.client.getClientId());
 
         // State reset on the actual connection
         await this.resetClientState(entry.client);
@@ -334,11 +333,8 @@ export class ClientPool {
         if (!this.closed) {
             this.closed = true;
 
-            // Stop abandon monitor
-            if (this.abandonMonitor) {
-                clearInterval(this.abandonMonitor);
-                this.abandonMonitor = null;
-            }
+            // Stop Rust-level abandon monitor
+            poolStopMonitor(this.poolId);
 
             // Reject all waiters
             for (const waiter of this.waiters) {
@@ -348,12 +344,14 @@ export class ClientPool {
 
             this.waiters = [];
 
-            // Close all clients
-            for (const entry of this.idle) {
+            // Unregister and close all active clients
+            for (const entry of this.active.values()) {
+                poolUnregisterClient(entry.client.getClientId());
                 entry.client.close();
             }
 
-            for (const entry of this.active.values()) {
+            // Close all idle clients
+            for (const entry of this.idle) {
                 entry.client.close();
             }
 
@@ -365,78 +363,6 @@ export class ClientPool {
     // ═══════════════════════════════════════════════════════════════════════════
     // INTERNAL
     // ═══════════════════════════════════════════════════════════════════════════
-
-    /**
-     * Commands that block on the server — abandon monitor skips these.
-     * Keep in sync with is_blocking_command() in glide-core/src/client/mod.rs.
-     */
-    private static readonly BLOCKING_COMMANDS = new Set([
-        "blpop",
-        "brpop",
-        "blmove",
-        "bzpopmax",
-        "bzpopmin",
-        "brpoplpush",
-        "blmpop",
-        "bzmpop",
-        "wait",
-        "waitaof",
-        "xread",
-        "xreadgroup",
-    ]);
-
-    /**
-     * Wrap a client with a Proxy that refreshes activity on every method call
-     * and marks blocking commands so the abandon monitor skips them.
-     */
-    private wrapClient(entry: PoolEntry): BaseClient {
-        const proxy = new Proxy(entry.client, {
-            get: (target, prop, receiver) => {
-                const value = Reflect.get(target, prop, receiver);
-
-                if (typeof value !== "function" || typeof prop !== "string") {
-                    return value;
-                }
-
-                // Return a wrapper that refreshes activity and tracks blocking
-                return (...args: unknown[]) => {
-                    this.lastActivity.set(entry.id, Date.now());
-
-                    const isBlocking = ClientPool.BLOCKING_COMMANDS.has(
-                        prop.toLowerCase(),
-                    );
-
-                    if (isBlocking) {
-                        this.blockingEntries.add(entry.id);
-                    }
-
-                    const result = (
-                        value as (...a: unknown[]) => unknown
-                    ).apply(target, args);
-
-                    // If result is a Promise, unmark blocking when it resolves
-                    if (
-                        isBlocking &&
-                        result &&
-                        typeof (result as { then?: unknown }).then ===
-                            "function"
-                    ) {
-                        (result as Promise<unknown>).then(
-                            () => this.blockingEntries.delete(entry.id),
-                            () => this.blockingEntries.delete(entry.id),
-                        );
-                    } else if (isBlocking) {
-                        this.blockingEntries.delete(entry.id);
-                    }
-
-                    return result;
-                };
-            },
-        });
-
-        this.proxyToEntryId.set(proxy, entry.id);
-        return proxy as BaseClient;
-    }
 
     private async createEntry(): Promise<PoolEntry> {
         const client = this.isCluster
@@ -488,59 +414,6 @@ export class ClientPool {
                 .catch(noop);
         } catch {
             // Connection broken — client will reconnect on next use
-        }
-    }
-
-    /**
-     * Notify the pool that a command was sent on a borrowed client.
-     * Resets the abandon inactivity timer for this client.
-     * Call this from application code if using raw acquire() with long-held clients.
-     */
-    notifyActivity(client: BaseClient): void {
-        const entryId = this.proxyToEntryId.get(client);
-
-        if (entryId !== undefined) {
-            this.lastActivity.set(entryId, Date.now());
-            return;
-        }
-
-        for (const [id, entry] of this.active) {
-            if (entry.client === client) {
-                this.lastActivity.set(id, Date.now());
-                return;
-            }
-        }
-    }
-
-    /** Scan active entries and force-release any that exceed abandon timeout. */
-    private scanForAbandoned(): void {
-        if (this.closed) return;
-
-        const now = Date.now();
-        const abandoned: PoolEntry[] = [];
-
-        for (const [id, entry] of this.active) {
-            // Skip clients currently executing a blocking command
-            if (this.blockingEntries.has(id)) continue;
-
-            const lastActive = this.lastActivity.get(id) ?? 0;
-
-            if (now - lastActive > this.abandonTimeoutMs) {
-                abandoned.push(entry);
-            }
-        }
-
-        for (const entry of abandoned) {
-            console.warn(
-                `[valkey-glide pool] Abandon detection: client ${entry.id} exceeded ` +
-                    `inactivity timeout (${this.abandonTimeoutMs}ms) — discarding connection`,
-            );
-            this.active.delete(entry.id);
-            this.lastActivity.delete(entry.id);
-
-            // Discard rather than return-to-idle for consistency with Rust core:
-            // guarantees a stale release from the original borrower cannot interfere.
-            entry.client.close();
         }
     }
 }

--- a/node/tests/Pool.test.ts
+++ b/node/tests/Pool.test.ts
@@ -437,5 +437,32 @@ describe("ClientPool", () => {
             },
             TIMEOUT,
         );
+
+        it(
+            "does not exceed maxSize during concurrent acquire while release is resetting",
+            async () => {
+                const pool = await ClientPool.create(standaloneConfig, {
+                    maxSize: 1,
+                    minIdle: 1,
+                });
+                await waitForIdle(pool, 1);
+
+                try {
+                    const firstClient = await pool.acquire();
+
+                    // release() is async (state reset). Concurrent acquires should
+                    // not create extra clients beyond maxSize.
+                    const releasePromise = pool.release(firstClient);
+                    const secondClient = await pool.acquire();
+                    await releasePromise;
+
+                    expect(pool.getMetrics().total).toBeLessThanOrEqual(1);
+                    await pool.release(secondClient);
+                } finally {
+                    pool.close();
+                }
+            },
+            TIMEOUT,
+        );
     });
 });

--- a/node/tests/Pool.test.ts
+++ b/node/tests/Pool.test.ts
@@ -378,27 +378,30 @@ describe("ClientPool", () => {
                 await waitForIdle(pool, 2);
                 const key = makeKey(false, "blpop-custom");
 
-                // BLPOP via customCommand — previously invisible to TS Proxy
-                const blockingPromise = pool.borrow(async (client) => {
-                    return await (client as GlideClient).customCommand([
-                        "BLPOP",
-                        key,
-                        "3", // 3 second server timeout
-                    ]);
-                });
+                try {
+                    // BLPOP via customCommand — previously invisible to TS Proxy
+                    const blockingPromise = pool.borrow(async (client) => {
+                        return await (client as GlideClient).customCommand([
+                            "BLPOP",
+                            key,
+                            "3", // 3 second server timeout
+                        ]);
+                    });
 
-                // Wait longer than abandon timeout
-                await new Promise((r) => setTimeout(r, 1500));
+                    // Wait longer than abandon timeout
+                    await new Promise((r) => setTimeout(r, 1500));
 
-                // Unblock by pushing a value from another client
-                await pool.borrow(async (client) => {
-                    await client.lpush(key, ["done"]);
-                });
+                    // Unblock by pushing a value from another client
+                    await pool.borrow(async (client) => {
+                        await client.lpush(key, ["done"]);
+                    });
 
-                // Blocking command should complete successfully (not be killed)
-                const result = await blockingPromise;
-                expect(result).not.toBeNull();
-                pool.close();
+                    // Blocking command should complete successfully (not be killed)
+                    const result = await blockingPromise;
+                    expect(result).toEqual([key, "done"]);
+                } finally {
+                    pool.close();
+                }
             },
             TIMEOUT,
         );
@@ -413,21 +416,24 @@ describe("ClientPool", () => {
                 });
                 await waitForIdle(pool, 1);
 
-                // Acquire and hold without sending commands
-                const client = await pool.acquire();
-                const originalId = client.getClientId();
-                expect(pool.activeCount).toBe(1);
+                try {
+                    // Acquire and hold without sending commands
+                    const client = await pool.acquire();
+                    const originalId = client.getClientId();
+                    expect(pool.activeCount).toBe(1);
 
-                // Wait for abandon monitor to discard (timeout + scan interval)
-                await new Promise((r) => setTimeout(r, 2000));
+                    // Wait for abandon monitor to discard (timeout + scan interval)
+                    await new Promise((r) => setTimeout(r, 2000));
 
-                // Trigger drain by acquiring again
-                const client2 = await pool.acquire();
+                    // Trigger drain by acquiring again
+                    const client2 = await pool.acquire();
 
-                // Original client should have been discarded
-                expect(client2.getClientId()).not.toBe(originalId);
-                await pool.release(client2);
-                pool.close();
+                    // Original client should have been discarded
+                    expect(client2.getClientId()).not.toBe(originalId);
+                    await pool.release(client2);
+                } finally {
+                    pool.close();
+                }
             },
             TIMEOUT,
         );

--- a/node/tests/Pool.test.ts
+++ b/node/tests/Pool.test.ts
@@ -364,5 +364,72 @@ describe("ClientPool", () => {
             },
             TIMEOUT,
         );
+
+        it(
+            "blocking customCommand is not reclaimed by abandon monitor",
+            async () => {
+                // Use a short abandon timeout to prove blocking detection works
+                const pool = await ClientPool.create(standaloneConfig, {
+                    maxSize: 2,
+                    minIdle: 2,
+                    acquireTimeoutS: 10,
+                    abandonTimeoutMs: 1000, // 1 second
+                });
+                await waitForIdle(pool, 2);
+                const key = makeKey(false, "blpop-custom");
+
+                // BLPOP via customCommand — previously invisible to TS Proxy
+                const blockingPromise = pool.borrow(async (client) => {
+                    return await (client as GlideClient).customCommand([
+                        "BLPOP",
+                        key,
+                        "3", // 3 second server timeout
+                    ]);
+                });
+
+                // Wait longer than abandon timeout
+                await new Promise((r) => setTimeout(r, 1500));
+
+                // Unblock by pushing a value from another client
+                await pool.borrow(async (client) => {
+                    await client.lpush(key, ["done"]);
+                });
+
+                // Blocking command should complete successfully (not be killed)
+                const result = await blockingPromise;
+                expect(result).not.toBeNull();
+                pool.close();
+            },
+            TIMEOUT,
+        );
+
+        it(
+            "abandon detection discards inactive clients",
+            async () => {
+                const pool = await ClientPool.create(standaloneConfig, {
+                    maxSize: 2,
+                    minIdle: 1,
+                    abandonTimeoutMs: 1000, // 1 second
+                });
+                await waitForIdle(pool, 1);
+
+                // Acquire and hold without sending commands
+                const client = await pool.acquire();
+                const originalId = client.getClientId();
+                expect(pool.activeCount).toBe(1);
+
+                // Wait for abandon monitor to discard (timeout + scan interval)
+                await new Promise((r) => setTimeout(r, 2000));
+
+                // Trigger drain by acquiring again
+                const client2 = await pool.acquire();
+
+                // Original client should have been discarded
+                expect(client2.getClientId()).not.toBe(originalId);
+                await pool.release(client2);
+                pool.close();
+            },
+            TIMEOUT,
+        );
     });
 });


### PR DESCRIPTION
### Summary

Moves Node pool abandon detection from a TypeScript Proxy wrapper to Rust-level hooks in the command dispatch path, matching the architecture used by Go/Python/Java. Fixes the `customCommand` blind spot where blocking commands sent via `customCommand(["BLPOP", ...])` were not detected by the JS Proxy (which only saw the method name "customCommand").

### Issue link

Closes #6715

### Features / Behaviour Changes

- Blocking commands sent through `customCommand()` are now correctly detected (uses Rust `is_blocking_command` which inspects actual command bytes)
- Activity tracking happens automatically in the Rust dispatch path with no per-command JS closure overhead
- `notifyActivity()` public method removed (no longer needed as activity is tracked automatically at the Rust level)
- No user-facing API changes otherwise (acquire/release/borrow/close unchanged)

### Implementation

**Rust side (`node/rust-client/`):**
- `pool.rs`: Self-contained abandon monitor using `CLIENT_POOL_MAP`, `CLIENT_ACTIVITY`, `CLIENT_BLOCKING` DashMaps. Monitor stores `JoinHandle` for clean abort on close.
- `lib.rs`: `send_command` checks `CLIENT_POOL_MAP` and calls `refresh_activity()` + `mark_blocking()`. Batch/script mark blocking for full execution duration via worker task mark/unmark.
- NAPI exports: `poolRegisterClient`, `poolUnregisterClient`, `poolDrainDiscarded`, `poolStartMonitor`, `poolStopMonitor`

**TypeScript side (`node/src/ClientPool.ts`):**
- Removed: `BLOCKING_COMMANDS` set, `wrapClient` Proxy, `proxyToEntryId` WeakMap, `blockingEntries`, `lastActivity`, `scanForAbandoned()`, `notifyActivity()`, JS `setInterval` monitor (~130 lines removed)
- Added: `poolRegisterClient`/`poolUnregisterClient` calls on acquire/release, `poolDrainDiscarded` on acquire, `poolStartMonitor`/`poolStopMonitor` on create/close

### Testing

- 2 new integration tests added:
  - `blocking customCommand is not reclaimed by abandon monitor` — 1s timeout, BLPOP via customCommand, proves detection works
  - `abandon detection discards inactive clients` — 1s timeout, holds client idle, verifies discard + replacement

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated. - internal change
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the valkey-glide-docs repository if necessary