### PR TITLE
fix(core): backport recovery-queue drain and escalation hardening to release-2.5

### DIFF
--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3635,6 +3635,29 @@ where
         }
     }
 
+    /// Fail all requests currently buffered in the recovery queue.
+    /// Called when escalating from RefreshingSlots to ReconnectToInitialNodes
+    /// so queued requests follow the documented fail-fast policy.
+    fn fail_recovery_queue(&mut self) {
+        let count = self.recovery_queue.len();
+        if count > 0 {
+            log_warn_rate_limited!(
+                "cluster",
+                5,
+                format!(
+                    "fail_recovery_queue: failing {} buffered requests on escalation to ReconnectToInitialNodes",
+                    count
+                )
+            );
+            for request in self.recovery_queue.drain(..) {
+                let _ = request.sender.send(Err(RedisError::from((
+                    ErrorKind::ClientError,
+                    "Connection in recovery",
+                ))));
+            }
+        }
+    }
+
     /// Fail all pending requests immediately with ClientError.
     /// Called when entering recovery to prevent requests from waiting for slow
     /// reconnection cycles (e.g., ReconnectToInitialNodes, RefreshingSlots).
@@ -3696,7 +3719,10 @@ where
                         log_trace_lazy!("cluster", format!("Slot refresh failed: {:?}", e));
 
                         if e.kind() == ErrorKind::AllConnectionsUnavailable {
-                            // If all connections unavailable, try reconnect
+                            // If all connections unavailable, try reconnect.
+                            // Fail any requests buffered during RefreshingSlots: they must
+                            // follow the fail-fast policy of ReconnectToInitialNodes.
+                            self.fail_recovery_queue();
                             let inner = self.inner.clone();
                             let handle = tokio::spawn(async move {
                                 ClusterConnInner::reconnect_to_initial_nodes(inner).await
@@ -3731,6 +3757,9 @@ where
                             // TODO - consider a gracefully closing of the client
                             // Since a panic indicates a bug in the refresh logic,
                             // it might be safer to close the client entirely
+                            // Fail any requests buffered during RefreshingSlots: they must
+                            // follow the fail-fast policy of ReconnectToInitialNodes.
+                            self.fail_recovery_queue();
                             let inner = self.inner.clone();
                             let handle = tokio::spawn(async move {
                                 ClusterConnInner::reconnect_to_initial_nodes(inner).await

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -662,12 +662,7 @@ impl<C> Dispose for ClusterConnInner<C> {
         }
 
         // Fail any requests buffered in the recovery queue
-        for request in self.recovery_queue.drain(..) {
-            let _ = request.sender.send(Err(RedisError::from((
-                ErrorKind::ClientError,
-                "Connection dropped",
-            ))));
-        }
+        fail_queued_senders(&mut self.recovery_queue, "Connection dropped");
 
         // Reduce the number of clients
         Telemetry::decr_total_clients(1);
@@ -1511,6 +1506,26 @@ enum ConnectionCheck<C> {
     Found((String, ConnectionFuture<C>)),
     OnlyAddress(String),
     RandomConnection,
+}
+
+/// Drain a recovery queue, failing every buffered request with a
+/// `ClientError` carrying `message`, and return the number failed.
+///
+/// Shared by the recovery-queue teardown paths (`fail_recovery_queue` on
+/// escalation to `ReconnectToInitialNodes`, and the `Drop` impl on client
+/// teardown) so the drain-and-fail behavior is defined once.
+fn fail_queued_senders<C>(
+    queue: &mut std::collections::VecDeque<PendingRequest<C>>,
+    message: &'static str,
+) -> usize {
+    let mut failed = 0;
+    for request in queue.drain(..) {
+        let _ = request
+            .sender
+            .send(Err(RedisError::from((ErrorKind::ClientError, message))));
+        failed += 1;
+    }
+    failed
 }
 
 impl<C> ClusterConnInner<C>
@@ -3651,12 +3666,7 @@ where
                     count
                 )
             );
-            for request in self.recovery_queue.drain(..) {
-                let _ = request.sender.send(Err(RedisError::from((
-                    ErrorKind::ClientError,
-                    "Connection in recovery",
-                ))));
-            }
+            fail_queued_senders(&mut self.recovery_queue, "Connection in recovery");
         }
     }
 
@@ -5059,6 +5069,69 @@ mod pipeline_routing_tests {
                 "message mismatch for routing {routing:?}: {err}",
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod recovery_queue_tests {
+    use super::{fail_queued_senders, CmdArg, Operation, PendingRequest, RequestInfo, Response};
+    use crate::{aio::MultiplexedConnection, ErrorKind};
+    use std::collections::VecDeque;
+    use tokio::sync::oneshot;
+
+    // A PendingRequest whose command needs no routing or live connection, so the
+    // queue can be built in isolation. fail_queued_senders only touches `sender`.
+    fn dummy_request() -> (
+        PendingRequest<MultiplexedConnection>,
+        oneshot::Receiver<crate::RedisResult<Response>>,
+    ) {
+        let (sender, receiver) = oneshot::channel();
+        let request = PendingRequest {
+            retry: 0,
+            sender,
+            info: RequestInfo {
+                cmd: CmdArg::OperationRequest(Operation::GetUsername),
+            },
+        };
+        (request, receiver)
+    }
+
+    // Locks in the drain behavior both escalation tests miss (PR #6770 review):
+    // fail_queued_senders must fail every buffered request with a ClientError
+    // carrying the given message and leave the queue empty. If the drain call is
+    // ever removed or turned into a no-op, this fails deterministically.
+    #[tokio::test]
+    async fn fail_queued_senders_fails_all_with_client_error_and_empties() {
+        let mut queue: VecDeque<PendingRequest<MultiplexedConnection>> = VecDeque::new();
+        let mut receivers = Vec::new();
+        for _ in 0..5 {
+            let (req, rx) = dummy_request();
+            queue.push_back(req);
+            receivers.push(rx);
+        }
+
+        let failed = fail_queued_senders(&mut queue, "Connection in recovery");
+
+        assert_eq!(failed, 5, "should report every buffered request as failed");
+        assert!(queue.is_empty(), "queue must be drained");
+
+        for rx in receivers {
+            let result = rx.await.expect("sender should have sent, not dropped");
+            let err = result.expect_err("buffered request must fail");
+            assert_eq!(err.kind(), ErrorKind::ClientError);
+            assert!(
+                err.to_string().contains("Connection in recovery"),
+                "unexpected message: {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn fail_queued_senders_on_empty_queue_is_noop() {
+        let mut queue: VecDeque<PendingRequest<MultiplexedConnection>> = VecDeque::new();
+        let failed = fail_queued_senders(&mut queue, "Connection in recovery");
+        assert_eq!(failed, 0);
+        assert!(queue.is_empty());
     }
 }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -4559,6 +4559,25 @@ where
         };
     }
 
+    // If all queried nodes failed and at least one returned AllConnectionsUnavailable,
+    // propagate it as a permanent error. This ensures the caller (poll_recover) can
+    // distinguish "no connections left" from a transient topology-parse failure and
+    // take the appropriate escalation path (fail_recovery_queue + ReconnectToInitialNodes)
+    // instead of endlessly retrying the slot refresh.
+    let all_failed = topology_join_results.iter().all(|(_, res)| res.is_err());
+    if all_failed {
+        if let Some(all_conn_err) = topology_join_results.iter().find_map(|(_, res)| {
+            res.as_ref()
+                .err()
+                .filter(|err| err.kind() == ErrorKind::AllConnectionsUnavailable)
+        }) {
+            return TopologyQueryResult {
+                topology_result: Err(all_conn_err.clone_mostly("")),
+                failed_connections: Some(failed_addresses),
+            };
+        }
+    }
+
     let topology_values = topology_join_results.iter().filter_map(|(addr, res)| {
         res.as_ref()
             .ok()

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3552,7 +3552,9 @@ where
         Ok((address, conn))
     }
 
-    /// Buffer incoming requests into the recovery queue while reconnect is in progress.
+    /// Buffer incoming requests into the recovery queue while recovery is in progress.
+    /// This covers both fast reconnect and slot refresh (the `Reconnect` and
+    /// `RefreshingSlots` states); the `ReconnectToInitialNodes` state fails fast instead.
     /// Requests beyond the queue cap are immediately failed to provide bounded memory usage.
     /// The cap is configured via `recovery_requests_queue_size` in `ClusterParams` (default 1000).
     fn buffer_pending_requests_to_recovery_queue(&mut self) {
@@ -3660,7 +3662,9 @@ where
 
     /// Fail all pending requests immediately with ClientError.
     /// Called when entering recovery to prevent requests from waiting for slow
-    /// reconnection cycles (e.g., ReconnectToInitialNodes, RefreshingSlots).
+    /// reconnection cycles (e.g., ReconnectToInitialNodes). Requests during
+    /// `RefreshingSlots` are buffered into the recovery queue instead, so this
+    /// runs only for the non-buffered states.
     fn fail_pending_requests(inner: &Core<C>) {
         let mut rx_guard = inner
             .pending_requests_rx

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7136,6 +7136,11 @@ mod cluster_async {
         );
     }
 
+    /// Per-command timeout for the concurrent harness.
+    /// Must stay well above the injected recovery delays (≤ 30 ms) so that
+    /// a slow drain is not counted as an error in `total_errors == 0` tests.
+    const CONCURRENT_CMD_TIMEOUT: Duration = Duration::from_secs(5);
+
     /// Shared harness for concurrent-request tests.
     /// Creates a multi-thread runtime, builds a cluster client pointing to `redis://{name}`,
     /// spawns `concurrency` tasks each running `pipeline_iterations * pipeline_size` SET commands,
@@ -7181,7 +7186,7 @@ mod cluster_async {
                                 .arg("value")
                                 .clone();
                             match tokio::time::timeout(
-                                std::time::Duration::from_secs(5),
+                                CONCURRENT_CMD_TIMEOUT,
                                 conn.req_packed_command(&cmd),
                             )
                             .await
@@ -7192,7 +7197,7 @@ mod cluster_async {
                                     errors += 1;
                                 }
                                 Err(_elapsed) => {
-                                    println!("[T{task_id}][iter {iter}][k {k}] cmd timeout (>5s)");
+                                    println!("[T{task_id}][iter {iter}][k {k}] cmd timeout (>{CONCURRENT_CMD_TIMEOUT:?})");
                                     errors += 1;
                                 }
                             }
@@ -7815,7 +7820,6 @@ mod cluster_async {
         let moved_fired_cluster = moved_fired.clone();
         let escalation_fired = Arc::new(atomic::AtomicBool::new(false));
         let escalation_fired_cluster = escalation_fired.clone();
-        let escalation_fired_other = escalation_fired.clone();
         let name_handler = name.to_string();
 
         let _handler = MockConnectionBehavior::register_new(
@@ -7874,11 +7878,9 @@ mod cluster_async {
             }),
         );
 
-        // Register other_host so the client can resolve it if it attempts to connect
-        // before the CLUSTER SLOTS topology update is applied.
-        // During the escalation window (moved_fired && !escalation_fired) it also returns
-        // AllConnectionsUnavailable so the topology refresh task sees the error on ALL nodes,
-        // ensuring the permanent error propagates to poll_recover.
+        // Register other_host so the client can resolve it if it attempts to connect.
+        // Once MOVED fires, other_host returns AllConnectionsUnavailable for all CLUSTER SLOTS
+        // queries, ensuring all_failed=true is deterministic regardless of query ordering.
         let other_host_name = "other_host";
         let name_for_other_handler = name.to_string();
         let moved_fired_other = moved_fired.clone();
@@ -7895,17 +7897,18 @@ mod cluster_async {
                     return Err(Ok(Value::SimpleString("OK".into())));
                 }
                 if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
-                    // During the escalation window: both nodes unavailable so the refresh
-                    // task's `all_failed` check triggers and propagates AllConnectionsUnavailable.
-                    if moved_fired_other.load(atomic::Ordering::SeqCst)
-                        && !escalation_fired_other.load(atomic::Ordering::SeqCst)
-                    {
+                    // From MOVED onwards, return AllConnectionsUnavailable for every CLUSTER SLOTS query.
+                    // The name handler returns it exactly once (on first post-MOVED call); other_host
+                    // returns it unconditionally so all_failed=true is guaranteed regardless of which
+                    // node's response the topology task reads first. After escalation, ReconnectToInitialNodes
+                    // reconnects to the seed node (name), so other_host is never queried during recovery.
+                    if moved_fired_other.load(atomic::Ordering::SeqCst) {
                         return Err(Err(RedisError::from((
                             ErrorKind::AllConnectionsUnavailable,
                             "all connections unavailable (test-injected, other_host)",
                         ))));
                     }
-                    // Post-escalation: return normal topology so ReconnectToInitialNodes succeeds.
+                    // Pre-MOVED: return normal topology
                     return Err(Ok(Value::Array(vec![Value::Array(vec![
                         Value::Int(0),
                         Value::Int(16383),
@@ -7927,6 +7930,11 @@ mod cluster_async {
         println!(
             "RefreshingSlots escalation fail-fast: {} errors, {} successes out of {} expected (total SETs: {})",
             total_errors, total_successes, expected_cmds, total_sets,
+        );
+        assert!(
+            escalation_fired.load(atomic::Ordering::SeqCst),
+            "AllConnectionsUnavailable escalation never fired — CLUSTER SLOTS never returned \
+             the injected error; the fail_recovery_queue() path was not exercised",
         );
         assert_eq!(
             total_successes + total_errors,
@@ -8076,6 +8084,11 @@ mod cluster_async {
         println!(
             "RefreshingSlots escalation fail-fast: {} errors, {} successes out of {} expected (total SETs: {})",
             total_errors, total_successes, expected_cmds, total_sets,
+        );
+        assert!(
+            escalation_fired.load(atomic::Ordering::SeqCst),
+            "Slot-refresh task-panic escalation never fired — CLUSTER SLOTS never returned \
+             Ok(()) to trigger the mock panic; the fail_recovery_queue() path was not exercised",
         );
         assert_eq!(
             total_successes + total_errors,

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7180,10 +7180,19 @@ mod cluster_async {
                                 .arg(format!("t{task_id}_key{k}"))
                                 .arg("value")
                                 .clone();
-                            match conn.req_packed_command(&cmd).await {
-                                Ok(_) => successes += 1,
-                                Err(e) => {
+                            match tokio::time::timeout(
+                                std::time::Duration::from_secs(5),
+                                conn.req_packed_command(&cmd),
+                            )
+                            .await
+                            {
+                                Ok(Ok(_)) => successes += 1,
+                                Ok(Err(e)) => {
                                     println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
+                                    errors += 1;
+                                }
+                                Err(_elapsed) => {
+                                    println!("[T{task_id}][iter {iter}][k {k}] cmd timeout (>5s)");
                                     errors += 1;
                                 }
                             }
@@ -7766,6 +7775,316 @@ mod cluster_async {
             "guard must short-circuit the retry loop: observed {refreshes} \
              post-startup CLUSTER SLOTS refresh(es), which only fires if the \
              retryable empty-receivers branch leaked through",
+        );
+    }
+
+    /// Tests that concurrent commands buffered in `recovery_queue` during `RefreshingSlots`
+    /// are immediately failed with `ClientError` when the slot-refresh task completes with
+    /// `AllConnectionsUnavailable` — verifying the `fail_recovery_queue()` path.
+    ///
+    /// ## Scenario
+    ///
+    /// 1. The Nth SET returns a non-circular MOVED → triggers `RefreshingSlots`.
+    /// 2. CLUSTER SLOTS is delayed 30 ms after MOVED fires → `RefreshingSlots` stays
+    ///    `Poll::Pending` → concurrent requests pile up in `recovery_queue`.
+    /// 3. After the delay CLUSTER SLOTS returns `AllConnectionsUnavailable` →
+    ///    `poll_recover` calls `fail_recovery_queue()` → all buffered requests receive
+    ///    `ClientError("Connection in recovery")` immediately.
+    /// 4. Client escalates to `ReconnectToInitialNodes`.
+    ///
+    /// ## Assertions
+    ///
+    /// - No commands are silently dropped (`total_successes + total_errors == expected_cmds`).
+    /// - Note: whether any command actually observes the fail-fast error depends on CI timing;
+    ///   the no-silent-drops check is the reliable guarantee this test provides.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_requests_fail_fast_on_refreshing_slots_all_connections_unavailable() {
+        let name = "test_concurrent_refreshing_slots_all_conn_unavailable";
+        const MOVED_ON_SET_N: usize = 30;
+        const CONCURRENCY: usize = 20;
+        const PIPELINE_ITERATIONS: usize = 5;
+        const PIPELINE_SIZE: usize = 10;
+        const DELAY_AFTER_MOVED_MS: u64 = 5;
+        const CLUSTER_SLOTS_DELAY_MS: u64 = 30;
+
+        let set_count = Arc::new(atomic::AtomicUsize::new(0));
+        let set_count_clone = set_count.clone();
+        let moved_fired = Arc::new(atomic::AtomicBool::new(false));
+        let moved_fired_clone = moved_fired.clone();
+        let moved_fired_cluster = moved_fired.clone();
+        let escalation_fired = Arc::new(atomic::AtomicBool::new(false));
+        let escalation_fired_cluster = escalation_fired.clone();
+        let escalation_fired_other = escalation_fired.clone();
+        let name_handler = name.to_string();
+
+        let _handler = MockConnectionBehavior::register_new(
+            name,
+            Arc::new(move |cmd: &[u8], port| {
+                let name = name_handler.as_str();
+                if contains_slice(cmd, b"PING") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    if moved_fired_cluster.load(atomic::Ordering::SeqCst)
+                        && !escalation_fired_cluster.load(atomic::Ordering::SeqCst)
+                    {
+                        // Delay to keep RefreshingSlots Pending while concurrent requests
+                        // accumulate in recovery_queue, then return AllConnectionsUnavailable
+                        // to exercise fail_recovery_queue(). Fire exactly once.
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            CLUSTER_SLOTS_DELAY_MS,
+                        ));
+                        escalation_fired_cluster.store(true, atomic::Ordering::SeqCst);
+                        return Err(Err(RedisError::from((
+                            ErrorKind::AllConnectionsUnavailable,
+                            "all connections unavailable (test-injected)",
+                        ))));
+                    }
+                    // Normal topology for startup and post-recovery (ReconnectToInitialNodes
+                    // can now complete successfully).
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::Int(port as i64),
+                        ]),
+                    ])])));
+                }
+                if contains_slice(cmd, b"SET") {
+                    let i = set_count_clone.fetch_add(1, atomic::Ordering::SeqCst);
+                    if i == MOVED_ON_SET_N {
+                        moved_fired_clone.store(true, atomic::Ordering::SeqCst);
+                        // Non-circular MOVED: different hostname triggers RefreshingSlots.
+                        return Err(parse_redis_value(b"-MOVED 0 other_host:6380\r\n"));
+                    }
+                    if moved_fired_clone.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(DELAY_AFTER_MOVED_MS));
+                    }
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        // Register other_host so the client can resolve it if it attempts to connect
+        // before the CLUSTER SLOTS topology update is applied.
+        // During the escalation window (moved_fired && !escalation_fired) it also returns
+        // AllConnectionsUnavailable so the topology refresh task sees the error on ALL nodes,
+        // ensuring the permanent error propagates to poll_recover.
+        let other_host_name = "other_host";
+        let name_for_other_handler = name.to_string();
+        let moved_fired_other = moved_fired.clone();
+        let _other_handler = MockConnectionBehavior::register_new(
+            other_host_name,
+            Arc::new(move |cmd: &[u8], _port| {
+                if contains_slice(cmd, b"PING") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    // During the escalation window: both nodes unavailable so the refresh
+                    // task's `all_failed` check triggers and propagates AllConnectionsUnavailable.
+                    if moved_fired_other.load(atomic::Ordering::SeqCst)
+                        && !escalation_fired_other.load(atomic::Ordering::SeqCst)
+                    {
+                        return Err(Err(RedisError::from((
+                            ErrorKind::AllConnectionsUnavailable,
+                            "all connections unavailable (test-injected, other_host)",
+                        ))));
+                    }
+                    // Post-escalation: return normal topology so ReconnectToInitialNodes succeeds.
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name_for_other_handler.as_bytes().to_vec().into()),
+                            Value::Int(6379),
+                        ]),
+                    ])])));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        let (total_successes, total_errors) =
+            run_concurrent_cluster_requests(name, CONCURRENCY, PIPELINE_ITERATIONS, PIPELINE_SIZE);
+
+        let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
+        let total_sets = set_count.load(atomic::Ordering::SeqCst);
+        println!(
+            "RefreshingSlots escalation fail-fast: {} errors, {} successes out of {} expected (total SETs: {})",
+            total_errors, total_successes, expected_cmds, total_sets,
+        );
+        assert_eq!(
+            total_successes + total_errors,
+            expected_cmds,
+            "Commands were silently dropped: {} succeeded + {} errors = {} != {} expected",
+            total_successes,
+            total_errors,
+            total_successes + total_errors,
+            expected_cmds,
+        );
+    }
+
+    /// Tests that concurrent commands buffered in `recovery_queue` during `RefreshingSlots`
+    /// are immediately failed with `ClientError` when the slot-refresh task **panics** —
+    /// verifying the `fail_recovery_queue()` panic-recovery path.
+    ///
+    /// ## Scenario
+    ///
+    /// 1. The Nth SET returns a non-circular MOVED → triggers `RefreshingSlots`.
+    /// 2. CLUSTER SLOTS is delayed 30 ms after MOVED fires → `RefreshingSlots` stays
+    ///    `Poll::Pending` → concurrent requests pile up in `recovery_queue`.
+    /// 3. After the delay CLUSTER SLOTS returns `Ok(())` (no response value).
+    ///    `MockConnection::req_packed_command` calls `.expect_err(…)` on that `Ok(())`
+    ///    and **panics inside the spawned refresh task**.
+    /// 4. The `JoinHandle` resolves as `Err(join_err)` with `!join_err.is_cancelled()` →
+    ///    `poll_recover` calls `fail_recovery_queue()` → all buffered requests receive
+    ///    `ClientError` immediately; client escalates to `ReconnectToInitialNodes`.
+    ///
+    /// ## Assertions
+    ///
+    /// - No commands are silently dropped (`total_successes + total_errors == expected_cmds`).
+    /// - Note: whether any command actually observes the fail-fast error depends on CI timing;
+    ///   the no-silent-drops check is the reliable guarantee this test provides.
+    #[test]
+    #[serial_test::serial]
+    fn test_async_cluster_requests_fail_fast_on_refreshing_slots_task_panic() {
+        let name = "test_concurrent_refreshing_slots_task_panic";
+        const MOVED_ON_SET_N: usize = 30;
+        const CONCURRENCY: usize = 20;
+        const PIPELINE_ITERATIONS: usize = 5;
+        const PIPELINE_SIZE: usize = 10;
+        const DELAY_AFTER_MOVED_MS: u64 = 5;
+        const CLUSTER_SLOTS_DELAY_MS: u64 = 30;
+
+        let set_count = Arc::new(atomic::AtomicUsize::new(0));
+        let set_count_clone = set_count.clone();
+        let moved_fired = Arc::new(atomic::AtomicBool::new(false));
+        let moved_fired_clone = moved_fired.clone();
+        let moved_fired_cluster = moved_fired.clone();
+        let escalation_fired = Arc::new(atomic::AtomicBool::new(false));
+        let escalation_fired_cluster = escalation_fired.clone();
+        let name_handler = name.to_string();
+
+        let _handler = MockConnectionBehavior::register_new(
+            name,
+            Arc::new(move |cmd: &[u8], port| {
+                let name = name_handler.as_str();
+                if contains_slice(cmd, b"PING") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    if moved_fired_cluster.load(atomic::Ordering::SeqCst)
+                        && !escalation_fired_cluster.load(atomic::Ordering::SeqCst)
+                    {
+                        // Delay to keep RefreshingSlots Pending while concurrent requests
+                        // accumulate in recovery_queue. Then return Ok(()) — the MockConnection
+                        // will call .expect_err() on this, panicking inside the spawned task.
+                        // Fire exactly once; subsequent calls return normal topology so that
+                        // ReconnectToInitialNodes can complete.
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            CLUSTER_SLOTS_DELAY_MS,
+                        ));
+                        escalation_fired_cluster.store(true, atomic::Ordering::SeqCst);
+                        // Returning Ok(()) causes MockConnection::req_packed_command to panic
+                        // via .expect_err("Handler did not specify a response"), which exercises
+                        // the Poll::Ready(Err(join_err)) path in poll_recover.
+                        return Ok(());
+                    }
+                    // Normal topology for startup and post-recovery.
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name.as_bytes().to_vec().into()),
+                            Value::Int(port as i64),
+                        ]),
+                    ])])));
+                }
+                if contains_slice(cmd, b"SET") {
+                    let i = set_count_clone.fetch_add(1, atomic::Ordering::SeqCst);
+                    if i == MOVED_ON_SET_N {
+                        moved_fired_clone.store(true, atomic::Ordering::SeqCst);
+                        // Non-circular MOVED: different hostname triggers RefreshingSlots.
+                        return Err(parse_redis_value(b"-MOVED 0 other_host:6380\r\n"));
+                    }
+                    if moved_fired_clone.load(atomic::Ordering::SeqCst) {
+                        std::thread::sleep(std::time::Duration::from_millis(DELAY_AFTER_MOVED_MS));
+                    }
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        // Register other_host so the client can resolve it if it attempts to connect
+        // before the CLUSTER SLOTS topology update is applied.
+        let other_host_name = "other_host";
+        let name_for_other_handler = name.to_string();
+        let _other_handler = MockConnectionBehavior::register_new(
+            other_host_name,
+            Arc::new(move |cmd: &[u8], _port| {
+                if contains_slice(cmd, b"PING") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    // Point back to the primary mock node so topology resolves correctly.
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name_for_other_handler.as_bytes().to_vec().into()),
+                            Value::Int(6379),
+                        ]),
+                    ])])));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
+
+        let (total_successes, total_errors) =
+            run_concurrent_cluster_requests(name, CONCURRENCY, PIPELINE_ITERATIONS, PIPELINE_SIZE);
+
+        let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
+        let total_sets = set_count.load(atomic::Ordering::SeqCst);
+        println!(
+            "RefreshingSlots escalation fail-fast: {} errors, {} successes out of {} expected (total SETs: {})",
+            total_errors, total_successes, expected_cmds, total_sets,
+        );
+        assert_eq!(
+            total_successes + total_errors,
+            expected_cmds,
+            "Commands were silently dropped: {} succeeded + {} errors = {} != {} expected",
+            total_successes,
+            total_errors,
+            total_successes + total_errors,
+            expected_cmds,
         );
     }
 

