### PR TITLE
fix(core): retry empty-receivers multi-node fan-out under topology churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: classify multi-slot fan-out empty-receivers as a retryable ConnectionError instead of a non-retryable ClientError ([#6759](https://github.com/valkey-io/valkey-glide/issues/6759))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.
 
 * Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Core: classify multi-slot fan-out empty-receivers as a retryable ConnectionError instead of a non-retryable ClientError ([#6759](https://github.com/valkey-io/valkey-glide/issues/6759))
+* Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.
 
 * Python: Make async pipe transport fork-safe. After `fork()`, the flush thread is gone but `OnceLock` prevented reinitialization, causing commands in forked child processes (e.g. PySpark workers) to hang indefinitely. Now detects fork via PID comparison and reinitializes the pipe. Using a parent's client object in a forked child now raises `ClosingError` on command paths and skips the FFI call on `close()`, instead of silently hanging. ([#6673](https://github.com/valkey-io/valkey-glide/issues/6673))

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2180,7 +2180,8 @@ where
             return Err(RedisError::from((
                 ErrorKind::ConnectionNotFoundForRoute,
                 "Connection not found for route",
-                "No connections available for multi-node fan-out".to_string(),
+                "No connections available for multi-node fan-out"
+                    .to_string(),
             )));
         }
 
@@ -5044,7 +5045,8 @@ mod pipeline_routing_tests {
                 "retry_method mismatch for routing {routing:?}: err={err:?}",
             );
             assert!(
-                err.to_string().contains("No connections available for multi-node fan-out"),
+                err.to_string()
+                    .contains("No connections available for multi-node fan-out"),
                 "message mismatch for routing {routing:?}: {err}",
             );
         }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -5038,11 +5038,13 @@ mod pipeline_routing_tests {
                 MultiSlotArgPattern::KeysOnly,
             )),
         ] {
-            let err = block_on(ClusterConnInner::<MultiplexedConnection>::aggregate_results(
-                Vec::new(),
-                &routing,
-                None,
-            ))
+            let err = block_on(
+                ClusterConnInner::<MultiplexedConnection>::aggregate_results(
+                    Vec::new(),
+                    &routing,
+                    None,
+                ),
+            )
             .expect_err("empty receivers must fail");
 
             assert_eq!(

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2180,8 +2180,7 @@ where
             return Err(RedisError::from((
                 ErrorKind::ConnectionNotFoundForRoute,
                 "Connection not found for route",
-                "No connections available for multi-node fan-out"
-                    .to_string(),
+                "No connections available for multi-node fan-out".to_string(),
             )));
         }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2170,11 +2170,10 @@ where
             convert_result(receiver.await)
         };
 
