### PR TITLE
feat(core): add structured JSON logging

### DIFF
--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -1704,6 +1704,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -1605,6 +1605,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -1543,6 +1543,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/ffi/miri-tests/mock-glide-core/Cargo.lock
+++ b/ffi/miri-tests/mock-glide-core/Cargo.lock
@@ -1543,6 +1543,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/ffi/miri-tests/mock-redis/Cargo.lock
+++ b/ffi/miri-tests/mock-redis/Cargo.lock
@@ -880,6 +880,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -1934,6 +1934,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/glide-core/redis-rs/Cargo.lock
+++ b/glide-core/redis-rs/Cargo.lock
@@ -1209,6 +1209,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/glide-core/telemetry/Cargo.lock
+++ b/glide-core/telemetry/Cargo.lock
@@ -708,6 +708,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -1625,6 +1625,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/logger_core/Cargo.lock
+++ b/logger_core/Cargo.lock
@@ -223,11 +223,18 @@ dependencies = [
  "file-rotate",
  "once_cell",
  "rand",
+ "serde_json",
  "test-env-helpers",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -345,6 +352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +378,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -715,3 +744,9 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/logger_core/Cargo.toml
+++ b/logger_core/Cargo.toml
@@ -17,3 +17,4 @@ tracing-appender = { version = "0.2.3", default-features = false }
 once_cell = "1.16.0"
 file-rotate = "0.8.0"
 tracing-subscriber = "0.3.17"
+serde_json = "1"

--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -2,21 +2,27 @@
  * Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
  */
 use once_cell::sync::OnceCell;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::{
+    fmt,
     path::{Path, PathBuf},
     sync::RwLock,
     sync::atomic::{AtomicUsize, Ordering},
 };
-use tracing::{self, event};
+use tracing::{
+    self, Event, Subscriber, event,
+    field::{Field, Visit},
+};
 use tracing_appender::rolling::{RollingFileAppender, RollingWriter, Rotation};
 use tracing_subscriber::{
     Registry,
     filter::Filtered,
     fmt::{
-        Layer,
-        format::{DefaultFields, Format},
+        FmtContext, FormatEvent, FormatFields, Layer,
+        format::{DefaultFields, Format, Writer},
     },
     layer::Layered,
+    registry::LookupSpan,
 };
 
 use tracing_subscriber::{
@@ -29,13 +35,14 @@ use tracing_subscriber::{
 use std::str::FromStr;
 
 // Layer-Filter pair determines whether a log will be collected
-type InnerFiltered = Filtered<Layer<Registry>, LevelFilter, Registry>;
+type InnerFiltered =
+    Filtered<Layer<Registry, DefaultFields, GlideLogFormat>, LevelFilter, Registry>;
 // A Reloadable pair of layer-filter
 type InnerLayered = Layered<reload::Layer<InnerFiltered, Registry>, Registry>;
 // A reloadable layer of subscriber to a rolling file
 type FileReload = Handle<
     Filtered<
-        Layer<InnerLayered, DefaultFields, Format, LazyRollingFileAppender>,
+        Layer<InnerLayered, DefaultFields, GlideLogFormat, LazyRollingFileAppender>,
         LevelFilter,
         InnerLayered,
     >,
@@ -78,6 +85,59 @@ pub fn level_may_be_enabled(level: tracing::Level) -> bool {
 
 const FILE_DIRECTORY: &str = "glide-logs";
 const ENV_GLIDE_LOG_DIR: &str = "GLIDE_LOG_DIR";
+const STRUCTURED_PAYLOAD_FIELD: &str = "glide_structured_payload";
+
+#[derive(Default)]
+/// Formats structured events as JSON and delegates all other events to the text formatter.
+struct GlideLogFormat {
+    text_format: Format,
+}
+
+impl<S, N> FormatEvent<S, N> for GlideLogFormat
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    /// Writes a structured payload as one JSON line or uses the existing text format.
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let mut visitor = StructuredPayloadVisitor::default();
+        event.record(&mut visitor);
+
+        if let Some(payload) = visitor.payload {
+            writeln!(writer, "{payload}")?;
+            return Ok(());
+        }
+
+        self.text_format.format_event(ctx, writer, event)
+    }
+}
+
+#[derive(Default)]
+/// Extracts the private structured payload field from a tracing event.
+struct StructuredPayloadVisitor {
+    payload: Option<String>,
+}
+
+impl Visit for StructuredPayloadVisitor {
+    /// Records the structured payload when tracing provides it as a string field.
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == STRUCTURED_PAYLOAD_FIELD {
+            self.payload = Some(value.to_string());
+        }
+    }
+
+    /// Records the structured payload when tracing provides it through debug formatting.
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name() == STRUCTURED_PAYLOAD_FIELD {
+            self.payload = Some(format!("{value:?}"));
+        }
+    }
+}
 
 /// Wraps [RollingFileAppender] to defer initialization until logging is required,
 /// allowing [init] to disable file logging on read-only filesystems.