--- a/glide-core/redis-rs/redis/tests/test_cluster_async.rs
+++ b/glide-core/redis-rs/redis/tests/test_cluster_async.rs
@@ -7136,6 +7136,76 @@ mod cluster_async {
         );
     }
 
+    /// Shared harness for concurrent-request tests.
+    /// Creates a multi-thread runtime, builds a cluster client pointing to `redis://{name}`,
+    /// spawns `concurrency` tasks each running `pipeline_iterations * pipeline_size` SET commands,
+    /// and returns `(total_successes, total_errors)`.
+    fn run_concurrent_cluster_requests(
+        name: &str,
+        concurrency: usize,
+        pipeline_iterations: usize,
+        pipeline_size: usize,
+    ) -> (usize, usize) {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_all()
+            .build()
+            .expect("failed to build runtime");
+
+        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
+            .retries(5)
+            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
+            .build()
+            .expect("failed to build ClusterClient");
+
+        let connection: ClusterConnection<MockConnection> = runtime
+            .block_on(client.get_async_generic_connection())
+            .expect("failed to get async connection");
+
+        let results = runtime.block_on(async move {
+            let barrier = Arc::new(tokio::sync::Barrier::new(concurrency));
+            let mut tasks = Vec::with_capacity(concurrency);
+
+            for task_id in 0..concurrency {
+                let mut conn = connection.clone();
+                let barrier = barrier.clone();
+                tasks.push(tokio::spawn(async move {
+                    barrier.wait().await;
+                    let mut successes = 0usize;
+                    let mut errors = 0usize;
+                    for iter in 0..pipeline_iterations {
+                        for k in 0..pipeline_size {
+                            let cmd = redis::Cmd::new()
+                                .arg("SET")
+                                .arg(format!("t{task_id}_key{k}"))
+                                .arg("value")
+                                .clone();
+                            match conn.req_packed_command(&cmd).await {
+                                Ok(_) => successes += 1,
+                                Err(e) => {
+                                    println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
+                                    errors += 1;
+                                }
+                            }
+                        }
+                    }
+                    (successes, errors)
+                }));
+            }
+
+            futures::future::join_all(tasks).await
+        });
+
+        let mut total_successes = 0usize;
+        let mut total_errors = 0usize;
+        for result in results {
+            let (s, e) = result.expect("task panicked");
+            total_successes += s;
+            total_errors += e;
+        }
+        (total_successes, total_errors)
+    }
+
     /// Mirrors the Python stress-test script that exposed the "Connection in recovery" bug.
     ///
     /// ## Scenario
@@ -7276,69 +7346,9 @@ mod cluster_async {
 
         // Use a multi-threaded runtime so that the background connection task and the
         // reconnect task can run on different OS threads simultaneously.
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .worker_threads(4)
-            .build()
-            .expect("failed to build multi-thread runtime");
+        let (total_cmd_successes, total_cmd_errors) =
+            run_concurrent_cluster_requests(name, CONCURRENCY, PIPELINE_ITERATIONS, PIPELINE_SIZE);
 
-        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
-            .retries(5)
-            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
-            .build()
-            .expect("failed to build ClusterClient");
-
-        let connection: ClusterConnection<MockConnection> = runtime
-            .block_on(client.get_async_generic_connection())
-            .expect("failed to get async connection");
-
-        // Each task sends PIPELINE_ITERATIONS × PIPELINE_SIZE individual SET commands.
-        // All tasks start simultaneously via a barrier.
-        // The circular MOVED fires mid-run (on SET #{MOVED_ON_SET_N} globally); commands
-        // arriving while the Sink is in recovery must be buffered and succeed, not fail.
-        let results = runtime.block_on(async move {
-            let barrier = Arc::new(tokio::sync::Barrier::new(CONCURRENCY));
-            let tasks: Vec<_> = (0..CONCURRENCY)
-                .map(|task_id| {
-                    let mut conn = connection.clone();
-                    let barrier = barrier.clone();
-                    tokio::spawn(async move {
-                        barrier.wait().await;
-                        let mut cmd_errors = 0usize;
-                        let mut cmd_successes = 0usize;
-                        for iter in 0..PIPELINE_ITERATIONS {
-                            for k in 0..PIPELINE_SIZE {
-                                let cmd = redis::Cmd::new()
-                                    .arg("SET")
-                                    .arg(format!("t{task_id}_key{k}"))
-                                    .arg("value")
-                                    .clone();
-                                match conn.req_packed_command(&cmd).await {
-                                    Ok(_) => cmd_successes += 1,
-                                    Err(e) => {
-                                        println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
-                                        cmd_errors += 1;
-                                    }
-                                }
-                            }
-                        }
-                        (task_id, cmd_successes, cmd_errors)
-                    })
-                })
-                .collect();
-            futures::future::join_all(tasks).await
-        });
-
-        let total_cmd_successes: usize = results
-            .iter()
-            .filter_map(|r| r.as_ref().ok())
-            .map(|(_, s, _)| s)
-            .sum();
-        let total_cmd_errors: usize = results
-            .iter()
-            .filter_map(|r| r.as_ref().ok())
-            .map(|(_, _, e)| e)
-            .sum();
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
         let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
 
@@ -7358,6 +7368,12 @@ mod cluster_async {
             "Expected zero command errors after recovery queue fix. \
              {} commands failed (total SETs to mock: {})",
             total_cmd_errors, total_sets,
+        );
+        assert_eq!(
+            total_cmd_successes, expected_cmds,
+            "all commands should succeed after circular MOVED recovery; \
+             {} successes out of {} expected ({} errors)",
+            total_cmd_successes, expected_cmds, total_cmd_errors,
         );
 
         println!(
@@ -7461,67 +7477,9 @@ mod cluster_async {
             }),
         );
 
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .worker_threads(4)
-            .build()
-            .expect("failed to build multi-thread runtime");
+        let (total_successes, total_errors) =
+            run_concurrent_cluster_requests(name, CONCURRENCY, PIPELINE_ITERATIONS, PIPELINE_SIZE);
 
