### PR TITLE
fix(go): use GoStringN for one-copy FFI string conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Changes
 
+* Go: Convert FFI string payloads with `GoStringN` (one copy, interior NULs preserved) instead of `GoBytes`+`string` in GET/MGET response parsing, pubsub callbacks, MONITOR client/command strings, and script hashes ([#6751](https://github.com/valkey-io/valkey-glide/issues/6751))
 * Java: Add `GlideString.asReadOnlyByteBuffer()` for zero-copy, read-only access to binary payloads  ([#6600](https://github.com/valkey-io/valkey-glide/issues/6600))
 * Core: Zero-copy receive path for GET/MGET ([#6559](https://github.com/valkey-io/valkey-glide/pull/6559))
 * Go: Expose `inflightRequestsLimit` configuration via `WithInflightRequestsLimit`, bringing the Go client to parity with Java, Python, and Node ([#6385](https://github.com/valkey-io/valkey-glide/issues/6385))

--- a/go/callbacks.go
+++ b/go/callbacks.go
@@ -70,11 +70,11 @@ func pubSubCallback(
 		return
 	}
 
-	msg := string(C.GoBytes(message, message_len))
-	cha := string(C.GoBytes(channel, channel_len))
+	msg := C.GoStringN((*C.char)(message), message_len)
+	cha := C.GoStringN((*C.char)(channel), channel_len)
 	pat := models.CreateNilStringResult()
 	if pattern_len > 0 && pattern != nil {
-		pat = models.CreateStringResult(string(C.GoBytes(pattern, pattern_len)))
+		pat = models.CreateStringResult(C.GoStringN((*C.char)(pattern), pattern_len))
 	}
 
 	go func() {

--- a/go/gostringn_copy.go
+++ b/go/gostringn_copy.go
@@ -1,0 +1,26 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+// convertViaGoStringN mirrors the production C.GoStringN path for
+// tests/benchmarks only. Must live in a non-test file: cgo is not supported
+// in *_test.go.
+func convertViaGoStringN(p unsafe.Pointer, n int) string {
+	return C.GoStringN((*C.char)(p), C.int(n))
+}
+
+func convertViaGoBytesString(p unsafe.Pointer, n int) string {
+	return string(C.GoBytes(p, C.int(n)))
+}
+
+func withCBytes(b []byte, fn func(p unsafe.Pointer, n int)) {
+	ptr := C.CBytes(b)
+	defer C.free(ptr)
+	fn(ptr, len(b))
+}

--- a/go/gostringn_copy_test.go
+++ b/go/gostringn_copy_test.go
@@ -1,0 +1,82 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+)
+
+func TestGoStringNMatchesGoBytesString(t *testing.T) {
+	cases := [][]byte{
+		{},
+		[]byte("hello"),
+		{0},
+		{0, 1, 2, 0, 3},
+		append([]byte("prefix"), append(make([]byte, 64), []byte("suffix")...)...),
+	}
+	large := make([]byte, 1<<20) // 1 MiB
+	for i := range large {
+		large[i] = byte(i % 251)
+	}
+	cases = append(cases, large)
+
+	for i, want := range cases {
+		withCBytes(want, func(p unsafe.Pointer, n int) {
+			gotN := convertViaGoStringN(p, n)
+			gotB := convertViaGoBytesString(p, n)
+			if gotN != gotB {
+				t.Fatalf("case %d: GoStringN != GoBytes+string", i)
+			}
+			if len(gotN) != len(want) {
+				t.Fatalf("case %d: len=%d want %d", i, len(gotN), len(want))
+			}
+			for j := range want {
+				if gotN[j] != want[j] {
+					t.Fatalf("case %d byte %d: got %d want %d", i, j, gotN[j], want[j])
+				}
+			}
+		})
+	}
+}
+
+var stringFromCSizes = []int{64, 1024, 65536, 1 << 20}
+
+func BenchmarkStringFromC_GoStringN(b *testing.B) {
+	for _, size := range stringFromCSizes {
+		b.Run(fmt.Sprintf("%dB", size), func(b *testing.B) {
+			payload := make([]byte, size)
+			withCBytes(payload, func(p unsafe.Pointer, n int) {
+				b.SetBytes(int64(n))
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					s := convertViaGoStringN(p, n)
+					if len(s) != n {
+						b.Fatal(len(s))
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkStringFromC_GoBytesThenString(b *testing.B) {
+	for _, size := range stringFromCSizes {
+		b.Run(fmt.Sprintf("%dB", size), func(b *testing.B) {
+			payload := make([]byte, size)
+			withCBytes(payload, func(p unsafe.Pointer, n int) {
+				b.SetBytes(int64(n))
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					s := convertViaGoBytesString(p, n)
+					if len(s) != n {
+						b.Fatal(len(s))
+					}
+				}
+			})
+		})
+	}
+}

--- a/go/monitor_client.go
+++ b/go/monitor_client.go
@@ -77,8 +77,8 @@ func monitorCallback(
 	line := MonitorLine{
 		Timestamp:  float64(timestamp),
 		DB:         int64(db),
-		ClientAddr: string(C.GoBytes(clientAddr, C.int(clientAddrLen))),
-		Command:    string(C.GoBytes(command, C.int(commandLen))),
+		ClientAddr: C.GoStringN((*C.char)(clientAddr), C.int(clientAddrLen)),
+		Command:    C.GoStringN((*C.char)(command), C.int(commandLen)),
 		Args:       args,
 	}
 

--- a/go/options/script_options.go
+++ b/go/options/script_options.go
@@ -134,7 +134,7 @@ func storeScript(script []byte) string {
 	defer C.free_script_hash_buffer(cHash)
 
 	len := C.int(cHash.len)
-	hash := string(C.GoBytes(unsafe.Pointer(cHash.ptr), len))
+	hash := C.GoStringN((*C.char)(unsafe.Pointer(cHash.ptr)), len)
 
 	return hash
 }

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -55,10 +55,11 @@ func convertCharArrayToString(response *C.struct_CommandResponse, isNilable bool
 	if response.string_value == nil {
 		return models.CreateNilStringResult(), nil
 	}
-	byteSlice := C.GoBytes(unsafe.Pointer(response.string_value), C.int(int64(response.string_value_len)))
-
-	// Create Go string from byte slice (preserving null characters)
-	return models.CreateStringResult(string(byteSlice)), nil
+	// GoStringN copies once and preserves interior NULs.
+	return models.CreateStringResult(C.GoStringN(
+		response.string_value,
+		C.int(response.string_value_len),
+	)), nil
 }
 
 // Fix after merging with https://github.com/valkey-io/valkey-glide/pull/2964
@@ -156,10 +157,11 @@ func parseString(response *C.struct_CommandResponse) (any, error) {
 	if response.string_value == nil {
 		return nil, nil
 	}
-	byteSlice := C.GoBytes(unsafe.Pointer(response.string_value), C.int(int64(response.string_value_len)))
-
-	// Create Go string from byte slice (preserving null characters)
-	return string(byteSlice), nil
+	// GoStringN copies once and preserves interior NULs.
+	return C.GoStringN(
+		response.string_value,
+		C.int(response.string_value_len),
+	), nil
 }
 
 func parseArray(response *C.struct_CommandResponse) (any, error) {


### PR DESCRIPTION
### Summary

Convert FFI string payloads with `C.GoStringN` instead of `C.GoBytes` + `string(...)`, so GET/MGET (and other string responses) copy once into the Go heap while preserving interior NULs.

### Issue link

This Pull Request is linked to issue: [Go: GoBytes+string double-copies FFI string payloads (large GET/MGET RSS)](https://github.com/valkey-io/valkey-glide/issues/6751)
Closes #6751

### Features / Behaviour Changes

Public API is unchanged. String responses still include interior NULs. Peak Go heap traffic for large values is about half of the previous conversion path (one alloc instead of two).

### Implementation

`C.GoStringN` at:
- `convertCharArrayToString` / `parseString` (GET/MGET and other string replies)
- pubsub callback message / channel / pattern
- MONITOR `ClientAddr` and `Command`
- script hash from `store_script`

MONITOR JSON args stay `C.GoBytes` because `json.Unmarshal` needs `[]byte`.

Test helpers that call cgo stay in `gostringn_copy.go` (unexported). Go does not allow `import "C"` in `*_test.go`.

### Limitations

Does not remove the FFI arena copy. Orthogonal to the Rust zero-copy receive path (#6559) and the ResponseArena leak fix (#6740 / #6741).

### Testing

- `go test -run TestGoStringNMatchesGoBytesString` — empty / ASCII / interior NUL / 1 MiB
- `go test -bench BenchmarkStringFromC_ -benchmem` — 64 B, 1 KiB, 64 KiB, 1 MiB; GoStringN is 1 alloc, GoBytes+string is 2
- Adserver large-GET RSS soak against tip FFI (#6741) + this change: VmRSS plateaus across 20×45 MiB GETs

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary