### PR TITLE
fix(go): declare pub/sub callback lengths as int64_t and reject out-of-range lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Go: Declare pub/sub callback lengths as `int64_t` and reject out-of-range lengths ([#6818](https://github.com/valkey-io/valkey-glide/pull/6818))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.

--- a/go/callbacks.go
+++ b/go/callbacks.go
@@ -7,11 +7,16 @@ import "C"
 
 import (
 	"log"
+	"math"
 	"sync"
 	"unsafe"
 
 	"github.com/valkey-io/valkey-glide/go/v2/models"
 )
+
+// maxPubSubPayloadLen is the largest length the pub/sub callback can copy.
+// C.GoBytes takes a 32-bit length, so anything longer cannot be copied whole.
+const maxPubSubPayloadLen = math.MaxInt32
 
 // Registry to track clients by their pointer address
 var (
@@ -54,27 +59,54 @@ func failureCallback(channelPtr unsafe.Pointer, cErrorMessage *C.char, cErrorTyp
 	resultChannel <- payload{value: nil, error: GoError(uint32(cErrorType), msg)}
 }
 
+// pubSubBytes copies length bytes from ptr, reporting failure when length falls
+// outside the range C.GoBytes accepts. The FFI layer passes int64_t lengths, so
+// narrowing to the 32-bit length C.GoBytes takes has to be checked rather than
+// silently truncating an oversized payload. name identifies the field in the log
+// line.
+func pubSubBytes(name string, ptr unsafe.Pointer, length int64) ([]byte, bool) {
+	if length < 0 || length > maxPubSubPayloadLen {
+		log.Printf("Dropping pub/sub message: %s length %d is outside the supported range of 0 to %d bytes\n",
+			name, length, maxPubSubPayloadLen)
+		return nil, false
+	}
+	return C.GoBytes(ptr, C.int(length)), true
+}
+
 //
 //export pubSubCallback
 func pubSubCallback(
 	clientPtr unsafe.Pointer,
 	pushKind C.PushKind,
 	message unsafe.Pointer,
-	message_len C.int,
+	message_len C.int64_t,
 	channel unsafe.Pointer,
-	channel_len C.int,
+	channel_len C.int64_t,
 	pattern unsafe.Pointer,
-	pattern_len C.int,
+	pattern_len C.int64_t,
 ) {
 	if clientPtr == nil {
 		return
 	}
 
-	msg := string(C.GoBytes(message, message_len))
-	cha := string(C.GoBytes(channel, channel_len))
+	messageBytes, ok := pubSubBytes("message", message, int64(message_len))
+	if !ok {
+		return
+	}
+	channelBytes, ok := pubSubBytes("channel", channel, int64(channel_len))
+	if !ok {
+		return
+	}
+
+	msg := string(messageBytes)
+	cha := string(channelBytes)
 	pat := models.CreateNilStringResult()
 	if pattern_len > 0 && pattern != nil {
-		pat = models.CreateStringResult(string(C.GoBytes(pattern, pattern_len)))
+		patternBytes, ok := pubSubBytes("pattern", pattern, int64(pattern_len))
+		if !ok {
+			return
+		}
+		pat = models.CreateStringResult(string(patternBytes))
 	}
 
 	go func() {

--- a/go/callbacks_test.go
+++ b/go/callbacks_test.go
@@ -1,0 +1,106 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+// Test files cannot use cgo, so these tests pass the Go types the cgo length and
+// pointer parameters alias: int64 for int64_t and unsafe.Pointer for uint8_t *.
+
+import (
+	"bytes"
+	"log"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+// The FFI layer declares the pub/sub callback length parameters as int64_t. Assert
+// the Go side agrees, so narrowing them back to a 32-bit type cannot slip through.
+func TestPubSubCallbackLengthParamsAre64Bit(t *testing.T) {
+	callbackType := reflect.TypeOf(pubSubCallback)
+	for name, index := range map[string]int{"message_len": 3, "channel_len": 5, "pattern_len": 7} {
+		if size := callbackType.In(index).Size(); size != 8 {
+			t.Errorf("%s is %d bytes wide, want 8", name, size)
+		}
+	}
+}
+
+func TestPubSubBytes(t *testing.T) {
+	payload := []byte("hello")
+
+	tests := []struct {
+		name   string
+		length int64
+		want   string
+		wantOk bool
+	}{
+		{name: "in range", length: 5, want: "hello", wantOk: true},
+		{name: "zero", length: 0, want: "", wantOk: true},
+		{name: "negative", length: -1, wantOk: false},
+		{name: "above 32-bit maximum", length: math.MaxInt32 + 1, wantOk: false},
+		// The length that motivated issue 6816: its low 32 bits are a small
+		// positive number, so narrowing without a check yields a short read.
+		{name: "narrows to a valid length", length: 1<<32 + 5, wantOk: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := pubSubBytes("message", unsafe.Pointer(&payload[0]), test.length)
+			if ok != test.wantOk {
+				t.Fatalf("ok = %v, want %v", ok, test.wantOk)
+			}
+			if ok && string(got) != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+			if !ok && got != nil {
+				t.Errorf("got %q, want no bytes", got)
+			}
+		})
+	}
+}
+
+func TestPubSubCallbackDropsOutOfRangeLength(t *testing.T) {
+	handler := NewMessageHandler(nil, nil)
+	client := &baseClient{}
+	client.setMessageHandler(handler)
+
+	// Stands in for the pointer the FFI layer passes back to identify the client.
+	token := []byte{0}
+	clientPtr := unsafe.Pointer(&token[0])
+	registerClient(client, uintptr(clientPtr))
+	defer unregisterClient(uintptr(clientPtr))
+
+	payload := []byte("hello")
+	payloadPtr := unsafe.Pointer(&payload[0])
+
+	var logged bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&logged)
+	defer log.SetOutput(previousOutput)
+
+	// A length whose low 32 bits are 5: truncating it would deliver a 5 byte
+	// message in place of a 4 GiB one.
+	pubSubCallback(clientPtr, 0, payloadPtr, 1<<32+5, payloadPtr, 5, nil, 0)
+
+	if message := handler.GetQueue().Pop(); message != nil {
+		t.Fatalf("delivered %+v, want the message dropped", message)
+	}
+	if !strings.Contains(logged.String(), "Dropping pub/sub message") {
+		t.Errorf("log output %q does not report the drop", logged.String())
+	}
+
+	// A message with in range lengths still arrives intact.
+	pubSubCallback(clientPtr, 0, payloadPtr, 5, payloadPtr, 5, nil, 0)
+
+	select {
+	case message := <-handler.GetQueue().WaitForMessage():
+		if message.Message != "hello" || message.Channel != "hello" {
+			t.Errorf("got message %q on channel %q, want %q on %q",
+				message.Message, message.Channel, "hello", "hello")
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("timed out waiting for the message")
+	}
+}


### PR DESCRIPTION
### Summary

The Go pub/sub callback read its three length parameters as 32-bit values while the FFI layer passed them as 64-bit. This declares them as `int64_t` on the Go side and narrows explicitly, with defined behaviour when a length does not fit.

### Issue link

This Pull Request is linked to issue: [Go: pubsub callback length parameters are int64_t in C and C.int in Go, and the registration cast hides it](https://github.com/valkey-io/valkey-glide/issues/6816)
Fixes #6816

### Features / Behaviour Changes

A pub/sub message whose message, channel or pattern length does not fit the 32-bit conversion is now dropped and reported through `log.Printf`, instead of being delivered truncated. Lengths in range behave as before.

### Implementation

`ffi/src/lib.rs` declares `PubSubCallback` with `i64` lengths, the generated `go/lib.h` agrees, and `go/base_client.go` forward-declares the callback with `int64_t message_len`, `int64_t channel_len` and `int64_t pattern_len`. The exported Go callback in `go/callbacks.go` declared all three as `C.int`, which is 32-bit, so Go read 32 bits where 64 were passed.

cgo would normally reject that. It does not here for two reasons: the callback is registered through `C.PubSubCallback(unsafe.Pointer(C.pubSubCallback))` in `go/base_client.go`, which erases the function type, and the forward declaration and the cgo-generated prototype live in separate translation units, so the two never meet at compile time.

Two changes:

1. `message_len`, `channel_len` and `pattern_len` are declared `C.int64_t`. The cgo-generated prototype in `_cgo_export.h` now reads `int64_t` for all three, matching the forward declaration and the header.
2. `C.GoBytes` still takes a 32-bit length, so the narrowing has not disappeared, only moved somewhere it can be checked. A single helper, `pubSubBytes`, validates the length against `[0, math.MaxInt32]` before converting, and the callback returns early when the check fails.

The narrowing behaviour I chose: an out-of-range length drops the message and logs the field name and the offending length. The alternatives I weighed:

- Clamping to `math.MaxInt32` would hand the subscriber a message that looks complete and give it no way to tell otherwise, which is the same class of failure the issue reports.
- Treating an out-of-range length as a protocol violation and panicking would take the process down. This runs inside an exported cgo callback on a Rust-owned thread, for a condition the application cannot act on.
- Dropping and logging never hands corrupt data to the application, leaves a record naming the field and the length, and matches what `go/callbacks.go` already does when it cannot deliver a message.

Dropping does mean the message is lost rather than surfaced as an error. The callback has no error return path to the application, so this is a local decision either way. If maintainers would rather clamp, or route it through a client-level error, that is a small change to `pubSubBytes`, and it is why this PR is a draft.

One detail reviewers may want to check: the low 32 bits decide which of the two current failures you get. A length of 4 GiB + 5 narrows to 5, and the subscriber silently receives a 5-byte message. A length of exactly 2 GiB narrows to `-2147483648`, and `C.GoBytes` panics with `gobytes: length out of range` inside the callback.

`go/callbacks.go` is the only non-test file touched. The monitor callback already uses `int64_t` throughout, and the `GET` and `MGET` response path is out of scope per the issue.

### Limitations

Reaching this bug needs a single pub/sub payload, channel name or pattern above the 32-bit signed range, so above 2 GiB. That is well past what a practical deployment publishes, so the practical risk is low. The mismatch itself is not in doubt: the two declarations disagree, and the registration cast is why no compiler catches it.

The out-of-range path is therefore not reachable against a live server. The tests exercise it by calling the exported callback directly rather than by publishing a 2 GiB message.

### Testing

`go/callbacks_test.go` is new and needs no server:

- `TestPubSubCallbackLengthParamsAre64Bit` reflects over `pubSubCallback` and asserts all three length parameters are 8 bytes wide, so narrowing them back to a 32-bit type fails the suite.
- `TestPubSubBytes` covers in-range, zero, negative, `math.MaxInt32 + 1`, and 4 GiB + 5. The last is the case from the issue: its low 32 bits are 5, so an unchecked narrowing returns a 5-byte payload.
- `TestPubSubCallbackDropsOutOfRangeLength` registers a queue-backed client, invokes the callback with a length of 4 GiB + 5, and asserts nothing reaches the queue and that the drop is logged. It then sends an in-range message through the same path and asserts it arrives intact.

Test files cannot use cgo, so the tests pass the Go types the cgo parameters alias, and `pubSubBytes` takes a plain `int64` with the conversion done at the callback boundary.

From `go/`:

- `go build ./...` is clean.
- `go vet ./...` is clean.
- `go test -run 'TestPubSubCallbackLengthParamsAre64Bit|TestPubSubBytes|TestPubSubCallbackDropsOutOfRangeLength' .` passes.

I also confirmed the mechanism outside this repo with a two-file cgo program that mirrors the split between `base_client.go` and `callbacks.go`. C passes `4294967301` through a cast function pointer, and the Go callback declared with `C.int` reads `5`, with no compiler diagnostic. Putting both declarations in one file instead makes the compiler report `conflicting types for 'cb'`, which is what the split hides.

Pre-existing on `main` and unrelated to this change: a repo-wide clippy failure on untouched Rust code, and intermittent failures in the self-hosted glide-core test job.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