-        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
-            .retries(5)
-            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
-            .build()
-            .expect("failed to build ClusterClient");
-
-        let connection: ClusterConnection<MockConnection> = runtime
-            .block_on(client.get_async_generic_connection())
-            .expect("failed to get async connection");
-
-        let results = runtime.block_on(async move {
-            let barrier = Arc::new(tokio::sync::Barrier::new(CONCURRENCY));
-            let tasks: Vec<_> = (0..CONCURRENCY)
-                .map(|task_id| {
-                    let mut conn = connection.clone();
-                    let barrier = barrier.clone();
-                    tokio::spawn(async move {
-                        barrier.wait().await;
-                        let mut cmd_errors = 0usize;
-                        let mut cmd_successes = 0usize;
-                        for iter in 0..PIPELINE_ITERATIONS {
-                            for k in 0..PIPELINE_SIZE {
-                                let cmd = redis::Cmd::new()
-                                    .arg("SET")
-                                    .arg(format!("t{task_id}_key{k}"))
-                                    .arg("value")
-                                    .clone();
-                                match conn.req_packed_command(&cmd).await {
-                                    Ok(_) => cmd_successes += 1,
-                                    Err(e) => {
-                                        println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
-                                        cmd_errors += 1;
-                                    }
-                                }
-                            }
-                        }
-                        (task_id, cmd_successes, cmd_errors)
-                    })
-                })
-                .collect();
-            futures::future::join_all(tasks).await
-        });
-
-        // Unwrap join results — if any worker panicked the test should fail loudly, not silently
-        // drop the worker's counts and produce a misleading assertion failure.
-        let total_errors: usize = results
-            .iter()
-            .map(|r| r.as_ref().expect("worker task panicked"))
-            .map(|(_, _, e)| e)
-            .sum();
-        let total_successes: usize = results
-            .iter()
-            .map(|r| r.as_ref().expect("worker task panicked"))
-            .map(|(_, s, _)| s)
-            .sum();
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
 
         // With fail-fast behavior, requests that arrive during ReconnectToInitialNodes recovery