@@ -127,6 +187,55 @@ pub enum Level {
     Trace = 4,
     Off = 5,
 }
+
+#[derive(Debug, Clone)]
+/// A typed key-value field included in a structured log event.
+pub struct StructuredField {
+    key: &'static str,
+    value: JsonValue,
+}
+
+/// Creates a structured field from a JSON-compatible value.
+pub fn structured_field<Value: Into<JsonValue>>(
+    key: &'static str,
+    value: Value,
+) -> StructuredField {
+    StructuredField {
+        key,
+        value: value.into(),
+    }
+}
+
+/// Creates a borrowed collection of typed fields for [`log_structured`].
+#[macro_export]
+macro_rules! structured_fields {
+    ($($key:literal => $value:expr),* $(,)?) => {
+        &[$($crate::structured_field($key, $value)),*]
+    };
+}
+
+/// Builds the single-line JSON payload written for a structured event.
+fn structured_payload(
+    log_level: &Level,
+    log_identifier: &str,
+    fields: &[StructuredField],
+) -> String {
+    let mut payload = JsonMap::with_capacity(fields.len() + 3);
+    for field in fields {
+        payload.insert(field.key.to_string(), field.value.clone());
+    }
+    payload.insert("glide_structured".to_string(), JsonValue::Bool(true));
+    payload.insert(
+        "glide_event".to_string(),
+        JsonValue::String(log_identifier.to_string()),
+    );
+    payload.insert(
+        "level".to_string(),
+        JsonValue::String(log_level.as_str().to_string()),
+    );
+    JsonValue::Object(payload).to_string()
+}
+
 impl Level {
     fn to_filter(&self) -> filter::LevelFilter {
         match self {
@@ -136,6 +245,18 @@ impl Level {
             Level::Warn => LevelFilter::WARN,
             Level::Error => LevelFilter::ERROR,
             Level::Off => LevelFilter::OFF,
+        }
+    }
+
+    /// Returns the lowercase level name stored in structured events.
+    fn as_str(&self) -> &'static str {
+        match self {
+            Level::Error => "error",
+            Level::Warn => "warn",
+            Level::Info => "info",
+            Level::Debug => "debug",
+            Level::Trace => "trace",
+            Level::Off => "off",
         }
     }
 }
