### PR TITLE
feat(python): expose PEM loader helpers from top-level glide packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Go: add mTLS client certificates with automatic reloading ([#6384](https://github.com/valkey-io/valkey-glide/pull/6384))
 * Node: add mTLS client certificate/key support with automatic certificate reloading ([#6383](https://github.com/valkey-io/valkey-glide/pull/6383))
 * Python: add automatic mTLS client certificate/key reload ([#6596](https://github.com/valkey-io/valkey-glide/pull/6596))
+* Python: expose PEM loader helpers from the top-level glide package
 
 ## 2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@
 * Go: add mTLS client certificates with automatic reloading ([#6384](https://github.com/valkey-io/valkey-glide/pull/6384))
 * Node: add mTLS client certificate/key support with automatic certificate reloading ([#6383](https://github.com/valkey-io/valkey-glide/pull/6383))
 * Python: add automatic mTLS client certificate/key reload ([#6596](https://github.com/valkey-io/valkey-glide/pull/6596))
-* Python: expose PEM loader helpers from the top-level glide package
 
 ## 2.5
 

--- a/python/glide-async/python/glide/__init__.py
+++ b/python/glide-async/python/glide/__init__.py
@@ -177,6 +177,10 @@ from glide_shared import (
     VectorFieldAttributesHnsw,
     VectorType,
     json_batch,
+    load_client_certificate_and_key_from_file,
+    load_client_certificate_from_file,
+    load_client_key_from_file,
+    load_root_certificates_from_file,
 )
 from glide_shared._glide_ffi import _GlideFFI as _FFI
 
@@ -292,6 +296,10 @@ __all__ = [
     "PeriodicChecksManualInterval",
     "PeriodicChecksStatus",
     "TlsAdvancedConfiguration",
+    "load_client_certificate_and_key_from_file",
+    "load_client_certificate_from_file",
+    "load_client_key_from_file",
+    "load_root_certificates_from_file",
     # Response
     "OK",
     "TClusterResponse",

--- a/python/glide-shared/glide_shared/__init__.py
+++ b/python/glide-shared/glide_shared/__init__.py
@@ -149,6 +149,10 @@ from .config import (
     ServerCredentials,
     ServiceType,
     TlsAdvancedConfiguration,
+    load_client_certificate_and_key_from_file,
+    load_client_certificate_from_file,
+    load_client_key_from_file,
+    load_root_certificates_from_file,
 )
 from .constants import (
     ALL_CHANNELS,
@@ -230,6 +234,10 @@ __all__ = [
     "PeriodicChecksManualInterval",
     "PeriodicChecksStatus",
     "TlsAdvancedConfiguration",
+    "load_client_certificate_and_key_from_file",
+    "load_client_certificate_from_file",
+    "load_client_key_from_file",
+    "load_root_certificates_from_file",
     # Response
     "OK",
     "TClusterResponse",

--- a/python/glide-shared/glide_shared/config.py
+++ b/python/glide-shared/glide_shared/config.py
@@ -1689,7 +1689,7 @@ def load_root_certificates_from_file(path: str) -> bytes:
 
     Example usage::
 
-        from glide_shared.config import load_root_certificates_from_file, TlsAdvancedConfiguration
+        from glide import load_root_certificates_from_file, TlsAdvancedConfiguration
 
         certs = load_root_certificates_from_file('/path/to/ca-cert.pem')
         tls_config = TlsAdvancedConfiguration(root_pem_cacerts=certs)
@@ -1763,7 +1763,7 @@ def load_client_certificate_and_key_from_file(
 
     Example::
 
-        from glide_shared.config import (
+        from glide import (
             TlsAdvancedConfiguration,
             load_client_certificate_and_key_from_file,
         )

--- a/python/glide-sync/glide_sync/__init__.py
+++ b/python/glide-sync/glide_sync/__init__.py
@@ -173,6 +173,10 @@ from glide_shared import (
     VectorFieldAttributesHnsw,
     VectorType,
     json_batch,
+    load_client_certificate_and_key_from_file,
+    load_client_certificate_from_file,
+    load_client_key_from_file,
+    load_root_certificates_from_file,
 )
 
 from .client_pool import ClientPool, PoolConfig
@@ -231,6 +235,10 @@ __all__ = [
     "PeriodicChecksManualInterval",
     "PeriodicChecksStatus",
     "TlsAdvancedConfiguration",
+    "load_client_certificate_and_key_from_file",
+    "load_client_certificate_from_file",
+    "load_client_key_from_file",
+    "load_root_certificates_from_file",
     # Response
     "OK",
     "TClusterResponse",

--- a/python/glide-sync/glide_sync/client_pool.py
+++ b/python/glide-sync/glide_sync/client_pool.py
@@ -9,9 +9,8 @@ class provides the acquire-with-timeout retry loop and maps client_id handles
 to usable GlideClient wrappers for command dispatch.
 
 Usage:
-    from glide_sync import GlideClient
+    from glide_sync import GlideClient, GlideClientConfiguration, NodeAddress
     from glide_sync.client_pool import ClientPool, PoolConfig
-    from glide_shared.config import GlideClientConfiguration, NodeAddress
 
     config = GlideClientConfiguration([NodeAddress("localhost", 6379)])
     pool = ClientPool(config, PoolConfig(max_size=10, min_idle=2))

--- a/python/tests/test_api_export.py
+++ b/python/tests/test_api_export.py
@@ -93,10 +93,6 @@ excluded_shared_symbols = [
     "AdvancedBaseClientConfiguration",  # ClassDef
     "StrPath",  # Assignment (type alias used in TlsAdvancedConfiguration + loader signatures)
     "MAX_UINT32",  # Assignment (uint32 wire bound reused by validators)
-    "load_root_certificates_from_file",  # FunctionDef
-    "load_client_certificate_from_file",  # FunctionDef
-    "load_client_key_from_file",  # FunctionDef
-    "load_client_certificate_and_key_from_file",  # FunctionDef
     # python/glide-shared/glide_shared/protobuf_codec.py
     "ProtobufCodec",  # ClassDef
     "PartialMessageException",  # Exception


### PR DESCRIPTION
### Summary

Re-export the four PEM loader helpers (`load_root_certificates_from_file`, `load_client_certificate_from_file`, `load_client_key_from_file`, `load_client_certificate_and_key_from_file`) from the top-level Python `glide` and `glide_sync` packages, so users configuring path-based mTLS can import them directly instead of reaching into `glide_shared`.

### Issue link

Related to a review comment on the mTLS section of [valkey-io/valkey-glide-docs#271](https://github.com/valkey-io/valkey-glide-docs/pull/271), which asked that PEM loaders be importable from the main `glide` package.

### Features / Behaviour Changes

- `glide` and `glide_sync` publicly export the four PEM loader helpers.
- `glide_shared` also re-exports them for parity (they are defined in `glide_shared.config`).
- Additive only: no existing name is renamed or removed.

### Implementation

Added the four names to the imports and `__all__` in each package's `__init__.py`:

- `python/glide-shared/glide_shared/__init__.py`
- `python/glide-async/python/glide/__init__.py`
- `python/glide-sync/glide_sync/__init__.py`

Removed the four names from `excluded_shared_symbols` in `python/tests/test_api_export.py`, so the existing re-export contract test now enforces that they are exposed from the top-level packages.

### Limitations

None. This is an additive re-export with no behavior change.

### Testing

`python/tests/test_api_export.py` passes: both `TestAPIExport::test_api_export` and `TestAPIExport::test_shared_symbols_re_exported` assert that the four helpers are exposed from `glide`, `glide_sync`, and `glide_shared`.

End-user smoke: importing each helper from `glide` and from `glide_sync` succeeds, and each helper returns the expected PEM bytes when called against a certificate and key on disk.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