@@ -7637,66 +7595,57 @@ mod cluster_async {
             }),
         );
 
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .worker_threads(4)
-            .build()
-            .expect("failed to build multi-thread runtime");
+        // Register other_host so the client can resolve it if it attempts to connect
+        // before the CLUSTER SLOTS topology update is applied.
+        let other_host_name = "other_host";
+        // Clone `name` so it can be captured by the other_host closure (name_handler already
+        // owns a clone used by the primary handler above).
+        let name_for_other_handler = name.to_string();
+        let _other_handler = MockConnectionBehavior::register_new(
+            other_host_name,
+            Arc::new(move |cmd: &[u8], _port| {
+                if contains_slice(cmd, b"PING") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"SETNAME") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"READONLY") {
+                    return Err(Ok(Value::SimpleString("OK".into())));
+                }
+                if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                    // Point back to the primary mock node so the client resolves topology
+                    // correctly and routes back to `name` rather than staying on other_host.
+                    return Err(Ok(Value::Array(vec![Value::Array(vec![
+                        Value::Int(0),
+                        Value::Int(16383),
+                        Value::Array(vec![
+                            Value::BulkString(name_for_other_handler.as_bytes().to_vec().into()),
+                            Value::Int(6379),
+                        ]),
+                    ])])));
+                }
+                Err(Ok(Value::SimpleString("OK".into())))
+            }),
+        );
 