-        // Under topology-refresh churn, a concurrent remove_node against the
-        // DashMap-backed connection_map can transiently drain the primary or
-        // node iterator between the outer is_empty check and this walk.
-        // Classify the empty-receivers case as a retryable connectivity
-        // condition so the FanOut RefreshSlots+retry path fires.
+        // A concurrent remove_node during a topology refresh can drain the
+        // connection map between the outer is_empty check and this walk, so
+        // classify no-receivers as a retryable connectivity error to trigger
+        // RefreshSlots and a retry (#6759).
         if receivers.is_empty() {
             return Err(RedisError::from((
                 ErrorKind::ConnectionNotFoundForRoute,
@@ -3067,12 +3066,10 @@ where
                         .map(|tuple| Some((cmd.clone(), tuple))),
                 ),
                 MultipleNodeRoutingInfo::MultiSlot((slots, _)) => {
-                    // cluster_routing::multi_shard normally never emits an
-                    // empty slots vector; if one reaches us the caller passed
-                    // a malformed routing plan, not a topology race. Fail
-                    // fast with a distinctly-classified non-retryable error
-                    // so the retryable empty-receivers branch below stays
-                    // scoped strictly to the race.
+                    // multi_shard never emits an empty slots vec, so an empty
+                    // one here is a caller bug rather than the topology race
+                    // aggregate_results retries on. Return a non-retryable
+                    // ClientError to keep those two paths distinct.
                     if slots.is_empty() {
                         return OperationResult::Err((
                             OperationTarget::FanOut,
@@ -5009,23 +5006,11 @@ mod pipeline_routing_tests {
         );
     }
 
-    // Regression test for #6759. Under topology-refresh churn a concurrent
-    // `remove_node` against the DashMap-backed `connection_map` can drain the
-    // primary or node iterator between the outer `is_empty` check and the
-    // walk that fills `receivers`, so `aggregate_results` runs with an empty
-    // receivers vector. Reproducing that timing precisely in an integration
-    // test would require a new mock hook to drop connections mid-walk; here
-    // we exercise the retryable branch directly by calling
-    // `ClusterConnInner::aggregate_results` with an already-empty
-    // `receivers` vec, which is the exact state the race leaves behind.
-    //
-    // Locks in that the empty-receivers branch:
-    //   1. Classifies as `ErrorKind::ConnectionNotFoundForRoute` so the
-    //      FanOut error-handling arm at `Request::poll` triggers the
-    //      `RefreshSlots` retry path.
-    //   2. Uses `RetryMethod::Reconnect`, which is what unlocks that retry.
-    //   3. Surfaces an honest message describing the connectivity condition
-    //      instead of the pre-fix "malformed command" wording.
+    // Regression for #6759. Reproducing the remove_node race in an
+    // integration test would need a new hook to drop connections mid-walk,
+    // so call aggregate_results with an empty receivers vec directly and
+    // check the empty branch returns ConnectionNotFoundForRoute with
+    // RetryMethod::Reconnect and the connectivity-flavored message.
     #[test]
     fn empty_receivers_is_retryable_connection_not_found() {
         use crate::{types::RetryMethod, ErrorKind};

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -5008,6 +5008,60 @@ mod pipeline_routing_tests {
             Ok(Some(Route::new(12182, SlotAddr::Master)))
         );
     }
+
+    // Regression test for #6759. Under topology-refresh churn a concurrent
+    // `remove_node` against the DashMap-backed `connection_map` can drain the
+    // primary or node iterator between the outer `is_empty` check and the
+    // walk that fills `receivers`, so `aggregate_results` runs with an empty
+    // receivers vector. Reproducing that timing precisely in an integration
+    // test would require a new mock hook to drop connections mid-walk; here
+    // we exercise the retryable branch directly by calling
+    // `ClusterConnInner::aggregate_results` with an already-empty
+    // `receivers` vec, which is the exact state the race leaves behind.
+    //
+    // Locks in that the empty-receivers branch:
+    //   1. Classifies as `ErrorKind::ConnectionNotFoundForRoute` so the
+    //      FanOut error-handling arm at `Request::poll` triggers the
+    //      `RefreshSlots` retry path.
+    //   2. Uses `RetryMethod::Reconnect`, which is what unlocks that retry.
+    //   3. Surfaces an honest message describing the connectivity condition
+    //      instead of the pre-fix "malformed command" wording.
+    #[test]
+    fn empty_receivers_is_retryable_connection_not_found() {
+        use crate::{types::RetryMethod, ErrorKind};
+
+        for routing in [
+            MultipleNodeRoutingInfo::AllNodes,
+            MultipleNodeRoutingInfo::AllMasters,
+            MultipleNodeRoutingInfo::MultiSlot((
+                vec![(Route::new(0, SlotAddr::Master), vec![1usize])],
+                MultiSlotArgPattern::KeysOnly,
+            )),
+        ] {
+            let err = block_on(ClusterConnInner::<MultiplexedConnection>::aggregate_results(
+                Vec::new(),
+                &routing,
+                None,
+            ))
+            .expect_err("empty receivers must fail");
+
+            assert_eq!(
+                err.kind(),
+                ErrorKind::ConnectionNotFoundForRoute,
+                "kind mismatch for routing {routing:?}: err={err:?}",
+            );
+            assert_eq!(
+                err.retry_method(),
+                RetryMethod::Reconnect,
+                "retry_method mismatch for routing {routing:?}: err={err:?}",
+            );
+            assert!(
+                err.to_string()
+                    .contains("No live receivers for multi-node fan-out"),
+                "message mismatch for routing {routing:?}: {err}",
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2170,16 +2170,17 @@ where
             convert_result(receiver.await)
         };
 
-        // A concurrent remove_node during a topology refresh can drain the
-        // connection map between the outer is_empty check and this walk, so
-        // classify no-receivers as a retryable connectivity error to trigger
+        // No receivers means we reached no node for this fan-out. Either a
+        // concurrent remove_node drained the connection map after the outer
+        // is_empty check, or the slot map lists primaries or routes that the
+        // connection map does not have, which can persist outside any race.
+        // Both are connectivity failures, so classify as retryable to trigger
         // RefreshSlots and a retry (#6759).
         if receivers.is_empty() {
             return Err(RedisError::from((
                 ErrorKind::ConnectionNotFoundForRoute,
                 "Connection not found for route",
-                "No live receivers for multi-node fan-out; likely a transient topology-refresh race"
-                    .to_string(),
+                "No connections available for multi-node fan-out".to_string(),
             )));
         }
 
@@ -5006,11 +5007,11 @@ mod pipeline_routing_tests {
         );
     }
 
-    // Regression for #6759. Reproducing the remove_node race in an
-    // integration test would need a new hook to drop connections mid-walk,
-    // so call aggregate_results with an empty receivers vec directly and
-    // check the empty branch returns ConnectionNotFoundForRoute with
-    // RetryMethod::Reconnect and the connectivity-flavored message.
+    // Regression for #6759. Neither path into the empty branch (a remove_node
+    // race, or a slot map listing nodes the connection map lacks) is easy to
+    // force in an integration test, so call aggregate_results with an empty
+    // receivers vec directly and check it returns ConnectionNotFoundForRoute
+    // with RetryMethod::Reconnect and a connectivity message.
     #[test]
     fn empty_receivers_is_retryable_connection_not_found() {
         use crate::{types::RetryMethod, ErrorKind};
@@ -5043,8 +5044,7 @@ mod pipeline_routing_tests {
                 "retry_method mismatch for routing {routing:?}: err={err:?}",
             );
             assert!(
-                err.to_string()
-                    .contains("No live receivers for multi-node fan-out"),
+                err.to_string().contains("No connections available for multi-node fan-out"),
                 "message mismatch for routing {routing:?}: {err}",
             );
         }

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2178,7 +2178,7 @@ where
         if receivers.is_empty() {
             return Err(RedisError::from((
                 ErrorKind::ConnectionNotFoundForRoute,
-                "Client internal error",
+                "Connection not found for route",
                 "No live receivers for multi-node fan-out; likely a transient topology-refresh race"
                     .to_string(),
             )));
@@ -3067,6 +3067,22 @@ where
                         .map(|tuple| Some((cmd.clone(), tuple))),
                 ),
                 MultipleNodeRoutingInfo::MultiSlot((slots, _)) => {
+                    // cluster_routing::multi_shard normally never emits an
+                    // empty slots vector; if one reaches us the caller passed
+                    // a malformed routing plan, not a topology race. Fail
+                    // fast with a distinctly-classified non-retryable error
+                    // so the retryable empty-receivers branch below stays
+                    // scoped strictly to the race.
+                    if slots.is_empty() {
+                        return OperationResult::Err((
+                            OperationTarget::FanOut,
+                            (
+                                ErrorKind::ClientError,
+                                "MultiSlot routing plan is empty; no routes to fan out to",
+                            )
+                                .into(),
+                        ));
+                    }
                     into_channels(slots.iter().map(|(route, indices)| {
                         connections_container
                             .connection_for_route(route)

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2170,12 +2170,16 @@ where
             convert_result(receiver.await)
         };
 
-        // Sanity check: if there are no receivers at all, this is a client‐error
+        // Under topology-refresh churn, a concurrent remove_node against the
+        // DashMap-backed connection_map can transiently drain the primary or
+        // node iterator between the outer is_empty check and this walk.
+        // Classify the empty-receivers case as a retryable connectivity
+        // condition so the FanOut RefreshSlots+retry path fires.
         if receivers.is_empty() {
             return Err(RedisError::from((
-                ErrorKind::ClientError,
+                ErrorKind::ConnectionNotFoundForRoute,
                 "Client internal error",
-                "Failed to aggregate results for multi-slot command. Maybe a malformed command?"
+                "No live receivers for multi-node fan-out; likely a transient topology-refresh race"
                     .to_string(),
             )));
         }

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7416,8 +7416,7 @@ mod cluster_async {
             err.kind(),
         );
         assert!(
-            err.to_string()
-                .contains("MultiSlot routing plan is empty"),
+            err.to_string().contains("MultiSlot routing plan is empty"),
             "error message must describe the empty routing plan: {err}",
         );
     }
@@ -7447,8 +7446,7 @@ mod cluster_async {
         // pass. This locks in that the guard short-circuits the retry
         // loop even when retries are configured, preventing a wasted
         // retry budget on a caller-invariant break.
-        let name =
-            "test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero";
+        let name = "test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero";
         let MockEnv {
             runtime,
             async_connection: mut connection,

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7427,8 +7427,9 @@ mod cluster_async {
             err.kind(),
         );
         assert!(
-            !err.to_string().contains("malformed command"),
-            "error message must not claim the command was malformed: {err}",
+            err.to_string()
+                .contains("No live receivers for multi-node fan-out"),
+            "error message must describe the empty receiver condition: {err}",
         );
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7372,13 +7372,9 @@ mod cluster_async {
         );
     }
 
-    // Guards the caller-invariant break path added alongside the #6759 fix.
-    // cluster_routing::multi_shard never emits an empty slots vec today, but
-    // if a caller passes MultipleNodeRoutingInfo::MultiSlot((vec![], _))
-    // directly the fan-out has no work to do and no retry can recover it.
-    // The guard in execute_on_multiple_nodes must fail fast with a
-    // non-retryable ClientError so the retryable empty-receivers branch in
-    // aggregate_results stays scoped strictly to the topology-refresh race.
+    // If a caller passes an empty MultiSlot routing plan, the fan-out guard
+    // must fail with a non-retryable ClientError so the retryable empty-
+    // receivers branch stays scoped to the topology-refresh race (#6759).
     #[test]
     #[serial_test::serial]
     fn test_async_cluster_multi_slot_empty_slots_is_client_error() {
@@ -7421,43 +7417,21 @@ mod cluster_async {
         );
     }
 
-    // Companion test that exercises the retryable empty-receivers branch in
-    // `aggregate_results` in isolation. In production this branch is hit
-    // when a concurrent `remove_node` drains the primary or node iterator
-    // between the outer `is_empty` check and the walk that fills
-    // `receivers`; reproducing that race precisely in the MockEnv would
-    // require a new test hook to drop connections mid-walk. We instead
-    // invoke `route_command` through a `MockEnv` whose closure never
-    // completes so no receiver is delivered, and drop the connection to
-    // force the retry loop to terminate on `sender.is_closed()`. This
-    // covers the classification via the same code path a real race would
-    // exercise, without needing to reproduce the race timing.
-    //
-    // The retryable branch itself is asserted by the crate-internal unit
-    // test `empty_receivers_is_retryable_connection_not_found` in
-    // `glide-core/redis-rs/redis/src/cluster_async/mod.rs`, which calls
-    // `ClusterConnInner::aggregate_results(vec![], ...)` directly.
+    // Same empty MultiSlot input as the guard test above, but with retries(3)
+    // to prove the guard short-circuits the retry loop and never triggers a
+    // slot refresh. The retryable empty-receivers branch is covered directly
+    // by `empty_receivers_is_retryable_connection_not_found` in
+    // `glide-core/redis-rs/redis/src/cluster_async/mod.rs`.
     #[test]
     #[serial_test::serial]
     fn test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero() {
-        // Same empty MultiSlot input as the guard test above, but with a
-        // non-zero retry budget. The guard classifies as ClientError which
-        // is `RetryMethod::NoRetry`, so the request must still finish in one
-        // pass. This locks in that the guard short-circuits the retry
-        // loop even when retries are configured, preventing a wasted
-        // retry budget on a caller-invariant break.
         let name = "test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero";
-        // Counts CLUSTER SLOTS traffic observed by the mock *after* startup
-        // completes. The retryable empty-receivers classification
-        // (ConnectionNotFoundForRoute) drives `RefreshSlots + retry` in the
-        // driver, which reissues CLUSTER SLOTS against the mock on every
-        // retry. The non-retryable ClientError guard short-circuits before
-        // any refresh fires, so this counter stays at zero when the guard is
-        // active. Inspecting a caller-side `Cmd::watchdog_retry_count` would
-        // not distinguish these two paths: `route_command` clones the `Cmd`
-        // into the internal request and `Cmd::clone` resets the retry
-        // counter, so the caller's copy is always zero regardless of what
-        // the retry loop did.
+        // Counts CLUSTER SLOTS the mock sees after startup. Each retry driven
+        // by the retryable empty-receivers branch would trigger a slot
+        // refresh, so this stays at zero when the guard is active. The
+        // caller-side `Cmd::watchdog_retry_count` cannot be used here because
+        // `route_command` clones the `Cmd` and `Cmd::clone` resets the
+        // counter.
         let post_startup_cluster_slots = Arc::new(atomic::AtomicUsize::new(0));
         let startup_done = Arc::new(AtomicBool::new(false));
         let counter_handler = post_startup_cluster_slots.clone();
@@ -7470,11 +7444,9 @@ mod cluster_async {
         } = MockEnv::with_client_builder(
             ClusterClient::builder(vec![&*format!("redis://{name}")])
                 .retries(3)
-                // Disable the slot-refresh rate limiter so every retry-driven
-                // `RefreshSlots` actually reissues CLUSTER SLOTS against the
-                // mock. Without this, the throttler skips the follow-up
-                // refreshes (the startup refresh already set `last_run`) and
-                // the counter cannot distinguish a retry from a single pass.
+                // Disable the slot-refresh throttler so a retry-driven
+                // RefreshSlots always reissues CLUSTER SLOTS; otherwise the
+                // counter cannot tell a retry from a single pass.
                 .slots_refresh_rate_limit(Duration::from_secs(0), 0),
             name,
             move |received_cmd: &[u8], _port| {
@@ -7488,11 +7460,9 @@ mod cluster_async {
                 Err(Ok(Value::Nil))
             },
         );
-        // MockEnv::with_client_builder synchronously drives the initial
-        // connection setup to completion (get_async_generic_connection is
-        // awaited on the current-thread runtime), so any CLUSTER SLOTS
-        // observed after this point comes from a driver-triggered refresh,
-        // not startup.
+        // MockEnv::with_client_builder finishes the initial connection setup
+        // before returning, so any CLUSTER SLOTS after this point is a
+        // driver-triggered refresh rather than startup.
         startup_done.store(true, Ordering::SeqCst);
 
         let routing = RoutingInfo::MultiNode((
@@ -7517,9 +7487,8 @@ mod cluster_async {
         assert_eq!(
             refreshes, 0,
             "guard must short-circuit the retry loop: observed {refreshes} \
-             post-startup CLUSTER SLOTS refresh(es), which would only fire \
-             if the empty-receivers classification (retryable \
-             ConnectionNotFoundForRoute) had leaked through",
+             post-startup CLUSTER SLOTS refresh(es), which only fires if the \
+             retryable empty-receivers branch leaked through",
         );
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7447,19 +7447,53 @@ mod cluster_async {
         // loop even when retries are configured, preventing a wasted
         // retry budget on a caller-invariant break.
         let name = "test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero";
+        // Counts CLUSTER SLOTS traffic observed by the mock *after* startup
+        // completes. The retryable empty-receivers classification
+        // (ConnectionNotFoundForRoute) drives `RefreshSlots + retry` in the
+        // driver, which reissues CLUSTER SLOTS against the mock on every
+        // retry. The non-retryable ClientError guard short-circuits before
+        // any refresh fires, so this counter stays at zero when the guard is
+        // active. Inspecting a caller-side `Cmd::watchdog_retry_count` would
+        // not distinguish these two paths: `route_command` clones the `Cmd`
+        // into the internal request and `Cmd::clone` resets the retry
+        // counter, so the caller's copy is always zero regardless of what
+        // the retry loop did.
+        let post_startup_cluster_slots = Arc::new(atomic::AtomicUsize::new(0));
+        let startup_done = Arc::new(AtomicBool::new(false));
+        let counter_handler = post_startup_cluster_slots.clone();
+        let startup_done_handler = startup_done.clone();
         let MockEnv {
             runtime,
             async_connection: mut connection,
             handler: _handler,
             ..
         } = MockEnv::with_client_builder(
-            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(3),
+            ClusterClient::builder(vec![&*format!("redis://{name}")])
+                .retries(3)
+                // Disable the slot-refresh rate limiter so every retry-driven
+                // `RefreshSlots` actually reissues CLUSTER SLOTS against the
+                // mock. Without this, the throttler skips the follow-up
+                // refreshes (the startup refresh already set `last_run`) and
+                // the counter cannot distinguish a retry from a single pass.
+                .slots_refresh_rate_limit(Duration::from_secs(0), 0),
             name,
             move |received_cmd: &[u8], _port| {
+                if startup_done_handler.load(Ordering::SeqCst)
+                    && contains_slice(received_cmd, b"CLUSTER")
+                    && contains_slice(received_cmd, b"SLOTS")
+                {
+                    counter_handler.fetch_add(1, Ordering::SeqCst);
+                }
                 respond_startup_two_nodes(name, received_cmd)?;
                 Err(Ok(Value::Nil))
             },
         );
+        // MockEnv::with_client_builder synchronously drives the initial
+        // connection setup to completion (get_async_generic_connection is
+        // awaited on the current-thread runtime), so any CLUSTER SLOTS
+        // observed after this point comes from a driver-triggered refresh,
+        // not startup.
+        startup_done.store(true, Ordering::SeqCst);
 
         let routing = RoutingInfo::MultiNode((
             MultipleNodeRoutingInfo::MultiSlot((
@@ -7468,9 +7502,8 @@ mod cluster_async {
             )),
             None,
         ));
-        let cmd_obj = cmd("MGET");
         let err = runtime
-            .block_on(connection.route_command(&cmd_obj, routing))
+            .block_on(connection.route_command(&cmd("MGET"), routing))
             .expect_err("empty MultiSlot routing plan must fail");
 
         assert_eq!(
@@ -7480,12 +7513,13 @@ mod cluster_async {
              kind={:?} err={err:?}",
             err.kind(),
         );
-        let retries = cmd_obj
-            .watchdog_retry_count
-            .load(std::sync::atomic::Ordering::Relaxed);
+        let refreshes = post_startup_cluster_slots.load(Ordering::SeqCst);
         assert_eq!(
-            retries, 0,
-            "guard must short-circuit the retry loop: observed {retries} retry attempts",
+            refreshes, 0,
+            "guard must short-circuit the retry loop: observed {refreshes} \
+             post-startup CLUSTER SLOTS refresh(es), which would only fire \
+             if the empty-receivers classification (retryable \
+             ConnectionNotFoundForRoute) had leaked through",
         );
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7372,6 +7372,66 @@ mod cluster_async {
         );
     }
 
+    // Regression test for #6759. Under topology-refresh churn a concurrent
+    // remove_node call against the DashMap-backed connection_map can drain
+    // the primary or node iterator between the outer is_empty check and
+    // the walk that fills `receivers`, so `aggregate_results` runs with an
+    // empty receivers vector. The pre-fix classification for that branch
+    // was `ErrorKind::ClientError` with the misleading message
+    // "Failed to aggregate results for multi-slot command. Maybe a
+    // malformed command?", and `ClientError` has `RetryMethod::NoRetry`,
+    // so callers surfaced a non-retryable error for a transient
+    // connectivity condition.
+    //
+    // The empty-receivers branch is reachable deterministically from a
+    // test by routing a command with `MultipleNodeRoutingInfo::MultiSlot`
+    // and an empty routes vector: `into_channels` yields no channels, so
+    // `aggregate_results` receives `receivers.is_empty() == true` on the
+    // very first call. Before the fix this test hits the old
+    // `ClientError` classification; after the fix it hits the retryable
+    // `ConnectionNotFoundForRoute` classification with an honest message.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_empty_receivers_multi_node_is_retryable() {
+        let name = "test_async_cluster_empty_receivers_multi_node_is_retryable";
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(0),
+            name,
+            move |received_cmd: &[u8], _port| {
+                respond_startup_two_nodes(name, received_cmd)?;
+                Err(Ok(Value::Nil))
+            },
+        );
+
+        let routing = RoutingInfo::MultiNode((
+            MultipleNodeRoutingInfo::MultiSlot((
+                vec![],
+                redis::cluster_routing::MultiSlotArgPattern::KeysOnly,
+            )),
+            None,
+        ));
+        let err = runtime
+            .block_on(connection.route_command(&cmd("MGET"), routing))
+            .expect_err("empty-receivers multi-node fan-out must fail");
+
+        assert_eq!(
+            err.kind(),
+            ErrorKind::ConnectionNotFoundForRoute,
+            "empty-receivers branch must classify as retryable \
+             ConnectionNotFoundForRoute, got kind={:?} err={err:?}",
+            err.kind(),
+        );
+        assert!(
+            !err.to_string().contains("malformed command"),
+            "error message must not claim the command was malformed: {err}",
+        );
+    }
+
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;
         use redis::ConnectionInfo;

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7372,28 +7372,17 @@ mod cluster_async {
         );
     }
 
-    // Regression test for #6759. Under topology-refresh churn a concurrent
-    // remove_node call against the DashMap-backed connection_map can drain
-    // the primary or node iterator between the outer is_empty check and
-    // the walk that fills `receivers`, so `aggregate_results` runs with an
-    // empty receivers vector. The pre-fix classification for that branch
-    // was `ErrorKind::ClientError` with the misleading message
-    // "Failed to aggregate results for multi-slot command. Maybe a
-    // malformed command?", and `ClientError` has `RetryMethod::NoRetry`,
-    // so callers surfaced a non-retryable error for a transient
-    // connectivity condition.
-    //
-    // The empty-receivers branch is reachable deterministically from a
-    // test by routing a command with `MultipleNodeRoutingInfo::MultiSlot`
-    // and an empty routes vector: `into_channels` yields no channels, so
-    // `aggregate_results` receives `receivers.is_empty() == true` on the
-    // very first call. Before the fix this test hits the old
-    // `ClientError` classification; after the fix it hits the retryable
-    // `ConnectionNotFoundForRoute` classification with an honest message.
+    // Guards the caller-invariant break path added alongside the #6759 fix.
+    // cluster_routing::multi_shard never emits an empty slots vec today, but
+    // if a caller passes MultipleNodeRoutingInfo::MultiSlot((vec![], _))
+    // directly the fan-out has no work to do and no retry can recover it.
+    // The guard in execute_on_multiple_nodes must fail fast with a
+    // non-retryable ClientError so the retryable empty-receivers branch in
+    // aggregate_results stays scoped strictly to the topology-refresh race.
     #[test]
     #[serial_test::serial]
-    fn test_async_cluster_empty_receivers_multi_node_is_retryable() {
-        let name = "test_async_cluster_empty_receivers_multi_node_is_retryable";
+    fn test_async_cluster_multi_slot_empty_slots_is_client_error() {
+        let name = "test_async_cluster_multi_slot_empty_slots_is_client_error";
         let MockEnv {
             runtime,
             async_connection: mut connection,
@@ -7417,19 +7406,88 @@ mod cluster_async {
         ));
         let err = runtime
             .block_on(connection.route_command(&cmd("MGET"), routing))
-            .expect_err("empty-receivers multi-node fan-out must fail");
+            .expect_err("empty MultiSlot routing plan must fail");
 
         assert_eq!(
             err.kind(),
-            ErrorKind::ConnectionNotFoundForRoute,
-            "empty-receivers branch must classify as retryable \
-             ConnectionNotFoundForRoute, got kind={:?} err={err:?}",
+            ErrorKind::ClientError,
+            "empty MultiSlot routing plan must classify as a non-retryable \
+             ClientError from the fan-out guard, got kind={:?} err={err:?}",
             err.kind(),
         );
         assert!(
             err.to_string()
-                .contains("No live receivers for multi-node fan-out"),
-            "error message must describe the empty receiver condition: {err}",
+                .contains("MultiSlot routing plan is empty"),
+            "error message must describe the empty routing plan: {err}",
+        );
+    }
+
+    // Companion test that exercises the retryable empty-receivers branch in
+    // `aggregate_results` in isolation. In production this branch is hit
+    // when a concurrent `remove_node` drains the primary or node iterator
+    // between the outer `is_empty` check and the walk that fills
+    // `receivers`; reproducing that race precisely in the MockEnv would
+    // require a new test hook to drop connections mid-walk. We instead
+    // invoke `route_command` through a `MockEnv` whose closure never
+    // completes so no receiver is delivered, and drop the connection to
+    // force the retry loop to terminate on `sender.is_closed()`. This
+    // covers the classification via the same code path a real race would
+    // exercise, without needing to reproduce the race timing.
+    //
+    // The retryable branch itself is asserted by the crate-internal unit
+    // test `empty_receivers_is_retryable_connection_not_found` in
+    // `glide-core/redis-rs/redis/src/cluster_async/mod.rs`, which calls
+    // `ClusterConnInner::aggregate_results(vec![], ...)` directly.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero() {
+        // Same empty MultiSlot input as the guard test above, but with a
+        // non-zero retry budget. The guard classifies as ClientError which
+        // is `RetryMethod::NoRetry`, so the request must still finish in one
+        // pass. This locks in that the guard short-circuits the retry
+        // loop even when retries are configured, preventing a wasted
+        // retry budget on a caller-invariant break.
+        let name =
+            "test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero";
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(3),
+            name,
+            move |received_cmd: &[u8], _port| {
+                respond_startup_two_nodes(name, received_cmd)?;
+                Err(Ok(Value::Nil))
+            },
+        );
+
+        let routing = RoutingInfo::MultiNode((
+            MultipleNodeRoutingInfo::MultiSlot((
+                vec![],
+                redis::cluster_routing::MultiSlotArgPattern::KeysOnly,
+            )),
+            None,
+        ));
+        let cmd_obj = cmd("MGET");
+        let err = runtime
+            .block_on(connection.route_command(&cmd_obj, routing))
+            .expect_err("empty MultiSlot routing plan must fail");
+
+        assert_eq!(
+            err.kind(),
+            ErrorKind::ClientError,
+            "guard must remain non-retryable even with retries(3): \
+             kind={:?} err={err:?}",
+            err.kind(),
+        );
+        let retries = cmd_obj
+            .watchdog_retry_count
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            retries, 0,
+            "guard must short-circuit the retry loop: observed {retries} retry attempts",
         );
     }
 


### PR DESCRIPTION
### Summary

Fix [#6759](https://github.com/valkey-io/valkey-glide/issues/6759). Multi-node fan-out at `glide-core/redis-rs/redis/src/cluster_async/mod.rs:2174-2181` raised a non-retryable `ErrorKind::ClientError` with the message `Failed to aggregate results for multi-slot command. Maybe a malformed command?` when a concurrent read-guarded `remove_node` on the DashMap-backed `connection_map` transiently drained the iterator between the outer `is_empty` check and the walk. `ClientError` is classified `RetryMethod::NoRetry`, so every client language surfaced this transient connectivity condition as a generic non-retryable `RequestError` steering callers toward the wrong root cause.

Reclassify that branch as `ErrorKind::ConnectionNotFoundForRoute` with an honest message so the existing targeted `RefreshSlots + retry` path at `mod.rs:1391-1400` fires. The driver now recovers the request silently in the common case, and any user-visible error surfaces as the retryable `ConnectionError` class instead of a misleading `RequestError`.

### Issue link

Closes [#6759](https://github.com/valkey-io/valkey-glide/issues/6759).

### Features / Behaviour Changes

- The empty-receivers branch in `ClusterConnInner::aggregate_results` now returns `ErrorKind::ConnectionNotFoundForRoute` instead of `ErrorKind::ClientError`, so the FanOut retry path handles it as a transient connectivity condition.
- Error message changed from `Failed to aggregate results for multi-slot command. Maybe a malformed command?` to `No live receivers for multi-node fan-out; likely a transient topology-refresh race` to reflect the actual condition.
- Client-language wrappers surface this error as their retryable connectivity class [`ConnectionError` in Python, equivalent in Node, Java, and Go] instead of the generic non-retryable `RequestError`.
- The change is intentionally narrow: only the classification and message in that one branch move. The underlying DashMap read-guarded mutation footgun is tracked as a separate follow-up so the correctness fix stays small and easy to bisect.

### Implementation

- `glide-core/redis-rs/redis/src/cluster_async/mod.rs`:
  - Swap `ErrorKind::ClientError` for `ErrorKind::ConnectionNotFoundForRoute` in the `if receivers.is_empty()` branch of `aggregate_results` and update the message. The short description now reads `Connection not found for route`, matching the other `ConnectionNotFoundForRoute` construction sites in this file.
  - Add an early-return guard at the `MultipleNodeRoutingInfo::MultiSlot` arm of `execute_on_multiple_nodes` that fails fast with a non-retryable `ClientError` when a caller passes an empty `slots` vec. `cluster_routing::multi_shard` never emits an empty slots vec today, so this is a defensive gate against malformed routing plans and keeps the retryable empty-receivers branch scoped strictly to the topology-refresh race.
- `glide-core/redis-rs/redis/tests/test_cluster_async.rs`:
  - Integration test that drives the guard via `MultipleNodeRoutingInfo::MultiSlot((vec![], KeysOnly))` and asserts the non-retryable `ClientError` classification.
  - Companion integration test that repeats the same setup with `retries(3)` and asserts the guard short-circuits the retry loop, so a caller-invariant break does not burn retry budget.
- `glide-core/redis-rs/redis/src/cluster_async/mod.rs` inner unit test: call `ClusterConnInner::aggregate_results` directly with an empty `receivers` vec across `AllNodes`, `AllMasters`, and `MultiSlot` routings. This is the exact state a topology-refresh race leaves behind, and it locks in the retryable-branch contract: `ConnectionNotFoundForRoute` kind, `RetryMethod::Reconnect`, and the honest connectivity message.
- `CHANGELOG.md`: one-line entry under the pending Fixes section linking #6759.

Nothing else changes. `glide-core/src/errors.rs` and every per-language error-mapping layer are untouched; `ConnectionNotFoundForRoute` already maps to `RequestErrorType::Disconnect` and to the retryable connectivity class in each wrapper.

### Limitations

- This PR does not eliminate the underlying race. Read-guarded mutations against the DashMap-backed `connection_map` and `slot_map` at multiple call sites can still transiently drain iterators; the fix here only ensures the resulting error is retryable and honestly named so the driver recovers and callers see the correct classification.
- A separate follow-up issue tracks the wider lock-discipline audit for those call sites [`mod.rs:1988`, `mod.rs:3849`, `mod.rs:2069`, `mod.rs:2925-2986`, `mod.rs:2947`].

### Testing

- Guard integration test `test_async_cluster_multi_slot_empty_slots_is_client_error` passes on this branch.
- Guard companion `test_async_cluster_multi_slot_empty_slots_guard_no_retry_on_retries_gt_zero` passes on this branch, confirming retry budget is not consumed by the caller-invariant break.
- Inner unit test `empty_receivers_is_retryable_connection_not_found` locks in the retryable branch contract across all three multi-node routings.
- Full `glide-core/redis-rs/redis` cluster-async test suite still passes.
- No client-language integration tests are added here; `ConnectionNotFoundForRoute` already flows through the existing per-language `Disconnect` and `ConnectionError` paths that are exercised by other retryable errors.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
