### PR TITLE
fix(go): allow ScopedConnection on pool-borrowed Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.

--- a/go/client_pool.go
+++ b/go/client_pool.go
@@ -248,6 +248,8 @@ func (p *ClientPool) GetClient(clientID int64) (*PooledClient, error) {
 			pending:    make(map[unsafe.Pointer]struct{}),
 			mu:         &sync.Mutex{},
 		},
+		clientConfig: p.clientConf,
+		connReqBytes: p.connReq,
 	}
 	client.setMessageHandler(NewMessageHandler(nil, nil))
 

--- a/go/client_pool.go
+++ b/go/client_pool.go
@@ -242,13 +242,15 @@ func (p *ClientPool) GetClient(clientID int64) (*PooledClient, error) {
 
 	// Create a Client wrapper pointing to the pooled adapter.
 	// The adapter is an AsyncClient type — commands via C.command() fire callbacks.
+	// connReqBytes carries the pool's serialized ConnectionRequest so ScopedConnection
+	// works on the borrowed client. clientConfig is intentionally not set: ScopedConnection
+	// always uses connReqBytes when present, so a config object here would never be read.
 	client := &Client{
 		baseClient: baseClient{
 			coreClient: unsafe.Pointer(adapterPtr),
 			pending:    make(map[unsafe.Pointer]struct{}),
 			mu:         &sync.Mutex{},
 		},
-		clientConfig: p.clientConf,
 		connReqBytes: p.connReq,
 	}
 	client.setMessageHandler(NewMessageHandler(nil, nil))

--- a/go/glide_client.go
+++ b/go/glide_client.go
@@ -32,6 +32,7 @@ var _ interfaces.GlideClientCommands = (*Client)(nil)
 type Client struct {
 	baseClient
 	clientConfig *config.ClientConfiguration // stored for scoped_connection
+	connReqBytes []byte                      // pre-serialized ConnectionRequest (set for pool-borrowed clients)
 }
 
 // Creates a new [Client] instance and establishes a connection to a standalone Valkey server.

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -35,6 +35,7 @@ var _ interfaces.GlideClusterClientCommands = (*ClusterClient)(nil)
 type ClusterClient struct {
 	baseClient
 	clientConfig *config.ClusterClientConfiguration // stored for scoped_connection
+	connReqBytes []byte                             // pre-serialized ConnectionRequest (set for pool-borrowed clients)
 }
 
 // Creates a new [ClusterClient] instance and establishes a connection to a Valkey Cluster.

--- a/go/integTest/pool_scope_test.go
+++ b/go/integTest/pool_scope_test.go
@@ -1247,3 +1247,79 @@ func TestScopeConcurrentMultiple(t *testing.T) {
 		})
 	}
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Pool + Scope combination test (regression for #6763)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+func TestPoolBorrowedClientScopedConnection(t *testing.T) {
+	// Verifies that a pool-borrowed client can open a ScopedConnection and execute
+	// a full WATCH/GET/MULTI/SET/EXEC cycle. This is the regression test for #6763:
+	// GetClient did not propagate clientConfig/connReqBytes, causing ScopedConnection
+	// to fail with "client configuration not available for scoped connections".
+	for _, tc := range scopeModes() {
+		t.Run(tc.name, func(t *testing.T) {
+			skipMode(t, tc.cluster)
+
+			pool := newPool(t, tc.cluster, glide.PoolConfig{
+				MaxSize:        2,
+				MinIdle:        1,
+				AcquireTimeout: 10 * time.Second,
+			})
+			defer pool.Close()
+
+			waitForPoolReady(t, pool, 1)
+
+			ctx := context.Background()
+			clientID, err := pool.Acquire(ctx)
+			require.NoError(t, err)
+
+			client, err := pool.GetClient(clientID)
+			require.NoError(t, err)
+			defer client.Close()
+
+			key := scopeTestKey("pool-scope-combo", tc.cluster)
+
+			// Seed a counter via the pooled client
+			_, err = client.Set(ctx, key, "10")
+			require.NoError(t, err)
+
+			// Open a scoped connection on the pool-borrowed client
+			routingKey := ""
+			if tc.cluster {
+				routingKey = key
+			}
+			scope, err := client.ScopedConnection(ctx, 10*time.Second, routingKey)
+			require.NoError(t, err, "ScopedConnection on pool-borrowed client should succeed (fix for #6763)")
+			defer scope.Close()
+
+			assert.False(t, scope.IsReleased())
+
+			// Full OCC cycle: WATCH → GET → MULTI → SET → EXEC
+			_, err = scope.Watch(ctx, key)
+			require.NoError(t, err)
+
+			val, err := scope.Get(ctx, key)
+			require.NoError(t, err)
+			assert.Equal(t, "10", val)
+
+			_, err = scope.Multi(ctx)
+			require.NoError(t, err)
+
+			_, err = scope.Set(ctx, key, "11")
+			require.NoError(t, err)
+
+			result, err := scope.Exec(ctx)
+			require.NoError(t, err)
+			assert.NotEmpty(t, result, "EXEC should commit (no conflict)")
+
+			// Verify via the pooled client
+			finalVal, err := client.Get(ctx, key)
+			require.NoError(t, err)
+			assert.Equal(t, "11", finalVal.Value())
+
+			// Cleanup
+			client.Client.Del(ctx, []string{key})
+		})
+	}
+}

