### PR TITLE
fix(core): allow the large reconnect Err variant to satisfy clippy

### DIFF
--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -198,6 +198,9 @@ impl TokioDisconnectNotifier {
     }
 }
 
+// The Err variant is large because it hands the connection back for the caller to retry
+// on. Boxing it would change the error type at every call site.
+#[allow(clippy::result_large_err)]
 async fn create_connection(
     connection_backend: ConnectionBackend,
     retry_strategy: RetryStrategy,
@@ -329,6 +332,9 @@ impl ConnectionBackend {
 }
 
 impl ReconnectingConnection {
+    // Large Err for the same reason as create_connection, and boxing it would change the
+    // error type at every call site.
+    #[allow(clippy::result_large_err)]
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn new(
         address: &NodeAddress,

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -200,6 +200,7 @@ impl TokioDisconnectNotifier {
 
 // The Err variant is large because it hands the connection back for the caller to retry
 // on. Boxing it would change the error type at every call site.
+// TODO: Box the Err payload and drop this allow - https://github.com/valkey-io/valkey-glide/issues/6819
 #[allow(clippy::result_large_err)]
 async fn create_connection(
     connection_backend: ConnectionBackend,
@@ -334,6 +335,7 @@ impl ConnectionBackend {
 impl ReconnectingConnection {
     // Large Err for the same reason as create_connection, and boxing it would change the
     // error type at every call site.
+    // TODO: Box the Err payload and drop this allow - https://github.com/valkey-io/valkey-glide/issues/6819
     #[allow(clippy::result_large_err)]
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn new(

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -1173,6 +1173,9 @@ impl StandaloneClient {
     }
 }
 
+// Passes through the large Err from ReconnectingConnection::new. Boxing it would change
+// the error type at every call site.
+#[allow(clippy::result_large_err)]
 #[allow(clippy::too_many_arguments)]
 async fn get_connection_and_replication_info(
     address: &NodeAddress,

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -1175,6 +1175,7 @@ impl StandaloneClient {
 
 // Passes through the large Err from ReconnectingConnection::new. Boxing it would change
 // the error type at every call site.
+// TODO: Box the Err payload and drop this allow - https://github.com/valkey-io/valkey-glide/issues/6819
 #[allow(clippy::result_large_err)]
 #[allow(clippy::too_many_arguments)]
 async fn get_connection_and_replication_info(


### PR DESCRIPTION
### Summary

`cargo clippy --all-features --all-targets -- -D warnings` fails on main with three `clippy::result_large_err` errors in `glide-core`.
Nothing in the flagged code has changed.
The lint job at `.github/actions/install-rust/action.yml` requests unpinned `toolchain: stable` and the repo carries no `clippy.toml`, so a newer stable clippy started enforcing `result_large_err` on code that previous toolchains accepted.
Main's last passing run of that job predates the toolchain release, so main had simply not been re-linted since.
Any new PR into main hits this.

This adds the scoped `#[allow(clippy::result_large_err)]` that clippy's own diagnostic suggests at the three sites, each with a short comment on why the size is accepted.

### Issue link

This Pull Request is linked to issue: none.
This is a CI-unblocking lint fix with no tracked issue.
Closes N/A

### Features / Behaviour Changes

None.
The change is three attributes and three comments.
No runtime behaviour, no public API, and no error type changes.

### Implementation

The three functions are:

| File | Function |
| --- | --- |
| `glide-core/src/client/reconnecting_connection.rs` | `create_connection` |
| `glide-core/src/client/reconnecting_connection.rs` | `ReconnectingConnection::new` |
| `glide-core/src/client/standalone_client.rs` | `get_connection_and_replication_info` |

All three return `Result<_, (ReconnectingConnection, RedisError)>`.
They hand the connection back alongside the error so the caller can retry on it.
That makes the `Err` variant 160 bytes against clippy's default 128 byte threshold.

Boxing the `Err` variant would be the real fix, but it changes the error type and every call site that constructs or destructures it.
The allow is chosen instead: it states the decision next to the code it applies to and costs nothing at runtime.
Two of the three functions already carry a scoped `#[allow(clippy::too_many_arguments)]`, so a local scoped allow is the established idiom at these sites, and the new attribute sits directly above the existing one.

The identical change is already proven on #6811, where it silenced the same three errors on the release branch.

### Limitations

The allow suppresses the lint rather than shrinking the variant.
Boxing the `Err` payload remains the better long-term fix and is deliberately left for a separate change that can carry the call-site churn.

Pinning the clippy toolchain is a separate open decision and is not touched here.

`redis-rs-CI` fails on main for an unrelated reason: `clippy::useless_format` at `glide-core/redis-rs/redis/src/cluster_async/mod.rs:2482`.
That is a different lint in a different crate and is out of scope here, so `redis-rs-CI` is expected to stay red on this PR.

### Testing

`cargo check -p glide-core` passes with the annotations in place.

Whether the lint is actually silenced is decided by the `lint` CI job on this PR.
The same three annotations already silenced the same three errors on #6811.

No tests are added: the change adds no code paths and there is nothing behavioural to assert.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
