### PR TITLE
Java: Fix flaky xread_binary_return_failures TimeoutException in cluster RESP3 on Windows

### DIFF
--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -8577,12 +8577,12 @@ public class SharedCommandTests {
                         : GlideClusterClient.createClient(commonClusterClientConfig().build()).get()) {
 
             // ensure that commands doesn't time out even if timeout > request timeout
-            long oneSecondInMS = 1000L;
+            long blockTimeMs = 2000L;
             assertNull(
                     testClient
                             .xread(
                                     createMap(key1, timestamp_1_1),
-                                    StreamReadOptions.builder().block(oneSecondInMS).build())
+                                    StreamReadOptions.builder().block(blockTimeMs).build())
                             .get());
 
             // with 0 timeout (no timeout) should never time out,
@@ -8593,7 +8593,7 @@ public class SharedCommandTests {
                             testClient
                                     .xread(
                                             createMap(key1, timestamp_1_1), StreamReadOptions.builder().block(0L).build())
-                                    .get(3, TimeUnit.SECONDS));
+                                    .get(5, TimeUnit.SECONDS));
         }
     }
 
@@ -8640,12 +8640,12 @@ public class SharedCommandTests {
                         : GlideClusterClient.createClient(commonClusterClientConfig().build()).get()) {
 
             // ensure that commands doesn't time out even if timeout > request timeout
-            long oneSecondInMS = 1000L;
+            long blockTimeMs = 2000L;
             assertNull(
                     testClient
                             .xreadBinary(
                                     createMap(key1, timestamp_1_1),
-                                    StreamReadOptions.builder().block(oneSecondInMS).build())
+                                    StreamReadOptions.builder().block(blockTimeMs).build())
                             .get());
 
             // with 0 timeout (no timeout) should never time out,
@@ -8656,7 +8656,7 @@ public class SharedCommandTests {
                             testClient
                                     .xreadBinary(
                                             createMap(key1, timestamp_1_1), StreamReadOptions.builder().block(0L).build())
-                                    .get(3, TimeUnit.SECONDS));
+                                    .get(5, TimeUnit.SECONDS));
         }
     }
 


### PR DESCRIPTION
### Summary

Fix flaky `SharedCommandTests.xread_binary_return_failures` (and `xread_return_failures`) that throw `TimeoutException` intermittently in cluster mode with RESP3 protocol on Windows.

### Issue link

This Pull Request is linked to issue: [[Java][Flaky Test] SharedCommandTests.xread_binary_return_failures - TimeoutException in cluster RESP3 on Windows](https://github.com/valkey-io/valkey-glide/issues/6753)
Closes #6753

### Features / Behaviour Changes

No behaviour changes. This PR fixes test flakiness only.

### Implementation

**Root cause:** The test uses `XREAD BLOCK 1000` (1-second server-side block) with the default client request timeout (250ms). The glide-core Rust layer extends the timeout for blocking commands by adding a `BLOCKING_CMD_TIMEOUT_EXTENSION` of 0.5 seconds, giving a total of **1.5 seconds** to complete.

In cluster mode with RESP3 on Windows, the total round-trip time exceeds this 1.5s budget due to:
- RESP3 protocol overhead (more complex response parsing)
- Potential cluster slot resolution and redirection latency
- Windows networking overhead (higher syscall latency, different TCP stack behavior)

**Fix:**
1. Increased block timeout from 1000ms to 2000ms — gives glide-core an effective timeout of 2.5s (2s block + 0.5s extension), providing much more margin while still testing the core invariant.
2. Increased `Future.get()` timeout from 3s to 5s — for the infinite-block assertion, provides more margin on slow Windows CI to reliably trigger the expected `TimeoutException` from the Future.
3. Renamed variable from `oneSecondInMS` to `blockTimeMs` to accurately reflect the new value.

Applied to both `xread_return_failures` and `xread_binary_return_failures` tests.

### Limitations

None

### Testing

Ran both tests 400+ times (50 batches × 8 parametrized variants: standalone/cluster × RESP2/RESP3) with zero failures.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Lint checked manually (matched surrounding style; lint tools not run locally per SHARED-RULES).
- [x] Destination branch is correct - main