@@ -164,6 +285,7 @@ pub fn init(minimal_level: Option<Level>, file_name: Option<&str>) -> Level {
     let level_filter = level.to_filter();
     let reloads = INITIATE_ONCE.init_once.get_or_init(|| {
         let stdout_fmt = tracing_subscriber::fmt::layer()
+            .event_format(GlideLogFormat::default())
             .with_ansi(true)
             .with_filter(LevelFilter::OFF);
 
@@ -179,6 +301,7 @@ pub fn init(minimal_level: Option<Level>, file_name: Option<&str>) -> Level {
         );
 
         let file_fmt = tracing_subscriber::fmt::layer()
+            .event_format(GlideLogFormat::default())
             .with_writer(file_appender)
             .with_filter(LevelFilter::OFF);
         let (file_layer, file_reload) = reload::Layer::new(file_fmt);
@@ -289,6 +412,41 @@ create_log!(log_debug, DEBUG);
 create_log!(log_info, INFO);
 create_log!(log_warn, WARN);
 create_log!(log_error, ERROR);
+
+/// Emits a structured event as exactly one JSON line.
+pub fn log_structured<Identifier: AsRef<str>>(
+    log_level: Level,
+    log_identifier: Identifier,
+    fields: &[StructuredField],
+) {
+    if INITIATE_ONCE.init_once.get().is_none() {
+        init(Some(Level::Warn), None);
+    };
+    let payload = structured_payload(&log_level, log_identifier.as_ref(), fields);
+    match log_level {
+        Level::Debug => event!(
+            tracing::Level::DEBUG,
+            glide_structured_payload = payload.as_str()
+        ),
+        Level::Trace => event!(
+            tracing::Level::TRACE,
+            glide_structured_payload = payload.as_str()
+        ),
+        Level::Info => event!(
+            tracing::Level::INFO,
+            glide_structured_payload = payload.as_str()
+        ),
+        Level::Warn => event!(
+            tracing::Level::WARN,
+            glide_structured_payload = payload.as_str()
+        ),
+        Level::Error => event!(
+            tracing::Level::ERROR,
+            glide_structured_payload = payload.as_str()
+        ),
+        Level::Off => (),
+    }
+}
 
 /// Lazy logging macros that only evaluate the message expression if the log level is enabled.
 /// This avoids the cost of `format!(...)` when the level is disabled.

--- a/logger_core/tests/test_logger.rs
+++ b/logger_core/tests/test_logger.rs
@@ -7,8 +7,9 @@ use test_env_helpers::*;
 #[after_all]
 #[before_all]
 mod tests {
-    use logger_core::{init, log_debug, log_trace};
+    use logger_core::{init, log_debug, log_structured, log_trace, structured_fields};
     use rand::{Rng, distributions::Alphanumeric};
+    use serde_json::Value;
     use std::{
         fs::{read_dir, read_to_string, remove_dir_all},
         path::Path,
@@ -81,6 +82,34 @@ mod tests {
             "Contents: {contents}"
         );
         assert!(contents.contains("foo"), "Contents: {contents}");
+    }
+
+    #[test]
+    fn structured_log_to_file_is_json_line() {
+        let identifier = generate_random_string(10);
+        init(Some(logger_core::Level::Debug), Some(identifier.as_str()));
+
+        log_structured(
+            logger_core::Level::Debug,
+            "resp_decode_error",
+            structured_fields!(
+                "parser_phase" => "frame_scan",
+                "buffer_len" => 512_usize,
+                "recoverable" => false,
+            ),
+        );
+
+        let contents = get_file_contents(identifier.as_str());
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1, "Contents: {contents}");
+
+        let event: Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(event["glide_structured"], true);
+        assert_eq!(event["glide_event"], "resp_decode_error");
+        assert_eq!(event["level"], "debug");
+        assert_eq!(event["parser_phase"], "frame_scan");
+        assert_eq!(event["buffer_len"], 512);
+        assert_eq!(event["recoverable"], false);
     }
 
     #[test]

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -1599,6 +1599,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -1617,6 +1617,7 @@ version = "0.1.0"
 dependencies = [
  "file-rotate",
  "once_cell",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",


### PR DESCRIPTION
### Summary

Add an opt-in structured logging API to `logger_core`. Callers can emit typed fields as a single JSON line while existing logs retain their current text format.

### Issue link

This Pull Request is linked to issue: [Add structured JSON event support to logger_core](https://github.com/valkey-io/valkey-glide/issues/6873)
Closes #6873

### Features / Behaviour Changes

- Adds `log_structured`, `structured_field`, and `structured_fields!`.
- Emits `glide_structured`, `glide_event`, and `level` on every structured event.
- Preserves current formatting for ordinary log events.

### Implementation

A custom tracing event formatter detects the private structured-payload field and writes its JSON value as exactly one line. All other events delegate to the existing tracing formatter.

### Limitations

This PR provides the generic logging facility only. It does not add component-specific diagnostic events.

### Testing

- `env -u RUST_LOG cargo test --all-features -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated. Not required: this is an internal logging API with no user-facing behavior.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). Equivalent Rust formatting and clippy checks are listed above.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary. No documentation update is necessary for this internal API.
