### PR TITLE
fix(deps): bump h2 to 0.4.16 in the remaining standalone workspaces

### DIFF
--- a/ffi/miri-tests/mock-glide-core/Cargo.lock
+++ b/ffi/miri-tests/mock-glide-core/Cargo.lock
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/ffi/miri-tests/mock-redis/Cargo.lock
+++ b/ffi/miri-tests/mock-redis/Cargo.lock
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/glide-core/telemetry/Cargo.lock
+++ b/glide-core/telemetry/Cargo.lock
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
### Summary

Brings `h2` to 0.4.16 in the three standalone Cargo workspaces that still pin the vulnerable 0.4.13, completing coverage for RUSTSEC-2026-0258 across the repository.

RUSTSEC-2026-0258 reports that `h2` accepts and queues empty DATA frames without any limit, so a stream that is not actively drained can grow memory without bound, or panic if the queued length overflows. Low severity, patched in h2 v0.4.16.

Eleven of the sixteen `Cargo.lock` files in this repository carry `h2` transitively, through `hyper` by way of `tonic`, `opentelemetry-otlp`, `reqwest`, and `telemetrylib`. #6784 moved eight of them to 0.4.16. This change covers the remaining three:

| Lockfile | Before | After |
| --- | --- | --- |
| `glide-core/telemetry/Cargo.lock` | 0.4.13 | 0.4.16 |
| `ffi/miri-tests/mock-glide-core/Cargo.lock` | 0.4.13 | 0.4.16 |
| `ffi/miri-tests/mock-redis/Cargo.lock` | 0.4.13 | 0.4.16 |

The other five lockfiles (`ffi/miri-tests/mock-logger-core`, `ffi/miri-tests/mock-telemetry`, `ffi/miri-tests/mock-tokio`, `logger_core`, `python/glide-shared`) do not resolve `h2` at all and need no change.

These three were missed because they are standalone workspaces, outside the graphs that `cargo deny` walks, so the advisory never surfaced for them. They are not dead fixtures. `.github/workflows/rust.yml` runs the telemetry tests directly, and the two mock workspaces are path dependencies of the Miri tests, so vulnerable code is compiled in CI today.

### Issue link

This Pull Request is linked to issue: no issue filed. It follows up on [fix(deps): bump h2 to 0.4.16 to resolve RUSTSEC-2026-0258](https://github.com/valkey-io/valkey-glide/pull/6784), which resolved the advisory for the eight lockfiles inside the `cargo deny` scan.

### Features / Behaviour Changes

None. No public API, configuration, or runtime behaviour changes. `h2` is only reached transitively, and 0.4.13 to 0.4.16 is a patch-level move within the same semver-compatible range.

### Implementation

Lockfile-only, six lines total: the `version` and `checksum` fields of the `h2` entry in each of the three files. No manifest, source, or workflow changes. Nothing in this repository depends on `h2` directly.

Two routes were used, per workspace:

- `glide-core/telemetry`: `cargo update -p h2 --precise 0.4.16` run inside the workspace. It rewrote the `h2` entry alone and left the other 81 resolved dependencies untouched.
- `ffi/miri-tests/mock-glide-core` and `ffi/miri-tests/mock-redis`: their checked-in lockfiles are already stale with respect to their manifests on `main`, so `cargo update` re-resolves a large set of unrelated crates (`jni`, `lru`, `rustls-platform-verifier`, `strum`, and others). To keep the change scoped to the advisory, the `h2` `version` and `checksum` lines were edited directly, using the same 0.4.16 checksum that `main`'s other eight lockfiles already carry: `a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27`.

The checksum was independently confirmed rather than trusted: resolving each of the two mock workspaces from scratch produces exactly that value for h2 0.4.16.

The full diff is +6/-6 across three files, with no other package moving:

```
 ffi/miri-tests/mock-glide-core/Cargo.lock | 4 ++--
 ffi/miri-tests/mock-redis/Cargo.lock      | 4 ++--
 glide-core/telemetry/Cargo.lock           | 4 ++--
 3 files changed, 6 insertions(+), 6 deletions(-)
```

### Limitations

The lockfile staleness in `ffi/miri-tests/mock-glide-core` and `ffi/miri-tests/mock-redis` is left as-is. It predates this change, is unrelated to the advisory, and regenerating those lockfiles would move dozens of unrelated crates in a security patch. It is worth a separate change.

More broadly, `cargo deny` still does not walk any of the standalone workspaces, so a future advisory can be missed the same way. Extending the deny scan to cover them is also worth a separate change.

### Testing

- `cargo check --locked` in `glide-core/telemetry`: passes. `--locked` is the point here, since it proves the lockfile is internally consistent rather than quietly regenerated. The output shows `Checking h2 v0.4.16` and finishes with `Finished dev profile`.
- `cargo check --locked` in `ffi/miri-tests/mock-glide-core` and `ffi/miri-tests/mock-redis`: cannot pass, and does not pass on unmodified `main` either. Both fail with `the lock file ... needs to be updated but --locked was passed to prevent this`, from the pre-existing staleness described above. Verified by stashing the h2 edits and re-running on pristine `main`, which reproduces the identical error in both workspaces. To validate these two anyway, each workspace was copied to a scratch directory and built with lock regeneration allowed: both compile cleanly, and cargo's own resolution independently lands on h2 0.4.16 with the checksum written here.
- Swept all sixteen `Cargo.lock` files afterwards: the eleven that resolve `h2` are all at 0.4.16, and none pins 0.4.13.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary

Notes on the unchecked items: no issue is filed, matching #6784, which was also a direct advisory fix. There is no test to add for a transitive lockfile pin; the verification above is the coverage. No CHANGELOG entry, again matching #6784, since there is no user-visible change. No linter or formatter was run because nothing lintable changed; `main` currently has a repo-wide clippy failure on unchanged Rust code (`result_large_err` in `glide-core/src/client/reconnecting_connection.rs` and `standalone_client.rs`, `useless_format` in `redis/src/cluster_async/mod.rs`) caused by an unpinned `stable` toolchain picking up a new Rust release. It is pre-existing and unrelated to this change, and is deliberately left alone here.
