### PR TITLE
fix(java): allow scopedConnection on pool-borrowed GlideClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
-* Java: Propagate pool ConnectionRequest into pool-borrowed clients so `scopedConnection` works on `PooledGlideClient`
-
+* Java: Allow scopedConnection on pool-borrowed GlideClient ([#6764](https://github.com/valkey-io/valkey-glide/issues/6764))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.
 
 * Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
+* Java: Propagate pool ConnectionRequest into pool-borrowed clients so `scopedConnection` works on `PooledGlideClient`
+
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.
 
 * Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))

--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -111,9 +111,9 @@ public class GlideClient extends BaseClient
     /**
      * Creates a GlideClient that wraps an existing native handle from the pool.
      *
-     * <p>The pool's Rust side creates the actual connection and registers it in the JNI handle table.
-     * This factory wires up the Java command dispatch chain so that commands flow through the
-     * existing native bridge.
+     * <p>Backward-compatible overload for callers that do not have the pool's serialized
+     * ConnectionRequest available. Scope acquisition ({@link #scopedConnection}) on the returned
+     * client requires the 4-arg overload so the pool's connection bytes are threaded through.
      *
      * @param nativeHandle the native client handle (same as client_id from pool)
      * @param maxInflight max inflight requests (0 = use core defaults)
@@ -122,10 +122,32 @@ public class GlideClient extends BaseClient
      */
     public static GlideClient fromPoolHandle(
             long nativeHandle, int maxInflight, long requestTimeoutMs) {
+        return fromPoolHandle(nativeHandle, maxInflight, requestTimeoutMs, null);
+    }
+
+    /**
+     * Creates a GlideClient that wraps an existing native handle from the pool.
+     *
+     * <p>The pool's Rust side creates the actual connection and registers it in the JNI handle table.
+     * This factory wires up the Java command dispatch chain so that commands flow through the
+     * existing native bridge, and seeds the {@link glide.managers.ConnectionManager} with the pool's
+     * native handle and serialized ConnectionRequest so {@link #scopedConnection} can materialize an
+     * isolated scope pool for this borrowed client.
+     *
+     * @param nativeHandle the native client handle (same as client_id from pool)
+     * @param maxInflight max inflight requests (0 = use core defaults)
+     * @param requestTimeoutMs request timeout in ms (0 = no Java-side timeout)
+     * @param connectionRequestBytes the pool's serialized protobuf ConnectionRequest, or {@code
+     *     null} when unavailable (scope acquisition will fail with "Client not connected")
+     * @return a fully-functional GlideClient backed by the pool connection
+     */
+    public static GlideClient fromPoolHandle(
+            long nativeHandle, int maxInflight, long requestTimeoutMs, byte[] connectionRequestBytes) {
         glide.internal.GlideCoreClient coreClient =
                 new glide.internal.GlideCoreClient(nativeHandle, maxInflight, requestTimeoutMs);
         glide.managers.CommandManager commandManager = new glide.managers.CommandManager(coreClient);
-        glide.managers.ConnectionManager connectionManager = new glide.managers.ConnectionManager();
+        glide.managers.ConnectionManager connectionManager =
+                new glide.managers.ConnectionManager(nativeHandle, connectionRequestBytes);
         glide.connectors.handlers.MessageHandler messageHandler =
                 new glide.connectors.handlers.MessageHandler(
                         java.util.Optional.empty(),

--- a/java/client/src/main/java/glide/api/GlideClient.java
+++ b/java/client/src/main/java/glide/api/GlideClient.java
@@ -137,8 +137,8 @@ public class GlideClient extends BaseClient
      * @param nativeHandle the native client handle (same as client_id from pool)
      * @param maxInflight max inflight requests (0 = use core defaults)
      * @param requestTimeoutMs request timeout in ms (0 = no Java-side timeout)
-     * @param connectionRequestBytes the pool's serialized protobuf ConnectionRequest, or {@code
-     *     null} when unavailable (scope acquisition will fail with "Client not connected")
+     * @param connectionRequestBytes the pool's serialized protobuf ConnectionRequest, or {@code null}
+     *     when unavailable (scope acquisition will fail with "Client not connected")
      * @return a fully-functional GlideClient backed by the pool connection
      */
     public static GlideClient fromPoolHandle(

--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -51,13 +51,15 @@ public class ClientPool implements AutoCloseable {
 
     private final long poolId;
     private final ClientPoolConfig config;
+    private final byte[] connectionRequestBytes;
     private final AtomicInteger state = new AtomicInteger(RUNNING);
     private final java.util.concurrent.ConcurrentHashMap<Long, GlideClient> clientCache =
             new java.util.concurrent.ConcurrentHashMap<>();
 
-    private ClientPool(long poolId, ClientPoolConfig config) {
+    private ClientPool(long poolId, ClientPoolConfig config, byte[] connectionRequestBytes) {
         this.poolId = poolId;
         this.config = config;
+        this.connectionRequestBytes = connectionRequestBytes;
     }
 
     /**
@@ -90,7 +92,7 @@ public class ClientPool implements AutoCloseable {
         if (poolId == -1) throw new IllegalArgumentException("Invalid pool configuration");
         if (poolId < 0) throw new RuntimeException("Pool creation failed: " + poolId);
 
-        ClientPool pool = new ClientPool(poolId, config);
+        ClientPool pool = new ClientPool(poolId, config, connectionRequestBytes);
 
         // Connectivity probe: create one client to validate the config eagerly.
         // If this fails, propagate the actual connection error (not a timeout).
@@ -197,7 +199,10 @@ public class ClientPool implements AutoCloseable {
         GlideClient cached = clientCache.get(clientId);
         if (cached != null) return cached;
         return clientCache.computeIfAbsent(
-                clientId, id -> GlideClient.fromPoolHandle(id, 0, config.getRequestTimeout().toMillis()));
+                clientId,
+                id ->
+                        GlideClient.fromPoolHandle(
+                                id, 0, config.getRequestTimeout().toMillis(), connectionRequestBytes));
     }
 
     /** Release a client back to the pool. */

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -577,8 +577,9 @@ public class ConnectionManager {
         return CompletableFuture.supplyAsync(
                 () -> {
                     if (poolBorrowed) {
-                        // The pool owns the native handle; releasing goes through the pool.
-                        isClosed = true;
+                        // The pool owns the native handle and the wrapper is cached and reused across
+                        // borrows, so this must not mark the manager closed. Releasing goes through the
+                        // pool.
                         return null;
                     }
                     if (!isClosed && nativeClientHandle != 0) {
@@ -602,8 +603,8 @@ public class ConnectionManager {
         }
 
         if (poolBorrowed) {
-            // The pool owns the native handle; releasing goes through the pool.
-            isClosed = true;
+            // The pool owns the native handle and the wrapper is cached and reused across borrows, so
+            // this must not mark the manager closed. Releasing goes through the pool.
             return;
         }
 

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -56,6 +56,23 @@ public class ConnectionManager {
     private volatile byte[] connectionRequestBytes;
 
     /**
+     * True when this manager wraps a pool-borrowed native client. The pool owns the native
+     * connection's lifecycle, so close() here must not tear it down.
+     */
+    private boolean poolBorrowed = false;
+
+    /**
+     * Constructor for pool-borrowed clients. Seeds the fields that {@code scopedConnection} reads
+     * (native handle plus the pool's serialized ConnectionRequest) so scope acquisition can proceed
+     * without going through {@link #connectToValkey}.
+     */
+    public ConnectionManager(long nativeClientHandle, byte[] connectionRequestBytes) {
+        this.nativeClientHandle = nativeClientHandle;
+        this.connectionRequestBytes = connectionRequestBytes;
+        this.poolBorrowed = true;
+    }
+
+    /**
      * Connect to Valkey using the native bridge.
      *
      * @param configuration Connection Configuration
@@ -559,6 +576,11 @@ public class ConnectionManager {
     public Future<Void> closeConnection() {
         return CompletableFuture.supplyAsync(
                 () -> {
+                    if (poolBorrowed) {
+                        // The pool owns the native handle; releasing goes through the pool.
+                        isClosed = true;
+                        return null;
+                    }
                     if (!isClosed && nativeClientHandle != 0) {
                         try {
                             // Clean up any pending async operations for this client
@@ -577,6 +599,12 @@ public class ConnectionManager {
     public void closeConnectionSync() {
         if (isClosed) {
             return; // Already closed
+        }
+
+        if (poolBorrowed) {
+            // The pool owns the native handle; releasing goes through the pool.
+            isClosed = true;
+            return;
         }
 
         try {

--- a/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
@@ -1,0 +1,98 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.pool;
+
+import static glide.TestConfiguration.STANDALONE_HOSTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.pool.ClientPool;
+import glide.api.models.pool.ClientPoolConfig;
+import glide.api.models.pool.PooledGlideClient;
+import glide.api.models.scope.IsolatedScope;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the pool + scope combination. Before this fix, {@link
+ * glide.api.GlideClient#fromPoolHandle} did not thread the pool's serialized ConnectionRequest into
+ * the pool-borrowed client, so {@code scopedConnection} failed with "Client not connected" even
+ * though the underlying core supported per-borrow isolated scopes.
+ */
+public class PooledClientScopeIntegrationTest {
+
+    private static boolean standaloneAvailable() {
+        return STANDALONE_HOSTS.length > 0 && !STANDALONE_HOSTS[0].isEmpty();
+    }
+
+    private static ClientPoolConfig standaloneConfig() {
+        assumeTrue(standaloneAvailable(), "No standalone endpoints configured");
+        String[] parts = STANDALONE_HOSTS[0].split(":");
+        return ClientPoolConfig.builder()
+                .maxSize(2)
+                .minIdle(1)
+                .acquireTimeout(Duration.ofSeconds(10))
+                .clientConfig(
+                        GlideClientConfiguration.builder()
+                                .address(
+                                        NodeAddress.builder()
+                                                .host(parts[0])
+                                                .port(Integer.parseInt(parts[1]))
+                                                .build())
+                                .requestTimeout(5000)
+                                .build())
+                .build();
+    }
+
+    private static void waitForPoolReady(ClientPool pool, int minIdle) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (pool.getIdleCount() < minIdle && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+    }
+
+    @Test
+    public void testScopedConnectionFromPooledClient() throws Exception {
+        ClientPool pool = ClientPool.create(standaloneConfig());
+        waitForPoolReady(pool, 1);
+
+        PooledGlideClient pooled = pool.acquire().get(10, TimeUnit.SECONDS);
+        try {
+            IsolatedScope scope =
+                    pooled.unwrap()
+                            .scopedConnection(Duration.ofSeconds(10))
+                            .get(10, TimeUnit.SECONDS);
+            assertNotNull(scope, "scopedConnection must return a scope on a pool-borrowed client");
+            assertFalse(scope.isReleased());
+
+            // Full WATCH/GET/MULTI/SET/EXEC to prove the scope holds a dedicated connection.
+            String key = "pooled-scope-" + UUID.randomUUID();
+            pooled.set(key, "10").get(5, TimeUnit.SECONDS);
+
+            assertEquals("OK", scope.watch(key).get(5, TimeUnit.SECONDS));
+            String observed = scope.get(key).get(5, TimeUnit.SECONDS);
+            assertEquals("10", observed);
+            assertEquals("OK", scope.multi().get(5, TimeUnit.SECONDS));
+            scope.set(key, String.valueOf(Integer.parseInt(observed) + 1)).get(5, TimeUnit.SECONDS);
+            String execResult = scope.exec().get(5, TimeUnit.SECONDS);
+            assertNotNull(execResult, "EXEC must succeed with no conflicting writer");
+
+            String finalVal = pooled.get(key).get(5, TimeUnit.SECONDS);
+            assertEquals("11", finalVal);
+
+            scope.close();
+            assertTrue(scope.isReleased());
+
+            pooled.unwrap().del(new String[] {key}).get(5, TimeUnit.SECONDS);
+        } finally {
+            pooled.close();
+            pool.close();
+        }
+    }
+}

--- a/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
@@ -41,10 +41,7 @@ public class PooledClientScopeIntegrationTest {
                 .clientConfig(
                         GlideClientConfiguration.builder()
                                 .address(
-                                        NodeAddress.builder()
-                                                .host(parts[0])
-                                                .port(Integer.parseInt(parts[1]))
-                                                .build())
+                                        NodeAddress.builder().host(parts[0]).port(Integer.parseInt(parts[1])).build())
                                 .requestTimeout(5000)
                                 .build())
                 .build();
@@ -65,9 +62,7 @@ public class PooledClientScopeIntegrationTest {
         PooledGlideClient pooled = pool.acquire().get(10, TimeUnit.SECONDS);
         try {
             IsolatedScope scope =
-                    pooled.unwrap()
-                            .scopedConnection(Duration.ofSeconds(10))
-                            .get(10, TimeUnit.SECONDS);
+                    pooled.unwrap().scopedConnection(Duration.ofSeconds(10)).get(10, TimeUnit.SECONDS);
             assertNotNull(scope, "scopedConnection must return a scope on a pool-borrowed client");
             assertFalse(scope.isReleased());
 


### PR DESCRIPTION
### Summary

`scopedConnection()` fails with `IllegalStateException("Client not connected")` on any Java client borrowed from a `ClientPool`, even though the Rust core already supports isolated scopes on pool clients. The cause is on the Java side only: `GlideClient.fromPoolHandle` built its `ConnectionManager` with no native client handle and no serialized `ConnectionRequest`, and those are the two fields `scopedConnection()` reads to materialize the scope's dedicated connection. This change threads the pool's serialized `ConnectionRequest` bytes and its native handle into the pool-borrowed `ConnectionManager`, so scope acquisition works on a `PooledGlideClient`.

### Issue link

This Pull Request is linked to issue: [[Java] GlideClient.fromPoolHandle does not propagate connection request bytes, breaking scopedConnection on pool-borrowed clients](https://github.com/valkey-io/valkey-glide/issues/6764)
Fixes #6764

The client pool and isolated execution scope feature this builds on landed in #6338.

### Features / Behaviour Changes

- `scopedConnection()` now succeeds on a client borrowed from a `ClientPool`, so you can run `WATCH` / `MULTI` / `EXEC` and other connection-affine sequences on pooled clients.
- New overload `GlideClient.fromPoolHandle(long nativeHandle, int maxInflight, long requestTimeoutMs, byte[] connectionRequestBytes)`. The existing 3-arg signature is retained and delegates to the new one with `null` bytes, so callers outside the pool are unaffected.
- Calling `close()` on a pool-borrowed client no longer tears down the pool's native connection. The pool owns that lifecycle and the connection is returned by releasing it back to the pool.

### Implementation

- `GlideClient.fromPoolHandle` takes the pool's serialized `ConnectionRequest` bytes as a fourth argument and hands them, along with the native handle, to the `ConnectionManager` it builds. The 3-arg overload stays and passes `null`.
- `ConnectionManager` gains a constructor `ConnectionManager(long nativeClientHandle, byte[] connectionRequestBytes)` that seeds those two fields directly instead of going through `connectToValkey`, and sets a `poolBorrowed` flag.
- When `poolBorrowed` is set, `closeConnection()` and `closeConnectionSync()` mark the wrapper closed and return without calling the native close.
- `ClientPool` captures `connectionRequestBytes` when the pool is created, holds them on the instance, and forwards them from `getClient` into the 4-arg overload.

The part I would most like reviewed is the early return in those two close paths. It leaves `isClosed` set on a manager whose native connection is still alive and still owned by the pool. Command dispatch goes through `GlideCoreClient` and never reads that flag, so commands keep working, but `isConnected()` and `getClientInfo()` do read it, which has a consequence for the pool's cached wrapper described under Limitations.

### Limitations

- Standalone only in test coverage. `ClientPool.getClient` returns a plain `GlideClient` for both modes, so a cluster pool has no cluster-aware wrapper to hang cluster-correct scope routing off; the no-routing-key `scopedConnection` overload passes slot 0, and a scope used on a key outside slot 0 will get a redirect from the wrong node. Cluster-aware wrappers for pool-borrowed clients are tracked in #6815, and the new test exercises the standalone path.
- Marking a pool-borrowed wrapper closed is sticky. `ClientPool.getClient` caches one `GlideClient` per client id and never evicts it, and the core returns a released client to idle under the same id, so a caller that mistakenly calls `close()` on a borrowed client leaves that cached wrapper reporting `isConnected() == false` and throwing from `getClientInfo()` for every later borrower of that id, while the underlying connection is alive and commands still succeed.
- The same missing propagation exists in the Go wrapper, and in Node once its pool management moves to Rust. Those are separate changes.

### Testing

- New `PooledClientScopeIntegrationTest.testScopedConnectionFromPooledClient` builds a standalone `ClientPool`, acquires a `PooledGlideClient`, opens a scope on it, and runs `WATCH`, `GET`, `MULTI`, `SET`, `EXEC` inside that scope. It then reads the committed value back through the pooled client and asserts the scope reports itself released after `close()`. The test skips itself when no standalone endpoint is configured.
- Locally, against a gradle-managed standalone server, the new test passes on this branch. Reverting only the three Java source changes and rerunning it reproduces the exact `IllegalStateException: Client not connected` at the `scopedConnection` call, so the test does fail without the fix.
- A local run of the wider `ClientPoolIntegrationTest` showed two failures, `testPoolConcurrentAccess[cluster]` and `testPoolBlockingCmdIsolation[standalone]`. Both reproduce on unmodified `main`, so they are pre-existing and not caused by this change.
- CI on this head is green for all four `Java Tests` jobs (JDK 8 and 17, engine 6.2 and 9.0) and all four `Java PubSubTests` jobs.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). Java formatting and checkstyle are clean on the changed files; `make prettier-fix` covers `.github/` and the Node folders, which this change does not touch.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise. Squash is intended here.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary. Left unchecked because I did not find a docs change this needs: it restores documented `scopedConnection` behaviour on pooled clients rather than adding a user-facing API.
