### PR TITLE
ci: fix rustup 'unknown proxy name' error in MUSL containers

### DIFF
--- a/.github/actions/install-shared-dependencies/action.yml
+++ b/.github/actions/install-shared-dependencies/action.yml
@@ -1,0 +1,114 @@
+name: Install shared software dependencies
+description: Install platform-specific dependencies for valkey-glide builds
+
+inputs:
+    os:
+        description: "The current operating system"
+        required: true
+    target:
+        description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
+        required: false
+        default: "x86_64-unknown-linux-gnu"
+    engine-version:
+        description: "Engine version to install"
+        required: false
+    language:
+        description: "The language being built (optional, for language-specific setup)"
+        required: false
+    github-token:
+        description: "GITHUB_TOKEN, GitHub App installation access token"
+        required: true
+
+runs:
+    using: "composite"
+    steps:
+        - name: Install software dependencies for macOS
+          shell: bash
+          if: "${{ inputs.os == 'macos' }}"
+          run: |
+              brew update
+              brew install openssl coreutils
+
+        - name: Install software dependencies for Ubuntu GNU
+          shell: bash
+          if: "${{ inputs.os == 'ubuntu' && !contains(inputs.target, 'musl')}}"
+          run: |
+              sudo apt update -y
+              sudo apt install -y git gcc pkg-config openssl libssl-dev
+
+        - name: Install software dependencies for MUSL
+          shell: bash
+          if: "${{ contains(inputs.target, 'musl') }}"
+          env:
+              GH_TARGET: ${{ inputs.target }}
+          run: |
+              apk update
+              RUSTUP_DIR=$(mktemp -d)
+              RUSTUP_INIT="$RUSTUP_DIR/rustup-init"
+              trap "rm -rf $RUSTUP_DIR" EXIT
+              case "$GH_TARGET" in
+                x86_64-unknown-linux-musl)
+                  RUSTUP_URL="https://static.rust-lang.org/rustup/archive/1.28.1/x86_64-unknown-linux-musl/rustup-init"
+                  RUSTUP_SHA256="8e60c9157b7aa2bf32baab5c124b80a31dd24ba6c41b39b50645d354d381f831"
+                  ;;
+                aarch64-unknown-linux-musl)
+                  RUSTUP_URL="https://static.rust-lang.org/rustup/archive/1.28.1/aarch64-unknown-linux-musl/rustup-init"
+                  RUSTUP_SHA256="b3ceb9642150570b1cc43b279441dc98062a100b1974e9f6a518517c8b5900a8"
+                  ;;
+                *)
+                  echo "Unsupported MUSL target: $GH_TARGET"
+                  exit 1
+                  ;;
+              esac
+              wget -O "$RUSTUP_INIT" "$RUSTUP_URL"
+              echo "$RUSTUP_SHA256  $RUSTUP_INIT" | sha256sum -c -
+              chmod +x "$RUSTUP_INIT"
+              "$RUSTUP_INIT" -y --no-modify-path --default-toolchain stable
+              source "$HOME/.cargo/env"
+              apk add protobuf-dev musl-dev make gcc envsubst openssl libressl-dev py3-pip
+
+        - name: Install software dependencies for Amazon-Linux
+          shell: bash
+          if: "${{ inputs.os == 'amazon-linux' }}"
+          run: |
+              yum install -y gcc pkgconfig openssl openssl-devel which curl gettext libasan libatomic tar --allowerasing
+
+        - name: Setup WSL (Windows only)
+          if: "${{ inputs.os == 'windows' && inputs.engine-version }}"
+          uses: Vampire/setup-wsl@887f39deb6c0976365e546926fe66f41b77d65ff # v6
+          with:
+              distribution: Ubuntu-22.04
+              use-cache: true
+              update: true
+              additional-packages: python3 python3-pip build-essential git pkg-config libssl-dev
+
+        - name: Setup Python for Windows
+          if: "${{ inputs.os == 'windows' }}"
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+          with:
+              python-version: "3.x"
+
+        - name: Install Rust toolchain
+          if: "${{ !contains(inputs.target, 'musl') }}"
+          uses: ./.github/actions/install-rust
+          with:
+              target: ${{ inputs.target }}
+
+        - name: Install protoc
+          if: "${{ !contains(inputs.target, 'musl') }}"
+          uses: ./.github/actions/install-protoc
+          with:
+              github-token: ${{ inputs.github-token }}
+
+        - name: Install engine
+          if: "${{ inputs.engine-version }}"
+          uses: ./.github/actions/install-engine
+          with:
+              engine-version: ${{ inputs.engine-version }}
+              target: ${{ inputs.target }}
+
+        - name: Install zig
+          if: ${{ contains(inputs.target, 'linux-gnu') }}
+          uses: ./.github/actions/install-zig
+          with:
+              target: ${{ inputs.target }}


### PR DESCRIPTION
### Summary

Fix rustup "unknown proxy name: 'tmp'" error that causes all 12 Go MUSL container test jobs to fail during the "Install shared software dependencies" CI step.

### Issue link

This Pull Request is linked to issue: [[Go][Flaky Test] Install shared software dependencies - rustup unknown proxy name tmp](https://github.com/valkey-io/valkey-glide/issues/6859)
Closes #6859

### Features / Behaviour Changes

No behaviour changes. This PR fixes CI infrastructure flakiness only.

### Implementation

**Root cause:** Rustup 1.28.1 uses `argv[0]` basename to determine its execution mode (installer vs. proxy). When rustup-init is downloaded to a random temp file via `mktemp` (e.g., `/tmp/tmp.kjEkFm`), the basename `tmp.kjEkFm` is parsed as proxy name `tmp`, which fails with:
```
error: unknown proxy name: 'tmp'; valid proxy names are 'rustc', 'rustdoc', 'cargo', ...
```

**Fix:** Replace `mktemp` (creates a randomly-named file) with `mktemp -d` (creates a temp directory), then place the binary inside as `rustup-init`. This ensures the executed binary has basename `rustup-init`, which rustup recognizes as its installer mode.

Changed lines:
```diff
-RUSTUP_INIT=$(mktemp)
-trap "rm -f $RUSTUP_INIT" EXIT
+RUSTUP_DIR=$(mktemp -d)
+RUSTUP_INIT="$RUSTUP_DIR/rustup-init"
+trap "rm -rf $RUSTUP_DIR" EXIT
```

### Limitations

None

### Testing

- Validated YAML syntax with Python yaml parser
- Confirmed `mktemp -d` produces the correct basename (`rustup-init`) for the binary path
- This is a CI infrastructure fix that can only be fully validated by running the CI pipeline

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated - N/A (CI infrastructure fix).
- [ ] CHANGELOG.md and documentation files are updated - N/A for flaky-test/CI fixes.
- [x] Lint checked manually (matched surrounding style; lint tools not run locally).
- [x] Destination branch is correct - main or release