### PR TITLE
Go: Fix flaky TestParallelizedSetWithGC timeout under ASAN with Go 1.22

### DIFF
--- a/go/base_client.go
+++ b/go/base_client.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -354,6 +355,11 @@ func (client *baseClient) executeCommandWithRoute(
 		C.uint64_t(spanPtr),
 	)
 	client.mu.Unlock()
+	// Keep args alive until after C.command returns, since toCStrings stores raw pointers
+	// to string data as uintptr values which are invisible to the GC. Without this, the GC
+	// may collect the underlying string data during the C call under heavy GC pressure
+	// (e.g., TestParallelizedSetWithGC with 640 goroutines calling runtime.GC()).
+	runtime.KeepAlive(args)
 	// Wait for result or context cancellation
 	var payload payload
 	select {
@@ -468,6 +474,9 @@ func (client *baseClient) executeBatch(
 		C.uint64_t(spanPtr),
 	)
 	client.mu.Unlock()
+	// Keep batch alive until after C.batch returns, since createCmdInfo stores raw pointers
+	// to string data via unsafe.StringData which are invisible to the GC.
+	runtime.KeepAlive(batch)
 
 	// Wait for result or context cancellation
 	var payload payload
@@ -9873,6 +9882,10 @@ func (client *baseClient) executeScriptWithRoute(
 		C.uint64_t(spanPtr),
 	)
 	client.mu.Unlock()
+	// Keep keys and args alive until after C.invoke_script returns, since toCStrings stores raw
+	// pointers to string data as uintptr values which are invisible to the GC.
+	runtime.KeepAlive(keys)
+	runtime.KeepAlive(args)
 
 	// Wait for result or context cancellation
 	var payload payload

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"strconv"
 	"unsafe"
 
@@ -696,6 +697,9 @@ func (client *ClusterClient) clusterScan(
 		argLengthsPtr,
 	)
 	client.mu.Unlock()
+	// Keep args alive until after C.request_cluster_scan returns, since toCStrings stores raw
+	// pointers to string data as uintptr values which are invisible to the GC.
+	runtime.KeepAlive(args)
 
 	// Wait for result or context cancellation
 	var payload payload

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -528,10 +528,13 @@ func (suite *GlideTestSuite) runParallelizedWithClients(
 	for _, client := range clients {
 		suite.T().Run(fmt.Sprintf("%T", client)[1:], func(t *testing.T) {
 			done := make(chan struct{}, parallelism)
+			// Use a stop flag to signal goroutines to exit on timeout, preventing
+			// goroutine leaks that cause "Fail in goroutine after test has completed" panics.
+			var stopped atomic.Int32
 			for i := 0; i < parallelism; i++ {
 				go func() {
 					defer func() { done <- struct{}{} }()
-					for !suite.T().Failed() && atomic.AddInt64(&count, -1) > 0 {
+					for stopped.Load() == 0 && !suite.T().Failed() && atomic.AddInt64(&count, -1) > 0 {
 						test(client)
 					}
 				}()
@@ -542,6 +545,7 @@ func (suite *GlideTestSuite) runParallelizedWithClients(
 				select {
 				case <-done:
 				case <-tm.C:
+					stopped.Store(1)
 					suite.T().Fatalf("parallelized test timeout")
 				}
 			}

--- a/go/integTest/parallelized_test.go
+++ b/go/integTest/parallelized_test.go
@@ -13,7 +13,9 @@ import (
 
 func (suite *GlideTestSuite) TestParallelizedSetWithGC() {
 	// The insane 640 parallelism is required to reproduce https://github.com/valkey-io/valkey-glide/issues/3207.
-	suite.runParallelizedWithDefaultClients(640, 640000, 2*time.Minute, func(client interfaces.BaseClientCommands) {
+	// Use a longer timeout to accommodate AddressSanitizer overhead in container environments
+	// where GC pressure from 640 goroutines significantly increases execution time.
+	suite.runParallelizedWithDefaultClients(640, 640000, 5*time.Minute, func(client interfaces.BaseClientCommands) {
 		runtime.GC()
 		key := uuid.New().String()
 		value := uuid.New().String()


### PR DESCRIPTION
### Summary

Fix flaky `TestParallelizedSetWithGC` that times out under AddressSanitizer (ASAN) with Go 1.22 in container CI environments.

### Issue link

This Pull Request is linked to issue: [[Go][Flaky Test] test-go-container failing on amazon-linux x86_64 with Go 1.22, valkey 8.0 and 9.0](https://github.com/valkey-io/valkey-glide/issues/6856)
Closes #6856

### Features / Behaviour Changes

No behaviour changes. This is a test reliability improvement and a preventive GC safety fix.

### Implementation

**Root cause:** The test's hardcoded 2-minute timeout is insufficient when running with AddressSanitizer (`CC="gcc -fsanitize=address"`). ASAN adds 2-3x overhead to memory operations, and combined with Go 1.22's GC (less efficient than Go 1.24), execution takes ~130s exceeding the 2-minute limit.

Three complementary fixes:

1. **Timeout increase** (`parallelized_test.go`): 2min → 5min to accommodate ASAN overhead
2. **Goroutine leak prevention** (`glide_test_suite_test.go`): Added `atomic.Int32` stop flag so goroutines exit promptly on timeout, preventing "Fail in goroutine after test has completed" panics
3. **GC safety** (`base_client.go`, `glide_cluster_client.go`): Added `runtime.KeepAlive` calls after C function calls to prevent GC from collecting string data passed via unsafe pointers under heavy GC pressure

### Limitations

None.

### Testing

- 10/10 passes with ASAN and Go 1.22 (the failing configuration)
- 20/20 passes without ASAN and Go 1.22
- `go build ./...` and `go vet ./...` pass cleanly

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.