-        let client = ClusterClient::builder(vec![&*format!("redis://{name}")])
-            .retries(5)
-            .slots_refresh_rate_limit(Duration::from_secs(0), 0)
-            .build()
-            .expect("failed to build ClusterClient");
+        let (total_successes, total_errors) =
+            run_concurrent_cluster_requests(name, CONCURRENCY, PIPELINE_ITERATIONS, PIPELINE_SIZE);
 
-        let connection: ClusterConnection<MockConnection> = runtime
-            .block_on(client.get_async_generic_connection())
-            .expect("failed to get async connection");
-
-        let results = runtime.block_on(async move {
-            let barrier = Arc::new(tokio::sync::Barrier::new(CONCURRENCY));
-            let tasks: Vec<_> = (0..CONCURRENCY)
-                .map(|task_id| {
-                    let mut conn = connection.clone();
-                    let barrier = barrier.clone();
-                    tokio::spawn(async move {
-                        barrier.wait().await;
-                        let mut cmd_errors = 0usize;
-                        let mut cmd_successes = 0usize;
-                        for iter in 0..PIPELINE_ITERATIONS {
-                            for k in 0..PIPELINE_SIZE {
-                                let cmd = redis::Cmd::new()
-                                    .arg("SET")
-                                    .arg(format!("t{task_id}_key{k}"))
-                                    .arg("value")
-                                    .clone();
-                                match conn.req_packed_command(&cmd).await {
-                                    Ok(_) => cmd_successes += 1,
-                                    Err(e) => {
-                                        println!("[T{task_id}][iter {iter}][k {k}] cmd error: {e}");
-                                        cmd_errors += 1;
-                                    }
-                                }
-                            }
-                        }
-                        (task_id, cmd_successes, cmd_errors)
-                    })
-                })
-                .collect();
-            futures::future::join_all(tasks).await
-        });
-
-        let total_errors: usize = results
-            .iter()
-            .map(|r| r.as_ref().expect("worker task panicked"))
-            .map(|(_, _, e)| e)
-            .sum();
         let total_sets = set_count.load(atomic::Ordering::SeqCst);
