### PR TITLE
Node: Fix flaky save test timeout in CI

### DIFF
--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -410,20 +410,24 @@ export function runBaseTests(config: {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "save %p",
         async (protocol) => {
-            await runTest(async (client: BaseClient) => {
-                await waitForSaveNotInProgress(client);
-
-                const result = await client.save();
-                expect(result).toEqual("OK");
-
-                if (client instanceof GlideClusterClient) {
+            await runTest(
+                async (client: BaseClient) => {
                     await waitForSaveNotInProgress(client);
-                    const clusterResult = await client.save(
-                        PRIMARY_SLOT_ROUTE_OPTION,
-                    );
-                    expect(clusterResult).toEqual("OK");
-                }
-            }, protocol);
+
+                    const result = await client.save();
+                    expect(result).toEqual("OK");
+
+                    if (client instanceof GlideClusterClient) {
+                        await waitForSaveNotInProgress(client);
+                        const clusterResult = await client.save(
+                            PRIMARY_SLOT_ROUTE_OPTION,
+                        );
+                        expect(clusterResult).toEqual("OK");
+                    }
+                },
+                protocol,
+                { requestTimeout: 25000 },
+            );
         },
         config.timeout,
     );


### PR DESCRIPTION
### Summary

Increase the `requestTimeout` for the `save` test from the default (250ms) to 25 seconds to prevent intermittent `TimeoutError` in CI.

The `SAVE` command performs synchronous RDB persistence to disk. In a cluster environment under CI load, this blocking operation can take significantly longer than the default request timeout, causing the test to flake.

### Issue link

This Pull Request is linked to issue: [[Node][Flaky Test] GlideClusterClient save - TimeoutError](https://github.com/valkey-io/valkey-glide/issues/6757)
Closes #6757

### Features / Behaviour Changes

No feature or behaviour changes. This is a test-only fix.

### Implementation

Pass `{ requestTimeout: 25000 }` as the `configOverrides` third argument to `runTest()` for the `save` test in `node/tests/SharedTests.ts`. This follows the same pattern used by other slow-command tests in the codebase (e.g., `clientGetName` test passes `{ clientName: "TEST_CLIENT" }`).

### Limitations

None.

### Testing

- Ran the `save` test 20 consecutive times locally — all passed reliably (45-50ms per save operation)
- No changes to test assertions or behaviour

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] ~CHANGELOG.md and documentation files are updated.~
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] ~Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary~