### PR TITLE
Redis-rs: Fix clippy::useless_format in cluster_async/mod.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Redis-rs: Fix clippy::useless_format in cluster_async/mod.rs ([#6829](https://github.com/valkey-io/valkey-glide/pull/6829))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -2524,8 +2524,8 @@ where
             .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
             .is_err()
         {
-            log_warn_lazy!("topology_refresh", format!(
-                "Concurrent slot refresh rejected by compare_exchange (another refresh is already in progress)"));
+            log_warn_lazy!("topology_refresh",
+                "Concurrent slot refresh rejected by compare_exchange (another refresh is already in progress)".to_string());
             return Ok(());
         }
         let acquire_elapsed = acquire_start.elapsed();


### PR DESCRIPTION
### Summary\n\nFix `clippy::useless_format` lint error by replacing `format!(\"literal\")` with `\"literal\".to_string()` for a string without format arguments.\n\n### Issue link\n\nThis Pull Request is linked to issue: [[Redis-rs][Flaky Test] Lint redis-rs - clippy::useless_format in cluster_async/mod.rs](https://github.com/valkey-io/valkey-glide/issues/6828)\nCloses #6828\n\n### Features / Behaviour Changes\n\nNo behaviour changes. This is a lint-only fix.\n\n### Implementation\n\nReplaced `format!(\"Concurrent slot refresh rejected by compare_exchange (another refresh is already in progress)\")` with `\"Concurrent slot refresh rejected by compare_exchange (another refresh is already in progress)\".to_string()` in `glide-core/redis-rs/redis/src/cluster_async/mod.rs`.\n\nThe `format!` macro is unnecessary when the argument is a literal string with no format parameters. Clippy correctly flags this as `useless_format`.\n\n### Limitations\n\nNone.\n\n### Testing\n\nThis is a lint fix — the code behavior is unchanged. The string value produced is identical.\n\n### Checklist\n\n- [x] This Pull Request is related to one issue.\n- [x] Commit message has a detailed description of what changed and why.\n- [ ] Tests are added or updated.\n- [ ] CHANGELOG.md and documentation files are updated.\n- [x] Linters have been run.\n- [x] Destination branch is correct - main or release"