### PR TITLE
fix(deps): bump h2 to 0.4.16 to resolve RUSTSEC-2026-0258 (backport #6784 to release-2.5)

### DIFF
--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -1073,9 +1073,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/ffi/miri-tests/mock-glide-core/Cargo.lock
+++ b/ffi/miri-tests/mock-glide-core/Cargo.lock
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/ffi/miri-tests/mock-redis/Cargo.lock
+++ b/ffi/miri-tests/mock-redis/Cargo.lock
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -1348,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/glide-core/redis-rs/Cargo.lock
+++ b/glide-core/redis-rs/Cargo.lock
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -195,6 +195,9 @@ impl TokioDisconnectNotifier {
     }
 }
 
+// The Err variant is large because it hands the connection back for the caller to retry
+// on. Boxing it would change the error type at every call site.
+#[allow(clippy::result_large_err)]
 async fn create_connection(
     connection_backend: ConnectionBackend,
     retry_strategy: RetryStrategy,
@@ -325,6 +328,9 @@ impl ConnectionBackend {
 }
 
 impl ReconnectingConnection {
+    // Large Err for the same reason as create_connection, and boxing it would change the
+    // error type at every call site.
+    #[allow(clippy::result_large_err)]
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn new(
         address: &NodeAddress,

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -1060,6 +1060,9 @@ impl StandaloneClient {
     }
 }
 
+// Passes through the large Err from ReconnectingConnection::new. Boxing it would change
+// the error type at every call site.
+#[allow(clippy::result_large_err)]
 #[allow(clippy::too_many_arguments)]
 async fn get_connection_and_replication_info(
     address: &NodeAddress,

--- a/glide-core/telemetry/Cargo.lock
+++ b/glide-core/telemetry/Cargo.lock
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
### Summary

Backport of #6784 to `release-2.5`, extended to cover every h2-bearing lockfile on this branch, plus the one clippy allow that `release-2.5` needs for its rust lint job to run green.

Two parts:

1. **The security fix.** Bumps the `h2` crate to 0.4.16, clearing [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258). **All eleven lockfiles in the tree that pin `h2` are covered**, so no known-vulnerable pin is left behind anywhere, whether or not CI audits it. Cherry-picked from the squash commit that merged #6784 into `main`, `f8dfc51a1d954a36d5cd54936d9f37985b65af01`, so the provenance is recorded in history. Only `h2`'s `version` and `checksum` lines change: 44 lines across 11 files, with no other dependency movement anywhere in any graph.
2. **A pre-existing clippy failure on unchanged code.** `clippy::result_large_err` errors on three `glide-core` functions that return `Result<..., (ReconnectingConnection, RedisError)>`. Scoped `#[allow(clippy::result_large_err)]` attributes silence it at those three sites.

**The clippy failure is not caused by the h2 bump.** The three flagged functions are byte-identical on `release-2.5` and `main`, and no recent commit changed their size. The lint started firing because `.github/actions/install-rust/action.yml` installs unpinned `stable`, and a newer clippy raised `result_large_err` on code that was accepted the day before. A lockfile-only change cannot affect the size of a Rust enum variant. The bump merely happens to be the first PR on this branch to run the lint job under the new clippy, so it is the first to see the failure.

On the advisory itself: `h2` accepted and queued empty DATA frames without any limit, so a stream that is not actively drained could grow memory without bound, or panic if the queued length overflows. The advisory is patched in `h2` v0.4.16. Nothing here depends on `h2` directly. It reaches the dependency tree transitively through `hyper`, which is pulled in by `tonic`, `opentelemetry-otlp`, `reqwest`, and `telemetrylib`, so the security fix is lockfile-only with no manifest or source changes.

### Issue link

There is no tracking issue for either part. Both are CI or scanner findings rather than reported defects: the `h2` bump answers a `cargo deny` advisory failure reported against the RustSec advisory database (https://rustsec.org/advisories/RUSTSEC-2026-0258), and the clippy allow answers a `-D warnings` lint failure in the `lint-rust` job.

The change being backported is #6784.

### Features / Behaviour Changes

None. The `h2` bump is a transitive dependency security bump with no API or behaviour change, and `#[allow(...)]` has no effect at runtime.

### Implementation

**Part 1, the `h2` bump.** The tree holds 16 `Cargo.lock` files. Five pin no `h2` at all and are untouched, to avoid lockfile churn where there is nothing to fix: `logger_core`, `python/glide-shared`, and the `ffi/miri-tests/mock-logger-core`, `mock-telemetry`, and `mock-tokio` workspaces. The other eleven all pin `h2` and all move to 0.4.16. Two lines per file, nothing else touched.

| Workspace | Previous on `release-2.5` | New | Audited by CI `cargo deny` |
| --- | --- | --- | --- |
| `glide-core/redis-rs` | 0.4.13 | 0.4.16 | yes, `redis-rs.yml` |
| `glide-core` | 0.4.14 | 0.4.16 | yes, `rust.yml` |
| `ffi` | 0.4.13 | 0.4.16 | yes, `rust.yml` and `go.yml` |
| `java` | 0.4.13 | 0.4.16 | yes, `java.yml` |
| `node/rust-client` | 0.4.13 | 0.4.16 | yes, `node.yml` |
| `python/glide-async` | 0.4.13 | 0.4.16 | yes, `python.yml` |
| `benchmarks/rust` | 0.4.13 | 0.4.16 | yes, `rust.yml` |
| `ffi/miri-tests` | 0.4.13 | 0.4.16 | no |
| `glide-core/telemetry` | 0.4.13 | 0.4.16 | no |
| `ffi/miri-tests/mock-glide-core` | 0.4.13 | 0.4.16 | no |
| `ffi/miri-tests/mock-redis` | 0.4.13 | 0.4.16 | no |

The last three are standalone workspaces with their own lockfiles that no `cargo deny` job reaches, which is why the advisory never showed up against them. That does not make them safe to skip. `rust.yml` runs the `glide-core/telemetry` tests directly, and `mock-glide-core` and `mock-redis` are path dependencies of the Miri tests, so all three are live code. A security backport should not leave a known-vulnerable pin behind just because no scanner enforces it.

`release-2.5` pinned exactly the same vulnerable `h2` versions that `main` did before #6784 (0.4.13 everywhere, 0.4.14 in `glide-core`), and every one of these eleven lockfiles is already consistent with its own manifests on this branch, so the bump lands as a plain two-line-per-file edit with no re-resolution.

**Every workspace whose lockfile CI audits with `cargo deny` is covered**, and so is every workspace it does not audit. The audited set on `release-2.5` is `glide-core`, `ffi`, `logger_core`, and `benchmarks/rust` (all through the `lint-rust` action from `rust.yml`), `ffi` again from `go.yml`, `java` from `java.yml`, `node/rust-client` from `node.yml`, `python/glide-async` from `python.yml`, plus `glide-core/redis-rs` through `redis-rs.yml`. `logger_core` is audited as well but does not pin `h2` at all, so it needs no change.

**Part 2, the clippy allow.** Three functions in `glide-core` return the connection alongside the error so the caller can retry on it, which makes the `Err` variant 160 bytes against clippy's 128 byte threshold:

| Site | Function |
| --- | --- |
| `glide-core/src/client/reconnecting_connection.rs:206` | `create_connection` |
| `glide-core/src/client/reconnecting_connection.rs:342` | `ReconnectingConnection::new` |
| `glide-core/src/client/standalone_client.rs:1078` | `get_connection_and_replication_info` |

Each gets a scoped `#[allow(clippy::result_large_err)]` with a short comment explaining why the size is accepted. Nine added lines, no logic changed. This is the override clippy itself suggests in its diagnostic, and two of the three functions already carry a scoped `#[allow(clippy::too_many_arguments)]`, so a local allow is the established idiom at these sites.

The allow is deliberate in preference to boxing the `Err` variant. Boxing changes the error type and every call site that constructs or destructures it, which is a refactor with real regression risk on a release branch, taken on code that is already shipped and unchanged. The allow records the decision next to the code it applies to and costs nothing at runtime. Reducing the variant properly belongs on `main`, where it can be exercised for a full release cycle.

`CHANGELOG.md` is deliberately unchanged. #6784 added no entry, and `release-2.5` has no convention of listing lockfile dependency bumps or lint annotations: the three most recent comparable security backports onto this branch (`8a5daf168` opentelemetry 0.32 advisory, `075b7c22d` crossbeam-epoch RUSTSEC-2026-0204, `00c519654` anyhow RUSTSEC-2026-0190) each landed with zero `CHANGELOG.md` change.

### Limitations

**Two of the eleven lockfiles carry the bump as a hand-applied two-line edit rather than a cargo rewrite.** In `ffi/miri-tests/mock-glide-core` and `ffi/miri-tests/mock-redis`, `cargo update -p h2 --precise 0.4.16` bumps `h2` correctly but also re-picks the `windows-sys` dependency edge of a few crates (`errno`, `rustix`, `tempfile`, `winapi-util`, `rustls-platform-verifier`, `nu-ansi-term`, `dirs-sys`) from 0.61.2 to 0.52.0 or 0.59.0. Those crates declare wide `windows-sys` ranges to permit deduplication, both versions were already present in both lockfiles, and no package is added or removed, but it is unrelated to this advisory and does not belong in a security patch. Those two files therefore carry only the `h2` `version` and `checksum` change, with the identical checksum cargo produced elsewhere, and `cargo check --locked` confirms both remain internally consistent. The other nine were written by cargo.

**The clippy allow suppresses rather than fixes.** The `Err` variant is still 160 bytes; the three functions still return the connection by value. Anyone adding a new function with the same signature will hit the same lint and will need the same allow. Shrinking the variant is the real fix and belongs on `main`.

**`clippy::result_large_err` is silenced only at these three sites.** The allow is per function, not crate wide, so the lint keeps protecting the rest of `glide-core`.

**The unpinned toolchain remains unpinned.** `.github/actions/install-rust/action.yml` still installs `stable`, so a future clippy release can promote another lint to an error on untouched code exactly as happened here. Pinning the lint toolchain is a separate CI concern and is out of scope for a backport.

Separately, `h2` remains a transitive dependency, so it is not version-pinned in any manifest and will continue to float within `hyper`'s requirement on future resolutions.

### Testing

There is no behaviour change in either part, so there is nothing to exercise at runtime. Verification is that the lockfiles are correct, consistent, and minimal, and that the annotated code still compiles.

`cargo check --locked` passes in all 11 changed workspaces. `--locked` makes cargo fail rather than silently rewrite a lockfile, so a pass proves each lockfile is fully consistent with its manifests and that cargo has no pending changes of its own. For the two hand-edited files it is the proof that the edit is well formed, and in every case cargo verifies the 0.4.16 checksum against the crate it downloads:

| Workspace | `cargo check --locked` |
| --- | --- |
| `benchmarks/rust` | pass |
| `ffi` | pass |
| `ffi/miri-tests` | pass |
| `ffi/miri-tests/mock-glide-core` | pass |
| `ffi/miri-tests/mock-redis` | pass |
| `glide-core` | pass |
| `glide-core/redis-rs` | pass |
| `glide-core/telemetry` | pass |
| `java` | pass |
| `node/rust-client` | pass |
| `python/glide-async` | pass |

`glide-core/redis-rs` has the `dummy-for-ort` shim as its workspace root, so `cargo check --locked --workspace` was run there to actually compile `redis` against the new `h2`. It also passes.

`cargo check -p glide-core` passes with the three allow attributes in place, confirming the annotations are well formed and the functions still compile.

`cargo update -p h2 --precise 0.4.16 --dry-run` reports no change in the eight workspaces cargo had already written (no `Locking` line at all, so no package added, removed, upgraded, or downgraded), confirming that 0.4.16 is exactly what cargo resolves for `h2` on this branch. `cargo metadata --locked` succeeds in all 11.

Full sweep of every `Cargo.lock` in the tree, which is the check that matters for a security bump:

```
benchmarks/rust/Cargo.lock                     0.4.16
ffi/Cargo.lock                                 0.4.16
ffi/miri-tests/Cargo.lock                      0.4.16
ffi/miri-tests/mock-glide-core/Cargo.lock      0.4.16
ffi/miri-tests/mock-logger-core/Cargo.lock     (no h2)
ffi/miri-tests/mock-redis/Cargo.lock           0.4.16
ffi/miri-tests/mock-telemetry/Cargo.lock       (no h2)
ffi/miri-tests/mock-tokio/Cargo.lock           (no h2)
glide-core/Cargo.lock                          0.4.16
glide-core/redis-rs/Cargo.lock                 0.4.16
glide-core/telemetry/Cargo.lock                0.4.16
java/Cargo.lock                                0.4.16
logger_core/Cargo.lock                         (no h2)
node/rust-client/Cargo.lock                    0.4.16
python/glide-async/Cargo.lock                  0.4.16
python/glide-shared/Cargo.lock                 (no h2)

total locks=16   with h2=11   not-0.4.16=0
```

Searching the tree for the vulnerable checksums returns nothing:

```
h2 0.4.13  2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54   0 files
h2 0.4.14  171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733   0 files
h2 0.4.16  a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27   11 files
```

Scope of the lockfile diff against `release-2.5`, showing two changed lines per file and 44 in total:

```
 benchmarks/rust/Cargo.lock                | 4 ++--
 ffi/Cargo.lock                            | 4 ++--
 ffi/miri-tests/Cargo.lock                 | 4 ++--
 ffi/miri-tests/mock-glide-core/Cargo.lock | 4 ++--
 ffi/miri-tests/mock-redis/Cargo.lock      | 4 ++--
 glide-core/Cargo.lock                     | 4 ++--
 glide-core/redis-rs/Cargo.lock            | 4 ++--
 glide-core/telemetry/Cargo.lock           | 4 ++--
 java/Cargo.lock                           | 4 ++--
 node/rust-client/Cargo.lock               | 4 ++--
 python/glide-async/Cargo.lock             | 4 ++--
 11 files changed, 22 insertions(+), 22 deletions(-)
```

Filtering that diff for any changed line that is not an `h2` `version` or `checksum` line returns nothing, so no other package entry, version, or dependency edge moved. Every one of the 11 files carries the identical new pin:

```
version  = "0.4.16"
checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
```

`cargo tree -i h2` confirms the resolved graph, not just the lockfile text:

```
benchmarks/rust        h2 v0.4.16
ffi                    h2 v0.4.16
ffi/miri-tests         h2 v0.4.16
glide-core             h2 v0.4.16
glide-core/redis-rs    h2 v0.4.16   (-p redis; the workspace root is a shim)
java                   h2 v0.4.16
node/rust-client       h2 v0.4.16
python/glide-async     h2 v0.4.16
```

The clippy side of the change is nine added lines across two files, three comments and three attributes, with no logic touched:

```
 glide-core/src/client/reconnecting_connection.rs | 6 ++++++
 glide-core/src/client/standalone_client.rs       | 3 +++
 2 files changed, 9 insertions(+)
```

Together the change touches only those eleven `Cargo.lock` files and those two `glide-core` source files: no manifest, workflow, `deny.toml`, or `CHANGELOG.md` change.

Neither `cargo clippy` nor `cargo deny` was run locally for this change. CI's `lint-rust` action and `redis-rs.yml` run both on every audited workspace and are the authoritative gate for whether the advisory is cleared and the lint is silenced.

Environment used: `cargo 1.91.1`, `rustc 1.91.1`, on macOS arm64.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] ~Tests are added or updated.~ Neither a lockfile bump nor an `#[allow(...)]` attribute has behaviour to test.
-   [ ] ~CHANGELOG.md and documentation files are updated.~ #6784 added no entry, and `release-2.5` does not list lockfile dependency bumps or lint annotations.
-   [ ] ~Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).~ CI's `lint-rust` job is the gate for the clippy change.
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] ~Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary~