--- a/go/integTest/pool_scope_test.go
+++ b/go/integTest/pool_scope_test.go
@@ -1252,74 +1252,71 @@ func TestScopeConcurrentMultiple(t *testing.T) {
 // Pool + Scope combination test (regression for #6763)
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// TestPoolBorrowedClientScopedConnection verifies that a pool-borrowed client can open a
+// ScopedConnection and execute a full WATCH/GET/MULTI/SET/EXEC cycle. This is the regression
+// test for #6763: GetClient did not propagate clientConfig/connReqBytes, causing
+// ScopedConnection to fail with "client configuration not available for scoped connections".
+//
+// Standalone-only: cluster-aware pool wrappers (GetClient returning *ClusterClient) are not
+// yet supported — tracked as a separate enhancement.
 func TestPoolBorrowedClientScopedConnection(t *testing.T) {
-	// Verifies that a pool-borrowed client can open a ScopedConnection and execute
-	// a full WATCH/GET/MULTI/SET/EXEC cycle. This is the regression test for #6763:
-	// GetClient did not propagate clientConfig/connReqBytes, causing ScopedConnection
-	// to fail with "client configuration not available for scoped connections".
-	for _, tc := range scopeModes() {
-		t.Run(tc.name, func(t *testing.T) {
-			skipMode(t, tc.cluster)
-
-			pool := newPool(t, tc.cluster, glide.PoolConfig{
-				MaxSize:        2,
-				MinIdle:        1,
-				AcquireTimeout: 10 * time.Second,
-			})
-			defer pool.Close()
-
-			waitForPoolReady(t, pool, 1)
-
-			ctx := context.Background()
-			clientID, err := pool.Acquire(ctx)
-			require.NoError(t, err)
-
-			client, err := pool.GetClient(clientID)
-			require.NoError(t, err)
-			defer client.Close()
-
-			key := scopeTestKey("pool-scope-combo", tc.cluster)
-
-			// Seed a counter via the pooled client
-			_, err = client.Set(ctx, key, "10")
-			require.NoError(t, err)
-
-			// Open a scoped connection on the pool-borrowed client
-			routingKey := ""
-			if tc.cluster {
-				routingKey = key
-			}
-			scope, err := client.ScopedConnection(ctx, 10*time.Second, routingKey)
-			require.NoError(t, err, "ScopedConnection on pool-borrowed client should succeed (fix for #6763)")
-			defer scope.Close()
-
-			assert.False(t, scope.IsReleased())
-
-			// Full OCC cycle: WATCH → GET → MULTI → SET → EXEC
-			_, err = scope.Watch(ctx, key)
-			require.NoError(t, err)
-
-			val, err := scope.Get(ctx, key)
-			require.NoError(t, err)
-			assert.Equal(t, "10", val)
-
-			_, err = scope.Multi(ctx)
-			require.NoError(t, err)
-
-			_, err = scope.Set(ctx, key, "11")
-			require.NoError(t, err)
-
-			result, err := scope.Exec(ctx)
-			require.NoError(t, err)
-			assert.NotEmpty(t, result, "EXEC should commit (no conflict)")
-
-			// Verify via the pooled client
-			finalVal, err := client.Get(ctx, key)
-			require.NoError(t, err)
-			assert.Equal(t, "11", finalVal.Value())
-
-			// Cleanup
-			client.Client.Del(ctx, []string{key})
-		})
+	if standaloneHosts == nil || *standaloneHosts == "" {
+		t.Skip("No --standalone-endpoints provided")
 	}
+
+	pool := newPool(t, false, glide.PoolConfig{
+		MaxSize:        2,
+		MinIdle:        1,
+		AcquireTimeout: 10 * time.Second,
+	})
+	defer pool.Close()
+
+	waitForPoolReady(t, pool, 1)
+
+	ctx := context.Background()
+	clientID, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+
+	client, err := pool.GetClient(clientID)
+	require.NoError(t, err)
+	defer client.Close()
+
+	key := scopeTestKey("pool-scope-combo", false)
+
+	// Seed a counter via the pooled client
+	_, err = client.Set(ctx, key, "10")
+	require.NoError(t, err)
+
+	// Open a scoped connection on the pool-borrowed client
+	scope, err := client.ScopedConnection(ctx, 10*time.Second, "")
+	require.NoError(t, err, "ScopedConnection on pool-borrowed client should succeed (fix for #6763)")
+	defer scope.Close()
+
+	assert.False(t, scope.IsReleased())
+
+	// Full OCC cycle: WATCH → GET → MULTI → SET → EXEC
+	_, err = scope.Watch(ctx, key)
+	require.NoError(t, err)
+
+	val, err := scope.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, "10", val)
+
+	_, err = scope.Multi(ctx)
+	require.NoError(t, err)
+
+	_, err = scope.Set(ctx, key, "11")
+	require.NoError(t, err)
+
+	result, err := scope.Exec(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result, "EXEC should commit (no conflict)")
+
+	// Verify via the pooled client
+	finalVal, err := client.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, "11", finalVal.Value())
+
+	// Cleanup
+	client.Client.Del(ctx, []string{key})
 }

