### PR TITLE
test(java): add disabled pool plus scope cluster integration test

### DIFF
--- a/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java
@@ -11,12 +11,16 @@ import glide.api.models.configuration.GlideClusterClientConfiguration;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.pool.ClientPool;
 import glide.api.models.pool.ClientPoolConfig;
+import glide.api.models.pool.PooledGlideClient;
+import glide.api.models.scope.IsolatedScope;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -101,6 +105,33 @@ public class ClientPoolIntegrationTest {
         while (pool.getIdleCount() < minIdle && System.currentTimeMillis() < deadline) {
             Thread.sleep(50);
         }
+    }
+
+    // Shared by the PoolAndScope cases.
+
+    /** A cluster-mode pool that is ready to hand out clients. */
+    private ClientPool clusterPool() throws InterruptedException {
+        ClientPool pool = ClientPool.create(poolConfig(true));
+        waitForPoolReady(pool, 1);
+        return pool;
+    }
+
+    /** Open a scope on a pooled client, pinned to the slot of {@code routingKey}. */
+    private static IsolatedScope scopeOn(PooledGlideClient client, String routingKey)
+            throws Exception {
+        return client
+                .unwrap()
+                .scopedConnection(Duration.ofSeconds(10), routingKey)
+                .get(10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * A cluster key under a hash tag other than the one {@link #testKey} uses, so it lands in a
+     * different slot.
+     */
+    private static String otherSlotKey(String prefix) {
+        String id = UUID.randomUUID().toString().substring(0, 8);
+        return "{pool-test-other}-" + prefix + "-" + id;
     }
 
     @ParameterizedTest
@@ -469,5 +500,46 @@ public class ClientPoolIntegrationTest {
                         .build();
 
         assertThrows(RuntimeException.class, () -> ClientPool.create(badConfig));
+    }
+
+    /**
+     * A scope opened on a pooled client commits a transaction on one slot, then refuses a key from
+     * another slot.
+     */
+    @Test
+    @Disabled(
+            "Pooled clients cannot open scopes: https://github.com/valkey-io/valkey-glide/issues/6764")
+    public void testPoolAndScopeCluster() throws Exception {
+        assumeMode(true);
+        ClientPool pool = clusterPool();
+        String key = testKey(true, "pool-scope");
+        String foreignKey = otherSlotKey("pool-scope");
+
+        try (PooledGlideClient client = pool.acquire().get(10, TimeUnit.SECONDS)) {
+            client.set(key, "10").get(5, TimeUnit.SECONDS);
+
+            try (IsolatedScope scope = scopeOn(client, key)) {
+                assertEquals("OK", scope.watch(key).get(5, TimeUnit.SECONDS));
+                assertEquals("10", scope.get(key).get(5, TimeUnit.SECONDS));
+                assertEquals("OK", scope.multi().get(5, TimeUnit.SECONDS));
+                scope.set(key, "11").get(5, TimeUnit.SECONDS);
+                String exec = scope.exec().get(5, TimeUnit.SECONDS);
+                assertNotNull(exec, "EXEC should commit, nobody touched the key");
+
+                // The scope is pinned to this key's slot, so another slot's key must be rejected.
+                ExecutionException ex =
+                        assertThrows(
+                                ExecutionException.class, () -> scope.get(foreignKey).get(5, TimeUnit.SECONDS));
+                assertTrue(
+                        ex.getMessage().toLowerCase().contains("crossslot"),
+                        "Expected a cross-slot error, got: " + ex.getMessage());
+            } // scope released here, before the client goes back to the pool
+
+            assertEquals("11", client.get(key).get(5, TimeUnit.SECONDS));
+            client.del(new String[] {key}).get(5, TimeUnit.SECONDS);
+        }
+
+        pool.close();
+        System.out.println("testPoolAndScopeCluster PASSED");
     }
 }


### PR DESCRIPTION
### Summary

Adds one Java integration test, `testPoolAndScopeCluster`, to `java/integTest/src/test/java/glide/pool/ClientPoolIntegrationTest.java`. It covers connection pooling and isolated scopes together against a cluster: a client is acquired from a cluster-mode pool, a scope is opened on it, a WATCH/MULTI/EXEC transaction runs on a single-slot key, and a key from a different slot is then rejected inside that same scope.

The test ships `@Disabled`, because a pooled client cannot open a scope on `main` (issue [6764](https://github.com/valkey-io/valkey-glide/issues/6764)). It is written as the finished test, so fixing 6764 means deleting the one `@Disabled` line.

### Issue link

This Pull Request is linked to issue: [[Java] GlideClient.fromPoolHandle does not propagate connection request bytes, breaking scopedConnection on pool-borrowed clients](https://github.com/valkey-io/valkey-glide/issues/6764)
Closes: nothing. Issue 6764 is the reason the test is disabled, and this PR does not fix it.

### Features / Behaviour Changes

None. This is a test-only change with no product behaviour change.

### Implementation

`testPoolAndScopeCluster` is cluster-only, so it uses a plain `@Test` plus the suite's `assumeMode(true)` assumption rather than the `@ParameterizedTest` over `clusterMode` that the neighbouring tests use.

The test body:

1. Creates a cluster-mode pool and acquires a `PooledGlideClient`.
2. Seeds a hash-tagged key through the pooled client, which also exercises cluster routing through the pool.
3. Opens an `IsolatedScope` on `client.unwrap()` with that key as the routing key, so the scope connects to the node owning its slot.
4. Runs WATCH, GET, MULTI, SET, EXEC on that key and asserts the transaction commits.
5. Reads a key under a different hash tag from inside the same scope and asserts it fails with a cross-slot error.
6. Reads the committed value back through the pooled client after the scope is closed.

Nested try-with-resources gives deterministic cleanup: the scope is released first, then the pooled client returns to the pool, and the pool is closed last.

Three small private helpers sit alongside the suite's existing helper block, marked as shared by the `PoolAndScope` cases, so further cases in this file are a short test body plus one helper call:

- `clusterPool()` creates a cluster-mode pool and waits for it to be ready.
- `scopeOn(client, routingKey)` opens a scope on a pooled client.
- `otherSlotKey(prefix)` builds a key under a hash tag other than the `{pool-test}` tag `testKey` uses, so it lands in a different slot. `{pool-test}` maps to slot 8289 and `{pool-test-other}` to slot 4527.

### Limitations

The test cannot run until issue 6764 is fixed. `GlideClient.fromPoolHandle` builds a bare `ConnectionManager`, so `getConnectionRequestBytes()` returns null and `scopedConnection` fails with `IllegalStateException("Client not connected")`. The test deliberately does not assert that current behaviour, so it needs no rewrite once the client is fixed.

Scope is one case only. Further pool plus scope cases are expected in this file, and no stubs for them are included here.

### Testing

Local runs on macOS (arm64), against servers started by the suite's own `cluster_manager` path, server version 9.0.1.

Compile:

```
./gradlew --no-daemon :integTest:compileTestJava
```

Result: BUILD SUCCESSFUL, so the new test compiles against the real API surface.

Suite run:

```
./gradlew --no-daemon :integTest:test --tests '*ClientPoolIntegrationTest*' --rerun -i
```

Results with this change (4 full-suite runs): `testPoolAndScopeCluster` reported SKIPPED every time, and every other case had the same outcome as on `main`.

Two neighbours fail on `main` as well, independently of this change:

- `testPoolConcurrentAccess[1] true` failed in 3 of 3 baseline full-suite runs and 4 of 4 runs with this change.
- `testPoolBlockingCmdIsolation[2] false` failed in 2 of 3 baseline full-suite runs, and in 2 of 2 baseline runs when executed on its own with a test filter, so its one baseline pass was luck rather than a difference caused by this change.

Both failures report `ClosingException: Client closed: Unable to submit command.` from a pooled client, which looks like pre-existing flakiness in the pool tests and is out of scope here.

Note that Gradle's console output prints `SKIPPED` without echoing the `@Disabled` reason, which is a Gradle reporting limitation rather than a missing reason on the annotation.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated. Skipped on purpose: test-only change with no product behaviour change.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). Formatting was matched by hand to the surrounding file, and CI spotless is the gate.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