+        let expected_cmds = CONCURRENCY * PIPELINE_ITERATIONS * PIPELINE_SIZE;
 
         assert_eq!(
             total_errors, 0,
-            "commands buffered during RefreshingSlots recovery must succeed; total SETs to mock: {}",
-            total_sets,
+            "commands buffered during RefreshingSlots recovery must all succeed; \
+             {} successes, {} errors out of {} expected",
+            total_successes, total_errors, expected_cmds,
+        );
+        assert_eq!(
+            total_successes, expected_cmds,
+            "all commands must succeed after buffering and drain; \
+             {} successes out of {} expected ({} errors, total SETs to mock: {})",
+            total_successes, expected_cmds, total_errors, total_sets,
         );
     }
 


### PR DESCRIPTION
## Backport of PR #6770 delta to release-2.5

### Summary

This PR backports the changes introduced in PR #6770 (merged to main on 2026-08-25) that were NOT present in the original PR #6707 (which introduced the base fix to release-2.5).

### Background

PR #6707 extended request buffering to the `RefreshingSlots` path. During the main cherry-pick review (PR #6770), additional correctness issues were identified and fixed:

1. **Bug fix**: When `RefreshingSlots` escalates to `ReconnectToInitialNodes` (due to `AllConnectionsUnavailable` or a task panic), requests buffered in `recovery_queue` were silently abandoned — never failed, never retried. Clients would hang waiting for responses that would never come.

