### PR TITLE
fix(go): example tests fail cleanly instead of panicking when no server is reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Go: Example tests fail cleanly instead of panicking when no server is reachable ([#6820](https://github.com/valkey-io/valkey-glide/pull/6820))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.

--- a/go/batch_test.go
+++ b/go/batch_test.go
@@ -23,6 +23,7 @@ func ExampleClient_Exec_transaction() {
 	result, err := client.Exec(context.Background(), *batch, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -38,6 +39,7 @@ func ExampleClient_Exec_pipeline() {
 	result, err := client.Exec(context.Background(), *batch, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -55,6 +57,7 @@ func ExampleClient_ExecWithOptions_transaction() {
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -72,6 +75,7 @@ func ExampleClient_ExecWithOptions_pipeline() {
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -87,6 +91,7 @@ func ExampleClusterClient_Exec_transaction() {
 	result, err := client.Exec(context.Background(), *batch, false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -102,6 +107,7 @@ func ExampleClusterClient_Exec_pipeline() {
 	result, err := client.Exec(context.Background(), *batch, false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -119,6 +125,7 @@ func ExampleClusterClient_ExecWithOptions_transaction() {
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -137,6 +144,7 @@ func ExampleClusterClient_ExecWithOptions_pipeline() {
 	result, err := client.ExecWithOptions(context.Background(), *batch, false, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -163,9 +171,17 @@ func ExampleClient_Watch_changedKey() {
 	var client *Client = getExampleClient() // example helper function
 	// Example 1: key is changed before transaction and transaction didn't execute
 	result, err := client.Watch(context.Background(), []string{"sampleKey"})
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println("Watch result: ", result)
 
 	result, err = client.Set(context.Background(), "sampleKey", "foobar")
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println("Set result: ", result)
 
 	transaction := pipeline.NewStandaloneBatch(true)
@@ -175,6 +191,7 @@ func ExampleClient_Watch_changedKey() {
 	result1, err := client.Exec(context.Background(), *transaction, false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	// Transaction result is `nil`, it is not executed at all
 	fmt.Printf("Transation result: %#v", result1)
@@ -189,6 +206,10 @@ func ExampleClient_Watch_unchangedKey() {
 	var client *Client = getExampleClient() // example helper function
 	// Example 2: key is unchanged before transaction
 	result, err := client.Watch(context.Background(), []string{"sampleKey"})
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println("Watch result: ", result)
 
 	transaction := pipeline.NewStandaloneBatch(true)
@@ -198,6 +219,7 @@ func ExampleClient_Watch_unchangedKey() {
 	result1, err := client.Exec(context.Background(), *transaction, false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Transation result: ", result1)
 
@@ -210,9 +232,17 @@ func ExampleClusterClient_Watch_changedKey() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	// Example 1: key is changed before transaction and transaction didn't execute
 	result, err := client.Watch(context.Background(), []string{"sampleKey"})
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println("Watch result: ", result)
 
 	result, err = client.Set(context.Background(), "sampleKey", "foobar")
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println("Set result: ", result)
 
 	transaction := pipeline.NewClusterBatch(true)
@@ -222,6 +252,7 @@ func ExampleClusterClient_Watch_changedKey() {
 	result1, err := client.Exec(context.Background(), *transaction, false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	// Transaction result is `nil`, it is not executed at all
 	fmt.Printf("Transation result: %#v", result1)
@@ -236,6 +267,10 @@ func ExampleClusterClient_Watch_unchangedKey() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 	// Example 2: key is unchanged before transaction
 	result, err := client.Watch(context.Background(), []string{"sampleKey"})
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println("Watch result: ", result)
 
 	transaction := pipeline.NewClusterBatch(true)
@@ -245,6 +280,7 @@ func ExampleClusterClient_Watch_unchangedKey() {
 	result1, err := client.Exec(context.Background(), *transaction, false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Transation result: ", result1)
 
@@ -258,6 +294,7 @@ func ExampleClient_Unwatch() {
 	result, err := client.Unwatch(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -270,6 +307,7 @@ func ExampleClusterClient_Unwatch() {
 	result, err := client.Unwatch(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -282,6 +320,7 @@ func ExampleClusterClient_UnwatchWithOptions() {
 	result, err := client.UnwatchWithOptions(context.Background(), options.RouteOption{Route: config.AllNodes})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 

--- a/go/bitmap_commands_test.go
+++ b/go/bitmap_commands_test.go
@@ -17,6 +17,7 @@ func ExampleClient_SetBit() {
 	result, err := client.SetBit(context.Background(), "my_key", 1, 1) // set bit should return the previous value of bit 1
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -31,6 +32,7 @@ func ExampleClusterClient_SetBit() {
 	result, err := client.SetBit(context.Background(), "my_key", 1, 1) // set bit should return the previous value of bit 1
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -44,6 +46,7 @@ func ExampleClient_GetBit() {
 	result, err := client.GetBit(context.Background(), "my_key", 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -58,6 +61,7 @@ func ExampleClusterClient_GetBit() {
 	result, err := client.GetBit(context.Background(), "my_key", 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -72,6 +76,7 @@ func ExampleClient_BitCount() {
 	result, err := client.BitCount(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -86,6 +91,7 @@ func ExampleClusterClient_BitCount() {
 	result, err := client.BitCount(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -102,6 +108,7 @@ func ExampleClient_BitCountWithOptions() {
 	result, err := client.BitCountWithOptions(context.Background(), "my_key", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -118,6 +125,7 @@ func ExampleClusterClient_BitCountWithOptions() {
 	result, err := client.BitCountWithOptions(context.Background(), "my_key", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -136,6 +144,7 @@ func ExampleClient_BitField() {
 	result, err := client.BitField(context.Background(), "mykey", commands)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -154,6 +163,7 @@ func ExampleClusterClient_BitField() {
 	result, err := client.BitField(context.Background(), "mykey", commands)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -175,6 +185,7 @@ func ExampleClient_BitFieldRO() {
 	result, err := client.BitFieldRO(context.Background(), key, commands)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -196,6 +207,7 @@ func ExampleClusterClient_BitFieldRO() {
 	result, err := client.BitFieldRO(context.Background(), key, commands)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -310,6 +322,7 @@ func ExampleClient_BitPos() {
 	result, err := client.BitPos(context.Background(), "my_key", 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -324,6 +337,7 @@ func ExampleClusterClient_BitPos() {
 	result, err := client.BitPos(context.Background(), "my_key", 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -342,6 +356,7 @@ func ExampleClient_BitPosWithOptions() {
 	result, err := client.BitPosWithOptions(context.Background(), "my_key", 1, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -361,6 +376,7 @@ func ExampleClusterClient_BitPosWithOptions() {
 	result, err := client.BitPosWithOptions(context.Background(), "my_key", 1, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 

--- a/go/connection_management_cluster_commands_test.go
+++ b/go/connection_management_cluster_commands_test.go
@@ -17,6 +17,7 @@ func ExampleClusterClient_Ping() {
 	result, err := client.Ping(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -34,6 +35,7 @@ func ExampleClusterClient_PingWithOptions() {
 	result, err := client.PingWithOptions(context.Background(), options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -45,6 +47,7 @@ func ExampleClusterClient_Echo() {
 	result, err := client.Echo(context.Background(), "Hello")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -56,6 +59,7 @@ func ExampleClusterClient_EchoWithOptions() {
 	result, err := client.EchoWithOptions(context.Background(), "Hello World", options.RouteOption{Route: config.RandomRoute})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.SingleValue())
 
@@ -67,6 +71,7 @@ func ExampleClusterClient_ClientId() {
 	result, err := client.ClientId(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	assert := result.IsSingleValue()
 	fmt.Println(assert)
@@ -80,6 +85,7 @@ func ExampleClusterClient_ClientIdWithOptions() {
 	result, err := client.ClientIdWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	assert := result.IsSingleValue()
 	fmt.Println(assert)
@@ -93,6 +99,7 @@ func ExampleClusterClient_ClientSetName() {
 	result, err := client.ClientSetName(context.Background(), connectionName)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -106,6 +113,7 @@ func ExampleClusterClient_ClientGetName() {
 	result, err := client.ClientGetName(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value() == connectionName)
 
@@ -119,6 +127,7 @@ func ExampleClusterClient_ClientSetNameWithOptions() {
 	result, err := client.ClientSetNameWithOptions(context.Background(), connectionName, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -133,6 +142,7 @@ func ExampleClusterClient_ClientGetNameWithOptions() {
 	result, err := client.ClientGetNameWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.SingleValue().Value() == connectionName)
 
@@ -144,6 +154,7 @@ func ExampleClusterClient_ClientPause() {
 	result, err := client.ClientPause(context.Background(), 0)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -160,6 +171,7 @@ func ExampleClusterClient_ClientPauseWithOptions() {
 	result, err := client.ClientPauseWithOptions(context.Background(), 0, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -171,6 +183,7 @@ func ExampleClusterClient_ClientUnpause() {
 	result, err := client.ClientUnpause(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -183,6 +196,7 @@ func ExampleClusterClient_ClientUnpauseWithOptions() {
 	result, err := client.ClientUnpauseWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 

--- a/go/connection_management_commands_test.go
+++ b/go/connection_management_commands_test.go
@@ -15,6 +15,7 @@ func ExampleClient_ClientPause() {
 	result, err := client.ClientPause(context.Background(), 0)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -26,6 +27,7 @@ func ExampleClient_ClientPauseWithMode() {
 	result, err := client.ClientPauseWithMode(context.Background(), 0, options.ClientPauseModeWrite)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -37,6 +39,7 @@ func ExampleClient_ClientUnpause() {
 	result, err := client.ClientUnpause(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -48,6 +51,7 @@ func ExampleClient_Ping() {
 	result, err := client.Ping(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -60,6 +64,7 @@ func ExampleClient_PingWithOptions() {
 	result, err := client.PingWithOptions(context.Background(), options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -71,6 +76,7 @@ func ExampleClient_Echo() {
 	result, err := client.Echo(context.Background(), "Hello World")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -82,6 +88,7 @@ func ExampleClient_ClientId() {
 	result, err := client.ClientId(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	assert := result > 0
 	fmt.Println(assert)
@@ -94,6 +101,7 @@ func ExampleClient_ClientSetName() {
 	result, err := client.ClientSetName(context.Background(), "ConnectionName")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -107,6 +115,7 @@ func ExampleClient_ClientGetName() {
 	result, err := client.ClientGetName(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value() == connectionName)
 

--- a/go/create_client_test.go
+++ b/go/create_client_test.go
@@ -26,6 +26,7 @@ func ExampleNewClient() {
 	client, err := NewClient(clientConf)
 	if err != nil {
 		fmt.Println("Failed to create a client and connect: ", err)
+		return
 	}
 	fmt.Printf("Client created and connected: %T", client)
 
@@ -48,6 +49,7 @@ func ExampleNewClusterClient() {
 	client, err := NewClusterClient(clientConf)
 	if err != nil {
 		fmt.Println("Failed to create a client and connect: ", err)
+		return
 	}
 	fmt.Printf("Client created and connected: %T", client)
 
@@ -72,6 +74,7 @@ func ExampleNewClusterClient_withDatabaseId() {
 	client, err := NewClusterClient(clientConf)
 	if err != nil {
 		fmt.Println("Failed to create a client and connect: ", err)
+		return
 	}
 	fmt.Printf("Client created and connected: %T", client)
 

--- a/go/example_utils.go
+++ b/go/example_utils.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/valkey-io/valkey-glide/go/v2/config"
+	"github.com/valkey-io/valkey-glide/go/v2/models"
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 )
 
@@ -57,6 +58,28 @@ func getClusterAddresses() []config.NodeAddress {
 	return clusterAddresses
 }
 
+// newUnavailableBaseClient returns the shared state of a client that is not connected to
+// any server: a usable mutex, no core client, and a callback-only message handler.
+//
+// Commands on such a client report "the client is closed" and GetQueue reports an error,
+// so an example that cannot reach a server fails with a readable message. Returning a nil
+// client instead would make the example panic on its first command, which aborts the whole
+// test binary and hides the result of every other example in the package.
+func newUnavailableBaseClient() baseClient {
+	return baseClient{
+		mu:             &sync.Mutex{},
+		messageHandler: NewMessageHandler(func(*models.PubSubMessage, any) {}, nil),
+	}
+}
+
+func newUnavailableClient() *Client {
+	return &Client{baseClient: newUnavailableBaseClient()}
+}
+
+func newUnavailableClusterClient() *ClusterClient {
+	return &ClusterClient{baseClient: newUnavailableBaseClient()}
+}
+
 // getExampleClient returns a Client instance for testing purposes.
 // This function is used in the examples of the Client methods.
 func getExampleClient() *Client {
@@ -70,7 +93,7 @@ func getExampleClient() *Client {
 	client, err := NewClient(config)
 	if err != nil {
 		fmt.Println("error connecting to server: ", err)
-		return nil
+		return newUnavailableClient()
 	}
 
 	standaloneClients = append(standaloneClients, client)
@@ -95,7 +118,7 @@ func getExampleClusterClient() *ClusterClient {
 	client, err := NewClusterClient(cConfig)
 	if err != nil {
 		fmt.Println("error connecting to server: ", err)
-		return nil
+		return newUnavailableClusterClient()
 	}
 
 	clusterClients = append(clusterClients, client)
@@ -127,7 +150,7 @@ func getExampleClientWithSubscription(mode config.PubSubChannelMode, channelOrPa
 	client, err := NewClient(config)
 	if err != nil {
 		fmt.Println("error connecting to server: ", err)
-		return nil
+		return newUnavailableClient()
 	}
 
 	standaloneClients = append(standaloneClients, client)
@@ -158,7 +181,7 @@ func getExampleClusterClientWithSubscription(
 	client, err := NewClusterClient(ccConfig)
 	if err != nil {
 		fmt.Println("error connecting to server: ", err)
-		return nil
+		return newUnavailableClusterClient()
 	}
 
 	clusterClients = append(clusterClients, client)

--- a/go/ft_commands_test.go
+++ b/go/ft_commands_test.go
@@ -36,11 +36,13 @@ func Example_clusterFtCreate() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	result, err := glideft.ClusterFtList(ctx, client)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result) > 0)
 
@@ -75,6 +77,7 @@ func Example_clusterFtSearch() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	client.HSet(ctx, prefix+"1", map[string]string{"title": "hello world", "score": "10"})
@@ -86,6 +89,7 @@ func Example_clusterFtSearch() {
 	result, err := glideft.ClusterFtSearch(ctx, client, index, "@score:[10 10]", nil)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.TotalResults)
 
@@ -119,6 +123,7 @@ func Example_clusterFtAggregate() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	client.HSet(ctx, prefix+"1", map[string]string{"score": "10"})
@@ -136,6 +141,7 @@ func Example_clusterFtAggregate() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(rows))
 
@@ -169,11 +175,13 @@ func Example_ftCreate() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	result, err := glideft.FtList(ctx, client)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result) > 0)
 
@@ -208,6 +216,7 @@ func Example_ftSearch() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	client.HSet(ctx, prefix+"1", map[string]string{"title": "hello world", "score": "10"})
@@ -219,6 +228,7 @@ func Example_ftSearch() {
 	result, err := glideft.FtSearch(ctx, client, index, "@score:[10 10]", nil)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.TotalResults)
 
@@ -252,6 +262,7 @@ func Example_ftAggregate() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	client.HSet(ctx, prefix+"1", map[string]string{"score": "10"})
@@ -269,6 +280,7 @@ func Example_ftAggregate() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(rows))
 

--- a/go/generic_base_commands_test.go
+++ b/go/generic_base_commands_test.go
@@ -18,6 +18,7 @@ func ExampleClient_Del() {
 	result2, err := client.Del(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -36,6 +37,7 @@ func ExampleClusterClient_Del() {
 	result2, err := client.Del(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -54,6 +56,7 @@ func ExampleClient_Exists() {
 	result2, err := client.Exists(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -72,6 +75,7 @@ func ExampleClusterClient_Exists() {
 	result2, err := client.Exists(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -90,6 +94,7 @@ func ExampleClient_Expire() {
 	result2, err := client.Expire(context.Background(), "key", 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -108,6 +113,7 @@ func ExampleClusterClient_Expire() {
 	result2, err := client.Expire(context.Background(), "key", 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -125,6 +131,7 @@ func ExampleClient_ExpireWithOptions() {
 	result1, err := client.ExpireWithOptions(context.Background(), "key", 1*time.Second, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -140,6 +147,7 @@ func ExampleClusterClient_ExpireWithOptions() {
 	result1, err := client.ExpireWithOptions(context.Background(), "key", 1*time.Second, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -155,6 +163,7 @@ func ExampleClient_ExpireAt() {
 	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Add(1*time.Second))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -170,6 +179,7 @@ func ExampleClusterClient_ExpireAt() {
 	result1, err := client.ExpireAt(context.Background(), "key", time.Now().Add(1*time.Second))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -190,6 +200,7 @@ func ExampleClient_ExpireAtWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -210,6 +221,7 @@ func ExampleClusterClient_ExpireAtWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -225,6 +237,7 @@ func ExampleClient_PExpire() {
 	result1, err := client.PExpire(context.Background(), "key", 5000*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -240,6 +253,7 @@ func ExampleClusterClient_PExpire() {
 	result1, err := client.PExpire(context.Background(), "key", 5000*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -255,6 +269,7 @@ func ExampleClient_PExpireWithOptions() {
 	result1, err := client.PExpireWithOptions(context.Background(), "key", 5000*time.Millisecond, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -270,6 +285,7 @@ func ExampleClusterClient_PExpireWithOptions() {
 	result1, err := client.PExpireWithOptions(context.Background(), "key", 5000*time.Millisecond, constants.HasNoExpiry)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -285,6 +301,7 @@ func ExampleClient_PExpireAt() {
 	result1, err := client.PExpireAt(context.Background(), "key", time.Now().Add(10000*time.Millisecond))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -300,6 +317,7 @@ func ExampleClusterClient_PExpireAt() {
 	result1, err := client.PExpireAt(context.Background(), "key", time.Now().Add(10000*time.Millisecond))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -320,6 +338,7 @@ func ExampleClient_PExpireAtWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -340,6 +359,7 @@ func ExampleClusterClient_PExpireAtWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -360,6 +380,7 @@ func ExampleClient_ExpireTime() {
 	) // ExpireTime("key") returns proper unix timestamp in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -380,6 +401,7 @@ func ExampleClusterClient_ExpireTime() {
 	) // ExpireTime("key") returns proper unix timestamp in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -400,6 +422,7 @@ func ExampleClient_PExpireTime() {
 	) // PExpireTime("key") returns proper unix time in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -420,6 +443,7 @@ func ExampleClusterClient_PExpireTime() {
 	) // PExpireTime("key") returns proper unix time in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -440,6 +464,7 @@ func ExampleClient_TTL() {
 	) // TTL("key") returns proper TTL in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -460,6 +485,7 @@ func ExampleClusterClient_TTL() {
 	) // TTL("key") returns proper TTL in seconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -480,6 +506,7 @@ func ExampleClient_PTTL() {
 	) // PTTL("key") returns proper TTL in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -500,6 +527,7 @@ func ExampleClusterClient_PTTL() {
 	) // PTTL("key") returns proper TTL in milliseconds
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -516,6 +544,7 @@ func ExampleClient_Unlink() {
 	result2, err := client.Unlink(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -534,6 +563,7 @@ func ExampleClusterClient_Unlink() {
 	result2, err := client.Unlink(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -552,6 +582,7 @@ func ExampleClient_Touch() {
 	result2, err := client.Touch(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -570,6 +601,7 @@ func ExampleClusterClient_Touch() {
 	result2, err := client.Touch(context.Background(), []string{"key1", "key2", "key3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -587,6 +619,7 @@ func ExampleClient_Type() {
 	result1, err := client.Type(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -602,6 +635,7 @@ func ExampleClusterClient_Type() {
 	result1, err := client.Type(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -617,6 +651,7 @@ func ExampleClient_Rename() {
 	result1, err := client.Rename(context.Background(), "key1", "key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -632,6 +667,7 @@ func ExampleClusterClient_Rename() {
 	result1, err := client.Rename(context.Background(), "{key}1", "{key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -647,6 +683,7 @@ func ExampleClient_RenameNX() {
 	result1, err := client.RenameNX(context.Background(), "key1", "key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -662,6 +699,7 @@ func ExampleClusterClient_RenameNX() {
 	result1, err := client.RenameNX(context.Background(), "{key}1", "{key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -678,6 +716,7 @@ func ExampleClient_Persist() {
 	result2, err := client.Persist(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -696,6 +735,7 @@ func ExampleClusterClient_Persist() {
 	result2, err := client.Persist(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -715,6 +755,7 @@ func ExampleClient_Restore() {
 	result2, err := client.Restore(context.Background(), "key1", 0, dump.Value())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -734,6 +775,7 @@ func ExampleClusterClient_Restore() {
 	result2, err := client.Restore(context.Background(), "key1", 0, dump.Value())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -754,6 +796,7 @@ func ExampleClient_RestoreWithOptions() {
 	result2, err := client.RestoreWithOptions(context.Background(), "key1", 0, dump.Value(), *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -774,6 +817,7 @@ func ExampleClusterClient_RestoreWithOptions() {
 	result2, err := client.RestoreWithOptions(context.Background(), "key1", 0, dump.Value(), *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -791,6 +835,7 @@ func ExampleClient_ObjectEncoding() {
 	result1, err := client.ObjectEncoding(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -806,6 +851,7 @@ func ExampleClusterClient_ObjectEncoding() {
 	result1, err := client.ObjectEncoding(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -821,6 +867,7 @@ func ExampleClient_Dump() {
 	result1, err := client.Dump(context.Background(), "key1") // Contains serialized value of the data stored at key1
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1.IsNil())
@@ -836,6 +883,7 @@ func ExampleClusterClient_Dump() {
 	result1, err := client.Dump(context.Background(), "key1") // Contains serialized value of the data stored at key1
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1.IsNil())
@@ -855,6 +903,7 @@ func ExampleClient_ObjectFreq() {
 	result, err := client.ObjectFreq(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -871,6 +920,7 @@ func ExampleClusterClient_ObjectFreq() {
 	result1, err := client.ObjectFreq(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -887,6 +937,7 @@ func ExampleClient_ObjectIdleTime() {
 	result1, err := client.ObjectIdleTime(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -905,6 +956,7 @@ func ExampleClusterClient_ObjectIdleTime() {
 	result1, err := client.ObjectIdleTime(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -924,6 +976,7 @@ func ExampleClient_ObjectRefCount() {
 	result1, err := client.ObjectRefCount(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -940,6 +993,7 @@ func ExampleClusterClient_ObjectRefCount() {
 	result1, err := client.ObjectRefCount(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -955,6 +1009,7 @@ func ExampleClient_Sort() {
 	result1, err := client.Sort(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -970,6 +1025,7 @@ func ExampleClusterClient_Sort() {
 	result1, err := client.Sort(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -989,6 +1045,7 @@ func ExampleClient_SortWithOptions() {
 	result1, err := client.SortWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1005,6 +1062,7 @@ func ExampleClusterClient_SortWithOptions() {
 	result1, err := client.SortWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1020,6 +1078,7 @@ func ExampleClient_SortStore() {
 	result1, err := client.SortStore(context.Background(), "key1", "key1_store")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1035,6 +1094,7 @@ func ExampleClusterClient_SortStore() {
 	result1, err := client.SortStore(context.Background(), "{key}1", "{key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1054,6 +1114,7 @@ func ExampleClient_SortStoreWithOptions() {
 	result1, err := client.SortStoreWithOptions(context.Background(), "key1", "key1_store", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1070,6 +1131,7 @@ func ExampleClusterClient_SortStoreWithOptions() {
 	result1, err := client.SortStoreWithOptions(context.Background(), "{key}1", "{key}2", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1085,6 +1147,7 @@ func ExampleClient_SortReadOnly() {
 	result1, err := client.SortReadOnly(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1100,6 +1163,7 @@ func ExampleClusterClient_SortReadOnly() {
 	result1, err := client.SortReadOnly(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1119,6 +1183,7 @@ func ExampleClient_SortReadOnlyWithOptions() {
 	result1, err := client.SortReadOnlyWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1135,6 +1200,7 @@ func ExampleClusterClient_SortReadOnlyWithOptions() {
 	result1, err := client.SortReadOnlyWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1150,6 +1216,7 @@ func ExampleClient_Wait() {
 	result, err := client.Wait(context.Background(), 2, 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Wait returns different results each time. Check it is the proper return type instead
@@ -1165,6 +1232,7 @@ func ExampleClusterClient_Wait() {
 	result, err := client.Wait(context.Background(), 2, 1*time.Second)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result < 10)
 
@@ -1179,6 +1247,7 @@ func ExampleClient_Copy() {
 	result2, err := client.Get(context.Background(), "key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1197,6 +1266,7 @@ func ExampleClusterClient_Copy() {
 	result2, err := client.Get(context.Background(), "{key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -1218,6 +1288,7 @@ func ExampleClient_CopyWithOptions() {
 	result, err := client.Get(context.Background(), "key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -1235,6 +1306,7 @@ func ExampleClusterClient_CopyWithOptions() {
 	result, err := client.Get(context.Background(), "{key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result.Value())
@@ -1254,6 +1326,7 @@ func ExampleClusterClient_CopyWithOptions_dbDestination() {
 	result, err := client.Get(context.Background(), "{key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result.Value())

--- a/go/generic_cluster_commands_test.go
+++ b/go/generic_cluster_commands_test.go
@@ -20,6 +20,7 @@ func ExampleClusterClient_CustomCommand() {
 	result, err := client.CustomCommand(context.Background(), []string{"ping"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.SingleValue().(string))
 
@@ -30,7 +31,11 @@ func ExampleClusterClient_CustomCommandWithRoute() {
 	var client *ClusterClient = getExampleClusterClient() // example helper function
 
 	route := config.SimpleNodeRoute(config.RandomRoute)
-	result, _ := client.CustomCommandWithRoute(context.Background(), []string{"ping"}, route)
+	result, err := client.CustomCommandWithRoute(context.Background(), []string{"ping"}, route)
+	if err != nil {
+		fmt.Println("Glide example failed with an error: ", err)
+		return
+	}
 	fmt.Println(result.SingleValue().(string))
 
 	// Output: PONG
@@ -48,6 +53,7 @@ func ExampleClusterClient_Scan() {
 	_, err := client.MSet(context.Background(), keysToSet)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	cursor := models.NewClusterScanCursor()
@@ -82,11 +88,13 @@ func ExampleClusterClient_ScanWithOptions_match() {
 	_, err := client.MSet(context.Background(), keysToSet)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	_, err = client.SAdd(context.Background(), "someKey", []string{"value"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	cursor := models.NewClusterScanCursor()
@@ -121,11 +129,13 @@ func ExampleClusterClient_ScanWithOptions_matchNonUTF8() {
 	_, err := client.MSet(context.Background(), keysToSet)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	_, err = client.SAdd(context.Background(), "someKey", []string{"value"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	cursor := models.NewClusterScanCursor()
@@ -160,6 +170,7 @@ func ExampleClusterClient_ScanWithOptions_count() {
 	_, err := client.MSet(context.Background(), keysToSet)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	cursor := models.NewClusterScanCursor()
@@ -194,11 +205,13 @@ func ExampleClusterClient_ScanWithOptions_type() {
 	_, err := client.MSet(context.Background(), keysToSet)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	_, err = client.SAdd(context.Background(), "someKey", []string{"value"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	cursor := models.NewClusterScanCursor()
@@ -226,6 +239,7 @@ func ExampleClusterClient_RandomKey() {
 	result, err := client.RandomKey(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(len(result.Value()) > 0)
@@ -241,6 +255,7 @@ func ExampleClusterClient_RandomKeyWithRoute() {
 	result, err := client.RandomKeyWithRoute(context.Background(), options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(len(result.Value()) > 0)

--- a/go/generic_commands_test.go
+++ b/go/generic_commands_test.go
@@ -18,6 +18,7 @@ func ExampleClient_CustomCommand() {
 	result, err := client.CustomCommand(context.Background(), []string{"ping"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -30,10 +31,12 @@ func ExampleClient_Move() {
 	_, err := client.Set(context.Background(), key, "hello")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	result, err := client.Move(context.Background(), key, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -46,10 +49,12 @@ func ExampleClusterClient_Move() {
 	_, err := client.Set(context.Background(), key, "hello")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	result, err := client.Move(context.Background(), key, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -63,6 +68,7 @@ func ExampleClient_Scan() {
 	result, err := client.Scan(context.Background(), models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -80,6 +86,7 @@ func ExampleClient_ScanWithOptions() {
 	result, err := client.ScanWithOptions(context.Background(), models.NewCursor(), *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -96,6 +103,7 @@ func ExampleClient_RandomKey() {
 	result, err := client.RandomKey(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result.Value()) > 0)
 

--- a/go/geospacial_commands_test.go
+++ b/go/geospacial_commands_test.go
@@ -25,6 +25,7 @@ func ExampleClient_GeoAdd() {
 	result, err := client.GeoAdd(context.Background(), uuid.New().String(), membersToCoordinates)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -44,6 +45,7 @@ func ExampleClusterClient_GeoAdd() {
 	result, err := client.GeoAdd(context.Background(), uuid.New().String(), membersToCoordinates)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -64,12 +66,14 @@ func ExampleClient_GeoHash() {
 	_, err := client.GeoAdd(context.Background(), key, membersToCoordinates)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Test getting geohash for multiple members
 	geoHashResults, err := client.GeoHash(context.Background(), key, []string{"Palermo", "Catania"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(geoHashResults)
 
@@ -89,12 +93,14 @@ func ExampleClusterClient_GeoHash() {
 	_, err := client.GeoAdd(context.Background(), key, membersToCoordinates)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Test getting geohash for multiple members
 	geoHashResults, err := client.GeoHash(context.Background(), key, []string{"Palermo", "Catania"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(geoHashResults)
 
@@ -112,11 +118,13 @@ func ExampleClient_GeoPos() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	positions, err := client.GeoPos(context.Background(), key, []string{"Palermo", "Catania"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(positions)
@@ -135,11 +143,13 @@ func ExampleClusterClient_GeoPos() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	positions, err := client.GeoPos(context.Background(), key, []string{"Palermo", "Catania"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(positions)
@@ -162,12 +172,14 @@ func ExampleClient_GeoDist() {
 	_, err := client.GeoAdd(context.Background(), key, membersToCoordinates)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Test getting geodist for multiple members
 	result, err := client.GeoDist(context.Background(), key, member1, member2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -189,11 +201,13 @@ func ExampleClusterClient_GeoDist() {
 	_, err := client.GeoAdd(context.Background(), key, membersToCoordinates)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	// Test getting geodist for multiple members
 	result, err := client.GeoDist(context.Background(), key, member1, member2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -216,6 +230,7 @@ func ExampleClient_GeoSearch() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -239,6 +254,7 @@ func ExampleClusterClient_GeoSearch() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -263,6 +279,7 @@ func ExampleClient_GeoSearchWithResultOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -287,6 +304,7 @@ func ExampleClusterClient_GeoSearchWithResultOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -312,6 +330,7 @@ func ExampleClient_GeoSearchWithFullOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -337,6 +356,7 @@ func ExampleClusterClient_GeoSearchWithFullOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -361,6 +381,7 @@ func ExampleClient_GeoSearchWithInfoOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -385,6 +406,7 @@ func ExampleClusterClient_GeoSearchWithInfoOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -410,6 +432,7 @@ func ExampleClient_GeoSearchStore() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -435,6 +458,7 @@ func ExampleClusterClient_GeoSearchStore() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -461,6 +485,7 @@ func ExampleClient_GeoSearchStoreWithInfoOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -487,6 +512,7 @@ func ExampleClusterClient_GeoSearchStoreWithInfoOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -513,6 +539,7 @@ func ExampleClient_GeoSearchStoreWithResultOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -539,6 +566,7 @@ func ExampleClusterClient_GeoSearchStoreWithResultOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -566,6 +594,7 @@ func ExampleClient_GeoSearchStoreWithFullOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -593,6 +622,7 @@ func ExampleClusterClient_GeoSearchStoreWithFullOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)

--- a/go/hash_commands_test.go
+++ b/go/hash_commands_test.go
@@ -24,6 +24,7 @@ func ExampleClient_HGet() {
 	payload2, err := client.HGet(context.Background(), "my_hash", "nonexistent_field")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(payload)
@@ -48,6 +49,7 @@ func ExampleClusterClient_HGet() {
 	payload2, err := client.HGet(context.Background(), "my_hash", "nonexistent_field")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(payload)
@@ -71,6 +73,7 @@ func ExampleClient_HGetAll() {
 	payload, err := client.HGetAll(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(payload["field1"])
@@ -95,6 +98,7 @@ func ExampleClusterClient_HGetAll() {
 	payload, err := client.HGetAll(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(payload["field1"])
@@ -119,6 +123,7 @@ func ExampleClient_HMGet() {
 	values, err := client.HMGet(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(values[0])
@@ -142,6 +147,7 @@ func ExampleClusterClient_HMGet() {
 	values, err := client.HMGet(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(values[0])
@@ -165,6 +171,7 @@ func ExampleClient_HSet() {
 	result1, err := client.HGet(context.Background(), "my_hash", "field1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -186,6 +193,7 @@ func ExampleClusterClient_HSet() {
 	result1, err := client.HGet(context.Background(), "my_hash", "field1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -208,6 +216,7 @@ func ExampleClient_HSetNX() {
 	payload, err := client.HGet(context.Background(), "my_hash", "field3")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -232,6 +241,7 @@ func ExampleClusterClient_HSetNX() {
 	payload, err := client.HGet(context.Background(), "my_hash", "field3")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -255,6 +265,7 @@ func ExampleClient_HDel() {
 	result1, err := client.HDel(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -276,6 +287,7 @@ func ExampleClusterClient_HDel() {
 	result1, err := client.HDel(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -297,6 +309,7 @@ func ExampleClient_HLen() {
 	result1, err := client.HLen(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -318,6 +331,7 @@ func ExampleClusterClient_HLen() {
 	result1, err := client.HLen(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -340,6 +354,7 @@ func ExampleClient_HVals() {
 	result1, err := client.HVals(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -362,6 +377,7 @@ func ExampleClusterClient_HVals() {
 	result1, err := client.HVals(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -383,6 +399,7 @@ func ExampleClient_HExists() {
 	result1, err := client.HExists(context.Background(), "my_hash", "field1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -404,6 +421,7 @@ func ExampleClusterClient_HExists() {
 	result1, err := client.HExists(context.Background(), "my_hash", "field1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -424,6 +442,7 @@ func ExampleClient_HKeys() {
 	result, err := client.HKeys(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -441,6 +460,7 @@ func ExampleClusterClient_HKeys() {
 	result, err := client.HKeys(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -459,6 +479,7 @@ func ExampleClient_HStrLen() {
 	result1, err := client.HStrLen(context.Background(), "my_hash", "field1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -480,6 +501,7 @@ func ExampleClusterClient_HStrLen() {
 	result1, err := client.HStrLen(context.Background(), "my_hash", "field1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -501,6 +523,7 @@ func ExampleClient_HIncrBy() {
 	result1, err := client.HIncrBy(context.Background(), "my_hash", "field1", 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -522,6 +545,7 @@ func ExampleClusterClient_HIncrBy() {
 	result1, err := client.HIncrBy(context.Background(), "my_hash", "field1", 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -543,6 +567,7 @@ func ExampleClient_HIncrByFloat() {
 	result1, err := client.HIncrByFloat(context.Background(), "my_hash", "field1", 1.5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -564,6 +589,7 @@ func ExampleClusterClient_HIncrByFloat() {
 	result1, err := client.HIncrByFloat(context.Background(), "my_hash", "field1", 1.5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -586,6 +612,7 @@ func ExampleClient_HScan() {
 	result, err := client.HScan(context.Background(), "my_hash", models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -608,6 +635,7 @@ func ExampleClusterClient_HScan() {
 	result, err := client.HScan(context.Background(), "my_hash", models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -630,6 +658,7 @@ func ExampleClient_HRandField() {
 	result, err := client.HRandField(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -649,6 +678,7 @@ func ExampleClusterClient_HRandField() {
 	result, err := client.HRandField(context.Background(), "my_hash")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -667,6 +697,7 @@ func ExampleClient_HRandFieldWithCount() {
 	result, err := client.HRandFieldWithCount(context.Background(), "my_hash", 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result) == 2)
 
@@ -685,6 +716,7 @@ func ExampleClusterClient_HRandFieldWithCount() {
 	result, err := client.HRandFieldWithCount(context.Background(), "my_hash", 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result) == 2)
 
@@ -702,6 +734,7 @@ func ExampleClient_HRandFieldWithCountWithValues() {
 	result, err := client.HRandFieldWithCountWithValues(context.Background(), "my_hash", 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result) == 2)
 
@@ -720,6 +753,7 @@ func ExampleClusterClient_HRandFieldWithCountWithValues() {
 	result, err := client.HRandFieldWithCountWithValues(context.Background(), "my_hash", 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result) == 2)
 
@@ -739,6 +773,7 @@ func ExampleClient_HScanWithOptions() {
 	result, err := client.HScanWithOptions(context.Background(), "my_hash", models.NewCursor(), *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -762,6 +797,7 @@ func ExampleClusterClient_HScanWithOptions() {
 	result, err := client.HScanWithOptions(context.Background(), "my_hash", models.NewCursor(), *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -786,6 +822,7 @@ func ExampleClient_HSetEx() {
 	result, err := client.HSetEx(context.Background(), "my_hash", fields, options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -807,6 +844,7 @@ func ExampleClusterClient_HSetEx() {
 	result, err := client.HSetEx(context.Background(), "my_hash", fields, options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -830,6 +868,7 @@ func ExampleClient_HGetEx() {
 	result, err := client.HGetEx(context.Background(), "my_hash", []string{"field1", "field2"}, options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result[0].Value())
 	fmt.Println(result[1].Value())
@@ -855,6 +894,7 @@ func ExampleClusterClient_HGetEx() {
 	result, err := client.HGetEx(context.Background(), "my_hash", []string{"field1", "field2"}, options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result[0].Value())
 	fmt.Println(result[1].Value())
@@ -885,6 +925,7 @@ func ExampleClient_HExpire() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result[0]) // 1 means expiration was set
 	fmt.Println(result[1]) // 1 means expiration was set
@@ -915,6 +956,7 @@ func ExampleClusterClient_HExpire() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result[0]) // 1 means expiration was set
 	fmt.Println(result[1]) // 1 means expiration was set
@@ -940,6 +982,7 @@ func ExampleClient_HTtl() {
 	result, err := client.HTtl(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("Field1 TTL > 0: %t\n", result[0] > 0)
 	fmt.Printf("Field2 TTL > 0: %t\n", result[1] > 0)
@@ -965,6 +1008,7 @@ func ExampleClusterClient_HTtl() {
 	result, err := client.HTtl(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("Field1 TTL > 0: %t\n", result[0] > 0)
 	fmt.Printf("Field2 TTL > 0: %t\n", result[1] > 0)
@@ -990,6 +1034,7 @@ func ExampleClient_HPersist() {
 	result, err := client.HPersist(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result[0]) // 1 means expiration was removed
 	fmt.Println(result[1]) // 1 means expiration was removed
@@ -1015,6 +1060,7 @@ func ExampleClusterClient_HPersist() {
 	result, err := client.HPersist(context.Background(), "my_hash", []string{"field1", "field2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result[0]) // 1 means expiration was removed
 	fmt.Println(result[1]) // 1 means expiration was removed

--- a/go/hyperloglog_commands_test.go
+++ b/go/hyperloglog_commands_test.go
@@ -14,6 +14,7 @@ func ExampleClient_PfAdd() {
 	result, err := client.PfAdd(context.Background(), uuid.New().String(), []string{"value1", "value2", "value3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -25,6 +26,7 @@ func ExampleClusterClient_PfAdd() {
 	result, err := client.PfAdd(context.Background(), uuid.New().String(), []string{"value1", "value2", "value3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -38,6 +40,7 @@ func ExampleClient_PfCount() {
 	result1, err := client.PfCount(context.Background(), []string{key})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -54,6 +57,7 @@ func ExampleClusterClient_PfCount() {
 	result1, err := client.PfCount(context.Background(), []string{key})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)

--- a/go/latency_commands_test.go
+++ b/go/latency_commands_test.go
@@ -43,6 +43,7 @@ func ExampleClient_LatencyReset() {
 	resetCount, err := client.LatencyReset(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("LatencyReset count: %v\n", resetCount)
 
@@ -56,6 +57,7 @@ func ExampleClient_LatencyReset_withEvents() {
 	resetCount, err := client.LatencyReset(context.Background(), "command")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("LatencyReset count: %v\n", resetCount)
 
@@ -97,6 +99,7 @@ func ExampleClusterClient_LatencyReset() {
 	resetCount, err := client.LatencyReset(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("LatencyReset count: %v\n", resetCount)
 
@@ -110,6 +113,7 @@ func ExampleClusterClient_LatencyResetWithOptions() {
 	resetCount, err := client.LatencyResetWithOptions(context.Background(), options.RouteOption{})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("LatencyReset count: %v\n", resetCount)
 

--- a/go/list_commands_test.go
+++ b/go/list_commands_test.go
@@ -18,6 +18,7 @@ func ExampleClient_LPush() {
 	result, err := client.LPush(context.Background(), "my_list", []string{"value1", "value2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -29,6 +30,7 @@ func ExampleClusterClient_LPush() {
 	result, err := client.LPush(context.Background(), "my_list", []string{"value1", "value2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -42,6 +44,7 @@ func ExampleClient_LPop() {
 	result2, err := client.LPop(context.Background(), "non_existent")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -60,6 +63,7 @@ func ExampleClusterClient_LPop() {
 	result2, err := client.LPop(context.Background(), "non_existent")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -78,6 +82,7 @@ func ExampleClient_LPopCount() {
 	result2, err := client.LPop(context.Background(), "non_existent")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -96,6 +101,7 @@ func ExampleClusterClient_LPopCount() {
 	result2, err := client.LPop(context.Background(), "non_existent")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -113,6 +119,7 @@ func ExampleClient_LPos() {
 	result1, err := client.LPos(context.Background(), "my_list", "e")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -128,6 +135,7 @@ func ExampleClusterClient_LPos() {
 	result1, err := client.LPos(context.Background(), "my_list", "e")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -148,6 +156,7 @@ func ExampleClient_LPosWithOptions() {
 	) // (Returns the second occurrence of the element "e")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -168,6 +177,7 @@ func ExampleClusterClient_LPosWithOptions() {
 	) // (Returns the second occurrence of the element "e")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -183,6 +193,7 @@ func ExampleClient_LPosCount() {
 	result1, err := client.LPosCount(context.Background(), "my_list", "e", 3)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -198,6 +209,7 @@ func ExampleClusterClient_LPosCount() {
 	result1, err := client.LPosCount(context.Background(), "my_list", "e", 3)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -215,6 +227,7 @@ func ExampleClient_LPosCountWithOptions() {
 		*options.NewLPosOptions().SetRank(2).SetMaxLen(1000))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -234,6 +247,7 @@ func ExampleClusterClient_LPosCountWithOptions() {
 		*options.NewLPosOptions().SetRank(2).SetMaxLen(1000))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -250,6 +264,7 @@ func ExampleClient_RPush() {
 	result, err := client.RPush(context.Background(), "my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -262,6 +277,7 @@ func ExampleClusterClient_RPush() {
 	result, err := client.RPush(context.Background(), "my_list", []string{"a", "b", "c", "d", "e", "e", "e"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -275,6 +291,7 @@ func ExampleClient_LRange() {
 	result1, err := client.LRange(context.Background(), "my_list", 0, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -290,6 +307,7 @@ func ExampleClusterClient_LRange() {
 	result1, err := client.LRange(context.Background(), "my_list", 0, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -305,6 +323,7 @@ func ExampleClient_LIndex() {
 	result1, err := client.LIndex(context.Background(), "my_list", 3)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -320,6 +339,7 @@ func ExampleClusterClient_LIndex() {
 	result1, err := client.LIndex(context.Background(), "my_list", 3)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -336,6 +356,7 @@ func ExampleClient_LTrim() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -354,6 +375,7 @@ func ExampleClusterClient_LTrim() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -371,6 +393,7 @@ func ExampleClient_LLen() {
 	result1, err := client.LLen(context.Background(), "my_list")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -386,6 +409,7 @@ func ExampleClusterClient_LLen() {
 	result1, err := client.LLen(context.Background(), "my_list")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -402,6 +426,7 @@ func ExampleClient_LRem() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -420,6 +445,7 @@ func ExampleClusterClient_LRem() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -438,6 +464,7 @@ func ExampleClient_RPop() {
 	result2, err := client.RPop(context.Background(), "non_existing_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -456,6 +483,7 @@ func ExampleClusterClient_RPop() {
 	result2, err := client.RPop(context.Background(), "non_existing_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -473,6 +501,7 @@ func ExampleClient_RPopCount() {
 	result1, err := client.RPopCount(context.Background(), "my_list", 4)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -488,6 +517,7 @@ func ExampleClusterClient_RPopCount() {
 	result1, err := client.RPopCount(context.Background(), "my_list", 4)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -504,6 +534,7 @@ func ExampleClient_LInsert() {
 	result1, err := client.LInsert(context.Background(), "my_list", constants.Before, "world", "there")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -520,6 +551,7 @@ func ExampleClusterClient_LInsert() {
 	result1, err := client.LInsert(context.Background(), "my_list", constants.Before, "world", "there")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -536,6 +568,7 @@ func ExampleClient_BLPop() {
 	result2, err := client.BLPop(context.Background(), []string{"list_a", "list_b"}, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -554,6 +587,7 @@ func ExampleClusterClient_BLPop() {
 	result2, err := client.BLPop(context.Background(), []string{"{list}-a", "{list}-b"}, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -573,6 +607,7 @@ func ExampleClient_BRPop() {
 	result2, err := client.BRPop(context.Background(), []string{"list_a", "list_b"}, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -592,6 +627,7 @@ func ExampleClusterClient_BRPop() {
 	result2, err := client.BRPop(context.Background(), []string{"{list}-a", "{list}-b"}, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -610,6 +646,7 @@ func ExampleClient_RPushX() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -628,6 +665,7 @@ func ExampleClusterClient_RPushX() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -646,6 +684,7 @@ func ExampleClient_LPushX() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -664,6 +703,7 @@ func ExampleClusterClient_LPushX() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -681,6 +721,7 @@ func ExampleClient_LMPop() {
 	result1, err := client.LMPop(context.Background(), []string{"my_list"}, constants.Left)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -698,6 +739,7 @@ func ExampleClusterClient_LMPop() {
 	result1, err := client.LMPop(context.Background(), []string{"my_list"}, constants.Left)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -715,6 +757,7 @@ func ExampleClient_LMPopCount() {
 	result1, err := client.LMPopCount(context.Background(), []string{"my_list"}, constants.Left, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -732,6 +775,7 @@ func ExampleClusterClient_LMPopCount() {
 	result1, err := client.LMPopCount(context.Background(), []string{"my_list"}, constants.Left, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -749,6 +793,7 @@ func ExampleClient_BLMPop() {
 	result1, err := client.BLMPop(context.Background(), []string{"my_list"}, constants.Left, 100*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -766,6 +811,7 @@ func ExampleClusterClient_BLMPop() {
 	result1, err := client.BLMPop(context.Background(), []string{"my_list"}, constants.Left, 100*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -783,6 +829,7 @@ func ExampleClient_BLMPopCount() {
 	result1, err := client.BLMPopCount(context.Background(), []string{"my_list"}, constants.Left, 2, 100*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -800,6 +847,7 @@ func ExampleClusterClient_BLMPopCount() {
 	result1, err := client.BLMPopCount(context.Background(), []string{"my_list"}, constants.Left, 2, 100*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -819,6 +867,7 @@ func ExampleClient_LSet() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -838,6 +887,7 @@ func ExampleClusterClient_LSet() {
 	result2, err := client.LRange(context.Background(), "my_list", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -858,6 +908,7 @@ func ExampleClient_LMove() {
 	result4, err := client.LRange(context.Background(), "my_list2", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -882,6 +933,7 @@ func ExampleClusterClient_LMove() {
 	result4, err := client.LRange(context.Background(), "{list}-2", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -913,6 +965,7 @@ func ExampleClient_BLMove() {
 	result4, err := client.LRange(context.Background(), "my_list2", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -944,6 +997,7 @@ func ExampleClusterClient_BLMove() {
 	result4, err := client.LRange(context.Background(), "{list}-2", 0, -1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)

--- a/go/memory_commands_test.go
+++ b/go/memory_commands_test.go
@@ -15,6 +15,7 @@ func ExampleClient_MemoryDoctor() {
 	result, err := client.MemoryDoctor(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	fmt.Printf("MemoryDoctor result is of type %T\n", result)
 
@@ -27,6 +28,7 @@ func ExampleClient_MemoryMallocStats() {
 	result, err := client.MemoryMallocStats(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	fmt.Printf("MemoryMallocStats result is of type %T\n", result)
 
@@ -39,6 +41,7 @@ func ExampleClient_MemoryPurge() {
 	result, err := client.MemoryPurge(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -51,6 +54,7 @@ func ExampleClient_MemoryStats() {
 	result, err := client.MemoryStats(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 
 	fmt.Println("TotalAllocated > 0:", result.TotalAllocated > 0)
@@ -66,6 +70,7 @@ func ExampleClusterClient_MemoryDoctor() {
 	result, err := client.MemoryDoctor(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	// Default routing returns multi-value (all primaries)
 	fmt.Println(result.IsMultiValue())
@@ -80,6 +85,7 @@ func ExampleClusterClient_MemoryDoctorWithOptions() {
 	result, err := client.MemoryDoctorWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	// RandomRoute returns single value
 	fmt.Println(result.IsSingleValue())
@@ -93,6 +99,7 @@ func ExampleClusterClient_MemoryMallocStats() {
 	result, err := client.MemoryMallocStats(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	// Default routing returns multi-value (all primaries)
 	fmt.Println(result.IsMultiValue())
@@ -107,6 +114,7 @@ func ExampleClusterClient_MemoryMallocStatsWithOptions() {
 	result, err := client.MemoryMallocStatsWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	// RandomRoute returns single value
 	fmt.Println(result.IsSingleValue())
@@ -120,6 +128,7 @@ func ExampleClusterClient_MemoryPurge() {
 	result, err := client.MemoryPurge(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -133,6 +142,7 @@ func ExampleClusterClient_MemoryPurgeWithOptions() {
 	result, err := client.MemoryPurgeWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -145,6 +155,7 @@ func ExampleClusterClient_MemoryStats() {
 	result, err := client.MemoryStats(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	// Default routing returns multi-value (all primaries)
 	fmt.Println(result.IsMultiValue())
@@ -159,6 +170,7 @@ func ExampleClusterClient_MemoryStatsWithOptions() {
 	result, err := client.MemoryStatsWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error:", err)
+		return
 	}
 	// RandomRoute returns single value
 	fmt.Println(result.IsSingleValue())

--- a/go/pubsub_commands_test.go
+++ b/go/pubsub_commands_test.go
@@ -30,6 +30,7 @@ func ExampleClient_Publish() {
 	result, err := publisher.Publish(context.Background(), "my_channel", "Hello, World!")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -61,6 +62,7 @@ func ExampleClusterClient_Publish() {
 	result, err := publisher.Publish(context.Background(), "my_channel", "Hello, World!", false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -86,6 +88,7 @@ func ExampleClient_PubSubChannels() {
 	result, err := publisher.PubSubChannels(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -105,6 +108,7 @@ func ExampleClusterClient_PubSubChannels() {
 	result, err := publisher.PubSubChannels(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -127,6 +131,7 @@ func ExampleClient_PubSubChannelsWithPattern() {
 	result, err := publisher.PubSubChannelsWithPattern(context.Background(), "news.*")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	sort.Strings(result)
@@ -150,6 +155,7 @@ func ExampleClusterClient_PubSubChannelsWithPattern() {
 	result, err := publisher.PubSubChannelsWithPattern(context.Background(), "news.*")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	sort.Strings(result)
@@ -171,6 +177,7 @@ func ExampleClusterClient_PubSubShardChannels() {
 	result, err := publisher.PubSubShardChannels(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -192,6 +199,7 @@ func ExampleClusterClient_PubSubShardChannelsWithPattern() {
 	result, err := publisher.PubSubShardChannelsWithPattern(context.Background(), "news.*")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	sort.Strings(result)
@@ -214,6 +222,7 @@ func ExampleClient_PubSubNumPat() {
 	result, err := publisher.PubSubNumPat(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -234,6 +243,7 @@ func ExampleClusterClient_PubSubNumPat() {
 	result, err := publisher.PubSubNumPat(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -258,6 +268,7 @@ func ExampleClient_PubSubNumSub() {
 	result, err := publisher.PubSubNumSub(context.Background(), "news.sports", "news.weather", "events.local")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Sort the channels for consistent output
@@ -296,6 +307,7 @@ func ExampleClusterClient_PubSubNumSub() {
 	result, err := publisher.PubSubNumSub(context.Background(), "news.sports", "news.weather", "events.local")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Sort the channels for consistent output
@@ -334,6 +346,7 @@ func ExampleClusterClient_PubSubShardNumSub() {
 	result, err := publisher.PubSubShardNumSub(context.Background(), "news.sports", "news.weather", "events.local")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Sort the channels for consistent output

--- a/go/scripting_and_function_commands_test.go
+++ b/go/scripting_and_function_commands_test.go
@@ -28,6 +28,7 @@ func ExampleClient_FunctionLoad() {
 	result, err := client.FunctionLoad(context.Background(), libraryCode, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -42,6 +43,7 @@ func ExampleClusterClient_FunctionLoad() {
 	result, err := client.FunctionLoad(context.Background(), libraryCode, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -60,6 +62,7 @@ func ExampleClusterClient_FunctionLoadWithRoute() {
 	result, err := client.FunctionLoadWithRoute(context.Background(), libraryCode, true, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -75,6 +78,7 @@ func ExampleClient_FunctionFlush() {
 	result, err := client.FunctionFlush(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -89,6 +93,7 @@ func ExampleClusterClient_FunctionFlush() {
 	result, err := client.FunctionFlush(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -107,6 +112,7 @@ func ExampleClusterClient_FunctionFlushWithRoute() {
 	result, err := client.FunctionFlushWithRoute(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -121,6 +127,7 @@ func ExampleClient_FunctionFlushSync() {
 	result, err := client.FunctionFlushSync(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -135,6 +142,7 @@ func ExampleClusterClient_FunctionFlushSync() {
 	result, err := client.FunctionFlushSync(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -153,6 +161,7 @@ func ExampleClusterClient_FunctionFlushSyncWithRoute() {
 	result, err := client.FunctionFlushSyncWithRoute(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -167,6 +176,7 @@ func ExampleClient_FunctionFlushAsync() {
 	result, err := client.FunctionFlushAsync(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -181,6 +191,7 @@ func ExampleClusterClient_FunctionFlushAsync() {
 	result, err := client.FunctionFlushAsync(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -196,6 +207,7 @@ func ExampleClusterClient_FunctionFlushAsyncWithRoute() {
 	result, err := client.FunctionFlushAsyncWithRoute(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -212,12 +224,14 @@ func ExampleClient_FCall() {
 	_, err := client.FunctionLoad(context.Background(), libraryCode, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	fcallResult, err := client.FCall(context.Background(), "myfunc")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(fcallResult)
@@ -233,12 +247,14 @@ func ExampleClusterClient_FCall() {
 	_, err := client.FunctionLoad(context.Background(), libraryCode, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	fcallResult, err := client.FCall(context.Background(), "myfunc")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(fcallResult)
@@ -258,12 +274,14 @@ func ExampleClusterClient_FCallWithRoute() {
 	_, err := client.FunctionLoadWithRoute(context.Background(), libraryCode, true, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	result, err := client.FCallWithRoute(context.Background(), "myfunc", opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	for _, value := range result.MultiValue() {
@@ -282,6 +300,7 @@ func ExampleClient_FCallWithKeysAndArgs() {
 	_, err := client.FunctionLoad(context.Background(), libraryCodeWithArgs, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
@@ -290,6 +309,7 @@ func ExampleClient_FCallWithKeysAndArgs() {
 	result, err := client.FCallWithKeysAndArgs(context.Background(), "myfunc", []string{key1, key2}, []string{"3", "4"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -305,6 +325,7 @@ func ExampleClusterClient_FCallWithKeysAndArgs() {
 	_, err := client.FunctionLoad(context.Background(), libraryCodeWithArgs, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
@@ -313,6 +334,7 @@ func ExampleClusterClient_FCallWithKeysAndArgs() {
 	result, err := client.FCallWithKeysAndArgs(context.Background(), "myfunc", []string{key1, key2}, []string{"3", "4"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -328,12 +350,14 @@ func ExampleClusterClient_FCallWithArgs() {
 	_, err := client.FunctionLoad(context.Background(), libraryCodeWithArgs, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	result, err := client.FCallWithArgs(context.Background(), "myfunc", []string{"1", "2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result.SingleValue())
@@ -353,12 +377,14 @@ func ExampleClusterClient_FCallWithArgsWithRoute() {
 	_, err := client.FunctionLoadWithRoute(context.Background(), libraryCodeWithArgs, true, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	result, err := client.FCallWithArgsWithRoute(context.Background(), "myfunc", []string{"1", "2"}, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	for _, value := range result.MultiValue() {
@@ -377,12 +403,14 @@ func ExampleClient_FCallReadOnly() {
 	_, err := client.FunctionLoad(context.Background(), libraryCode, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	fcallResult, err := client.FCallReadOnly(context.Background(), "myfunc")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(fcallResult)
@@ -398,12 +426,14 @@ func ExampleClusterClient_FCallReadOnly() {
 	_, err := client.FunctionLoad(context.Background(), libraryCode, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	fcallResult, err := client.FCallReadOnly(context.Background(), "myfunc")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(fcallResult)
@@ -423,12 +453,14 @@ func ExampleClusterClient_FCallReadOnlyWithRoute() {
 	_, err := client.FunctionLoadWithRoute(context.Background(), libraryCode, true, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	result, err := client.FCallReadOnlyWithRoute(context.Background(), "myfunc", opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	for _, value := range result.MultiValue() {
@@ -447,6 +479,7 @@ func ExampleClient_FCallReadOnlyWithKeysAndArgs() {
 	_, err := client.FunctionLoad(context.Background(), libraryCodeWithArgs, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
@@ -460,6 +493,7 @@ func ExampleClient_FCallReadOnlyWithKeysAndArgs() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -475,6 +509,7 @@ func ExampleClusterClient_FCallReadOnlyWithKeysAndArgs() {
 	_, err := client.FunctionLoad(context.Background(), libraryCodeWithArgs, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
@@ -488,6 +523,7 @@ func ExampleClusterClient_FCallReadOnlyWithKeysAndArgs() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -503,12 +539,14 @@ func ExampleClusterClient_FCallReadOnlyWithArgs() {
 	_, err := client.FunctionLoad(context.Background(), libraryCodeWithArgs, true)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	result, err := client.FCallReadOnlyWithArgs(context.Background(), "myfunc", []string{"1", "2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result.SingleValue())
@@ -528,12 +566,14 @@ func ExampleClusterClient_FCallReadOnlyWithArgsWithRoute() {
 	_, err := client.FunctionLoadWithRoute(context.Background(), libraryCodeWithArgs, true, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Call function
 	result, err := client.FCallReadOnlyWithArgsWithRoute(context.Background(), "myfunc", []string{"1", "2"}, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	for _, value := range result.MultiValue() {
@@ -662,6 +702,7 @@ func ExampleClient_FunctionDelete() {
 	result, err := client.FunctionDelete(context.Background(), "mylib")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -684,6 +725,7 @@ func ExampleClusterClient_FunctionDelete() {
 	result, err := client.FunctionDelete(context.Background(), "mylib")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -710,6 +752,7 @@ func ExampleClusterClient_FunctionDeleteWithRoute() {
 	result, err := client.FunctionDeleteWithRoute(context.Background(), "mylib", opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(result)
@@ -779,6 +822,7 @@ func ExampleClient_FunctionList() {
 	libs, err := client.FunctionList(context.Background(), query)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Printf("There are %d libraries loaded.\n", len(libs))
@@ -812,6 +856,7 @@ func ExampleClusterClient_FunctionList() {
 	libs, err := client.FunctionList(context.Background(), query)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Printf("There are %d libraries loaded.\n", len(libs))

--- a/go/server_management_cluster_commands_test.go
+++ b/go/server_management_cluster_commands_test.go
@@ -21,6 +21,7 @@ func ExampleClusterClient_Info() {
 	response, err := client.Info(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	for _, data := range response {
 		if strings.Contains(data, "cluster_enabled:1") {
@@ -42,6 +43,7 @@ func ExampleClusterClient_InfoWithOptions() {
 	response, err := client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	for _, data := range response.MultiValue() {
@@ -63,6 +65,7 @@ func ExampleClusterClient_TimeWithOptions() {
 	clusterResponse, err := client.TimeWithOptions(context.Background(), opts) // gives: {1 [1738714595 942076] map[]}
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(len(clusterResponse.SingleValue()) == 2)
@@ -79,6 +82,7 @@ func ExampleClusterClient_DBSizeWithOptions() {
 	result, err := client.DBSizeWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -91,6 +95,7 @@ func ExampleClusterClient_FlushAll() {
 	result, err := client.FlushAll(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -102,6 +107,7 @@ func ExampleClusterClient_FlushDB() {
 	result, err := client.FlushDB(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -126,6 +132,7 @@ func ExampleClusterClient_FlushAllWithOptions() {
 	result, err := client.FlushAllWithOptions(context.Background(), flushOptions)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -150,6 +157,7 @@ func ExampleClusterClient_FlushDBWithOptions() {
 	result, err := client.FlushDBWithOptions(context.Background(), flushOptions)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -186,6 +194,7 @@ func ExampleClusterClient_LolwutWithOptions() {
 	result, err := client.LolwutWithOptions(context.Background(), randomRouteOptions)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	if len(result.SingleValue()) > 0 {
@@ -201,6 +210,7 @@ func ExampleClusterClient_LastSave() {
 	result, err := client.LastSave(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsSingleValue())
 
@@ -215,6 +225,7 @@ func ExampleClusterClient_LastSaveWithOptions() {
 	result, err := client.LastSaveWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsSingleValue())
 
@@ -226,6 +237,7 @@ func ExampleClusterClient_ConfigResetStat() {
 	result, err := client.ConfigResetStat(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -238,6 +250,7 @@ func ExampleClusterClient_ConfigResetStatWithOptions() {
 	result, err := client.ConfigResetStatWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -250,6 +263,7 @@ func ExampleClusterClient_ConfigSet() {
 	result, err := client.ConfigSet(context.Background(), configParam)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -264,6 +278,7 @@ func ExampleClusterClient_ConfigSetWithOptions() {
 	result, err := client.ConfigSetWithOptions(context.Background(), configParam, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -279,6 +294,7 @@ func ExampleClusterClient_ConfigGet() {
 	result, err := client.ConfigGet(context.Background(), configParamGet)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -295,6 +311,7 @@ func ExampleClusterClient_ConfigGetWithOptions() {
 	result, err := client.ConfigGetWithOptions(context.Background(), configParamGet, opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.SingleValue())
 
@@ -311,6 +328,7 @@ func ExampleClusterClient_ConfigRewrite() {
 	res, err := client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	for _, data := range res.MultiValue() {
 		lines := strings.Split(data, "\n")
@@ -352,6 +370,7 @@ func ExampleClusterClient_ConfigRewriteWithOptions() {
 	response, err := client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	for _, data := range response.MultiValue() {
@@ -383,6 +402,7 @@ func ExampleClusterClient_ConfigRewriteWithOptions() {
 	response, err = client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	lines := strings.Split(response.SingleValue(), "\n")
 	var configFile string
@@ -410,6 +430,7 @@ func ExampleClusterClient_ConfigRewriteWithOptions() {
 	response, err = client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	for _, data := range response.MultiValue() {
 		lines := strings.Split(data, "\n")

--- a/go/server_management_commands_test.go
+++ b/go/server_management_commands_test.go
@@ -21,6 +21,7 @@ func ExampleClient_Select() {
 	result, err := client.Select(context.Background(), 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -33,6 +34,7 @@ func ExampleClient_ConfigGet() {
 	result, err := client.ConfigGet(context.Background(), []string{"timeout", "maxmemory"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -48,6 +50,7 @@ func ExampleClient_ConfigSet() {
 	) // example configuration
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -62,6 +65,7 @@ func ExampleClient_DBSize() {
 	result, err := client.DBSize(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -76,6 +80,7 @@ func ExampleClient_Time() {
 	result, err := client.Time(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	serverTime, _ := strconv.ParseInt(result[0], 10, 64)
 	fmt.Println((serverTime - clientTime) < timeMargin)
@@ -91,6 +96,7 @@ func ExampleClusterClient_Time() {
 	result, err := client.Time(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	serverTime, _ := strconv.ParseInt(result[0], 10, 64)
 	fmt.Println((serverTime - clientTime) < timeMargin)
@@ -104,6 +110,7 @@ func ExampleClient_Info() {
 	response, err := client.Info(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("response is of type %T\n", response)
 
@@ -117,6 +124,7 @@ func ExampleClient_InfoWithOptions() {
 	response, err := client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("response is of type %T\n", response)
 
@@ -129,6 +137,7 @@ func ExampleClient_FlushAll() {
 	result, err := client.FlushAll(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -141,6 +150,7 @@ func ExampleClient_FlushAllWithOptions() {
 	result, err := client.FlushAllWithOptions(context.Background(), options.ASYNC)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -153,6 +163,7 @@ func ExampleClient_FlushDB() {
 	result, err := client.FlushDB(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -165,6 +176,7 @@ func ExampleClient_FlushDBWithOptions() {
 	result, err := client.FlushDBWithOptions(context.Background(), options.SYNC)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -217,6 +229,7 @@ func ExampleClient_LastSave() {
 	response, err := client.LastSave(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response > 0)
 
@@ -228,6 +241,7 @@ func ExampleClient_ConfigResetStat() {
 	response, err := client.ConfigResetStat(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -242,6 +256,7 @@ func ExampleClient_ConfigRewrite() {
 	response, err := client.InfoWithOptions(context.Background(), opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	lines := strings.Split(response, "\n")
 	var configFile string

--- a/go/set_commands_test.go
+++ b/go/set_commands_test.go
@@ -18,6 +18,7 @@ func ExampleClient_SAdd() {
 	result, err := client.SAdd(context.Background(), key, []string{"member1", "member2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -31,6 +32,7 @@ func ExampleClusterClient_SAdd() {
 	result, err := client.SAdd(context.Background(), key, []string{"member1", "member2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -45,6 +47,7 @@ func ExampleClient_SRem() {
 	result, err := client.SRem(context.Background(), key, []string{"member1", "member2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -59,6 +62,7 @@ func ExampleClusterClient_SRem() {
 	result, err := client.SRem(context.Background(), key, []string{"member1", "member2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -74,6 +78,7 @@ func ExampleClient_SMembers() {
 	result, err := client.SMembers(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -89,6 +94,7 @@ func ExampleClusterClient_SMembers() {
 	result, err := client.SMembers(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -104,6 +110,7 @@ func ExampleClient_SCard() {
 	result, err := client.SCard(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 2
@@ -118,6 +125,7 @@ func ExampleClusterClient_SCard() {
 	result, err := client.SCard(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 2
@@ -132,6 +140,7 @@ func ExampleClient_SIsMember() {
 	result, err := client.SIsMember(context.Background(), key, "member1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: true
@@ -146,6 +155,7 @@ func ExampleClusterClient_SIsMember() {
 	result, err := client.SIsMember(context.Background(), key, "member1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: true
@@ -162,6 +172,7 @@ func ExampleClient_SDiff() {
 	result, err := client.SDiff(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: map[member1:{}]
@@ -178,6 +189,7 @@ func ExampleClusterClient_SDiff() {
 	result, err := client.SDiff(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: map[member1:{}]
@@ -195,6 +207,7 @@ func ExampleClient_SDiffStore() {
 	result, err := client.SDiffStore(context.Background(), destination, []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -212,6 +225,7 @@ func ExampleClusterClient_SDiffStore() {
 	result, err := client.SDiffStore(context.Background(), destination, []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -228,6 +242,7 @@ func ExampleClient_SInter() {
 	result, err := client.SInter(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: map[member2:{}]
@@ -244,6 +259,7 @@ func ExampleClusterClient_SInter() {
 	result, err := client.SInter(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: map[member2:{}]
@@ -261,6 +277,7 @@ func ExampleClient_SInterStore() {
 	result, err := client.SInterStore(context.Background(), destination, []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -278,6 +295,7 @@ func ExampleClusterClient_SInterStore() {
 	result, err := client.SInterStore(context.Background(), destination, []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -294,6 +312,7 @@ func ExampleClient_SInterCard() {
 	result, err := client.SInterCard(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -310,6 +329,7 @@ func ExampleClusterClient_SInterCard() {
 	result, err := client.SInterCard(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -327,6 +347,7 @@ func ExampleClient_SInterCardLimit() {
 	result, err := client.SInterCardLimit(context.Background(), []string{key1, key2}, limit)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -344,6 +365,7 @@ func ExampleClusterClient_SInterCardLimit() {
 	result, err := client.SInterCardLimit(context.Background(), []string{key1, key2}, limit)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 1
@@ -358,6 +380,7 @@ func ExampleClient_SRandMember() {
 	result, err := client.SRandMember(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsNil()) // Unable to test for a random value so just check if it is not nil
 
@@ -373,6 +396,7 @@ func ExampleClusterClient_SRandMember() {
 	result, err := client.SRandMember(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsNil()) // Unable to test for a random value so just check if it is not nil
 
@@ -389,6 +413,7 @@ func ExampleClient_SRandMemberCount() {
 	result, err := client.SRandMemberCount(context.Background(), key, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result)) // Cannot test exact values as they are random
 
@@ -405,6 +430,7 @@ func ExampleClusterClient_SRandMemberCount() {
 	result, err := client.SRandMemberCount(context.Background(), key, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result)) // Cannot test exact values as they are random
 
@@ -420,6 +446,7 @@ func ExampleClient_SPop() {
 	result, err := client.SPop(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsNil())
 	// Output: false
@@ -434,6 +461,7 @@ func ExampleClusterClient_SPop() {
 	result, err := client.SPop(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsNil())
 	// Output: false
@@ -448,6 +476,7 @@ func ExampleClient_SPopCount() {
 	result, err := client.SPopCount(context.Background(), key, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result))
 	// Output: 2
@@ -462,6 +491,7 @@ func ExampleClusterClient_SPopCount() {
 	result, err := client.SPopCount(context.Background(), key, 2)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(result))
 	// Output: 2
@@ -478,6 +508,7 @@ func ExampleClient_SMIsMember() {
 	result, err := client.SMIsMember(context.Background(), key, memberTest)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: [true true false]
@@ -494,6 +525,7 @@ func ExampleClusterClient_SMIsMember() {
 	result, err := client.SMIsMember(context.Background(), key, memberTest)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: [true true false]
@@ -511,6 +543,7 @@ func ExampleClient_SUnionStore() {
 	result, err := client.SUnionStore(context.Background(), destination, []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 3
@@ -528,6 +561,7 @@ func ExampleClusterClient_SUnionStore() {
 	result, err := client.SUnionStore(context.Background(), destination, []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 3
@@ -544,6 +578,7 @@ func ExampleClient_SUnion() {
 	result, err := client.SUnion(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: map[member1:{} member2:{} member3:{}]
@@ -560,6 +595,7 @@ func ExampleClusterClient_SUnion() {
 	result, err := client.SUnion(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: map[member1:{} member2:{} member3:{}]
@@ -572,6 +608,7 @@ func ExampleClient_SScan() {
 	result, err := client.SScan(context.Background(), key, models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	sort.Strings(result.Data) // Sort for consistent comparison
 	fmt.Println("Cursor:", result.Cursor)
@@ -589,6 +626,7 @@ func ExampleClusterClient_SScan() {
 	result, err := client.SScan(context.Background(), key, models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	sort.Strings(result.Data) // Sort for consistent comparison
 	fmt.Println("Cursor:", result.Cursor)
@@ -607,6 +645,7 @@ func ExampleClient_SScanWithOptions() {
 	result, err := client.SScanWithOptions(context.Background(), key, models.NewCursor(), *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	sort.Strings(result.Data) // Sort for consistent comparison
 	fmt.Println("Cursor:", result.Cursor)
@@ -625,6 +664,7 @@ func ExampleClusterClient_SScanWithOptions() {
 	result, err := client.SScanWithOptions(context.Background(), key, models.NewCursor(), *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	sort.Strings(result.Data) // Sort for consistent comparison
 	fmt.Println("Cursor:", result.Cursor)
@@ -646,6 +686,7 @@ func ExampleClient_SMove() {
 	result, err := client.SMove(context.Background(), source, destination, member)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: true
@@ -662,6 +703,7 @@ func ExampleClusterClient_SMove() {
 	result, err := client.SMove(context.Background(), source, destination, member)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: true

--- a/go/sorted_set_commands_test.go
+++ b/go/sorted_set_commands_test.go
@@ -21,6 +21,7 @@ func ExampleClient_ZAdd() {
 	result, err := client.ZAdd(context.Background(), "key1", map[string]float64{"one": 1.0, "two": 2.0, "three": 3.0})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -33,6 +34,7 @@ func ExampleClusterClient_ZAdd() {
 	result, err := client.ZAdd(context.Background(), "key1", map[string]float64{"one": 1.0, "two": 2.0, "three": 3.0})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -51,6 +53,7 @@ func ExampleClient_ZAddWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -69,6 +72,7 @@ func ExampleClusterClient_ZAddWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -81,6 +85,7 @@ func ExampleClient_ZAddIncr() {
 	result, err := client.ZAddIncr(context.Background(), "key1", "one", 1.0)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -94,6 +99,7 @@ func ExampleClusterClient_ZAddIncr() {
 	result, err := client.ZAddIncr(context.Background(), "key1", "one", 1.0)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -107,6 +113,8 @@ func ExampleClient_ZAddIncrWithOptions() {
 	opts, err := options.NewZAddOptions().SetChanged(true) // should return an error
 	result, err := client.ZAddIncrWithOptions(context.Background(), "key1", "one", 1.0, *opts)
 	if err != nil {
+		// This example deliberately demonstrates the error, so it keeps going and prints
+		// the zero-value result as part of its expected output.
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
@@ -122,6 +130,8 @@ func ExampleClusterClient_ZAddIncrWithOptions() {
 	opts, err := options.NewZAddOptions().SetChanged(true) // should return an error
 	result, err := client.ZAddIncrWithOptions(context.Background(), "key1", "one", 1.0, *opts)
 	if err != nil {
+		// This example deliberately demonstrates the error, so it keeps going and prints
+		// the zero-value result as part of its expected output.
 		fmt.Println("Glide example failed with an error: ", err)
 	}
 	fmt.Println(result)
@@ -138,6 +148,7 @@ func ExampleClient_ZIncrBy() {
 	result1, err := client.ZIncrBy(context.Background(), "key1", 3.0, "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -154,6 +165,7 @@ func ExampleClusterClient_ZIncrBy() {
 	result1, err := client.ZIncrBy(context.Background(), "key1", 3.0, "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -170,6 +182,7 @@ func ExampleClient_ZPopMin() {
 	result1, err := client.ZPopMin(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -186,6 +199,7 @@ func ExampleClusterClient_ZPopMin() {
 	result1, err := client.ZPopMin(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -203,6 +217,7 @@ func ExampleClient_ZPopMinWithOptions() {
 	result1, err := client.ZPopMinWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -220,6 +235,7 @@ func ExampleClusterClient_ZPopMinWithOptions() {
 	result1, err := client.ZPopMinWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -236,6 +252,7 @@ func ExampleClient_ZPopMax() {
 	result1, err := client.ZPopMax(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -252,6 +269,7 @@ func ExampleClusterClient_ZPopMax() {
 	result1, err := client.ZPopMax(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -269,6 +287,7 @@ func ExampleClient_ZPopMaxWithOptions() {
 	result1, err := client.ZPopMaxWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -286,6 +305,7 @@ func ExampleClusterClient_ZPopMaxWithOptions() {
 	result1, err := client.ZPopMaxWithOptions(context.Background(), "key1", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -302,6 +322,7 @@ func ExampleClient_ZRem() {
 	result1, err := client.ZRem(context.Background(), "key1", []string{"one", "two", "nonMember"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -318,6 +339,7 @@ func ExampleClusterClient_ZRem() {
 	result1, err := client.ZRem(context.Background(), "key1", []string{"one", "two", "nonMember"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -334,6 +356,7 @@ func ExampleClient_ZCard() {
 	result1, err := client.ZCard(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -350,6 +373,7 @@ func ExampleClusterClient_ZCard() {
 	result1, err := client.ZCard(context.Background(), "key1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -367,6 +391,7 @@ func ExampleClient_BZPopMin() {
 	result1, err := client.BZPopMin(context.Background(), []string{"key1", "key2"}, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(zaddResult1)
 	fmt.Println(zaddResult2)
@@ -386,6 +411,7 @@ func ExampleClusterClient_BZPopMin() {
 	result1, err := client.BZPopMin(context.Background(), []string{"{key}1", "{key}2"}, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(zaddResult1)
 	fmt.Println(zaddResult2)
@@ -412,6 +438,7 @@ func ExampleClient_ZRange() {
 	// `result` contains members which have scores within the range of negative infinity to 3, in descending order
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -438,6 +465,7 @@ func ExampleClusterClient_ZRange() {
 	// `result` contains members which have scores within the range of negative infinity to 3, in descending order
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -462,6 +490,7 @@ func ExampleClient_ZRangeWithScores() {
 	result2, err := client.ZRangeWithScores(context.Background(), "key1", query)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -486,6 +515,7 @@ func ExampleClusterClient_ZRangeWithScores() {
 	result2, err := client.ZRangeWithScores(context.Background(), "key1", query)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -509,6 +539,7 @@ func ExampleClient_ZRangeStore() {
 	// `result` contains members which have scores within the range of negative infinity to 3, in descending order
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -527,6 +558,7 @@ func ExampleClusterClient_ZRangeStore() {
 	// `result` contains members which have scores within the range of negative infinity to 3, in descending order
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -540,6 +572,7 @@ func ExampleClient_ZRank() {
 	result1, err := client.ZRank(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -556,6 +589,7 @@ func ExampleClusterClient_ZRank() {
 	result1, err := client.ZRank(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -572,6 +606,7 @@ func ExampleClient_ZRankWithScore() {
 	res, err := client.ZRankWithScore(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(res.Value().Rank)
@@ -590,6 +625,7 @@ func ExampleClusterClient_ZRankWithScore() {
 	res, err := client.ZRankWithScore(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(res.Value().Rank)
@@ -612,6 +648,7 @@ func ExampleClient_ZRevRank() {
 	result1, err := client.ZRevRank(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -632,6 +669,7 @@ func ExampleClusterClient_ZRevRank() {
 	result1, err := client.ZRevRank(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -652,6 +690,7 @@ func ExampleClient_ZRevRankWithScore() {
 	res, err := client.ZRevRankWithScore(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(res.Value().Rank)
@@ -674,6 +713,7 @@ func ExampleClusterClient_ZRevRankWithScore() {
 	res, err := client.ZRevRankWithScore(context.Background(), "key1", "two")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(res.Value().Rank)
@@ -696,6 +736,7 @@ func ExampleClient_ZScore() {
 	result1, err := client.ZScore(context.Background(), "key1", "three")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -716,6 +757,7 @@ func ExampleClusterClient_ZScore() {
 	result1, err := client.ZScore(context.Background(), "key1", "three")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -740,6 +782,7 @@ func ExampleClient_ZCount() {
 	result1, err := client.ZCount(context.Background(), "key1", *zCountRange)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -764,6 +807,7 @@ func ExampleClusterClient_ZCount() {
 	result1, err := client.ZCount(context.Background(), "key1", *zCountRange)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -784,6 +828,7 @@ func ExampleClient_ZScan() {
 	result, err := client.ZScan(context.Background(), "key1", models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -804,6 +849,7 @@ func ExampleClusterClient_ZScan() {
 	result, err := client.ZScan(context.Background(), "key1", models.NewCursor())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -829,6 +875,7 @@ func ExampleClient_ZScanWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -854,6 +901,7 @@ func ExampleClusterClient_ZScanWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Cursor:", result.Cursor)
 	fmt.Println("Collection:", result.Data)
@@ -874,6 +922,7 @@ func ExampleClient_ZRemRangeByLex() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -894,6 +943,7 @@ func ExampleClusterClient_ZRemRangeByLex() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -910,6 +960,7 @@ func ExampleClient_ZRemRangeByRank() {
 	result1, err := client.ZRemRangeByRank(context.Background(), "key1", 1, 3)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -926,6 +977,7 @@ func ExampleClusterClient_ZRemRangeByRank() {
 	result1, err := client.ZRemRangeByRank(context.Background(), "key1", 1, 3)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -945,6 +997,7 @@ func ExampleClient_ZRemRangeByScore() {
 	))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -964,6 +1017,7 @@ func ExampleClusterClient_ZRemRangeByScore() {
 	))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	fmt.Println(result1)
@@ -980,6 +1034,7 @@ func ExampleClient_BZMPop() {
 	result, err := client.BZMPop(context.Background(), []string{"key1"}, constants.MAX, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(result.Value())
 	fmt.Println(string(jsonSummary))
@@ -993,6 +1048,7 @@ func ExampleClusterClient_BZMPop() {
 	result, err := client.BZMPop(context.Background(), []string{"key1"}, constants.MAX, 500*time.Millisecond)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(result.Value())
 	fmt.Println(string(jsonSummary))
@@ -1013,6 +1069,7 @@ func ExampleClient_BZMPopWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	kms := models.KeyWithArrayOfMembersAndScores{
 		Key: "key1",
@@ -1046,6 +1103,7 @@ func ExampleClusterClient_BZMPopWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(result.Value())
 	fmt.Println(string(jsonSummary))
@@ -1060,6 +1118,7 @@ func ExampleClient_ZRandMember() {
 	result, err := client.ZRandMember(context.Background(), "key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1075,6 +1134,7 @@ func ExampleClusterClient_ZRandMember() {
 	result, err := client.ZRandMember(context.Background(), "key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1090,6 +1150,7 @@ func ExampleClient_ZRandMemberWithCount() {
 	result, err := client.ZRandMemberWithCount(context.Background(), "key1", 4)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1105,6 +1166,7 @@ func ExampleClusterClient_ZRandMemberWithCount() {
 	result, err := client.ZRandMemberWithCount(context.Background(), "key1", 4)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1120,6 +1182,7 @@ func ExampleClient_ZRandMemberWithCountWithScores() {
 	result, err := client.ZRandMemberWithCountWithScores(context.Background(), "key1", 4)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1135,6 +1198,7 @@ func ExampleClusterClient_ZRandMemberWithCountWithScores() {
 	result, err := client.ZRandMemberWithCountWithScores(context.Background(), "key1", 4)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1150,6 +1214,7 @@ func ExampleClient_ZMScore() {
 	result, err := client.ZMScore(context.Background(), "key1", []string{"c", "b", "e"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1165,6 +1230,7 @@ func ExampleClusterClient_ZMScore() {
 	result, err := client.ZMScore(context.Background(), "key1", []string{"c", "b", "e"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// If the key does not exist, an empty string is returned
@@ -1184,6 +1250,7 @@ func ExampleClient_ZInter() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1201,6 +1268,7 @@ func ExampleClusterClient_ZInter() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1221,6 +1289,7 @@ func ExampleClient_ZInterWithScores() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: [{b 3.5} {c 5.5} {d 7}]
@@ -1240,6 +1309,7 @@ func ExampleClusterClient_ZInterWithScores() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1256,6 +1326,7 @@ func ExampleClient_ZInterStore() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1272,6 +1343,7 @@ func ExampleClusterClient_ZInterStore() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1293,6 +1365,7 @@ func ExampleClient_ZInterStoreWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1314,6 +1387,7 @@ func ExampleClusterClient_ZInterStoreWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1328,6 +1402,7 @@ func ExampleClient_ZDiff() {
 	result, err := client.ZDiff(context.Background(), []string{"key1", "key2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: [a]
@@ -1341,6 +1416,7 @@ func ExampleClusterClient_ZDiff() {
 	result, err := client.ZDiff(context.Background(), []string{"{key}1", "{key}2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1355,6 +1431,7 @@ func ExampleClient_ZDiffWithScores() {
 	result, err := client.ZDiffWithScores(context.Background(), []string{"key1", "key2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: [{a 1}]
@@ -1368,6 +1445,7 @@ func ExampleClusterClient_ZDiffWithScores() {
 	result, err := client.ZDiffWithScores(context.Background(), []string{"{key}1", "{key}2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1382,6 +1460,7 @@ func ExampleClient_ZDiffStore() {
 	result, err := client.ZDiffStore(context.Background(), "dest", []string{"key1", "key2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1396,6 +1475,7 @@ func ExampleClusterClient_ZDiffStore() {
 	result, err := client.ZDiffStore(context.Background(), "{key}dest", []string{"{key}1", "{key}2"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1518,6 +1598,7 @@ func ExampleClient_ZUnionStore() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(zUnionStoreResult)
@@ -1547,6 +1628,7 @@ func ExampleClusterClient_ZUnionStore() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(zUnionStoreResult)
@@ -1577,6 +1659,7 @@ func ExampleClient_ZUnionStoreWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(zUnionStoreWithOptionsResult)
@@ -1607,6 +1690,7 @@ func ExampleClusterClient_ZUnionStoreWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(zUnionStoreWithOptionsResult)
@@ -1625,6 +1709,7 @@ func ExampleClient_ZInterCard() {
 	res, err := client.ZInterCard(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(res)
 
@@ -1643,6 +1728,7 @@ func ExampleClusterClient_ZInterCard() {
 	res, err := client.ZInterCard(context.Background(), []string{key1, key2})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(res)
 
@@ -1665,6 +1751,7 @@ func ExampleClient_ZInterCardWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(res)
 
@@ -1687,6 +1774,7 @@ func ExampleClusterClient_ZInterCardWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(res)
 
@@ -1708,6 +1796,7 @@ func ExampleClient_ZLexCount() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -1729,6 +1818,7 @@ func ExampleClusterClient_ZLexCount() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 

--- a/go/stream_commands_test.go
+++ b/go/stream_commands_test.go
@@ -27,6 +27,7 @@ func ExampleClient_XAdd() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	matches, _ := regexp.Match(
 		`^\d{13}-0$`,
@@ -46,6 +47,7 @@ func ExampleClusterClient_XAdd() {
 	})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	matches, _ := regexp.Match(
 		`^\d{13}-0$`,
@@ -67,6 +69,7 @@ func ExampleClient_XAddWithOptions() {
 	result, err := client.XAddWithOptions(context.Background(), "mystream", values, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -84,6 +87,7 @@ func ExampleClusterClient_XAddWithOptions() {
 	result, err := client.XAddWithOptions(context.Background(), "mystream", values, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -107,6 +111,7 @@ func ExampleClient_XTrim() {
 	count, err := client.XTrim(context.Background(), "mystream", *options.NewXTrimOptionsWithMaxLen(0).SetExactTrimming())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -130,6 +135,7 @@ func ExampleClusterClient_XTrim() {
 	count, err := client.XTrim(context.Background(), "mystream", *options.NewXTrimOptionsWithMaxLen(0).SetExactTrimming())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -147,6 +153,7 @@ func ExampleClient_XLen() {
 	count, err := client.XLen(context.Background(), "mystream")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -164,6 +171,7 @@ func ExampleClusterClient_XLen() {
 	count, err := client.XLen(context.Background(), "mystream")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -198,6 +206,7 @@ func ExampleClient_XAutoClaim() {
 	response, err := client.XAutoClaim(context.Background(), key, group, consumer, 0, "0-1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -233,6 +242,7 @@ func ExampleClusterClient_XAutoClaim() {
 	response, err := client.XAutoClaim(context.Background(), key, group, consumer, 0, "0-1")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -269,6 +279,7 @@ func ExampleClient_XAutoClaimWithOptions() {
 	response, err := client.XAutoClaimWithOptions(context.Background(), key, group, consumer, 0, "0-1", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -304,6 +315,7 @@ func ExampleClusterClient_XAutoClaimWithOptions() {
 	response, err := client.XAutoClaimWithOptions(context.Background(), key, group, consumer, 0, "0-1", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -338,6 +350,7 @@ func ExampleClient_XAutoClaimJustId() {
 	response, err := client.XAutoClaimJustId(context.Background(), key, group, consumer, 0, "0-0")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -372,6 +385,7 @@ func ExampleClusterClient_XAutoClaimJustId() {
 	response, err := client.XAutoClaimJustId(context.Background(), key, group, consumer, 0, "0-0")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -407,6 +421,7 @@ func ExampleClient_XAutoClaimJustIdWithOptions() {
 	response, err := client.XAutoClaimJustIdWithOptions(context.Background(), key, group, consumer, 0, "0-1", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -442,6 +457,7 @@ func ExampleClusterClient_XAutoClaimJustIdWithOptions() {
 	response, err := client.XAutoClaimJustIdWithOptions(context.Background(), key, group, consumer, 0, "0-1", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -470,6 +486,7 @@ func ExampleClient_XReadGroup() {
 	response, err := client.XReadGroup(context.Background(), group, consumer, map[string]string{key: "0"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -508,6 +525,7 @@ func ExampleClusterClient_XReadGroup() {
 	response, err := client.XReadGroup(context.Background(), group, consumer, map[string]string{key: "0"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -547,6 +565,7 @@ func ExampleClient_XReadGroupWithOptions() {
 	response, err := client.XReadGroupWithOptions(context.Background(), group, consumer, map[string]string{key: ">"}, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -593,6 +612,7 @@ func ExampleClusterClient_XReadGroupWithOptions() {
 	response, err := client.XReadGroupWithOptions(context.Background(), group, consumer, map[string]string{key: ">"}, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -631,6 +651,7 @@ func ExampleClient_XRead() {
 	response, err := client.XRead(context.Background(), map[string]string{key: "0-0"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -669,6 +690,7 @@ func ExampleClusterClient_XRead() {
 	response, err := client.XRead(context.Background(), map[string]string{key: "0-0"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -719,6 +741,7 @@ func ExampleClient_XReadWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -769,6 +792,7 @@ func ExampleClusterClient_XReadWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Check that we have the stream with the correct name in the map
@@ -806,6 +830,7 @@ func ExampleClient_XDel() {
 	count, err := client.XDel(context.Background(), key, []string{"0-1", "0-2", "0-3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -826,6 +851,7 @@ func ExampleClusterClient_XDel() {
 	count, err := client.XDel(context.Background(), key, []string{"0-1", "0-2", "0-3"})
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -855,6 +881,7 @@ func ExampleClient_XPending() {
 	summary, err := client.XPending(context.Background(), key, group)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(summary)
 	fmt.Println(string(jsonSummary))
@@ -885,6 +912,7 @@ func ExampleClusterClient_XPending() {
 	summary, err := client.XPending(context.Background(), key, group)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(summary)
 	fmt.Println(string(jsonSummary))
@@ -920,6 +948,7 @@ func ExampleClient_XPendingWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonDetails, _ := json.Marshal(details)
 
@@ -967,6 +996,7 @@ func ExampleClusterClient_XPendingWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonDetails, _ := json.Marshal(details)
 
@@ -1022,6 +1052,7 @@ func ExampleClient_XGroupSetId() {
 	) // get the pending messages, which should include the entry we previously acked
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(summary)
 	fmt.Println(string(jsonSummary))
@@ -1065,6 +1096,7 @@ func ExampleClusterClient_XGroupSetId() {
 	) // get the pending messages, which should include the entry we previously acked
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(summary)
 	fmt.Println(string(jsonSummary))
@@ -1119,6 +1151,7 @@ func ExampleClient_XGroupSetIdWithOptions() {
 	) // get the pending messages, which should include the entry we previously acked
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(summary)
 	fmt.Println(string(jsonSummary))
@@ -1173,6 +1206,7 @@ func ExampleClusterClient_XGroupSetIdWithOptions() {
 	) // get the pending messages, which should include the entry we previously acked
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonSummary, _ := json.Marshal(summary)
 	fmt.Println(string(jsonSummary))
@@ -1196,6 +1230,7 @@ func ExampleClient_XGroupCreate() {
 	response, err := client.XGroupCreate(context.Background(), key, group, "0") // create the group (no MKSTREAM needed)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1218,6 +1253,7 @@ func ExampleClusterClient_XGroupCreate() {
 	response, err := client.XGroupCreate(context.Background(), key, group, "0") // create the group (no MKSTREAM needed)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1239,6 +1275,7 @@ func ExampleClient_XGroupCreateWithOptions() {
 	) // create the group (no MKSTREAM needed)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1260,6 +1297,7 @@ func ExampleClusterClient_XGroupCreateWithOptions() {
 	) // create the group (no MKSTREAM needed)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1277,6 +1315,7 @@ func ExampleClient_XGroupDestroy() {
 	success, err := client.XGroupDestroy(context.Background(), key, group) // destroy the group
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(success)
 
@@ -1294,6 +1333,7 @@ func ExampleClusterClient_XGroupDestroy() {
 	success, err := client.XGroupDestroy(context.Background(), key, group) // destroy the group
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(success)
 
@@ -1312,6 +1352,7 @@ func ExampleClient_XGroupCreateConsumer() {
 	success, err := client.XGroupCreateConsumer(context.Background(), key, group, consumer)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(success)
 
@@ -1330,6 +1371,7 @@ func ExampleClusterClient_XGroupCreateConsumer() {
 	success, err := client.XGroupCreateConsumer(context.Background(), key, group, consumer)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(success)
 
@@ -1356,6 +1398,7 @@ func ExampleClient_XGroupDelConsumer() {
 	count, err := client.XGroupDelConsumer(context.Background(), key, group, consumer)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Consumer deleted. Messages pending:", count)
 
@@ -1383,6 +1426,7 @@ func ExampleClusterClient_XGroupDelConsumer() {
 	count, err := client.XGroupDelConsumer(context.Background(), key, group, consumer)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println("Consumer deleted. Messages pending:", count)
 
@@ -1416,6 +1460,7 @@ func ExampleClient_XAck() {
 	) // ack the message and remove it from the pending list
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -1448,6 +1493,7 @@ func ExampleClusterClient_XAck() {
 	) // ack the message and remove it from the pending list
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(count)
 
@@ -1483,6 +1529,7 @@ func ExampleClient_XClaim() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1499,6 +1546,7 @@ func ExampleClient_XClaim() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("Claimed %d message\n", len(response))
 
@@ -1540,6 +1588,7 @@ func ExampleClusterClient_XClaim() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1556,6 +1605,7 @@ func ExampleClusterClient_XClaim() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("Claimed %d message\n", len(response))
 
@@ -1597,6 +1647,7 @@ func ExampleClient_XClaimWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1615,6 +1666,7 @@ func ExampleClient_XClaimWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("Claimed %d message\n", len(response))
 
@@ -1665,6 +1717,7 @@ func ExampleClusterClient_XClaimWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1683,6 +1736,7 @@ func ExampleClusterClient_XClaimWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Printf("Claimed %d message\n", len(response))
 
@@ -1733,6 +1787,7 @@ func ExampleClient_XClaimJustId() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1749,6 +1804,7 @@ func ExampleClient_XClaimJustId() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1784,6 +1840,7 @@ func ExampleClusterClient_XClaimJustId() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1800,6 +1857,7 @@ func ExampleClusterClient_XClaimJustId() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1835,6 +1893,7 @@ func ExampleClient_XClaimJustIdWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1853,6 +1912,7 @@ func ExampleClient_XClaimJustIdWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1888,6 +1948,7 @@ func ExampleClusterClient_XClaimJustIdWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	if len(result) == 0 {
 		fmt.Println("No pending messages")
@@ -1906,6 +1967,7 @@ func ExampleClusterClient_XClaimJustIdWithOptions() {
 	)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1936,6 +1998,7 @@ func ExampleClient_XRange() {
 		options.NewInfiniteStreamBoundary(constants.PositiveInfinity))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1966,6 +2029,7 @@ func ExampleClusterClient_XRange() {
 		options.NewInfiniteStreamBoundary(constants.PositiveInfinity))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -1985,6 +2049,7 @@ func ExampleClient_XRangeWithOptions() {
 		*options.NewXRangeOptions().SetCount(1))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(response))
 
@@ -2004,6 +2069,7 @@ func ExampleClusterClient_XRangeWithOptions() {
 		*options.NewXRangeOptions().SetCount(1))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(len(response))
 
@@ -2034,6 +2100,7 @@ func ExampleClient_XRevRange() {
 		options.NewStreamBoundary(streamId1, true))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -2064,6 +2131,7 @@ func ExampleClusterClient_XRevRange() {
 		options.NewStreamBoundary(streamId1, true))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -2095,6 +2163,7 @@ func ExampleClient_XRevRangeWithOptions() {
 		*options.NewXRangeOptions().SetCount(2))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -2126,6 +2195,7 @@ func ExampleClusterClient_XRevRangeWithOptions() {
 		*options.NewXRangeOptions().SetCount(2))
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -2146,6 +2216,7 @@ func ExampleClient_XInfoStream() {
 	response, err := client.XInfoStream(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Response Structure is as follows:
@@ -2201,6 +2272,7 @@ func ExampleClusterClient_XInfoStream() {
 	response, err := client.XInfoStream(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Response Structure is as follows:
@@ -2263,6 +2335,7 @@ func ExampleClient_XInfoStreamFullWithOptions() {
 	response, err := client.XInfoStreamFullWithOptions(context.Background(), key, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Print some of response values
@@ -2314,6 +2387,7 @@ func ExampleClusterClient_XInfoStreamFullWithOptions() {
 	response, err := client.XInfoStreamFullWithOptions(context.Background(), key, *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Print some of response values
@@ -2372,6 +2446,7 @@ func ExampleClient_XInfoConsumers() {
 	response, err := client.XInfoConsumers(context.Background(), key, group)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Expanded:
@@ -2421,6 +2496,7 @@ func ExampleClusterClient_XInfoConsumers() {
 	response, err := client.XInfoConsumers(context.Background(), key, group)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	// Expanded:
@@ -2462,6 +2538,7 @@ func ExampleClient_XInfoGroups() {
 	response, err := client.XInfoGroups(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(response)
@@ -2508,6 +2585,7 @@ func ExampleClusterClient_XInfoGroups() {
 	response, err := client.XInfoGroups(context.Background(), key)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 
 	fmt.Println(response)

--- a/go/string_commands_test.go
+++ b/go/string_commands_test.go
@@ -17,6 +17,7 @@ func ExampleClient_Set() {
 	result, err := client.Set(context.Background(), "my_key", "my_value")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -29,6 +30,7 @@ func ExampleClusterClient_Set() {
 	result, err := client.Set(context.Background(), "my_key", "my_value")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -43,6 +45,7 @@ func ExampleClient_SetWithOptions() {
 	result, err := client.SetWithOptions(context.Background(), "my_key", "my_value", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -57,6 +60,7 @@ func ExampleClusterClient_SetWithOptions() {
 	result, err := client.SetWithOptions(context.Background(), "my_key", "my_value", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -70,6 +74,7 @@ func ExampleClient_Get_keyexists() {
 	result, err := client.Get(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -83,6 +88,7 @@ func ExampleClusterClient_Get_keyexists() {
 	result, err := client.Get(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 
@@ -95,6 +101,7 @@ func ExampleClient_Get_keynotexists() {
 	result, err := client.Get(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsNil()) // missing key returns nil result
 
@@ -107,6 +114,7 @@ func ExampleClusterClient_Get_keynotexists() {
 	result, err := client.Get(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.IsNil()) // missing key returns nil result
 
@@ -120,6 +128,7 @@ func ExampleClient_GetEx() {
 	result, err := client.GetEx(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 	ttl, _ := client.TTL(context.Background(), "my_key")
@@ -137,6 +146,7 @@ func ExampleClusterClient_GetEx() {
 	result, err := client.GetEx(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 	ttl, _ := client.TTL(context.Background(), "my_key")
@@ -156,6 +166,7 @@ func ExampleClient_GetExWithOptions() {
 	result, err := client.GetExWithOptions(context.Background(), "my_key", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 	ttl, _ := client.TTL(context.Background(), "my_key")
@@ -175,6 +186,7 @@ func ExampleClusterClient_GetExWithOptions() {
 	result, err := client.GetExWithOptions(context.Background(), "my_key", *options)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 	ttl, _ := client.TTL(context.Background(), "my_key")
@@ -195,6 +207,7 @@ func ExampleClient_MSet() {
 	result, err := client.MSet(context.Background(), keyValueMap)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -211,6 +224,7 @@ func ExampleClusterClient_MSet() {
 	result, err := client.MSet(context.Background(), keyValueMap)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -228,6 +242,7 @@ func ExampleClient_MGet() {
 	result, err := client.MGet(context.Background(), keys)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	for _, res := range result {
 		fmt.Println(res.Value())
@@ -250,6 +265,7 @@ func ExampleClusterClient_MGet() {
 	result, err := client.MGet(context.Background(), keys)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	for _, res := range result {
 		fmt.Println(res.Value())
@@ -268,6 +284,7 @@ func ExampleClient_MSetNX() {
 	result, err := client.MSetNX(context.Background(), keyValueMap)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	client.Set(context.Background(), "my_key3", "my_value3")
@@ -286,6 +303,7 @@ func ExampleClusterClient_MSetNX() {
 	result, err := client.MSetNX(context.Background(), keyValueMap)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	client.Set(context.Background(), "{my_key}3", "my_value3")
@@ -304,6 +322,7 @@ func ExampleClient_Incr() {
 	result, err := client.Incr(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -317,6 +336,7 @@ func ExampleClusterClient_Incr() {
 	result, err := client.Incr(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -330,6 +350,7 @@ func ExampleClient_IncrBy() {
 	result, err := client.IncrBy(context.Background(), "my_key", 5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 10
@@ -342,6 +363,7 @@ func ExampleClusterClient_IncrBy() {
 	result, err := client.IncrBy(context.Background(), "my_key", 5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	// Output: 10
@@ -354,6 +376,7 @@ func ExampleClient_IncrByFloat() {
 	result, err := client.IncrByFloat(context.Background(), "my_key", 5.5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -367,6 +390,7 @@ func ExampleClusterClient_IncrByFloat() {
 	result, err := client.IncrByFloat(context.Background(), "my_key", 5.5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -380,6 +404,7 @@ func ExampleClient_Decr() {
 	result, err := client.Decr(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -393,6 +418,7 @@ func ExampleClusterClient_Decr() {
 	result, err := client.Decr(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -406,6 +432,7 @@ func ExampleClient_DecrBy() {
 	result, err := client.DecrBy(context.Background(), "my_key", 5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -419,6 +446,7 @@ func ExampleClusterClient_DecrBy() {
 	result, err := client.DecrBy(context.Background(), "my_key", 5)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -432,6 +460,7 @@ func ExampleClient_Strlen() {
 	result, err := client.Strlen(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -445,6 +474,7 @@ func ExampleClusterClient_Strlen() {
 	result, err := client.Strlen(context.Background(), "my_key")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -458,6 +488,7 @@ func ExampleClient_SetRange_one() {
 	result, err := client.SetRange(context.Background(), "my_key", 3, "example")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	value, _ := client.Get(context.Background(), "my_key")
@@ -475,6 +506,7 @@ func ExampleClusterClient_SetRange_one() {
 	result, err := client.SetRange(context.Background(), "my_key", 3, "example")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	value, _ := client.Get(context.Background(), "my_key")
@@ -492,6 +524,7 @@ func ExampleClient_SetRange_two() {
 	result, err := client.SetRange(context.Background(), "my_key", 1, "a")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -505,6 +538,7 @@ func ExampleClusterClient_SetRange_two() {
 	result, err := client.SetRange(context.Background(), "my_key", 1, "a")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -518,6 +552,7 @@ func ExampleClient_GetRange_one() {
 	result, err := client.GetRange(context.Background(), "my_key", 0, 7)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -531,6 +566,7 @@ func ExampleClusterClient_GetRange_one() {
 	result, err := client.GetRange(context.Background(), "my_key", 0, 7)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 
@@ -545,6 +581,7 @@ func ExampleClient_GetRange_two() {
 	result, err := client.GetRange(context.Background(), "my_key", 0, 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println([]byte(result))
 
@@ -561,6 +598,7 @@ func ExampleClusterClient_GetRange_two() {
 	result, err := client.GetRange(context.Background(), "my_key", 0, 1)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println([]byte(result))
 
@@ -576,6 +614,7 @@ func ExampleClient_Append() {
 	result, err := client.Append(context.Background(), "my_key", "e")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	value, _ := client.Get(context.Background(), "my_key")
@@ -593,6 +632,7 @@ func ExampleClusterClient_Append() {
 	result, err := client.Append(context.Background(), "my_key", "e")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result)
 	value, _ := client.Get(context.Background(), "my_key")
@@ -610,6 +650,7 @@ func ExampleClient_GetDel() {
 	result, err := client.GetDel(context.Background(), "my_key") // return value and delete key
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 	value, _ := client.Get(context.Background(), "my_key") // key should be missing
@@ -627,6 +668,7 @@ func ExampleClusterClient_GetDel() {
 	result, err := client.GetDel(context.Background(), "my_key") // return value and delete key
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Value())
 	value, _ := client.Get(context.Background(), "my_key") // key should be missing
@@ -644,6 +686,7 @@ func ExampleClient_LCS() {
 	result, err := client.LCS(context.Background(), "my_key1", "my_key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.MatchString)
 
@@ -659,6 +702,7 @@ func ExampleClusterClient_LCS() {
 	result, err := client.LCS(context.Background(), "{my_key}1", "{my_key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.MatchString)
 
@@ -676,6 +720,7 @@ func ExampleClient_LCSLen() {
 	result, err := client.LCSLen(context.Background(), "my_key1", "my_key2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Len)
 
@@ -693,6 +738,7 @@ func ExampleClusterClient_LCSLen() {
 	result, err := client.LCSLen(context.Background(), "{my_key}1", "{my_key}2")
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(result.Len)
 
@@ -712,6 +758,7 @@ func ExampleClient_LCSWithOptions_basic() {
 	result, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonRes, _ := json.MarshalIndent(result, "", "  ")
 	fmt.Println("Basic LCS result:\n", string(jsonRes))
@@ -761,6 +808,7 @@ func ExampleClusterClient_LCSWithOptions_basic() {
 	result, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *opts)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonRes, _ := json.MarshalIndent(result, "", "  ")
 	fmt.Println("Basic LCS result:\n", string(jsonRes))
@@ -811,6 +859,7 @@ func ExampleClient_LCSWithOptions_minmatchlen() {
 	result2, err := client.LCSWithOptions(context.Background(), "my_key1", "my_key2", *optsWithMin)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonRes2, _ := json.MarshalIndent(result2, "", "  ")
 	fmt.Println("With MinMatchLen 4:\n", string(jsonRes2))
@@ -850,6 +899,7 @@ func ExampleClusterClient_LCSWithOptions_minmatchlen() {
 	result2, err := client.LCSWithOptions(context.Background(), "{key}1", "{key}2", *optsWithMin)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	jsonRes2, _ := json.MarshalIndent(result2, "", "  ")
 	fmt.Println("With MinMatchLen 4:\n", string(jsonRes2))

--- a/go/update_connection_password_test.go
+++ b/go/update_connection_password_test.go
@@ -12,6 +12,7 @@ func ExampleClient_UpdateConnectionPassword() {
 	response, err := client.UpdateConnectionPassword(context.Background(), "", false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -23,6 +24,7 @@ func ExampleClient_ResetConnectionPassword() {
 	response, err := client.ResetConnectionPassword(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -34,6 +36,7 @@ func ExampleClusterClient_UpdateConnectionPassword() {
 	response, err := client.UpdateConnectionPassword(context.Background(), "", false)
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 
@@ -45,6 +48,7 @@ func ExampleClusterClient_ResetConnectionPassword() {
 	response, err := client.ResetConnectionPassword(context.Background())
 	if err != nil {
 		fmt.Println("Glide example failed with an error: ", err)
+		return
 	}
 	fmt.Println(response)
 


### PR DESCRIPTION
### Summary

The Go example tests abort the whole test binary when no server is reachable, instead of reporting which
example failed. `getExampleClient()` prints the connection error and returns `nil`; the example then calls a
method on that nil client and panics. Go's example runner reports the failure and re-panics, so the process
dies. A plain `go test ./...` in `go/` produces one `--- FAIL` line and a stack trace, and the remaining 686
examples never run.

A second defect compounds it. Many examples print the error and then go on to use the result they were just
told is invalid. In one of those the use is a type assertion on a nil interface, which panics as well, so
fixing only the nil client moves the crash instead of removing it.

This is test-only. No shipped code changes.

### Issue link

This Pull Request is linked to issue: [Go: ExampleClient_Exec_transaction panics instead of failing cleanly when no server is reachable](https://github.com/valkey-io/valkey-glide/issues/6817)
Fixes #6817

### Features / Behaviour Changes

`go test ./...` in `go/` with no server reachable:

* Before: one `--- FAIL`, then `panic: runtime error: invalid memory address or nil pointer dereference`,
  exit status 2, and 686 examples that never run.
* After: a `--- FAIL` for every example that needs a server, each carrying the connection error and its
  got/want diff, exit status 1, and the package runs to completion.

With a server reachable, nothing changes. No `// Output:` block was edited, and no example prints anything
new on its success path.

### Implementation

The first part of the fix is in the shared helper. `example_utils.go` now returns an unconnected client
instead of `nil` when it cannot connect. `baseClient.executeCommand` and `executeBatch` already check
`coreClient == nil` and return a closed-client error, so a client that holds a live mutex and no core client
reports `the client is closed` for every command rather than being dereferenced as nil. Its message handler
is callback-only, which makes `GetQueue()` return an error instead of handing back a queue that would never
receive a message and would leave a pub/sub example blocked until the test timeout.

This belongs in the helper rather than at the call sites. There are 683 `getExampleClient()` and
`getExampleClusterClient()` calls, so a per-call guard would be a much larger change, and the helper cannot
guard on the caller's behalf: the nil dereference happens in the caller's frame, after the helper has already
returned. The one thing the helper can do at a single point is hand back something that is safe to call.

The second part is in the examples themselves. An example that has been told a command failed now stops
instead of printing that command's result:

```go
result, err := client.Exec(context.Background(), *batch, true)
if err != nil {
	fmt.Println("Glide example failed with an error: ", err)
	return
}
fmt.Println(result)
```

That is the shape the issue points at in `ExampleClient_Exec_transaction`, and it repeats across every
example file, so it is applied uniformly: 672 early returns in 24 files. Each insertion touches only the
error branch, so the success path is byte for byte what it was.

Two places needed a decision rather than the mechanical edit:

* `ExampleClusterClient_CustomCommandWithRoute` discarded its error into `_` and then asserted the nil result
  to `string`. It checks the error now.
* `ExampleClient_ZAddIncrWithOptions` and its cluster twin are about the error: their `// Output:` expects
  both the error line and the zero-value result. Those two keep going, with a comment recording why.

### Limitations

The examples still fail when no server is reachable. That is the correct outcome, since they assert on real
command output. What changes is that they fail one at a time with a readable reason instead of taking the
binary down.

`go/integTest` needs a managed cluster and is untouched here.

The unconnected client relies on the `coreClient == nil` checks in `baseClient`. A future command path that
skips that check would panic again in the examples that call it. That check is already the contract for a
closed client, so this leans on the same guarantee `Close()` gives.

### Testing

Both halves were run. In this environment `localhost:6379` is unreachable, so the plain no-flag run is
genuinely the no-server case. The servers for the success case were started with `utils/cluster_manager.py`.

No server reachable, `go test ./...` from `go/`:

```
before:  --- FAIL: ExampleClient_Exec_transaction (2.00s)
         panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
         ...
         exit status 2
         FAIL    github.com/valkey-io/valkey-glide/go/v2 3.130s

after:   681 lines of "--- FAIL: Example...", each with the connection error and a got/want diff
         0 panics
         FAIL    github.com/valkey-io/valkey-glide/go/v2 666.092s
         exit status 1
```

Server reachable, `go test -v -standalonenode=... -clusternodes=... .` from `go/`:

```
before:  713 PASS, 0 FAIL, exit 0
after:   713 PASS, 0 FAIL, exit 0
```

The two result sets match example for example. Only the per-example timings differ.

`go build ./...` and `go vet ./...` are clean, and `gofmt -l` reports nothing on the changed files. The
`make go-lint` target was not run for this change.

Two failures on `main` are unrelated to this PR and may show red: a repo-wide clippy failure and an
intermittent self-hosted glide-core test job. `go/integTest` also fails locally, because no managed cluster
is provisioned for it here.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). Not run
      for this change; `go build`, `go vet` and `gofmt -l` are clean.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary. No user-facing behaviour changed, so no docs update is needed.
