### PR TITLE
Add Windows ARM64 support to CI

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -12,6 +12,10 @@ on:
             - .github/actions/install-engine/action.yml
             - .github/json_matrices/**
             - .github/workflows/create-test-matrices/action.yml
+            - python/glide-sync/MANIFEST.in
+            - python/glide-sync/build_utils.py
+            - python/glide-sync/pyproject.toml
+            - python/glide-sync/setup.py
     push:
         tags:
             - "v*.*"
@@ -493,6 +497,104 @@ jobs:
                   path: python/glide-sync/wheels
                   if-no-files-found: error
 
+    build-windows-arm64-sync:
+        if: github.repository_owner == 'valkey-io'
+        name: Build sync wheel for Windows ARM64
+        runs-on: windows-11-arm
+        timeout-minutes: 120
+        steps:
+            - name: Checkout
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  submodules: "true"
+
+            - name: Set the release version
+              shell: pwsh
+              env:
+                  EVENT_NAME: ${{ github.event_name }}
+                  INPUT_VERSION: ${{ github.event.inputs.version }}
+              run: |
+                  if ($env:EVENT_NAME -eq "pull_request") {
+                      $releaseVersion = "0.1.0"
+                  } elseif ($env:EVENT_NAME -eq "workflow_dispatch") {
+                      $releaseVersion = $env:INPUT_VERSION
+                  } else {
+                      $releaseVersion = $env:GITHUB_REF -replace "^refs/tags/v", ""
+                  }
+                  "RELEASE_VERSION=$releaseVersion" >> $env:GITHUB_ENV
+
+            - name: Install native build dependencies
+              uses: ./.github/actions/install-shared-dependencies
+              with:
+                  os: windows
+                  target: aarch64-pc-windows-msvc
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Set up Python 3.14
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+              with:
+                  python-version: "3.14"
+                  architecture: arm64
+
+            - name: Install Python build dependencies
+              run: python -m pip install --upgrade pip mypy-protobuf "cibuildwheel>=4.0.0"
+
+            - name: Generate protobuf files
+              shell: pwsh
+              run: |
+                  $protoSource = (Resolve-Path "glide-core\src\protobuf").Path
+                  $protoDestination = (Resolve-Path "python\glide-shared\glide_shared").Path
+                  $mypyPlugin = (Get-Command protoc-gen-mypy).Source
+                  $protoFiles = Get-ChildItem "$protoSource\*.proto" | ForEach-Object { $_.FullName }
+
+                  & protoc "--plugin=protoc-gen-mypy=$mypyPlugin" "--proto_path=protobuf=$protoSource" "--python_out=$protoDestination" "--mypy_out=$protoDestination" @protoFiles
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "Failed to generate Python protobuf files"
+                  }
+
+            - name: Prepare the sync client package
+              shell: pwsh
+              run: |
+                  $pyproject = "python\glide-sync\pyproject.toml"
+                  $content = Get-Content $pyproject -Raw
+                  $versionDeclaration = "version = `"$env:RELEASE_VERSION`""
+                  $content = $content.Replace('dynamic = ["version"]', $versionDeclaration)
+                  if (-not $content.Contains($versionDeclaration)) {
+                      throw "Failed to set the release version in $pyproject"
+                  }
+                  [IO.File]::WriteAllText((Resolve-Path $pyproject), $content)
+
+                  Get-Content "python\.gitignore" |
+                      Where-Object { $_ -notmatch "\*_pb2\.(py|pyi)" } |
+                      Set-Content "python\glide-sync\.gitignore"
+                  Copy-Item "python\README.md" "python\glide-sync\README.md"
+
+            - name: Build Python Sync client wheels
+              run: python -m cibuildwheel python/glide-sync --output-dir python/glide-sync/wheels
+              env:
+                  CIBW_ARCHS_WINDOWS: ARM64
+                  CIBW_BUILD: ${{ github.event_name != 'pull_request' && 'cp39-win_arm64 cp310-win_arm64 cp311-win_arm64 cp312-win_arm64 cp313-win_arm64 cp314-win_arm64' || 'cp314-win_arm64' }}
+
+            - name: Smoke test wheel
+              shell: pwsh
+              run: |
+                  $wheel = Get-ChildItem "python\glide-sync\wheels\*cp314*win_arm64.whl"
+                  if ($wheel.Count -ne 1) {
+                      throw "Expected one CPython 3.14 Windows ARM64 wheel, found $($wheel.Count)"
+                  }
+
+                  python -m venv "$env:RUNNER_TEMP\smoke-sync"
+                  & "$env:RUNNER_TEMP\smoke-sync\Scripts\python.exe" -m pip install $wheel.FullName
+                  & "$env:RUNNER_TEMP\smoke-sync\Scripts\python.exe" -c "from glide_sync import GlideClient; print('Sync smoke test passed')"
+
+            - name: Upload Python Sync client wheels
+              if: github.event_name != 'pull_request'
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              with:
+                  name: wheels-aarch64-pc-windows-msvc-sync
+                  path: python/glide-sync/wheels
+                  if-no-files-found: error
+
     publish-async-to-pypi:
         if: ${{ github.event_name == 'push' || inputs.publish_async == true }}
         name: Publish the async PyPi package
@@ -572,7 +674,7 @@ jobs:
         name: Publish the sync PyPi package
         runs-on: ubuntu-latest
         environment: AWS_ACTIONS
-        needs: publish-binaries
+        needs: [publish-binaries, build-windows-arm64-sync]
         steps:
             - name: Checkout
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -834,12 +834,13 @@ fn create_pipe_writer(pipe_write_fd: i32) -> &'static SharedPipeWriter {
                 }
                 let mut off = 0;
                 while off < data.len() {
+                    #[cfg(windows)]
+                    let write_len = libc::c_uint::try_from(data.len() - off)
+                        .expect("pipe write buffer length exceeds c_uint");
+                    #[cfg(not(windows))]
+                    let write_len = data.len() - off;
                     let w = unsafe {
-                        libc::write(
-                            fd,
-                            data[off..].as_ptr() as *const libc::c_void,
-                            data.len() - off,
-                        )
+                        libc::write(fd, data[off..].as_ptr() as *const libc::c_void, write_len)
                     };
                     if w > 0 {
                         off += w as usize;
@@ -1341,11 +1342,11 @@ unsafe fn process_push_notification(
             client_adapter_ptr,
             push_msg.kind.into(),
             message_ptr,
-            message_len,
+            message_len.into(),
             channel_ptr,
-            channel_len,
+            channel_len.into(),
             pattern_ptr,
-            pattern_len,
+            pattern_len.into(),
         );
         let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
             message_ptr,

--- a/ffi/tests/ffi_client_tests.rs
+++ b/ffi/tests/ffi_client_tests.rs
@@ -161,7 +161,7 @@ fn execute_command(
     client_ptr: *const c_void,
     index: usize,
     command_bytes: &[u8],
-    arg_count: u64,
+    arg_count: c_ulong,
     command_type: RequestType,
 ) -> Option<Box<CommandResult>> {
     let command_len = command_bytes.len();
@@ -241,13 +241,7 @@ fn test_command(client_ptr: *const c_void, async_client: bool) {
     // Good command: PING IS_WORKING
     let good_cmd_idx = 0;
     let ping_value = b"IS_WORKING";
-    let good_res = execute_command(
-        client_ptr,
-        good_cmd_idx,
-        ping_value,
-        1_u64,
-        RequestType::Ping,
-    );
+    let good_res = execute_command(client_ptr, good_cmd_idx, ping_value, 1, RequestType::Ping);
     let ping_res = if async_client {
         assert!(good_res.is_none()); // result should be returned through callback
         let metrics = ASYNC_METRICS.read().expect(ASYNC_READ_LOCK_ERR);
@@ -264,7 +258,7 @@ fn test_command(client_ptr: *const c_void, async_client: bool) {
         client_ptr,
         bad_cmd_idx,
         b"NOTAREALCMD",
-        1_u64,
+        1,
         RequestType::SAdd,
     );
     let (err_msg, err_type) = if async_client {
@@ -284,7 +278,7 @@ fn execute_command_with_route_info(
     client_ptr: *const c_void,
     index: usize,
     command_bytes: &[u8],
-    arg_count: u64,
+    arg_count: c_ulong,
     command_type: RequestType,
     route_info: *const RouteInfo,
 ) -> Option<Box<CommandResult>> {
@@ -346,7 +340,7 @@ fn test_command_with_route_info(client_ptr: *const c_void, async_client: bool) {
         client_ptr,
         good_cmd_idx,
         ping_value,
-        1_u64,
+        1,
         RequestType::Ping,
         route_info_ptr,
     );
@@ -367,7 +361,7 @@ fn test_command_with_route_info(client_ptr: *const c_void, async_client: bool) {
         client_ptr,
         bad_cmd_idx,
         b"NOTAREALCMD",
-        1_u64,
+        1,
         RequestType::SAdd,
         route_info_ptr,
     );
@@ -390,7 +384,7 @@ fn test_command_with_route_info(client_ptr: *const c_void, async_client: bool) {
         client_ptr,
         null_route_cmd_idx,
         ping_value,
-        1_u64,
+        1,
         RequestType::Ping,
         std::ptr::null(),
     );

--- a/python/glide-sync/MANIFEST.in
+++ b/python/glide-sync/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
+include build_utils.py
 # Ensure ffi, glide-core and logger are included
 recursive-include ffi *
 recursive-include glide-core *

--- a/python/glide-sync/build_utils.py
+++ b/python/glide-sync/build_utils.py
@@ -1,0 +1,15 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+
+def rust_cdylib_filename(crate_name: str, current_platform: str) -> str:
+    """Return Cargo's cdylib output filename for the target platform."""
+    platform_parts = {
+        "linux": ("lib", ".so"),
+        "darwin": ("lib", ".dylib"),
+        "win32": ("", ".dll"),
+    }
+    try:
+        prefix, suffix = platform_parts[current_platform]
+    except KeyError as error:
+        raise RuntimeError(f"Unsupported platform: {current_platform}") from error
+    return f"{prefix}{crate_name}{suffix}"

--- a/python/glide-sync/pyproject.toml
+++ b/python/glide-sync/pyproject.toml
@@ -99,3 +99,7 @@ else
     exit 1
 fi
 """
+
+[tool.cibuildwheel.windows]
+# Rust and protoc are installed on the runner before cibuildwheel starts.
+before-build = ""

--- a/python/glide-sync/setup.py
+++ b/python/glide-sync/setup.py
@@ -33,6 +33,7 @@ import sysconfig
 from dataclasses import dataclass
 from pathlib import Path
 
+from build_utils import rust_cdylib_filename
 from setuptools import Command, setup
 from setuptools.command.build_ext import build_ext as build_ext_orig
 from setuptools.command.build_py import build_py as build_py_orig
@@ -96,7 +97,7 @@ def vendor_dependencies():
     for _name, folder in VENDORED_DEPENDENCIES.items():
         if folder.dist.exists():
             remove_existing(folder.dist)
-        print(f"[INFO] Copying {folder.source} → {folder.dist}")
+        print(f"[INFO] Copying {folder.source} -> {folder.dist}")
         shutil.copytree(folder.source, folder.dist, ignore=ignore_dirs)
 
     # Vendor only the Rust build files for glide-shared (Cargo.toml + src/)
@@ -192,15 +193,14 @@ class build_ext(build_ext_orig):
             check=True,
         )
 
-        # Determine shared library path based on platform
+        # Determine shared library paths based on platform
         target_dir = "release" if release else "debug"
-        suffix = {"linux": ".so", "darwin": ".dylib", "win32": ".dll"}[sys.platform]
-        lib_name = "libglide_ffi" + suffix
+        lib_name = rust_cdylib_filename("glide_ffi", sys.platform)
 
         built_lib = ffi_path / "target" / target_dir / lib_name
         dest_dir = Path(self.build_lib) / "glide_sync"
         dest_dir.mkdir(parents=True, exist_ok=True)
-        print(f"[INFO] Copying {built_lib} → {dest_dir / lib_name}")
+        print(f"[INFO] Copying {built_lib} -> {dest_dir / lib_name}")
         shutil.copy2(built_lib, dest_dir / lib_name)
 
         # Build _fast_response native extension from glide-shared Rust crate
@@ -229,12 +229,15 @@ class build_ext(build_ext_orig):
             "EXT_SUFFIX"
         )  # e.g. .cpython-311-darwin.so
         src_lib = (
-            glide_shared_rs / "target" / target_dir / ("lib_fast_response" + suffix)
+            glide_shared_rs
+            / "target"
+            / target_dir
+            / rust_cdylib_filename("_fast_response", sys.platform)
         )
         dest_shared = Path(self.build_lib) / "glide_shared"
         dest_shared.mkdir(parents=True, exist_ok=True)
         dest_ext = dest_shared / ("_fast_response" + ext_suffix)
-        print(f"[INFO] Copying {src_lib} → {dest_ext}")
+        print(f"[INFO] Copying {src_lib} -> {dest_ext}")
         shutil.copy2(src_lib, dest_ext)
 
         super().run()
@@ -276,7 +279,7 @@ class build_py(build_py_orig):
             source = ROOT.parent / "glide-shared" / "glide_shared"
         dest = Path(self.build_lib) / "glide_shared"
 
-        print(f"[INFO] Vendoring glide_shared from {source} → {dest}")
+        print(f"[INFO] Vendoring glide_shared from {source} -> {dest}")
         shutil.copytree(source, dest, dirs_exist_ok=True)
         super().run()
 

--- a/python/glide-sync/tests/test_build_utils.py
+++ b/python/glide-sync/tests/test_build_utils.py
@@ -1,0 +1,34 @@
+# Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+BUILD_UTILS_PATH = Path(__file__).resolve().parent.parent / "build_utils.py"
+BUILD_UTILS_SPEC = spec_from_file_location("glide_sync_build_utils", BUILD_UTILS_PATH)
+if BUILD_UTILS_SPEC is None or BUILD_UTILS_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {BUILD_UTILS_PATH}")
+BUILD_UTILS = module_from_spec(BUILD_UTILS_SPEC)
+BUILD_UTILS_SPEC.loader.exec_module(BUILD_UTILS)
+rust_cdylib_filename = BUILD_UTILS.rust_cdylib_filename
+
+
+@pytest.mark.parametrize(
+    ("current_platform", "crate_name", "expected"),
+    [
+        ("linux", "glide_ffi", "libglide_ffi.so"),
+        ("darwin", "glide_ffi", "libglide_ffi.dylib"),
+        ("win32", "glide_ffi", "glide_ffi.dll"),
+        ("win32", "_fast_response", "_fast_response.dll"),
+    ],
+)
+def test_rust_cdylib_filename(
+    current_platform: str, crate_name: str, expected: str
+) -> None:
+    assert rust_cdylib_filename(crate_name, current_platform) == expected
+
+
+def test_rust_cdylib_filename_rejects_unknown_platform() -> None:
+    with pytest.raises(RuntimeError, match="Unsupported platform: freebsd"):
+        rust_cdylib_filename("glide_ffi", "freebsd")


### PR DESCRIPTION
Hi @xShinnRyuu , I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
So I updates the CI workflows to add support for Windows ARM64 builds and tests. Could you please help to review? Thanks.

### Summary

Add Windows ARM64 wheel support for `valkey-glide-sync` to the existing PyPI release pipeline.

### Features / Behaviour Changes

- Builds native Windows ARM64 wheels for CPython 3.9–3.14.
- Builds only CPython 3.14 on pull requests for faster validation.
- Smoke-tests the CPython 3.14 wheel on a native `windows-11-arm` runner.
- Includes Windows ARM64 artifacts when publishing `valkey-glide-sync` to PyPI.

### Implementation

- Added a dedicated Windows ARM64 sync-wheel job to `pypi-cd.yml`.
- Configured native ARM64 Python, Rust, MSVC, and protobuf tooling.
- Added Windows-specific `cibuildwheel` configuration.
- Added platform-aware Cargo `cdylib` filename handling for `.dll`, `.so`, and `.dylib` outputs.
- Fixed Windows FFI integer-width differences for pipe writes, PubSub callback lengths, and test helpers.
- Made sync publishing depend on the Windows ARM64 build so its wheels are collected before publishing.
- Included the new packaging helper in source distributions.

Reviewers should pay particular attention to the FFI type conversions and the new release-job dependency.

### Limitations

- This adds Windows ARM64 support only for `valkey-glide-sync`; the async client remains unsupported on Windows ARM64.
- Windows ARM64 PyPy wheels are not built.
- The release job runs only in the `valkey-io` repository because the existing pipeline is owner-gated.

### Testing

- Built a native `cp312-win_arm64` wheel with `cibuildwheel`.
- Verified the wheel contains `glide_ffi.dll` and the `_fast_response` `.pyd`.
- Installed the wheel and successfully imported `GlideClient`.
- Verified build identifiers for CPython 3.9–3.14 Windows ARM64.
- Verified the source distribution contains the packaging helper.
- Passed 5 packaging-helper unit tests.
- Passed 11 FFI PubSub callback tests.
- Passed Rust formatting and Clippy checks.
- Passed Black, isort, Flake8, mypy, and workflow Prettier checks.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated or are not required for this CI-only change.
- [x] Linters have been run and Prettier has been run.
- [x] Destination branch is correct — `main`.
- [x] Squash merge will be used.
- [x] No valkey-glide-docs update is required.