2. **Test hardening**: Existing concurrent tests were refactored to use a shared harness with per-command timeouts (prevents CI hangs). Two new tests explicitly cover the escalation paths.

3. **Doc corrections**: Recovery-state buffering docs corrected.

### Changes

#### `glide-core/redis-rs/redis/src/cluster_async/mod.rs`
- New `fail_queued_senders()` free function — shared drain helper used by Drop and `fail_recovery_queue`
- New `fail_recovery_queue()` method — drains `recovery_queue` and fails all buffered requests with `ClientError("Connection in recovery")`
- Two call sites in `poll_recover` (`RefreshingSlots` arm): `AllConnectionsUnavailable` path and task-panic path — both now call `fail_recovery_queue()` before transitioning to `ReconnectToInitialNodes`
- `TopologyQueryResult` all-failed propagation: surfaces `AllConnectionsUnavailable` when all topology nodes fail
- New `recovery_queue_tests` unit-test module for `fail_queued_senders`

#### `glide-core/redis-rs/redis/tests/test_cluster_async.rs`
- `CONCURRENT_CMD_TIMEOUT` constant and `run_concurrent_cluster_requests()` shared test harness with per-command 5s timeout
- Existing concurrent tests refactored to use shared harness; assertions strengthened
- Two new escalation tests:
  - `test_async_cluster_requests_fail_fast_on_refreshing_slots_all_connections_unavailable`
  - `test_async_cluster_requests_fail_fast_on_refreshing_slots_task_panic`

### Related
- Original fix: #6707 (release-2.5)
- Main cherry-pick: #6770 (main)