--- a/go/isolated_scope.go
+++ b/go/isolated_scope.go
@@ -256,14 +256,20 @@ func (client *Client) ScopedConnection(ctx context.Context, timeout time.Duratio
 	clientID := uint64(uintptr(client.coreClient))
 	client.mu.Unlock()
 
-	// Get connection request bytes
-	request, err := client.getConnectionRequest()
-	if err != nil {
-		return nil, err
-	}
-	connReqBytes, err := proto.Marshal(request)
-	if err != nil {
-		return nil, err
+	// Use pre-serialized connection request bytes if available (pool-borrowed clients),
+	// otherwise serialize from the client configuration.
+	var connReqBytes []byte
+	if client.connReqBytes != nil {
+		connReqBytes = client.connReqBytes
+	} else {
+		request, err := client.getConnectionRequest()
+		if err != nil {
+			return nil, err
+		}
+		connReqBytes, err = proto.Marshal(request)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	routingSlot := uint16(0)
@@ -350,14 +356,20 @@ func (client *ClusterClient) ScopedConnection(
 	clientID := uint64(uintptr(client.coreClient))
 	client.mu.Unlock()
 
-	// Get connection request bytes
-	request, err := client.getConnectionRequest()
-	if err != nil {
-		return nil, err
-	}
-	connReqBytes, err := proto.Marshal(request)
-	if err != nil {
-		return nil, err
+	// Use pre-serialized connection request bytes if available (pool-borrowed clients),
+	// otherwise serialize from the client configuration.
+	var connReqBytes []byte
+	if client.connReqBytes != nil {
+		connReqBytes = client.connReqBytes
+	} else {
+		request, err := client.getConnectionRequest()
+		if err != nil {
+			return nil, err
+		}
+		connReqBytes, err = proto.Marshal(request)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	routingSlot := uint16(0)


### PR DESCRIPTION
### Summary

Propagate the pool's serialized `ConnectionRequest` bytes into pool-borrowed `Client` wrappers so `ScopedConnection` works on pooled clients.

See also the same fix for Java under PR #6765.  Node is not currently impacted, but would be when we refactor Node to use the Rust core for all pool management (currently a TODO).

### Issue link

Closes #6763

### Features / Behaviour Changes

`ClientPool.GetClient()` now sets `clientConfig` and `connReqBytes` on the returned `Client`. `ScopedConnection` checks for pre-serialized bytes before falling back to config serialization, so pool-borrowed clients can open scopes without error.

### Implementation

- Added `connReqBytes []byte` field to `Client` and `ClusterClient`
- `GetClient()` propagates the pool's `clientConf` and `connReq` into the wrapper
- Both `Client.ScopedConnection` and `ClusterClient.ScopedConnection` use pre-serialized bytes when available, falling back to the existing `getConnectionRequest()` path for non-pooled clients

### Testing

Added `TestPoolBorrowedClientScopedConnection` with parameterized over standalone + cluster. Acquires from pool, opens a scope, runs a full WATCH/GET/MULTI/SET/EXEC cycle, verifies commit.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary